### PR TITLE
BUGFIX: seq --> array inside GFOR creates batche array

### DIFF
--- a/src/api/cpp/seq.cpp
+++ b/src/api/cpp/seq.cpp
@@ -80,7 +80,8 @@ seq::operator array() const
 {
     dim_type diff = s.end - s.begin;
     dim_type len = (int)((diff + (signbit(diff) == 0 ? 1 : -1)) / s.step);
-    array res = s.begin + s.step * iota(len);
+    array tmp = (m_gfor) ? iota(1, 1, 1, len) : iota(len);
+    array res = s.begin + s.step * tmp;
     return res;
 }
 


### PR DESCRIPTION
- array(ii) outside gfor creates array of size [n, 1]
- array(ii) inside gfor creates array of size [1, 1, 1, n]
- Related to #326 