### PR TITLE
Fixes for double precision support in OpenCL backend

### DIFF
--- a/src/backend/opencl/JIT/BinaryNode.hpp
+++ b/src/backend/opencl/JIT/BinaryNode.hpp
@@ -70,11 +70,11 @@ namespace JIT
             m_rhs->genKerName(kerStream);
 
             if (m_gen_name) return;
-            // Make the hex representation of enum part of the Kernel name
-            kerStream << "_" << std::setw(2) << std::setfill('0') << std::hex << m_op;
-            kerStream << std::setw(2) << std::setfill('0') << std::hex << m_lhs->getId();
-            kerStream << std::setw(2) << std::setfill('0') << std::hex << m_rhs->getId();
-            kerStream << std::setw(2) << std::setfill('0') << std::hex << m_id << std::dec;
+            // Make the dec representation of enum part of the Kernel name
+            kerStream << "_" << std::setw(3) << std::setfill('0') << std::dec << m_op;
+            kerStream << std::setw(3) << std::setfill('0') << std::dec << m_lhs->getId();
+            kerStream << std::setw(3) << std::setfill('0') << std::dec << m_rhs->getId();
+            kerStream << std::setw(3) << std::setfill('0') << std::dec << m_id << std::dec;
             m_gen_name = true;
         }
 

--- a/src/backend/opencl/JIT/BufferNode.hpp
+++ b/src/backend/opencl/JIT/BufferNode.hpp
@@ -53,7 +53,7 @@ namespace JIT
             if (m_gen_name) return;
 
             kerStream << "_" << m_name_str;
-            kerStream << std::setw(2) << std::setfill('0') << std::hex << m_id << std::dec;
+            kerStream << std::setw(3) << std::setfill('0') << std::dec << m_id << std::dec;
             m_gen_name = true;
         }
 

--- a/src/backend/opencl/JIT/ScalarNode.hpp
+++ b/src/backend/opencl/JIT/ScalarNode.hpp
@@ -45,7 +45,7 @@ namespace JIT
             if (m_gen_name) return;
 
             kerStream << "_" << m_name_str;
-            kerStream << std::setw(2) << std::setfill('0') << std::hex << m_id << std::dec;
+            kerStream << std::setw(3) << std::setfill('0') << std::dec << m_id << std::dec;
             m_gen_name = true;
         }
 

--- a/src/backend/opencl/JIT/UnaryNode.hpp
+++ b/src/backend/opencl/JIT/UnaryNode.hpp
@@ -63,10 +63,10 @@ namespace JIT
         {
             m_child->genKerName(kerStream);
 
-            // Make the hex representation of enum part of the Kernel name
-            kerStream << "_" << std::setw(2) << std::setfill('0') << std::hex << m_op;
-            kerStream << std::setw(2) << std::setfill('0') << std::hex << m_child->getId();
-            kerStream << std::setw(2) << std::setfill('0') << std::hex << m_id << std::dec;
+            // Make the dec representation of enum part of the Kernel name
+            kerStream << "_" << std::setw(3) << std::setfill('0') << std::dec << m_op;
+            kerStream << std::setw(3) << std::setfill('0') << std::dec << m_child->getId();
+            kerStream << std::setw(3) << std::setfill('0') << std::dec << m_id << std::dec;
             m_gen_name = true;
         }
 

--- a/src/backend/opencl/kernel/fast.cl
+++ b/src/backend/opencl/kernel/fast.cl
@@ -7,10 +7,6 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if T == double
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#endif
-
 #define MAX_VAL(A,B) (A<B) ? (B) : (A)
 
 inline int idx_y(const int i)

--- a/src/backend/opencl/kernel/fast.hpp
+++ b/src/backend/opencl/kernel/fast.hpp
@@ -58,6 +58,11 @@ void fast(unsigned* out_feat,
                         << " -D ARC_LENGTH=" << arc_length
                         << " -D NONMAX=" << static_cast<unsigned>(nonmax);
 
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
+
                 buildProgram(fastProgs[device],
                              fast_cl,
                              fast_cl_len,

--- a/src/backend/opencl/kernel/histogram.cl
+++ b/src/backend/opencl/kernel/histogram.cl
@@ -7,10 +7,6 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if T == double || U == double
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#endif
-
 __kernel
 void histogram(__global outType *         d_dst,
                KParam                     oInfo,

--- a/src/backend/opencl/kernel/histogram.hpp
+++ b/src/backend/opencl/kernel/histogram.hpp
@@ -45,10 +45,12 @@ void histogram(Param out, const Param in, const Param minmax, dim_type nbins)
                     options << " -D inType=" << dtype_traits<inType>::getName()
                             << " -D outType=" << dtype_traits<outType>::getName()
                             << " -D THRD_LOAD=" << THRD_LOAD;
+
                     if (std::is_same<inType, double>::value ||
                         std::is_same<inType, cdouble>::value) {
                         options << " -D USE_DOUBLE";
                     }
+
                     Program prog;
                     buildProgram(prog, histogram_cl, histogram_cl_len, options.str());
                     histProgs[device]   = new Program(prog);

--- a/src/backend/opencl/kernel/jit.cl
+++ b/src/backend/opencl/kernel/jit.cl
@@ -7,8 +7,6 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-
 #define __add(lhs, rhs) (lhs) + (rhs)
 #define __sub(lhs, rhs) (lhs) - (rhs)
 #define __mul(lhs, rhs) (lhs) * (rhs)

--- a/src/backend/opencl/kernel/orb.cl
+++ b/src/backend/opencl/kernel/orb.cl
@@ -7,10 +7,6 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if T == double
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
-#endif
-
 // Reference pattern, generated for a patch size of 31x31, as suggested by
 // original ORB paper
 #define REF_PAT_SAMPLES 256

--- a/src/backend/opencl/kernel/orb.hpp
+++ b/src/backend/opencl/kernel/orb.hpp
@@ -95,6 +95,11 @@ void orb(unsigned* out_feat,
                 options << " -D T=" << dtype_traits<T>::getName()
                         << " -D BLOCK_SIZE=" << ORB_THREADS_X;
 
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
+
                 buildProgram(orbProgs[device],
                              orb_cl,
                              orb_cl_len,

--- a/src/backend/opencl/kernel/random.cl
+++ b/src/backend/opencl/kernel/random.cl
@@ -8,7 +8,6 @@
  ********************************************************/
 
 #ifdef USE_DOUBLE
-#pragma OPENCL EXTENSION cl_khr_fp64 : enable
 #define SKEIN_KS_PARITY SKEIN_KS_PARITY64
 #define RotL RotL_64
 #define uint_t uint64_t


### PR DESCRIPTION
- JIT name strings now use decimal instead of hex before hashing
- Properly enabling double precision support for JIT, FAST and ORB