### PR TITLE
Fixed wrong memory type allocation on OpenCL backend of FAST.

### DIFF
--- a/src/backend/opencl/kernel/fast.hpp
+++ b/src/backend/opencl/kernel/fast.hpp
@@ -73,7 +73,7 @@ void fast(unsigned* out_feat,
         // same coordinates as features, dimensions should be equal to in.
         cl::Buffer d_score = cl::Buffer(getContext(), CL_MEM_READ_WRITE, in.info.dims[0] * in.info.dims[1] * sizeof(T));
         std::vector<T> score_init(in.info.dims[0] * in.info.dims[1], (T)0);
-        getQueue().enqueueWriteBuffer(d_score, CL_TRUE, 0, in.info.dims[0] * in.info.dims[1] * sizeof(unsigned), &score_init[0]);
+        getQueue().enqueueWriteBuffer(d_score, CL_TRUE, 0, in.info.dims[0] * in.info.dims[1] * sizeof(T), &score_init[0]);
 
         cl::Buffer d_flags = d_score;
         if (nonmax) {


### PR DESCRIPTION
Fixes #176
