### PR TITLE
Reduce Boost.Compute header includes

### DIFF
--- a/src/backend/opencl/kernel/sort.hpp
+++ b/src/backend/opencl/kernel/sort.hpp
@@ -18,7 +18,10 @@
 
 #undef min
 #undef max
-#include <boost/compute.hpp>
+#include <boost/compute/core.hpp>
+#include <boost/compute/algorithm/stable_sort.hpp>
+#include <boost/compute/functional/operator.hpp>
+#include <boost/compute/iterator/buffer_iterator.hpp>
 namespace compute = boost::compute;
 
 using cl::Buffer;

--- a/src/backend/opencl/kernel/sort_by_key.hpp
+++ b/src/backend/opencl/kernel/sort_by_key.hpp
@@ -18,7 +18,10 @@
 
 #undef min
 #undef max
-#include <boost/compute.hpp>
+#include <boost/compute/core.hpp>
+#include <boost/compute/algorithm/sort_by_key.hpp>
+#include <boost/compute/functional/operator.hpp>
+#include <boost/compute/iterator/buffer_iterator.hpp>
 namespace compute = boost::compute;
 
 using cl::Buffer;

--- a/src/backend/opencl/kernel/sort_index.hpp
+++ b/src/backend/opencl/kernel/sort_index.hpp
@@ -18,7 +18,11 @@
 
 #undef min
 #undef max
-#include <boost/compute.hpp>
+#include <boost/compute/core.hpp>
+#include <boost/compute/algorithm/iota.hpp>
+#include <boost/compute/algorithm/sort_by_key.hpp>
+#include <boost/compute/functional/operator.hpp>
+#include <boost/compute/iterator/buffer_iterator.hpp>
 namespace compute = boost::compute;
 
 using cl::Buffer;


### PR DESCRIPTION
This reduces the number of Boost.Compute header includes to
only those necessary for the file. This should help improve
compilation times.
