### PR TITLE
Added cmake code for CUDA Compute variables

### DIFF
--- a/common/CUDACheckCompute.cmake
+++ b/common/CUDACheckCompute.cmake
@@ -1,0 +1,37 @@
+#############################
+#Sourced from:
+#https://raw.githubusercontent.com/jwetzl/CudaLBFGS/master/CheckComputeCapability.cmake
+#############################
+# Check for GPUs present and their compute capability
+# based on http://stackoverflow.com/questions/2285185/easiest-way-to-test-for-existence-of-cuda-capable-gpu-from-cmake/2297877#2297877 (Christopher Bruns)
+
+if(CUDA_FOUND)
+    message(STATUS "${CMAKE_SOURCE_DIR}/common/cuda_compute_capability.c")
+    try_run(RUN_RESULT_VAR COMPILE_RESULT_VAR
+        ${CMAKE_BINARY_DIR}
+        ${CMAKE_SOURCE_DIR}/common/cuda_compute_capability.c
+        CMAKE_FLAGS
+        -DINCLUDE_DIRECTORIES:STRING=${CUDA_TOOLKIT_INCLUDE}
+        -DLINK_LIBRARIES:STRING=${CUDA_CUDART_LIBRARY}
+        COMPILE_OUTPUT_VARIABLE COMPILE_OUTPUT_VAR
+        RUN_OUTPUT_VARIABLE RUN_OUTPUT_VAR)
+    message(STATUS "Compile: ${RUN_OUTPUT_VAR}")
+    if (COMPILE_RESULT_VAR)
+        message(STATUS "compiled -> " ${RUN_RESULT_VAR})
+    else()
+        message(STATUS "didn't compile")
+    endif()
+    # COMPILE_RESULT_VAR is TRUE when compile succeeds
+    # RUN_RESULT_VAR is zero when a GPU is found
+    if(COMPILE_RESULT_VAR AND NOT RUN_RESULT_VAR)
+        message(STATUS "worked")
+        set(CUDA_HAVE_GPU TRUE CACHE BOOL "Whether CUDA-capable GPU is present")
+        set(CUDA_COMPUTE_CAPABILITY ${RUN_OUTPUT_VAR} CACHE STRING "Compute capability of CUDA-capable GPU present")
+        set(CUDA_GENERATE_CODE "arch=compute_${CUDA_COMPUTE_CAPABILITY},code=sm_${CUDA_COMPUTE_CAPABILITY}" CACHE STRING "Which GPU architectures to generate code for (each arch/code pair will be passed as --generate-code option to nvcc, separate multiple pairs by ;)")
+        mark_as_advanced(CUDA_COMPUTE_CAPABILITY CUDA_GENERATE_CODE)
+        set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS} -arch compute_${CUDA_COMPUTE_CAPABILITY})
+    else()
+        message(STATUS "didn't work")
+        set(CUDA_HAVE_GPU FALSE CACHE BOOL "Whether CUDA-capable GPU is present")
+    endif()
+endif()

--- a/common/cuda_compute_capability.c
+++ b/common/cuda_compute_capability.c
@@ -1,0 +1,52 @@
+/*
+* Copyright (C) 2011 Florian Rathgeber, florian.rathgeber@gmail.com
+*
+* This code is licensed under the MIT License.  See the FindCUDA.cmake script
+* for the text of the license.
+*
+* Based on code by Christopher Bruns published on Stack Overflow (CC-BY):
+* http://stackoverflow.com/questions/2285185
+*/
+
+#include <stdio.h>
+#include <cuda_runtime.h>
+
+int main() {
+    int deviceCount, device, major = 9999, minor = 9999;
+    int gpuDeviceCount = 0;
+    struct cudaDeviceProp properties;
+
+    if (cudaGetDeviceCount(&deviceCount) != cudaSuccess)
+    {
+        printf("Couldn't get device count: %s\n", cudaGetErrorString(cudaGetLastError()));
+        return 1;
+    }
+    /* machines with no GPUs can still report one emulation device */
+    for (device = 0; device < deviceCount; ++device) {
+        cudaGetDeviceProperties(&properties, device);
+        if (properties.major != 9999) {/* 9999 means emulation only */
+            ++gpuDeviceCount;
+            /*  get minimum compute capability of all devices */
+            if (major > properties.major) {
+                major = properties.major;
+                minor = properties.minor;
+            } else if (minor > properties.minor) {
+                minor = properties.minor;
+            }
+        }
+    }
+
+    /* don't just return the number of gpus, because other runtime cuda
+    errors can also yield non-zero return values */
+    if (gpuDeviceCount > 0) {
+        if ((major == 2 && minor == 1))
+        {
+            // There is no --arch compute_21 flag for nvcc, so force minor to 0
+            minor = 0;
+        }
+        /* this output will be parsed by FindCUDA.cmake */
+        printf("%d%d", major, minor);
+        return 0; /* success */
+    }
+    return 1; /* failure */
+}

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -1,5 +1,6 @@
 INCLUDE(${CMAKE_SOURCE_DIR}/common/CLKernelToH.cmake)
 INCLUDE(${CMAKE_SOURCE_DIR}/common/FindNVVM.cmake)
+INCLUDE(${CMAKE_SOURCE_DIR}/common/CUDACheckCompute.cmake)
 
 FIND_PACKAGE(Boost)
 INCLUDE_DIRECTORIES(${BOOST_INCLUDE_DIR})
@@ -30,7 +31,18 @@ FILE(GLOB cuda_src
     "../../array/*.cpp"
     )
 
-FILE(GLOB cuda_ptx "ptx/PTX64/sm_20/*.ptx")
+if(${CUDA_COMPUTE_CAPABILITY} STREQUAL "21")
+    SET(PTX_COMPUTE "20")
+elseif(${CUDA_COMPUTE_CAPABILITY} STREQUAL "32")
+    SET(PTX_COMPUTE "30")
+elseif(${CUDA_COMPUTE_CAPABILITY} STREQUAL "52")
+    SET(PTX_COMPUTE "50")
+else()
+  SET(PTX_COMPUTE ${CUDA_COMPUTE_CAPABILITY})
+endif()
+
+
+FILE(GLOB cuda_ptx "ptx/PTX64/sm_${PTX_COMPUTE}/*.ptx")
 
 SET( ptx_headers
     "ptx_headers")
@@ -52,7 +64,7 @@ IF(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND "${APPLE}")
     SET(CUDA_HOST_COMPILER "/usr/bin/clang++")
 ENDIF()
 
-CUDA_ADD_LIBRARY(afcuda SHARED ${cuda_src} OPTIONS "-arch=sm_20")
+CUDA_ADD_LIBRARY(afcuda SHARED ${cuda_src} OPTIONS ${CUDA_CODE_GENERATION})
 ADD_DEPENDENCIES(afcuda ${ptx_targets})
 
 


### PR DESCRIPTION
Added cmake files to generate CUDA architecture variable.
common/CUDACheckCompute call cuda_compute_capability.c which runs cudaDeviceProp API to fetch compute version.

Fixes #27 
