### PR TITLE
Calling af_init to initialize contexts

### DIFF
--- a/include/af/device.h
+++ b/include/af/device.h
@@ -33,6 +33,8 @@ extern "C" {
 
     AFAPI af_err af_info();
 
+    AFAPI af_err af_init();
+
     AFAPI af_err af_deviceprop(char* d_name, char* d_platform, char *d_toolkit, char* d_compute);
 
     AFAPI af_err af_get_device_count(int *num_of_devices);

--- a/src/backend/ArrayInfo.hpp
+++ b/src/backend/ArrayInfo.hpp
@@ -11,7 +11,7 @@
 #include <af/array.h>
 #include <af/util.h>
 #include <af/dim4.hpp>
-
+#include <af/device.h>
 
 
 dim_type
@@ -37,7 +37,7 @@ public:
         dim_size(size),
         dim_offsets(offset),
         dim_strides(stride)
-    { }
+    { af_init(); }
 
 #if __cplusplus > 199711L
     //Copy constructors are deprecated if there is a

--- a/src/backend/cuda/platform.hpp
+++ b/src/backend/cuda/platform.hpp
@@ -47,11 +47,6 @@ struct cudaDevice_t {
     cudaDeviceProp prop;
     size_t flops;
     int nativeId;
-
-    //cudaDevice_t(cudaDeviceProp p, size_t f, int nId)
-    //    : prop(p), flops(f), nativeId(nId)
-    //{
-    //}
 };
 
 class DeviceManager

--- a/src/backend/data.cpp
+++ b/src/backend/data.cpp
@@ -11,6 +11,7 @@
 #include <af/dim4.hpp>
 #include <af/array.h>
 #include <af/data.h>
+#include <af/device.h>
 #include <af/util.h>
 #include <copy.hpp>
 #include <err_common.hpp>
@@ -53,6 +54,7 @@ af_err af_create_array(af_array *result, const void * const data,
                        const unsigned ndims, const dim_type * const dims,
                        const af_dtype type)
 {
+    af_init();
     af_err ret = AF_ERR_ARG;
     af_array out;
     try {
@@ -83,6 +85,7 @@ af_err af_constant(af_array *result, const double value,
                    const unsigned ndims, const dim_type * const dims,
                    const af_dtype type)
 {
+    af_init();
     af_err ret = AF_ERR_ARG;
     af_array out;
     try {
@@ -117,6 +120,7 @@ static inline af_array cplx(const af_array lhs, const af_array rhs)
 af_err af_constant_c64(af_array *result, const void* value,
                        const unsigned ndims, const dim_type * const dims)
 {
+    af_init();
     af_err ret = AF_ERR_ARG;
     af_array out_real;
     af_array out_imag;
@@ -140,6 +144,7 @@ af_err af_constant_c64(af_array *result, const void* value,
 af_err af_constant_c32(af_array *result, const void* value,
                        const unsigned ndims, const dim_type * const dims)
 {
+    af_init();
     af_err ret = AF_ERR_ARG;
     af_array out_real;
     af_array out_imag;
@@ -164,6 +169,7 @@ af_err af_constant_c32(af_array *result, const void* value,
 af_err af_create_handle(af_array *result, const unsigned ndims, const dim_type * const dims,
                         const af_dtype type)
 {
+    af_init();
     af_err ret = AF_ERR_ARG;
     af_array out;
     try {
@@ -235,6 +241,7 @@ static inline af_array randu_(const af::dim4 &dims)
 
 af_err af_randu(af_array *out, const unsigned ndims, const dim_type * const dims, const af_dtype type)
 {
+    af_init();
     af_err ret = AF_SUCCESS;
     af_array result;
     try {
@@ -266,6 +273,7 @@ af_err af_randu(af_array *out, const unsigned ndims, const dim_type * const dims
 
 af_err af_randn(af_array *out, const unsigned ndims, const dim_type * const dims, const af_dtype type)
 {
+    af_init();
     af_err ret = AF_SUCCESS;
     af_array result;
     try {
@@ -360,6 +368,7 @@ static inline af_array iota_(const dim4& d, const unsigned rep)
 af_err af_iota(af_array *result, const unsigned ndims, const dim_type * const dims,
                const unsigned rep, const af_dtype type)
 {
+    af_init();
     af_err ret = AF_ERR_ARG;
     af_array out;
     try {

--- a/src/backend/device.cpp
+++ b/src/backend/device.cpp
@@ -18,6 +18,18 @@
 
 using namespace detail;
 
+af_err af_init()
+{
+    try {
+        static bool first = true;
+        if(first) {
+            getInfo();
+            first = false;
+        }
+    } CATCHALL;
+    return AF_SUCCESS;
+}
+
 af_err af_info()
 {
     std::cout << getInfo();


### PR DESCRIPTION
- af_init calls info function which initializes device manager

Fixes #92 
