### PR TITLE
PERF Batching + Blocks images in rotate and transform

### DIFF
--- a/src/backend/opencl/kernel/rotate.cl
+++ b/src/backend/opencl/kernel/rotate.cl
@@ -17,14 +17,22 @@ typedef struct {
 __kernel
 void rotate_kernel(__global T *d_out, const KParam out,
                    __global const T *d_in, const KParam in,
-                   const tmat_t t, const dim_type nimages)
+                   const tmat_t t, const dim_type nimages, const dim_type blocksYPerImage)
 {
+    // Compute which image set
+    const dim_type setId = get_group_id(1) / blocksYPerImage;
+    const dim_type blockIdx_y = get_group_id(1) - setId * blocksYPerImage;
+
     // Get thread indices
-    int xx = get_global_id(0);
-    int yy = get_global_id(1);
+    const dim_type xx = get_global_id(0);
+    const dim_type yy = get_local_id(1) + blockIdx_y * get_local_size(1);
+
+    const dim_type limages = min(out.dims[2] - setId * nimages, nimages);
 
     if(xx >= out.dims[0] || yy >= out.dims[1])
         return;
 
-    INTERP(d_out, out, d_in, in, t.tmat, xx, yy, nimages);
+    __global T *optr = d_out + setId * nimages * out.strides[2];
+    __global const T *iptr = d_in + in.offset + setId * nimages * in.strides[2];
+    INTERP(optr, out, iptr, in, t.tmat, xx, yy, limages);
 }

--- a/src/backend/opencl/kernel/rotate.hpp
+++ b/src/backend/opencl/kernel/rotate.hpp
@@ -33,6 +33,8 @@ namespace opencl
     {
         static const dim_type TX = 16;
         static const dim_type TY = 16;
+        // Used for batching images
+        static const dim_type TI = 4;
 
         typedef struct {
             float tmat[6];
@@ -81,10 +83,8 @@ namespace opencl
                 });
 
                 auto rotateOp = make_kernel<Buffer, const KParam, const Buffer, const KParam,
-                                             const tmat_t, const dim_type>
+                                             const tmat_t, const dim_type, const dim_type>
                                            (*rotateKernels[device]);
-
-                const dim_type nimages = in.info.dims[2];
 
                 const float c = cos(-theta), s = sin(-theta);
                 float tx, ty;
@@ -108,12 +108,22 @@ namespace opencl
                 t.tmat[5] = ty;
 
                 NDRange local(TX, TY, 1);
+
+                dim_type nimages = in.info.dims[2];
+                dim_type global_y = local[1] * divup(out.info.dims[1], local[1]);
+                const dim_type blocksYPerImage = global_y / local[1];
+
+                if(nimages > TI) {
+                    dim_type tile_images = divup(nimages, TI);
+                    nimages = TI;
+                    global_y = global_y * tile_images;
+                }
+
                 NDRange global(local[0] * divup(out.info.dims[0], local[0]),
-                               local[1] * divup(out.info.dims[1], local[1]),
-                               1);
+                               global_y, 1);
 
                 rotateOp(EnqueueArgs(getQueue(), global, local),
-                         out.data, out.info, in.data, in.info, t, nimages);
+                         out.data, out.info, in.data, in.info, t, nimages, blocksYPerImage);
 
                 CL_DEBUG_FINISH(getQueue());
             } catch (cl::Error err) {


### PR DESCRIPTION
- Batching all images in single block set is slow at high blocks
- Divide batches of images into sets and launch blocks for that

Fixes #201
