### PR TITLE
OpenCL JIT Fixes

### DIFF
--- a/src/api/c/type_util.hpp
+++ b/src/api/c/type_util.hpp
@@ -29,5 +29,5 @@ struct ToNum<unsigned char>
 template<>
 struct ToNum<char>
 {
-    inline int operator()(unsigned char val) { return static_cast<int>(val); }
+    inline int operator()(char val) { return static_cast<int>(val); }
 };

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -91,7 +91,7 @@ namespace opencl
         if (!node) {
             bool is_linear = isOwner() || (this->ndims() == 1);
             BufferNode *buf_node = new BufferNode(dtype_traits<T>::getName(),
-                                                  shortname<T>(true), *this, is_linear);
+                                                  shortname<T>(true), *this, is_linear, data);
             const_cast<Array<T> *>(this)->node = Node_ptr(reinterpret_cast<Node *>(buf_node));
         }
 

--- a/src/backend/opencl/JIT/BufferNode.hpp
+++ b/src/backend/opencl/JIT/BufferNode.hpp
@@ -16,10 +16,12 @@ namespace opencl
 namespace JIT
 {
 
+
     class BufferNode : public Node
     {
     private:
         std::string m_name_str;
+        const std::shared_ptr<cl::Buffer> m_data;
         const Param m_param;
         bool m_gen_name;
         bool m_set_arg;
@@ -29,9 +31,11 @@ namespace JIT
 
         BufferNode(const char *type_str,
                    const char *name_str,
-                   const Param param, bool is_linear)
+                   const Param param, const bool is_linear,
+                   const std::shared_ptr<cl::Buffer> data)
             : Node(type_str),
               m_name_str(name_str),
+              m_data(data),
               m_param(param),
               m_gen_name(false),
               m_set_arg(false),


### PR DESCRIPTION
- BufferNodes were pointing to freed memory
- JIT Nodes will now hold on to shared pointers
- This ensures memory is only freed after evaluation 