### PR TITLE
Fixes #167: Check if driver is unloaded when freeing array

### DIFF
--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -34,7 +34,9 @@ namespace cuda
     template<typename T>
     void cudaFreeWrapper(T *ptr)
     {
-        CUDA_CHECK(cudaFree(ptr));
+	cudaError_t err = cudaFree(ptr);
+	if (err != cudaErrorCudartUnloading) // see issue #167
+		CUDA_CHECK(err);
     }
 
     template<typename T>


### PR DESCRIPTION
Global variables are freed after the driver has been unloaded. This fix
throws exceptions when `cudaFree` returns errors which are not
`cudaErrorCudartUnloading`. 
