### PR TITLE
BUGFIX: increased filter/mask length for convolve kernels

### DIFF
--- a/src/backend/opencl/convolve.cpp
+++ b/src/backend/opencl/convolve.cpp
@@ -84,7 +84,8 @@ Array<T> * convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> 
     const dim4 cfDims   = c_filter.dims();
     const dim4 rfDims   = r_filter.dims();
 
-    if((cfDims[0]*rfDims[0]) > (kernel::MAX_CONV2_FILTER_LEN * kernel::MAX_CONV2_FILTER_LEN)) {
+    if ((cfDims[0] > kernel::MAX_SCONV_FILTER_LEN) ||
+            (rfDims[0] > kernel::MAX_SCONV_FILTER_LEN)) {
         // call upon fft
         OPENCL_NOT_SUPPORTED();
     }

--- a/src/backend/opencl/kernel/convolve.hpp
+++ b/src/backend/opencl/kernel/convolve.hpp
@@ -48,6 +48,7 @@ static const dim_type CUBE_Z    =  4;
 static const dim_type MAX_CONV1_FILTER_LEN = 129;
 static const dim_type MAX_CONV2_FILTER_LEN = 17;
 static const dim_type MAX_CONV3_FILTER_LEN = 5;
+static const dim_type MAX_SCONV_FILTER_LEN = 81;
 
 template<typename T, dim_type baseDim>
 void prepareKernelArgs(NDRange &global, NDRange &local, size_t &loc_size, dim_type &blk_x,


### PR DESCRIPTION
Modified the following cuda/opencl kernels to handle large kernel lengths
more appropriately
* convolve for vector arrays
* two dimensional convolutions
* separable convolve