### PR TITLE
Remove C++11 conditional from src/api/c.

### DIFF
--- a/src/api/c/mean.cpp
+++ b/src/api/c/mean.cpp
@@ -33,7 +33,7 @@ static outType mean(const af_array &in)
 template<typename inType, typename outType>
 static outType mean(const af_array &in, const af_array &weights)
 {
-    typedef baseOutType<outType> bType;
+    typedef typename baseOutType<outType>::type bType;
 
     Array<outType> input = cast<outType>(getArray<inType>(in));
     Array<outType> wts   = cast<outType>(getArray<bType>(weights));
@@ -55,7 +55,7 @@ static af_array mean(const af_array &in, dim_type dim)
 template<typename inType, typename outType>
 static af_array mean(const af_array &in, const af_array &weights, dim_type dim)
 {
-    typedef baseOutType<outType> bType;
+    typedef typename baseOutType<outType>::type bType;
 
     Array<outType> input = cast<outType>(getArray<inType>(in));
     Array<outType> wts   = cast<outType>(getArray<bType>(weights));

--- a/src/api/c/stats.h
+++ b/src/api/c/stats.h
@@ -9,11 +9,37 @@
 
 #pragma once
 
+template<typename T, typename Other>
+struct is_same{
+    static const bool value = false;
+};
+
 template<typename T>
-using baseOutType = typename std::conditional<  std::is_same<T, cdouble>::value ||
-                                                std::is_same<T, double>::value,
-                                              double,
-                                              float>::type;
+struct is_same<T, T> {
+    static const bool value = true;
+};
+
+template<bool, typename T, typename O>
+struct cond_type;
+
+template<typename T, typename Other>
+struct cond_type<true, T, Other> {
+    typedef T type;
+};
+
+template<typename T, typename Other>
+struct cond_type<false, T, Other> {
+    typedef Other type;
+};
+
+template<typename T>
+struct baseOutType {
+    typedef typename cond_type< is_same<T, cdouble>::value ||
+                                is_same<T, double>::value,
+                                double,
+                                float>::type type;
+};
+
 template<typename T>
 inline T mean(const Array<T>& in)
 {

--- a/src/api/c/var.cpp
+++ b/src/api/c/var.cpp
@@ -43,7 +43,7 @@ static outType varAll(const af_array& in, bool isbiased)
 template<typename inType, typename outType>
 static outType varAll(const af_array& in, const af_array weights)
 {
-    typedef baseOutType<outType> bType;
+    typedef typename baseOutType<outType>::type bType;
 
     Array<outType> input = cast<outType>(getArray<inType>(in));
     Array<outType> wts   = cast<outType>(getArray<bType>(weights));
@@ -91,7 +91,7 @@ static af_array var(const af_array& in, bool isbiased, int dim)
 template<typename inType, typename outType>
 static af_array var(const af_array& in, const af_array& weights, dim_type dim)
 {
-    typedef baseOutType<outType> bType;
+    typedef typename baseOutType<outType>::type bType;
 
     Array<outType> input = cast<outType>(getArray<inType>(in));
     Array<outType> wts   = cast<outType>(getArray<bType>(weights));


### PR DESCRIPTION
There was a std::contitional in src/api/c. Removed it because
CUDA on OSX cannot compile with C++11 on CUDA framework < 7.0