### PR TITLE
Changes to backend API

### DIFF
--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -23,14 +23,14 @@ template<typename Ty, typename Tp>
 static inline af_array approx1(const af_array in, const af_array pos,
                                const af_interp_type method, const float offGrid)
 {
-    return getHandle(*approx1<Ty>(getArray<Ty>(in), getArray<Tp>(pos), method, offGrid));
+    return getHandle(approx1<Ty>(getArray<Ty>(in), getArray<Tp>(pos), method, offGrid));
 }
 
 template<typename Ty, typename Tp>
 static inline af_array approx2(const af_array in, const af_array pos0, const af_array pos1,
                                const af_interp_type method, const float offGrid)
 {
-    return getHandle(*approx2<Ty>(getArray<Ty>(in), getArray<Tp>(pos0), getArray<Tp>(pos1),
+    return getHandle(approx2<Ty>(getArray<Ty>(in), getArray<Tp>(pos0), getArray<Tp>(pos1),
                                  method, offGrid));
 }
 

--- a/src/api/c/assign.cpp
+++ b/src/api/c/assign.cpp
@@ -39,46 +39,42 @@ void assign(af_array &out, const unsigned &ndims, const af_seq *index, const af_
     AF_CHECK(af_eval(out));
 
     vector<af_seq> index_(index, index+ndims);
-    dim4 const oStrides = af::toStride(index_, outDs);
 
     dim4 oDims = af::toDims(index_, outDs);
-    dim4 oOffsets = af::toOffset(index_, outDs);
-
-    Array<T> *dst = createRefArray<T>(getArray<T>(out), oDims, oOffsets, oStrides);
 
     for (int i = 0; i < 4; i++) {
         if (oDims[i] != iDims[i])
             AF_ERROR("Size mismatch between input and output", AF_ERR_SIZE);
     }
 
+
+    Array<T> dst = createSubArray<T>(getArray<T>(out), index_, false);
+
     bool noCaseExecuted = true;
     if (isComplex) {
         noCaseExecuted = false;
         switch(iType) {
-            case c64: copy<cdouble, T>(*dst, getArray<cdouble>(in), scalar<T>(0), 1.0);  break;
-            case c32: copy<cfloat , T>(*dst, getArray<cfloat >(in), scalar<T>(0), 1.0);  break;
+            case c64: copyArray<cdouble, T>(dst, getArray<cdouble>(in));  break;
+            case c32: copyArray<cfloat , T>(dst, getArray<cfloat >(in));  break;
             default : noCaseExecuted = true; break;
         }
     }
 
-    static const T ZERO = scalar<T>(0);
     if(noCaseExecuted) {
         noCaseExecuted = false;
         switch(iType) {
-            case f64: copy<double , T>(*dst, getArray<double>(in), ZERO, 1.0);  break;
-            case f32: copy<float  , T>(*dst, getArray<float >(in), ZERO, 1.0);  break;
-            case s32: copy<int    , T>(*dst, getArray<int   >(in), ZERO, 1.0);  break;
-            case u32: copy<uint   , T>(*dst, getArray<uint  >(in), ZERO, 1.0);  break;
-            case u8 : copy<uchar  , T>(*dst, getArray<uchar >(in), ZERO, 1.0);  break;
-            case b8 : copy<char   , T>(*dst, getArray<char  >(in), ZERO, 1.0);  break;
+            case f64: copyArray<double , T>(dst, getArray<double>(in));  break;
+            case f32: copyArray<float  , T>(dst, getArray<float >(in));  break;
+            case s32: copyArray<int    , T>(dst, getArray<int   >(in));  break;
+            case u32: copyArray<uint   , T>(dst, getArray<uint  >(in));  break;
+            case u8 : copyArray<uchar  , T>(dst, getArray<uchar >(in));  break;
+            case b8 : copyArray<char   , T>(dst, getArray<char  >(in));  break;
             default : noCaseExecuted = true; break;
         }
     }
 
     if (noCaseExecuted)
         TYPE_ERROR(1, iType);
-
-    delete dst;
 }
 
 af_err af_assign(af_array *out,

--- a/src/api/c/assign.cpp
+++ b/src/api/c/assign.cpp
@@ -94,22 +94,30 @@ af_err af_assign(af_array *out,
         if (*out != lhs) AF_CHECK(af_copy_array(&res, lhs));
         else             res = lhs;
 
-        if (lhs != rhs) {
-            ArrayInfo oInfo = getInfo(lhs);
-            af_dtype oType  = oInfo.getType();
-            switch(oType) {
-            case c64: assign<cdouble, true >(res, ndims, index, rhs);  break;
-            case c32: assign<cfloat , true >(res, ndims, index, rhs);  break;
-            case f64: assign<double , false>(res, ndims, index, rhs);  break;
-            case f32: assign<float  , false>(res, ndims, index, rhs);  break;
-            case s32: assign<int    , false>(res, ndims, index, rhs);  break;
-            case u32: assign<uint   , false>(res, ndims, index, rhs);  break;
-            case u8 : assign<uchar  , false>(res, ndims, index, rhs);  break;
-            case b8 : assign<char   , false>(res, ndims, index, rhs);  break;
-            default : TYPE_ERROR(1, oType); break;
-            }
-        }
+        try {
 
+            if (lhs != rhs) {
+                ArrayInfo oInfo = getInfo(lhs);
+                af_dtype oType  = oInfo.getType();
+                switch(oType) {
+                case c64: assign<cdouble, true >(res, ndims, index, rhs);  break;
+                case c32: assign<cfloat , true >(res, ndims, index, rhs);  break;
+                case f64: assign<double , false>(res, ndims, index, rhs);  break;
+                case f32: assign<float  , false>(res, ndims, index, rhs);  break;
+                case s32: assign<int    , false>(res, ndims, index, rhs);  break;
+                case u32: assign<uint   , false>(res, ndims, index, rhs);  break;
+                case u8 : assign<uchar  , false>(res, ndims, index, rhs);  break;
+                case b8 : assign<char   , false>(res, ndims, index, rhs);  break;
+                default : TYPE_ERROR(1, oType); break;
+                }
+            }
+
+        } catch(...) {
+            if (*out != lhs) {
+                AF_CHECK(af_destroy_array(res));
+            }
+            throw;
+        }
         std::swap(*out, res);
     }
     CATCHALL;

--- a/src/api/c/bilateral.cpp
+++ b/src/api/c/bilateral.cpp
@@ -21,7 +21,7 @@ using namespace detail;
 template<typename inType, typename outType, bool isColor>
 static inline af_array bilateral(const af_array &in, const float &sp_sig, const float &chr_sig)
 {
-    return getHandle(*bilateral<inType, outType, isColor>(getArray<inType>(in), sp_sig, chr_sig));
+    return getHandle(bilateral<inType, outType, isColor>(getArray<inType>(in), sp_sig, chr_sig));
 }
 
 template<bool isColor>

--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -28,7 +28,7 @@ template<typename T, af_op_t op>
 static inline af_array arithOp(const af_array lhs, const af_array rhs,
                                const dim4 &odims)
 {
-    af_array res = getHandle(*arithOp<T, op>(getArray<T>(lhs), getArray<T>(rhs), odims));
+    af_array res = getHandle(arithOp<T, op>(getArray<T>(lhs), getArray<T>(rhs), odims));
     // All inputs to this function are temporary references
     // Delete the temporary references
     destroyHandle<T>(lhs);
@@ -222,7 +222,7 @@ af_err af_hypot(af_array *out, const af_array lhs, const af_array rhs, bool batc
 template<typename T, af_op_t op>
 static inline af_array logicOp(const af_array lhs, const af_array rhs, const dim4 &odims)
 {
-    af_array res = getHandle(*logicOp<T, op>(getArray<T>(lhs), getArray<T>(rhs), odims));
+    af_array res = getHandle(logicOp<T, op>(getArray<T>(lhs), getArray<T>(rhs), odims));
     // All inputs to this function are temporary references
     // Delete the temporary references
     destroyHandle<T>(lhs);
@@ -308,7 +308,7 @@ af_err af_or(af_array *out, const af_array lhs, const af_array rhs, bool batchMo
 template<typename T, af_op_t op>
 static inline af_array bitOp(const af_array lhs, const af_array rhs, const dim4 &odims)
 {
-    af_array res = getHandle(*bitOp<T, op>(getArray<T>(lhs), getArray<T>(rhs), odims));
+    af_array res = getHandle(bitOp<T, op>(getArray<T>(lhs), getArray<T>(rhs), odims));
     // All inputs to this function are temporary references
     // Delete the temporary references
     destroyHandle<T>(lhs);

--- a/src/api/c/blas.cpp
+++ b/src/api/c/blas.cpp
@@ -21,14 +21,14 @@ template<typename T>
 static inline af_array matmul(const af_array lhs, const af_array rhs,
                     af_blas_transpose optLhs, af_blas_transpose optRhs)
 {
-    return getHandle(*detail::matmul<T>(getArray<T>(lhs), getArray<T>(rhs), optLhs, optRhs));
+    return getHandle(detail::matmul<T>(getArray<T>(lhs), getArray<T>(rhs), optLhs, optRhs));
 }
 
 template<typename T>
 static inline af_array dot(const af_array lhs, const af_array rhs,
                     af_blas_transpose optLhs, af_blas_transpose optRhs)
 {
-    return getHandle(*detail::dot<T>(getArray<T>(lhs), getArray<T>(rhs), optLhs, optRhs));
+    return getHandle(detail::dot<T>(getArray<T>(lhs), getArray<T>(rhs), optLhs, optRhs));
 }
 
 af_err af_matmul(   af_array *out,

--- a/src/api/c/complex.cpp
+++ b/src/api/c/complex.cpp
@@ -27,7 +27,7 @@ template<typename To, typename Ti>
 static inline af_array cplx(const af_array lhs, const af_array rhs,
                             const dim4 &odims, bool destroy=true)
 {
-    af_array res = getHandle(*cplx<To, Ti>(getArray<Ti>(lhs), getArray<Ti>(rhs), odims));
+    af_array res = getHandle(cplx<To, Ti>(getArray<Ti>(lhs), getArray<Ti>(rhs), odims));
     if (destroy) {
         // All inputs to this function are temporary references
         // Delete the temporary references
@@ -115,8 +115,8 @@ af_err af_real(af_array *out, const af_array in)
         af_array res;
         switch (type) {
 
-        case c32: res = getHandle(*real<float , cfloat >(getArray<cfloat >(in))); break;
-        case c64: res = getHandle(*real<double, cdouble>(getArray<cdouble>(in))); break;
+        case c32: res = getHandle(real<float , cfloat >(getArray<cfloat >(in))); break;
+        case c64: res = getHandle(real<double, cdouble>(getArray<cdouble>(in))); break;
 
         default: TYPE_ERROR(0, type);
         }
@@ -141,8 +141,8 @@ af_err af_imag(af_array *out, const af_array in)
         af_array res;
         switch (type) {
 
-        case c32: res = getHandle(*imag<float , cfloat >(getArray<cfloat >(in))); break;
-        case c64: res = getHandle(*imag<double, cdouble>(getArray<cdouble>(in))); break;
+        case c32: res = getHandle(imag<float , cfloat >(getArray<cfloat >(in))); break;
+        case c64: res = getHandle(imag<double, cdouble>(getArray<cdouble>(in))); break;
 
         default: TYPE_ERROR(0, type);
         }
@@ -167,8 +167,8 @@ af_err af_conjg(af_array *out, const af_array in)
         af_array res;
         switch (type) {
 
-        case c32: res = getHandle(*conj<cfloat >(getArray<cfloat >(in))); break;
-        case c64: res = getHandle(*conj<cdouble>(getArray<cdouble>(in))); break;
+        case c32: res = getHandle(conj<cfloat >(getArray<cfloat >(in))); break;
+        case c64: res = getHandle(conj<cdouble>(getArray<cdouble>(in))); break;
 
         default: TYPE_ERROR(0, type);
         }
@@ -192,10 +192,10 @@ af_err af_abs(af_array *out, const af_array in)
         af_array input = cast(in, type);
 
         switch (type) {
-        case f32: res = getHandle(*abs<float ,  float >(getArray<float  >(input))); break;
-        case f64: res = getHandle(*abs<double,  double>(getArray<double >(input))); break;
-        case c32: res = getHandle(*abs<float , cfloat >(getArray<cfloat >(input))); break;
-        case c64: res = getHandle(*abs<double, cdouble>(getArray<cdouble>(input))); break;
+        case f32: res = getHandle(abs<float ,  float >(getArray<float  >(input))); break;
+        case f64: res = getHandle(abs<double,  double>(getArray<double >(input))); break;
+        case c32: res = getHandle(abs<float , cfloat >(getArray<cfloat >(input))); break;
+        case c64: res = getHandle(abs<double, cdouble>(getArray<cdouble>(input))); break;
         default:
             TYPE_ERROR(1, in_type); break;
         }

--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -24,13 +24,13 @@ using namespace detail;
 template<typename T, typename accT, dim_type baseDim, bool expand>
 inline static af_array convolve(const af_array &s, const af_array &f, ConvolveBatchKind kind)
 {
-    return getHandle(*convolve<T, accT, baseDim, expand>(getArray<T>(s), getArray<T>(f), kind));
+    return getHandle(convolve<T, accT, baseDim, expand>(getArray<T>(s), getArray<T>(f), kind));
 }
 
 template<typename T, typename accT, bool expand>
 inline static af_array convolve2(const af_array &s, const af_array &c_f, const af_array &r_f)
 {
-    return getHandle(*convolve2<T, accT, expand>(getArray<T>(s), getArray<T>(c_f), getArray<T>(r_f)));
+    return getHandle(convolve2<T, accT, expand>(getArray<T>(s), getArray<T>(c_f), getArray<T>(r_f)));
 }
 
 template<dim_type baseDim>

--- a/src/api/c/corrcoef.cpp
+++ b/src/api/c/corrcoef.cpp
@@ -26,30 +26,24 @@ using namespace detail;
 template<typename Ti, typename To>
 static To corrcoef(const af_array& X, const af_array& Y)
 {
-    Array<To>* xIn = cast<To>(getArray<Ti>(X));
-    Array<To>* yIn = cast<To>(getArray<Ti>(Y));
+    Array<To> xIn = cast<To>(getArray<Ti>(X));
+    Array<To> yIn = cast<To>(getArray<Ti>(Y));
 
-    dim4 dims = xIn->dims();
-    dim_type n= xIn->elements();
+    dim4 dims = xIn.dims();
+    dim_type n= xIn.elements();
 
-    To xSum = detail::reduce_all<af_add_t, To, To>(*xIn);
-    To ySum = detail::reduce_all<af_add_t, To, To>(*yIn);
+    To xSum = detail::reduce_all<af_add_t, To, To>(xIn);
+    To ySum = detail::reduce_all<af_add_t, To, To>(yIn);
 
-    Array<To>* xSq = detail::arithOp<To, af_mul_t>(*xIn, *xIn, dims);
-    Array<To>* ySq = detail::arithOp<To, af_mul_t>(*yIn, *yIn, dims);
-    Array<To>* xy  = detail::arithOp<To, af_mul_t>(*xIn, *yIn, dims);
+    Array<To> xSq = detail::arithOp<To, af_mul_t>(xIn, xIn, dims);
+    Array<To> ySq = detail::arithOp<To, af_mul_t>(yIn, yIn, dims);
+    Array<To> xy  = detail::arithOp<To, af_mul_t>(xIn, yIn, dims);
 
-    To xSqSum = detail::reduce_all<af_add_t, To, To>(*xSq);
-    To ySqSum = detail::reduce_all<af_add_t, To, To>(*ySq);
-    To xySum  = detail::reduce_all<af_add_t, To, To>(*xy);
+    To xSqSum = detail::reduce_all<af_add_t, To, To>(xSq);
+    To ySqSum = detail::reduce_all<af_add_t, To, To>(ySq);
+    To xySum  = detail::reduce_all<af_add_t, To, To>(xy);
 
     To result = (n*xySum - xSum*ySum)/(sqrt(n*xSqSum-xSum*xSum)*sqrt(n*ySqSum-ySum*ySum));
-
-    destroyArray<To>(*xy);
-    destroyArray<To>(*ySq);
-    destroyArray<To>(*xSq);
-    destroyArray<To>(*yIn);
-    destroyArray<To>(*xIn);
 
     return result;
 }

--- a/src/api/c/covariance.cpp
+++ b/src/api/c/covariance.cpp
@@ -27,34 +27,24 @@ using namespace detail;
 template<typename T, typename cType>
 static af_array cov(const af_array& X, const af_array& Y, bool isbiased)
 {
-    Array<cType> *xArr = cast<cType>(getArray<T>(X));
-    Array<cType> *yArr = cast<cType>(getArray<T>(Y));
+    Array<cType> xArr = cast<cType>(getArray<T>(X));
+    Array<cType> yArr = cast<cType>(getArray<T>(Y));
 
-    dim4 xDims = xArr->dims();
+    dim4 xDims = xArr.dims();
     dim_type N = isbiased ? xDims[0] : xDims[0]-1;
 
-    Array<cType>* xmArr = createValueArray<cType>(xDims, mean<cType>(*xArr));
-    Array<cType>* ymArr = createValueArray<cType>(xDims, mean<cType>(*yArr));
-    Array<cType>* nArr  = createValueArray<cType>(xDims, scalar<cType>(N));
+    Array<cType> xmArr = createValueArray<cType>(xDims, mean<cType>(xArr));
+    Array<cType> ymArr = createValueArray<cType>(xDims, mean<cType>(yArr));
+    Array<cType> nArr  = createValueArray<cType>(xDims, scalar<cType>(N));
 
-    Array<cType>* diffX = detail::arithOp<cType, af_sub_t>(*xArr, *xmArr, xDims);
-    Array<cType>* diffY = detail::arithOp<cType, af_sub_t>(*yArr, *ymArr, xDims);
-    Array<cType>* mulXY = detail::arithOp<cType, af_mul_t>(*diffX, *diffY, xDims);
-    Array<cType>* redArr= detail::reduce<af_add_t, cType, cType>(*mulXY, 0);
+    Array<cType> diffX = detail::arithOp<cType, af_sub_t>(xArr, xmArr, xDims);
+    Array<cType> diffY = detail::arithOp<cType, af_sub_t>(yArr, ymArr, xDims);
+    Array<cType> mulXY = detail::arithOp<cType, af_mul_t>(diffX, diffY, xDims);
+    Array<cType> redArr= detail::reduce<af_add_t, cType, cType>(mulXY, 0);
     xDims[0] = 1;
-    Array<cType>* result= detail::arithOp<cType, af_div_t>(*redArr, *nArr, xDims);
+    Array<cType> result= detail::arithOp<cType, af_div_t>(redArr, nArr, xDims);
 
-    destroyArray<cType>(*redArr);
-    destroyArray<cType>(*mulXY);
-    destroyArray<cType>(*diffY);
-    destroyArray<cType>(*diffX);
-    destroyArray<cType>(*nArr);
-    destroyArray<cType>(*ymArr);
-    destroyArray<cType>(*xmArr);
-    destroyArray<cType>(*yArr);
-    destroyArray<cType>(*xArr);
-
-    return getHandle<cType>(*result);
+    return getHandle<cType>(result);
 }
 
 af_err af_cov(af_array* out, const af_array X, const af_array Y, bool isbiased)

--- a/src/api/c/data.cpp
+++ b/src/api/c/data.cpp
@@ -115,7 +115,7 @@ template<typename To, typename Ti>
 static inline af_array createCplx(dim4 dims, const Ti real, const Ti imag)
 {
     To cval = scalar<To, Ti>(real, imag);
-    af_array out = getHandle(*createValueArray<To>(dims, cval));
+    af_array out = getHandle(createValueArray<To>(dims, cval));
     return out;
 }
 
@@ -155,7 +155,7 @@ af_err af_constant_long(af_array *result, const intl val,
             d[i] = dims[i];
         }
 
-        out = getHandle(*createValueArray<intl>(d, val));
+        out = getHandle(createValueArray<intl>(d, val));
 
         std::swap(*result, out);
     } CATCHALL;
@@ -175,7 +175,7 @@ af_err af_constant_ulong(af_array *result, const uintl val,
             d[i] = dims[i];
         }
 
-        out = getHandle(*createValueArray<uintl>(d, val));
+        out = getHandle(createValueArray<uintl>(d, val));
 
         std::swap(*result, out);
     } CATCHALL;
@@ -243,19 +243,19 @@ af_err af_copy_array(af_array *out, const af_array in)
 template<typename T>
 static inline af_array randn_(const af::dim4 &dims)
 {
-    return getHandle(*randn<T>(dims));
+    return getHandle(randn<T>(dims));
 }
 
 template<typename T>
 static inline af_array randu_(const af::dim4 &dims)
 {
-    return getHandle(*randu<T>(dims));
+    return getHandle(randu<T>(dims));
 }
 
 template<typename T>
 static inline af_array identity_(const af::dim4 &dims)
 {
-    return getHandle(*detail::identity<T>(dims));
+    return getHandle(detail::identity<T>(dims));
 }
 
 af_err af_randu(af_array *out, const unsigned ndims, const dim_type * const dims, const af_dtype type)
@@ -370,7 +370,7 @@ template<typename T>
 static af_array weakCopyHandle(const af_array in)
 {
     detail::Array<T> *A = reinterpret_cast<detail::Array<T> *>(in);
-    detail::Array<T> *out = detail::createEmptyArray<T>(af::dim4());
+    detail::Array<T> *out = detail::initArray<T>();
     *out= *A;
     return reinterpret_cast<af_array>(out);
 }
@@ -405,7 +405,7 @@ af_err af_weak_copy(af_array *out, const af_array in)
 template<typename T>
 static inline af_array iota_(const dim4& d, const unsigned rep)
 {
-    return getHandle(*iota<T>(d, rep));
+    return getHandle(iota<T>(d, rep));
 }
 
 //Strong Exception Guarantee
@@ -499,7 +499,7 @@ af_err af_get_numdims(unsigned *nd, const af_array in)
 template<typename T>
 static inline void eval(af_array arr)
 {
-    getArray<T>(arr).eval();
+    evalArray(getArray<T>(arr));
     return;
 }
 
@@ -529,13 +529,13 @@ af_err af_eval(af_array arr)
 template<typename T>
 static inline af_array diagCreate(const af_array in, const int num)
 {
-    return getHandle(*diagCreate<T>(getArray<T>(in), num));
+    return getHandle(diagCreate<T>(getArray<T>(in), num));
 }
 
 template<typename T>
 static inline af_array diagExtract(const af_array in, const int num)
 {
-    return getHandle(*diagExtract<T>(getArray<T>(in), num));
+    return getHandle(diagExtract<T>(getArray<T>(in), num));
 }
 
 af_err af_diag_create(af_array *out, const af_array in, const int num)

--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -106,14 +106,14 @@ af_err af_device_array(af_array *arr, const void *data,
         }
 
         switch (type) {
-        case f32: res = getHandle(*createDeviceDataArray<float  >(d, data)); break;
-        case f64: res = getHandle(*createDeviceDataArray<double >(d, data)); break;
-        case c32: res = getHandle(*createDeviceDataArray<cfloat >(d, data)); break;
-        case c64: res = getHandle(*createDeviceDataArray<cdouble>(d, data)); break;
-        case s32: res = getHandle(*createDeviceDataArray<int    >(d, data)); break;
-        case u32: res = getHandle(*createDeviceDataArray<uint   >(d, data)); break;
-        case u8 : res = getHandle(*createDeviceDataArray<uchar  >(d, data)); break;
-        case b8 : res = getHandle(*createDeviceDataArray<char   >(d, data)); break;
+        case f32: res = getHandle(createDeviceDataArray<float  >(d, data)); break;
+        case f64: res = getHandle(createDeviceDataArray<double >(d, data)); break;
+        case c32: res = getHandle(createDeviceDataArray<cfloat >(d, data)); break;
+        case c64: res = getHandle(createDeviceDataArray<cdouble>(d, data)); break;
+        case s32: res = getHandle(createDeviceDataArray<int    >(d, data)); break;
+        case u32: res = getHandle(createDeviceDataArray<uint   >(d, data)); break;
+        case u8 : res = getHandle(createDeviceDataArray<uchar  >(d, data)); break;
+        case b8 : res = getHandle(createDeviceDataArray<char   >(d, data)); break;
         default: TYPE_ERROR(4, type);
         }
 

--- a/src/api/c/diff.cpp
+++ b/src/api/c/diff.cpp
@@ -21,13 +21,13 @@ using namespace detail;
 template<typename T>
 static inline af_array diff1(const af_array in, const int dim)
 {
-    return getHandle(*diff1<T>(getArray<T>(in), dim));
+    return getHandle(diff1<T>(getArray<T>(in), dim));
 }
 
 template<typename T>
 static inline af_array diff2(const af_array in, const int dim)
 {
-    return getHandle(*diff2<T>(getArray<T>(in), dim));
+    return getHandle(diff2<T>(getArray<T>(in), dim));
 }
 
 af_err af_diff1(af_array *out, const af_array in, const int dim)

--- a/src/api/c/fast.cpp
+++ b/src/api/c/fast.cpp
@@ -24,23 +24,23 @@ static af_features fast(af_array const &in, const float thr,
                         const unsigned arc_length, const bool non_max,
                         const float feature_ratio)
 {
-    Array<float> *x = createEmptyArray<float>(dim4());
-    Array<float> *y = createEmptyArray<float>(dim4());
-    Array<float> *score = createEmptyArray<float>(dim4());
+    Array<float> x = createEmptyArray<float>(dim4());
+    Array<float> y = createEmptyArray<float>(dim4());
+    Array<float> score = createEmptyArray<float>(dim4());
 
     af_features feat;
-    feat.n = fast<T>(*x, *y, *score,
+    feat.n = fast<T>(x, y, score,
                      getArray<T>(in), thr,
                      arc_length, non_max, feature_ratio);
 
-    Array<float> *orientation = createValueArray<float>(feat.n, 0.0);
-    Array<float> *size = createValueArray<float>(feat.n, 1.0);
+    Array<float> orientation = createValueArray<float>(feat.n, 0.0);
+    Array<float> size = createValueArray<float>(feat.n, 1.0);
 
-    feat.x           = getHandle(*x);
-    feat.y           = getHandle(*y);
-    feat.score       = getHandle(*score);
-    feat.orientation = getHandle(*orientation);
-    feat.size        = getHandle(*size);
+    feat.x           = getHandle(x);
+    feat.y           = getHandle(y);
+    feat.score       = getHandle(score);
+    feat.orientation = getHandle(orientation);
+    feat.size        = getHandle(size);
 
     return feat;
 }

--- a/src/api/c/fft.cpp
+++ b/src/api/c/fft.cpp
@@ -21,13 +21,13 @@ using namespace detail;
 template<typename inType, typename outType, int rank, bool isR2C>
 static af_array fft(af_array in, double normalize, dim_type const npad, dim_type const * const pad)
 {
-    return getHandle(*fft<inType, outType, rank, isR2C>(getArray<inType>(in), normalize, npad, pad));
+    return getHandle(fft<inType, outType, rank, isR2C>(getArray<inType>(in), normalize, npad, pad));
 }
 
 template<typename T, int rank>
 static af_array ifft(af_array in, double normalize, dim_type const npad, dim_type const * const pad)
 {
-    return getHandle(*ifft<T, rank>(getArray<T>(in), normalize, npad, pad));
+    return getHandle(ifft<T, rank>(getArray<T>(in), normalize, npad, pad));
 }
 
 template<int rank>

--- a/src/api/c/handle.hpp
+++ b/src/api/c/handle.hpp
@@ -35,26 +35,28 @@ template<typename T>
 static af_array
 getHandle(const detail::Array<T> &A)
 {
-    af_array arr = reinterpret_cast<af_array>(&A);
+    detail::Array<T> *ret = detail::initArray<T>();
+    *ret = A;
+    af_array arr = reinterpret_cast<af_array>(ret);
     return arr;
 }
 
 template<typename T>
 static af_array createHandle(af::dim4 d)
 {
-    return getHandle(*detail::createEmptyArray<T>(d));
+    return getHandle(detail::createEmptyArray<T>(d));
 }
 
 template<typename T>
 static af_array createHandleFromValue(af::dim4 d, double val)
 {
-    return getHandle(*detail::createValueArray<T>(d, detail::scalar<T>(val)));
+    return getHandle(detail::createValueArray<T>(d, detail::scalar<T>(val)));
 }
 
 template<typename T>
 static af_array createHandleFromData(af::dim4 d, const T * const data)
 {
-    return getHandle(*detail::createHostDataArray<T>(d, data));
+    return getHandle(detail::createHostDataArray<T>(d, data));
 }
 
 template<typename T>
@@ -67,13 +69,13 @@ template<typename T>
 static af_array copyArray(const af_array in)
 {
     const detail::Array<T> &inArray = getArray<T>(in);
-    return getHandle<T>(*detail::copyArray<T>(inArray));
+    return getHandle<T>(detail::copyArray<T>(inArray));
 }
 
 template<typename T>
 static void destroyHandle(const af_array arr)
 {
-    detail::destroyArray(getWritableArray<T>(arr));
+    detail::destroyArray(reinterpret_cast<detail::Array<T>*>(arr));
 }
 
 af_array weakCopy(const af_array in);

--- a/src/api/c/histogram.cpp
+++ b/src/api/c/histogram.cpp
@@ -21,7 +21,7 @@ template<typename inType,typename outType>
 static inline af_array histogram(const af_array in, const unsigned &nbins,
                                  const double &minval, const double &maxval)
 {
-    return getHandle(*histogram<inType,outType>(getArray<inType>(in),nbins,minval,maxval));
+    return getHandle(histogram<inType,outType>(getArray<inType>(in),nbins,minval,maxval));
 }
 
 af_err af_histogram(af_array *out, const af_array in,

--- a/src/api/c/implicit.hpp
+++ b/src/api/c/implicit.hpp
@@ -26,16 +26,16 @@ template<typename To> af_array cast(const af_array in)
 {
     const ArrayInfo info = getInfo(in);
     switch (info.getType()) {
-    case f32: return getHandle(*cast<To, float  >(getArray<float  >(in)));
-    case f64: return getHandle(*cast<To, double >(getArray<double >(in)));
-    case c32: return getHandle(*cast<To, cfloat >(getArray<cfloat >(in)));
-    case c64: return getHandle(*cast<To, cdouble>(getArray<cdouble>(in)));
-    case s32: return getHandle(*cast<To, int    >(getArray<int    >(in)));
-    case u32: return getHandle(*cast<To, uint   >(getArray<uint   >(in)));
-    case u8 : return getHandle(*cast<To, uchar  >(getArray<uchar  >(in)));
-    case b8 : return getHandle(*cast<To, char   >(getArray<char   >(in)));
-    case s64: return getHandle(*cast<To, intl   >(getArray<intl   >(in)));
-    case u64: return getHandle(*cast<To, uintl  >(getArray<uintl  >(in)));
+    case f32: return getHandle(cast<To, float  >(getArray<float  >(in)));
+    case f64: return getHandle(cast<To, double >(getArray<double >(in)));
+    case c32: return getHandle(cast<To, cfloat >(getArray<cfloat >(in)));
+    case c64: return getHandle(cast<To, cdouble>(getArray<cdouble>(in)));
+    case s32: return getHandle(cast<To, int    >(getArray<int    >(in)));
+    case u32: return getHandle(cast<To, uint   >(getArray<uint   >(in)));
+    case u8 : return getHandle(cast<To, uchar  >(getArray<uchar  >(in)));
+    case b8 : return getHandle(cast<To, char   >(getArray<char   >(in)));
+    case s64: return getHandle(cast<To, intl   >(getArray<intl   >(in)));
+    case u64: return getHandle(cast<To, uintl  >(getArray<uintl  >(in)));
     default: TYPE_ERROR(1, info.getType());
     }
 }

--- a/src/api/c/index.cpp
+++ b/src/api/c/index.cpp
@@ -26,18 +26,11 @@ using std::swap;
 template<typename T>
 static void indexArray(af_array &dest, const af_array &src, const unsigned ndims, const af_seq *index)
 {
-    using af::toOffset;
-    using af::toDims;
-    using af::toStride;
-
     const Array<T> &parent = getArray<T>(src);
     vector<af_seq> index_(index, index+ndims);
+    Array<T> dst =  createSubArray(parent, index_);
 
-    Array<T>* dst =  createSubArray(    parent,
-                                        toDims(index_, parent.dims()),
-                                        toOffset(index_, parent.dims()),
-                                        toStride(index_, parent.dims()) );
-    dest = getHandle(*dst);
+    dest = getHandle(dst);
 }
 
 af_err af_index(af_array *result, const af_array in, const unsigned ndims, const af_seq* index)
@@ -72,14 +65,14 @@ static af_array arrayIndex(const af_array &in, const af_array &idx, const unsign
     af_dtype inType  = inInfo.getType();
 
     switch(inType) {
-        case f32: return getHandle(*arrayIndex<float   , idx_t > (getArray<float   >(in), getArray<idx_t>(idx), dim));
-        case c32: return getHandle(*arrayIndex<cfloat  , idx_t > (getArray<cfloat  >(in), getArray<idx_t>(idx), dim));
-        case f64: return getHandle(*arrayIndex<double  , idx_t > (getArray<double  >(in), getArray<idx_t>(idx), dim));
-        case c64: return getHandle(*arrayIndex<cdouble , idx_t > (getArray<cdouble >(in), getArray<idx_t>(idx), dim));
-        case s32: return getHandle(*arrayIndex<int     , idx_t > (getArray<int     >(in), getArray<idx_t>(idx), dim));
-        case u32: return getHandle(*arrayIndex<unsigned, idx_t > (getArray<unsigned>(in), getArray<idx_t>(idx), dim));
-        case  u8: return getHandle(*arrayIndex<uchar   , idx_t > (getArray<uchar   >(in), getArray<idx_t>(idx), dim));
-        case  b8: return getHandle(*arrayIndex<char    , idx_t > (getArray<char    >(in), getArray<idx_t>(idx), dim));
+        case f32: return getHandle(arrayIndex<float   , idx_t > (getArray<float   >(in), getArray<idx_t>(idx), dim));
+        case c32: return getHandle(arrayIndex<cfloat  , idx_t > (getArray<cfloat  >(in), getArray<idx_t>(idx), dim));
+        case f64: return getHandle(arrayIndex<double  , idx_t > (getArray<double  >(in), getArray<idx_t>(idx), dim));
+        case c64: return getHandle(arrayIndex<cdouble , idx_t > (getArray<cdouble >(in), getArray<idx_t>(idx), dim));
+        case s32: return getHandle(arrayIndex<int     , idx_t > (getArray<int     >(in), getArray<idx_t>(idx), dim));
+        case u32: return getHandle(arrayIndex<unsigned, idx_t > (getArray<unsigned>(in), getArray<idx_t>(idx), dim));
+        case  u8: return getHandle(arrayIndex<uchar   , idx_t > (getArray<uchar   >(in), getArray<idx_t>(idx), dim));
+        case  b8: return getHandle(arrayIndex<char    , idx_t > (getArray<char    >(in), getArray<idx_t>(idx), dim));
         default : TYPE_ERROR(1, inType);
     }
 }

--- a/src/api/c/join.cpp
+++ b/src/api/c/join.cpp
@@ -20,7 +20,7 @@ using namespace detail;
 template<typename Tx, typename Ty>
 static inline af_array join(const int dim, const af_array first, const af_array second)
 {
-    return getHandle(*join<Tx, Ty>(dim, getArray<Tx>(first), getArray<Ty>(second)));
+    return getHandle(join<Tx, Ty>(dim, getArray<Tx>(first), getArray<Ty>(second)));
 }
 
 af_err af_join(af_array *out, const int dim, const af_array first, const af_array second)

--- a/src/api/c/match_template.cpp
+++ b/src/api/c/match_template.cpp
@@ -22,16 +22,16 @@ static
 af_array match_template(const af_array &sImg, const af_array tImg, af_match_type mType)
 {
     switch(mType) {
-        case AF_SAD : return getHandle(*match_template<inType, outType, AF_SAD >(getArray<inType>(sImg), getArray<inType>(tImg)));
-        case AF_ZSAD: return getHandle(*match_template<inType, outType, AF_ZSAD>(getArray<inType>(sImg), getArray<inType>(tImg)));
-        case AF_LSAD: return getHandle(*match_template<inType, outType, AF_LSAD>(getArray<inType>(sImg), getArray<inType>(tImg)));
-        case AF_SSD : return getHandle(*match_template<inType, outType, AF_SSD >(getArray<inType>(sImg), getArray<inType>(tImg)));
-        case AF_ZSSD: return getHandle(*match_template<inType, outType, AF_ZSSD>(getArray<inType>(sImg), getArray<inType>(tImg)));
-        case AF_LSSD: return getHandle(*match_template<inType, outType, AF_LSSD>(getArray<inType>(sImg), getArray<inType>(tImg)));
-        case AF_NCC : return getHandle(*match_template<inType, outType, AF_NCC >(getArray<inType>(sImg), getArray<inType>(tImg)));
-        case AF_ZNCC: return getHandle(*match_template<inType, outType, AF_ZNCC>(getArray<inType>(sImg), getArray<inType>(tImg)));
-        case AF_SHD : return getHandle(*match_template<inType, outType, AF_SHD >(getArray<inType>(sImg), getArray<inType>(tImg)));
-        default:      return getHandle(*match_template<inType, outType, AF_SAD >(getArray<inType>(sImg), getArray<inType>(tImg)));
+        case AF_SAD : return getHandle(match_template<inType, outType, AF_SAD >(getArray<inType>(sImg), getArray<inType>(tImg)));
+        case AF_ZSAD: return getHandle(match_template<inType, outType, AF_ZSAD>(getArray<inType>(sImg), getArray<inType>(tImg)));
+        case AF_LSAD: return getHandle(match_template<inType, outType, AF_LSAD>(getArray<inType>(sImg), getArray<inType>(tImg)));
+        case AF_SSD : return getHandle(match_template<inType, outType, AF_SSD >(getArray<inType>(sImg), getArray<inType>(tImg)));
+        case AF_ZSSD: return getHandle(match_template<inType, outType, AF_ZSSD>(getArray<inType>(sImg), getArray<inType>(tImg)));
+        case AF_LSSD: return getHandle(match_template<inType, outType, AF_LSSD>(getArray<inType>(sImg), getArray<inType>(tImg)));
+        case AF_NCC : return getHandle(match_template<inType, outType, AF_NCC >(getArray<inType>(sImg), getArray<inType>(tImg)));
+        case AF_ZNCC: return getHandle(match_template<inType, outType, AF_ZNCC>(getArray<inType>(sImg), getArray<inType>(tImg)));
+        case AF_SHD : return getHandle(match_template<inType, outType, AF_SHD >(getArray<inType>(sImg), getArray<inType>(tImg)));
+        default:      return getHandle(match_template<inType, outType, AF_SAD >(getArray<inType>(sImg), getArray<inType>(tImg)));
     }
 }
 

--- a/src/api/c/mean.cpp
+++ b/src/api/c/mean.cpp
@@ -25,9 +25,8 @@ using namespace detail;
 template<typename inType, typename outType>
 static outType mean(const af_array &in)
 {
-    Array<outType> *input = cast<outType>(getArray<inType>(in));
-    outType result = mean<outType>(*input); /* defined in stats.h */
-    destroyArray<outType>(*input);
+    Array<outType> input = cast<outType>(getArray<inType>(in));
+    outType result = mean<outType>(input); /* defined in stats.h */
     return result;
 }
 
@@ -36,13 +35,10 @@ static outType mean(const af_array &in, const af_array &weights)
 {
     typedef baseOutType<outType> bType;
 
-    Array<outType> *input = cast<outType>(getArray<inType>(in));
-    Array<outType> *wts   = cast<outType>(getArray<bType>(weights));
+    Array<outType> input = cast<outType>(getArray<inType>(in));
+    Array<outType> wts   = cast<outType>(getArray<bType>(weights));
 
-    outType result = mean<outType, bType>(*input, getArray<bType>(weights)); /* defined in stats.h */
-
-    destroyArray<outType>(*input);
-    destroyArray<outType>(*wts);
+    outType result = mean<outType, bType>(input, getArray<bType>(weights)); /* defined in stats.h */
 
     return result;
 }
@@ -50,12 +46,10 @@ static outType mean(const af_array &in, const af_array &weights)
 template<typename inType, typename outType>
 static af_array mean(const af_array &in, dim_type dim)
 {
-    Array<outType> *input = cast<outType>(getArray<inType>(in));
-    Array<outType>* result= mean<outType>(*input, dim); /* defined in stats.h */
+    Array<outType> input = cast<outType>(getArray<inType>(in));
+    Array<outType>  result= mean<outType>(input, dim); /* defined in stats.h */
 
-    destroyArray<outType>(*input);
-
-    return getHandle<outType>(*result);
+    return getHandle<outType>(result);
 }
 
 template<typename inType, typename outType>
@@ -63,14 +57,11 @@ static af_array mean(const af_array &in, const af_array &weights, dim_type dim)
 {
     typedef baseOutType<outType> bType;
 
-    Array<outType> *input = cast<outType>(getArray<inType>(in));
-    Array<outType> *wts   = cast<outType>(getArray<bType>(weights));
-    Array<outType> *retVal= mean<outType>(*input, *wts, dim); /* defined in stats.h */
+    Array<outType> input = cast<outType>(getArray<inType>(in));
+    Array<outType> wts   = cast<outType>(getArray<bType>(weights));
+    Array<outType> retVal= mean<outType>(input, wts, dim); /* defined in stats.h */
 
-    destroyArray<outType>(*input);
-    destroyArray<outType>(*wts);
-
-    return getHandle<outType>(*retVal);
+    return getHandle<outType>(retVal);
 }
 
 af_err af_mean(af_array *out, const af_array in, dim_type dim)

--- a/src/api/c/meanshift.cpp
+++ b/src/api/c/meanshift.cpp
@@ -21,7 +21,7 @@ using namespace detail;
 template<typename T, bool is_color>
 static inline af_array meanshift(const af_array &in, const float &s_sigma, const float &c_sigma, const unsigned iter)
 {
-    return getHandle(*meanshift<T, is_color>(getArray<T>(in), s_sigma, c_sigma, iter));
+    return getHandle(meanshift<T, is_color>(getArray<T>(in), s_sigma, c_sigma, iter));
 }
 
 template<bool is_color>

--- a/src/api/c/medfilt.cpp
+++ b/src/api/c/medfilt.cpp
@@ -22,9 +22,9 @@ template<typename T>
 static af_array medfilt(af_array const &in, dim_type w_len, dim_type w_wid, af_pad_type edge_pad)
 {
     switch(edge_pad) {
-        case AF_ZERO     : return getHandle<T>(*medfilt<T, AF_ZERO     >(getArray<T>(in), w_len, w_wid)); break;
-        case AF_SYMMETRIC: return getHandle<T>(*medfilt<T, AF_SYMMETRIC>(getArray<T>(in), w_len, w_wid)); break;
-        default          : return getHandle<T>(*medfilt<T, AF_ZERO     >(getArray<T>(in), w_len, w_wid)); break;
+        case AF_ZERO     : return getHandle<T>(medfilt<T, AF_ZERO     >(getArray<T>(in), w_len, w_wid)); break;
+        case AF_SYMMETRIC: return getHandle<T>(medfilt<T, AF_SYMMETRIC>(getArray<T>(in), w_len, w_wid)); break;
+        default          : return getHandle<T>(medfilt<T, AF_ZERO     >(getArray<T>(in), w_len, w_wid)); break;
     }
 }
 

--- a/src/api/c/median.cpp
+++ b/src/api/c/median.cpp
@@ -34,12 +34,12 @@ static T median(const af_array& in)
 
     af_array temp = 0;
     AF_CHECK(af_moddims(&temp, in, 1, dims.get()));
-    Array<T>* sortedArr = detail::sort<T, true>(input, 0);
+    Array<T> sortedArr = sort<T, true>(input, 0);
 
     T result;
     T resPtr[2];
     af_array res = 0;
-    AF_CHECK(af_index(&res, getHandle<T>(*sortedArr), 1, mdSpan));
+    AF_CHECK(af_index(&res, getHandle<T>(sortedArr), 1, mdSpan));
     AF_CHECK(af_get_data_ptr((void*)&resPtr, res));
 
     if (nElems % 2 == 1) {
@@ -49,7 +49,6 @@ static T median(const af_array& in)
     }
 
     AF_CHECK(af_destroy_array(res));
-    destroyArray<T>(*sortedArr);
     AF_CHECK(af_destroy_array(temp));
 
     return result;
@@ -59,7 +58,7 @@ template<typename T>
 static af_array median(const af_array& in, dim_type dim)
 {
     const Array<T> input = getArray<T>(in);
-    Array<T>* sortedIn   = detail::sort<T, true>(input, dim);
+    Array<T> sortedIn   = sort<T, true>(input, dim);
 
     int nElems    = input.elements();
     double mid    = (nElems + 1) / 2;
@@ -68,11 +67,10 @@ static af_array median(const af_array& in, dim_type dim)
     af_seq slices[4] = {af_span, af_span, af_span, af_span};
     slices[dim] = {mid-1, mid-1, 1};
 
-    AF_CHECK(af_index(&left, getHandle<T>(*sortedIn), input.ndims(), slices));
+    AF_CHECK(af_index(&left, getHandle<T>(sortedIn), input.ndims(), slices));
 
     if (nElems % 2 == 1) {
         // mid-1 is our guy
-        destroyArray<T>(*sortedIn);
         return left;
     } else {
         // ((mid-1)+mid)/2 is our guy
@@ -80,7 +78,7 @@ static af_array median(const af_array& in, dim_type dim)
         af_array right = 0;
         slices[dim] = {mid, mid, 1};
 
-        AF_CHECK(af_index(&right, getHandle<T>(*sortedIn), dims.ndims(), slices));
+        AF_CHECK(af_index(&right, getHandle<T>(sortedIn), dims.ndims(), slices));
 
         af_array sumarr = 0;
         af_array carr   = 0;
@@ -94,8 +92,6 @@ static af_array median(const af_array& in, dim_type dim)
         AF_CHECK(af_destroy_array(right));
         AF_CHECK(af_destroy_array(sumarr));
         AF_CHECK(af_destroy_array(carr));
-        destroyArray<T>(*sortedIn);
-
         return result;
     }
 }

--- a/src/api/c/moddims.cpp
+++ b/src/api/c/moddims.cpp
@@ -23,17 +23,14 @@ template<typename T>
 af_array modDims(const af_array in, const af::dim4 &newDims)
 {
     const Array<T> &In = getArray<T>(in);
-    Array<T> *Out = createEmptyArray<T>(dim4());
+    Array<T> Out = In;
 
-    if (In.isLinear()) {
-        // Increments ref count on shared_ptr of raw data
-        *Out = In;
-    } else {
-        *Out = *copyArray<T>(In);
+    if (!In.isLinear()) {
+        Out = copyArray<T>(In);
     }
+    Out.modDims(newDims);
 
-    Out->modDims(newDims);
-    return getHandle(*Out);
+    return getHandle(Out);
 }
 
 af_err af_moddims(af_array *out, const af_array in,

--- a/src/api/c/morph.cpp
+++ b/src/api/c/morph.cpp
@@ -23,8 +23,8 @@ static inline af_array morph(const af_array &in, const af_array &mask)
 {
     const Array<T> &input = getArray<T>(in);
     const Array<T> &filter = getArray<T>(mask);
-    Array<T> *out = morph<T, isDilation>(input, filter);
-    return getHandle(*out);
+    Array<T> out = morph<T, isDilation>(input, filter);
+    return getHandle(out);
 }
 
 template<typename T, bool isDilation>
@@ -32,8 +32,8 @@ static inline af_array morph3d(const af_array &in, const af_array &mask)
 {
     const Array<T> &input = getArray<T>(in);
     const Array<T> &filter = getArray<T>(mask);
-    Array<T> *out = morph3d<T, isDilation>(input, filter);
-    return getHandle(*out);
+    Array<T> out = morph3d<T, isDilation>(input, filter);
+    return getHandle(out);
 }
 
 template<bool isDilation>

--- a/src/api/c/orb.cpp
+++ b/src/api/c/orb.cpp
@@ -25,24 +25,24 @@ static void orb(af_features& feat, af_array& descriptor,
                 const unsigned max_feat, const float scl_fctr,
                 const unsigned levels)
 {
-    Array<float> *x     = createEmptyArray<float>(dim4());
-    Array<float> *y     = createEmptyArray<float>(dim4());
-    Array<float> *score = createEmptyArray<float>(dim4());
-    Array<float> *ori   = createEmptyArray<float>(dim4());
-    Array<float> *size  = createEmptyArray<float>(dim4());
-    Array<uint > *desc  = createEmptyArray<uint >(dim4());
+    Array<float> x     = createEmptyArray<float>(dim4());
+    Array<float> y     = createEmptyArray<float>(dim4());
+    Array<float> score = createEmptyArray<float>(dim4());
+    Array<float> ori   = createEmptyArray<float>(dim4());
+    Array<float> size  = createEmptyArray<float>(dim4());
+    Array<uint > desc  = createEmptyArray<uint >(dim4());
 
-    feat.n = orb<T, convAccT>(*x, *y, *score, *ori, *size, *desc,
+    feat.n = orb<T, convAccT>(x, y, score, ori, size, desc,
                               getArray<T>(in), fast_thr, max_feat,
                               scl_fctr, levels);
 
-    feat.x           = getHandle(*x);
-    feat.y           = getHandle(*y);
-    feat.score       = getHandle(*score);
-    feat.orientation = getHandle(*ori);
-    feat.size        = getHandle(*size);
+    feat.x           = getHandle(x);
+    feat.y           = getHandle(y);
+    feat.score       = getHandle(score);
+    feat.orientation = getHandle(ori);
+    feat.size        = getHandle(size);
 
-    descriptor = getHandle<unsigned>(*desc);
+    descriptor = getHandle<unsigned>(desc);
 }
 
 af_err af_orb(af_features* feat, af_array* desc,

--- a/src/api/c/reduce.cpp
+++ b/src/api/c/reduce.cpp
@@ -26,7 +26,7 @@ using namespace detail;
 template<af_op_t op, typename Ti, typename To>
 static inline af_array reduce(const af_array in, const int dim)
 {
-    return getHandle(*reduce<op,Ti,To>(getArray<Ti>(in), dim));
+    return getHandle(reduce<op,Ti,To>(getArray<Ti>(in), dim));
 }
 
 template<af_op_t op, typename To>
@@ -336,12 +336,12 @@ static inline void ireduce(af_array *res, af_array *loc,
     dim4 odims = In.dims();
     odims[dim] = 1;
 
-    Array<T> *Res = createEmptyArray<T>(odims);
-    Array<uint> *Loc = createEmptyArray<uint>(odims);
-    ireduce<op, T>(*Res, *Loc, In, dim);
+    Array<T> Res = createEmptyArray<T>(odims);
+    Array<uint> Loc = createEmptyArray<uint>(odims);
+    ireduce<op, T>(Res, Loc, In, dim);
 
-    *res = getHandle(*Res);
-    *loc = getHandle(*Loc);
+    *res = getHandle(Res);
+    *loc = getHandle(Loc);
 }
 
 template<af_op_t op>

--- a/src/api/c/regions.cpp
+++ b/src/api/c/regions.cpp
@@ -21,7 +21,7 @@ using namespace detail;
 template<typename T>
 static af_array regions(af_array const &in, af_connectivity connectivity)
 {
-    return getHandle<T>(*regions<T>(getArray<uchar>(in), connectivity));
+    return getHandle<T>(regions<T>(getArray<uchar>(in), connectivity));
 }
 
 af_err af_regions(af_array *out, const af_array in, af_connectivity connectivity, af_dtype type)

--- a/src/api/c/reorder.cpp
+++ b/src/api/c/reorder.cpp
@@ -21,7 +21,7 @@ using namespace detail;
 template<typename T>
 static inline af_array reorder(const af_array in, const af::dim4 &rdims)
 {
-    return getHandle(*reorder<T>(getArray<T>(in), rdims));
+    return getHandle(reorder<T>(getArray<T>(in), rdims));
 }
 
 af_err af_reorder(af_array *out, const af_array in, const af::dim4 &rdims)

--- a/src/api/c/resize.cpp
+++ b/src/api/c/resize.cpp
@@ -22,7 +22,7 @@ template<typename T>
 static inline af_array resize(const af_array in, const dim_type odim0, const dim_type odim1,
                               const af_interp_type method)
 {
-    return getHandle(*resize<T>(getArray<T>(in), odim0, odim1, method));
+    return getHandle(resize<T>(getArray<T>(in), odim0, odim1, method));
 }
 
 af_err af_resize(af_array *out, const af_array in, const dim_type odim0, const dim_type odim1,

--- a/src/api/c/rotate.cpp
+++ b/src/api/c/rotate.cpp
@@ -21,7 +21,7 @@ template<typename T>
 static inline af_array rotate(const af_array in, const float theta, const af::dim4 &odims,
                               const af_interp_type method)
 {
-    return getHandle(*rotate<T>(getArray<T>(in), theta, odims, method));
+    return getHandle(rotate<T>(getArray<T>(in), theta, odims, method));
 }
 
 

--- a/src/api/c/scan.cpp
+++ b/src/api/c/scan.cpp
@@ -24,7 +24,7 @@ using namespace detail;
 template<af_op_t op, typename Ti, typename To>
 static inline af_array scan(const af_array in, const int dim)
 {
-    return getHandle(*scan<op,Ti,To>(getArray<Ti>(in), dim));
+    return getHandle(scan<op,Ti,To>(getArray<Ti>(in), dim));
 }
 
 

--- a/src/api/c/set.cpp
+++ b/src/api/c/set.cpp
@@ -21,7 +21,7 @@ using namespace detail;
 template<typename T>
 static inline af_array setUnique(const af_array in, const bool is_sorted)
 {
-    return getHandle(*setUnique(getArray<T>(in), is_sorted));
+    return getHandle(setUnique(getArray<T>(in), is_sorted));
 }
 
 af_err af_set_unique(af_array *out, const af_array in, const bool is_sorted)
@@ -51,7 +51,7 @@ af_err af_set_unique(af_array *out, const af_array in, const bool is_sorted)
 template<typename T>
 static inline af_array setUnion(const af_array first, const af_array second, const bool is_unique)
 {
-    return getHandle(*setUnion(getArray<T>(first), getArray<T>(second), is_unique));
+    return getHandle(setUnion(getArray<T>(first), getArray<T>(second), is_unique));
 }
 
 af_err af_set_union(af_array *out, const af_array first, const af_array second, const bool is_unique)
@@ -83,7 +83,7 @@ af_err af_set_union(af_array *out, const af_array first, const af_array second, 
 template<typename T>
 static inline af_array setIntersect(const af_array first, const af_array second, const bool is_unique)
 {
-    return getHandle(*setIntersect(getArray<T>(first), getArray<T>(second), is_unique));
+    return getHandle(setIntersect(getArray<T>(first), getArray<T>(second), is_unique));
 }
 
 af_err af_set_intersect(af_array *out, const af_array first, const af_array second, const bool is_unique)

--- a/src/api/c/shift.cpp
+++ b/src/api/c/shift.cpp
@@ -20,7 +20,7 @@ using namespace detail;
 template<typename T>
 static inline af_array shift(const af_array in, const af::dim4 &sdims)
 {
-    return getHandle(*shift<T>(getArray<T>(in), sdims));
+    return getHandle(shift<T>(getArray<T>(in), sdims));
 }
 
 af_err af_shift(af_array *out, const af_array in, const af::dim4 &sdims)

--- a/src/api/c/sobel.cpp
+++ b/src/api/c/sobel.cpp
@@ -23,10 +23,10 @@ typedef std::pair<af_array, af_array> ArrayPair;
 template<typename Ti, typename To>
 ArrayPair sobelDerivatives(const af_array &in, const unsigned &ker_size)
 {
-    typedef std::pair< Array<To>*, Array<To>* > BAPair;
+    typedef std::pair< Array<To>, Array<To> > BAPair;
     BAPair  out = sobelDerivatives<Ti, To>(getArray<Ti>(in), ker_size);
-    return std::make_pair(getHandle<To>(*out.first),
-                          getHandle<To>(*out.second));
+    return std::make_pair(getHandle<To>(out.first),
+                          getHandle<To>(out.second));
 }
 
 af_err af_sobel_operator(af_array *dx, af_array *dy, const af_array img, const unsigned ker_size)

--- a/src/api/c/sort.cpp
+++ b/src/api/c/sort.cpp
@@ -29,9 +29,9 @@ static inline af_array sort(const af_array in, const unsigned dim, const bool is
 {
     const Array<T> &inArray = getArray<T>(in);
     if(isAscending) {
-        return getHandle(*sort<T, 1>(inArray, dim));
+        return getHandle(sort<T, 1>(inArray, dim));
     } else {
-        return getHandle(*sort<T, 0>(inArray, dim));
+        return getHandle(sort<T, 0>(inArray, dim));
     }
 }
 
@@ -70,16 +70,16 @@ static inline void sort_index(af_array *val, af_array *idx, const af_array in,
     const Array<T> &inArray = getArray<T>(in);
 
     // Initialize Dummy Arrays
-    Array<T> *valArray = createEmptyArray<T>(af::dim4());
-    Array<uint> *idxArray = createEmptyArray<uint>(af::dim4());
+    Array<T> valArray = createEmptyArray<T>(af::dim4());
+    Array<uint> idxArray = createEmptyArray<uint>(af::dim4());
 
     if(isAscending) {
-        sort_index<T, 1>(*valArray, *idxArray, inArray, dim);
+        sort_index<T, 1>(valArray, idxArray, inArray, dim);
     } else {
-        sort_index<T, 0>(*valArray, *idxArray, inArray, dim);
+        sort_index<T, 0>(valArray, idxArray, inArray, dim);
     }
-    *val = getHandle(*valArray);
-    *idx = getHandle(*idxArray);
+    *val = getHandle(valArray);
+    *idx = getHandle(idxArray);
 }
 
 af_err af_sort_index(af_array *out, af_array *indices, const af_array in, const unsigned dim, const bool isAscending)
@@ -120,16 +120,16 @@ static inline void sort_by_key(af_array *okey, af_array *oval, const af_array ik
     const Array<Tv> &ivalArray = getArray<Tv>(ival);
 
     // Initialize Dummy Arrays
-    Array<Tk> *okeyArray = createEmptyArray<Tk>(af::dim4());
-    Array<Tv> *ovalArray = createEmptyArray<Tv>(af::dim4());
+    Array<Tk> okeyArray = createEmptyArray<Tk>(af::dim4());
+    Array<Tv> ovalArray = createEmptyArray<Tv>(af::dim4());
 
     if(isAscending) {
-        sort_by_key<Tk, Tv, 1>(*okeyArray, *ovalArray, ikeyArray, ivalArray, dim);
+        sort_by_key<Tk, Tv, 1>(okeyArray, ovalArray, ikeyArray, ivalArray, dim);
     } else {
-        sort_by_key<Tk, Tv, 0>(*okeyArray, *ovalArray, ikeyArray, ivalArray, dim);
+        sort_by_key<Tk, Tv, 0>(okeyArray, ovalArray, ikeyArray, ivalArray, dim);
     }
-    *okey = getHandle(*okeyArray);
-    *oval = getHandle(*ovalArray);
+    *okey = getHandle(okeyArray);
+    *oval = getHandle(ovalArray);
 }
 
 template<typename Tk>

--- a/src/api/c/stats.h
+++ b/src/api/c/stats.h
@@ -17,60 +17,50 @@ using baseOutType = typename std::conditional<  std::is_same<T, cdouble>::value 
 template<typename T>
 inline T mean(const Array<T>& in)
 {
-    return division(detail::reduce_all<af_add_t, T, T>(in), in.elements());
+    return division(reduce_all<af_add_t, T, T>(in), in.elements());
 }
 
 template<typename T, typename wType>
 inline T mean(const Array<T>& in, const Array<wType>& weights)
 {
-    Array<T> *wts   = cast<T>(weights);
+    Array<T> wts   = cast<T>(weights);
 
     dim4 iDims = in.dims();
 
-    Array<T>* wtdInput = detail::arithOp<T, af_mul_t>(in, *wts, iDims);
+    Array<T> wtdInput = arithOp<T, af_mul_t>(in, wts, iDims);
 
-    T wtdSum = detail::reduce_all<af_add_t, T, T>(*wtdInput);
-    wType wtsSum = detail::reduce_all<af_add_t, wType, wType>(weights);
-
-    destroyArray<T>(*wtdInput);
-    destroyArray<T>(*wts);
+    T wtdSum = reduce_all<af_add_t, T, T>(wtdInput);
+    wType wtsSum = reduce_all<af_add_t, wType, wType>(weights);
 
     return division(wtdSum, wtsSum);
 }
 
 template<typename T>
-inline Array<T>* mean(const Array<T>& in, dim_type dim)
+inline Array<T> mean(const Array<T>& in, dim_type dim)
 {
-    Array<T>* redArr = reduce<af_add_t, T, T>(in, dim);
+    Array<T> redArr = reduce<af_add_t, T, T>(in, dim);
 
     dim4 iDims = in.dims();
-    dim4 oDims = redArr->dims();
+    dim4 oDims = redArr.dims();
 
-    Array<T> *cnstArr = createValueArray<T>(oDims, scalar<T>(iDims[dim]));
-    Array<T> *result  = detail::arithOp<T, af_div_t>(*redArr, *cnstArr, oDims);
-
-    destroyArray<T>(*cnstArr);
-    destroyArray<T>(*redArr);
+    Array<T> cnstArr = createValueArray<T>(oDims, scalar<T>(iDims[dim]));
+    Array<T> result  = arithOp<T, af_div_t>(redArr, cnstArr, oDims);
 
     return result;
 }
 
 template<typename T>
-inline Array<T>* mean(const Array<T>& in, const Array<T>& wts, dim_type dim)
+inline Array<T> mean(const Array<T>& in, const Array<T>& wts, dim_type dim)
 {
     dim4 iDims = in.dims();
 
-    Array<T>* wtdInput = detail::arithOp<T, af_mul_t>(in, wts, iDims);
-    Array<T>* redArr   = reduce<af_add_t, T, T>(*wtdInput, dim);
-    Array<T>* wtsSum   = reduce<af_add_t, T, T>(wts, dim);
+    Array<T> wtdInput = arithOp<T, af_mul_t>(in, wts, iDims);
+    Array<T> redArr   = reduce<af_add_t, T, T>(wtdInput, dim);
+    Array<T> wtsSum   = reduce<af_add_t, T, T>(wts, dim);
 
-    dim4 oDims = redArr->dims();
+    dim4 oDims = redArr.dims();
 
-    Array<T> *result = detail::arithOp<T, af_div_t>(*redArr, *wtsSum, oDims);
-
-    destroyArray<T>(*wtsSum);
-    destroyArray<T>(*redArr);
-    destroyArray<T>(*wtdInput);
+    Array<T> result = arithOp<T, af_div_t>(redArr, wtsSum, oDims);
 
     return result;
 }

--- a/src/api/c/tile.cpp
+++ b/src/api/c/tile.cpp
@@ -20,7 +20,7 @@ using namespace detail;
 template<typename T>
 static inline af_array tile(const af_array in, const af::dim4 &tileDims)
 {
-    return getHandle(*tile<T>(getArray<T>(in), tileDims));
+    return getHandle(tile<T>(getArray<T>(in), tileDims));
 }
 
 af_err af_tile(af_array *out, const af_array in, const af::dim4 &tileDims)

--- a/src/api/c/transform.cpp
+++ b/src/api/c/transform.cpp
@@ -22,7 +22,7 @@ template<typename T>
 static inline af_array transform(const af_array in, const af_array tf, const af::dim4 &odims,
                                  const af_interp_type method, const bool inverse)
 {
-    return getHandle(*transform<T>(getArray<T>(in), getArray<float>(tf), odims, method, inverse));
+    return getHandle(transform<T>(getArray<T>(in), getArray<float>(tf), odims, method, inverse));
 }
 
 af_err af_transform(af_array *out, const af_array in, const af_array tf,

--- a/src/api/c/transpose.cpp
+++ b/src/api/c/transpose.cpp
@@ -22,7 +22,7 @@ using namespace detail;
 template<typename T>
 static inline af_array trs(const af_array in, const bool conjugate)
 {
-    return getHandle<T>(*detail::transpose<T>(getArray<T>(in), conjugate));
+    return getHandle<T>(detail::transpose<T>(getArray<T>(in), conjugate));
 }
 
 af_err af_transpose(af_array *out, af_array in, const bool conjugate)

--- a/src/api/c/unary.cpp
+++ b/src/api/c/unary.cpp
@@ -25,7 +25,7 @@ using namespace detail;
 template<typename T, af_op_t op>
 static inline af_array unaryOp(const af_array in)
 {
-    af_array res = getHandle(*unaryOp<T, op>(getArray<T>(in)));
+    af_array res = getHandle(unaryOp<T, op>(getArray<T>(in)));
     // All inputs to this function are temporary references
     // Delete the temporary references
     destroyHandle<T>(in);
@@ -124,7 +124,7 @@ af_err af_not(af_array *out, const af_array in)
 template<typename T, af_op_t op>
 static inline af_array checkOp(const af_array in)
 {
-    af_array res = getHandle(*checkOp<T, op>(getArray<T>(in)));
+    af_array res = getHandle(checkOp<T, op>(getArray<T>(in)));
     // All inputs to this function are temporary references
     // Delete the temporary references
     destroyHandle<T>(in);

--- a/src/api/c/where.cpp
+++ b/src/api/c/where.cpp
@@ -22,7 +22,7 @@ using namespace detail;
 template<typename T>
 static inline af_array where(const af_array in)
 {
-    return getHandle(*where<T>(getArray<T>(in)));
+    return getHandle(where<T>(getArray<T>(in)));
 }
 
 af_err af_where(af_array *idx, const af_array in)

--- a/src/backend/cpu/Array.cpp
+++ b/src/backend/cpu/Array.cpp
@@ -17,6 +17,9 @@
 
 namespace cpu
 {
+    using TNJ::BufferNode;
+    using TNJ::Node;
+    using TNJ::Node_ptr;
 
     using af::dim4;
 
@@ -54,117 +57,7 @@ namespace cpu
         owner(false)
     { }
 
-    template<typename T>
-    Array<T>::~Array()
-    { }
-
-    using TNJ::BufferNode;
-    using TNJ::Node;
-    using TNJ::Node_ptr;
-
-    template<typename T>
-    Node_ptr Array<T>::getNode() const
-    {
-        if (!node) {
-
-            BufferNode<T> *buf_node = new BufferNode<T>(data,
-                                                        dims().get(),
-                                                        strides().get(),
-                                                        offset);
-
-            const_cast<Array<T> *>(this)->node = Node_ptr(reinterpret_cast<Node *>(buf_node));
-        }
-
-        return node;
-    }
-
-    template<typename T>
-    Array<T> *
-    createHostDataArray(const dim4 &size, const T * const data)
-    {
-        Array<T> *out = new Array<T>(size, data);
-        return out;
-    }
-
-    template<typename T>
-    Array<T> *
-    createDeviceDataArray(const dim4 &size, const void *data)
-    {
-        Array<T> *out = new Array<T>(size, (const T * const) data);
-        return out;
-    }
-
-    template<typename T>
-    Array<T> *
-    createValueArray(const dim4 &size, const T& value)
-    {
-        TNJ::ScalarNode<T> *node = new TNJ::ScalarNode<T>(value);
-        return createNodeArray<T>(size, TNJ::Node_ptr(
-                                      reinterpret_cast<TNJ::Node *>(node)));
-    }
-
-    template<typename T>
-    Array<T>*
-    createEmptyArray(const dim4 &size)
-    {
-        Array<T> *out = new Array<T>(size);
-        return out;
-    }
-
-    template<typename T>
-    Array<T> *
-    createNodeArray(const dim4 &dims, Node_ptr node)
-    {
-        return new Array<T>(dims, node);
-    }
-
-    template<typename T>
-    Array<T> *
-    createSubArray(const Array<T>& parent, const dim4 &dims, const dim4 &offset, const dim4 &stride)
-    {
-        Array<T> *out = new Array<T>(parent, dims, offset, stride);
-        // FIXME: check what is happening with the references here
-        if (stride[0] != 1 ||
-            stride[1] <  0 ||
-            stride[2] <  0 ||
-            stride[3] <  0) out = copyArray(*out);
-        return out;
-    }
-
-    template<typename T>
-    Array<T> *
-    createRefArray(const Array<T>& parent, const dim4 &dims, const dim4 &offset, const dim4 &stride)
-    {
-        return new Array<T>(parent, dims, offset, stride);
-    }
-
-    template<typename inType, typename outType>
-    Array<outType> *
-    createPaddedArray(Array<inType> const &in, dim4 const &dims, outType default_value)
-    {
-        Array<outType> *ret = createValueArray<outType>(dims, default_value);
-
-        copy<inType, outType>(*ret, in, outType(default_value), 1.0);
-
-        return ret;
-    }
-
-    template<typename T>
-    void scaleArray(Array<T> &arr, double factor)
-    {
-        T * src_ptr = arr.get();
-        for(dim_type i=0; i< (dim_type)arr.elements(); ++i)
-            src_ptr[i] *= factor;
-    }
-
-    template<typename T>
-    void
-    destroyArray(Array<T> &A)
-    {
-        delete &A;
-    }
-
-    template<typename T>
+        template<typename T>
     void Array<T>::eval()
     {
         if (isReady()) return;
@@ -209,20 +102,123 @@ namespace cpu
         const_cast<Array<T> *>(this)->eval();
     }
 
+    template<typename T>
+    Array<T>::~Array()
+    { }
+
+    template<typename T>
+    Node_ptr Array<T>::getNode() const
+    {
+        if (!node) {
+
+            BufferNode<T> *buf_node = new BufferNode<T>(data,
+                                                        dims().get(),
+                                                        strides().get(),
+                                                        offset);
+
+            const_cast<Array<T> *>(this)->node = Node_ptr(reinterpret_cast<Node *>(buf_node));
+        }
+
+        return node;
+    }
+
+    template<typename T>
+    Array<T>
+    createHostDataArray(const dim4 &size, const T * const data)
+    {
+        return Array<T>(size, data);
+    }
+
+    template<typename T>
+    Array<T>
+    createDeviceDataArray(const dim4 &size, const void *data)
+    {
+        return Array<T>(size, (const T * const) data);
+    }
+
+    template<typename T>
+    Array<T>
+    createValueArray(const dim4 &size, const T& value)
+    {
+        TNJ::ScalarNode<T> *node = new TNJ::ScalarNode<T>(value);
+        return createNodeArray<T>(size, TNJ::Node_ptr(
+                                      reinterpret_cast<TNJ::Node *>(node)));
+    }
+
+    template<typename T>
+    Array<T>
+    createEmptyArray(const dim4 &size)
+    {
+        return Array<T>(size);
+    }
+
+    template<typename T>
+    Array<T> *initArray() { return new Array<T>(dim4()); }
+
+
+    template<typename T>
+    Array<T>
+    createNodeArray(const dim4 &dims, Node_ptr node)
+    {
+        return Array<T>(dims, node);
+    }
+
+
+    template<typename T>
+    Array<T> createSubArray(const Array<T>& parent,
+                            const std::vector<af_seq> &index,
+                            bool copy)
+    {
+        dim4 dims   = af::toDims  (index, parent.dims());
+        dim4 offset = af::toOffset(index, parent.dims());
+        dim4 stride = af::toStride (index, parent.dims());
+
+        Array<T> out = Array<T>(parent, dims, offset, stride);
+
+        if (!copy) return out;
+
+        if (stride[0] != 1 ||
+            stride[1] <  0 ||
+            stride[2] <  0 ||
+            stride[3] <  0) {
+
+            out = copyArray(out);
+        }
+
+        return out;
+    }
+
+    template<typename T>
+    void
+    destroyArray(Array<T> *A)
+    {
+        delete A;
+    }
+
+
+    template<typename T>
+    void evalArray(const Array<T> &A)
+    {
+        A.eval();
+    }
+
+
 #define INSTANTIATE(T)                                                  \
-    template       Array<T>*  createHostDataArray<T>  (const dim4 &size, const T * const data); \
-    template       Array<T>*  createDeviceDataArray<T>  (const dim4 &size, const void *data); \
-    template       Array<T>*  createValueArray<T> (const dim4 &size, const T &value); \
-    template       Array<T>*  createEmptyArray<T> (const dim4 &size);   \
-    template       Array<T>*  createSubArray<T>   (const Array<T> &parent, const dim4 &dims, const dim4 &offset, const dim4 &stride); \
-    template       Array<T>*  createRefArray<T>   (const Array<T> &parent, const dim4 &dims, const dim4 &offset, const dim4 &stride); \
-    template       Array<T>*  createNodeArray<T>   (const dim4 &size, TNJ::Node_ptr node); \
-    template       void       scaleArray<T>       (Array<T> &arr, double factor); \
-    template       void       destroyArray<T>     (Array<T> &A);        \
-    template       TNJ::Node_ptr Array<T>::getNode() const;                \
-    template                  Array<T>::~Array();                       \
+    template       Array<T>  createHostDataArray<T>   (const dim4 &size, const T * const data); \
+    template       Array<T>  createDeviceDataArray<T> (const dim4 &size, const void *data); \
+    template       Array<T>  createValueArray<T>      (const dim4 &size, const T &value); \
+    template       Array<T>  createEmptyArray<T>      (const dim4 &size); \
+    template       Array<T>  *initArray<T      >      ();               \
+    template       Array<T>  createSubArray<T>        (const Array<T> &parent, \
+                                                       const std::vector<af_seq> &index, \
+                                                       bool copy);      \
+    template       void      destroyArray<T>          (Array<T> *A);    \
+    template       void      evalArray<T>             (const Array<T> &A); \
+    template       Array<T>  createNodeArray<T>       (const dim4 &size, TNJ::Node_ptr node); \
+    template       Array<T>::~Array        ();                          \
     template       void Array<T>::eval();                               \
     template       void Array<T>::eval() const;                         \
+    template       TNJ::Node_ptr Array<T>::getNode() const;             \
 
     INSTANTIATE(float)
     INSTANTIATE(double)
@@ -234,29 +230,4 @@ namespace cpu
     INSTANTIATE(char)
     INSTANTIATE(intl)
     INSTANTIATE(uintl)
-
-#define INSTANTIATE_CREATE_PADDED_ARRAY(SRC_T) \
-    template Array<float  >* createPaddedArray<SRC_T, float  >(Array<SRC_T> const &src, dim4 const &dims, float   default_value); \
-    template Array<double >* createPaddedArray<SRC_T, double >(Array<SRC_T> const &src, dim4 const &dims, double  default_value); \
-    template Array<cfloat >* createPaddedArray<SRC_T, cfloat >(Array<SRC_T> const &src, dim4 const &dims, cfloat  default_value); \
-    template Array<cdouble>* createPaddedArray<SRC_T, cdouble>(Array<SRC_T> const &src, dim4 const &dims, cdouble default_value); \
-    template Array<int    >* createPaddedArray<SRC_T, int    >(Array<SRC_T> const &src, dim4 const &dims, int     default_value); \
-    template Array<uint   >* createPaddedArray<SRC_T, uint   >(Array<SRC_T> const &src, dim4 const &dims, uint    default_value); \
-    template Array<uchar  >* createPaddedArray<SRC_T, uchar  >(Array<SRC_T> const &src, dim4 const &dims, uchar   default_value); \
-    template Array<char   >* createPaddedArray<SRC_T, char   >(Array<SRC_T> const &src, dim4 const &dims, char    default_value);
-
-    INSTANTIATE_CREATE_PADDED_ARRAY(float )
-    INSTANTIATE_CREATE_PADDED_ARRAY(double)
-    INSTANTIATE_CREATE_PADDED_ARRAY(int   )
-    INSTANTIATE_CREATE_PADDED_ARRAY(uint  )
-    INSTANTIATE_CREATE_PADDED_ARRAY(uchar )
-    INSTANTIATE_CREATE_PADDED_ARRAY(char  )
-
-#define INSTANTIATE_CREATE_COMPLEX_PADDED_ARRAY(SRC_T) \
-    template Array<cfloat >* createPaddedArray<SRC_T, cfloat >(Array<SRC_T> const &src, dim4 const &dims, cfloat  default_value); \
-    template Array<cdouble>* createPaddedArray<SRC_T, cdouble>(Array<SRC_T> const &src, dim4 const &dims, cdouble default_value);
-
-    INSTANTIATE_CREATE_COMPLEX_PADDED_ARRAY(cfloat )
-    INSTANTIATE_CREATE_COMPLEX_PADDED_ARRAY(cdouble)
-
 }

--- a/src/backend/cpu/Array.hpp
+++ b/src/backend/cpu/Array.hpp
@@ -18,6 +18,7 @@
 #include <TNJ/Node.hpp>
 #include <memory>
 #include <algorithm>
+#include <vector>
 
 namespace cpu
 {
@@ -29,53 +30,36 @@ namespace cpu
 
     // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    Array<T>*
-    createNodeArray(const af::dim4 &size, TNJ::Node_ptr node);
+    Array<T> createNodeArray(const af::dim4 &size, TNJ::Node_ptr node);
 
     // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    Array<T> *
-    createValueArray(const af::dim4 &size, const T& value);
+    Array<T> createValueArray(const af::dim4 &size, const T& value);
 
     // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    Array<T>*
-    createHostDataArray(const af::dim4 &size, const T * const data);
+    Array<T> createHostDataArray(const af::dim4 &size, const T * const data);
 
-    // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    Array<T>*
-    createDeviceDataArray(const af::dim4 &size, const void *data);
+    Array<T> createDeviceDataArray(const af::dim4 &size, const void *data);
 
     // Create an Array object and do not assign any values to it
-    template<typename T>
-    Array<T>*
-    createEmptyArray(const af::dim4 &size);
-
-    // Creates a new Array View(sub array).
-    template<typename T>
-    Array<T> *
-    createSubArray(const Array<T>& parent, const dim4 &dims, const dim4 &offset, const dim4 &stride);
-
-    // Creates a pure reference Array - a virtual view, no copies are made
-    template<typename T>
-    Array<T> *
-    createRefArray(const Array<T>& parent, const dim4 &dims, const dim4 &offset, const dim4 &stride);
-
-    template<typename inType, typename outType>
-    Array<outType> *
-    createPaddedArray(Array<inType> const &in, dim4 const &dims, outType default_value=outType(0));
+    template<typename T> Array<T> *initArray();
 
     template<typename T>
-    void scaleArray(Array<T> &arr, double factor);
+    Array<T> createEmptyArray(const af::dim4 &size);
 
     template<typename T>
-    void
-    destroyArray(Array<T> &arr);
+    Array<T> createSubArray(const Array<T>& parent,
+                            const std::vector<af_seq> &index,
+                            bool copy=true);
 
     template<typename T>
-    void
-    operator <<(std::ostream &out, const Array<T> &arr);
+    void evalArray(const Array<T> &A);
+
+    // Creates a new Array object on the heap and returns a reference to it.
+    template<typename T>
+    void destroyArray(Array<T> *A);
 
     template<typename T>
     void *getDevicePtr(const Array<T>& arr)
@@ -129,17 +113,20 @@ namespace cpu
 
         TNJ::Node_ptr getNode() const;
 
-        friend Array<T>* createValueArray<T>(const af::dim4 &size, const T& value);
-        friend Array<T>* createHostDataArray<T>(const af::dim4 &size, const T * const data);
-        friend Array<T>* createDeviceDataArray<T>(const af::dim4 &size, const void *data);
-        friend Array<T>* createEmptyArray<T>(const af::dim4 &size);
-        friend Array<T>* createSubArray<T>(const Array<T>& parent,
-                                           const dim4 &dims, const dim4 &offset, const dim4 &stride);
-        friend Array<T>* createRefArray<T>(const Array<T>& parent,
-                                           const dim4 &dims, const dim4 &offset, const dim4 &stride);
-        friend void      destroyArray<T>(Array<T> &arr);
-        friend Array<T>* createNodeArray<T>(const af::dim4 &dims, TNJ::Node_ptr node);
+        friend Array<T> createValueArray<T>(const af::dim4 &size, const T& value);
+        friend Array<T> createHostDataArray<T>(const af::dim4 &size, const T * const data);
+        friend Array<T> createDeviceDataArray<T>(const af::dim4 &size, const void *data);
 
+        friend Array<T> *initArray<T>();
+        friend Array<T> createEmptyArray<T>(const af::dim4 &size);
+        friend Array<T> createNodeArray<T>(const af::dim4 &dims, TNJ::Node_ptr node);
+
+        friend Array<T> createSubArray<T>(const Array<T>& parent,
+                                          const std::vector<af_seq> &index,
+                                          bool copy);
+
+        friend void destroyArray<T>(Array<T> *arr);
+        friend void evalArray<T>(const Array<T> &arr);
         friend void *getDevicePtr<T>(const Array<T>& arr);
     };
 

--- a/src/backend/cpu/ArrayIndex.cpp
+++ b/src/backend/cpu/ArrayIndex.cpp
@@ -27,7 +27,7 @@ dim_type trimIndex(dim_type idx, const dim_type &len)
 }
 
 template<typename in_t, typename idx_t>
-Array<in_t>* arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, const unsigned dim)
+Array<in_t> arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, const unsigned dim)
 {
     const dim4 iDims = input.dims();
     const dim4 iStrides = input.strides();
@@ -39,11 +39,11 @@ Array<in_t>* arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, c
     for (dim_type d=0; d<4; ++d)
         oDims[d] = (d==int(dim) ? indices.elements() : iDims[d]);
 
-    Array<in_t>* out = createEmptyArray<in_t>(oDims);
+    Array<in_t> out = createEmptyArray<in_t>(oDims);
 
-    dim4 oStrides = out->strides();
+    dim4 oStrides = out.strides();
 
-    in_t *outPtr = out->get();
+    in_t *outPtr = out.get();
 
     for (dim_type l=0; l<oDims[3]; ++l) {
 
@@ -75,11 +75,11 @@ Array<in_t>* arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, c
 }
 
 #define INSTANTIATE(T)  \
-    template Array<T> * arrayIndex<T, float   >(const Array<T> &input, const Array<float   > &indices, const unsigned dim); \
-    template Array<T> * arrayIndex<T, double  >(const Array<T> &input, const Array<double  > &indices, const unsigned dim); \
-    template Array<T> * arrayIndex<T, int     >(const Array<T> &input, const Array<int     > &indices, const unsigned dim); \
-    template Array<T> * arrayIndex<T, unsigned>(const Array<T> &input, const Array<unsigned> &indices, const unsigned dim); \
-    template Array<T> * arrayIndex<T, uchar   >(const Array<T> &input, const Array<uchar   > &indices, const unsigned dim);
+    template Array<T>  arrayIndex<T, float   >(const Array<T> &input, const Array<float   > &indices, const unsigned dim); \
+    template Array<T>  arrayIndex<T, double  >(const Array<T> &input, const Array<double  > &indices, const unsigned dim); \
+    template Array<T>  arrayIndex<T, int     >(const Array<T> &input, const Array<int     > &indices, const unsigned dim); \
+    template Array<T>  arrayIndex<T, unsigned>(const Array<T> &input, const Array<unsigned> &indices, const unsigned dim); \
+    template Array<T>  arrayIndex<T, uchar   >(const Array<T> &input, const Array<uchar   > &indices, const unsigned dim);
 
 INSTANTIATE(float   );
 INSTANTIATE(cfloat  );

--- a/src/backend/cpu/ArrayIndex.hpp
+++ b/src/backend/cpu/ArrayIndex.hpp
@@ -13,6 +13,6 @@ namespace cpu
 {
 
 template<typename in_t, typename idx_t>
-Array<in_t>* arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, const unsigned dim);
+Array<in_t> arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, const unsigned dim);
 
 }

--- a/src/backend/cpu/approx.cpp
+++ b/src/backend/cpu/approx.cpp
@@ -130,27 +130,27 @@ namespace cpu
     }
 
     template<typename Ty, typename Tp>
-    Array<Ty> *approx1(const Array<Ty> &in, const Array<Tp> &pos,
+    Array<Ty> approx1(const Array<Ty> &in, const Array<Tp> &pos,
                        const af_interp_type method, const float offGrid)
     {
         af::dim4 odims = in.dims();
         odims[0] = pos.dims()[0];
 
         // Create output placeholder
-        Array<Ty> *out = createEmptyArray<Ty>(odims);
+        Array<Ty> out = createEmptyArray<Ty>(odims);
 
         switch(method) {
             case AF_INTERP_NEAREST:
                 approx1_<Ty, Tp, AF_INTERP_NEAREST>
-                        (out->get(), out->dims(), out->elements(),
+                        (out.get(), out.dims(), out.elements(),
                          in.get(), in.dims(), in.elements(), pos.get(), pos.dims(),
-                         out->strides(), in.strides(), pos.strides(), offGrid);
+                         out.strides(), in.strides(), pos.strides(), offGrid);
                 break;
             case AF_INTERP_LINEAR:
                 approx1_<Ty, Tp, AF_INTERP_LINEAR>
-                        (out->get(), out->dims(), out->elements(),
+                        (out.get(), out.dims(), out.elements(),
                          in.get(), in.dims(), in.elements(), pos.get(), pos.dims(),
-                         out->strides(), in.strides(), pos.strides(), offGrid);
+                         out.strides(), in.strides(), pos.strides(), offGrid);
                 break;
             default:
                 break;
@@ -292,7 +292,7 @@ namespace cpu
     }
 
     template<typename Ty, typename Tp>
-    Array<Ty> *approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
+    Array<Ty> approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
                        const af_interp_type method, const float offGrid)
     {
         af::dim4 odims = in.dims();
@@ -300,23 +300,23 @@ namespace cpu
         odims[1] = pos0.dims()[1];
 
         // Create output placeholder
-        Array<Ty> *out = createEmptyArray<Ty>(odims);
+        Array<Ty> out = createEmptyArray<Ty>(odims);
 
         switch(method) {
             case AF_INTERP_NEAREST:
                 approx2_<Ty, Tp, AF_INTERP_NEAREST>
-                        (out->get(), out->dims(), out->elements(),
+                        (out.get(), out.dims(), out.elements(),
                          in.get(), in.dims(), in.elements(),
                          pos0.get(), pos0.dims(), pos1.get(), pos1.dims(),
-                         out->strides(), in.strides(), pos0.strides(), pos1.strides(),
+                         out.strides(), in.strides(), pos0.strides(), pos1.strides(),
                          offGrid);
                 break;
             case AF_INTERP_LINEAR:
                 approx2_<Ty, Tp, AF_INTERP_LINEAR>
-                        (out->get(), out->dims(), out->elements(),
+                        (out.get(), out.dims(), out.elements(),
                          in.get(), in.dims(), in.elements(),
                          pos0.get(), pos0.dims(), pos1.get(), pos1.dims(),
-                         out->strides(), in.strides(), pos0.strides(), pos1.strides(),
+                         out.strides(), in.strides(), pos0.strides(), pos1.strides(),
                          offGrid);
                 break;
             default:
@@ -326,9 +326,9 @@ namespace cpu
     }
 
 #define INSTANTIATE(Ty, Tp)                                                                     \
-    template Array<Ty>* approx1<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos,              \
+    template Array<Ty> approx1<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos,              \
                                         const af_interp_type method, const float offGrid);      \
-    template Array<Ty>* approx2<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos0,             \
+    template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos0,             \
                                         const Array<Tp> &pos1, const af_interp_type method,     \
                                         const float offGrid);                                   \
 

--- a/src/backend/cpu/approx.hpp
+++ b/src/backend/cpu/approx.hpp
@@ -13,10 +13,10 @@
 namespace cpu
 {
     template<typename Ty, typename Tp>
-    Array<Ty> *approx1(const Array<Ty> &in, const Array<Tp> &pos,
-                       const af_interp_type method, const float offGrid);
+    Array<Ty> approx1(const Array<Ty> &in, const Array<Tp> &pos,
+                      const af_interp_type method, const float offGrid);
 
     template<typename Ty, typename Tp>
-    Array<Ty> *approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
-                       const af_interp_type method, const float offGrid);
+    Array<Ty> approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
+                      const af_interp_type method, const float offGrid);
 }

--- a/src/backend/cpu/arith.hpp
+++ b/src/backend/cpu/arith.hpp
@@ -70,7 +70,7 @@ NUMERIC_FN(af_atan2_t, atan2)
 NUMERIC_FN(af_hypot_t, hypot)
 
 template<typename T, af_op_t op>
-Array<T>* arithOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
+Array<T> arithOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
 {
     TNJ::Node_ptr lhs_node = lhs.getNode();
     TNJ::Node_ptr rhs_node = rhs.getNode();

--- a/src/backend/cpu/backend.hpp
+++ b/src/backend/cpu/backend.hpp
@@ -8,5 +8,17 @@
  ********************************************************/
 
 #pragma once
+#ifdef __DH__
+#undef __DH__
+#endif
+
+#ifdef __CUDACC__
+#include <cpu_runtime.h>
+#define __DH__ __device__ __host__
+#else
+#define __DH__
+#endif
+
 #include "types.hpp"
+
 namespace detail = cpu;

--- a/src/backend/cpu/bilateral.cpp
+++ b/src/backend/cpu/bilateral.cpp
@@ -35,18 +35,18 @@ static inline unsigned getIdx(const dim4 &strides,
 }
 
 template<typename inType, typename outType, bool isColor>
-Array<outType> * bilateral(const Array<inType> &in, const float &s_sigma, const float &c_sigma)
+Array<outType> bilateral(const Array<inType> &in, const float &s_sigma, const float &c_sigma)
 {
     const dim4 dims     = in.dims();
     const dim4 istrides = in.strides();
 
-    Array<outType>* out = createEmptyArray<outType>(dims);
-    const dim4 ostrides = out->strides();
+    Array<outType> out = createEmptyArray<outType>(dims);
+    const dim4 ostrides = out.strides();
 
     dim_type bCount     = dims[2];
     if (isColor) bCount*= dims[3];
 
-    outType *outData    = out->get();
+    outType *outData    = out.get();
     const inType * inData = in.get();
 
     // clamp spatical and chromatic sigma's
@@ -92,8 +92,8 @@ Array<outType> * bilateral(const Array<inType> &in, const float &s_sigma, const 
 }
 
 #define INSTANTIATE(inT, outT)\
-template Array<outT> * bilateral<inT, outT,true >(const Array<inT> &in, const float &s_sigma, const float &c_sigma);\
-template Array<outT> * bilateral<inT, outT,false>(const Array<inT> &in, const float &s_sigma, const float &c_sigma);
+template Array<outT> bilateral<inT, outT,true >(const Array<inT> &in, const float &s_sigma, const float &c_sigma);\
+template Array<outT> bilateral<inT, outT,false>(const Array<inT> &in, const float &s_sigma, const float &c_sigma);
 
 INSTANTIATE(double, double)
 INSTANTIATE(float ,  float)

--- a/src/backend/cpu/bilateral.hpp
+++ b/src/backend/cpu/bilateral.hpp
@@ -13,6 +13,6 @@ namespace cpu
 {
 
 template<typename inType, typename outType, bool isColor>
-Array<outType> * bilateral(const Array<inType> &in, const float &s_sigma, const float &c_sigma);
+Array<outType> bilateral(const Array<inType> &in, const float &s_sigma, const float &c_sigma);
 
 }

--- a/src/backend/cpu/blas.cpp
+++ b/src/backend/cpu/blas.cpp
@@ -154,8 +154,8 @@ struct cblas_types<cdouble> {
 #endif
 
 template<typename T>
-Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs)
+Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
+                af_blas_transpose optLhs, af_blas_transpose optRhs)
 {
     CBLAS_TRANSPOSE lOpts = toCblasTranspose(optLhs);
     CBLAS_TRANSPOSE rOpts = toCblasTranspose(optRhs);
@@ -171,7 +171,7 @@ Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
     int K = lDims[aColDim];
 
     //FIXME: Leaks on errors.
-    Array<T> *out = createEmptyArray<T>(af::dim4(M, N, 1, 1));
+    Array<T> out = createEmptyArray<T>(af::dim4(M, N, 1, 1));
     auto alpha = getScale<T, BT, 1>();
     auto beta  = getScale<T, BT, 0>();
 
@@ -184,22 +184,22 @@ Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
             M, N,
             alpha, REINTERPRET_CAST(const BT*, lhs.get()), lStrides[1],
             REINTERPRET_CAST(const BT*, rhs.get()), rStrides[0],
-            beta, REINTERPRET_CAST(BT*, out->get()), 1);
+            beta, REINTERPRET_CAST(BT*, out.get()), 1);
     } else {
         gemm_func<T, BT>()(
             CblasColMajor, lOpts, rOpts,
             M, N, K,
             alpha, REINTERPRET_CAST(const BT*, lhs.get()), lStrides[1],
             REINTERPRET_CAST(const BT*, rhs.get()), rStrides[1],
-            beta, REINTERPRET_CAST(BT*, out->get()), out->dims()[0]);
+            beta, REINTERPRET_CAST(BT*, out.get()), out.dims()[0]);
     }
 
     return out;
 }
 
 template<typename T>
-Array<T>* dot(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs)
+Array<T> dot(const Array<T> &lhs, const Array<T> &rhs,
+             af_blas_transpose optLhs, af_blas_transpose optRhs)
 {
     int N = lhs.dims()[0];
 
@@ -215,8 +215,8 @@ Array<T>* dot(const Array<T> &lhs, const Array<T> &rhs,
 #undef REINTEPRET_CAST
 
 #define INSTANTIATE_BLAS(TYPE)                                                          \
-    template Array<TYPE>* matmul<TYPE>(const Array<TYPE> &lhs, const Array<TYPE> &rhs,  \
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
+    template Array<TYPE> matmul<TYPE>(const Array<TYPE> &lhs, const Array<TYPE> &rhs,  \
+                                      af_blas_transpose optLhs, af_blas_transpose optRhs);
 
 INSTANTIATE_BLAS(float)
 INSTANTIATE_BLAS(cfloat)
@@ -224,8 +224,8 @@ INSTANTIATE_BLAS(double)
 INSTANTIATE_BLAS(cdouble)
 
 #define INSTANTIATE_DOT(TYPE)                                                       \
-    template Array<TYPE>* dot<TYPE>(const Array<TYPE> &lhs, const Array<TYPE> &rhs, \
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
+    template Array<TYPE> dot<TYPE>(const Array<TYPE> &lhs, const Array<TYPE> &rhs, \
+                                   af_blas_transpose optLhs, af_blas_transpose optRhs);
 
 INSTANTIATE_DOT(float)
 INSTANTIATE_DOT(double)

--- a/src/backend/cpu/blas.hpp
+++ b/src/backend/cpu/blas.hpp
@@ -22,10 +22,10 @@ namespace cpu
 {
 
 template<typename T>
-Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
+Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
+                af_blas_transpose optLhs, af_blas_transpose optRhs);
 template<typename T>
-Array<T>* dot(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
+Array<T> dot(const Array<T> &lhs, const Array<T> &rhs,
+             af_blas_transpose optLhs, af_blas_transpose optRhs);
 
 }

--- a/src/backend/cpu/cast.hpp
+++ b/src/backend/cpu/cast.hpp
@@ -66,7 +66,7 @@ CAST_B8(uchar)
 CAST_B8(char)
 
 template<typename To, typename Ti>
-Array<To>* cast(const Array<Ti> &in)
+Array<To> cast(const Array<Ti> &in)
 {
     TNJ::Node_ptr in_node = in.getNode();
     TNJ::UnaryNode<To, Ti, af_cast_t> *node = new TNJ::UnaryNode<To, Ti, af_cast_t>(in_node);

--- a/src/backend/cpu/complex.hpp
+++ b/src/backend/cpu/complex.hpp
@@ -30,7 +30,7 @@ namespace cpu
     };
 
     template<typename To, typename Ti>
-    Array<To>* cplx(const Array<Ti> &lhs, const Array<Ti> &rhs, const af::dim4 &odims)
+    Array<To> cplx(const Array<Ti> &lhs, const Array<Ti> &rhs, const af::dim4 &odims)
     {
         TNJ::Node_ptr lhs_node = lhs.getNode();
         TNJ::Node_ptr rhs_node = rhs.getNode();
@@ -58,7 +58,7 @@ namespace cpu
     CPLX_UNARY_FN(abs)
 
     template<typename To, typename Ti>
-    Array<To>* real(const Array<Ti> &in)
+    Array<To> real(const Array<Ti> &in)
     {
         TNJ::Node_ptr in_node = in.getNode();
         TNJ::UnaryNode<To, Ti, af_real_t> *node = new TNJ::UnaryNode<To, Ti, af_real_t>(in_node);
@@ -68,7 +68,7 @@ namespace cpu
     }
 
     template<typename To, typename Ti>
-    Array<To>* imag(const Array<Ti> &in)
+    Array<To> imag(const Array<Ti> &in)
     {
         TNJ::Node_ptr in_node = in.getNode();
         TNJ::UnaryNode<To, Ti, af_imag_t> *node = new TNJ::UnaryNode<To, Ti, af_imag_t>(in_node);
@@ -78,7 +78,7 @@ namespace cpu
     }
 
     template<typename To, typename Ti>
-    Array<To>* abs(const Array<Ti> &in)
+    Array<To> abs(const Array<Ti> &in)
     {
         TNJ::Node_ptr in_node = in.getNode();
         TNJ::UnaryNode<To, Ti, af_abs_t> *node = new TNJ::UnaryNode<To, Ti, af_abs_t>(in_node);
@@ -88,7 +88,7 @@ namespace cpu
     }
 
     template<typename T>
-    Array<T>* conj(const Array<T> &in)
+    Array<T> conj(const Array<T> &in)
     {
         TNJ::Node_ptr in_node = in.getNode();
         TNJ::UnaryNode<T, T, af_conj_t> *node = new TNJ::UnaryNode<T, T, af_conj_t>(in_node);

--- a/src/backend/cpu/convolve.hpp
+++ b/src/backend/cpu/convolve.hpp
@@ -14,9 +14,9 @@ namespace cpu
 {
 
 template<typename T, typename accT, dim_type baseDim, bool expand>
-Array<T> * convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);
+Array<T> convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);
 
 template<typename T, typename accT, bool expand>
-Array<T> * convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);
+Array<T> convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);
 
 }

--- a/src/backend/cpu/copy.cpp
+++ b/src/backend/cpu/copy.cpp
@@ -17,10 +17,10 @@
 #include <vector>
 #include <cassert>
 #include <err_cpu.hpp>
+#include <math.hpp>
 
 namespace cpu
 {
-
     template<typename T>
     static void stridedCopy(T* dst, const dim4& ostrides, const T* src, const dim4 &dims, const dim4 &strides, unsigned dim)
     {
@@ -56,15 +56,15 @@ namespace cpu
     }
 
     template<typename T>
-    Array<T> *copyArray(const Array<T> &A)
+    Array<T> copyArray(const Array<T> &A)
     {
-        Array<T> *out = createEmptyArray<T>(A.dims());
-        copyData(out->get(), A);
+        Array<T> out = createEmptyArray<T>(A.dims());
+        copyData(out.get(), A);
         return out;
     }
 
     template<typename inType, typename outType>
-    void copy(Array<outType> &dst, const Array<inType> &src, outType default_value, double factor)
+    static void copy(Array<outType> &dst, const Array<inType> &src, outType default_value, double factor)
     {
         dim4 src_dims       = src.dims();
         dim4 dst_dims       = dst.dims();
@@ -111,9 +111,27 @@ namespace cpu
         }
     }
 
+
+    template<typename inType, typename outType>
+    Array<outType>
+    padArray(Array<inType> const &in, dim4 const &dims,
+             outType default_value, double factor)
+    {
+        Array<outType> ret = createValueArray<outType>(dims, default_value);
+        copy<inType, outType>(ret, in, outType(default_value), factor);
+        return ret;
+    }
+
+    template<typename inType, typename outType>
+    void copyArray(Array<outType> &out, Array<inType> const &in)
+    {
+        copy<inType, outType>(out, in, scalar<outType>(0), 1.0);
+    }
+
+
 #define INSTANTIATE(T)                                                  \
     template void      copyData<T> (T *data, const Array<T> &from);     \
-    template Array<T>* copyArray<T>(const Array<T> &A);                 \
+    template Array<T>  copyArray<T>(const Array<T> &A);                 \
 
     INSTANTIATE(float  )
     INSTANTIATE(double )
@@ -126,47 +144,39 @@ namespace cpu
     INSTANTIATE(intl   )
     INSTANTIATE(uintl  )
 
-#define INSTANTIATE_COPY(SRC_T)                                                       \
-    template void copy<SRC_T, float  >(Array<float  > &dst, const Array<SRC_T> &src, float   default_value, double factor); \
-    template void copy<SRC_T, double >(Array<double > &dst, const Array<SRC_T> &src, double  default_value, double factor); \
-    template void copy<SRC_T, cfloat >(Array<cfloat > &dst, const Array<SRC_T> &src, cfloat  default_value, double factor); \
-    template void copy<SRC_T, cdouble>(Array<cdouble> &dst, const Array<SRC_T> &src, cdouble default_value, double factor); \
-    template void copy<SRC_T, int    >(Array<int    > &dst, const Array<SRC_T> &src, int     default_value, double factor); \
-    template void copy<SRC_T, uint   >(Array<uint   > &dst, const Array<SRC_T> &src, uint    default_value, double factor); \
-    template void copy<SRC_T, uchar  >(Array<uchar  > &dst, const Array<SRC_T> &src, uchar   default_value, double factor); \
-    template void copy<SRC_T, char   >(Array<char   > &dst, const Array<SRC_T> &src, char    default_value, double factor);
 
-    INSTANTIATE_COPY(float )
-    INSTANTIATE_COPY(double)
-    INSTANTIATE_COPY(int   )
-    INSTANTIATE_COPY(uint  )
-    INSTANTIATE_COPY(uchar )
-    INSTANTIATE_COPY(char  )
+#define INSTANTIATE_PAD_ARRAY(SRC_T)                                    \
+    template Array<float  > padArray<SRC_T, float  >(Array<SRC_T> const &src, dim4 const &dims, float   default_value, double factor); \
+    template Array<double > padArray<SRC_T, double >(Array<SRC_T> const &src, dim4 const &dims, double  default_value, double factor); \
+    template Array<cfloat > padArray<SRC_T, cfloat >(Array<SRC_T> const &src, dim4 const &dims, cfloat  default_value, double factor); \
+    template Array<cdouble> padArray<SRC_T, cdouble>(Array<SRC_T> const &src, dim4 const &dims, cdouble default_value, double factor); \
+    template Array<int    > padArray<SRC_T, int    >(Array<SRC_T> const &src, dim4 const &dims, int     default_value, double factor); \
+    template Array<uint   > padArray<SRC_T, uint   >(Array<SRC_T> const &src, dim4 const &dims, uint    default_value, double factor); \
+    template Array<uchar  > padArray<SRC_T, uchar  >(Array<SRC_T> const &src, dim4 const &dims, uchar   default_value, double factor); \
+    template Array<char   > padArray<SRC_T, char   >(Array<SRC_T> const &src, dim4 const &dims, char    default_value, double factor); \
+    template void copyArray<SRC_T, float  >(Array<float  > &dst, Array<SRC_T> const &src); \
+    template void copyArray<SRC_T, double >(Array<double > &dst, Array<SRC_T> const &src); \
+    template void copyArray<SRC_T, cfloat >(Array<cfloat > &dst, Array<SRC_T> const &src); \
+    template void copyArray<SRC_T, cdouble>(Array<cdouble> &dst, Array<SRC_T> const &src); \
+    template void copyArray<SRC_T, int    >(Array<int    > &dst, Array<SRC_T> const &src); \
+    template void copyArray<SRC_T, uint   >(Array<uint   > &dst, Array<SRC_T> const &src); \
+    template void copyArray<SRC_T, uchar  >(Array<uchar  > &dst, Array<SRC_T> const &src); \
+    template void copyArray<SRC_T, char   >(Array<char   > &dst, Array<SRC_T> const &src);
 
-#define INSTANTIATE_COMPLEX_COPY(SRC_T)                                               \
-    template void copy<SRC_T, cfloat >(Array<cfloat > &dst, const Array<SRC_T> &src, cfloat  default_value, double factor); \
-    template void copy<SRC_T, cdouble>(Array<cdouble> &dst, const Array<SRC_T> &src, cdouble default_value, double factor);
+    INSTANTIATE_PAD_ARRAY(float )
+    INSTANTIATE_PAD_ARRAY(double)
+    INSTANTIATE_PAD_ARRAY(int   )
+    INSTANTIATE_PAD_ARRAY(uint  )
+    INSTANTIATE_PAD_ARRAY(uchar )
+    INSTANTIATE_PAD_ARRAY(char  )
 
-    INSTANTIATE_COMPLEX_COPY(cfloat )
-    INSTANTIATE_COMPLEX_COPY(cdouble)
+#define INSTANTIATE_PAD_ARRAY_COMPLEX(SRC_T)                            \
+    template Array<cfloat > padArray<SRC_T, cfloat >(Array<SRC_T> const &src, dim4 const &dims, cfloat  default_value, double factor); \
+    template Array<cdouble> padArray<SRC_T, cdouble>(Array<SRC_T> const &src, dim4 const &dims, cdouble default_value, double factor); \
+    template void copyArray<SRC_T, cfloat  >(Array<cfloat  > &dst, Array<SRC_T> const &src); \
+    template void copyArray<SRC_T, cdouble   >(Array<cdouble > &dst, Array<SRC_T> const &src);
 
-#define INSTANTIATE_UNSUPPORTED_COMPLEX_COPY(cmplxType, T)              \
-    template<> void copy(Array<T> &dst, const Array<cfloat> &src,       \
-                                    T  default_value, double factor)    \
-    {                                                                   \
-        TYPE_ERROR(0,(af_dtype) af::dtype_traits<T>::af_type);          \
-    }                                                                   \
-    template<> void copy(Array<T> &dst, const Array<cdouble> &src,      \
-                                        T default_value, double factor) \
-    {                                                                   \
-        TYPE_ERROR(0,(af_dtype) af::dtype_traits<T>::af_type);          \
-    }                                                                   \
-
-    INSTANTIATE_UNSUPPORTED_COMPLEX_COPY(cfloat, double)
-    INSTANTIATE_UNSUPPORTED_COMPLEX_COPY(cfloat, float)
-    INSTANTIATE_UNSUPPORTED_COMPLEX_COPY(cfloat, int)
-    INSTANTIATE_UNSUPPORTED_COMPLEX_COPY(cfloat, uint)
-    INSTANTIATE_UNSUPPORTED_COMPLEX_COPY(cfloat, char)
-    INSTANTIATE_UNSUPPORTED_COMPLEX_COPY(cfloat, uchar)
+    INSTANTIATE_PAD_ARRAY_COMPLEX(cfloat )
+    INSTANTIATE_PAD_ARRAY_COMPLEX(cdouble)
 
 }

--- a/src/backend/cpu/copy.hpp
+++ b/src/backend/cpu/copy.hpp
@@ -6,6 +6,7 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#pragma once
 
 #include <af/array.h>
 #include <Array.hpp>

--- a/src/backend/cpu/copy.hpp
+++ b/src/backend/cpu/copy.hpp
@@ -17,9 +17,12 @@ namespace cpu
     void copyData(T *data, const Array<T> &A);
 
     template<typename T>
-    Array<T>* copyArray(const Array<T> &A);
+    Array<T> copyArray(const Array<T> &A);
 
     template<typename inType, typename outType>
-    void copy(Array<outType> &dst, const Array<inType> &src, outType default_value, double factor);
+    void copyArray(Array<outType> &out, const Array<inType> &in);
 
+    template<typename inType, typename outType>
+    Array<outType> padArray(Array<inType> const &in, dim4 const &dims,
+                            outType default_value=outType(0), double factor=1.0);
 }

--- a/src/backend/cpu/diagonal.cpp
+++ b/src/backend/cpu/diagonal.cpp
@@ -18,14 +18,14 @@
 namespace cpu
 {
     template<typename T>
-    Array<T>* diagCreate(const Array<T> &in, const int num)
+    Array<T> diagCreate(const Array<T> &in, const int num)
     {
         int size = in.dims()[0] + std::abs(num);
         int batch = in.dims()[1];
-        Array<T> *out = createEmptyArray<T>(dim4(size, size, batch));
+        Array<T> out = createEmptyArray<T>(dim4(size, size, batch));
 
         const T *iptr = in.get();
-        T *optr = out->get();
+        T *optr = out.get();
 
         for (int k = 0; k < batch; k++) {
             for (int j = 0; j < size; j++) {
@@ -34,10 +34,10 @@ namespace cpu
                     if (i == j - num) {
                         val = (num > 0) ? iptr[i] : iptr[j];
                     }
-                    optr[i + j * out->strides()[1]] = val;
+                    optr[i + j * out.strides()[1]] = val;
                 }
             }
-            optr += out->strides()[2];
+            optr += out.strides()[2];
             iptr += in.strides()[1];
         }
 
@@ -45,13 +45,13 @@ namespace cpu
     }
 
     template<typename T>
-    Array<T>* diagExtract(const Array<T> &in, const int num)
+    Array<T> diagExtract(const Array<T> &in, const int num)
     {
         const dim_type *idims = in.dims().get();
         dim_type size = std::max(idims[0], idims[1]) - std::abs(num);
-        Array<T> *out = createEmptyArray<T>(dim4(size, 1, idims[2], idims[3]));
+        Array<T> out = createEmptyArray<T>(dim4(size, 1, idims[2], idims[3]));
 
-        const dim_type *odims = out->dims().get();
+        const dim_type *odims = out.dims().get();
 
         const int i_off = (num > 0) ? (num * in.strides()[1]) : (-num);
 
@@ -59,7 +59,7 @@ namespace cpu
 
             for (int k = 0; k < odims[2]; k++) {
                 const T *iptr = in.get() + l * in.strides()[3] + k * in.strides()[2] + i_off;
-                T *optr = out->get() + l * out->strides()[3] + k * out->strides()[2];
+                T *optr = out.get() + l * out.strides()[3] + k * out.strides()[2];
 
                 for (int i = 0; i < odims[0]; i++) {
                     T val = scalar<T>(0);
@@ -73,8 +73,8 @@ namespace cpu
     }
 
 #define INSTANTIATE_DIAGONAL(T)                                          \
-    template Array<T>*  diagExtract<T>    (const Array<T> &in, const int num); \
-    template Array<T>*  diagCreate <T>    (const Array<T> &in, const int num);
+    template Array<T>  diagExtract<T>    (const Array<T> &in, const int num); \
+    template Array<T>  diagCreate <T>    (const Array<T> &in, const int num);
 
     INSTANTIATE_DIAGONAL(float)
     INSTANTIATE_DIAGONAL(double)

--- a/src/backend/cpu/diagonal.hpp
+++ b/src/backend/cpu/diagonal.hpp
@@ -14,8 +14,8 @@
 namespace cpu
 {
     template<typename T>
-    Array<T>* diagCreate(const Array<T> &in, const int num);
+    Array<T> diagCreate(const Array<T> &in, const int num);
 
     template<typename T>
-    Array<T>* diagExtract(const Array<T> &in, const int num);
+    Array<T> diagExtract(const Array<T> &in, const int num);
 }

--- a/src/backend/cpu/diff.cpp
+++ b/src/backend/cpu/diff.cpp
@@ -23,7 +23,7 @@ namespace cpu
     }
 
     template<typename T>
-    Array<T>* diff1(const Array<T> &in, const int dim)
+    Array<T>  diff1(const Array<T> &in, const int dim)
     {
         // Bool for dimension
         bool is_dim0 = dim == 0;
@@ -36,11 +36,11 @@ namespace cpu
         dims[dim]--;
 
         // Create output placeholder
-        Array<T> *outArray = createValueArray(dims, (T)0);
+        Array<T> outArray = createValueArray(dims, (T)0);
 
         // Get pointers to raw data
         const T *inPtr = in.get();
-              T *outPtr = outArray->get();
+              T *outPtr = outArray.get();
 
         // TODO: Improve this
         for(dim_type l = 0; l < dims[3]; l++) {
@@ -52,7 +52,7 @@ namespace cpu
                         int jdx = getIdx(in.strides(), in.offsets(),
                                          i + is_dim0, j + is_dim1,
                                          k + is_dim2, l + is_dim3);
-                        int odx = getIdx(outArray->strides(), outArray->offsets(), i, j, k, l);
+                        int odx = getIdx(outArray.strides(), outArray.offsets(), i, j, k, l);
                         outPtr[odx] = inPtr[jdx] - inPtr[idx];
                     }
                 }
@@ -63,7 +63,7 @@ namespace cpu
     }
 
     template<typename T>
-    Array<T>* diff2(const Array<T> &in, const int dim)
+    Array<T>  diff2(const Array<T> &in, const int dim)
     {
         // Bool for dimension
         bool is_dim0 = dim == 0;
@@ -76,11 +76,11 @@ namespace cpu
         dims[dim] -= 2;
 
         // Create output placeholder
-        Array<T> *outArray = createValueArray(dims, (T)0);
+        Array<T> outArray = createValueArray(dims, (T)0);
 
         // Get pointers to raw data
         const T *inPtr = in.get();
-              T *outPtr = outArray->get();
+              T *outPtr = outArray.get();
 
         // TODO: Improve this
         for(dim_type l = 0; l < dims[3]; l++) {
@@ -95,7 +95,7 @@ namespace cpu
                         int kdx = getIdx(in.strides(), in.offsets(),
                                          i + 2 * is_dim0, j + 2 * is_dim1,
                                          k + 2 * is_dim2, l + 2 * is_dim3);
-                        int odx = getIdx(outArray->strides(), outArray->offsets(), i, j, k, l);
+                        int odx = getIdx(outArray.strides(), outArray.offsets(), i, j, k, l);
                         outPtr[odx] = inPtr[kdx] + inPtr[idx] - inPtr[jdx] - inPtr[jdx];
                     }
                 }
@@ -106,8 +106,8 @@ namespace cpu
     }
 
 #define INSTANTIATE(T)                                                  \
-    template Array<T>* diff1<T>  (const Array<T> &in, const int dim);   \
-    template Array<T>* diff2<T>  (const Array<T> &in, const int dim);   \
+    template Array<T>  diff1<T>  (const Array<T> &in, const int dim);   \
+    template Array<T>  diff2<T>  (const Array<T> &in, const int dim);   \
 
 
     INSTANTIATE(float)

--- a/src/backend/cpu/diff.hpp
+++ b/src/backend/cpu/diff.hpp
@@ -13,8 +13,8 @@
 namespace cpu
 {
     template<typename T>
-    Array<T> *diff1(const Array<T> &in, const int dim);
+    Array<T> diff1(const Array<T> &in, const int dim);
 
     template<typename T>
-    Array<T> *diff2(const Array<T> &in, const int dim);
+    Array<T> diff2(const Array<T> &in, const int dim);
 }

--- a/src/backend/cpu/fast.cpp
+++ b/src/backend/cpu/fast.cpp
@@ -249,7 +249,7 @@ unsigned fast(Array<float> &x_out, Array<float> &y_out, Array<float> &score_out,
 
     // Matrix containing scores for detected features, scores are stored in the
     // same coordinates as features, dimensions should be equal to in.
-    Array<T> *V = NULL;
+    Array<T> V = createEmptyArray<T>(dim4());
     if (nonmax == 1) {
         dim4 V_dims(in_dims[0], in_dims[1]);
         V = createValueArray<T>(V_dims, (T)0);
@@ -257,14 +257,14 @@ unsigned fast(Array<float> &x_out, Array<float> &y_out, Array<float> &score_out,
 
     // Arrays containing all features detected before non-maximal suppression.
     dim4 max_feat_dims(max_feat);
-    Array<float> *x = createEmptyArray<float>(max_feat_dims);
-    Array<float> *y = createEmptyArray<float>(max_feat_dims);
-    Array<float> *score = createEmptyArray<float>(max_feat_dims);
+    Array<float> x = createEmptyArray<float>(max_feat_dims);
+    Array<float> y = createEmptyArray<float>(max_feat_dims);
+    Array<float> score = createEmptyArray<float>(max_feat_dims);
 
     // Feature counter
     unsigned count = 0;
 
-    locate_features<T>(in, *V, *x, *y, *score, &count, thr, arc_length, nonmax, max_feat);
+    locate_features<T>(in, V, x, y, score, &count, thr, arc_length, nonmax, max_feat);
 
     // If more features than max_feat were detected, feat wasn't populated
     // with them anyway, so the real number of features will be that of
@@ -272,9 +272,9 @@ unsigned fast(Array<float> &x_out, Array<float> &y_out, Array<float> &score_out,
     unsigned feat_found = std::min(max_feat, count);
     dim4 feat_found_dims(feat_found);
 
-    Array<float> *x_total = NULL;
-    Array<float> *y_total = NULL;
-    Array<float> *score_total = NULL;
+    Array<float> x_total = createEmptyArray<float>(af::dim4());
+    Array<float> y_total = createEmptyArray<float>(af::dim4());
+    Array<float> score_total = createEmptyArray<float>(af::dim4());
 
     if (nonmax == 1) {
 
@@ -283,14 +283,9 @@ unsigned fast(Array<float> &x_out, Array<float> &y_out, Array<float> &score_out,
         score_total = createEmptyArray<float>(feat_found_dims);
 
         count = 0;
-        non_maximal<T>(*V, *x, *y,
-                       *x_total, *y_total, *score_total,
+        non_maximal<T>(V, x, y,
+                       x_total, y_total, score_total,
                        &count, feat_found);
-
-        destroyArray<T>(*V);
-        destroyArray<float>(*x);
-        destroyArray<float>(*y);
-        destroyArray<float>(*score);
 
         feat_found = std::min(max_feat, count);
     } else {
@@ -302,13 +297,13 @@ unsigned fast(Array<float> &x_out, Array<float> &y_out, Array<float> &score_out,
     if (feat_found > 0) {
         feat_found_dims = dim4(feat_found);
 
-        x_out = *createEmptyArray<float>(feat_found_dims);
-        y_out = *createEmptyArray<float>(feat_found_dims);
-        score_out = *createEmptyArray<float>(feat_found_dims);
+        x_out = createEmptyArray<float>(feat_found_dims);
+        y_out = createEmptyArray<float>(feat_found_dims);
+        score_out = createEmptyArray<float>(feat_found_dims);
 
-        float *x_total_ptr = x_total->get();
-        float *y_total_ptr = y_total->get();
-        float *score_total_ptr = score_total->get();
+        float *x_total_ptr = x_total.get();
+        float *y_total_ptr = y_total.get();
+        float *score_total_ptr = score_total.get();
 
 
         float *x_out_ptr = x_out.get();
@@ -321,10 +316,6 @@ unsigned fast(Array<float> &x_out, Array<float> &y_out, Array<float> &score_out,
             score_out_ptr[i] = score_total_ptr[i];
         }
     }
-
-    destroyArray<float>(*x_total);
-    destroyArray<float>(*y_total);
-    destroyArray<float>(*score_total);
 
     return feat_found;
 }

--- a/src/backend/cpu/fft.hpp
+++ b/src/backend/cpu/fft.hpp
@@ -13,9 +13,9 @@ namespace cpu
 {
 
 template<typename inType, typename outType, int rank, bool isR2C>
-Array<outType> * fft(Array<inType> const &in, double normalize, dim_type const npad, dim_type const * const pad);
+Array<outType> fft(Array<inType> const &in, double normalize, dim_type const npad, dim_type const * const pad);
 
 template<typename T, int rank>
-Array<T> * ifft(Array<T> const &in, double normalize, dim_type const npad, dim_type const * const pad);
+Array<T> ifft(Array<T> const &in, double normalize, dim_type const npad, dim_type const * const pad);
 
 }

--- a/src/backend/cpu/histogram.cpp
+++ b/src/backend/cpu/histogram.cpp
@@ -19,16 +19,16 @@ namespace cpu
 {
 
 template<typename inType, typename outType>
-Array<outType> * histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval)
+Array<outType> histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval)
 {
     const dim4 inDims   = in.dims();
     dim4 outDims        = dim4(nbins,1,inDims[2],inDims[3]);
 
     // create an array with first two dimensions swapped
-    Array<outType>* out = createEmptyArray<outType>(outDims);
+    Array<outType> out = createEmptyArray<outType>(outDims);
 
     // get data pointers for input and output Arrays
-    outType *outData    = out->get();
+    outType *outData    = out.get();
     const inType* inData= in.get();
 
     dim_type batchCount = inDims[2];
@@ -60,7 +60,7 @@ Array<outType> * histogram(const Array<inType> &in, const unsigned &nbins, const
 }
 
 #define INSTANTIATE(in_t,out_t)\
-template Array<out_t> * histogram(const Array<in_t> &in, const unsigned &nbins, const double &minval, const double &maxval);
+template Array<out_t> histogram(const Array<in_t> &in, const unsigned &nbins, const double &minval, const double &maxval);
 
 INSTANTIATE(float , uint)
 INSTANTIATE(double, uint)

--- a/src/backend/cpu/histogram.hpp
+++ b/src/backend/cpu/histogram.hpp
@@ -13,6 +13,6 @@ namespace cpu
 {
 
 template<typename inType, typename outType>
-Array<outType> * histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval);
+Array<outType> histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval);
 
 }

--- a/src/backend/cpu/identity.cpp
+++ b/src/backend/cpu/identity.cpp
@@ -17,11 +17,11 @@
 namespace cpu
 {
     template<typename T>
-    Array<T> *identity(const dim4& dims)
+    Array<T> identity(const dim4& dims)
     {
-        Array<T> *out = createEmptyArray<T>(dims);
-        T *ptr = out->get();
-        const dim_type *out_dims  = out->dims().get();
+        Array<T> out = createEmptyArray<T>(dims);
+        T *ptr = out.get();
+        const dim_type *out_dims  = out.dims().get();
 
         for (int k = 0; k < out_dims[2] * out_dims[3]; k++) {
 
@@ -36,7 +36,7 @@ namespace cpu
     }
 
 #define INSTANTIATE_IDENTITY(T)                              \
-    template Array<T>*  identity<T>    (const af::dim4 &dims);
+    template Array<T>  identity<T>    (const af::dim4 &dims);
 
     INSTANTIATE_IDENTITY(float)
     INSTANTIATE_IDENTITY(double)

--- a/src/backend/cpu/identity.hpp
+++ b/src/backend/cpu/identity.hpp
@@ -13,5 +13,5 @@
 namespace cpu
 {
     template<typename T>
-    Array<T> *identity(const dim4& dim);
+    Array<T> identity(const dim4& dim);
 }

--- a/src/backend/cpu/iota.cpp
+++ b/src/backend/cpu/iota.cpp
@@ -48,22 +48,22 @@ namespace cpu
     // Wrapper Functions
     ///////////////////////////////////////////////////////////////////////////
     template<typename T>
-    Array<T> *iota(const dim4& dim, const unsigned rep)
+    Array<T> iota(const dim4& dim, const unsigned rep)
     {
-        Array<T> *out = createEmptyArray<T>(dim);
+        Array<T> out = createEmptyArray<T>(dim);
         switch(rep) {
-            case 0: iota<T, 0>(out->get(), out->dims(), out->strides()); break;
-            case 1: iota<T, 1>(out->get(), out->dims(), out->strides()); break;
-            case 2: iota<T, 2>(out->get(), out->dims(), out->strides()); break;
-            case 3: iota<T, 3>(out->get(), out->dims(), out->strides()); break;
+            case 0: iota<T, 0>(out.get(), out.dims(), out.strides()); break;
+            case 1: iota<T, 1>(out.get(), out.dims(), out.strides()); break;
+            case 2: iota<T, 2>(out.get(), out.dims(), out.strides()); break;
+            case 3: iota<T, 3>(out.get(), out.dims(), out.strides()); break;
             default: AF_ERROR("Invalid rep selection", AF_ERR_INVALID_ARG);
         }
 
         return out;
     }
 
-#define INSTANTIATE(T)                                                         \
-    template Array<T>* iota<T>(const af::dim4 &dims, const unsigned rep);      \
+#define INSTANTIATE(T)                                                  \
+    template Array<T> iota<T>(const af::dim4 &dims, const unsigned rep); \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cpu/iota.hpp
+++ b/src/backend/cpu/iota.hpp
@@ -13,5 +13,5 @@
 namespace cpu
 {
     template<typename T>
-    Array<T> *iota(const dim4& dim, const unsigned rep);
+    Array<T> iota(const dim4& dim, const unsigned rep);
 }

--- a/src/backend/cpu/join.cpp
+++ b/src/backend/cpu/join.cpp
@@ -68,7 +68,7 @@ namespace cpu
     }
 
     template<typename Tx, typename Ty>
-    Array<Tx> *join(const int dim, const Array<Tx> &first, const Array<Ty> &second)
+    Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second)
     {
         // All dimensions except join dimension must be equal
         // Compute output dims
@@ -84,24 +84,24 @@ namespace cpu
             }
         }
 
-        Array<Tx> *out = createEmptyArray<Tx>(odims);
+        Array<Tx> out = createEmptyArray<Tx>(odims);
 
-        Tx* outPtr = out->get();
+        Tx* outPtr = out.get();
         const Tx* fptr = first.get();
         const Ty* sptr = second.get();
 
         switch(dim) {
             case 0: join_<Tx, Ty, 0>(outPtr, fptr, sptr, odims, fdims, sdims,
-                                     out->strides(), first.strides(), second.strides());
+                                     out.strides(), first.strides(), second.strides());
                     break;
             case 1: join_<Tx, Ty, 1>(outPtr, fptr, sptr, odims, fdims, sdims,
-                                     out->strides(), first.strides(), second.strides());
+                                     out.strides(), first.strides(), second.strides());
                     break;
             case 2: join_<Tx, Ty, 2>(outPtr, fptr, sptr, odims, fdims, sdims,
-                                     out->strides(), first.strides(), second.strides());
+                                     out.strides(), first.strides(), second.strides());
                     break;
             case 3: join_<Tx, Ty, 3>(outPtr, fptr, sptr, odims, fdims, sdims,
-                                     out->strides(), first.strides(), second.strides());
+                                     out.strides(), first.strides(), second.strides());
                     break;
         }
 
@@ -109,7 +109,7 @@ namespace cpu
     }
 
 #define INSTANTIATE(Tx, Ty)                                                                             \
-    template Array<Tx>* join<Tx, Ty>(const int dim, const Array<Tx> &first, const Array<Ty> &second);   \
+    template Array<Tx> join<Tx, Ty>(const int dim, const Array<Tx> &first, const Array<Ty> &second);   \
 
     INSTANTIATE(float,   float)
     INSTANTIATE(double,  double)

--- a/src/backend/cpu/join.hpp
+++ b/src/backend/cpu/join.hpp
@@ -13,5 +13,5 @@
 namespace cpu
 {
     template<typename Tx, typename Ty>
-    Array<Tx> *join(const int dim, const Array<Tx> &first, const Array<Ty> &second);
+    Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second);
 }

--- a/src/backend/cpu/logic.hpp
+++ b/src/backend/cpu/logic.hpp
@@ -70,7 +70,7 @@ LOGIC_CPLX_FN(double, af_or_t, ||)
 #undef LOGIC_CPLX_FN
 
     template<typename T, af_op_t op>
-    Array<uchar>* logicOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
+    Array<uchar> logicOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
     {
         TNJ::Node_ptr lhs_node = lhs.getNode();
         TNJ::Node_ptr rhs_node = rhs.getNode();
@@ -102,7 +102,7 @@ LOGIC_CPLX_FN(double, af_or_t, ||)
 #undef BITWISE_FN
 
     template<typename T, af_op_t op>
-    Array<T>* bitOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
+    Array<T> bitOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
     {
         TNJ::Node_ptr lhs_node = lhs.getNode();
         TNJ::Node_ptr rhs_node = rhs.getNode();

--- a/src/backend/cpu/match_template.cpp
+++ b/src/backend/cpu/match_template.cpp
@@ -20,7 +20,7 @@ namespace cpu
 {
 
 template<typename inType, typename outType, af_match_type mType>
-Array<outType>* match_template(const Array<inType> &sImg, const Array<inType> &tImg)
+Array<outType> match_template(const Array<inType> &sImg, const Array<inType> &tImg)
 {
     const dim4 sDims = sImg.dims();
     const dim4 tDims = tImg.dims();
@@ -32,8 +32,8 @@ Array<outType>* match_template(const Array<inType> &sImg, const Array<inType> &t
     const dim_type sDim0  = sDims[0];
     const dim_type sDim1  = sDims[1];
 
-    Array<outType> *out = createEmptyArray<outType>(sDims);
-    const dim4 oStrides = out->strides();
+    Array<outType> out = createEmptyArray<outType>(sDims);
+    const dim4 oStrides = out.strides();
 
     const dim_type batchNum = sDims[2];
 
@@ -56,7 +56,7 @@ Array<outType>* match_template(const Array<inType> &sImg, const Array<inType> &t
     }
 
     for(dim_type b=0; b<batchNum; ++b) {
-        outType * dst      = out->get() + b*oStrides[2];
+        outType * dst      = out.get() + b*oStrides[2];
         const inType * src = sImg.get() + b*sStrides[2];
 
         // slide through image window after window
@@ -138,15 +138,15 @@ Array<outType>* match_template(const Array<inType> &sImg, const Array<inType> &t
 }
 
 #define INSTANTIATE(in_t, out_t)\
-    template Array<out_t> * match_template<in_t, out_t, AF_SAD >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_LSAD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_ZSAD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_SSD >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_LSSD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_ZSSD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_NCC >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_ZNCC>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_SHD >(const Array<in_t> &sImg, const Array<in_t> &tImg);
+    template Array<out_t> match_template<in_t, out_t, AF_SAD >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_LSAD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_ZSAD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_SSD >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_LSSD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_ZSSD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_NCC >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_ZNCC>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_SHD >(const Array<in_t> &sImg, const Array<in_t> &tImg);
 
 INSTANTIATE(double, double)
 INSTANTIATE(float ,  float)

--- a/src/backend/cpu/match_template.hpp
+++ b/src/backend/cpu/match_template.hpp
@@ -13,6 +13,6 @@ namespace cpu
 {
 
 template<typename inType, typename outType, af_match_type mType>
-Array<outType>* match_template(const Array<inType> &sImg, const Array<inType> &tImg);
+Array<outType> match_template(const Array<inType> &sImg, const Array<inType> &tImg);
 
 }

--- a/src/backend/cpu/meanshift.cpp
+++ b/src/backend/cpu/meanshift.cpp
@@ -28,13 +28,13 @@ inline dim_type clamp(dim_type a, dim_type mn, dim_type mx)
 }
 
 template<typename T, bool is_color>
-Array<T> * meanshift(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter)
+Array<T>  meanshift(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter)
 {
     const dim4 dims     = in.dims();
     const dim4 istrides = in.strides();
 
-    Array<T>* out       = createEmptyArray<T>(dims);
-    const dim4 ostrides = out->strides();
+    Array<T> out       = createEmptyArray<T>(dims);
+    const dim4 ostrides = out.strides();
 
     const dim_type bIndex   = (is_color ? 3 : 2);
     const dim_type bCount   = dims[bIndex];
@@ -51,7 +51,7 @@ Array<T> * meanshift(const Array<T> &in, const float &s_sigma, const float &c_si
 
     for(dim_type batchId=0; batchId<bCount; ++batchId) {
 
-        T *outData       = out->get() + batchId*ostrides[bIndex];
+        T *outData       = out.get() + batchId*ostrides[bIndex];
         const T * inData = in.get()   + batchId*istrides[bIndex];
 
         for(dim_type j=0; j<dims[1]; ++j) {
@@ -141,8 +141,8 @@ Array<T> * meanshift(const Array<T> &in, const float &s_sigma, const float &c_si
 }
 
 #define INSTANTIATE(T) \
-    template Array<T> * meanshift<T, true >(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter); \
-    template Array<T> * meanshift<T, false>(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter);
+    template Array<T>  meanshift<T, true >(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter); \
+    template Array<T>  meanshift<T, false>(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter);
 
 INSTANTIATE(float )
 INSTANTIATE(double)

--- a/src/backend/cpu/meanshift.hpp
+++ b/src/backend/cpu/meanshift.hpp
@@ -13,6 +13,6 @@ namespace cpu
 {
 
 template<typename T, bool is_color>
-Array<T> * meanshift(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter);
+Array<T> meanshift(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter);
 
 }

--- a/src/backend/cpu/medfilt.cpp
+++ b/src/backend/cpu/medfilt.cpp
@@ -21,14 +21,14 @@ namespace cpu
 {
 
 template<typename T, af_pad_type pad>
-Array<T> * medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid)
+Array<T> medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid)
 {
     const dim4 dims     = in.dims();
     const dim4 istrides = in.strides();
 
-    Array<T> * out      = createEmptyArray<T>(dims);
+    Array<T> out      = createEmptyArray<T>(dims);
 
-    const dim4 ostrides = out->strides();
+    const dim4 ostrides = out.strides();
 
     std::vector<T> wind_vals;
     wind_vals.reserve(w_len*w_wid);
@@ -36,7 +36,7 @@ Array<T> * medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid)
     for(dim_type batchId=0; batchId<dims[2]; batchId++) {
 
         T const * in_ptr = in.get() + batchId*istrides[2];
-        T * out_ptr = out->get() + batchId*ostrides[2];
+        T * out_ptr = out.get() + batchId*ostrides[2];
 
         for(dim_type col=0; col<dims[1]; col++) {
 
@@ -133,8 +133,8 @@ Array<T> * medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid)
 }
 
 #define INSTANTIATE(T)\
-    template Array<T> * medfilt<T, AF_ZERO     >(const Array<T> &in, dim_type w_len, dim_type w_wid); \
-    template Array<T> * medfilt<T, AF_SYMMETRIC>(const Array<T> &in, dim_type w_len, dim_type w_wid);
+    template Array<T> medfilt<T, AF_ZERO     >(const Array<T> &in, dim_type w_len, dim_type w_wid); \
+    template Array<T> medfilt<T, AF_SYMMETRIC>(const Array<T> &in, dim_type w_len, dim_type w_wid);
 
 INSTANTIATE(float )
 INSTANTIATE(double)

--- a/src/backend/cpu/medfilt.hpp
+++ b/src/backend/cpu/medfilt.hpp
@@ -13,6 +13,6 @@ namespace cpu
 {
 
 template<typename T, af_pad_type edge_pad>
-Array<T> * medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid);
+Array<T> medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid);
 
 }

--- a/src/backend/cpu/morph.cpp
+++ b/src/backend/cpu/morph.cpp
@@ -29,7 +29,7 @@ static inline unsigned getIdx(const dim4 &strides,
 }
 
 template<typename T, bool isDilation>
-Array<T> * morph(const Array<T> &in, const Array<T> &mask)
+Array<T> morph(const Array<T> &in, const Array<T> &mask)
 {
     const dim4 dims       = in.dims();
     const dim4 window     = mask.dims();
@@ -39,10 +39,10 @@ Array<T> * morph(const Array<T> &in, const Array<T> &mask)
     const dim4 fstrides   = mask.strides();
     const dim_type bCount = dims[2];
 
-    Array<T>* out         = createEmptyArray<T>(dims);
-    const dim4 ostrides   = out->strides();
+    Array<T> out         = createEmptyArray<T>(dims);
+    const dim4 ostrides   = out.strides();
 
-    T* outData            = out->get();
+    T* outData            = out.get();
     const T*   inData     = in.get();
     const T*   filter     = mask.get();
 
@@ -89,7 +89,7 @@ Array<T> * morph(const Array<T> &in, const Array<T> &mask)
 }
 
 template<typename T, bool isDilation>
-Array<T> * morph3d(const Array<T> &in, const Array<T> &mask)
+Array<T> morph3d(const Array<T> &in, const Array<T> &mask)
 {
     const dim4 dims       = in.dims();
     const dim4 window     = mask.dims();
@@ -100,10 +100,10 @@ Array<T> * morph3d(const Array<T> &in, const Array<T> &mask)
     const dim4 fstrides   = mask.strides();
     const dim_type bCount = dims[3];
 
-    Array<T>* out         = createEmptyArray<T>(dims);
-    const dim4 ostrides   = out->strides();
+    Array<T> out         = createEmptyArray<T>(dims);
+    const dim4 ostrides   = out.strides();
 
-    T* outData            = out->get();
+    T* outData            = out.get();
     const T*   inData     = in.get();
     const T*   filter     = mask.get();
 
@@ -156,10 +156,10 @@ Array<T> * morph3d(const Array<T> &in, const Array<T> &mask)
 }
 
 #define INSTANTIATE(T)\
-    template Array<T> * morph  <T, true >(const Array<T> &in, const Array<T> &mask);\
-    template Array<T> * morph  <T, false>(const Array<T> &in, const Array<T> &mask);\
-    template Array<T> * morph3d<T, true >(const Array<T> &in, const Array<T> &mask);\
-    template Array<T> * morph3d<T, false>(const Array<T> &in, const Array<T> &mask);
+    template Array<T> morph  <T, true >(const Array<T> &in, const Array<T> &mask);\
+    template Array<T> morph  <T, false>(const Array<T> &in, const Array<T> &mask);\
+    template Array<T> morph3d<T, true >(const Array<T> &in, const Array<T> &mask);\
+    template Array<T> morph3d<T, false>(const Array<T> &in, const Array<T> &mask);
 
 INSTANTIATE(float )
 INSTANTIATE(double)

--- a/src/backend/cpu/morph.hpp
+++ b/src/backend/cpu/morph.hpp
@@ -13,9 +13,9 @@ namespace cpu
 {
 
 template<typename T, bool isDilation>
-Array<T> * morph(const Array<T> &in, const Array<T> &mask);
+Array<T> morph(const Array<T> &in, const Array<T> &mask);
 
 template<typename T, bool isDilation>
-Array<T> * morph3d(const Array<T> &in, const Array<T> &mask);
+Array<T> morph3d(const Array<T> &in, const Array<T> &mask);
 
 }

--- a/src/backend/cpu/random.cpp
+++ b/src/backend/cpu/random.cpp
@@ -69,33 +69,33 @@ nrand(GenType &generator)
 }
 
 template<typename T>
-Array<T>* randn(const af::dim4 &dims)
+Array<T> randn(const af::dim4 &dims)
 {
     static default_random_engine generator;
     static auto gen = nrand<T>(generator);
 
-    Array<T> *outArray = createEmptyArray<T>(dims);
-    T *outPtr = outArray->get();
-    generate(outPtr, outPtr + outArray->elements(), nrand<T>(generator));
+    Array<T> outArray = createEmptyArray<T>(dims);
+    T *outPtr = outArray.get();
+    generate(outPtr, outPtr + outArray.elements(), nrand<T>(generator));
     return outArray;
 }
 
 template<typename T>
-Array<T>* randu(const af::dim4 &dims)
+Array<T> randu(const af::dim4 &dims)
 {
     static default_random_engine generator;
     static auto gen = urand<T>(generator);
 
-    Array<T> *outArray = createEmptyArray<T>(dims);
-    T *outPtr = outArray->get();
-    for (int i = 0; i < (int)outArray->elements(); i++) {
+    Array<T> outArray = createEmptyArray<T>(dims);
+    T *outPtr = outArray.get();
+    for (int i = 0; i < (int)outArray.elements(); i++) {
         outPtr[i] = gen();
     }
     return outArray;
 }
 
 #define INSTANTIATE_UNIFORM(T)                              \
-    template Array<T>*  randu<T>    (const af::dim4 &dims);
+    template Array<T>  randu<T>    (const af::dim4 &dims);
 
 INSTANTIATE_UNIFORM(float)
 INSTANTIATE_UNIFORM(double)
@@ -106,7 +106,7 @@ INSTANTIATE_UNIFORM(uint)
 INSTANTIATE_UNIFORM(uchar)
 
 #define INSTANTIATE_NORMAL(T)                              \
-    template Array<T>*  randn<T>(const af::dim4 &dims);
+    template Array<T>  randn<T>(const af::dim4 &dims);
 
 INSTANTIATE_NORMAL(float)
 INSTANTIATE_NORMAL(double)
@@ -115,14 +115,14 @@ INSTANTIATE_NORMAL(cdouble)
 
 
 template<>
-Array<char> *randu(const af::dim4 &dims)
+Array<char> randu(const af::dim4 &dims)
 {
     static default_random_engine generator;
     static auto gen = urand<float>(generator);
 
-    Array<char> *outArray = createEmptyArray<char>(dims);
-    char *outPtr = outArray->get();
-    for (int i = 0; i < (int)outArray->elements(); i++) {
+    Array<char> outArray = createEmptyArray<char>(dims);
+    char *outPtr = outArray.get();
+    for (int i = 0; i < (int)outArray.elements(); i++) {
         outPtr[i] = gen() > 0.5;
     }
     return outArray;

--- a/src/backend/cpu/random.hpp
+++ b/src/backend/cpu/random.hpp
@@ -7,13 +7,14 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#pragma once
+#include <af/array.h>
+#include <Array.hpp>
 
 namespace cpu
 {
     template<typename T>
-    Array<T> *randu(const af::dim4 &dims);
+    Array<T> randu(const af::dim4 &dims);
 
     template<typename T>
-    Array<T> *randn(const af::dim4 &dims);
+    Array<T> randn(const af::dim4 &dims);
 }

--- a/src/backend/cpu/reduce.cpp
+++ b/src/backend/cpu/reduce.cpp
@@ -61,31 +61,31 @@ namespace cpu
     };
 
     template<af_op_t op, typename Ti, typename To>
-    Array<To>* reduce(const Array<Ti> &in, const int dim)
+    Array<To> reduce(const Array<Ti> &in, const int dim)
     {
         dim4 odims = in.dims();
         odims[dim] = 1;
 
-        Array<To> *out = createEmptyArray<To>(odims);
+        Array<To> out = createEmptyArray<To>(odims);
 
         switch (in.ndims()) {
         case 1:
-            reduce_dim<op, Ti, To, 1>()(out->get(), out->strides(), out->dims(),
+            reduce_dim<op, Ti, To, 1>()(out.get(), out.strides(), out.dims(),
                                         in.get(), in.strides(), in.dims(), dim);
             break;
 
         case 2:
-            reduce_dim<op, Ti, To, 2>()(out->get(), out->strides(), out->dims(),
+            reduce_dim<op, Ti, To, 2>()(out.get(), out.strides(), out.dims(),
                                         in.get(), in.strides(), in.dims(), dim);
             break;
 
         case 3:
-            reduce_dim<op, Ti, To, 3>()(out->get(), out->strides(), out->dims(),
+            reduce_dim<op, Ti, To, 3>()(out.get(), out.strides(), out.dims(),
                                         in.get(), in.strides(), in.dims(), dim);
             break;
 
         case 4:
-            reduce_dim<op, Ti, To, 4>()(out->get(), out->strides(), out->dims(),
+            reduce_dim<op, Ti, To, 4>()(out.get(), out.strides(), out.dims(),
                                         in.get(), in.strides(), in.dims(), dim);
             break;
         }
@@ -129,7 +129,7 @@ namespace cpu
     }
 
 #define INSTANTIATE(ROp, Ti, To)                                        \
-    template Array<To>* reduce<ROp, Ti, To>(const Array<Ti> &in, const int dim); \
+    template Array<To> reduce<ROp, Ti, To>(const Array<Ti> &in, const int dim); \
     template To reduce_all<ROp, Ti, To>(const Array<Ti> &in);
 
     //min

--- a/src/backend/cpu/reduce.hpp
+++ b/src/backend/cpu/reduce.hpp
@@ -14,7 +14,7 @@
 namespace cpu
 {
     template<af_op_t op, typename Ti, typename To>
-    Array<To>* reduce(const Array<Ti> &in, const int dim);
+    Array<To> reduce(const Array<Ti> &in, const int dim);
 
     template<af_op_t op, typename Ti, typename To>
     To reduce_all(const Array<Ti> &in);

--- a/src/backend/cpu/regions.cpp
+++ b/src/backend/cpu/regions.cpp
@@ -21,7 +21,7 @@
 using af::dim4;
 
 namespace cpu
-{ 
+{
 
 template<typename T>
 class LabelNode
@@ -104,15 +104,15 @@ static void setUnion(LabelNode<T>* x, LabelNode<T>* y)
 }
 
 template<typename T>
-Array<T> * regions(const Array<uchar> &in, af_connectivity connectivity)
+Array<T> regions(const Array<uchar> &in, af_connectivity connectivity)
 {
     const dim4 in_dims = in.dims();
 
     // Create output placeholder
-    Array<T> *out = createValueArray(in_dims, (T)0);
+    Array<T> out = createValueArray(in_dims, (T)0);
 
     const uchar *in_ptr  = in.get();
-          T     *out_ptr = out->get();
+          T     *out_ptr = out.get();
 
     // Map labels
     typedef typename std::map<T, LabelNode<T>* > label_map_t;
@@ -202,7 +202,7 @@ Array<T> * regions(const Array<uchar> &in, af_connectivity connectivity)
 }
 
 #define INSTANTIATE(T)\
-    template Array<T> * regions<T>(const Array<uchar> &in, af_connectivity connectivity);
+    template Array<T> regions<T>(const Array<uchar> &in, af_connectivity connectivity);
 
 INSTANTIATE(float )
 INSTANTIATE(double)

--- a/src/backend/cpu/regions.hpp
+++ b/src/backend/cpu/regions.hpp
@@ -13,6 +13,6 @@ namespace cpu
 {
 
 template<typename T>
-Array<T> * regions(const Array<uchar> &in, af_connectivity connectivity);
+Array<T>  regions(const Array<uchar> &in, af_connectivity connectivity);
 
 }

--- a/src/backend/cpu/reorder.cpp
+++ b/src/backend/cpu/reorder.cpp
@@ -15,20 +15,20 @@
 namespace cpu
 {
     template<typename T>
-    Array<T> *reorder(const Array<T> &in, const af::dim4 &rdims)
+    Array<T> reorder(const Array<T> &in, const af::dim4 &rdims)
     {
         const af::dim4 iDims = in.dims();
         af::dim4 oDims(0);
         for(int i = 0; i < 4; i++)
             oDims[i] = iDims[rdims[i]];
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
-        T* outPtr = out->get();
+        T* outPtr = out.get();
         const T* inPtr = in.get();
 
         const af::dim4 ist = in.strides();
-        const af::dim4 ost = out->strides();
+        const af::dim4 ost = out.strides();
 
 
         dim_type ids[4]  = {0};
@@ -58,7 +58,7 @@ namespace cpu
     }
 
 #define INSTANTIATE(T)                                                         \
-    template Array<T>* reorder<T>(const Array<T> &in, const af::dim4 &rdims);  \
+    template Array<T> reorder<T>(const Array<T> &in, const af::dim4 &rdims);  \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cpu/reorder.hpp
+++ b/src/backend/cpu/reorder.hpp
@@ -13,5 +13,5 @@
 namespace cpu
 {
     template<typename T>
-    Array<T> *reorder(const Array<T> &in, const af::dim4 &rdims);
+    Array<T> reorder(const Array<T> &in, const af::dim4 &rdims);
 }

--- a/src/backend/cpu/resize.cpp
+++ b/src/backend/cpu/resize.cpp
@@ -124,20 +124,20 @@ namespace cpu
     }
 
     template<typename T>
-    Array<T>* resize(const Array<T> &in, const dim_type odim0, const dim_type odim1,
-                     const af_interp_type method)
+    Array<T> resize(const Array<T> &in, const dim_type odim0, const dim_type odim1,
+                    const af_interp_type method)
     {
         af::dim4 idims = in.dims();
         af::dim4 odims(odim0, odim1, idims[2], idims[3]);
 
         // Create output placeholder
-        Array<T> *outArray = createValueArray(odims, (T)0);
+        Array<T> outArray = createValueArray(odims, (T)0);
 
         // Get pointers to raw data
         const T *inPtr = in.get();
-              T *outPtr = outArray->get();
+              T *outPtr = outArray.get();
 
-        af::dim4 ostrides = outArray->strides();
+        af::dim4 ostrides = outArray.strides();
         af::dim4 istrides = in.strides();
 
         switch(method) {
@@ -155,8 +155,8 @@ namespace cpu
 
 
 #define INSTANTIATE(T)                                                                            \
-    template Array<T>* resize<T> (const Array<T> &in, const dim_type odim0, const dim_type odim1, \
-                                  const af_interp_type method);
+    template Array<T> resize<T> (const Array<T> &in, const dim_type odim0, const dim_type odim1, \
+                                 const af_interp_type method);
 
 
     INSTANTIATE(float)

--- a/src/backend/cpu/resize.hpp
+++ b/src/backend/cpu/resize.hpp
@@ -13,6 +13,6 @@
 namespace cpu
 {
     template<typename T>
-    Array<T> *resize(const Array<T> &in, const dim_type odim0, const dim_type odim1,
-                     const af_interp_type method);
+    Array<T> resize(const Array<T> &in, const dim_type odim0, const dim_type odim1,
+                    const af_interp_type method);
 }

--- a/src/backend/cpu/rotate.cpp
+++ b/src/backend/cpu/rotate.cpp
@@ -64,20 +64,20 @@ namespace cpu
     }
 
     template<typename T>
-    Array<T> *rotate(const Array<T> &in, const float theta, const af::dim4 &odims,
+    Array<T> rotate(const Array<T> &in, const float theta, const af::dim4 &odims,
                      const af_interp_type method)
     {
-        Array<T> *out = createEmptyArray<T>(odims);
+        Array<T> out = createEmptyArray<T>(odims);
         const af::dim4 idims = in.dims();
 
         switch(method) {
             case AF_INTERP_NEAREST:
                 rotate_<T, AF_INTERP_NEAREST>
-                       (out->get(), in.get(), theta, odims, idims, out->strides(), in.strides());
+                       (out.get(), in.get(), theta, odims, idims, out.strides(), in.strides());
                 break;
             case AF_INTERP_BILINEAR:
                 rotate_<T, AF_INTERP_BILINEAR>
-                       (out->get(), in.get(), theta, odims, idims, out->strides(), in.strides());
+                       (out.get(), in.get(), theta, odims, idims, out.strides(), in.strides());
                 break;
             default:
                 AF_ERROR("Unsupported interpolation type", AF_ERR_ARG);
@@ -89,8 +89,8 @@ namespace cpu
 
 
 #define INSTANTIATE(T)                                                                          \
-    template Array<T> *rotate(const Array<T> &in, const float theta,                            \
-                              const af::dim4 &odims, const af_interp_type method);              \
+    template Array<T> rotate(const Array<T> &in, const float theta,                            \
+                             const af::dim4 &odims, const af_interp_type method); \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cpu/rotate.hpp
+++ b/src/backend/cpu/rotate.hpp
@@ -13,6 +13,6 @@
 namespace cpu
 {
     template<typename T>
-    Array<T> *rotate(const Array<T> &in, const float theta, const af::dim4 &odims,
-                     const af_interp_type method);
+    Array<T> rotate(const Array<T> &in, const float theta, const af::dim4 &odims,
+                    const af_interp_type method);
 }

--- a/src/backend/cpu/scan.cpp
+++ b/src/backend/cpu/scan.cpp
@@ -63,30 +63,30 @@ namespace cpu
     };
 
     template<af_op_t op, typename Ti, typename To>
-    Array<To>* scan(const Array<Ti>& in, const int dim)
+    Array<To> scan(const Array<Ti>& in, const int dim)
     {
         dim4 dims = in.dims();
 
-        Array<To> *out = createValueArray<To>(dims, 0);
+        Array<To> out = createValueArray<To>(dims, 0);
 
         switch (in.ndims()) {
         case 1:
-            scan_dim<op, Ti, To, 1>()(out->get(), out->strides(), out->dims(),
+            scan_dim<op, Ti, To, 1>()(out.get(), out.strides(), out.dims(),
                                       in.get(), in.strides(), in.dims(), dim);
             break;
 
         case 2:
-            scan_dim<op, Ti, To, 2>()(out->get(), out->strides(), out->dims(),
+            scan_dim<op, Ti, To, 2>()(out.get(), out.strides(), out.dims(),
                                       in.get(), in.strides(), in.dims(), dim);
             break;
 
         case 3:
-            scan_dim<op, Ti, To, 3>()(out->get(), out->strides(), out->dims(),
+            scan_dim<op, Ti, To, 3>()(out.get(), out.strides(), out.dims(),
                                       in.get(), in.strides(), in.dims(), dim);
             break;
 
         case 4:
-            scan_dim<op, Ti, To, 4>()(out->get(), out->strides(), out->dims(),
+            scan_dim<op, Ti, To, 4>()(out.get(), out.strides(), out.dims(),
                                       in.get(), in.strides(), in.dims(), dim);
             break;
         }
@@ -95,7 +95,7 @@ namespace cpu
     }
 
 #define INSTANTIATE(ROp, Ti, To)                                        \
-    template Array<To>* scan<ROp, Ti, To>(const Array<Ti> &in, const int dim); \
+    template Array<To> scan<ROp, Ti, To>(const Array<Ti> &in, const int dim); \
 
     //accum
     INSTANTIATE(af_add_t, float  , float  )

--- a/src/backend/cpu/scan.hpp
+++ b/src/backend/cpu/scan.hpp
@@ -14,5 +14,5 @@
 namespace cpu
 {
     template<af_op_t op, typename Ti, typename To>
-    Array<To>* scan(const Array<Ti>& in, const int dim);
+    Array<To> scan(const Array<Ti>& in, const int dim);
 }

--- a/src/backend/cpu/set.cpp
+++ b/src/backend/cpu/set.cpp
@@ -25,91 +25,89 @@ namespace cpu
     using af::dim4;
 
     template<typename T>
-    Array<T>* setUnique(const Array<T> &in,
+    Array<T> setUnique(const Array<T> &in,
                         const bool is_sorted)
     {
-        Array<T> *out;
+        Array<T> out = createEmptyArray<T>(af::dim4());
         if (is_sorted) out = copyArray<T>(in);
         else           out = sort<T, 1>(in, 0);
 
-        T *ptr = out->get();
+        T *ptr = out.get();
         T *last = std::unique(ptr, ptr + in.elements());
         dim_type dist = (dim_type)std::distance(ptr, last);
 
         dim4 dims(dist, 1, 1, 1);
-        out->resetDims(dims);
+        out.resetDims(dims);
         return out;
     }
 
     template<typename T>
-    Array<T>* setUnion(const Array<T> &first,
+    Array<T> setUnion(const Array<T> &first,
                        const Array<T> &second,
                        const bool is_unique)
     {
         Array<T> uFirst = first;
         Array<T> uSecond = second;
-        Array<T> *out;
 
         if (!is_unique) {
             // FIXME: Perhaps copy + unique would do ?
-            uFirst  = *setUnique(first, false);
-            uSecond = *setUnique(second, false);
+            uFirst  = setUnique(first, false);
+            uSecond = setUnique(second, false);
         }
 
         dim_type first_elements  = uFirst.elements();
         dim_type second_elements = uSecond.elements();
         dim_type elements = first_elements + second_elements;
 
-        out = createEmptyArray<T>(af::dim4(elements));
+        Array<T> out = createEmptyArray<T>(af::dim4(elements));
 
-        T *ptr = out->get();
+        T *ptr = out.get();
         T *last = std::set_union(uFirst.get() , uFirst.get()  + first_elements,
                                  uSecond.get(), uSecond.get() + second_elements,
                                  ptr);
 
         dim_type dist = (dim_type)std::distance(ptr, last);
         dim4 dims(dist, 1, 1, 1);
-        out->resetDims(dims);
+        out.resetDims(dims);
 
         return out;
     }
 
     template<typename T>
-    Array<T>* setIntersect(const Array<T> &first,
-                           const Array<T> &second,
-                           const bool is_unique)
+    Array<T> setIntersect(const Array<T> &first,
+                          const Array<T> &second,
+                          const bool is_unique)
     {
         Array<T> uFirst = first;
         Array<T> uSecond = second;
-        Array<T> *out;
 
         if (!is_unique) {
-            uFirst  = *setUnique(first, false);
-            uSecond = *setUnique(second, false);
+            uFirst  = setUnique(first, false);
+            uSecond = setUnique(second, false);
         }
 
         dim_type first_elements  = uFirst.elements();
         dim_type second_elements = uSecond.elements();
         dim_type elements = std::max(first_elements, second_elements);
 
-        out = createEmptyArray<T>(af::dim4(elements));
+        Array<T> out = createEmptyArray<T>(af::dim4(elements));
 
-        T *ptr = out->get();
+        T *ptr = out.get();
         T *last = std::set_intersection(uFirst.get() , uFirst.get()  + first_elements,
                                         uSecond.get(), uSecond.get() + second_elements,
                                         ptr);
 
         dim_type dist = (dim_type)std::distance(ptr, last);
         dim4 dims(dist, 1, 1, 1);
-        out->resetDims(dims);
+        out.resetDims(dims);
 
         return out;
     }
 
 #define INSTANTIATE(T)                                                  \
-    template Array<T>* setUnique<T>(const Array<T> &in, const bool is_sorted); \
-    template Array<T>* setUnion<T>(const Array<T> &first, const Array<T> &second, const bool is_unique); \
-    template Array<T>* setIntersect<T>(const Array<T> &first, const Array<T> &second, const bool is_unique); \
+    template Array<T> setUnique<T>(const Array<T> &in, const bool is_sorted); \
+    template Array<T> setUnion<T>(const Array<T> &first, const Array<T> &second, const bool is_unique); \
+    template Array<T> setIntersect<T>(const Array<T> &first, const Array<T> &second, const bool is_unique); \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cpu/set.hpp
+++ b/src/backend/cpu/set.hpp
@@ -12,14 +12,14 @@
 
 namespace cpu
 {
-    template<typename T> Array<T>* setUnique(const Array<T> &in,
-                                             const bool is_sorted);
+    template<typename T> Array<T> setUnique(const Array<T> &in,
+                                            const bool is_sorted);
 
-    template<typename T> Array<T>* setUnion(const Array<T> &first,
-                                            const Array<T> &second,
-                                            const bool is_unique);
+    template<typename T> Array<T> setUnion(const Array<T> &first,
+                                           const Array<T> &second,
+                                           const bool is_unique);
 
-    template<typename T> Array<T>* setIntersect(const Array<T> &first,
-                                                const Array<T> &second,
-                                                const bool is_unique);
+    template<typename T> Array<T> setIntersect(const Array<T> &first,
+                                               const Array<T> &second,
+                                               const bool is_unique);
 }

--- a/src/backend/cpu/shift.cpp
+++ b/src/backend/cpu/shift.cpp
@@ -21,18 +21,18 @@ namespace cpu
     }
 
     template<typename T>
-    Array<T> *shift(const Array<T> &in, const af::dim4 &sdims)
+    Array<T> shift(const Array<T> &in, const af::dim4 &sdims)
     {
         const af::dim4 iDims = in.dims();
         af::dim4 oDims = iDims;
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
-        T* outPtr = out->get();
+        T* outPtr = out.get();
         const T* inPtr = in.get();
 
         const af::dim4 ist = in.strides();
-        const af::dim4 ost = out->strides();
+        const af::dim4 ost = out.strides();
 
         dim_type sdims_[4];
         // Need to do this because we are mapping output to input in the kernel
@@ -69,8 +69,8 @@ namespace cpu
         return out;
     }
 
-#define INSTANTIATE(T)                                                          \
-    template Array<T>* shift<T>(const Array<T> &in, const af::dim4 &sdims);     \
+#define INSTANTIATE(T)                                                  \
+    template Array<T> shift<T>(const Array<T> &in, const af::dim4 &sdims); \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cpu/shift.hpp
+++ b/src/backend/cpu/shift.hpp
@@ -13,5 +13,5 @@
 namespace cpu
 {
     template<typename T>
-    Array<T> *shift(const Array<T> &in, const af::dim4 &sdims);
+    Array<T> shift(const Array<T> &in, const af::dim4 &sdims);
 }

--- a/src/backend/cpu/sobel.cpp
+++ b/src/backend/cpu/sobel.cpp
@@ -80,20 +80,20 @@ void derivative(To *optr, Ti const *iptr, dim4 const &dims, dim4 const &strides)
 }
 
 template<typename Ti, typename To>
-std::pair< Array<To>*, Array<To>* >
+std::pair< Array<To>, Array<To> >
 sobelDerivatives(const Array<Ti> &img, const unsigned &ker_size)
 {
-    Array<To> *dx = createEmptyArray<To>(img.dims());
-    Array<To> *dy = createEmptyArray<To>(img.dims());
+    Array<To> dx = createEmptyArray<To>(img.dims());
+    Array<To> dy = createEmptyArray<To>(img.dims());
 
-    derivative<Ti, To, true >(dx->get(), img.get(), img.dims(), img.strides());
-    derivative<Ti, To, false>(dy->get(), img.get(), img.dims(), img.strides());
+    derivative<Ti, To, true >(dx.get(), img.get(), img.dims(), img.strides());
+    derivative<Ti, To, false>(dy.get(), img.get(), img.dims(), img.strides());
 
     return std::make_pair(dx, dy);
 }
 
 #define INSTANTIATE(Ti, To)                                                 \
-    template std::pair< Array<To>*, Array<To>* >                            \
+    template std::pair< Array<To>, Array<To> >                            \
     sobelDerivatives(const Array<Ti> &img, const unsigned &ker_size);
 
 INSTANTIATE(float , float)

--- a/src/backend/cpu/sobel.hpp
+++ b/src/backend/cpu/sobel.hpp
@@ -14,7 +14,7 @@ namespace cpu
 {
 
 template<typename Ti, typename To>
-std::pair< Array<To>*, Array<To>* >
+std::pair< Array<To>, Array<To> >
 sobelDerivatives(const Array<Ti> &img, const unsigned &ker_size);
 
 }

--- a/src/backend/cpu/sort.cpp
+++ b/src/backend/cpu/sort.cpp
@@ -58,11 +58,11 @@ namespace cpu
     // Wrapper Functions
     ///////////////////////////////////////////////////////////////////////////
     template<typename T, bool isAscending>
-    Array<T>* sort(const Array<T> &in, const unsigned dim)
+    Array<T> sort(const Array<T> &in, const unsigned dim)
     {
-        Array<T> *out = copyArray<T>(in);
+        Array<T> out = copyArray<T>(in);
         switch(dim) {
-            case 0: sort0<T, isAscending>(*out);
+            case 0: sort0<T, isAscending>(out);
                     break;
             default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
         }
@@ -70,8 +70,8 @@ namespace cpu
     }
 
 #define INSTANTIATE(T)                                                  \
-    template Array<T>* sort<T, true>(const Array<T> &in, const unsigned dim); \
-    template Array<T>*  sort<T,false>(const Array<T> &in, const unsigned dim); \
+    template Array<T> sort<T, true>(const Array<T> &in, const unsigned dim); \
+    template Array<T> sort<T,false>(const Array<T> &in, const unsigned dim); \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cpu/sort.hpp
+++ b/src/backend/cpu/sort.hpp
@@ -13,5 +13,5 @@
 namespace cpu
 {
     template<typename T, bool isAscending>
-    Array<T>* sort(const Array<T> &in, const unsigned dim);
+    Array<T> sort(const Array<T> &in, const unsigned dim);
 }

--- a/src/backend/cpu/sort_by_key.cpp
+++ b/src/backend/cpu/sort_by_key.cpp
@@ -38,14 +38,14 @@ namespace cpu
         if(isAscending) { op = less<Tk>(); }
 
         // Get pointers and initialize original index locations
-        Array<uint> *oidx = createValueArray(ikey.dims(), 0u);
-            uint *oidx_ptr = oidx->get();
+        Array<uint> oidx = createValueArray(ikey.dims(), 0u);
+            uint *oidx_ptr = oidx.get();
               Tk *okey_ptr = okey.get();
               Tv *oval_ptr = oval.get();
         const Tk *ikey_ptr = ikey.get();
         const Tv *ival_ptr = ival.get();
 
-        std::vector<uint> seq_vec(oidx->dims()[0]);
+        std::vector<uint> seq_vec(oidx.dims()[0]);
         std::iota(seq_vec.begin(), seq_vec.end(), 0);
 
         const Tk *comp_ptr = nullptr;
@@ -54,14 +54,14 @@ namespace cpu
         for(dim_type w = 0; w < ikey.dims()[3]; w++) {
             dim_type okeyW = w * okey.strides()[3];
             dim_type ovalW = w * oval.strides()[3];
-            dim_type oidxW = w * oidx->strides()[3];
+            dim_type oidxW = w * oidx.strides()[3];
             dim_type ikeyW = w * ikey.strides()[3];
             dim_type ivalW = w * ival.strides()[3];
 
             for(dim_type z = 0; z < ikey.dims()[2]; z++) {
                 dim_type okeyWZ = okeyW + z * okey.strides()[2];
                 dim_type ovalWZ = ovalW + z * oval.strides()[2];
-                dim_type oidxWZ = oidxW + z * oidx->strides()[2];
+                dim_type oidxWZ = oidxW + z * oidx.strides()[2];
                 dim_type ikeyWZ = ikeyW + z * ikey.strides()[2];
                 dim_type ivalWZ = ivalW + z * ival.strides()[2];
 
@@ -69,7 +69,7 @@ namespace cpu
 
                     dim_type okeyOffset = okeyWZ + y * okey.strides()[1];
                     dim_type ovalOffset = ovalWZ + y * oval.strides()[1];
-                    dim_type oidxOffset = oidxWZ + y * oidx->strides()[1];
+                    dim_type oidxOffset = oidxWZ + y * oidx.strides()[1];
                     dim_type ikeyOffset = ikeyWZ + y * ikey.strides()[1];
                     dim_type ivalOffset = ivalWZ + y * ival.strides()[1];
 
@@ -98,8 +98,8 @@ namespace cpu
     void sort_by_key(Array<Tk> &okey, Array<Tv> &oval,
                const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim)
     {
-        okey = *createEmptyArray<Tk>(ikey.dims());
-        oval = *createEmptyArray<Tv>(ival.dims());
+        okey = createEmptyArray<Tk>(ikey.dims());
+        oval = createEmptyArray<Tv>(ival.dims());
         switch(dim) {
             case 0: sort0_by_key<Tk, Tv, isAscending>(okey, oval, ikey, ival);
                     break;

--- a/src/backend/cpu/sort_index.cpp
+++ b/src/backend/cpu/sort_index.cpp
@@ -82,8 +82,8 @@ namespace cpu
     template<typename T, bool isAscending>
     void sort_index(Array<T> &val, Array<uint> &idx, const Array<T> &in, const uint dim)
     {
-        val = *createEmptyArray<T>(in.dims());
-        idx = *createEmptyArray<uint>(in.dims());
+        val = createEmptyArray<T>(in.dims());
+        idx = createEmptyArray<uint>(in.dims());
         switch(dim) {
             case 0: sort0_index<T, isAscending>(val, idx, in);
                     break;

--- a/src/backend/cpu/tile.cpp
+++ b/src/backend/cpu/tile.cpp
@@ -15,7 +15,7 @@
 namespace cpu
 {
     template<typename T>
-    Array<T> *tile(const Array<T> &in, const af::dim4 &tileDims)
+    Array<T> tile(const Array<T> &in, const af::dim4 &tileDims)
     {
         const af::dim4 iDims = in.dims();
         af::dim4 oDims = iDims;
@@ -25,13 +25,13 @@ namespace cpu
             throw std::runtime_error("Elements are 0");
         }
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
-        T* outPtr = out->get();
+        T* outPtr = out.get();
         const T* inPtr = in.get();
 
         const af::dim4 ist = in.strides();
-        const af::dim4 ost = out->strides();
+        const af::dim4 ost = out.strides();
 
         for(dim_type ow = 0; ow < oDims[3]; ow++) {
             const dim_type iw = ow % iDims[3];
@@ -59,7 +59,7 @@ namespace cpu
     }
 
 #define INSTANTIATE(T)                                                         \
-    template Array<T>* tile<T>(const Array<T> &in, const af::dim4 &tileDims);  \
+    template Array<T> tile<T>(const Array<T> &in, const af::dim4 &tileDims);  \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cpu/tile.hpp
+++ b/src/backend/cpu/tile.hpp
@@ -13,5 +13,5 @@
 namespace cpu
 {
     template<typename T>
-    Array<T> *tile(const Array<T> &in, const af::dim4 &tileDims);
+    Array<T> tile(const Array<T> &in, const af::dim4 &tileDims);
 }

--- a/src/backend/cpu/transform.cpp
+++ b/src/backend/cpu/transform.cpp
@@ -91,23 +91,23 @@ namespace cpu
     }
 
     template<typename T>
-    Array<T>* transform(const Array<T> &in, const Array<float> &transform, const af::dim4 &odims,
+    Array<T> transform(const Array<T> &in, const Array<float> &transform, const af::dim4 &odims,
                         const af_interp_type method, const bool inverse)
     {
         const af::dim4 idims = in.dims();
 
-        Array<T> *out = createEmptyArray<T>(odims);
+        Array<T> out = createEmptyArray<T>(odims);
 
         switch(method) {
             case AF_INTERP_NEAREST:
                 transform_<T, AF_INTERP_NEAREST>
-                          (out->get(), in.get(), transform.get(), odims, idims,
-                           out->strides(), in.strides(), transform.strides(), inverse);
+                          (out.get(), in.get(), transform.get(), odims, idims,
+                           out.strides(), in.strides(), transform.strides(), inverse);
                 break;
             case AF_INTERP_BILINEAR:
                 transform_<T, AF_INTERP_BILINEAR>
-                          (out->get(), in.get(), transform.get(), odims, idims,
-                           out->strides(), in.strides(), transform.strides(), inverse);
+                          (out.get(), in.get(), transform.get(), odims, idims,
+                           out.strides(), in.strides(), transform.strides(), inverse);
                 break;
             default:
                 AF_ERROR("Unsupported interpolation type", AF_ERR_ARG);
@@ -119,9 +119,9 @@ namespace cpu
 
 
 #define INSTANTIATE(T)                                                                          \
-    template Array<T>* transform(const Array<T> &in, const Array<float> &transform,             \
-                                 const af::dim4 &odims, const af_interp_type method,            \
-                                 const bool inverse);                                           \
+    template Array<T> transform(const Array<T> &in, const Array<float> &transform,             \
+                                const af::dim4 &odims, const af_interp_type method, \
+                                const bool inverse);                    \
 
 
     INSTANTIATE(float)

--- a/src/backend/cpu/transform.hpp
+++ b/src/backend/cpu/transform.hpp
@@ -13,6 +13,6 @@
 namespace cpu
 {
     template<typename T>
-    Array<T> *transform(const Array<T> &in, const Array<float> &tf, const af::dim4 &odims,
+    Array<T> transform(const Array<T> &in, const Array<float> &tf, const af::dim4 &odims,
                         const af_interp_type method, const bool inverse);
 }

--- a/src/backend/cpu/transpose.cpp
+++ b/src/backend/cpu/transpose.cpp
@@ -77,32 +77,32 @@ void transpose_(T *out, const T *in, const af::dim4 &odims, const af::dim4 &idim
 }
 
 template<typename T>
-Array<T> * transpose(const Array<T> &in, const bool conjugate)
+Array<T> transpose(const Array<T> &in, const bool conjugate)
 {
     const dim4 inDims = in.dims();
 
     dim4 outDims   = dim4(inDims[1],inDims[0],inDims[2],inDims[3]);
 
     // create an array with first two dimensions swapped
-    Array<T>* out  = createEmptyArray<T>(outDims);
+    Array<T> out  = createEmptyArray<T>(outDims);
 
     // get data pointers for input and output Arrays
-    T* outData          = out->get();
+    T* outData          = out.get();
     const T*   inData   = in.get();
 
     if(conjugate) {
         transpose_<T, true>(outData, inData,
-                            out->dims(), in.dims(), out->strides(), in.strides());
+                            out.dims(), in.dims(), out.strides(), in.strides());
     } else {
         transpose_<T, false>(outData, inData,
-                             out->dims(), in.dims(), out->strides(), in.strides());
+                             out.dims(), in.dims(), out.strides(), in.strides());
     }
 
     return out;
 }
 
 #define INSTANTIATE(T)\
-    template Array<T> * transpose(const Array<T> &in, const bool conjugate);
+    template Array<T> transpose(const Array<T> &in, const bool conjugate);
 
 INSTANTIATE(float  )
 INSTANTIATE(cfloat )

--- a/src/backend/cpu/transpose.hpp
+++ b/src/backend/cpu/transpose.hpp
@@ -13,6 +13,6 @@ namespace cpu
 {
 
 template<typename T>
-Array<T> * transpose(const Array<T> &in, const bool conjugate);
+Array<T>  transpose(const Array<T> &in, const bool conjugate);
 
 }

--- a/src/backend/cpu/unary.hpp
+++ b/src/backend/cpu/unary.hpp
@@ -64,7 +64,7 @@ UNARY_FN(lgamma)
 #undef UNARY_FN
 
     template<typename T, af_op_t op>
-    Array<T>* unaryOp(const Array<T> &in)
+    Array<T> unaryOp(const Array<T> &in)
     {
         TNJ::Node_ptr in_node = in.getNode();
         TNJ::UnaryNode<T, T, op> *node = new TNJ::UnaryNode<T, T, op>(in_node);
@@ -90,7 +90,7 @@ UNARY_FN(lgamma)
     CHECK_FN(iszero, iszero)
 
     template<typename T, af_op_t op>
-    Array<char> *checkOp(const Array<T> &in)
+    Array<char> checkOp(const Array<T> &in)
     {
         TNJ::Node_ptr in_node = in.getNode();
         TNJ::UnaryNode<char, T, op> *node = new TNJ::UnaryNode<char, T, op>(in_node);

--- a/src/backend/cpu/where.cpp
+++ b/src/backend/cpu/where.cpp
@@ -21,7 +21,7 @@ using af::dim4;
 namespace cpu
 {
     template<typename T>
-    Array<uint> *where(const Array<T> &in)
+    Array<uint> where(const Array<T> &in)
     {
         const dim_type *dims    = in.dims().get();
         const dim_type *strides = in.strides().get();
@@ -54,12 +54,12 @@ namespace cpu
             }
         }
 
-        Array<uint> *out = createHostDataArray(dim4(count), out_vec);
+        Array<uint> out = createHostDataArray(dim4(count), out_vec);
         return out;
     }
 
 #define INSTANTIATE(T)                                  \
-    template Array<uint>* where<T>(const Array<T> &in);    \
+    template Array<uint> where<T>(const Array<T> &in);    \
 
     INSTANTIATE(float  )
     INSTANTIATE(cfloat )

--- a/src/backend/cpu/where.hpp
+++ b/src/backend/cpu/where.hpp
@@ -13,5 +13,5 @@
 namespace cpu
 {
     template<typename T>
-    Array<uint>* where(const Array<T>& in);
+    Array<uint> where(const Array<T>& in);
 }

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -19,6 +19,11 @@ using af::dim4;
 
 namespace cuda
 {
+
+    using JIT::BufferNode;
+    using JIT::Node;
+    using JIT::Node_ptr;
+
     template<typename T>
     Array<T>::Array(af::dim4 dims) :
         ArrayInfo(dims, af::dim4(0,0,0,0), calcStrides(dims), (af_dtype)dtype_traits<T>::af_type),
@@ -65,116 +70,6 @@ namespace cuda
     {
     }
 
-    template<typename T>
-    Array<T>::~Array() {}
-
-
-    using JIT::BufferNode;
-    using JIT::Node;
-    using JIT::Node_ptr;
-
-    template<typename T>
-    Node_ptr Array<T>::getNode() const
-    {
-        if (!node) {
-            bool is_linear = isLinear();
-            BufferNode<T> *buf_node = new BufferNode<T>(irname<T>(),
-                                                        afShortName<T>(), data,
-                                                        *this, offset, is_linear);
-            const_cast<Array<T> *>(this)->node = Node_ptr(reinterpret_cast<Node *>(buf_node));
-        }
-
-        return node;
-    }
-
-    template<typename T>
-    Array<T> *
-    createNodeArray(const dim4 &dims, Node_ptr node)
-    {
-        return new Array<T>(dims, node);
-    }
-
-    template<typename T>
-    Array<T> *
-    createHostDataArray(const dim4 &size, const T * const data)
-    {
-        Array<T> *out = new Array<T>(size, data, false);
-        return out;
-    }
-
-    template<typename T>
-    Array<T> *
-    createDeviceDataArray(const dim4 &size, const void *data)
-    {
-        Array<T> *out = new Array<T>(size, (const T * const)data, true);
-        return out;
-    }
-
-    template<typename T>
-    Array<T>*
-    createValueArray(const dim4 &size, const T& value)
-    {
-        return createScalarNode<T>(size, value);
-    }
-
-    template<typename T>
-    Array<T>*
-    createEmptyArray(const dim4 &size)
-    {
-        Array<T> *out = new Array<T>(size);
-        return out;
-    }
-
-    template<typename T>
-    Array<T> *
-    createSubArray(const Array<T>& parent, const dim4 &dims, const dim4 &offset, const dim4 &stride)
-    {
-
-        Array<T> *out = new Array<T>(parent, dims, offset, stride);
-
-        // FIXME: Implement this for CUDA
-        if (stride[0] != 1 ||
-            stride[1] <  0 ||
-            stride[2] <  0 ||
-            stride[3] <  0) {
-            out = copyArray(*out);
-        }
-
-        return out;
-    }
-
-    template<typename T>
-    Array<T> *
-    createRefArray(const Array<T>& parent, const dim4 &dims, const dim4 &offset, const dim4 &stride)
-    {
-        return new Array<T>(parent, dims, offset, stride);
-    }
-
-    template<typename inType, typename outType>
-    Array<outType> *
-    createPaddedArray(Array<inType> const &in, dim4 const &dims, outType default_value, double factor)
-    {
-        Array<outType> *ret = createEmptyArray<outType>(dims);
-
-        copy<inType, outType>(*ret, in, default_value, factor);
-
-        return ret;
-    }
-
-    template<typename T>
-    Array<T>*
-    createParamArray(Param<T> &tmp)
-    {
-        Array<T> *out = new Array<T>(tmp);
-        return out;
-    }
-
-    template<typename T>
-    void
-    destroyArray(Array<T> &A)
-    {
-        delete &A;
-    }
 
     template<typename T>
     void Array<T>::eval()
@@ -208,17 +103,115 @@ namespace cuda
         const_cast<Array<T> *>(this)->eval();
     }
 
+    template<typename T>
+    Array<T>::~Array() {}
+
+    template<typename T>
+    Node_ptr Array<T>::getNode() const
+    {
+        if (!node) {
+            bool is_linear = isLinear();
+            BufferNode<T> *buf_node = new BufferNode<T>(irname<T>(),
+                                                        afShortName<T>(), data,
+                                                        *this, offset, is_linear);
+            const_cast<Array<T> *>(this)->node = Node_ptr(reinterpret_cast<Node *>(buf_node));
+        }
+
+        return node;
+    }
+
+    template<typename T>
+    Array<T> createNodeArray(const dim4 &dims, Node_ptr node)
+    {
+        return Array<T>(dims, node);
+    }
+
+    template<typename T>
+    Array<T> createHostDataArray(const dim4 &size, const T * const data)
+    {
+        return Array<T>(size, data, false);
+    }
+
+    template<typename T>
+    Array<T> createDeviceDataArray(const dim4 &size, const void *data)
+    {
+        return Array<T>(size, (const T * const)data, true);
+    }
+
+    template<typename T>
+    Array<T> createValueArray(const dim4 &size, const T& value)
+    {
+        return createScalarNode<T>(size, value);
+    }
+
+    template<typename T>
+    Array<T> createEmptyArray(const dim4 &size)
+    {
+        return Array<T>(size);
+    }
+
+    template<typename T>
+    Array<T> *initArray()
+    {
+        return new Array<T>(dim4());
+    }
+
+    template<typename T>
+    Array<T> createSubArray(const Array<T>& parent,
+                            const std::vector<af_seq> &index,
+                            bool copy)
+    {
+        dim4 dims   = af::toDims  (index, parent.dims());
+        dim4 offset = af::toOffset(index, parent.dims());
+        dim4 stride = af::toStride (index, parent.dims());
+
+        Array<T> out = Array<T>(parent, dims, offset, stride);
+
+        if (!copy) return out;
+
+        if (stride[0] != 1 ||
+            stride[1] <  0 ||
+            stride[2] <  0 ||
+            stride[3] <  0) {
+
+            out = copyArray(out);
+        }
+
+        return out;
+    }
+
+    template<typename T>
+    Array<T> createParamArray(Param<T> &tmp)
+    {
+        return Array<T>(tmp);
+    }
+
+    template<typename T>
+    void destroyArray(Array<T> *A)
+    {
+        delete A;
+    }
+
+    template<typename T>
+    void evalArray(const Array<T> &A)
+    {
+        A.eval();
+    }
+
 #define INSTANTIATE(T)                                                  \
-    template       Array<T>*  createHostDataArray<T>  (const dim4 &size, const T * const data); \
-    template       Array<T>*  createDeviceDataArray<T>  (const dim4 &size, const void *data); \
-    template       Array<T>*  createValueArray<T> (const dim4 &size, const T &value); \
-    template       Array<T>*  createEmptyArray<T> (const dim4 &size);   \
-    template       Array<T>*  createParamArray<T> (Param<T> &tmp);      \
-    template       Array<T>*  createSubArray<T>       (const Array<T> &parent, const dim4 &dims, const dim4 &offset, const dim4 &stride); \
-    template       Array<T>*  createRefArray<T>   (const Array<T> &parent, const dim4 &dims, const dim4 &offset, const dim4 &stride); \
-    template       void       destroyArray<T>     (Array<T> &A);        \
-    template       Array<T>*  createNodeArray<T>   (const dim4 &size, JIT::Node_ptr node); \
-    template                  Array<T>::~Array();                       \
+    template       Array<T>  createHostDataArray<T>   (const dim4 &size, const T * const data); \
+    template       Array<T>  createDeviceDataArray<T> (const dim4 &size, const void *data); \
+    template       Array<T>  createValueArray<T>      (const dim4 &size, const T &value); \
+    template       Array<T>  createEmptyArray<T>      (const dim4 &size); \
+    template       Array<T>  *initArray<T      >      ();               \
+    template       Array<T>  createParamArray<T>      (Param<T> &tmp);  \
+    template       Array<T>  createSubArray<T>        (const Array<T> &parent, \
+                                                       const std::vector<af_seq> &index, \
+                                                       bool copy);      \
+    template       void      destroyArray<T>          (Array<T> *A);    \
+    template       void      evalArray<T>             (const Array<T> &A); \
+    template       Array<T>  createNodeArray<T>       (const dim4 &size, JIT::Node_ptr node); \
+    template       Array<T>::~Array        ();                          \
     template       void Array<T>::eval();                               \
     template       void Array<T>::eval() const;                         \
 
@@ -232,29 +225,5 @@ namespace cuda
     INSTANTIATE(char)
     INSTANTIATE(intl)
     INSTANTIATE(uintl)
-
-#define INSTANTIATE_CREATE_PADDED_ARRAY(SRC_T) \
-    template Array<float  >* createPaddedArray<SRC_T, float  >(Array<SRC_T> const &src, dim4 const &dims, float   default_value, double factor); \
-    template Array<double >* createPaddedArray<SRC_T, double >(Array<SRC_T> const &src, dim4 const &dims, double  default_value, double factor); \
-    template Array<cfloat >* createPaddedArray<SRC_T, cfloat >(Array<SRC_T> const &src, dim4 const &dims, cfloat  default_value, double factor); \
-    template Array<cdouble>* createPaddedArray<SRC_T, cdouble>(Array<SRC_T> const &src, dim4 const &dims, cdouble default_value, double factor); \
-    template Array<int    >* createPaddedArray<SRC_T, int    >(Array<SRC_T> const &src, dim4 const &dims, int     default_value, double factor); \
-    template Array<uint   >* createPaddedArray<SRC_T, uint   >(Array<SRC_T> const &src, dim4 const &dims, uint    default_value, double factor); \
-    template Array<uchar  >* createPaddedArray<SRC_T, uchar  >(Array<SRC_T> const &src, dim4 const &dims, uchar   default_value, double factor); \
-    template Array<char   >* createPaddedArray<SRC_T, char   >(Array<SRC_T> const &src, dim4 const &dims, char    default_value, double factor);
-
-    INSTANTIATE_CREATE_PADDED_ARRAY(float )
-    INSTANTIATE_CREATE_PADDED_ARRAY(double)
-    INSTANTIATE_CREATE_PADDED_ARRAY(int   )
-    INSTANTIATE_CREATE_PADDED_ARRAY(uint  )
-    INSTANTIATE_CREATE_PADDED_ARRAY(uchar )
-    INSTANTIATE_CREATE_PADDED_ARRAY(char  )
-
-#define INSTANTIATE_CREATE_COMPLEX_PADDED_ARRAY(SRC_T) \
-    template Array<cfloat >* createPaddedArray<SRC_T, cfloat >(Array<SRC_T> const &src, dim4 const &dims, cfloat  default_value, double factor); \
-    template Array<cdouble>* createPaddedArray<SRC_T, cdouble>(Array<SRC_T> const &src, dim4 const &dims, cdouble default_value, double factor);
-
-    INSTANTIATE_CREATE_COMPLEX_PADDED_ARRAY(cfloat )
-    INSTANTIATE_CREATE_COMPLEX_PADDED_ARRAY(cdouble)
 
 }

--- a/src/backend/cuda/Array.hpp
+++ b/src/backend/cuda/Array.hpp
@@ -24,6 +24,7 @@
 #include <Param.hpp>
 #include <JIT/Node.hpp>
 #include <boost/shared_ptr.hpp>
+#include <vector>
 
 namespace cuda
 {
@@ -38,50 +39,40 @@ namespace cuda
 
     // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    Array<T>*
-    createNodeArray(const af::dim4 &size, JIT::Node_ptr node);
+    Array<T> createNodeArray(const af::dim4 &size, JIT::Node_ptr node);
 
     // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    Array<T>*
-    createValueArray(const af::dim4 &size, const T& value);
+    Array<T> createValueArray(const af::dim4 &size, const T& value);
 
     // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    Array<T>*
-    createHostDataArray(const af::dim4 &size, const T * const data);
+    Array<T> createHostDataArray(const af::dim4 &size, const T * const data);
 
     template<typename T>
-    Array<T>*
-    createDeviceDataArray(const af::dim4 &size, const void *data);
+    Array<T> createDeviceDataArray(const af::dim4 &size, const void *data);
 
     // Create an Array object and do not assign any values to it
+    template<typename T> Array<T> *initArray();
+
     template<typename T>
-    Array<T>*
-    createEmptyArray(const af::dim4 &size);
+    Array<T> createEmptyArray(const af::dim4 &size);
 
     // Create an Array object from Param<T>
     template<typename T>
-    Array<T>*
-    createParamArray(Param<T> &tmp);
+    Array<T> createParamArray(Param<T> &tmp);
+
+    template<typename T>
+    Array<T> createSubArray(const Array<T>& parent,
+                            const std::vector<af_seq> &index,
+                            bool copy=true);
+
+    template<typename T>
+    void evalArray(const Array<T> &A);
 
     // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    void
-    destroyArray(Array<T> &A);
-
-    template<typename T>
-    Array<T> *
-    createSubArray(const Array<T>& parent, const af::dim4 &dims, const af::dim4 &offset, const af::dim4 &stride);
-
-    // Creates a pure reference Array - a virtual view, no copies are made
-    template<typename T>
-    Array<T> *
-    createRefArray(const Array<T>& parent, const dim4 &dims, const dim4 &offset, const dim4 &stride);
-
-    template<typename inType, typename outType>
-    Array<outType> *
-    createPaddedArray(Array<inType> const &in, dim4 const &dims, outType default_value, double factor=1.0);
+    void destroyArray(Array<T> *A);
 
     template<typename T>
     void *getDevicePtr(const Array<T>& arr)
@@ -104,7 +95,6 @@ namespace cuda
         Array(const Array<T>& parnt, const dim4 &dims, const dim4 &offset, const dim4 &stride);
         Array(Param<T> &tmp);
         Array(af::dim4 dims, JIT::Node_ptr n);
-
     public:
 
         ~Array();
@@ -150,18 +140,21 @@ namespace cuda
 
         JIT::Node_ptr getNode() const;
 
-        friend Array<T>* createValueArray<T>(const af::dim4 &size, const T& value);
-        friend Array<T>* createHostDataArray<T>(const af::dim4 &size, const T * const data);
-        friend Array<T>* createDeviceDataArray<T>(const af::dim4 &size, const void *data);
+        friend Array<T> createValueArray<T>(const af::dim4 &size, const T& value);
+        friend Array<T> createHostDataArray<T>(const af::dim4 &size, const T * const data);
+        friend Array<T> createDeviceDataArray<T>(const af::dim4 &size, const void *data);
 
-        friend Array<T>* createEmptyArray<T>(const af::dim4 &size);
-        friend Array<T>* createParamArray<T>(Param<T> &tmp);
-        friend Array<T>* createNodeArray<T>(const af::dim4 &dims, JIT::Node_ptr node);
-        friend Array<T>* createSubArray<T>(const Array<T>& parent,
-                                           const dim4 &dims, const dim4 &offset, const dim4 &stride);
-        friend Array<T>* createRefArray<T>(const Array<T>& parent,
-                                           const dim4 &dims, const dim4 &offset, const dim4 &stride);
-        friend void      destroyArray<T>(Array<T> &arr);
+        friend Array<T> *initArray<T>();
+        friend Array<T> createEmptyArray<T>(const af::dim4 &size);
+        friend Array<T> createParamArray<T>(Param<T> &tmp);
+        friend Array<T> createNodeArray<T>(const af::dim4 &dims, JIT::Node_ptr node);
+
+        friend Array<T> createSubArray<T>(const Array<T>& parent,
+                                          const std::vector<af_seq> &index,
+                                          bool copy);
+
+        friend void destroyArray<T>(Array<T> *arr);
+        friend void evalArray<T>(const Array<T> &arr);
         friend void *getDevicePtr<T>(const Array<T>& arr);
     };
 

--- a/src/backend/cuda/ArrayIndex.cu
+++ b/src/backend/cuda/ArrayIndex.cu
@@ -15,7 +15,7 @@ namespace cuda
 {
 
 template<typename in_t, typename idx_t>
-Array<in_t>* arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, const unsigned dim)
+Array<in_t> arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, const unsigned dim)
 {
     const dim4 iDims = input.dims();
 
@@ -23,26 +23,26 @@ Array<in_t>* arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, c
     for (dim_type d=0; d<4; ++d)
         oDims[d] = (d==dim ? indices.elements() : iDims[d]);
 
-    Array<in_t> *out = createEmptyArray<in_t>(oDims);
+    Array<in_t> out = createEmptyArray<in_t>(oDims);
 
     dim_type nDims = iDims.ndims();
 
     switch(dim) {
-        case 0: kernel::arrayIndex<in_t, idx_t, 0>(*out, input, indices, nDims); break;
-        case 1: kernel::arrayIndex<in_t, idx_t, 1>(*out, input, indices, nDims); break;
-        case 2: kernel::arrayIndex<in_t, idx_t, 2>(*out, input, indices, nDims); break;
-        case 3: kernel::arrayIndex<in_t, idx_t, 3>(*out, input, indices, nDims); break;
+        case 0: kernel::arrayIndex<in_t, idx_t, 0>(out, input, indices, nDims); break;
+        case 1: kernel::arrayIndex<in_t, idx_t, 1>(out, input, indices, nDims); break;
+        case 2: kernel::arrayIndex<in_t, idx_t, 2>(out, input, indices, nDims); break;
+        case 3: kernel::arrayIndex<in_t, idx_t, 3>(out, input, indices, nDims); break;
     }
 
     return out;
 }
 
 #define INSTANTIATE(T)  \
-    template Array<T> * arrayIndex<T, float   >(const Array<T> &input, const Array<float   > &indices, const unsigned dim); \
-    template Array<T> * arrayIndex<T, double  >(const Array<T> &input, const Array<double  > &indices, const unsigned dim); \
-    template Array<T> * arrayIndex<T, int     >(const Array<T> &input, const Array<int     > &indices, const unsigned dim); \
-    template Array<T> * arrayIndex<T, unsigned>(const Array<T> &input, const Array<unsigned> &indices, const unsigned dim); \
-    template Array<T> * arrayIndex<T, uchar   >(const Array<T> &input, const Array<uchar   > &indices, const unsigned dim);
+    template Array<T> arrayIndex<T, float   >(const Array<T> &input, const Array<float   > &indices, const unsigned dim); \
+    template Array<T> arrayIndex<T, double  >(const Array<T> &input, const Array<double  > &indices, const unsigned dim); \
+    template Array<T> arrayIndex<T, int     >(const Array<T> &input, const Array<int     > &indices, const unsigned dim); \
+    template Array<T> arrayIndex<T, unsigned>(const Array<T> &input, const Array<unsigned> &indices, const unsigned dim); \
+    template Array<T> arrayIndex<T, uchar   >(const Array<T> &input, const Array<uchar   > &indices, const unsigned dim);
 
 INSTANTIATE(float   );
 INSTANTIATE(cfloat  );

--- a/src/backend/cuda/ArrayIndex.hpp
+++ b/src/backend/cuda/ArrayIndex.hpp
@@ -13,6 +13,6 @@ namespace cuda
 {
 
 template<typename in_t, typename idx_t>
-Array<in_t>* arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, const unsigned dim);
+Array<in_t> arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, const unsigned dim);
 
 }

--- a/src/backend/cuda/approx.cu
+++ b/src/backend/cuda/approx.cu
@@ -16,22 +16,22 @@
 namespace cuda
 {
     template<typename Ty, typename Tp>
-    Array<Ty> *approx1(const Array<Ty> &in, const Array<Tp> &pos,
-                       const af_interp_type method, const float offGrid)
+    Array<Ty> approx1(const Array<Ty> &in, const Array<Tp> &pos,
+                      const af_interp_type method, const float offGrid)
     {
         af::dim4 idims = in.dims();
         af::dim4 odims = in.dims();
         odims[0] = pos.dims()[0];
 
         // Create output placeholder
-        Array<Ty> *out = createEmptyArray<Ty>(odims);
+        Array<Ty> out = createEmptyArray<Ty>(odims);
 
         switch(method) {
             case AF_INTERP_NEAREST:
-                kernel::approx1<Ty, Tp, AF_INTERP_NEAREST> (*out, in, pos, offGrid);
+                kernel::approx1<Ty, Tp, AF_INTERP_NEAREST> (out, in, pos, offGrid);
                 break;
             case AF_INTERP_LINEAR:
-                kernel::approx1<Ty, Tp, AF_INTERP_LINEAR> (*out, in, pos, offGrid);
+                kernel::approx1<Ty, Tp, AF_INTERP_LINEAR> (out, in, pos, offGrid);
                 break;
             default:
                 break;
@@ -40,8 +40,8 @@ namespace cuda
     }
 
     template<typename Ty, typename Tp>
-    Array<Ty> *approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
-                       const af_interp_type method, const float offGrid)
+    Array<Ty> approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
+                      const af_interp_type method, const float offGrid)
     {
         af::dim4 idims = in.dims();
         af::dim4 odims = pos0.dims();
@@ -49,14 +49,14 @@ namespace cuda
         odims[3] = in.dims()[3];
 
         // Create output placeholder
-        Array<Ty> *out = createEmptyArray<Ty>(odims);
+        Array<Ty> out = createEmptyArray<Ty>(odims);
 
         switch(method) {
             case AF_INTERP_NEAREST:
-                kernel::approx2<Ty, Tp, AF_INTERP_NEAREST> (*out, in, pos0, pos1, offGrid);
+                kernel::approx2<Ty, Tp, AF_INTERP_NEAREST> (out, in, pos0, pos1, offGrid);
                 break;
             case AF_INTERP_LINEAR:
-                kernel::approx2<Ty, Tp, AF_INTERP_LINEAR> (*out, in, pos0, pos1, offGrid);
+                kernel::approx2<Ty, Tp, AF_INTERP_LINEAR> (out, in, pos0, pos1, offGrid);
                 break;
             default:
                 break;
@@ -64,12 +64,12 @@ namespace cuda
         return out;
     }
 
-#define INSTANTIATE(Ty, Tp)                                                                     \
-    template Array<Ty>* approx1<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos,              \
-                                        const af_interp_type method, const float offGrid);      \
-    template Array<Ty>* approx2<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos0,             \
-                                        const Array<Tp> &pos1, const af_interp_type method,     \
-                                        const float offGrid);                                   \
+#define INSTANTIATE(Ty, Tp)                                             \
+    template Array<Ty> approx1<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos, \
+                                       const af_interp_type method, const float offGrid); \
+    template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos0, \
+                                       const Array<Tp> &pos1, const af_interp_type method, \
+                                       const float offGrid);            \
 
     INSTANTIATE(float  , float )
     INSTANTIATE(double , double)

--- a/src/backend/cuda/approx.hpp
+++ b/src/backend/cuda/approx.hpp
@@ -13,10 +13,10 @@
 namespace cuda
 {
     template<typename Ty, typename Tp>
-    Array<Ty> *approx1(const Array<Ty> &in, const Array<Tp> &pos,
-                       const af_interp_type method, const float offGrid);
+    Array<Ty> approx1(const Array<Ty> &in, const Array<Tp> &pos,
+                      const af_interp_type method, const float offGrid);
 
     template<typename Ty, typename Tp>
-    Array<Ty> *approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
-                       const af_interp_type method, const float offGrid);
+    Array<Ty> approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
+                      const af_interp_type method, const float offGrid);
 }

--- a/src/backend/cuda/arith.hpp
+++ b/src/backend/cuda/arith.hpp
@@ -18,7 +18,7 @@
 namespace cuda
 {
     template<typename T, af_op_t op>
-    Array<T>* arithOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
+    Array<T> arithOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
     {
         return createBinaryNode<T, T, op>(lhs, rhs, odims);
     }

--- a/src/backend/cuda/bilateral.cu
+++ b/src/backend/cuda/bilateral.cu
@@ -20,16 +20,16 @@ namespace cuda
 {
 
 template<typename inType, typename outType, bool isColor>
-Array<outType> * bilateral(const Array<inType> &in, const float &s_sigma, const float &c_sigma)
+Array<outType> bilateral(const Array<inType> &in, const float &s_sigma, const float &c_sigma)
 {
-    Array<outType>* out = createEmptyArray<outType>(in.dims());
-    kernel::bilateral<inType, outType, isColor>(*out, in, s_sigma, c_sigma);
+    Array<outType>out = createEmptyArray<outType>(in.dims());
+    kernel::bilateral<inType, outType, isColor>(out, in, s_sigma, c_sigma);
     return out;
 }
 
 #define INSTANTIATE(inT, outT)\
-template Array<outT> * bilateral<inT, outT,true >(const Array<inT> &in, const float &s_sigma, const float &c_sigma);\
-template Array<outT> * bilateral<inT, outT,false>(const Array<inT> &in, const float &s_sigma, const float &c_sigma);
+template Array<outT> bilateral<inT, outT,true >(const Array<inT> &in, const float &s_sigma, const float &c_sigma);\
+template Array<outT> bilateral<inT, outT,false>(const Array<inT> &in, const float &s_sigma, const float &c_sigma);
 
 INSTANTIATE(double, double)
 INSTANTIATE(float ,  float)

--- a/src/backend/cuda/bilateral.hpp
+++ b/src/backend/cuda/bilateral.hpp
@@ -13,6 +13,6 @@ namespace cuda
 {
 
 template<typename inType, typename outType, bool isColor>
-Array<outType> * bilateral(const Array<inType> &in, const float &s_sigma, const float &c_sigma);
+Array<outType> bilateral(const Array<inType> &in, const float &s_sigma, const float &c_sigma);
 
 }

--- a/src/backend/cuda/binary.hpp
+++ b/src/backend/cuda/binary.hpp
@@ -70,7 +70,7 @@ BINARY(hypot)
 #undef BINARY
 
 template<typename To, typename Ti, af_op_t op>
-Array<To> *createBinaryNode(const Array<Ti> &lhs, const Array<Ti> &rhs, const af::dim4 &odims)
+Array<To> createBinaryNode(const Array<Ti> &lhs, const Array<Ti> &rhs, const af::dim4 &odims)
 {
     BinOp<To, Ti, op> bop;
 

--- a/src/backend/cuda/blas.cpp
+++ b/src/backend/cuda/blas.cpp
@@ -139,8 +139,8 @@ BLAS_FUNC(dot, double, D)
 using namespace std;
 
 template<typename T>
-Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs)
+Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
+                af_blas_transpose optLhs, af_blas_transpose optRhs)
 {
     cublasOperation_t lOpts = toCblasTranspose(optLhs);
     cublasOperation_t rOpts = toCblasTranspose(optRhs);
@@ -155,7 +155,7 @@ Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
     int N = rDims[bColDim];
     int K = lDims[aColDim];
 
-    Array<T> *out = createEmptyArray<T>(af::dim4(M, N, 1, 1));
+    Array<T> out = createEmptyArray<T>(af::dim4(M, N, 1, 1));
     T alpha = scalar<T>(1);
     T beta  = scalar<T>(0);
 
@@ -168,7 +168,7 @@ Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
             M, N,
             &alpha, lhs.get(),   lStrides[1],
                     rhs.get(),   rStrides[0],
-            &beta , out->get(),            1);
+            &beta , out.get(),            1);
     } else {
         cublasStatus_t err =
             gemm_func<T>()(
@@ -176,7 +176,7 @@ Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
                 M, N, K,
                 &alpha, lhs.get(),  lStrides[1],
                         rhs.get(),  rStrides[1],
-                &beta , out->get(), out->dims()[0]);
+                &beta , out.get(), out.dims()[0]);
 
         if(err != CUBLAS_STATUS_SUCCESS) {
             std::cout <<__PRETTY_FUNCTION__<< " ERROR: " << cublasErrorString(err) << std::endl;
@@ -188,8 +188,8 @@ Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
 }
 
 template<typename T>
-Array<T>* dot(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs)
+Array<T> dot(const Array<T> &lhs, const Array<T> &rhs,
+             af_blas_transpose optLhs, af_blas_transpose optRhs)
 {
     int N = lhs.dims()[0];
 
@@ -203,8 +203,8 @@ Array<T>* dot(const Array<T> &lhs, const Array<T> &rhs,
 }
 
 #define INSTANTIATE_BLAS(TYPE)                                                          \
-    template Array<TYPE>* matmul<TYPE>(const Array<TYPE> &lhs, const Array<TYPE> &rhs,  \
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
+    template Array<TYPE> matmul<TYPE>(const Array<TYPE> &lhs, const Array<TYPE> &rhs,  \
+                                      af_blas_transpose optLhs, af_blas_transpose optRhs);
 
 INSTANTIATE_BLAS(float)
 INSTANTIATE_BLAS(cfloat)
@@ -212,12 +212,8 @@ INSTANTIATE_BLAS(double)
 INSTANTIATE_BLAS(cdouble)
 
 #define INSTANTIATE_DOT(TYPE)                                                       \
-    template Array<TYPE>* dot<TYPE>(const Array<TYPE> &lhs, const Array<TYPE> &rhs, \
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
-
-template<typename T>
-Array<T>* dot(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
+    template Array<TYPE> dot<TYPE>(const Array<TYPE> &lhs, const Array<TYPE> &rhs, \
+                                   af_blas_transpose optLhs, af_blas_transpose optRhs);
 
 INSTANTIATE_DOT(float)
 INSTANTIATE_DOT(double)

--- a/src/backend/cuda/blas.hpp
+++ b/src/backend/cuda/blas.hpp
@@ -15,10 +15,10 @@ namespace cuda
 {
 
 template<typename T>
-Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
+Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
+                af_blas_transpose optLhs, af_blas_transpose optRhs);
 template<typename T>
-Array<T>* dot(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
+Array<T> dot(const Array<T> &lhs, const Array<T> &rhs,
+             af_blas_transpose optLhs, af_blas_transpose optRhs);
 
 }

--- a/src/backend/cuda/cast.hpp
+++ b/src/backend/cuda/cast.hpp
@@ -37,7 +37,7 @@ struct CastOp
 };
 
 template<typename To, typename Ti>
-Array<To>* cast(const Array<Ti> &in)
+Array<To> cast(const Array<Ti> &in)
 {
     CastOp<To, Ti> cop;
     JIT::Node_ptr in_node = in.getNode();

--- a/src/backend/cuda/complex.hpp
+++ b/src/backend/cuda/complex.hpp
@@ -40,7 +40,7 @@ namespace cuda
     template<> STATIC_ const std::string conj_name<cdouble>() { return cuMangledName<cdouble, false>("___conj"); }
 
     template<typename To, typename Ti>
-    Array<To>* cplx(const Array<Ti> &lhs, const Array<Ti> &rhs, const af::dim4 &odims)
+    Array<To> cplx(const Array<Ti> &lhs, const Array<Ti> &rhs, const af::dim4 &odims)
     {
         JIT::Node_ptr lhs_node = lhs.getNode();
         JIT::Node_ptr rhs_node = rhs.getNode();
@@ -55,7 +55,7 @@ namespace cuda
     }
 
     template<typename To, typename Ti>
-    Array<To>* real(const Array<Ti> &in)
+    Array<To> real(const Array<Ti> &in)
     {
         JIT::Node_ptr in_node = in.getNode();
         JIT::UnaryNode *node = new JIT::UnaryNode(irname<To>(),
@@ -67,7 +67,7 @@ namespace cuda
     }
 
     template<typename To, typename Ti>
-    Array<To>* imag(const Array<Ti> &in)
+    Array<To> imag(const Array<Ti> &in)
     {
         JIT::Node_ptr in_node = in.getNode();
         JIT::UnaryNode *node = new JIT::UnaryNode(irname<To>(),
@@ -79,7 +79,7 @@ namespace cuda
     }
 
     template<typename To, typename Ti>
-    Array<To>* abs(const Array<Ti> &in)
+    Array<To> abs(const Array<Ti> &in)
     {
         JIT::Node_ptr in_node = in.getNode();
         JIT::UnaryNode *node = new JIT::UnaryNode(irname<To>(),
@@ -91,7 +91,7 @@ namespace cuda
     }
 
     template<typename T>
-    Array<T>* conj(const Array<T> &in)
+    Array<T> conj(const Array<T> &in)
     {
         JIT::Node_ptr in_node = in.getNode();
         JIT::UnaryNode *node = new JIT::UnaryNode(irname<T>(),

--- a/src/backend/cuda/convolve.cpp
+++ b/src/backend/cuda/convolve.cpp
@@ -21,7 +21,7 @@ namespace cuda
 {
 
 template<typename T, typename accT, dim_type baseDim, bool expand>
-Array<T> * convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind)
+Array<T> convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind)
 {
     const dim4 sDims    = signal.dims();
     const dim4 fDims    = filter.dims();
@@ -40,15 +40,15 @@ Array<T> * convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatc
         if (kind==ONE2ALL) oDims[baseDim] = fDims[baseDim];
     }
 
-    Array<T> *out   = createEmptyArray<T>(oDims);
+    Array<T> out   = createEmptyArray<T>(oDims);
 
-    kernel::convolve_nd<T, accT, baseDim, expand>(*out, signal, filter, kind);
+    kernel::convolve_nd<T, accT, baseDim, expand>(out, signal, filter, kind);
 
     return out;
 }
 
 template<typename T, typename accT, bool expand>
-Array<T> * convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter)
+Array<T> convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter)
 {
     const dim4 cfDims   = c_filter.dims();
     const dim4 rfDims   = r_filter.dims();
@@ -63,26 +63,24 @@ Array<T> * convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> 
         oDims = sDims;
     }
 
-    Array<T> *temp= createEmptyArray<T>(oDims);
-    Array<T> *out = createEmptyArray<T>(oDims);
+    Array<T> temp= createEmptyArray<T>(oDims);
+    Array<T> out = createEmptyArray<T>(oDims);
 
-    kernel::convolve2<T, accT, 0, expand>(*temp, signal, c_filter);
-    kernel::convolve2<T, accT, 1, expand>(*out, *temp, r_filter);
-
-    destroyArray<T>(*temp);
+    kernel::convolve2<T, accT, 0, expand>(temp, signal, c_filter);
+    kernel::convolve2<T, accT, 1, expand>(out, temp, r_filter);
 
     return out;
 }
 
 #define INSTANTIATE(T, accT)  \
-    template Array<T> * convolve <T, accT, 1, true >(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
-    template Array<T> * convolve <T, accT, 1, false>(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
-    template Array<T> * convolve <T, accT, 2, true >(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
-    template Array<T> * convolve <T, accT, 2, false>(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
-    template Array<T> * convolve <T, accT, 3, true >(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
-    template Array<T> * convolve <T, accT, 3, false>(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
-    template Array<T> * convolve2<T, accT, true >(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);  \
-    template Array<T> * convolve2<T, accT, false>(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);
+    template Array<T> convolve <T, accT, 1, true >(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
+    template Array<T> convolve <T, accT, 1, false>(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
+    template Array<T> convolve <T, accT, 2, true >(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
+    template Array<T> convolve <T, accT, 2, false>(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
+    template Array<T> convolve <T, accT, 3, true >(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
+    template Array<T> convolve <T, accT, 3, false>(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
+    template Array<T> convolve2<T, accT, true >(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);  \
+    template Array<T> convolve2<T, accT, false>(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);
 
 INSTANTIATE(cdouble, cdouble)
 INSTANTIATE(cfloat ,  cfloat)

--- a/src/backend/cuda/convolve.hpp
+++ b/src/backend/cuda/convolve.hpp
@@ -14,9 +14,9 @@ namespace cuda
 {
 
 template<typename T, typename accT, dim_type baseDim, bool expand>
-Array<T> * convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);
+Array<T> convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);
 
 template<typename T, typename accT, bool expand>
-Array<T> * convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);
+Array<T> convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);
 
 }

--- a/src/backend/cuda/copy.hpp
+++ b/src/backend/cuda/copy.hpp
@@ -6,6 +6,7 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#pragma once
 
 #include <af/array.h>
 #include <Array.hpp>

--- a/src/backend/cuda/copy.hpp
+++ b/src/backend/cuda/copy.hpp
@@ -17,9 +17,12 @@ namespace cuda
     void copyData(T *data, const Array<T> &A);
 
     template<typename T>
-    Array<T>* copyArray(const Array<T> &A);
+    Array<T> copyArray(const Array<T> &A);
 
     template<typename inType, typename outType>
-    void copy(Array<outType> &dst, const Array<inType> &src, outType default_value, double factor);
+    void copyArray(Array<outType> &out, const Array<inType> &in);
 
+    template<typename inType, typename outType>
+    Array<outType> padArray(Array<inType> const &in, dim4 const &dims,
+                            outType default_value, double factor=1.0);
 }

--- a/src/backend/cuda/diagonal.cu
+++ b/src/backend/cuda/diagonal.cu
@@ -19,32 +19,32 @@
 namespace cuda
 {
     template<typename T>
-    Array<T>* diagCreate(const Array<T> &in, const int num)
+    Array<T> diagCreate(const Array<T> &in, const int num)
     {
         int size = in.dims()[0] + std::abs(num);
         int batch = in.dims()[1];
-        Array<T> *out = createEmptyArray<T>(dim4(size, size, batch));
+        Array<T> out = createEmptyArray<T>(dim4(size, size, batch));
 
-        kernel::diagCreate<T>(*out, in, num);
+        kernel::diagCreate<T>(out, in, num);
 
         return out;
     }
 
     template<typename T>
-    Array<T>* diagExtract(const Array<T> &in, const int num)
+    Array<T> diagExtract(const Array<T> &in, const int num)
     {
         const dim_type *idims = in.dims().get();
         dim_type size = std::max(idims[0], idims[1]) - std::abs(num);
-        Array<T> *out = createEmptyArray<T>(dim4(size, 1, idims[2], idims[3]));
+        Array<T> out = createEmptyArray<T>(dim4(size, 1, idims[2], idims[3]));
 
-        kernel::diagExtract<T>(*out, in, num);
+        kernel::diagExtract<T>(out, in, num);
 
         return out;
     }
 
 #define INSTANTIATE_DIAGONAL(T)                                          \
-    template Array<T>*  diagExtract<T>    (const Array<T> &in, const int num); \
-    template Array<T>*  diagCreate <T>    (const Array<T> &in, const int num);
+    template Array<T>  diagExtract<T>    (const Array<T> &in, const int num); \
+    template Array<T>  diagCreate <T>    (const Array<T> &in, const int num);
 
     INSTANTIATE_DIAGONAL(float)
     INSTANTIATE_DIAGONAL(double)

--- a/src/backend/cuda/diagonal.hpp
+++ b/src/backend/cuda/diagonal.hpp
@@ -14,8 +14,8 @@
 namespace cuda
 {
     template<typename T>
-    Array<T>* diagCreate(const Array<T> &in, const int num);
+    Array<T> diagCreate(const Array<T> &in, const int num);
 
     template<typename T>
-    Array<T>* diagExtract(const Array<T> &in, const int num);
+    Array<T> diagExtract(const Array<T> &in, const int num);
 }

--- a/src/backend/cuda/diff.cu
+++ b/src/backend/cuda/diff.cu
@@ -17,7 +17,7 @@ namespace cuda
 {
 
     template<typename T, bool isDiff2>
-    static Array<T> *diff(const Array<T> &in, const int dim)
+    static Array<T> diff(const Array<T> &in, const int dim)
     {
         const af::dim4 iDims = in.dims();
         af::dim4 oDims = iDims;
@@ -27,16 +27,16 @@ namespace cuda
             AF_ERROR("Elements are 0", AF_ERR_SIZE);
         }
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
         switch (dim) {
-            case (0):   kernel::diff<T, 0, isDiff2>(*out, in, in.ndims());
+            case (0):   kernel::diff<T, 0, isDiff2>(out, in, in.ndims());
                 break;
-            case (1):   kernel::diff<T, 1, isDiff2>(*out, in, in.ndims());
+            case (1):   kernel::diff<T, 1, isDiff2>(out, in, in.ndims());
                 break;
-            case (2):   kernel::diff<T, 2, isDiff2>(*out, in, in.ndims());
+            case (2):   kernel::diff<T, 2, isDiff2>(out, in, in.ndims());
                 break;
-            case (3):   kernel::diff<T, 3, isDiff2>(*out, in, in.ndims());
+            case (3):   kernel::diff<T, 3, isDiff2>(out, in, in.ndims());
                 break;
         }
 
@@ -44,20 +44,20 @@ namespace cuda
     }
 
     template<typename T>
-    Array<T> *diff1(const Array<T> &in, const int dim)
+    Array<T> diff1(const Array<T> &in, const int dim)
     {
         return diff<T, false>(in, dim);
     }
 
     template<typename T>
-    Array<T> *diff2(const Array<T> &in, const int dim)
+    Array<T> diff2(const Array<T> &in, const int dim)
     {
         return diff<T, true>(in, dim);
     }
 
 #define INSTANTIATE(T)                                                  \
-    template Array<T>* diff1<T>  (const Array<T> &in, const int dim);   \
-    template Array<T>* diff2<T>  (const Array<T> &in, const int dim);   \
+    template Array<T> diff1<T>  (const Array<T> &in, const int dim);   \
+    template Array<T> diff2<T>  (const Array<T> &in, const int dim);   \
 
 
     INSTANTIATE(float)

--- a/src/backend/cuda/diff.hpp
+++ b/src/backend/cuda/diff.hpp
@@ -13,8 +13,8 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *diff1(const Array<T> &in, const int dim);
+    Array<T> diff1(const Array<T> &in, const int dim);
 
     template<typename T>
-    Array<T> *diff2(const Array<T> &in, const int dim);
+    Array<T> diff2(const Array<T> &in, const int dim);
 }

--- a/src/backend/cuda/fast.cu
+++ b/src/backend/cuda/fast.cu
@@ -40,9 +40,9 @@ unsigned fast(Array<float> &x_out, Array<float> &y_out, Array<float> &score_out,
     if (nfeat > 0) {
         const dim4 out_dims(nfeat);
 
-        x_out = *createDeviceDataArray<float>(out_dims, d_x_out);
-        y_out = *createDeviceDataArray<float>(out_dims, d_y_out);
-        score_out = *createDeviceDataArray<float>(out_dims, d_score_out);
+        x_out = createDeviceDataArray<float>(out_dims, d_x_out);
+        y_out = createDeviceDataArray<float>(out_dims, d_y_out);
+        score_out = createDeviceDataArray<float>(out_dims, d_score_out);
     }
 
     return nfeat;

--- a/src/backend/cuda/fft.cu
+++ b/src/backend/cuda/fft.cu
@@ -11,6 +11,7 @@
 #include <af/defines.h>
 #include <ArrayInfo.hpp>
 #include <Array.hpp>
+#include <copy.hpp>
 #include <fft.hpp>
 #include <err_cuda.hpp>
 #include <cufft.h>
@@ -211,7 +212,7 @@ template<> cdouble zero<cdouble>() { return make_cuDoubleComplex(0.0, 0.0); }
 
 
 template<typename inType, typename outType, int rank, bool isR2C>
-Array<outType> * fft(Array<inType> const &in, double normalize, dim_type const npad, dim_type const * const pad)
+Array<outType> fft(Array<inType> const &in, double normalize, dim_type const npad, dim_type const * const pad)
 {
     ARG_ASSERT(1, (in.isOwner()==true));
 
@@ -226,15 +227,15 @@ Array<outType> * fft(Array<inType> const &in, double normalize, dim_type const n
 
     pdims[rank] = in.dims()[rank];
 
-    Array<outType> *ret = createPaddedArray<inType, outType>(in, (npad>0 ? pdims : in.dims()), zero<outType>(), normalize);
+    Array<outType> ret = padArray<inType, outType>(in, (npad>0 ? pdims : in.dims()), zero<outType>(), normalize);
 
-    cufft_common<outType, rank, CUFFT_FORWARD>(*ret);
+    cufft_common<outType, rank, CUFFT_FORWARD>(ret);
 
     return ret;
 }
 
 template<typename T, int rank>
-Array<T> * ifft(Array<T> const &in, double normalize, dim_type const npad, dim_type const * const pad)
+Array<T> ifft(Array<T> const &in, double normalize, dim_type const npad, dim_type const * const pad)
 {
     ARG_ASSERT(1, (in.isOwner()==true));
 
@@ -249,28 +250,28 @@ Array<T> * ifft(Array<T> const &in, double normalize, dim_type const npad, dim_t
 
     pdims[rank] = in.dims()[rank];
 
-    Array<T> *ret = createPaddedArray<T, T>(in, (npad>0 ? pdims : in.dims()), zero<T>(), normalize);
+    Array<T> ret = padArray<T, T>(in, (npad>0 ? pdims : in.dims()), zero<T>(), normalize);
 
-    cufft_common<T, rank, CUFFT_INVERSE>(*ret);
+    cufft_common<T, rank, CUFFT_INVERSE>(ret);
 
     return ret;
 }
 
 #define INSTANTIATE1(T1, T2)\
-    template Array<T2> * fft <T1, T2, 1, true >(const Array<T1> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T2> * fft <T1, T2, 2, true >(const Array<T1> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T2> * fft <T1, T2, 3, true >(const Array<T1> &in, double normalize, dim_type const npad, dim_type const * const pad);
+    template Array<T2> fft <T1, T2, 1, true >(const Array<T1> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T2> fft <T1, T2, 2, true >(const Array<T1> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T2> fft <T1, T2, 3, true >(const Array<T1> &in, double normalize, dim_type const npad, dim_type const * const pad);
 
 INSTANTIATE1(float  , cfloat )
 INSTANTIATE1(double , cdouble)
 
 #define INSTANTIATE2(T)\
-    template Array<T> * fft <T, T, 1, false>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T> * fft <T, T, 2, false>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T> * fft <T, T, 3, false>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T> * ifft<T, 1>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T> * ifft<T, 2>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T> * ifft<T, 3>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad);
+    template Array<T> fft <T, T, 1, false>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T> fft <T, T, 2, false>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T> fft <T, T, 3, false>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T> ifft<T, 1>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T> ifft<T, 2>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T> ifft<T, 3>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad);
 
 INSTANTIATE2(cfloat )
 INSTANTIATE2(cdouble)

--- a/src/backend/cuda/fft.hpp
+++ b/src/backend/cuda/fft.hpp
@@ -13,9 +13,9 @@ namespace cuda
 {
 
 template<typename inType, typename outType, int rank, bool isR2C>
-Array<outType> * fft(Array<inType> const &in, double normalize, dim_type const npad, dim_type const * const pad);
+Array<outType> fft(Array<inType> const &in, double normalize, dim_type const npad, dim_type const * const pad);
 
 template<typename T, int rank>
-Array<T> * ifft(Array<T> const &in, double normalize, dim_type const npad, dim_type const * const pad);
+Array<T> ifft(Array<T> const &in, double normalize, dim_type const npad, dim_type const * const pad);
 
 }

--- a/src/backend/cuda/histogram.cu
+++ b/src/backend/cuda/histogram.cu
@@ -21,7 +21,7 @@ namespace cuda
 {
 
 template<typename inType, typename outType>
-Array<outType> * histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval)
+Array<outType> histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval)
 {
 
     ARG_ASSERT(1, (nbins<=kernel::MAX_BINS));
@@ -29,8 +29,8 @@ Array<outType> * histogram(const Array<inType> &in, const unsigned &nbins, const
     const dim4 dims     = in.dims();
     const dim4 istrides = in.strides();
     dim4 outDims        = dim4(nbins, 1, dims[2], dims[3]);
-    Array<outType>* out = createValueArray<outType>(outDims, outType(0));
-    const dim4 ostrides = out->strides();
+    Array<outType> out  = createValueArray<outType>(outDims, outType(0));
+    const dim4 ostrides = out.strides();
 
     // create an array to hold min and max values for
     // batch operation handling, this will reduce
@@ -43,21 +43,18 @@ Array<outType> * histogram(const Array<inType> &in, const unsigned &nbins, const
     }
 
     dim4 minmax_dims(dims[2]*2);
-    Array<cfloat>* minmax = createHostDataArray<cfloat>(minmax_dims, h_minmax);
+    Array<cfloat> minmax = createHostDataArray<cfloat>(minmax_dims, h_minmax);
 
     // cleanup the host memory used
     delete[] h_minmax;
 
-    kernel::histogram<inType, outType>(*out, in, minmax->get(), nbins);
-
-    // destroy the minmax array
-    destroyArray(*minmax);
+    kernel::histogram<inType, outType>(out, in, minmax.get(), nbins);
 
     return out;
 }
 
 #define INSTANTIATE(in_t,out_t)\
-template Array<out_t> * histogram(const Array<in_t> &in, const unsigned &nbins, const double &minval, const double &maxval);
+template Array<out_t> histogram(const Array<in_t> &in, const unsigned &nbins, const double &minval, const double &maxval);
 
 INSTANTIATE(float , uint)
 INSTANTIATE(double, uint)

--- a/src/backend/cuda/histogram.hpp
+++ b/src/backend/cuda/histogram.hpp
@@ -13,6 +13,6 @@ namespace cuda
 {
 
 template<typename inType, typename outType>
-Array<outType> * histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval);
+Array<outType> histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval);
 
 }

--- a/src/backend/cuda/identity.cu
+++ b/src/backend/cuda/identity.cu
@@ -18,15 +18,15 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *identity(const dim4& dims)
+    Array<T> identity(const dim4& dims)
     {
-        Array<T>* out  = createEmptyArray<T>(dims);
-        kernel::identity<T>(*out);
+        Array<T> out  = createEmptyArray<T>(dims);
+        kernel::identity<T>(out);
         return out;
     }
 
 #define INSTANTIATE_IDENTITY(T)                              \
-    template Array<T>*  identity<T>    (const af::dim4 &dims);
+    template Array<T>  identity<T>    (const af::dim4 &dims);
 
     INSTANTIATE_IDENTITY(float)
     INSTANTIATE_IDENTITY(double)

--- a/src/backend/cuda/identity.hpp
+++ b/src/backend/cuda/identity.hpp
@@ -13,5 +13,5 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *identity(const dim4& dim);
+    Array<T> identity(const dim4& dim);
 }

--- a/src/backend/cuda/iota.cu
+++ b/src/backend/cuda/iota.cu
@@ -17,21 +17,21 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *iota(const dim4& dim, const unsigned rep)
+    Array<T> iota(const dim4& dim, const unsigned rep)
     {
-        Array<T> *out = createEmptyArray<T>(dim);
+        Array<T> out = createEmptyArray<T>(dim);
         switch(rep) {
-            case 0: kernel::iota<T, 0>(*out); break;
-            case 1: kernel::iota<T, 1>(*out); break;
-            case 2: kernel::iota<T, 2>(*out); break;
-            case 3: kernel::iota<T, 3>(*out); break;
+            case 0: kernel::iota<T, 0>(out); break;
+            case 1: kernel::iota<T, 1>(out); break;
+            case 2: kernel::iota<T, 2>(out); break;
+            case 3: kernel::iota<T, 3>(out); break;
             default: AF_ERROR("Invalid rep selection", AF_ERR_INVALID_ARG);
         }
         return out;
     }
 
-#define INSTANTIATE(T)                                                         \
-    template Array<T>* iota<T>(const af::dim4 &dims, const unsigned rep);      \
+#define INSTANTIATE(T)                                                  \
+    template Array<T> iota<T>(const af::dim4 &dims, const unsigned rep); \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cuda/iota.hpp
+++ b/src/backend/cuda/iota.hpp
@@ -13,6 +13,5 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *iota(const dim4& dim, const unsigned rep);
+    Array<T> iota(const dim4& dim, const unsigned rep);
 }
-

--- a/src/backend/cuda/join.cu
+++ b/src/backend/cuda/join.cu
@@ -16,7 +16,7 @@
 namespace cuda
 {
     template<typename Tx, typename Ty>
-    Array<Tx> *join(const int dim, const Array<Tx> &first, const Array<Ty> &second)
+    Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second)
     {
         // All dimensions except join dimension must be equal
         // Compute output dims
@@ -31,16 +31,16 @@ namespace cuda
                 odims[i] = fdims[i];
             }
         }
-        Array<Tx> *out = createEmptyArray<Tx>(odims);
+        Array<Tx> out = createEmptyArray<Tx>(odims);
 
         switch(dim) {
-            case 0: kernel::join<Tx, Ty, 0>(*out, first, second);
+            case 0: kernel::join<Tx, Ty, 0>(out, first, second);
                     break;
-            case 1: kernel::join<Tx, Ty, 1>(*out, first, second);
+            case 1: kernel::join<Tx, Ty, 1>(out, first, second);
                     break;
-            case 2: kernel::join<Tx, Ty, 2>(*out, first, second);
+            case 2: kernel::join<Tx, Ty, 2>(out, first, second);
                     break;
-            case 3: kernel::join<Tx, Ty, 3>(*out, first, second);
+            case 3: kernel::join<Tx, Ty, 3>(out, first, second);
                     break;
         }
 
@@ -48,7 +48,7 @@ namespace cuda
     }
 
 #define INSTANTIATE(Tx, Ty)                                                                             \
-    template Array<Tx>* join<Tx, Ty>(const int dim, const Array<Tx> &first, const Array<Ty> &second);   \
+    template Array<Tx> join<Tx, Ty>(const int dim, const Array<Tx> &first, const Array<Ty> &second);   \
 
     INSTANTIATE(float,   float)
     INSTANTIATE(double,  double)

--- a/src/backend/cuda/join.hpp
+++ b/src/backend/cuda/join.hpp
@@ -13,6 +13,5 @@
 namespace cuda
 {
     template<typename Tx, typename Ty>
-    Array<Tx> *join(const int dim, const Array<Tx> &first, const Array<Ty> &second);
+    Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second);
 }
-

--- a/src/backend/cuda/logic.hpp
+++ b/src/backend/cuda/logic.hpp
@@ -17,13 +17,13 @@
 namespace cuda
 {
     template<typename T, af_op_t op>
-    Array<uchar>* logicOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
+    Array<uchar> logicOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
     {
         return createBinaryNode<uchar, T, op>(lhs, rhs, odims);
     }
 
     template<typename T, af_op_t op>
-    Array<T>* bitOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
+    Array<T> bitOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
     {
         return createBinaryNode<T, T, op>(lhs, rhs, odims);
     }

--- a/src/backend/cuda/match_template.cu
+++ b/src/backend/cuda/match_template.cu
@@ -21,32 +21,32 @@ namespace cuda
 {
 
 template<typename inType, typename outType, af_match_type mType>
-Array<outType>* match_template(const Array<inType> &sImg, const Array<inType> &tImg)
+Array<outType> match_template(const Array<inType> &sImg, const Array<inType> &tImg)
 {
-    Array<outType> *out = createEmptyArray<outType>(sImg.dims());
+    Array<outType> out = createEmptyArray<outType>(sImg.dims());
 
     bool needMean = mType==AF_ZSAD || mType==AF_LSAD ||
                     mType==AF_ZSSD || mType==AF_LSSD ||
                     mType==AF_ZNCC;
 
     if (needMean)
-        kernel::matchTemplate<inType, outType, mType, true>(*out, sImg, tImg);
+        kernel::matchTemplate<inType, outType, mType, true>(out, sImg, tImg);
     else
-        kernel::matchTemplate<inType, outType, mType, false>(*out, sImg, tImg);
+        kernel::matchTemplate<inType, outType, mType, false>(out, sImg, tImg);
 
     return out;
 }
 
 #define INSTANTIATE(in_t, out_t)\
-    template Array<out_t> * match_template<in_t, out_t, AF_SAD >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_LSAD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_ZSAD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_SSD >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_LSSD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_ZSSD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_NCC >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_ZNCC>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_SHD >(const Array<in_t> &sImg, const Array<in_t> &tImg);
+    template Array<out_t> match_template<in_t, out_t, AF_SAD >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_LSAD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_ZSAD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_SSD >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_LSSD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_ZSSD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_NCC >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_ZNCC>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_SHD >(const Array<in_t> &sImg, const Array<in_t> &tImg);
 
 INSTANTIATE(double, double)
 INSTANTIATE(float ,  float)

--- a/src/backend/cuda/match_template.hpp
+++ b/src/backend/cuda/match_template.hpp
@@ -13,6 +13,6 @@ namespace cuda
 {
 
 template<typename inType, typename outType, af_match_type mType>
-Array<outType>* match_template(const Array<inType> &sImg, const Array<inType> &tImg);
+Array<outType> match_template(const Array<inType> &sImg, const Array<inType> &tImg);
 
 }

--- a/src/backend/cuda/meanshift.cu
+++ b/src/backend/cuda/meanshift.cu
@@ -21,20 +21,20 @@ namespace cuda
 {
 
 template<typename T, bool is_color>
-Array<T> * meanshift(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter)
+Array<T> meanshift(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter)
 {
     const dim4 dims = in.dims();
 
-    Array<T>* out   = createEmptyArray<T>(dims);
+    Array<T> out   = createEmptyArray<T>(dims);
 
-    kernel::meanshift<T, is_color>(*out, in, s_sigma, c_sigma, iter);
+    kernel::meanshift<T, is_color>(out, in, s_sigma, c_sigma, iter);
 
     return out;
 }
 
 #define INSTANTIATE(T) \
-    template Array<T> * meanshift<T, true >(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter); \
-    template Array<T> * meanshift<T, false>(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter);
+    template Array<T> meanshift<T, true >(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter); \
+    template Array<T> meanshift<T, false>(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter);
 
 INSTANTIATE(float )
 INSTANTIATE(double)

--- a/src/backend/cuda/meanshift.hpp
+++ b/src/backend/cuda/meanshift.hpp
@@ -13,6 +13,6 @@ namespace cuda
 {
 
 template<typename T, bool is_color>
-Array<T> * meanshift(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter);
+Array<T> meanshift(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter);
 
 }

--- a/src/backend/cuda/medfilt.cu
+++ b/src/backend/cuda/medfilt.cu
@@ -21,22 +21,22 @@ namespace cuda
 {
 
 template<typename T, af_pad_type pad>
-Array<T> * medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid)
+Array<T> medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid)
 {
     ARG_ASSERT(2, (w_len<=kernel::MAX_MEDFILTER_LEN));
 
     const dim4 dims     = in.dims();
 
-    Array<T> * out      = createEmptyArray<T>(dims);
+    Array<T> out      = createEmptyArray<T>(dims);
 
-    kernel::medfilt<T, pad>(*out, in, w_len, w_wid);
+    kernel::medfilt<T, pad>(out, in, w_len, w_wid);
 
     return out;
 }
 
 #define INSTANTIATE(T)\
-    template Array<T> * medfilt<T, AF_ZERO     >(const Array<T> &in, dim_type w_len, dim_type w_wid); \
-    template Array<T> * medfilt<T, AF_SYMMETRIC>(const Array<T> &in, dim_type w_len, dim_type w_wid);
+    template Array<T> medfilt<T, AF_ZERO     >(const Array<T> &in, dim_type w_len, dim_type w_wid); \
+    template Array<T> medfilt<T, AF_SYMMETRIC>(const Array<T> &in, dim_type w_len, dim_type w_wid);
 
 INSTANTIATE(float )
 INSTANTIATE(double)

--- a/src/backend/cuda/medfilt.hpp
+++ b/src/backend/cuda/medfilt.hpp
@@ -13,6 +13,6 @@ namespace cuda
 {
 
 template<typename T, af_pad_type edge_pad>
-Array<T> * medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid);
+Array<T> medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid);
 
 }

--- a/src/backend/cuda/morph.hpp
+++ b/src/backend/cuda/morph.hpp
@@ -13,9 +13,9 @@ namespace cuda
 {
 
 template<typename T, bool isDilation>
-Array<T> * morph(const Array<T> &in, const Array<T> &mask);
+Array<T> morph(const Array<T> &in, const Array<T> &mask);
 
 template<typename T, bool isDilation>
-Array<T> * morph3d(const Array<T> &in, const Array<T> &mask);
+Array<T> morph3d(const Array<T> &in, const Array<T> &mask);
 
 }

--- a/src/backend/cuda/morph3d_impl.hpp
+++ b/src/backend/cuda/morph3d_impl.hpp
@@ -21,7 +21,7 @@ namespace cuda
 {
 
 template<typename T, bool isDilation>
-Array<T> * morph3d(const Array<T> &in, const Array<T> &mask)
+Array<T> morph3d(const Array<T> &in, const Array<T> &mask)
 {
     const dim4 mdims = mask.dims();
 
@@ -35,16 +35,16 @@ Array<T> * morph3d(const Array<T> &in, const Array<T> &mask)
         AF_ERROR("Batch not supported for volumetic morph operations in CUDA backend",
                  AF_ERR_NOT_SUPPORTED);
 
-    Array<T>* out       = createEmptyArray<T>(in.dims());
+    Array<T> out       = createEmptyArray<T>(in.dims());
 
     CUDA_CHECK(cudaMemcpyToSymbol(kernel::cFilter, mask.get(),
                                   mdims[0] * mdims[1] *mdims[2] * sizeof(T),
                                   0, cudaMemcpyDeviceToDevice));
 
     if (isDilation)
-        kernel::morph3d<T, true >(*out, in, mdims[0]);
+        kernel::morph3d<T, true >(out, in, mdims[0]);
     else
-        kernel::morph3d<T, false>(*out, in, mdims[0]);
+        kernel::morph3d<T, false>(out, in, mdims[0]);
 
     return out;
 }
@@ -52,4 +52,4 @@ Array<T> * morph3d(const Array<T> &in, const Array<T> &mask)
 }
 
 #define INSTANTIATE(T, ISDILATE)                                        \
-    template Array<T> * morph3d<T, ISDILATE>(const Array<T> &in, const Array<T> &mask);
+    template Array<T> morph3d<T, ISDILATE>(const Array<T> &in, const Array<T> &mask);

--- a/src/backend/cuda/morph_impl.hpp
+++ b/src/backend/cuda/morph_impl.hpp
@@ -21,7 +21,7 @@ namespace cuda
 {
 
 template<typename T, bool isDilation>
-Array<T> * morph(const Array<T> &in, const Array<T> &mask)
+Array<T>  morph(const Array<T> &in, const Array<T> &mask)
 {
     const dim4 mdims = mask.dims();
 
@@ -30,16 +30,16 @@ Array<T> * morph(const Array<T> &in, const Array<T> &mask)
     if (mdims[0] > 19)
         AF_ERROR("Upto 19x19 square kernels are only supported in cuda currently", AF_ERR_SIZE);
 
-    Array<T>* out = createEmptyArray<T>(in.dims());
+    Array<T> out = createEmptyArray<T>(in.dims());
 
     CUDA_CHECK(cudaMemcpyToSymbol(kernel::cFilter, mask.get(),
                                   mdims[0] * mdims[1] * sizeof(T),
                                   0, cudaMemcpyDeviceToDevice));
 
     if (isDilation)
-        kernel::morph<T, true >(*out, in, mdims[0]);
+        kernel::morph<T, true >(out, in, mdims[0]);
     else
-        kernel::morph<T, false>(*out, in, mdims[0]);
+        kernel::morph<T, false>(out, in, mdims[0]);
 
     return out;
 }
@@ -47,4 +47,4 @@ Array<T> * morph(const Array<T> &in, const Array<T> &mask)
 }
 
 #define INSTANTIATE(T, ISDILATE)                                        \
-    template Array<T> * morph  <T, ISDILATE>(const Array<T> &in, const Array<T> &mask);
+    template Array<T> morph  <T, ISDILATE>(const Array<T> &in, const Array<T> &mask);

--- a/src/backend/cuda/orb.cu
+++ b/src/backend/cuda/orb.cu
@@ -62,12 +62,12 @@ unsigned orb(Array<float> &x, Array<float> &y,
         const dim4 feat_dims(nfeat_out);
         const dim4 desc_dims(8, nfeat_out);
 
-        x     = *createDeviceDataArray<float>(feat_dims, x_out);
-        y     = *createDeviceDataArray<float>(feat_dims, y_out);
-        score = *createDeviceDataArray<float>(feat_dims, score_out);
-        ori   = *createDeviceDataArray<float>(feat_dims, orientation_out);
-        size  = *createDeviceDataArray<float>(feat_dims, size_out);
-        desc  = *createDeviceDataArray<unsigned>(desc_dims, desc_out);
+        x     = createDeviceDataArray<float>(feat_dims, x_out);
+        y     = createDeviceDataArray<float>(feat_dims, y_out);
+        score = createDeviceDataArray<float>(feat_dims, score_out);
+        ori   = createDeviceDataArray<float>(feat_dims, orientation_out);
+        size  = createDeviceDataArray<float>(feat_dims, size_out);
+        desc  = createDeviceDataArray<unsigned>(desc_dims, desc_out);
 
     }
 

--- a/src/backend/cuda/random.cu
+++ b/src/backend/cuda/random.cu
@@ -17,33 +17,33 @@
 namespace cuda
 {
     template<typename T>
-    Array<T>* randu(const af::dim4 &dims)
+    Array<T> randu(const af::dim4 &dims)
     {
-        Array<T>* out = createEmptyArray<T>(dims);
-        kernel::randu(out->get(), out->elements());
+        Array<T> out = createEmptyArray<T>(dims);
+        kernel::randu(out.get(), out.elements());
         return out;
     }
 
     template<typename T>
-    Array<T>* randn(const af::dim4 &dims)
+    Array<T> randn(const af::dim4 &dims)
     {
-        Array<T>* out  = createEmptyArray<T>(dims);
-        kernel::randn(out->get(), out->elements());
+        Array<T> out  = createEmptyArray<T>(dims);
+        kernel::randn(out.get(), out.elements());
         return out;
     }
 
-    template Array<float>  * randu<float>   (const af::dim4 &dims);
-    template Array<double> * randu<double>  (const af::dim4 &dims);
-    template Array<cfloat> * randu<cfloat>  (const af::dim4 &dims);
-    template Array<cdouble>* randu<cdouble> (const af::dim4 &dims);
-    template Array<int>    * randu<int>     (const af::dim4 &dims);
-    template Array<uint>   * randu<uint>    (const af::dim4 &dims);
-    template Array<char>   * randu<char>    (const af::dim4 &dims);
-    template Array<uchar>  * randu<uchar>   (const af::dim4 &dims);
+    template Array<float>   randu<float>   (const af::dim4 &dims);
+    template Array<double>  randu<double>  (const af::dim4 &dims);
+    template Array<cfloat>  randu<cfloat>  (const af::dim4 &dims);
+    template Array<cdouble> randu<cdouble> (const af::dim4 &dims);
+    template Array<int>     randu<int>     (const af::dim4 &dims);
+    template Array<uint>    randu<uint>    (const af::dim4 &dims);
+    template Array<char>    randu<char>    (const af::dim4 &dims);
+    template Array<uchar>   randu<uchar>   (const af::dim4 &dims);
 
-    template Array<float>  * randn<float>   (const af::dim4 &dims);
-    template Array<double> * randn<double>  (const af::dim4 &dims);
-    template Array<cfloat> * randn<cfloat>  (const af::dim4 &dims);
-    template Array<cdouble>* randn<cdouble> (const af::dim4 &dims);
+    template Array<float>   randn<float>   (const af::dim4 &dims);
+    template Array<double>  randn<double>  (const af::dim4 &dims);
+    template Array<cfloat>  randn<cfloat>  (const af::dim4 &dims);
+    template Array<cdouble> randn<cdouble> (const af::dim4 &dims);
 
 }

--- a/src/backend/cuda/random.hpp
+++ b/src/backend/cuda/random.hpp
@@ -13,8 +13,8 @@
 namespace cuda
 {
     template<typename T>
-    Array<T>* randu(const af::dim4 &dims);
+    Array<T> randu(const af::dim4 &dims);
 
     template<typename T>
-    Array<T>* randn(const af::dim4 &dims);
+    Array<T> randn(const af::dim4 &dims);
 }

--- a/src/backend/cuda/reduce.hpp
+++ b/src/backend/cuda/reduce.hpp
@@ -14,7 +14,7 @@
 namespace cuda
 {
     template<af_op_t op, typename Ti, typename To>
-    Array<To>* reduce(const Array<Ti> &in, const int dim);
+    Array<To> reduce(const Array<Ti> &in, const int dim);
 
     template<af_op_t op, typename Ti, typename To>
     To reduce_all(const Array<Ti> &in);

--- a/src/backend/cuda/reduce_impl.hpp
+++ b/src/backend/cuda/reduce_impl.hpp
@@ -23,13 +23,13 @@ using af::dim4;
 namespace cuda
 {
     template<af_op_t op, typename Ti, typename To>
-    Array<To>* reduce(const Array<Ti> &in, const int dim)
+    Array<To> reduce(const Array<Ti> &in, const int dim)
     {
 
         dim4 odims = in.dims();
         odims[dim] = 1;
-        Array<To> *out = createEmptyArray<To>(odims);
-        kernel::reduce<Ti, To, op>(*out, in, dim);
+        Array<To> out = createEmptyArray<To>(odims);
+        kernel::reduce<Ti, To, op>(out, in, dim);
         return out;
     }
 
@@ -41,5 +41,5 @@ namespace cuda
 }
 
 #define INSTANTIATE(Op, Ti, To)                                         \
-    template Array<To>* reduce<Op, Ti, To>(const Array<Ti> &in, const int dim); \
+    template Array<To> reduce<Op, Ti, To>(const Array<Ti> &in, const int dim); \
     template To reduce_all<Op, Ti, To>(const Array<Ti> &in);

--- a/src/backend/cuda/regions.cu
+++ b/src/backend/cuda/regions.cu
@@ -21,13 +21,13 @@ namespace cuda
 {
 
 template<typename T>
-Array<T> * regions(const Array<uchar> &in, af_connectivity connectivity)
+Array<T>  regions(const Array<uchar> &in, af_connectivity connectivity)
 {
     ARG_ASSERT(2, (connectivity==AF_CONNECTIVITY_4 || connectivity==AF_CONNECTIVITY_8));
 
     const dim4 dims = in.dims();
 
-    Array<T> * out  = createEmptyArray<T>(dims);
+    Array<T>  out  = createEmptyArray<T>(dims);
 
     // Create bindless texture object for the equiv map.
     cudaTextureObject_t tex = 0;
@@ -48,10 +48,10 @@ Array<T> * regions(const Array<uchar> &in, af_connectivity connectivity)
 
     switch(connectivity) {
         case AF_CONNECTIVITY_4:
-            ::regions<T, false, 2>(*out, in, tex);
+            ::regions<T, false, 2>(out, in, tex);
             break;
         case AF_CONNECTIVITY_8:
-            ::regions<T, true,  2>(*out, in, tex);
+            ::regions<T, true,  2>(out, in, tex);
             break;
     }
 
@@ -59,7 +59,7 @@ Array<T> * regions(const Array<uchar> &in, af_connectivity connectivity)
 }
 
 #define INSTANTIATE(T)\
-    template Array<T> * regions<T>(const Array<uchar> &in, af_connectivity connectivity);
+    template Array<T>  regions<T>(const Array<uchar> &in, af_connectivity connectivity);
 
 INSTANTIATE(float )
 INSTANTIATE(double)

--- a/src/backend/cuda/regions.hpp
+++ b/src/backend/cuda/regions.hpp
@@ -13,6 +13,6 @@ namespace cuda
 {
 
 template<typename T>
-Array<T> * regions(const Array<uchar> &in, af_connectivity connectivity);
+Array<T>  regions(const Array<uchar> &in, af_connectivity connectivity);
 
 }

--- a/src/backend/cuda/reorder.cu
+++ b/src/backend/cuda/reorder.cu
@@ -16,22 +16,22 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *reorder(const Array<T> &in, const af::dim4 &rdims)
+    Array<T> reorder(const Array<T> &in, const af::dim4 &rdims)
     {
         const af::dim4 iDims = in.dims();
         af::dim4 oDims(0);
         for(int i = 0; i < 4; i++)
             oDims[i] = iDims[rdims[i]];
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
-        kernel::reorder<T>(*out, in, rdims.get());
+        kernel::reorder<T>(out, in, rdims.get());
 
         return out;
     }
 
 #define INSTANTIATE(T)                                                         \
-    template Array<T>* reorder<T>(const Array<T> &in, const af::dim4 &rdims);  \
+    template Array<T> reorder<T>(const Array<T> &in, const af::dim4 &rdims);  \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cuda/reorder.hpp
+++ b/src/backend/cuda/reorder.hpp
@@ -13,5 +13,5 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *reorder(const Array<T> &in, const af::dim4 &rdims);
+    Array<T> reorder(const Array<T> &in, const af::dim4 &rdims);
 }

--- a/src/backend/cuda/resize.cu
+++ b/src/backend/cuda/resize.cu
@@ -16,7 +16,7 @@
 namespace cuda
 {
     template<typename T>
-    Array<T>* resize(const Array<T> &in, const dim_type odim0, const dim_type odim1,
+    Array<T> resize(const Array<T> &in, const dim_type odim0, const dim_type odim1,
                      const af_interp_type method)
     {
         const af::dim4 iDims = in.dims();
@@ -26,14 +26,14 @@ namespace cuda
             AF_ERROR("Elements are 0", AF_ERR_SIZE);
         }
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
         switch(method) {
             case AF_INTERP_NEAREST:
-                kernel::resize<T, AF_INTERP_NEAREST >(*out, in);
+                kernel::resize<T, AF_INTERP_NEAREST >(out, in);
                 break;
             case AF_INTERP_BILINEAR:
-                kernel::resize<T, AF_INTERP_BILINEAR>(*out, in);
+                kernel::resize<T, AF_INTERP_BILINEAR>(out, in);
                 break;
             default:
                 break;
@@ -44,8 +44,8 @@ namespace cuda
 
 
 #define INSTANTIATE(T)                                                                            \
-    template Array<T>* resize<T> (const Array<T> &in, const dim_type odim0, const dim_type odim1, \
-                                  const af_interp_type method);
+    template Array<T> resize<T> (const Array<T> &in, const dim_type odim0, const dim_type odim1, \
+                                 const af_interp_type method);
 
 
     INSTANTIATE(float)

--- a/src/backend/cuda/resize.hpp
+++ b/src/backend/cuda/resize.hpp
@@ -13,6 +13,6 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *resize(const Array<T> &in, const dim_type odim0, const dim_type odim1,
-                     const af_interp_type method);
+    Array<T> resize(const Array<T> &in, const dim_type odim0, const dim_type odim1,
+                    const af_interp_type method);
 }

--- a/src/backend/cuda/rotate.cu
+++ b/src/backend/cuda/rotate.cu
@@ -15,17 +15,17 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *rotate(const Array<T> &in, const float theta, const af::dim4 &odims,
+    Array<T> rotate(const Array<T> &in, const float theta, const af::dim4 &odims,
                      const af_interp_type method)
     {
-        Array<T> *out = createEmptyArray<T>(odims);
+        Array<T> out = createEmptyArray<T>(odims);
 
         switch(method) {
             case AF_INTERP_NEAREST:
-                kernel::rotate<T, AF_INTERP_NEAREST> (*out, in, theta);
+                kernel::rotate<T, AF_INTERP_NEAREST> (out, in, theta);
                 break;
             case AF_INTERP_BILINEAR:
-                kernel::rotate<T, AF_INTERP_BILINEAR>(*out, in, theta);
+                kernel::rotate<T, AF_INTERP_BILINEAR>(out, in, theta);
                 break;
             default:
                 AF_ERROR("Unsupported interpolation type", AF_ERR_ARG);
@@ -36,8 +36,8 @@ namespace cuda
 
 
 #define INSTANTIATE(T)                                                                          \
-    template Array<T> *rotate(const Array<T> &in, const float theta,                            \
-                              const af::dim4 &odims, const af_interp_type method);              \
+    template Array<T> rotate(const Array<T> &in, const float theta,                            \
+                             const af::dim4 &odims, const af_interp_type method); \
 
 
     INSTANTIATE(float)

--- a/src/backend/cuda/rotate.hpp
+++ b/src/backend/cuda/rotate.hpp
@@ -13,6 +13,6 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *rotate(const Array<T> &in, const float theta, const af::dim4 &odims,
-                     const af_interp_type method);
+    Array<T> rotate(const Array<T> &in, const float theta, const af::dim4 &odims,
+                    const af_interp_type method);
 }

--- a/src/backend/cuda/scalar.hpp
+++ b/src/backend/cuda/scalar.hpp
@@ -16,7 +16,7 @@ namespace cuda
 {
 
 template<typename T>
-Array<T>* createScalarNode(const dim4 &size, const T val)
+Array<T> createScalarNode(const dim4 &size, const T val)
 {
     JIT::ScalarNode<T> *node = new JIT::ScalarNode<T>(val);
     return createNodeArray<T>(size, JIT::Node_ptr(reinterpret_cast<JIT::Node *>(node)));

--- a/src/backend/cuda/scan.cu
+++ b/src/backend/cuda/scan.cu
@@ -22,15 +22,15 @@
 namespace cuda
 {
     template<af_op_t op, typename Ti, typename To>
-    Array<To>* scan(const Array<Ti> &in, const int dim)
+    Array<To> scan(const Array<Ti> &in, const int dim)
     {
-        Array<To> *out = createEmptyArray<To>(in.dims());
+        Array<To> out = createEmptyArray<To>(in.dims());
 
         switch (dim) {
-        case 0: kernel::scan_first<Ti, To, op   >(*out, in); break;
-        case 1: kernel::scan_dim  <Ti, To, op, 1>(*out, in); break;
-        case 2: kernel::scan_dim  <Ti, To, op, 2>(*out, in); break;
-        case 3: kernel::scan_dim  <Ti, To, op, 3>(*out, in); break;
+        case 0: kernel::scan_first<Ti, To, op   >(out, in); break;
+        case 1: kernel::scan_dim  <Ti, To, op, 1>(out, in); break;
+        case 2: kernel::scan_dim  <Ti, To, op, 2>(out, in); break;
+        case 3: kernel::scan_dim  <Ti, To, op, 3>(out, in); break;
         }
 
         return out;
@@ -38,7 +38,7 @@ namespace cuda
 
 
 #define INSTANTIATE(ROp, Ti, To)                                        \
-    template Array<To>* scan<ROp, Ti, To>(const Array<Ti> &in, const int dim); \
+    template Array<To> scan<ROp, Ti, To>(const Array<Ti> &in, const int dim); \
 
     //accum
     INSTANTIATE(af_add_t, float  , float  )

--- a/src/backend/cuda/scan.hpp
+++ b/src/backend/cuda/scan.hpp
@@ -14,5 +14,5 @@
 namespace cuda
 {
     template<af_op_t op, typename Ti, typename To>
-    Array<To>* scan(const Array<Ti>& in, const int dim);
+    Array<To> scan(const Array<Ti>& in, const int dim);
 }

--- a/src/backend/cuda/set.cu
+++ b/src/backend/cuda/set.cu
@@ -26,23 +26,23 @@ namespace cuda
     using af::dim4;
 
     template<typename T>
-    Array<T>* setUnique(const Array<T> &in,
+    Array<T> setUnique(const Array<T> &in,
                         const bool is_sorted)
     {
-        Array<T> *out = copyArray<T>(in);
+        Array<T> out = copyArray<T>(in);
 
-        thrust::device_ptr<T> out_ptr = thrust::device_pointer_cast<T>(out->get());
-        thrust::device_ptr<T> out_ptr_end = out_ptr + out->dims()[0];
+        thrust::device_ptr<T> out_ptr = thrust::device_pointer_cast<T>(out.get());
+        thrust::device_ptr<T> out_ptr_end = out_ptr + out.dims()[0];
 
         if(!is_sorted) thrust::sort(out_ptr, out_ptr_end);
         thrust::device_ptr<T> out_ptr_last = thrust::unique(out_ptr, out_ptr_end);
 
-        out->resetDims(dim4(thrust::distance(out_ptr, out_ptr_last)));
+        out.resetDims(dim4(thrust::distance(out_ptr, out_ptr_last)));
         return out;
     }
 
     template<typename T>
-    Array<T>* setUnion(const Array<T> &first,
+    Array<T> setUnion(const Array<T> &first,
                        const Array<T> &second,
                        const bool is_unique)
     {
@@ -50,12 +50,12 @@ namespace cuda
         Array<T> unique_second = second;
 
         if (!is_unique) {
-            unique_first = *setUnique(first, false);
-            unique_second = *setUnique(second, false);
+            unique_first = setUnique(first, false);
+            unique_second = setUnique(second, false);
         }
 
         dim_type out_size = unique_first.dims()[0] + unique_second.dims()[0];
-        Array<T> *out = createEmptyArray<T>(dim4(out_size));
+        Array<T> out = createEmptyArray<T>(dim4(out_size));
 
         thrust::device_ptr<T> first_ptr = thrust::device_pointer_cast<T>(unique_first.get());
         thrust::device_ptr<T> first_ptr_end = first_ptr + unique_first.dims()[0];
@@ -63,19 +63,19 @@ namespace cuda
         thrust::device_ptr<T> second_ptr = thrust::device_pointer_cast<T>(unique_second.get());
         thrust::device_ptr<T> second_ptr_end = second_ptr + unique_second.dims()[0];
 
-        thrust::device_ptr<T> out_ptr = thrust::device_pointer_cast<T>(out->get());
+        thrust::device_ptr<T> out_ptr = thrust::device_pointer_cast<T>(out.get());
 
         thrust::device_ptr<T> out_ptr_last = thrust::set_union(first_ptr, first_ptr_end,
                                                                second_ptr, second_ptr_end,
                                                                out_ptr);
 
-        out->resetDims(dim4(thrust::distance(out_ptr, out_ptr_last)));
+        out.resetDims(dim4(thrust::distance(out_ptr, out_ptr_last)));
 
         return out;
     }
 
     template<typename T>
-    Array<T>* setIntersect(const Array<T> &first,
+    Array<T> setIntersect(const Array<T> &first,
                            const Array<T> &second,
                            const bool is_unique)
     {
@@ -83,12 +83,12 @@ namespace cuda
         Array<T> unique_second = second;
 
         if (!is_unique) {
-            unique_first = *setUnique(first, false);
-            unique_second = *setUnique(second, false);
+            unique_first = setUnique(first, false);
+            unique_second = setUnique(second, false);
         }
 
         dim_type out_size = std::max(unique_first.dims()[0], unique_second.dims()[0]);
-        Array<T> *out = createEmptyArray<T>(dim4(out_size));
+        Array<T> out = createEmptyArray<T>(dim4(out_size));
 
         thrust::device_ptr<T> first_ptr = thrust::device_pointer_cast<T>(unique_first.get());
         thrust::device_ptr<T> first_ptr_end = first_ptr + unique_first.dims()[0];
@@ -96,21 +96,21 @@ namespace cuda
         thrust::device_ptr<T> second_ptr = thrust::device_pointer_cast<T>(unique_second.get());
         thrust::device_ptr<T> second_ptr_end = second_ptr + unique_second.dims()[0];
 
-        thrust::device_ptr<T> out_ptr = thrust::device_pointer_cast<T>(out->get());
+        thrust::device_ptr<T> out_ptr = thrust::device_pointer_cast<T>(out.get());
 
         thrust::device_ptr<T> out_ptr_last = thrust::set_intersection(first_ptr, first_ptr_end,
                                                                       second_ptr, second_ptr_end,
                                                                       out_ptr);
 
-        out->resetDims(dim4(thrust::distance(out_ptr, out_ptr_last)));
+        out.resetDims(dim4(thrust::distance(out_ptr, out_ptr_last)));
 
         return out;
     }
 
 #define INSTANTIATE(T)                                                  \
-    template Array<T>* setUnique<T>(const Array<T> &in, const bool is_sorted); \
-    template Array<T>* setUnion<T>(const Array<T> &first, const Array<T> &second, const bool is_unique); \
-    template Array<T>* setIntersect<T>(const Array<T> &first, const Array<T> &second, const bool is_unique); \
+    template Array<T> setUnique<T>(const Array<T> &in, const bool is_sorted); \
+    template Array<T> setUnion<T>(const Array<T> &first, const Array<T> &second, const bool is_unique); \
+    template Array<T> setIntersect<T>(const Array<T> &first, const Array<T> &second, const bool is_unique); \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cuda/set.hpp
+++ b/src/backend/cuda/set.hpp
@@ -12,14 +12,14 @@
 
 namespace cuda
 {
-    template<typename T> Array<T>* setUnique(const Array<T> &in,
-                                             const bool is_sorted);
+    template<typename T> Array<T> setUnique(const Array<T> &in,
+                                            const bool is_sorted);
 
-    template<typename T> Array<T>* setUnion(const Array<T> &first,
-                                            const Array<T> &second,
-                                            const bool is_unique);
+    template<typename T> Array<T> setUnion(const Array<T> &first,
+                                           const Array<T> &second,
+                                           const bool is_unique);
 
-    template<typename T> Array<T>* setIntersect(const Array<T> &first,
-                                                const Array<T> &second,
-                                                const bool is_unique);
+    template<typename T> Array<T> setIntersect(const Array<T> &first,
+                                               const Array<T> &second,
+                                               const bool is_unique);
 }

--- a/src/backend/cuda/shift.cu
+++ b/src/backend/cuda/shift.cu
@@ -16,20 +16,20 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *shift(const Array<T> &in, const af::dim4 &sdims)
+    Array<T> shift(const Array<T> &in, const af::dim4 &sdims)
     {
         const af::dim4 iDims = in.dims();
         af::dim4 oDims = iDims;
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
-        kernel::shift<T>(*out, in, sdims.get());
+        kernel::shift<T>(out, in, sdims.get());
 
         return out;
     }
 
 #define INSTANTIATE(T)                                                          \
-    template Array<T>* shift<T>(const Array<T> &in, const af::dim4 &sdims);     \
+    template Array<T> shift<T>(const Array<T> &in, const af::dim4 &sdims);     \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cuda/shift.hpp
+++ b/src/backend/cuda/shift.hpp
@@ -13,5 +13,5 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *shift(const Array<T> &in, const af::dim4 &sdims);
+    Array<T> shift(const Array<T> &in, const af::dim4 &sdims);
 }

--- a/src/backend/cuda/sobel.cu
+++ b/src/backend/cuda/sobel.cu
@@ -21,19 +21,19 @@ namespace cuda
 {
 
 template<typename Ti, typename To>
-std::pair< Array<To>*, Array<To>* >
+std::pair< Array<To>, Array<To> >
 sobelDerivatives(const Array<Ti> &img, const unsigned &ker_size)
 {
-    Array<To> *dx = createEmptyArray<To>(img.dims());
-    Array<To> *dy = createEmptyArray<To>(img.dims());
+    Array<To> dx = createEmptyArray<To>(img.dims());
+    Array<To> dy = createEmptyArray<To>(img.dims());
 
-    kernel::sobel<Ti, To>(*dx, *dy, img, ker_size);
+    kernel::sobel<Ti, To>(dx, dy, img, ker_size);
 
     return std::make_pair(dx, dy);
 }
 
-#define INSTANTIATE(Ti, To)                                                 \
-    template std::pair< Array<To>*, Array<To>* >                            \
+#define INSTANTIATE(Ti, To)                                             \
+    template std::pair< Array<To>, Array<To> >                          \
     sobelDerivatives(const Array<Ti> &img, const unsigned &ker_size);
 
 INSTANTIATE(float , float)

--- a/src/backend/cuda/sobel.hpp
+++ b/src/backend/cuda/sobel.hpp
@@ -14,7 +14,7 @@ namespace cuda
 {
 
 template<typename Ti, typename To>
-std::pair< Array<To>*, Array<To>* >
+std::pair< Array<To>, Array<To> >
 sobelDerivatives(const Array<Ti> &img, const unsigned &ker_size);
 
 }

--- a/src/backend/cuda/sort.cu
+++ b/src/backend/cuda/sort.cu
@@ -18,12 +18,12 @@
 namespace cuda
 {
     template<typename T, bool isAscending>
-    Array<T>* sort(const Array<T> &in, const unsigned dim)
+    Array<T> sort(const Array<T> &in, const unsigned dim)
     {
-        Array<T> *out = copyArray<T>(in);
+        Array<T> out = copyArray<T>(in);
         switch(dim) {
 
-        case 0: kernel::sort0<T, isAscending>(*out);
+        case 0: kernel::sort0<T, isAscending>(out);
             break;
         default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
         }
@@ -31,8 +31,8 @@ namespace cuda
     }
 
 #define INSTANTIATE(T)                                                  \
-    template Array<T>* sort<T, true>(const Array<T> &in, const unsigned dim); \
-    template Array<T>*  sort<T,false>(const Array<T> &in, const unsigned dim); \
+    template Array<T> sort<T, true>(const Array<T> &in, const unsigned dim); \
+    template Array<T>  sort<T,false>(const Array<T> &in, const unsigned dim); \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cuda/sort.hpp
+++ b/src/backend/cuda/sort.hpp
@@ -13,5 +13,5 @@
 namespace cuda
 {
     template<typename T, bool isAscending>
-    Array<T>* sort(const Array<T> &in, const unsigned dim);
+    Array<T> sort(const Array<T> &in, const unsigned dim);
 }

--- a/src/backend/cuda/sort_by_key_impl.hpp
+++ b/src/backend/cuda/sort_by_key_impl.hpp
@@ -21,8 +21,8 @@ namespace cuda
     void sort_by_key(Array<Tk> &okey, Array<Tv> &oval,
                const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim)
     {
-        okey = *copyArray<Tk>(ikey);
-        oval = *copyArray<Tv>(ival);
+        okey = copyArray<Tk>(ikey);
+        oval = copyArray<Tv>(ival);
         switch(dim) {
         case 0: kernel::sort0_by_key<Tk, Tv, isAscending>(okey, oval);
             break;

--- a/src/backend/cuda/sort_index.cu
+++ b/src/backend/cuda/sort_index.cu
@@ -20,8 +20,8 @@ namespace cuda
     template<typename T, bool isAscending>
     void sort_index(Array<T> &val, Array<uint> &idx, const Array<T> &in, const uint dim)
     {
-        val = *copyArray<T>(in);
-        idx = *createEmptyArray<uint>(in.dims());
+        val = copyArray<T>(in);
+        idx = createEmptyArray<uint>(in.dims());
         switch(dim) {
             case 0: kernel::sort0_index<T, isAscending>(val, idx);
                     break;

--- a/src/backend/cuda/tile.cu
+++ b/src/backend/cuda/tile.cu
@@ -16,7 +16,7 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *tile(const Array<T> &in, const af::dim4 &tileDims)
+    Array<T> tile(const Array<T> &in, const af::dim4 &tileDims)
     {
         const af::dim4 iDims = in.dims();
         af::dim4 oDims = iDims;
@@ -26,15 +26,15 @@ namespace cuda
             AF_ERROR("Elements are 0", AF_ERR_SIZE);
         }
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
-        kernel::tile<T>(*out, in);
+        kernel::tile<T>(out, in);
 
         return out;
     }
 
 #define INSTANTIATE(T)                                                         \
-    template Array<T>* tile<T>(const Array<T> &in, const af::dim4 &tileDims);  \
+    template Array<T> tile<T>(const Array<T> &in, const af::dim4 &tileDims);  \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cuda/tile.hpp
+++ b/src/backend/cuda/tile.hpp
@@ -13,5 +13,5 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *tile(const Array<T> &in, const af::dim4 &tileDims);
+    Array<T> tile(const Array<T> &in, const af::dim4 &tileDims);
 }

--- a/src/backend/cuda/transform.cu
+++ b/src/backend/cuda/transform.cu
@@ -15,19 +15,19 @@
 namespace cuda
 {
     template<typename T>
-    Array<T>* transform(const Array<T> &in, const Array<float> &transform, const af::dim4 &odims,
+    Array<T> transform(const Array<T> &in, const Array<float> &transform, const af::dim4 &odims,
                         const af_interp_type method, const bool inverse)
     {
         const af::dim4 idims = in.dims();
 
-        Array<T> *out = createEmptyArray<T>(odims);
+        Array<T> out = createEmptyArray<T>(odims);
 
         switch(method) {
             case AF_INTERP_NEAREST:
-                kernel::transform<T, AF_INTERP_NEAREST> (*out, in, transform, inverse);
+                kernel::transform<T, AF_INTERP_NEAREST> (out, in, transform, inverse);
                 break;
             case AF_INTERP_BILINEAR:
-                kernel::transform<T, AF_INTERP_BILINEAR>(*out, in, transform, inverse);
+                kernel::transform<T, AF_INTERP_BILINEAR>(out, in, transform, inverse);
                 break;
             default:
                 AF_ERROR("Unsupported interpolation type", AF_ERR_ARG);
@@ -38,7 +38,7 @@ namespace cuda
 
 
 #define INSTANTIATE(T)                                                                          \
-    template Array<T>* transform(const Array<T> &in, const Array<float> &transform,             \
+    template Array<T> transform(const Array<T> &in, const Array<float> &transform,             \
                                  const af::dim4 &odims, const af_interp_type method,            \
                                  const bool inverse);                                           \
 

--- a/src/backend/cuda/transform.hpp
+++ b/src/backend/cuda/transform.hpp
@@ -13,6 +13,6 @@
 namespace cuda
 {
     template<typename T>
-    Array<T> *transform(const Array<T> &in, const Array<float> &tf, const af::dim4 &odims,
+    Array<T> transform(const Array<T> &in, const Array<float> &tf, const af::dim4 &odims,
                         const af_interp_type method, const bool inverse);
 }

--- a/src/backend/cuda/transpose.cu
+++ b/src/backend/cuda/transpose.cu
@@ -18,23 +18,23 @@ namespace cuda
 {
 
 template<typename T>
-Array<T> * transpose(const Array<T> &in, const bool conjugate)
+Array<T>  transpose(const Array<T> &in, const bool conjugate)
 {
     const dim4 inDims   = in.dims();
     const dim4 inStrides= in.strides();
 
     dim4 outDims  = dim4(inDims[1],inDims[0],inDims[2],inDims[3]);
 
-    Array<T>* out  = createEmptyArray<T>(outDims);
+    Array<T> out  = createEmptyArray<T>(outDims);
 
-    if(conjugate)   { kernel::transpose<T, true>(*out, in, inDims.ndims()); }
-    else            { kernel::transpose<T, false>(*out, in, inDims.ndims());}
+    if(conjugate)   { kernel::transpose<T, true>(out, in, inDims.ndims()); }
+    else            { kernel::transpose<T, false>(out, in, inDims.ndims());}
 
     return out;
 }
 
 #define INSTANTIATE(T)\
-    template Array<T> * transpose(const Array<T> &in, const bool conjugate);
+    template Array<T>  transpose(const Array<T> &in, const bool conjugate);
 
 INSTANTIATE(float  )
 INSTANTIATE(cfloat )

--- a/src/backend/cuda/transpose.hpp
+++ b/src/backend/cuda/transpose.hpp
@@ -13,6 +13,6 @@ namespace cuda
 {
 
 template<typename T>
-Array<T> * transpose(const Array<T> &in, const bool conjugate);
+Array<T>  transpose(const Array<T> &in, const bool conjugate);
 
 }

--- a/src/backend/cuda/unary.hpp
+++ b/src/backend/cuda/unary.hpp
@@ -78,7 +78,7 @@ UNARY_FN(floor)
 #undef UNARY_FN
 
     template<typename T, af_op_t op>
-    Array<T>* unaryOp(const Array<T> &in)
+    Array<T> unaryOp(const Array<T> &in)
     {
 
         UnOp<T, op> uop;
@@ -115,7 +115,7 @@ UNARY2_FN(isinf, isINF)
 UNARY2_FN(iszero, iszero)
 
     template<typename T, af_op_t op>
-    Array<char>* checkOp(const Array<T> &in)
+    Array<char> checkOp(const Array<T> &in)
     {
         UnOp<T, op> uop;
 

--- a/src/backend/cuda/where.cu
+++ b/src/backend/cuda/where.cu
@@ -21,7 +21,7 @@
 namespace cuda
 {
     template<typename T>
-    Array<uint>* where(const Array<T> &in)
+    Array<uint> where(const Array<T> &in)
     {
         Param<uint> out;
         kernel::where<T>(out, in);
@@ -30,7 +30,7 @@ namespace cuda
 
 
 #define INSTANTIATE(T)                                  \
-    template Array<uint>* where<T>(const Array<T> &in);    \
+    template Array<uint> where<T>(const Array<T> &in);    \
 
     INSTANTIATE(float  )
     INSTANTIATE(cfloat )

--- a/src/backend/cuda/where.hpp
+++ b/src/backend/cuda/where.hpp
@@ -13,5 +13,5 @@
 namespace cuda
 {
     template<typename T>
-    Array<uint>* where(const Array<T>& in);
+    Array<uint> where(const Array<T>& in);
 }

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -19,6 +19,11 @@ using af::dim4;
 
 namespace opencl
 {
+
+    using JIT::BufferNode;
+    using JIT::Node;
+    using JIT::Node_ptr;
+
     template<typename T>
     Array<T>::Array(af::dim4 dims) :
         ArrayInfo(dims, af::dim4(0,0,0,0), calcStrides(dims), (af_dtype)dtype_traits<T>::af_type),
@@ -73,137 +78,6 @@ namespace opencl
     {
     }
 
-    template<typename T>
-    Array<T>::~Array()
-    { }
-
-    using JIT::BufferNode;
-    using JIT::Node;
-    using JIT::Node_ptr;
-
-    template<typename T>
-    Node_ptr Array<T>::getNode() const
-    {
-        if (!node) {
-            bool is_linear = isLinear();
-            BufferNode *buf_node = new BufferNode(dtype_traits<T>::getName(),
-                                                  shortname<T>(true), *this, is_linear, data);
-            const_cast<Array<T> *>(this)->node = Node_ptr(reinterpret_cast<Node *>(buf_node));
-        }
-
-        return node;
-    }
-
-    using af::dim4;
-
-    template<typename T>
-    Array<T> *
-    createNodeArray(const dim4 &dims, Node_ptr node)
-    {
-        return new Array<T>(dims, node);
-    }
-
-    template<typename T>
-    Array<T> *
-    createSubArray(const Array<T>& parent, const dim4 &dims, const dim4 &offset, const dim4 &stride)
-    {
-
-        Array<T> *out = new Array<T>(parent, dims, offset, stride);
-
-        if (stride[0] != 1 ||
-            stride[1] <  0 ||
-            stride[2] <  0 ||
-            stride[3] <  0) {
-
-            out = copyArray(*out);
-        }
-
-        return out;
-    }
-
-    template<typename T>
-    Array<T> *
-    createRefArray(const Array<T>& parent, const dim4 &dims, const dim4 &offset, const dim4 &stride)
-    {
-        return new Array<T>(parent, dims, offset, stride);
-    }
-
-    template<typename T>
-    Array<T> *
-    createHostDataArray(const dim4 &size, const T * const data)
-    {
-        if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
-            !opencl::isDoubleSupported(opencl::getActiveDeviceId())) {
-            TYPE_ERROR(1, (std::is_same<T, double>::value ? f64 : c64));
-        }
-        Array<T> *out = new Array<T>(size, data);
-        return out;
-    }
-
-    template<typename T>
-    Array<T> *
-    createDeviceDataArray(const dim4 &size, const void *data)
-    {
-        if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
-            !opencl::isDoubleSupported(opencl::getActiveDeviceId())) {
-            TYPE_ERROR(1, (std::is_same<T, double>::value ? f64 : c64));
-        }
-        Array<T> *out = new Array<T>(size, (cl_mem)(data));
-        return out;
-    }
-
-    template<typename T>
-    Array<T>*
-    createValueArray(const dim4 &size, const T& value)
-    {
-        if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
-            !opencl::isDoubleSupported(opencl::getActiveDeviceId())) {
-            TYPE_ERROR(1, (std::is_same<T, double>::value ? f64 : c64));
-        }
-        return createScalarNode<T>(size, value);
-    }
-
-    template<typename T>
-    Array<T>*
-    createEmptyArray(const dim4 &size)
-    {
-        if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
-            !opencl::isDoubleSupported(opencl::getActiveDeviceId())) {
-            TYPE_ERROR(1, (std::is_same<T, double>::value ? f64 : c64));
-        }
-        Array<T> *out = new Array<T>(size);
-        return out;
-    }
-
-    template<typename inType, typename outType>
-    Array<outType> *
-    createPaddedArray(Array<inType> const &in, dim4 const &dims, outType default_value, double factor)
-    {
-        Array<outType> *ret = createEmptyArray<outType>(dims);
-
-        copy<inType, outType>(*ret, in, default_value, factor);
-
-        return ret;
-    }
-
-    template<typename T>
-    Array<T>*
-    createParamArray(Param &tmp)
-    {
-        if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
-            !opencl::isDoubleSupported(opencl::getActiveDeviceId())) {
-            TYPE_ERROR(1, (std::is_same<T, double>::value ? f64 : c64));
-        }
-        Array<T> *out = new Array<T>(tmp);
-        return out;
-    }
-
-    template<typename T>
-    void
-    destroyArray(Array<T> &A)
-    {
-        delete &A;
-    }
 
     template<typename T>
     void Array<T>::eval()
@@ -235,23 +109,148 @@ namespace opencl
         const_cast<Array<T> *>(this)->eval();
     }
 
+    template<typename T>
+    Array<T>::~Array()
+    { }
+
+    template<typename T>
+    Node_ptr Array<T>::getNode() const
+    {
+        if (!node) {
+            bool is_linear = isLinear();
+            BufferNode *buf_node = new BufferNode(dtype_traits<T>::getName(),
+                                                  shortname<T>(true), *this, is_linear, data);
+            const_cast<Array<T> *>(this)->node = Node_ptr(reinterpret_cast<Node *>(buf_node));
+        }
+
+        return node;
+    }
+
+    using af::dim4;
+
+    template<typename T>
+    Array<T>
+    createNodeArray(const dim4 &dims, Node_ptr node)
+    {
+        return Array<T>(dims, node);
+    }
+
+    template<typename T>
+    Array<T> createSubArray(const Array<T>& parent,
+                            const std::vector<af_seq> &index,
+                            bool copy)
+    {
+        dim4 dims   = af::toDims  (index, parent.dims());
+        dim4 offset = af::toOffset(index, parent.dims());
+        dim4 stride = af::toStride (index, parent.dims());
+
+        Array<T> out = Array<T>(parent, dims, offset, stride);
+
+        if (!copy) return out;
+
+        if (stride[0] != 1 ||
+            stride[1] <  0 ||
+            stride[2] <  0 ||
+            stride[3] <  0) {
+
+            out = copyArray(out);
+        }
+
+        return out;
+    }
+
+    template<typename T>
+    Array<T>
+    createHostDataArray(const dim4 &size, const T * const data)
+    {
+        if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
+            !opencl::isDoubleSupported(opencl::getActiveDeviceId())) {
+            TYPE_ERROR(1, (std::is_same<T, double>::value ? f64 : c64));
+        }
+        return Array<T>(size, data);
+    }
+
+    template<typename T>
+    Array<T>
+    createDeviceDataArray(const dim4 &size, const void *data)
+    {
+        if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
+            !opencl::isDoubleSupported(opencl::getActiveDeviceId())) {
+            TYPE_ERROR(1, (std::is_same<T, double>::value ? f64 : c64));
+        }
+
+        return Array<T>(size, (cl_mem)(data));
+    }
+
+    template<typename T>
+    Array<T>
+    createValueArray(const dim4 &size, const T& value)
+    {
+        if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
+            !opencl::isDoubleSupported(opencl::getActiveDeviceId())) {
+            TYPE_ERROR(1, (std::is_same<T, double>::value ? f64 : c64));
+        }
+        return createScalarNode<T>(size, value);
+    }
+
+    template<typename T>
+    Array<T>
+    createEmptyArray(const dim4 &size)
+    {
+        if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
+            !opencl::isDoubleSupported(opencl::getActiveDeviceId())) {
+            TYPE_ERROR(1, (std::is_same<T, double>::value ? f64 : c64));
+        }
+        return Array<T>(size);
+    }
+
+    template<typename T>
+    Array<T> *initArray()
+    {
+        return new Array<T>(dim4());
+    }
+
+    template<typename T>
+    Array<T>
+    createParamArray(Param &tmp)
+    {
+        if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
+            !opencl::isDoubleSupported(opencl::getActiveDeviceId())) {
+            TYPE_ERROR(1, (std::is_same<T, double>::value ? f64 : c64));
+        }
+        return Array<T>(tmp);
+    }
+
+    template<typename T>
+    void
+    destroyArray(Array<T> *A)
+    {
+        delete A;
+    }
+
+    template<typename T>
+    void evalArray(const Array<T> &A)
+    {
+        A.eval();
+    }
+
 
 #define INSTANTIATE(T)                                                  \
-    template       Array<T>*  createHostDataArray<T>  (const dim4 &size, const T * const data); \
-    template       Array<T>*  createDeviceDataArray<T>  (const dim4 &size, const void *data); \
-    template       Array<T>*  createValueArray<T> (const dim4 &size, const T &value); \
-    template       Array<T>*  createEmptyArray<T> (const dim4 &size);   \
-    template       Array<T>*  createParamArray<T> (Param &tmp);         \
-    template       Array<T>*  createSubArray<T>   (const Array<T> &parent, const dim4 &dims, \
-                                                   const dim4 &offset, const dim4 &stride); \
-    template       Array<T>*  createRefArray<T>   (const Array<T> &parent, const dim4 &dims, \
-                                                   const dim4 &offset, const dim4 &stride); \
-    template       Array<T>*  createNodeArray<T>   (const dim4 &size, JIT::Node_ptr node); \
-    template       JIT::Node_ptr Array<T>::getNode() const;             \
+    template       Array<T>  createHostDataArray<T>   (const dim4 &size, const T * const data); \
+    template       Array<T>  createDeviceDataArray<T> (const dim4 &size, const void *data); \
+    template       Array<T>  createValueArray<T>      (const dim4 &size, const T &value); \
+    template       Array<T>  createEmptyArray<T>      (const dim4 &size); \
+    template       Array<T>  *initArray<T      >      ();               \
+    template       Array<T>  createParamArray<T>      (Param &tmp);  \
+    template       Array<T>  createSubArray<T>        (const Array<T> &parent, \
+                                                       const std::vector<af_seq> &index, \
+                                                       bool copy);      \
+    template       void      destroyArray<T>          (Array<T> *A);    \
+    template       void      evalArray<T>             (const Array<T> &A); \
+    template       Array<T>  createNodeArray<T>       (const dim4 &size, JIT::Node_ptr node); \
+    template       Array<T>::~Array        ();                          \
     template       void Array<T>::eval();                               \
     template       void Array<T>::eval() const;                         \
-    template       void       destroyArray<T>     (Array<T> &A);        \
-    template                  Array<T>::~Array();
 
     INSTANTIATE(float)
     INSTANTIATE(double)
@@ -263,29 +262,5 @@ namespace opencl
     INSTANTIATE(char)
     INSTANTIATE(intl)
     INSTANTIATE(uintl)
-
-#define INSTANTIATE_CREATE_PADDED_ARRAY(SRC_T) \
-    template Array<float  >* createPaddedArray<SRC_T, float  >(Array<SRC_T> const &src, dim4 const &dims, float   default_value, double factor); \
-    template Array<double >* createPaddedArray<SRC_T, double >(Array<SRC_T> const &src, dim4 const &dims, double  default_value, double factor); \
-    template Array<cfloat >* createPaddedArray<SRC_T, cfloat >(Array<SRC_T> const &src, dim4 const &dims, cfloat  default_value, double factor); \
-    template Array<cdouble>* createPaddedArray<SRC_T, cdouble>(Array<SRC_T> const &src, dim4 const &dims, cdouble default_value, double factor); \
-    template Array<int    >* createPaddedArray<SRC_T, int    >(Array<SRC_T> const &src, dim4 const &dims, int     default_value, double factor); \
-    template Array<uint   >* createPaddedArray<SRC_T, uint   >(Array<SRC_T> const &src, dim4 const &dims, uint    default_value, double factor); \
-    template Array<uchar  >* createPaddedArray<SRC_T, uchar  >(Array<SRC_T> const &src, dim4 const &dims, uchar   default_value, double factor); \
-    template Array<char   >* createPaddedArray<SRC_T, char   >(Array<SRC_T> const &src, dim4 const &dims, char    default_value, double factor);
-
-    INSTANTIATE_CREATE_PADDED_ARRAY(float )
-    INSTANTIATE_CREATE_PADDED_ARRAY(double)
-    INSTANTIATE_CREATE_PADDED_ARRAY(int   )
-    INSTANTIATE_CREATE_PADDED_ARRAY(uint  )
-    INSTANTIATE_CREATE_PADDED_ARRAY(uchar )
-    INSTANTIATE_CREATE_PADDED_ARRAY(char  )
-
-#define INSTANTIATE_CREATE_COMPLEX_PADDED_ARRAY(SRC_T) \
-    template Array<cfloat >* createPaddedArray<SRC_T, cfloat >(Array<SRC_T> const &src, dim4 const &dims, cfloat  default_value, double factor); \
-    template Array<cdouble>* createPaddedArray<SRC_T, cdouble>(Array<SRC_T> const &src, dim4 const &dims, cdouble default_value, double factor);
-
-    INSTANTIATE_CREATE_COMPLEX_PADDED_ARRAY(cfloat )
-    INSTANTIATE_CREATE_COMPLEX_PADDED_ARRAY(cdouble)
 
 }

--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -32,51 +32,40 @@ namespace opencl
 
     // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    Array<T>*
-    createNodeArray(const af::dim4 &size, JIT::Node_ptr node);
+    Array<T> createNodeArray(const af::dim4 &size, JIT::Node_ptr node);
 
     // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    Array<T>*
-    createValueArray(const af::dim4 &size, const T& value);
+    Array<T> createValueArray(const af::dim4 &size, const T& value);
 
     // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    Array<T>*
-    createHostDataArray(const af::dim4 &size, const T * const data);
+    Array<T> createHostDataArray(const af::dim4 &size, const T * const data);
 
-    // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    Array<T>*
-    createDeviceDataArray(const af::dim4 &size, const void *data);
+    Array<T> createDeviceDataArray(const af::dim4 &size, const void *data);
 
     // Create an Array object and do not assign any values to it
-    template<typename T>
-    Array<T>*
-    createEmptyArray(const af::dim4 &size);
+    template<typename T> Array<T> *initArray();
 
-    // Create an Array object from Param<T>
     template<typename T>
-    Array<T>*
-    createParamArray(Param &tmp);
+    Array<T> createEmptyArray(const af::dim4 &size);
+
+    // Create an Array object from Param
+    template<typename T>
+    Array<T> createParamArray(Param &tmp);
+
+    template<typename T>
+    Array<T> createSubArray(const Array<T>& parent,
+                            const std::vector<af_seq> &index,
+                            bool copy=true);
+
+    template<typename T>
+    void evalArray(const Array<T> &A);
 
     // Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
-    void
-    destroyArray(Array<T> &A);
-
-    template<typename T>
-    Array<T> *
-    createSubArray(const Array<T>& parent, const af::dim4 &dims, const af::dim4 &offset, const af::dim4 &stride);
-
-    // Creates a pure reference Array - a virtual view, no copies are made
-    template<typename T>
-    Array<T> *
-    createRefArray(const Array<T>& parent, const dim4 &dims, const dim4 &offset, const dim4 &stride);
-
-    template<typename inType, typename outType>
-    Array<outType> *
-    createPaddedArray(Array<inType> const &in, dim4 const &dims, outType default_value, double factor=1.0);
+    void destroyArray(Array<T> *A);
 
     template<typename T>
     void *getDevicePtr(const Array<T>& arr)
@@ -146,18 +135,22 @@ namespace opencl
 
         JIT::Node_ptr getNode() const;
 
-        friend Array<T>* createValueArray<T>(const af::dim4 &size, const T& value);
-        friend Array<T>* createHostDataArray<T>(const af::dim4 &size, const T * const data);
-        friend Array<T>* createDeviceDataArray<T>(const af::dim4 &size, const void *data);
+        friend Array<T> createValueArray<T>(const af::dim4 &size, const T& value);
+        friend Array<T> createHostDataArray<T>(const af::dim4 &size, const T * const data);
+        friend Array<T> createDeviceDataArray<T>(const af::dim4 &size, const void *data);
 
-        friend Array<T>* createEmptyArray<T>(const af::dim4 &size);
-        friend Array<T>* createSubArray<T>(const Array<T>& parent,
-                                           const dim4 &dims, const dim4 &offset, const dim4 &stride);
-        friend Array<T>* createRefArray<T>(const Array<T>& parent,
-                                           const dim4 &dims, const dim4 &offset, const dim4 &stride);
-        friend Array<T>* createParamArray<T>(Param &tmp);
-        friend Array<T>* createNodeArray<T>(const af::dim4 &dims, JIT::Node_ptr node);
-        friend void      destroyArray<T>(Array<T> &arr);
+        friend Array<T> *initArray<T>();
+        friend Array<T> createEmptyArray<T>(const af::dim4 &size);
+        friend Array<T> createParamArray<T>(Param &tmp);
+        friend Array<T> createNodeArray<T>(const af::dim4 &dims, JIT::Node_ptr node);
+
+        friend Array<T> createSubArray<T>(const Array<T>& parent,
+                                          const std::vector<af_seq> &index,
+                                          bool copy);
+
+        friend void destroyArray<T>(Array<T> *arr);
+        friend void evalArray<T>(const Array<T> &arr);
         friend void *getDevicePtr<T>(const Array<T>& arr);
     };
+
 }

--- a/src/backend/opencl/ArrayIndex.cpp
+++ b/src/backend/opencl/ArrayIndex.cpp
@@ -17,7 +17,7 @@ namespace opencl
 {
 
 template<typename in_t, typename idx_t>
-Array<in_t>* arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, const unsigned dim)
+Array<in_t> arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, const unsigned dim)
 {
     const dim4 iDims = input.dims();
 
@@ -25,26 +25,26 @@ Array<in_t>* arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, c
     for (dim_type d=0; d<4; ++d)
         oDims[d] = (d==int(dim) ? indices.elements() : iDims[d]);
 
-    Array<in_t> *out = createEmptyArray<in_t>(oDims);
+    Array<in_t> out = createEmptyArray<in_t>(oDims);
 
     dim_type nDims = iDims.ndims();
 
     switch(dim) {
-        case 0: kernel::arrayIndex<in_t, idx_t, 0>(*out, input, indices, nDims); break;
-        case 1: kernel::arrayIndex<in_t, idx_t, 1>(*out, input, indices, nDims); break;
-        case 2: kernel::arrayIndex<in_t, idx_t, 2>(*out, input, indices, nDims); break;
-        case 3: kernel::arrayIndex<in_t, idx_t, 3>(*out, input, indices, nDims); break;
+        case 0: kernel::arrayIndex<in_t, idx_t, 0>(out, input, indices, nDims); break;
+        case 1: kernel::arrayIndex<in_t, idx_t, 1>(out, input, indices, nDims); break;
+        case 2: kernel::arrayIndex<in_t, idx_t, 2>(out, input, indices, nDims); break;
+        case 3: kernel::arrayIndex<in_t, idx_t, 3>(out, input, indices, nDims); break;
     }
 
     return out;
 }
 
 #define INSTANTIATE(T)  \
-    template Array<T> * arrayIndex<T, float   >(const Array<T> &input, const Array<float   > &indices, const unsigned dim); \
-    template Array<T> * arrayIndex<T, double  >(const Array<T> &input, const Array<double  > &indices, const unsigned dim); \
-    template Array<T> * arrayIndex<T, int     >(const Array<T> &input, const Array<int     > &indices, const unsigned dim); \
-    template Array<T> * arrayIndex<T, unsigned>(const Array<T> &input, const Array<unsigned> &indices, const unsigned dim); \
-    template Array<T> * arrayIndex<T, uchar   >(const Array<T> &input, const Array<uchar   > &indices, const unsigned dim);
+    template Array<T> arrayIndex<T, float   >(const Array<T> &input, const Array<float   > &indices, const unsigned dim); \
+    template Array<T> arrayIndex<T, double  >(const Array<T> &input, const Array<double  > &indices, const unsigned dim); \
+    template Array<T> arrayIndex<T, int     >(const Array<T> &input, const Array<int     > &indices, const unsigned dim); \
+    template Array<T> arrayIndex<T, unsigned>(const Array<T> &input, const Array<unsigned> &indices, const unsigned dim); \
+    template Array<T> arrayIndex<T, uchar   >(const Array<T> &input, const Array<uchar   > &indices, const unsigned dim);
 
 INSTANTIATE(float   );
 INSTANTIATE(cfloat  );

--- a/src/backend/opencl/ArrayIndex.hpp
+++ b/src/backend/opencl/ArrayIndex.hpp
@@ -13,6 +13,6 @@ namespace opencl
 {
 
 template<typename in_t, typename idx_t>
-Array<in_t>* arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, const unsigned dim);
+Array<in_t> arrayIndex(const Array<in_t> &input, const Array<idx_t> &indices, const unsigned dim);
 
 }

--- a/src/backend/opencl/approx.cpp
+++ b/src/backend/opencl/approx.cpp
@@ -17,8 +17,8 @@
 namespace opencl
 {
     template<typename Ty, typename Tp>
-    Array<Ty> *approx1(const Array<Ty> &in, const Array<Tp> &pos,
-                       const af_interp_type method, const float offGrid)
+    Array<Ty> approx1(const Array<Ty> &in, const Array<Tp> &pos,
+                      const af_interp_type method, const float offGrid)
     {
         if ((std::is_same<Ty, double>::value || std::is_same<Ty, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
@@ -28,14 +28,14 @@ namespace opencl
         odims[0] = pos.dims()[0];
 
         // Create output placeholder
-        Array<Ty> *out = createEmptyArray<Ty>(odims);
+        Array<Ty> out = createEmptyArray<Ty>(odims);
 
         switch(method) {
             case AF_INTERP_NEAREST:
-                kernel::approx1<Ty, Tp, AF_INTERP_NEAREST>(*out, in, pos, offGrid);
+                kernel::approx1<Ty, Tp, AF_INTERP_NEAREST>(out, in, pos, offGrid);
                 break;
             case AF_INTERP_LINEAR:
-                kernel::approx1<Ty, Tp, AF_INTERP_LINEAR> (*out, in, pos, offGrid);
+                kernel::approx1<Ty, Tp, AF_INTERP_LINEAR> (out, in, pos, offGrid);
                 break;
             default:
                 break;
@@ -44,8 +44,8 @@ namespace opencl
     }
 
     template<typename Ty, typename Tp>
-    Array<Ty> *approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
-                       const af_interp_type method, const float offGrid)
+    Array<Ty> approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
+                      const af_interp_type method, const float offGrid)
     {
         if ((std::is_same<Ty, double>::value || std::is_same<Ty, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
@@ -56,14 +56,14 @@ namespace opencl
         odims[3] = in.dims()[3];
 
         // Create output placeholder
-        Array<Ty> *out = createEmptyArray<Ty>(odims);
+        Array<Ty> out = createEmptyArray<Ty>(odims);
 
         switch(method) {
             case AF_INTERP_NEAREST:
-                kernel::approx2<Ty, Tp, AF_INTERP_NEAREST>(*out, in, pos0, pos1, offGrid);
+                kernel::approx2<Ty, Tp, AF_INTERP_NEAREST>(out, in, pos0, pos1, offGrid);
                 break;
             case AF_INTERP_LINEAR:
-                kernel::approx2<Ty, Tp, AF_INTERP_LINEAR> (*out, in, pos0, pos1, offGrid);
+                kernel::approx2<Ty, Tp, AF_INTERP_LINEAR> (out, in, pos0, pos1, offGrid);
                 break;
             default:
                 break;
@@ -71,12 +71,12 @@ namespace opencl
         return out;
     }
 
-#define INSTANTIATE(Ty, Tp)                                                                     \
-    template Array<Ty>* approx1<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos,              \
-                                        const af_interp_type method, const float offGrid);      \
-    template Array<Ty>* approx2<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos0,             \
-                                        const Array<Tp> &pos1, const af_interp_type method,     \
-                                        const float offGrid);                                   \
+#define INSTANTIATE(Ty, Tp)                                             \
+    template Array<Ty> approx1<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos, \
+                                       const af_interp_type method, const float offGrid); \
+    template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos0, \
+                                       const Array<Tp> &pos1, const af_interp_type method, \
+                                       const float offGrid);            \
 
     INSTANTIATE(float  , float )
     INSTANTIATE(double , double)

--- a/src/backend/opencl/approx.hpp
+++ b/src/backend/opencl/approx.hpp
@@ -13,10 +13,10 @@
 namespace opencl
 {
     template<typename Ty, typename Tp>
-    Array<Ty> *approx1(const Array<Ty> &in, const Array<Tp> &pos,
-                       const af_interp_type method, const float offGrid);
+    Array<Ty> approx1(const Array<Ty> &in, const Array<Tp> &pos,
+                      const af_interp_type method, const float offGrid);
 
     template<typename Ty, typename Tp>
-    Array<Ty> *approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
-                       const af_interp_type method, const float offGrid);
+    Array<Ty> approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
+                      const af_interp_type method, const float offGrid);
 }

--- a/src/backend/opencl/arith.hpp
+++ b/src/backend/opencl/arith.hpp
@@ -17,7 +17,7 @@
 namespace opencl
 {
     template<typename T, af_op_t op>
-    Array<T>* arithOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
+    Array<T> arithOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
     {
         return createBinaryNode<T, T, op>(lhs, rhs, odims);
     }

--- a/src/backend/opencl/backend.hpp
+++ b/src/backend/opencl/backend.hpp
@@ -8,11 +8,17 @@
  ********************************************************/
 
 #pragma once
-#if __APPLE__
-#include <OpenCL/cl.h>
+#ifdef __DH__
+#undef __DH__
+#endif
+
+#ifdef __CUDACC__
+#include <opencl_runtime.h>
+#define __DH__ __device__ __host__
 #else
-#include <CL/cl.h>
+#define __DH__
 #endif
 
 #include "types.hpp"
+
 namespace detail = opencl;

--- a/src/backend/opencl/bilateral.cpp
+++ b/src/backend/opencl/bilateral.cpp
@@ -20,20 +20,20 @@ namespace opencl
 {
 
 template<typename inType, typename outType, bool isColor>
-Array<outType> * bilateral(const Array<inType> &in, const float &s_sigma, const float &c_sigma)
+Array<outType> bilateral(const Array<inType> &in, const float &s_sigma, const float &c_sigma)
 {
     if ((std::is_same<inType, double>::value || std::is_same<inType, cdouble>::value) &&
         !isDoubleSupported(getActiveDeviceId())) {
         OPENCL_NOT_SUPPORTED();
     }
-    Array<outType>* out       = createEmptyArray<outType>(in.dims());
-    kernel::bilateral<inType, outType, isColor>(*out, in, s_sigma, c_sigma);
+    Array<outType> out       = createEmptyArray<outType>(in.dims());
+    kernel::bilateral<inType, outType, isColor>(out, in, s_sigma, c_sigma);
     return out;
 }
 
 #define INSTANTIATE(inT, outT)\
-template Array<outT> * bilateral<inT, outT,true >(const Array<inT> &in, const float &s_sigma, const float &c_sigma);\
-template Array<outT> * bilateral<inT, outT,false>(const Array<inT> &in, const float &s_sigma, const float &c_sigma);
+template Array<outT> bilateral<inT, outT,true >(const Array<inT> &in, const float &s_sigma, const float &c_sigma);\
+template Array<outT> bilateral<inT, outT,false>(const Array<inT> &in, const float &s_sigma, const float &c_sigma);
 
 INSTANTIATE(double, double)
 INSTANTIATE(float ,  float)

--- a/src/backend/opencl/bilateral.hpp
+++ b/src/backend/opencl/bilateral.hpp
@@ -13,6 +13,6 @@ namespace opencl
 {
 
 template<typename inType, typename outType, bool isColor>
-Array<outType> * bilateral(const Array<inType> &in, const float &s_sigma, const float &c_sigma);
+Array<outType> bilateral(const Array<inType> &in, const float &s_sigma, const float &c_sigma);
 
 }

--- a/src/backend/opencl/binary.hpp
+++ b/src/backend/opencl/binary.hpp
@@ -171,7 +171,7 @@ struct BinOp<To, Ti, af_hypot_t>
 };
 
 template<typename To, typename Ti, af_op_t op>
-Array<To> *createBinaryNode(const Array<Ti> &lhs, const Array<Ti> &rhs, const af::dim4 &odims)
+Array<To> createBinaryNode(const Array<Ti> &lhs, const Array<Ti> &rhs, const af::dim4 &odims)
 {
     BinOp<To, Ti, op> bop;
 

--- a/src/backend/opencl/blas.cpp
+++ b/src/backend/opencl/blas.cpp
@@ -81,8 +81,8 @@ initBlas() {
 }
 
 template<typename T>
-Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs)
+Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
+                af_blas_transpose optLhs, af_blas_transpose optRhs)
 {
     initBlas();
     clblasTranspose lOpts = toClblasTranspose(optLhs);
@@ -99,7 +99,7 @@ Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
     int K = lDims[aColDim];
 
     //FIXME: Leaks on errors.
-    Array<T> *out = createEmptyArray<T>(af::dim4(M, N, 1, 1));
+    Array<T> out = createEmptyArray<T>(af::dim4(M, N, 1, 1));
     auto alpha = scalar<T>(1);
     auto beta  = scalar<T>(0);
 
@@ -117,7 +117,7 @@ Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
             (*lhs.get())(),    lhs.getOffset(),   lStrides[1],
             (*rhs.get())(),    rhs.getOffset(),   rStrides[0],
             beta ,
-            (*out->get())(),   out->getOffset(),             1,
+            (*out.get())(),   out.getOffset(),             1,
             1, &getQueue()(), 0, nullptr, &event());
     } else {
         gemm_func<T> gemm;
@@ -128,7 +128,7 @@ Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
                 (*lhs.get())(),    lhs.getOffset(),   lStrides[1],
                 (*rhs.get())(),    rhs.getOffset(),   rStrides[1],
                 beta,
-                (*out->get())(),   out->getOffset(),  out->dims()[0],
+                (*out.get())(),   out.getOffset(),  out.dims()[0],
                 1, &getQueue()(), 0, nullptr, &event());
 
     }
@@ -140,8 +140,8 @@ Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
 }
 
 template<typename T>
-Array<T>* dot(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs)
+Array<T> dot(const Array<T> &lhs, const Array<T> &rhs,
+             af_blas_transpose optLhs, af_blas_transpose optRhs)
 {
     initBlas();
 
@@ -152,7 +152,7 @@ Array<T>* dot(const Array<T> &lhs, const Array<T> &rhs,
     cl::Buffer scratch(getContext(), CL_MEM_READ_WRITE, sizeof(T) * N);
     clblasStatus err;
     err = dot(N,
-              (*out->get())(), out->getOffset(),
+              (*out.get())(), out.getOffset(),
               (*lhs.get())(),  lhs.getOffset(), lhs.strides()[0],
               (*rhs.get())(),  rhs.getOffset(), rhs.strides()[0],
               scratch(),
@@ -165,7 +165,7 @@ Array<T>* dot(const Array<T> &lhs, const Array<T> &rhs,
 }
 
 #define INSTANTIATE_BLAS(TYPE)                                                          \
-    template Array<TYPE>* matmul<TYPE>(const Array<TYPE> &lhs, const Array<TYPE> &rhs,  \
+    template Array<TYPE> matmul<TYPE>(const Array<TYPE> &lhs, const Array<TYPE> &rhs,  \
                     af_blas_transpose optLhs, af_blas_transpose optRhs);
 
 INSTANTIATE_BLAS(float)
@@ -174,12 +174,12 @@ INSTANTIATE_BLAS(double)
 INSTANTIATE_BLAS(cdouble)
 
 #define INSTANTIATE_DOT(TYPE)                                                       \
-    template Array<TYPE>* dot<TYPE>(const Array<TYPE> &lhs, const Array<TYPE> &rhs, \
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
+    template Array<TYPE> dot<TYPE>(const Array<TYPE> &lhs, const Array<TYPE> &rhs, \
+                                   af_blas_transpose optLhs, af_blas_transpose optRhs);
 
 template<typename T>
-Array<T>* dot(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
+Array<T> dot(const Array<T> &lhs, const Array<T> &rhs,
+              af_blas_transpose optLhs, af_blas_transpose optRhs);
 
 INSTANTIATE_DOT(float)
 INSTANTIATE_DOT(double)

--- a/src/backend/opencl/blas.hpp
+++ b/src/backend/opencl/blas.hpp
@@ -15,10 +15,10 @@ namespace opencl
 {
 
 template<typename T>
-Array<T>* matmul(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
+Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
+                af_blas_transpose optLhs, af_blas_transpose optRhs);
 template<typename T>
-Array<T>* dot(const Array<T> &lhs, const Array<T> &rhs,
-                    af_blas_transpose optLhs, af_blas_transpose optRhs);
+Array<T> dot(const Array<T> &lhs, const Array<T> &rhs,
+             af_blas_transpose optLhs, af_blas_transpose optRhs);
 
 }

--- a/src/backend/opencl/cast.hpp
+++ b/src/backend/opencl/cast.hpp
@@ -104,7 +104,7 @@ struct CastOp<cdouble, cdouble>
 #undef CAST_CFN
 
 template<typename To, typename Ti>
-Array<To>* cast(const Array<Ti> &in)
+Array<To> cast(const Array<Ti> &in)
 {
     CastOp<To, Ti> cop;
     JIT::Node_ptr in_node = in.getNode();

--- a/src/backend/opencl/complex.hpp
+++ b/src/backend/opencl/complex.hpp
@@ -18,13 +18,13 @@
 namespace opencl
 {
     template<typename To, typename Ti>
-    Array<To>* cplx(const Array<Ti> &lhs, const Array<Ti> &rhs, const af::dim4 &odims)
+    Array<To> cplx(const Array<Ti> &lhs, const Array<Ti> &rhs, const af::dim4 &odims)
     {
         return createBinaryNode<To, Ti, af_cplx2_t>(lhs, rhs, odims);
     }
 
     template<typename To, typename Ti>
-    Array<To>* real(const Array<Ti> &in)
+    Array<To> real(const Array<Ti> &in)
     {
         JIT::Node_ptr in_node = in.getNode();
         JIT::UnaryNode *node = new JIT::UnaryNode(dtype_traits<To>::getName(),
@@ -36,7 +36,7 @@ namespace opencl
     }
 
     template<typename To, typename Ti>
-    Array<To>* imag(const Array<Ti> &in)
+    Array<To> imag(const Array<Ti> &in)
     {
         JIT::Node_ptr in_node = in.getNode();
         JIT::UnaryNode *node = new JIT::UnaryNode(dtype_traits<To>::getName(),
@@ -52,7 +52,7 @@ namespace opencl
     template<> STATIC_ const char *abs_name<cdouble>() { return "__cabs"; }
 
     template<typename To, typename Ti>
-    Array<To>* abs(const Array<Ti> &in)
+    Array<To> abs(const Array<Ti> &in)
     {
         JIT::Node_ptr in_node = in.getNode();
         JIT::UnaryNode *node = new JIT::UnaryNode(dtype_traits<To>::getName(),
@@ -68,7 +68,7 @@ namespace opencl
     template<> STATIC_ const char *conj_name<cdouble>() { return "__cconj"; }
 
     template<typename T>
-    Array<T>* conj(const Array<T> &in)
+    Array<T> conj(const Array<T> &in)
     {
         JIT::Node_ptr in_node = in.getNode();
         JIT::UnaryNode *node = new JIT::UnaryNode(dtype_traits<T>::getName(),

--- a/src/backend/opencl/convolve.cpp
+++ b/src/backend/opencl/convolve.cpp
@@ -21,7 +21,7 @@ namespace opencl
 {
 
 template<typename T, typename accT, dim_type baseDim, bool expand>
-Array<T> * convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind)
+Array<T> convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind)
 {
     if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
         !isDoubleSupported(getActiveDeviceId())) {
@@ -44,7 +44,7 @@ Array<T> * convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatc
         if (kind==ONE2ALL) oDims[baseDim] = fDims[baseDim];
     }
 
-    Array<T> *out   = createEmptyArray<T>(oDims);
+    Array<T> out   = createEmptyArray<T>(oDims);
     bool callKernel = true;
 
     dim_type MCFL2 = kernel::MAX_CONV2_FILTER_LEN;
@@ -65,7 +65,7 @@ Array<T> * convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatc
     }
 
     if (callKernel)
-        kernel::convolve_nd<T, accT, baseDim, expand>(*out, signal, filter, kind);
+        kernel::convolve_nd<T, accT, baseDim, expand>(out, signal, filter, kind);
     else {
         // call upon fft
         OPENCL_NOT_SUPPORTED();
@@ -75,7 +75,7 @@ Array<T> * convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatc
 }
 
 template<typename T, typename accT, bool expand>
-Array<T> * convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter)
+Array<T> convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter)
 {
     if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
         !isDoubleSupported(getActiveDeviceId())) {
@@ -100,26 +100,24 @@ Array<T> * convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> 
         oDims = sDims;
     }
 
-    Array<T> *temp= createEmptyArray<T>(oDims);
-    Array<T> *out = createEmptyArray<T>(oDims);
+    Array<T> temp= createEmptyArray<T>(oDims);
+    Array<T> out = createEmptyArray<T>(oDims);
 
-    kernel::convolve2<T, accT, 0, expand>(*temp, signal, c_filter);
-    kernel::convolve2<T, accT, 1, expand>(*out, *temp, r_filter);
-
-    destroyArray<T>(*temp);
+    kernel::convolve2<T, accT, 0, expand>(temp, signal, c_filter);
+    kernel::convolve2<T, accT, 1, expand>(out, temp, r_filter);
 
     return out;
 }
 
 #define INSTANTIATE(T, accT)  \
-    template Array<T> * convolve <T, accT, 1, true >(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
-    template Array<T> * convolve <T, accT, 1, false>(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
-    template Array<T> * convolve <T, accT, 2, true >(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
-    template Array<T> * convolve <T, accT, 2, false>(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
-    template Array<T> * convolve <T, accT, 3, true >(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
-    template Array<T> * convolve <T, accT, 3, false>(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
-    template Array<T> * convolve2<T, accT, true >(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);  \
-    template Array<T> * convolve2<T, accT, false>(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);
+    template Array<T> convolve <T, accT, 1, true >(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
+    template Array<T> convolve <T, accT, 1, false>(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
+    template Array<T> convolve <T, accT, 2, true >(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
+    template Array<T> convolve <T, accT, 2, false>(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
+    template Array<T> convolve <T, accT, 3, true >(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
+    template Array<T> convolve <T, accT, 3, false>(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);   \
+    template Array<T> convolve2<T, accT, true >(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);  \
+    template Array<T> convolve2<T, accT, false>(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);
 
 INSTANTIATE(cdouble, cdouble)
 INSTANTIATE(cfloat ,  cfloat)

--- a/src/backend/opencl/convolve.hpp
+++ b/src/backend/opencl/convolve.hpp
@@ -14,9 +14,9 @@ namespace opencl
 {
 
 template<typename T, typename accT, dim_type baseDim, bool expand>
-Array<T> * convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);
+Array<T> convolve(Array<T> const& signal, Array<T> const& filter, ConvolveBatchKind kind);
 
 template<typename T, typename accT, bool expand>
-Array<T> * convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);
+Array<T> convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> const& r_filter);
 
 }

--- a/src/backend/opencl/copy.hpp
+++ b/src/backend/opencl/copy.hpp
@@ -17,9 +17,12 @@ namespace opencl
     void copyData(T *data, const Array<T> &A);
 
     template<typename T>
-    Array<T>* copyArray(const Array<T> &A);
+    Array<T> copyArray(const Array<T> &A);
 
     template<typename inType, typename outType>
-    void copy(Array<outType> &dst, const Array<inType> &src, outType default_value, double factor);
+    void copyArray(Array<outType> &out, const Array<inType> &in);
 
+    template<typename inType, typename outType>
+    Array<outType> padArray(Array<inType> const &in, dim4 const &dims,
+                            outType default_value, double factor=1.0);
 }

--- a/src/backend/opencl/copy.hpp
+++ b/src/backend/opencl/copy.hpp
@@ -6,6 +6,7 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#pragma once
 
 #include <af/array.h>
 #include <Array.hpp>

--- a/src/backend/opencl/diagonal.cpp
+++ b/src/backend/opencl/diagonal.cpp
@@ -19,33 +19,33 @@
 namespace opencl
 {
     template<typename T>
-    Array<T>* diagCreate(const Array<T> &in, const int num)
+    Array<T> diagCreate(const Array<T> &in, const int num)
     {
         int size = in.dims()[0] + std::abs(num);
         int batch = in.dims()[1];
-        Array<T> *out = createEmptyArray<T>(dim4(size, size, batch));
+        Array<T> out = createEmptyArray<T>(dim4(size, size, batch));
 
-        kernel::diagCreate<T>(*out, in, num);
+        kernel::diagCreate<T>(out, in, num);
 
         return out;
     }
 
     template<typename T>
-    Array<T>* diagExtract(const Array<T> &in, const int num)
+    Array<T> diagExtract(const Array<T> &in, const int num)
     {
         const dim_type *idims = in.dims().get();
         dim_type size = std::max(idims[0], idims[1]) - std::abs(num);
-        Array<T> *out = createEmptyArray<T>(dim4(size, 1, idims[2], idims[3]));
+        Array<T> out = createEmptyArray<T>(dim4(size, 1, idims[2], idims[3]));
 
-        kernel::diagExtract<T>(*out, in, num);
+        kernel::diagExtract<T>(out, in, num);
 
         return out;
 
     }
 
 #define INSTANTIATE_DIAGONAL(T)                                          \
-    template Array<T>*  diagExtract<T>    (const Array<T> &in, const int num); \
-    template Array<T>*  diagCreate <T>    (const Array<T> &in, const int num);
+    template Array<T>  diagExtract<T>    (const Array<T> &in, const int num); \
+    template Array<T>  diagCreate <T>    (const Array<T> &in, const int num);
 
     INSTANTIATE_DIAGONAL(float)
     INSTANTIATE_DIAGONAL(double)

--- a/src/backend/opencl/diagonal.hpp
+++ b/src/backend/opencl/diagonal.hpp
@@ -14,8 +14,8 @@
 namespace opencl
 {
     template<typename T>
-    Array<T>* diagCreate(const Array<T> &in, const int num);
+    Array<T> diagCreate(const Array<T> &in, const int num);
 
     template<typename T>
-    Array<T>* diagExtract(const Array<T> &in, const int num);
+    Array<T> diagExtract(const Array<T> &in, const int num);
 }

--- a/src/backend/opencl/diff.cpp
+++ b/src/backend/opencl/diff.cpp
@@ -17,7 +17,7 @@
 namespace opencl
 {
     template<typename T, bool isDiff2>
-    static Array<T> *diff(const Array<T> &in, const int dim)
+    static Array<T> diff(const Array<T> &in, const int dim)
     {
         if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
@@ -31,20 +31,20 @@ namespace opencl
             throw std::runtime_error("Elements are 0");
         }
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
         switch (dim) {
 
-            case (0):    kernel::diff<T, 0, isDiff2>(*out, in, in.ndims());
+            case (0):    kernel::diff<T, 0, isDiff2>(out, in, in.ndims());
                          break;
 
-            case (1):    kernel::diff<T, 1, isDiff2>(*out, in, in.ndims());
+            case (1):    kernel::diff<T, 1, isDiff2>(out, in, in.ndims());
                          break;
 
-            case (2):    kernel::diff<T, 2, isDiff2>(*out, in, in.ndims());
+            case (2):    kernel::diff<T, 2, isDiff2>(out, in, in.ndims());
                          break;
 
-            case (3):    kernel::diff<T, 3, isDiff2>(*out, in, in.ndims());
+            case (3):    kernel::diff<T, 3, isDiff2>(out, in, in.ndims());
                          break;
         }
 
@@ -52,20 +52,20 @@ namespace opencl
     }
 
     template<typename T>
-    Array<T> *diff1(const Array<T> &in, const int dim)
+    Array<T> diff1(const Array<T> &in, const int dim)
     {
         return diff<T, false>(in, dim);
     }
 
     template<typename T>
-    Array<T> *diff2(const Array<T> &in, const int dim)
+    Array<T> diff2(const Array<T> &in, const int dim)
     {
         return diff<T, true>(in, dim);
     }
 
-#define INSTANTIATE(T)                                                  \
-    template Array<T>* diff1<T>  (const Array<T> &in, const int dim);   \
-    template Array<T>* diff2<T>  (const Array<T> &in, const int dim);   \
+#define INSTANTIATE(T)                                                 \
+    template Array<T> diff1<T>  (const Array<T> &in, const int dim);   \
+    template Array<T> diff2<T>  (const Array<T> &in, const int dim);   \
 
 
     INSTANTIATE(float)

--- a/src/backend/opencl/diff.hpp
+++ b/src/backend/opencl/diff.hpp
@@ -13,8 +13,8 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *diff1(const Array<T> &in, const int dim);
+    Array<T> diff1(const Array<T> &in, const int dim);
 
     template<typename T>
-    Array<T> *diff2(const Array<T> &in, const int dim);
+    Array<T> diff2(const Array<T> &in, const int dim);
 }

--- a/src/backend/opencl/fast.cpp
+++ b/src/backend/opencl/fast.cpp
@@ -38,9 +38,9 @@ unsigned fast(Array<float> &x_out, Array<float> &y_out, Array<float> &score_out,
                              thr, feature_ratio);
 
     if (nfeat > 0) {
-        x_out = *createParamArray<float>(x);
-        y_out = *createParamArray<float>(y);
-        score_out = *createParamArray<float>(score);
+        x_out = createParamArray<float>(x);
+        y_out = createParamArray<float>(y);
+        score_out = createParamArray<float>(score);
     }
 
     return nfeat;

--- a/src/backend/opencl/fft.cpp
+++ b/src/backend/opencl/fft.cpp
@@ -11,6 +11,7 @@
 #include <af/defines.h>
 #include <ArrayInfo.hpp>
 #include <Array.hpp>
+#include <copy.hpp>
 #include <fft.hpp>
 #include <err_opencl.hpp>
 #include <clFFT.h>
@@ -246,7 +247,7 @@ inline bool isSupLen(dim_type length)
 }
 
 template<typename inType, typename outType, int rank, bool isR2C>
-Array<outType> * fft(Array<inType> const &in, double normalize, dim_type const npad, dim_type const * const pad)
+Array<outType> fft(Array<inType> const &in, double normalize, dim_type const npad, dim_type const * const pad)
 {
     ARG_ASSERT(1, (in.isOwner()==true));
 
@@ -271,15 +272,15 @@ Array<outType> * fft(Array<inType> const &in, double normalize, dim_type const n
 
     pdims[rank] = in.dims()[rank];
 
-    Array<outType> *ret = createPaddedArray<inType, outType>(in, (npad>0 ? pdims : in.dims()), zero<outType>(), normalize);
+    Array<outType> ret = padArray<inType, outType>(in, (npad>0 ? pdims : in.dims()), zero<outType>(), normalize);
 
-    clfft_common<outType, rank, CLFFT_FORWARD>(*ret);
+    clfft_common<outType, rank, CLFFT_FORWARD>(ret);
 
     return ret;
 }
 
 template<typename T, int rank>
-Array<T> * ifft(Array<T> const &in, double normalize, dim_type const npad, dim_type const * const pad)
+Array<T> ifft(Array<T> const &in, double normalize, dim_type const npad, dim_type const * const pad)
 {
     ARG_ASSERT(1, (in.isOwner()==true));
 
@@ -307,28 +308,28 @@ Array<T> * ifft(Array<T> const &in, double normalize, dim_type const npad, dim_t
 
     pdims[rank] = in.dims()[rank];
 
-    Array<T> *ret = createPaddedArray<T, T>(in, (npad>0 ? pdims : in.dims()), zero<T>(), normalize);
+    Array<T> ret = padArray<T, T>(in, (npad>0 ? pdims : in.dims()), zero<T>(), normalize);
 
-    clfft_common<T, rank, CLFFT_BACKWARD>(*ret);
+    clfft_common<T, rank, CLFFT_BACKWARD>(ret);
 
     return ret;
 }
 
 #define INSTANTIATE1(T1, T2)\
-    template Array<T2> * fft <T1, T2, 1, true >(const Array<T1> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T2> * fft <T1, T2, 2, true >(const Array<T1> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T2> * fft <T1, T2, 3, true >(const Array<T1> &in, double normalize, dim_type const npad, dim_type const * const pad);
+    template Array<T2> fft <T1, T2, 1, true >(const Array<T1> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T2> fft <T1, T2, 2, true >(const Array<T1> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T2> fft <T1, T2, 3, true >(const Array<T1> &in, double normalize, dim_type const npad, dim_type const * const pad);
 
 INSTANTIATE1(float  , cfloat )
 INSTANTIATE1(double , cdouble)
 
 #define INSTANTIATE2(T)\
-    template Array<T> * fft <T, T, 1, false>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T> * fft <T, T, 2, false>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T> * fft <T, T, 3, false>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T> * ifft<T, 1>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T> * ifft<T, 2>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
-    template Array<T> * ifft<T, 3>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad);
+    template Array<T> fft <T, T, 1, false>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T> fft <T, T, 2, false>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T> fft <T, T, 3, false>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T> ifft<T, 1>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T> ifft<T, 2>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad); \
+    template Array<T> ifft<T, 3>(const Array<T> &in, double normalize, dim_type const npad, dim_type const * const pad);
 
 INSTANTIATE2(cfloat )
 INSTANTIATE2(cdouble)

--- a/src/backend/opencl/fft.hpp
+++ b/src/backend/opencl/fft.hpp
@@ -13,9 +13,9 @@ namespace opencl
 {
 
 template<typename inType, typename outType, int rank, bool isR2C>
-Array<outType> * fft(Array<inType> const &in, double normalize, dim_type const npad, dim_type const * const pad);
+Array<outType> fft(Array<inType> const &in, double normalize, dim_type const npad, dim_type const * const pad);
 
 template<typename T, int rank>
-Array<T> * ifft(Array<T> const &in, double normalize, dim_type const npad, dim_type const * const pad);
+Array<T> ifft(Array<T> const &in, double normalize, dim_type const npad, dim_type const * const pad);
 
 }

--- a/src/backend/opencl/histogram.cpp
+++ b/src/backend/opencl/histogram.cpp
@@ -21,7 +21,7 @@ namespace opencl
 {
 
 template<typename inType, typename outType>
-Array<outType> * histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval)
+Array<outType> histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval)
 {
     if ((std::is_same<inType, double>::value || std::is_same<inType, cdouble>::value) &&
         !isDoubleSupported(getActiveDeviceId())) {
@@ -31,7 +31,7 @@ Array<outType> * histogram(const Array<inType> &in, const unsigned &nbins, const
 
     const dim4 dims     = in.dims();
     dim4 outDims        = dim4(nbins, 1, dims[2], dims[3]);
-    Array<outType>* out = createValueArray<outType>(outDims, outType(0));
+    Array<outType> out = createValueArray<outType>(outDims, outType(0));
 
     // create an array to hold min and max values for
     // batch operation handling, this will reduce
@@ -44,21 +44,18 @@ Array<outType> * histogram(const Array<inType> &in, const unsigned &nbins, const
     }
 
     dim4 minmax_dims(dims[2]*2);
-    Array<cfloat>* minmax = createHostDataArray<cfloat>(minmax_dims, h_minmax);
+    Array<cfloat> minmax = createHostDataArray<cfloat>(minmax_dims, h_minmax);
 
     // cleanup the host memory used
     delete[] h_minmax;
 
-    kernel::histogram<inType, outType>(*out, in, *minmax, nbins);
-
-    // destroy the minmax array
-    destroyArray(*minmax);
+    kernel::histogram<inType, outType>(out, in, minmax, nbins);
 
     return out;
 }
 
 #define INSTANTIATE(in_t,out_t)\
-    template Array<out_t> * histogram(const Array<in_t> &in, const unsigned &nbins, const double &minval, const double &maxval);
+    template Array<out_t> histogram(const Array<in_t> &in, const unsigned &nbins, const double &minval, const double &maxval);
 
 INSTANTIATE(float , uint)
 INSTANTIATE(double, uint)

--- a/src/backend/opencl/histogram.hpp
+++ b/src/backend/opencl/histogram.hpp
@@ -13,6 +13,6 @@ namespace opencl
 {
 
 template<typename inType, typename outType>
-Array<outType> * histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval);
+Array<outType> histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval);
 
 }

--- a/src/backend/opencl/identity.cpp
+++ b/src/backend/opencl/identity.cpp
@@ -18,15 +18,15 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *identity(const dim4& dims)
+    Array<T> identity(const dim4& dims)
     {
-        Array<T>* out  = createEmptyArray<T>(dims);
-        kernel::identity<T>(*out);
+        Array<T> out  = createEmptyArray<T>(dims);
+        kernel::identity<T>(out);
         return out;
     }
 
 #define INSTANTIATE_IDENTITY(T)                              \
-    template Array<T>*  identity<T>    (const af::dim4 &dims);
+    template Array<T>  identity<T>    (const af::dim4 &dims);
 
     INSTANTIATE_IDENTITY(float)
     INSTANTIATE_IDENTITY(double)

--- a/src/backend/opencl/identity.hpp
+++ b/src/backend/opencl/identity.hpp
@@ -13,5 +13,5 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *identity(const dim4& dim);
+    Array<T> identity(const dim4& dim);
 }

--- a/src/backend/opencl/iota.cpp
+++ b/src/backend/opencl/iota.cpp
@@ -17,25 +17,25 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *iota(const dim4& dim, const unsigned rep)
+    Array<T> iota(const dim4& dim, const unsigned rep)
     {
         if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
             OPENCL_NOT_SUPPORTED();
         }
-        Array<T> *out = createEmptyArray<T>(dim);
+        Array<T> out = createEmptyArray<T>(dim);
         switch(rep) {
-            case 0: kernel::iota<T, 0>(*out); break;
-            case 1: kernel::iota<T, 1>(*out); break;
-            case 2: kernel::iota<T, 2>(*out); break;
-            case 3: kernel::iota<T, 3>(*out); break;
+            case 0: kernel::iota<T, 0>(out); break;
+            case 1: kernel::iota<T, 1>(out); break;
+            case 2: kernel::iota<T, 2>(out); break;
+            case 3: kernel::iota<T, 3>(out); break;
             default: AF_ERROR("Invalid rep selection", AF_ERR_INVALID_ARG);
         }
         return out;
     }
 
 #define INSTANTIATE(T)                                                         \
-    template Array<T>* iota<T>(const af::dim4 &dims, const unsigned rep);      \
+    template Array<T> iota<T>(const af::dim4 &dims, const unsigned rep);      \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/opencl/iota.hpp
+++ b/src/backend/opencl/iota.hpp
@@ -13,6 +13,5 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *iota(const dim4& dim, const unsigned rep);
+    Array<T> iota(const dim4& dim, const unsigned rep);
 }
-

--- a/src/backend/opencl/join.cpp
+++ b/src/backend/opencl/join.cpp
@@ -16,7 +16,7 @@
 namespace opencl
 {
     template<typename Tx, typename Ty>
-    Array<Tx> *join(const int dim, const Array<Tx> &first, const Array<Ty> &second)
+    Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second)
     {
         if ((std::is_same<Tx, double>::value || std::is_same<Tx, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
@@ -41,16 +41,16 @@ namespace opencl
             }
         }
 
-        Array<Tx> *out = createEmptyArray<Tx>(odims);
+        Array<Tx> out = createEmptyArray<Tx>(odims);
 
         switch(dim) {
-            case 0: kernel::join<Tx, Ty, 0>(*out, first, second);
+            case 0: kernel::join<Tx, Ty, 0>(out, first, second);
                     break;
-            case 1: kernel::join<Tx, Ty, 1>(*out, first, second);
+            case 1: kernel::join<Tx, Ty, 1>(out, first, second);
                     break;
-            case 2: kernel::join<Tx, Ty, 2>(*out, first, second);
+            case 2: kernel::join<Tx, Ty, 2>(out, first, second);
                     break;
-            case 3: kernel::join<Tx, Ty, 3>(*out, first, second);
+            case 3: kernel::join<Tx, Ty, 3>(out, first, second);
                     break;
         }
 
@@ -58,7 +58,7 @@ namespace opencl
     }
 
 #define INSTANTIATE(Tx, Ty)                                                                             \
-    template Array<Tx>* join<Tx, Ty>(const int dim, const Array<Tx> &first, const Array<Ty> &second);   \
+    template Array<Tx> join<Tx, Ty>(const int dim, const Array<Tx> &first, const Array<Ty> &second);   \
 
     INSTANTIATE(float,   float)
     INSTANTIATE(double,  double)

--- a/src/backend/opencl/join.hpp
+++ b/src/backend/opencl/join.hpp
@@ -13,6 +13,5 @@
 namespace opencl
 {
     template<typename Tx, typename Ty>
-    Array<Tx> *join(const int dim, const Array<Tx> &first, const Array<Ty> &second);
+    Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second);
 }
-

--- a/src/backend/opencl/logic.hpp
+++ b/src/backend/opencl/logic.hpp
@@ -18,13 +18,13 @@
 namespace opencl
 {
     template<typename T, af_op_t op>
-    Array<uchar> *logicOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
+    Array<uchar> logicOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
     {
         return createBinaryNode<uchar, T, op>(lhs, rhs, odims);
     }
 
     template<typename T, af_op_t op>
-    Array<T> *bitOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
+    Array<T> bitOp(const Array<T> &lhs, const Array<T> &rhs, const af::dim4 &odims)
     {
         return createBinaryNode<T, T, op>(lhs, rhs, odims);
     }

--- a/src/backend/opencl/match_template.cpp
+++ b/src/backend/opencl/match_template.cpp
@@ -21,32 +21,32 @@ namespace opencl
 {
 
 template<typename inType, typename outType, af_match_type mType>
-Array<outType>* match_template(const Array<inType> &sImg, const Array<inType> &tImg)
+Array<outType> match_template(const Array<inType> &sImg, const Array<inType> &tImg)
 {
-    Array<outType> *out = createEmptyArray<outType>(sImg.dims());
+    Array<outType> out = createEmptyArray<outType>(sImg.dims());
 
     bool needMean = mType==AF_ZSAD || mType==AF_LSAD ||
                     mType==AF_ZSSD || mType==AF_LSSD ||
                     mType==AF_ZNCC;
 
     if (needMean)
-        kernel::matchTemplate<inType, outType, mType, true>(*out, sImg, tImg);
+        kernel::matchTemplate<inType, outType, mType, true >(out, sImg, tImg);
     else
-        kernel::matchTemplate<inType, outType, mType, false>(*out, sImg, tImg);
+        kernel::matchTemplate<inType, outType, mType, false>(out, sImg, tImg);
 
     return out;
 }
 
 #define INSTANTIATE(in_t, out_t)\
-    template Array<out_t> * match_template<in_t, out_t, AF_SAD >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_LSAD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_ZSAD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_SSD >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_LSSD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_ZSSD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_NCC >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_ZNCC>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
-    template Array<out_t> * match_template<in_t, out_t, AF_SHD >(const Array<in_t> &sImg, const Array<in_t> &tImg);
+    template Array<out_t> match_template<in_t, out_t, AF_SAD >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_LSAD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_ZSAD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_SSD >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_LSSD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_ZSSD>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_NCC >(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_ZNCC>(const Array<in_t> &sImg, const Array<in_t> &tImg); \
+    template Array<out_t> match_template<in_t, out_t, AF_SHD >(const Array<in_t> &sImg, const Array<in_t> &tImg);
 
 INSTANTIATE(double, double)
 INSTANTIATE(float ,  float)

--- a/src/backend/opencl/match_template.hpp
+++ b/src/backend/opencl/match_template.hpp
@@ -13,6 +13,6 @@ namespace opencl
 {
 
 template<typename inType, typename outType, af_match_type mType>
-Array<outType>* match_template(const Array<inType> &sImg, const Array<inType> &tImg);
+Array<outType> match_template(const Array<inType> &sImg, const Array<inType> &tImg);
 
 }

--- a/src/backend/opencl/meanshift.cpp
+++ b/src/backend/opencl/meanshift.cpp
@@ -21,7 +21,7 @@ namespace opencl
 {
 
 template<typename T, bool is_color>
-Array<T> * meanshift(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter)
+Array<T> meanshift(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter)
 {
     if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
         !isDoubleSupported(getActiveDeviceId())) {
@@ -29,16 +29,16 @@ Array<T> * meanshift(const Array<T> &in, const float &s_sigma, const float &c_si
     }
     const dim4 dims = in.dims();
 
-    Array<T>* out   = createEmptyArray<T>(dims);
+    Array<T> out   = createEmptyArray<T>(dims);
 
-    kernel::meanshift<T, is_color>(*out, in, s_sigma, c_sigma, iter);
+    kernel::meanshift<T, is_color>(out, in, s_sigma, c_sigma, iter);
 
     return out;
 }
 
 #define INSTANTIATE(T) \
-    template Array<T> * meanshift<T, true >(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter); \
-    template Array<T> * meanshift<T, false>(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter);
+    template Array<T> meanshift<T, true >(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter); \
+    template Array<T> meanshift<T, false>(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter);
 
 INSTANTIATE(float )
 INSTANTIATE(double)

--- a/src/backend/opencl/meanshift.hpp
+++ b/src/backend/opencl/meanshift.hpp
@@ -13,6 +13,6 @@ namespace opencl
 {
 
 template<typename T, bool is_color>
-Array<T> * meanshift(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter);
+Array<T> meanshift(const Array<T> &in, const float &s_sigma, const float &c_sigma, const unsigned iter);
 
 }

--- a/src/backend/opencl/medfilt.cpp
+++ b/src/backend/opencl/medfilt.cpp
@@ -21,7 +21,7 @@ namespace opencl
 {
 
 template<typename T, af_pad_type pad>
-Array<T> * medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid)
+Array<T> medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid)
 {
     if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
         !isDoubleSupported(getActiveDeviceId())) {
@@ -31,23 +31,23 @@ Array<T> * medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid)
 
     const dim4 dims     = in.dims();
 
-    Array<T> * out      = createEmptyArray<T>(dims);
+    Array<T> out      = createEmptyArray<T>(dims);
 
     switch(w_len) {
-        case  3: kernel::medfilt<T, pad,  3,  3>(*out, in); break;
-        case  5: kernel::medfilt<T, pad,  5,  5>(*out, in); break;
-        case  7: kernel::medfilt<T, pad,  7,  7>(*out, in); break;
-        case  9: kernel::medfilt<T, pad,  9,  9>(*out, in); break;
-        case 11: kernel::medfilt<T, pad, 11, 11>(*out, in); break;
-        case 13: kernel::medfilt<T, pad, 13, 13>(*out, in); break;
-        case 15: kernel::medfilt<T, pad, 15, 15>(*out, in); break;
+        case  3: kernel::medfilt<T, pad,  3,  3>(out, in); break;
+        case  5: kernel::medfilt<T, pad,  5,  5>(out, in); break;
+        case  7: kernel::medfilt<T, pad,  7,  7>(out, in); break;
+        case  9: kernel::medfilt<T, pad,  9,  9>(out, in); break;
+        case 11: kernel::medfilt<T, pad, 11, 11>(out, in); break;
+        case 13: kernel::medfilt<T, pad, 13, 13>(out, in); break;
+        case 15: kernel::medfilt<T, pad, 15, 15>(out, in); break;
     }
     return out;
 }
 
 #define INSTANTIATE(T)\
-    template Array<T> * medfilt<T, AF_ZERO     >(const Array<T> &in, dim_type w_len, dim_type w_wid); \
-    template Array<T> * medfilt<T, AF_SYMMETRIC>(const Array<T> &in, dim_type w_len, dim_type w_wid);
+    template Array<T> medfilt<T, AF_ZERO     >(const Array<T> &in, dim_type w_len, dim_type w_wid); \
+    template Array<T> medfilt<T, AF_SYMMETRIC>(const Array<T> &in, dim_type w_len, dim_type w_wid);
 
 INSTANTIATE(float )
 INSTANTIATE(double)

--- a/src/backend/opencl/medfilt.hpp
+++ b/src/backend/opencl/medfilt.hpp
@@ -13,6 +13,6 @@ namespace opencl
 {
 
 template<typename T, af_pad_type edge_pad>
-Array<T> * medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid);
+Array<T> medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid);
 
 }

--- a/src/backend/opencl/morph.hpp
+++ b/src/backend/opencl/morph.hpp
@@ -13,9 +13,9 @@ namespace opencl
 {
 
 template<typename T, bool isDilation>
-Array<T> * morph(const Array<T> &in, const Array<T> &mask);
+Array<T> morph(const Array<T> &in, const Array<T> &mask);
 
 template<typename T, bool isDilation>
-Array<T> * morph3d(const Array<T> &in, const Array<T> &mask);
+Array<T> morph3d(const Array<T> &in, const Array<T> &mask);
 
 }

--- a/src/backend/opencl/morph3d_impl.hpp
+++ b/src/backend/opencl/morph3d_impl.hpp
@@ -22,7 +22,7 @@ namespace opencl
 {
 
 template<typename T, bool isDilation>
-Array<T> * morph3d(const Array<T> &in, const Array<T> &mask)
+Array<T> morph3d(const Array<T> &in, const Array<T> &mask)
 {
     if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
         !isDoubleSupported(getActiveDeviceId())) {
@@ -40,13 +40,13 @@ Array<T> * morph3d(const Array<T> &in, const Array<T> &mask)
     if (dims[3]>1)
         AF_ERROR("Batch not supported for volumetic morphological operations", AF_ERR_NOT_SUPPORTED);
 
-    Array<T>* out   = createEmptyArray<T>(dims);
+    Array<T> out   = createEmptyArray<T>(dims);
 
     switch(mdims[0]) {
-        case  3: kernel::morph3d<T, isDilation,  3>(*out, in, mask); break;
-        case  5: kernel::morph3d<T, isDilation,  5>(*out, in, mask); break;
-        case  7: kernel::morph3d<T, isDilation,  7>(*out, in, mask); break;
-        default: kernel::morph3d<T, isDilation,  3>(*out, in, mask); break;
+        case  3: kernel::morph3d<T, isDilation,  3>(out, in, mask); break;
+        case  5: kernel::morph3d<T, isDilation,  5>(out, in, mask); break;
+        case  7: kernel::morph3d<T, isDilation,  7>(out, in, mask); break;
+        default: kernel::morph3d<T, isDilation,  3>(out, in, mask); break;
     }
 
     return out;
@@ -55,4 +55,4 @@ Array<T> * morph3d(const Array<T> &in, const Array<T> &mask)
 }
 
 #define INSTANTIATE(T, ISDILATE)                                                 \
-    template Array<T> * morph3d<T, ISDILATE>(const Array<T> &in, const Array<T> &mask);
+    template Array<T> morph3d<T, ISDILATE>(const Array<T> &in, const Array<T> &mask);

--- a/src/backend/opencl/morph_impl.hpp
+++ b/src/backend/opencl/morph_impl.hpp
@@ -22,7 +22,7 @@ namespace opencl
 {
 
 template<typename T, bool isDilation>
-Array<T> * morph(const Array<T> &in, const Array<T> &mask)
+Array<T> morph(const Array<T> &in, const Array<T> &mask)
 {
     if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
         !isDoubleSupported(getActiveDeviceId())) {
@@ -36,19 +36,19 @@ Array<T> * morph(const Array<T> &in, const Array<T> &mask)
         AF_ERROR("Upto 19x19 square kernels are only supported in opencl currently", AF_ERR_SIZE);
 
     const dim4 dims = in.dims();
-    Array<T>* out   = createEmptyArray<T>(dims);
+    Array<T> out   = createEmptyArray<T>(dims);
 
     switch(mdims[0]) {
-        case  3: kernel::morph<T, isDilation,  3>(*out, in, mask); break;
-        case  5: kernel::morph<T, isDilation,  5>(*out, in, mask); break;
-        case  7: kernel::morph<T, isDilation,  7>(*out, in, mask); break;
-        case  9: kernel::morph<T, isDilation,  9>(*out, in, mask); break;
-        case 11: kernel::morph<T, isDilation, 11>(*out, in, mask); break;
-        case 13: kernel::morph<T, isDilation, 13>(*out, in, mask); break;
-        case 15: kernel::morph<T, isDilation, 15>(*out, in, mask); break;
-        case 17: kernel::morph<T, isDilation, 17>(*out, in, mask); break;
-        case 19: kernel::morph<T, isDilation, 19>(*out, in, mask); break;
-        default: kernel::morph<T, isDilation,  3>(*out, in, mask); break;
+        case  3: kernel::morph<T, isDilation,  3>(out, in, mask); break;
+        case  5: kernel::morph<T, isDilation,  5>(out, in, mask); break;
+        case  7: kernel::morph<T, isDilation,  7>(out, in, mask); break;
+        case  9: kernel::morph<T, isDilation,  9>(out, in, mask); break;
+        case 11: kernel::morph<T, isDilation, 11>(out, in, mask); break;
+        case 13: kernel::morph<T, isDilation, 13>(out, in, mask); break;
+        case 15: kernel::morph<T, isDilation, 15>(out, in, mask); break;
+        case 17: kernel::morph<T, isDilation, 17>(out, in, mask); break;
+        case 19: kernel::morph<T, isDilation, 19>(out, in, mask); break;
+        default: kernel::morph<T, isDilation,  3>(out, in, mask); break;
     }
 
     return out;
@@ -57,4 +57,4 @@ Array<T> * morph(const Array<T> &in, const Array<T> &mask)
 }
 
 #define INSTANTIATE(T, ISDILATE)                                                 \
-    template Array<T> * morph  <T, ISDILATE>(const Array<T> &in, const Array<T> &mask);
+    template Array<T> morph  <T, ISDILATE>(const Array<T> &in, const Array<T> &mask);

--- a/src/backend/opencl/orb.cpp
+++ b/src/backend/opencl/orb.cpp
@@ -46,12 +46,12 @@ unsigned orb(Array<float> &x_out, Array<float> &y_out,
         const dim4 out_dims(nfeat);
         const dim4 desc_dims(8, nfeat);
 
-        x_out     = *createParamArray<float>(x);
-        y_out     = *createParamArray<float>(y);
-        score_out = *createParamArray<float>(score);
-        ori_out   = *createParamArray<float>(ori);
-        size_out  = *createParamArray<float>(size);
-        desc_out  = *createParamArray<unsigned>(desc);
+        x_out     = createParamArray<float>(x);
+        y_out     = createParamArray<float>(y);
+        score_out = createParamArray<float>(score);
+        ori_out   = createParamArray<float>(ori);
+        size_out  = createParamArray<float>(size);
+        desc_out  = createParamArray<unsigned>(desc);
     }
 
     return nfeat;

--- a/src/backend/opencl/orb.hpp
+++ b/src/backend/opencl/orb.hpp
@@ -22,4 +22,5 @@ unsigned orb(Array<float> &x, Array<float> &y, Array<float> &score,
              const Array<T>& image,
              const float fast_thr, const unsigned max_feat,
              const float scl_fctr, const unsigned levels);
+
 }

--- a/src/backend/opencl/random.cpp
+++ b/src/backend/opencl/random.cpp
@@ -18,47 +18,52 @@
 namespace opencl
 {
     template<typename T>
-    Array<T>* randu(const af::dim4 &dims)
+    Array<T> randu(const af::dim4 &dims)
     {
         if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
             OPENCL_NOT_SUPPORTED();
         }
-        Array<T> *out = createEmptyArray<T>(dims);
-        kernel::random<T, true>(*out->get(), out->elements());
+        Array<T> out = createEmptyArray<T>(dims);
+        kernel::random<T, true>(*out.get(), out.elements());
         return out;
     }
 
     template<typename T>
-    Array<T>* randn(const af::dim4 &dims)
+    Array<T> randn(const af::dim4 &dims)
     {
         if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
             OPENCL_NOT_SUPPORTED();
         }
-        Array<T> *out = createEmptyArray<T>(dims);
-        kernel::random<T, false>(*out->get(), out->elements());
+        Array<T> out = createEmptyArray<T>(dims);
+        kernel::random<T, false>(*out.get(), out.elements());
         return out;
     }
 
-    template Array<float>  * randu<float>   (const af::dim4 &dims);
-    template Array<double> * randu<double>  (const af::dim4 &dims);
-    template Array<int>    * randu<int>     (const af::dim4 &dims);
-    template Array<uint>   * randu<uint>    (const af::dim4 &dims);
-    template Array<char>   * randu<char>    (const af::dim4 &dims);
-    template Array<uchar>  * randu<uchar>   (const af::dim4 &dims);
+    template Array<float>  randu<float>   (const af::dim4 &dims);
+    template Array<double> randu<double>  (const af::dim4 &dims);
+    template Array<int>    randu<int>     (const af::dim4 &dims);
+    template Array<uint>   randu<uint>    (const af::dim4 &dims);
+    template Array<char>   randu<char>    (const af::dim4 &dims);
+    template Array<uchar>  randu<uchar>   (const af::dim4 &dims);
 
-    template Array<float>  * randn<float>   (const af::dim4 &dims);
-    template Array<double> * randn<double>  (const af::dim4 &dims);
+    template Array<float>  randn<float>   (const af::dim4 &dims);
+    template Array<double> randn<double>  (const af::dim4 &dims);
 
-#define COMPLEX_RANDOM(fn, T, TR, is_randu)                     \
-    template<> Array<T>* fn<T>(const af::dim4 &dims)            \
-    {                                                           \
-        Array<T> *out = createEmptyArray<T>(dims);              \
-        dim_type elements = out->elements() * 2;                \
-        kernel::random<TR, is_randu>(*out->get(), elements);    \
-        return out;                                             \
-    }                                                           \
+#define COMPLEX_RANDOM(fn, T, TR, is_randu)                 \
+    template<> Array<T> fn<T>(const af::dim4 &dims)         \
+    {                                                       \
+        if ((std::is_same<T, double>::value ||              \
+             std::is_same<T, cdouble>::value) &&            \
+            !isDoubleSupported(getActiveDeviceId())) {      \
+            OPENCL_NOT_SUPPORTED();                         \
+        }                                                   \
+        Array<T> out = createEmptyArray<T>(dims);           \
+        dim_type elements = out.elements() * 2;             \
+        kernel::random<TR, is_randu>(*out.get(), elements); \
+        return out;                                         \
+    }                                                       \
 
     COMPLEX_RANDOM(randu, cfloat, float, true)
     COMPLEX_RANDOM(randu, cdouble, double, true)

--- a/src/backend/opencl/random.hpp
+++ b/src/backend/opencl/random.hpp
@@ -13,8 +13,8 @@
 namespace opencl
 {
     template<typename T>
-    Array<T>* randu(const af::dim4 &dims);
+    Array<T> randu(const af::dim4 &dims);
 
     template<typename T>
-    Array<T>* randn(const af::dim4 &dims);
+    Array<T> randn(const af::dim4 &dims);
 }

--- a/src/backend/opencl/reduce.hpp
+++ b/src/backend/opencl/reduce.hpp
@@ -14,7 +14,7 @@
 namespace opencl
 {
     template<af_op_t op, typename Ti, typename To>
-    Array<To>* reduce(const Array<Ti> &in, const int dim);
+    Array<To> reduce(const Array<Ti> &in, const int dim);
 
     template<af_op_t op, typename Ti, typename To>
     To reduce_all(const Array<Ti> &in);

--- a/src/backend/opencl/reduce_impl.hpp
+++ b/src/backend/opencl/reduce_impl.hpp
@@ -21,12 +21,12 @@ using af::dim4;
 namespace opencl
 {
     template<af_op_t op, typename Ti, typename To>
-    Array<To>* reduce(const Array<Ti> &in, const int dim)
+    Array<To> reduce(const Array<Ti> &in, const int dim)
     {
         dim4 odims = in.dims();
         odims[dim] = 1;
-        Array<To> *out = createEmptyArray<To>(odims);
-        kernel::reduce<Ti, To, op>(*out, in, dim);
+        Array<To> out = createEmptyArray<To>(odims);
+        kernel::reduce<Ti, To, op>(out, in, dim);
         return out;
     }
 
@@ -38,5 +38,5 @@ namespace opencl
 }
 
 #define INSTANTIATE(Op, Ti, To)                                         \
-    template Array<To>* reduce<Op, Ti, To>(const Array<Ti> &in, const int dim); \
+    template Array<To> reduce<Op, Ti, To>(const Array<Ti> &in, const int dim); \
     template To reduce_all<Op, Ti, To>(const Array<Ti> &in);

--- a/src/backend/opencl/regions.cpp
+++ b/src/backend/opencl/regions.cpp
@@ -21,7 +21,7 @@ namespace opencl
 {
 
 template<typename T>
-Array<T> * regions(const Array<uchar> &in, af_connectivity connectivity)
+Array<T> regions(const Array<uchar> &in, af_connectivity connectivity)
 {
     if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
         !isDoubleSupported(getActiveDeviceId())) {
@@ -31,14 +31,14 @@ Array<T> * regions(const Array<uchar> &in, af_connectivity connectivity)
 
     const af::dim4 dims = in.dims();
 
-    Array<T> * out  = createEmptyArray<T>(dims);
+    Array<T> out  = createEmptyArray<T>(dims);
 
     switch(connectivity) {
         case AF_CONNECTIVITY_4:
-            kernel::regions<T, false, 2>(*out, in);
+            kernel::regions<T, false, 2>(out, in);
             break;
         case AF_CONNECTIVITY_8:
-            kernel::regions<T, true,  2>(*out, in);
+            kernel::regions<T, true,  2>(out, in);
             break;
     }
 
@@ -46,7 +46,7 @@ Array<T> * regions(const Array<uchar> &in, af_connectivity connectivity)
 }
 
 #define INSTANTIATE(T)                                                                          \
-    template Array<T> * regions<T>(const Array<uchar> &in, af_connectivity connectivity);
+    template Array<T> regions<T>(const Array<uchar> &in, af_connectivity connectivity);
 
 INSTANTIATE(float )
 INSTANTIATE(double)

--- a/src/backend/opencl/regions.hpp
+++ b/src/backend/opencl/regions.hpp
@@ -13,6 +13,6 @@ namespace opencl
 {
 
 template<typename T>
-Array<T> * regions(const Array<uchar> &in, af_connectivity connectivity);
+Array<T>  regions(const Array<uchar> &in, af_connectivity connectivity);
 
 }

--- a/src/backend/opencl/reorder.cpp
+++ b/src/backend/opencl/reorder.cpp
@@ -16,7 +16,7 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *reorder(const Array<T> &in, const af::dim4 &rdims)
+    Array<T> reorder(const Array<T> &in, const af::dim4 &rdims)
     {
         if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
@@ -27,15 +27,15 @@ namespace opencl
         for(int i = 0; i < 4; i++)
             oDims[i] = iDims[rdims[i]];
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
-        kernel::reorder<T>(*out, in, rdims.get());
+        kernel::reorder<T>(out, in, rdims.get());
 
         return out;
     }
 
 #define INSTANTIATE(T)                                                         \
-    template Array<T>* reorder<T>(const Array<T> &in, const af::dim4 &rdims);  \
+    template Array<T> reorder<T>(const Array<T> &in, const af::dim4 &rdims);  \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/opencl/reorder.hpp
+++ b/src/backend/opencl/reorder.hpp
@@ -13,5 +13,5 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *reorder(const Array<T> &in, const af::dim4 &rdims);
+    Array<T> reorder(const Array<T> &in, const af::dim4 &rdims);
 }

--- a/src/backend/opencl/resize.cpp
+++ b/src/backend/opencl/resize.cpp
@@ -17,8 +17,8 @@
 namespace opencl
 {
     template<typename T>
-    Array<T>* resize(const Array<T> &in, const dim_type odim0, const dim_type odim1,
-                     const af_interp_type method)
+    Array<T> resize(const Array<T> &in, const dim_type odim0, const dim_type odim1,
+                    const af_interp_type method)
     {
         if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
@@ -31,14 +31,14 @@ namespace opencl
             throw std::runtime_error("Elements is 0");
         }
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
         switch(method) {
             case AF_INTERP_NEAREST:
-                kernel::resize<T, AF_INTERP_NEAREST> (*out, in);
+                kernel::resize<T, AF_INTERP_NEAREST> (out, in);
                 break;
             case AF_INTERP_BILINEAR:
-                kernel::resize<T, AF_INTERP_BILINEAR>(*out, in);
+                kernel::resize<T, AF_INTERP_BILINEAR>(out, in);
                 break;
             default:
                 break;
@@ -47,9 +47,10 @@ namespace opencl
     }
 
 
-#define INSTANTIATE(T)                                                                            \
-    template Array<T>* resize<T> (const Array<T> &in, const dim_type odim0, const dim_type odim1, \
-                                  const af_interp_type method);
+#define INSTANTIATE(T)                                                  \
+    template Array<T> resize<T> (const Array<T> &in,                    \
+                                 const dim_type odim0, const dim_type odim1, \
+                                 const af_interp_type method);
 
 
     INSTANTIATE(float)

--- a/src/backend/opencl/resize.hpp
+++ b/src/backend/opencl/resize.hpp
@@ -13,6 +13,6 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *resize(const Array<T> &in, const dim_type odim0, const dim_type odim1,
-                     const af_interp_type method);
+    Array<T> resize(const Array<T> &in, const dim_type odim0, const dim_type odim1,
+                    const af_interp_type method);
 }

--- a/src/backend/opencl/rotate.cpp
+++ b/src/backend/opencl/rotate.cpp
@@ -16,7 +16,7 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *rotate(const Array<T> &in, const float theta, const af::dim4 &odims,
+    Array<T> rotate(const Array<T> &in, const float theta, const af::dim4 &odims,
                      const af_interp_type method)
     {
         if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
@@ -24,14 +24,14 @@ namespace opencl
             OPENCL_NOT_SUPPORTED();
         }
 
-        Array<T> *out = createEmptyArray<T>(odims);
+        Array<T> out = createEmptyArray<T>(odims);
 
         switch(method) {
             case AF_INTERP_NEAREST:
-                kernel::rotate<T, AF_INTERP_NEAREST> (*out, in, theta);
+                kernel::rotate<T, AF_INTERP_NEAREST> (out, in, theta);
                 break;
             case AF_INTERP_BILINEAR:
-                kernel::rotate<T, AF_INTERP_BILINEAR> (*out, in, theta);
+                kernel::rotate<T, AF_INTERP_BILINEAR> (out, in, theta);
                 break;
             default:
                 AF_ERROR("Unsupported interpolation type", AF_ERR_ARG);
@@ -42,9 +42,9 @@ namespace opencl
     }
 
 
-#define INSTANTIATE(T)                                                                          \
-    template Array<T> *rotate(const Array<T> &in, const float theta,                            \
-                              const af::dim4 &odims, const af_interp_type method);              \
+#define INSTANTIATE(T)                                                  \
+    template Array<T> rotate(const Array<T> &in, const float theta,     \
+                             const af::dim4 &odims, const af_interp_type method); \
 
 
     INSTANTIATE(float)
@@ -55,4 +55,3 @@ namespace opencl
     INSTANTIATE(uint)
     INSTANTIATE(uchar)
 }
-

--- a/src/backend/opencl/rotate.hpp
+++ b/src/backend/opencl/rotate.hpp
@@ -13,6 +13,6 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *rotate(const Array<T> &in, const float theta, const af::dim4 &odims,
-                     const af_interp_type method);
+    Array<T> rotate(const Array<T> &in, const float theta, const af::dim4 &odims,
+                    const af_interp_type method);
 }

--- a/src/backend/opencl/scalar.hpp
+++ b/src/backend/opencl/scalar.hpp
@@ -16,7 +16,7 @@ namespace opencl
 {
 
 template<typename T>
-Array<T>* createScalarNode(const dim4 &size, const T val)
+Array<T> createScalarNode(const dim4 &size, const T val)
 {
     JIT::ScalarNode<T> *node = new JIT::ScalarNode<T>(val);
     return createNodeArray<T>(size, JIT::Node_ptr(reinterpret_cast<JIT::Node *>(node)));

--- a/src/backend/opencl/scan.cpp
+++ b/src/backend/opencl/scan.cpp
@@ -21,16 +21,16 @@
 namespace opencl
 {
     template<af_op_t op, typename Ti, typename To>
-    Array<To>* scan(const Array<Ti>& in, const int dim)
+    Array<To> scan(const Array<Ti>& in, const int dim)
     {
         if ((std::is_same<Ti, double>::value || std::is_same<Ti, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
             OPENCL_NOT_SUPPORTED();
         }
-        Array<To> *out = createEmptyArray<To>(in.dims());
+        Array<To> out = createEmptyArray<To>(in.dims());
 
         try {
-            Param Out = *out;
+            Param Out = out;
             Param In  =   in;
             switch (dim) {
             case 0: kernel::scan_first<Ti, To, op   >(Out, In); break;
@@ -47,7 +47,7 @@ namespace opencl
     }
 
 #define INSTANTIATE(ROp, Ti, To)                                        \
-    template Array<To>* scan<ROp, Ti, To>(const Array<Ti>& in, const int dim); \
+    template Array<To> scan<ROp, Ti, To>(const Array<Ti>& in, const int dim); \
 
     //accum
     INSTANTIATE(af_add_t, float  , float  )

--- a/src/backend/opencl/scan.hpp
+++ b/src/backend/opencl/scan.hpp
@@ -14,5 +14,5 @@
 namespace opencl
 {
     template<af_op_t op, typename Ti, typename To>
-    Array<To>* scan(const Array<Ti>& in, const int dim);
+    Array<To> scan(const Array<Ti>& in, const int dim);
 }

--- a/src/backend/opencl/set.cpp
+++ b/src/backend/opencl/set.cpp
@@ -28,22 +28,22 @@ namespace opencl
     using af::dim4;
 
     template<typename T>
-    Array<T>* setUnique(const Array<T> &in,
-                        const bool is_sorted)
+    Array<T> setUnique(const Array<T> &in,
+                       const bool is_sorted)
     {
         try {
             if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
                 !isDoubleSupported(getActiveDeviceId())) {
                 OPENCL_NOT_SUPPORTED();
             }
-            Array<T> *out = copyArray<T>(in);
+            Array<T> out = copyArray<T>(in);
 
             compute::command_queue queue(getQueue()());
 
-            compute::buffer out_data((*out->get())());
+            compute::buffer out_data((*out.get())());
 
             compute::buffer_iterator<T> begin(out_data, 0);
-            compute::buffer_iterator<T> end(out_data, out->dims()[0]);
+            compute::buffer_iterator<T> end(out_data, out.dims()[0]);
 
             if (!is_sorted) {
                 compute::sort(begin, end, queue);
@@ -51,7 +51,7 @@ namespace opencl
 
             end = compute::unique(begin, end, queue);
 
-            out->resetDims(dim4(std::distance(begin, end), 1, 1, 1));
+            out.resetDims(dim4(std::distance(begin, end), 1, 1, 1));
 
             return out;
         } catch (std::exception &ex) {
@@ -60,9 +60,9 @@ namespace opencl
     }
 
     template<typename T>
-    Array<T>* setUnion(const Array<T> &first,
-                       const Array<T> &second,
-                       const bool is_unique)
+    Array<T> setUnion(const Array<T> &first,
+                      const Array<T> &second,
+                      const bool is_unique)
     {
         try {
             if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
@@ -73,18 +73,18 @@ namespace opencl
             Array<T> unique_second = second;
 
             if (!is_unique) {
-                unique_first  = *setUnique(first, false);
-                unique_second = *setUnique(second, false);
+                unique_first  = setUnique(first, false);
+                unique_second = setUnique(second, false);
             }
 
             size_t out_size = unique_first.dims()[0] + unique_second.dims()[0];
-            Array<T> *out = createEmptyArray<T>(dim4(out_size, 1, 1, 1));
+            Array<T> out = createEmptyArray<T>(dim4(out_size, 1, 1, 1));
 
             compute::command_queue queue(getQueue()());
 
             compute::buffer first_data((*unique_first.get())());
             compute::buffer second_data((*unique_second.get())());
-            compute::buffer out_data((*out->get())());
+            compute::buffer out_data((*out.get())());
 
             compute::buffer_iterator<T> first_begin(first_data, 0);
             compute::buffer_iterator<T> first_end(first_data, unique_first.dims()[0]);
@@ -96,7 +96,7 @@ namespace opencl
                 first_begin, first_end, second_begin, second_end, out_begin, queue
                 );
 
-            out->resetDims(dim4(std::distance(out_begin, out_end), 1, 1, 1));
+            out.resetDims(dim4(std::distance(out_begin, out_end), 1, 1, 1));
             return out;
 
         } catch (std::exception &ex) {
@@ -105,9 +105,9 @@ namespace opencl
     }
 
     template<typename T>
-    Array<T>* setIntersect(const Array<T> &first,
-                           const Array<T> &second,
-                           const bool is_unique)
+    Array<T> setIntersect(const Array<T> &first,
+                          const Array<T> &second,
+                          const bool is_unique)
     {
         try {
             if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
@@ -118,18 +118,18 @@ namespace opencl
             Array<T> unique_second = second;
 
             if (!is_unique) {
-                unique_first  = *setUnique(first, false);
-                unique_second = *setUnique(second, false);
+                unique_first  = setUnique(first, false);
+                unique_second = setUnique(second, false);
             }
 
             size_t out_size = std::max(unique_first.dims()[0], unique_second.dims()[0]);
-            Array<T> *out = createEmptyArray<T>(dim4(out_size, 1, 1, 1));
+            Array<T> out = createEmptyArray<T>(dim4(out_size, 1, 1, 1));
 
             compute::command_queue queue(getQueue()());
 
             compute::buffer first_data((*unique_first.get())());
             compute::buffer second_data((*unique_second.get())());
-            compute::buffer out_data((*out->get())());
+            compute::buffer out_data((*out.get())());
 
             compute::buffer_iterator<T> first_begin(first_data, 0);
             compute::buffer_iterator<T> first_end(first_data, unique_first.dims()[0]);
@@ -141,7 +141,7 @@ namespace opencl
                 first_begin, first_end, second_begin, second_end, out_begin, queue
                 );
 
-            out->resetDims(dim4(std::distance(out_begin, out_end), 1, 1, 1));
+            out.resetDims(dim4(std::distance(out_begin, out_end), 1, 1, 1));
             return out;
         } catch (std::exception &ex) {
             AF_ERROR(ex.what(), AF_ERR_INTERNAL);
@@ -149,9 +149,9 @@ namespace opencl
     }
 
 #define INSTANTIATE(T)                                                  \
-    template Array<T>* setUnique<T>(const Array<T> &in, const bool is_sorted); \
-    template Array<T>* setUnion<T>(const Array<T> &first, const Array<T> &second, const bool is_unique); \
-    template Array<T>* setIntersect<T>(const Array<T> &first, const Array<T> &second, const bool is_unique); \
+    template Array<T> setUnique<T>(const Array<T> &in, const bool is_sorted); \
+    template Array<T> setUnion<T>(const Array<T> &first, const Array<T> &second, const bool is_unique); \
+    template Array<T> setIntersect<T>(const Array<T> &first, const Array<T> &second, const bool is_unique); \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/opencl/set.hpp
+++ b/src/backend/opencl/set.hpp
@@ -12,14 +12,14 @@
 
 namespace opencl
 {
-    template<typename T> Array<T>* setUnique(const Array<T> &in,
-                                             const bool is_sorted);
+    template<typename T> Array<T> setUnique(const Array<T> &in,
+                                            const bool is_sorted);
 
-    template<typename T> Array<T>* setUnion(const Array<T> &first,
-                                            const Array<T> &second,
-                                            const bool is_unique);
+    template<typename T> Array<T> setUnion(const Array<T> &first,
+                                           const Array<T> &second,
+                                           const bool is_unique);
 
-    template<typename T> Array<T>* setIntersect(const Array<T> &first,
-                                                const Array<T> &second,
-                                                const bool is_unique);
+    template<typename T> Array<T> setIntersect(const Array<T> &first,
+                                               const Array<T> &second,
+                                               const bool is_unique);
 }

--- a/src/backend/opencl/shift.cpp
+++ b/src/backend/opencl/shift.cpp
@@ -16,7 +16,7 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *shift(const Array<T> &in, const af::dim4 &sdims)
+    Array<T> shift(const Array<T> &in, const af::dim4 &sdims)
     {
         if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
@@ -25,15 +25,15 @@ namespace opencl
         const af::dim4 iDims = in.dims();
         af::dim4 oDims = iDims;
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
-        kernel::shift<T>(*out, in, sdims.get());
+        kernel::shift<T>(out, in, sdims.get());
 
         return out;
     }
 
 #define INSTANTIATE(T)                                                          \
-    template Array<T>* shift<T>(const Array<T> &in, const af::dim4 &sdims);     \
+    template Array<T> shift<T>(const Array<T> &in, const af::dim4 &sdims);     \
 
     INSTANTIATE(float)
     INSTANTIATE(double)
@@ -44,4 +44,3 @@ namespace opencl
     INSTANTIATE(uchar)
     INSTANTIATE(char)
 }
-

--- a/src/backend/opencl/shift.hpp
+++ b/src/backend/opencl/shift.hpp
@@ -13,5 +13,5 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *shift(const Array<T> &in, const af::dim4 &sdims);
+    Array<T> shift(const Array<T> &in, const af::dim4 &sdims);
 }

--- a/src/backend/opencl/sobel.cpp
+++ b/src/backend/opencl/sobel.cpp
@@ -21,21 +21,21 @@ namespace opencl
 {
 
 template<typename Ti, typename To>
-std::pair< Array<To>*, Array<To>* >
+std::pair< Array<To>, Array<To> >
 sobelDerivatives(const Array<Ti> &img, const unsigned &ker_size)
 {
-    Array<To> *dx = createEmptyArray<To>(img.dims());
-    Array<To> *dy = createEmptyArray<To>(img.dims());
+    Array<To> dx = createEmptyArray<To>(img.dims());
+    Array<To> dy = createEmptyArray<To>(img.dims());
 
     switch(ker_size) {
-        case 3: kernel::sobel<Ti, To, 3>(*dx, *dy, img); break;
+        case 3: kernel::sobel<Ti, To, 3>(dx, dy, img); break;
     }
 
     return std::make_pair(dx, dy);
 }
 
-#define INSTANTIATE(Ti, To)                                                 \
-    template std::pair< Array<To>*, Array<To>* >                            \
+#define INSTANTIATE(Ti, To)                                             \
+    template std::pair< Array<To>, Array<To> >                            \
     sobelDerivatives(const Array<Ti> &img, const unsigned &ker_size);
 
 INSTANTIATE(float , float)
@@ -46,4 +46,3 @@ INSTANTIATE(char  , int)
 INSTANTIATE(uchar , int)
 
 }
-

--- a/src/backend/opencl/sobel.hpp
+++ b/src/backend/opencl/sobel.hpp
@@ -14,7 +14,7 @@ namespace opencl
 {
 
 template<typename Ti, typename To>
-std::pair< Array<To>*, Array<To>* >
+std::pair< Array<To>, Array<To> >
 sobelDerivatives(const Array<Ti> &img, const unsigned &ker_size);
 
 }

--- a/src/backend/opencl/sort.cpp
+++ b/src/backend/opencl/sort.cpp
@@ -18,12 +18,12 @@
 namespace opencl
 {
     template<typename T, bool isAscending>
-    Array<T>* sort(const Array<T> &in, const unsigned dim)
+    Array<T> sort(const Array<T> &in, const unsigned dim)
     {
         try {
-            Array<T> *out = copyArray<T>(in);
+            Array<T> out = copyArray<T>(in);
             switch(dim) {
-            case 0: kernel::sort0<T, isAscending>(*out);
+            case 0: kernel::sort0<T, isAscending>(out);
                 break;
             default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
             }
@@ -34,8 +34,8 @@ namespace opencl
     }
 
 #define INSTANTIATE(T)                                                  \
-    template Array<T>* sort<T, true>(const Array<T> &in, const unsigned dim); \
-    template Array<T>*  sort<T,false>(const Array<T> &in, const unsigned dim); \
+    template Array<T> sort<T, true>(const Array<T> &in, const unsigned dim); \
+    template Array<T> sort<T,false>(const Array<T> &in, const unsigned dim); \
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/opencl/sort.hpp
+++ b/src/backend/opencl/sort.hpp
@@ -13,5 +13,5 @@
 namespace opencl
 {
     template<typename T, bool isAscending>
-    Array<T>* sort(const Array<T> &in, const unsigned dim);
+    Array<T> sort(const Array<T> &in, const unsigned dim);
 }

--- a/src/backend/opencl/sort_by_key.cpp
+++ b/src/backend/opencl/sort_by_key.cpp
@@ -31,8 +31,8 @@ namespace opencl
         }
 
         try {
-            okey = *copyArray<Tk>(ikey);
-            oval = *copyArray<Tv>(ival);
+            okey = copyArray<Tk>(ikey);
+            oval = copyArray<Tv>(ival);
             switch(dim) {
             case 0: kernel::sort0_by_key<Tk, Tv, isAscending>(okey, oval);
                 break;
@@ -43,13 +43,15 @@ namespace opencl
         }
     }
 
-#define INSTANTIATE(Tk, Tv)                                                                     \
-    template void                                                                               \
-    sort_by_key<Tk, Tv, true>(Array<Tk> &okey, Array<Tv> &oval,                                 \
-                        const Array<Tk> &ikey, const Array<Tv> &ival, const unsigned dim);      \
-    template void                                                                               \
-    sort_by_key<Tk, Tv,false>(Array<Tk> &okey, Array<Tv> &oval,                                 \
-                        const Array<Tk> &ikey, const Array<Tv> &ival, const unsigned dim);      \
+#define INSTANTIATE(Tk, Tv)                                             \
+    template void                                                       \
+    sort_by_key<Tk, Tv, true>(Array<Tk> &okey, Array<Tv> &oval,         \
+                              const Array<Tk> &ikey, const Array<Tv> &ival, \
+                              const unsigned dim);                      \
+    template void                                                       \
+    sort_by_key<Tk, Tv,false>(Array<Tk> &okey, Array<Tv> &oval,         \
+                              const Array<Tk> &ikey, const Array<Tv> &ival, \
+                              const unsigned dim);                      \
 
 #define INSTANTIATE1(Tk)       \
     INSTANTIATE(Tk, float)     \

--- a/src/backend/opencl/sort_index.cpp
+++ b/src/backend/opencl/sort_index.cpp
@@ -26,8 +26,8 @@ namespace opencl
         }
 
         try {
-            val = *copyArray<T>(in);
-            idx = *createEmptyArray<uint>(in.dims());
+            val = copyArray<T>(in);
+            idx = createEmptyArray<uint>(in.dims());
 
             switch(dim) {
             case 0: kernel::sort0_index<T, isAscending>(val, idx);

--- a/src/backend/opencl/tile.cpp
+++ b/src/backend/opencl/tile.cpp
@@ -15,7 +15,7 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *tile(const Array<T> &in, const af::dim4 &tileDims)
+    Array<T> tile(const Array<T> &in, const af::dim4 &tileDims)
     {
         if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
@@ -25,15 +25,15 @@ namespace opencl
         af::dim4 oDims = iDims;
         oDims *= tileDims;
 
-        Array<T> *out = createEmptyArray<T>(oDims);
+        Array<T> out = createEmptyArray<T>(oDims);
 
-        kernel::tile<T>(*out, in);
+        kernel::tile<T>(out, in);
 
         return out;
     }
 
 #define INSTANTIATE(T)                                                         \
-    template Array<T>* tile<T>(const Array<T> &in, const af::dim4 &tileDims);  \
+    template Array<T> tile<T>(const Array<T> &in, const af::dim4 &tileDims);  \
 
     INSTANTIATE(float)
     INSTANTIATE(double)
@@ -45,4 +45,3 @@ namespace opencl
     INSTANTIATE(char)
 
 }
-

--- a/src/backend/opencl/tile.hpp
+++ b/src/backend/opencl/tile.hpp
@@ -13,5 +13,5 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *tile(const Array<T> &in, const af::dim4 &tileDims);
+    Array<T> tile(const Array<T> &in, const af::dim4 &tileDims);
 }

--- a/src/backend/opencl/transform.cpp
+++ b/src/backend/opencl/transform.cpp
@@ -17,24 +17,25 @@
 namespace opencl
 {
     template<typename T>
-    Array<T>* transform(const Array<T> &in, const Array<float> &transform, const af::dim4 &odims,
-                        const af_interp_type method, const bool inverse)
+    Array<T> transform(const Array<T> &in, const Array<float> &transform,
+                       const af::dim4 &odims,
+                       const af_interp_type method, const bool inverse)
     {
         if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
             OPENCL_NOT_SUPPORTED();
         }
-        Array<T> *out = createEmptyArray<T>(odims);
+        Array<T> out = createEmptyArray<T>(odims);
 
         if(inverse) {
             switch(method) {
                 case AF_INTERP_NEAREST:
                     kernel::transform<T, true, AF_INTERP_NEAREST>
-                                     (*out, in, transform);
+                                     (out, in, transform);
                     break;
                 case AF_INTERP_BILINEAR:
                     kernel::transform<T, true, AF_INTERP_BILINEAR>
-                                     (*out, in, transform);
+                                     (out, in, transform);
                     break;
                 default:
                     AF_ERROR("Unsupported interpolation type", AF_ERR_ARG);
@@ -44,11 +45,11 @@ namespace opencl
             switch(method) {
                 case AF_INTERP_NEAREST:
                     kernel::transform<T, false, AF_INTERP_NEAREST>
-                                     (*out, in, transform);
+                                     (out, in, transform);
                     break;
                 case AF_INTERP_BILINEAR:
                     kernel::transform<T, false, AF_INTERP_BILINEAR>
-                                     (*out, in, transform);
+                                     (out, in, transform);
                     break;
                 default:
                     AF_ERROR("Unsupported interpolation type", AF_ERR_ARG);
@@ -60,10 +61,10 @@ namespace opencl
     }
 
 
-#define INSTANTIATE(T)                                                                          \
-    template Array<T>* transform(const Array<T> &in, const Array<float> &transform,             \
-                                 const af::dim4 &odims, const af_interp_type method,            \
-                                 const bool inverse);                                           \
+#define INSTANTIATE(T)                                                  \
+    template Array<T> transform(const Array<T> &in, const Array<float> &transform, \
+                                const af::dim4 &odims, const af_interp_type method, \
+                                const bool inverse);                    \
 
 
     INSTANTIATE(float)
@@ -74,4 +75,3 @@ namespace opencl
     INSTANTIATE(uint)
     INSTANTIATE(uchar)
 }
-

--- a/src/backend/opencl/transform.hpp
+++ b/src/backend/opencl/transform.hpp
@@ -13,6 +13,6 @@
 namespace opencl
 {
     template<typename T>
-    Array<T> *transform(const Array<T> &in, const Array<float> &tf, const af::dim4 &odims,
+    Array<T> transform(const Array<T> &in, const Array<float> &tf, const af::dim4 &odims,
                         const af_interp_type method, const bool inverse);
 }

--- a/src/backend/opencl/transpose.cpp
+++ b/src/backend/opencl/transpose.cpp
@@ -18,7 +18,7 @@ namespace opencl
 {
 
 template<typename T>
-Array<T> * transpose(const Array<T> &in, const bool conjugate)
+Array<T> transpose(const Array<T> &in, const bool conjugate)
 {
     if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
         !isDoubleSupported(getActiveDeviceId())) {
@@ -26,25 +26,25 @@ Array<T> * transpose(const Array<T> &in, const bool conjugate)
     }
     const dim4 inDims   = in.dims();
     dim4 outDims  = dim4(inDims[1],inDims[0],inDims[2],inDims[3]);
-    Array<T>* out  = createEmptyArray<T>(outDims);
+    Array<T> out  = createEmptyArray<T>(outDims);
 
     if(conjugate) {
         if(inDims[0] % kernel::TILE_DIM == 0 && inDims[1] % kernel::TILE_DIM == 0)
-            kernel::transpose<T, true, true>(*out, in);
+            kernel::transpose<T, true, true>(out, in);
         else
-            kernel::transpose<T, true, false>(*out, in);
+            kernel::transpose<T, true, false>(out, in);
     } else {
         if(inDims[0] % kernel::TILE_DIM == 0 && inDims[1] % kernel::TILE_DIM == 0)
-            kernel::transpose<T, false, true>(*out, in);
+            kernel::transpose<T, false, true>(out, in);
         else
-            kernel::transpose<T, false, false>(*out, in);
+            kernel::transpose<T, false, false>(out, in);
     }
 
     return out;
 }
 
 #define INSTANTIATE(T)\
-    template Array<T> * transpose(const Array<T> &in, const bool conjugate);
+    template Array<T> transpose(const Array<T> &in, const bool conjugate);
 
 INSTANTIATE(float  )
 INSTANTIATE(cfloat )

--- a/src/backend/opencl/transpose.hpp
+++ b/src/backend/opencl/transpose.hpp
@@ -13,6 +13,6 @@ namespace opencl
 {
 
 template<typename T>
-Array<T> * transpose(const Array<T> &in, const bool conjugate);
+Array<T>  transpose(const Array<T> &in, const bool conjugate);
 
 }

--- a/src/backend/opencl/unary.hpp
+++ b/src/backend/opencl/unary.hpp
@@ -67,7 +67,7 @@ UNARY_FN(isnan)
 UNARY_FN(iszero)
 
 template<typename T, af_op_t op>
-Array<T>* unaryOp(const Array<T> &in)
+Array<T> unaryOp(const Array<T> &in)
 {
     JIT::Node_ptr in_node = in.getNode();
 
@@ -80,7 +80,7 @@ Array<T>* unaryOp(const Array<T> &in)
 }
 
 template<typename T, af_op_t op>
-Array<char>* checkOp(const Array<T> &in)
+Array<char> checkOp(const Array<T> &in)
 {
     JIT::Node_ptr in_node = in.getNode();
 

--- a/src/backend/opencl/where.cpp
+++ b/src/backend/opencl/where.cpp
@@ -19,7 +19,7 @@
 namespace opencl
 {
     template<typename T>
-    Array<uint>* where(const Array<T> &in)
+    Array<uint> where(const Array<T> &in)
     {
         if ((std::is_same<T, double>::value || std::is_same<T, cdouble>::value) &&
             !isDoubleSupported(getActiveDeviceId())) {
@@ -33,7 +33,7 @@ namespace opencl
 
 
 #define INSTANTIATE(T)                                  \
-    template Array<uint>* where<T>(const Array<T> &in);    \
+    template Array<uint> where<T>(const Array<T> &in);  \
 
     INSTANTIATE(float  )
     INSTANTIATE(cfloat )

--- a/src/backend/opencl/where.hpp
+++ b/src/backend/opencl/where.hpp
@@ -13,5 +13,5 @@
 namespace opencl
 {
     template<typename T>
-    Array<uint>* where(const Array<T>& in);
+    Array<uint> where(const Array<T>& in);
 }

--- a/test/basic.cpp
+++ b/test/basic.cpp
@@ -34,6 +34,8 @@ TEST(BasicTests, constant1000x1000)
     for(size_t i = 0; i < elements; i++) {
         ASSERT_FLOAT_EQ(valA, h_a[i]);
     }
+
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(a));
 }
 
 TEST(BasicTests, constant10x10)
@@ -55,6 +57,8 @@ TEST(BasicTests, constant10x10)
     for(size_t i = 0; i < elements; i++) {
         ASSERT_FLOAT_EQ(valA, h_a[i]);
     }
+
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(a));
 }
 
 TEST(BasicTests, constant100x100)
@@ -76,6 +80,8 @@ TEST(BasicTests, constant100x100)
     for(size_t i = 0; i < elements; i++) {
         ASSERT_FLOAT_EQ(valA, h_a[i]);
     }
+
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(a));
 }
 
 //TODO: Test All The Types \o/
@@ -119,6 +125,13 @@ TEST(BasicTests, AdditionSameType)
         err = err + df * df;
     }
     ASSERT_NEAR(0.0f, err, 1e-8);
+
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(af32));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(af64));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(bf32));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(bf64));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(cf32));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(cf64));
 }
 
 TEST(BasicTests, Additionf64f64)
@@ -151,6 +164,11 @@ TEST(BasicTests, Additionf64f64)
         err = err + df * df;
     }
     ASSERT_NEAR(0.0f, err, 1e-8);
+
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(a));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(b));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(c));
+
 }
 
 TEST(BasicTests, Additionf32f64)
@@ -184,6 +202,10 @@ TEST(BasicTests, Additionf32f64)
         err = err + df * df;
     }
     ASSERT_NEAR(0.0f, err, 1e-8);
+
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(a));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(b));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(c));
 }
 
 TEST(BasicArrayTests, constant10x10)

--- a/test/blas.cpp
+++ b/test/blas.cpp
@@ -95,6 +95,15 @@ void MatMulCheck(string TestFile)
             FAIL();
         }
     }
+
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(a));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(aT));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(b));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(bT));
+
+    for (size_t i = 0; i <  out.size(); i++) {
+        ASSERT_EQ(AF_SUCCESS, af_destroy_array(out[i]));
+    }
 }
 
 TYPED_TEST(MatrixMultiply, Square)

--- a/test/fft.cpp
+++ b/test/fft.cpp
@@ -35,6 +35,8 @@ TEST(fft, Invalid_Array)
                 dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<float>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_fft(&outArray, inArray, 1.0, 0));
+
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
 }
 
 TEST(fft2, Invalid_Array)
@@ -51,6 +53,7 @@ TEST(fft2, Invalid_Array)
                 dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<float>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_fft2(&outArray, inArray, 1.0, 0, 0));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
 }
 
 TEST(fft3, Invalid_Array)
@@ -67,6 +70,7 @@ TEST(fft3, Invalid_Array)
                 dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<float>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_fft3(&outArray, inArray, 1.0, 0, 0, 0));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
 }
 
 TEST(ifft1, Invalid_Array)
@@ -83,6 +87,7 @@ TEST(ifft1, Invalid_Array)
                 dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<cfloat>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_ifft(&outArray, inArray, 0.01, 0));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
 }
 
 TEST(ifft2, Invalid_Array)
@@ -99,6 +104,7 @@ TEST(ifft2, Invalid_Array)
                 dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<cfloat>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_ifft2(&outArray, inArray, 0.01, 0, 0));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
 }
 
 TEST(ifft3, Invalid_Array)
@@ -115,6 +121,7 @@ TEST(ifft3, Invalid_Array)
                 dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<cfloat>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_ifft3(&outArray, inArray, 0.01, 0, 0, 0));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
 }
 
 template<typename inType, typename outType, bool isInverse>
@@ -137,7 +144,7 @@ void fftTest(string pTestFile, dim_type pad0=0, dim_type pad1=0, dim_type pad2=0
                 dims.ndims(), dims.get(), (af_dtype)af::dtype_traits<inType>::af_type));
 
     if (isInverse){
-        switch(dims.ndims()) {
+        switch (dims.ndims()) {
             case 1 : ASSERT_EQ(AF_SUCCESS, af_ifft (&outArray, inArray, 1.0, pad0));              break;
             case 2 : ASSERT_EQ(AF_SUCCESS, af_ifft2(&outArray, inArray, 1.0, pad0, pad1));        break;
             case 3 : ASSERT_EQ(AF_SUCCESS, af_ifft3(&outArray, inArray, 1.0, pad0, pad1, pad2));  break;

--- a/test/histogram.cpp
+++ b/test/histogram.cpp
@@ -48,6 +48,7 @@ TYPED_TEST(Histogram,InvalidArgs)
     ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(), newDims.ndims(), newDims.get(), (af_dtype) af::dtype_traits<TypeParam>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_histogram(&outArray,inArray,256,0,255));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
 }
 
 template<typename inType, typename outType>

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -84,6 +84,11 @@ DimCheck(const vector<af_seq> &seqs) {
         }
         delete[] h_indexed[k];
     }
+
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(a));
+    for (size_t i = 0; i < indexed_array.size(); i++) {
+        ASSERT_EQ(AF_SUCCESS, af_destroy_array(indexed_array[i]));
+    }
 }
 
 template<typename T>
@@ -284,6 +289,11 @@ DimCheck2D(const vector<vector<af_seq>> &seqs,string TestFile)
             FAIL() << "indexed_array[" << i << "] FAILED" << endl;
         }
         delete[] h_indexed[i];
+    }
+
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(a));
+    for (size_t i = 0; i < indexed_arrays.size(); i++) {
+        ASSERT_EQ(AF_SUCCESS, af_destroy_array(indexed_arrays[i]));
     }
 }
 

--- a/test/moddims.cpp
+++ b/test/moddims.cpp
@@ -74,6 +74,10 @@ void moddimsTest(string pTestFile, bool isSubRef=false, const vector<af_seq> *se
 
         outData          = new T[nElems];
         ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+
+        ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
+        ASSERT_EQ(AF_SUCCESS, af_destroy_array(outArray));
+        ASSERT_EQ(AF_SUCCESS, af_destroy_array(subArray));
     } else {
         af_array inArray   = 0;
         af_array outArray  = 0;
@@ -87,6 +91,9 @@ void moddimsTest(string pTestFile, bool isSubRef=false, const vector<af_seq> *se
 
         outData          = new T[dims.elements()];
         ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+
+        ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
+        ASSERT_EQ(AF_SUCCESS, af_destroy_array(outArray));
     }
 
     for (size_t testIter=0; testIter<tests.size(); ++testIter) {
@@ -131,6 +138,8 @@ void moddimsArgsTest(string pTestFile)
     newDims[1] = dims[0]*dims[2];
     ASSERT_EQ(AF_ERR_ARG, af_moddims(&outArray,inArray,0,newDims.get()));
     ASSERT_EQ(AF_ERR_ARG, af_moddims(&outArray,inArray,newDims.ndims(),nullptr));
+
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
 }
 
 TYPED_TEST(Moddims,InvalidArgs)
@@ -158,6 +167,8 @@ void moddimsMismatchTest(string pTestFile)
     newDims[0] = dims[1]-1;
     newDims[1] = (dims[0]-1)*dims[2];
     ASSERT_EQ(AF_ERR_SIZE, af_moddims(&outArray,inArray,newDims.ndims(),newDims.get()));
+
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
 }
 
 TYPED_TEST(Moddims,Mismatch)

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -75,11 +75,11 @@ void reduceTest(string pTestFile, int off = 0, bool isSubRef=false, const vector
 
         // Delete
         delete[] outData;
+        ASSERT_EQ(AF_SUCCESS, af_destroy_array(outArray));
     }
 
 
     ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_destroy_array(outArray));
 }
 
 vector<af_seq> init_subs()

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -49,6 +49,7 @@ void reduceTest(string pTestFile, int off = 0, bool isSubRef=false, const vector
     if (isSubRef) {
         ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<Ti>::af_type));
         ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv.size(), &seqv.front()));
+        ASSERT_EQ(AF_SUCCESS, af_destroy_array(tempArray));
     } else {
         ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<Ti>::af_type));
     }
@@ -77,9 +78,8 @@ void reduceTest(string pTestFile, int off = 0, bool isSubRef=false, const vector
     }
 
 
-    if(inArray   != 0) af_destroy_array(inArray);
-    if(outArray  != 0) af_destroy_array(outArray);
-    if(tempArray != 0) af_destroy_array(tempArray);
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(outArray));
 }
 
 vector<af_seq> init_subs()

--- a/test/scan.cpp
+++ b/test/scan.cpp
@@ -49,6 +49,7 @@ void scanTest(string pTestFile, int off = 0, bool isSubRef=false, const vector<a
     if (isSubRef) {
         ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<Ti>::af_type));
         ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv.size(), &seqv.front()));
+        ASSERT_EQ(AF_SUCCESS, af_destroy_array(tempArray));
     } else {
 
         ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<Ti>::af_type));
@@ -75,11 +76,10 @@ void scanTest(string pTestFile, int off = 0, bool isSubRef=false, const vector<a
 
         // Delete
         delete[] outData;
+        ASSERT_EQ(AF_SUCCESS, af_destroy_array(outArray));
     }
 
-    if(inArray   != 0) af_destroy_array(inArray);
-    if(outArray  != 0) af_destroy_array(outArray);
-    if(tempArray != 0) af_destroy_array(tempArray);
+    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
 }
 
 vector<af_seq> init_subs()


### PR DESCRIPTION
- All backend functions now return `Array<T>` instead of `Array<T> *`
- This works now because raw data is stored in a shared_ptr

- Fixes #403 
- Fixes #406 
- Fixes #109 (No longer relevant)