### PR TITLE
BUGFIX: 2d separable convolution

### DIFF
--- a/src/backend/cpu/convolve.cpp
+++ b/src/backend/cpu/convolve.cpp
@@ -13,6 +13,7 @@
 #include <Array.hpp>
 #include <convolve.hpp>
 #include <err_cpu.hpp>
+#include <math.hpp>
 
 using af::dim4;
 
@@ -205,42 +206,37 @@ void convolve2_separable(T *optr, T const *iptr, T const *fptr,
                         dim4 const &oDims, dim4 const &sDims, dim4 const &orgDims, dim_type fDim,
                         dim4 const &oStrides, dim4 const &sStrides, dim_type fStride)
 {
-    const dim_type outr_dim = (conv_dim+1)%2;
-    dim_type iStart = (expand ? 0 : fDim/2);
-    dim_type iEnd   = (expand ? oDims[conv_dim] : (iStart + std::min(sDims[conv_dim], orgDims[conv_dim])));
-    dim_type jStart = (expand ? 0 : fDim/2);
-    dim_type jEnd   = (expand ? oDims[outr_dim] : (jStart + std::min(sDims[outr_dim], orgDims[outr_dim])));
+    for(dim_type j=0; j<oDims[1]; ++j) {
 
-    for(dim_type j=jStart; j<jEnd; ++j) {
-        dim_type joff = (j-jStart)*oStrides[outr_dim];
+        dim_type jOff = j*oStrides[1];
+        dim_type cj = j + (conv_dim==1)*(expand ? 0: fDim>>1);
 
-        for(dim_type i=iStart; i<iEnd; ++i) {
-            dim_type ioff = (i-iStart)*oStrides[conv_dim];
+        for(dim_type i=0; i<oDims[0]; ++i) {
 
-            accType accum = accType(0);
+            dim_type iOff = i*oStrides[0];
+            dim_type ci = i + (conv_dim==0)*(expand ? 0 : fDim>>1);
 
-            dim_type s_joff = j * sStrides[outr_dim];
-            bool isJValid = (j>=0 && j<sDims[outr_dim]);
+            accType accum = scalar<accType>(0);
 
-            for(dim_type w=0; w<fDim; ++w) {
-                // offset right index: we have already
-                // choosen the changing index to be pointed
-                // by i, therefore no need to check that here
-                dim_type idx = i-w;
+            for(dim_type f=0; f<fDim; ++f) {
+                T f_val = fptr[f];
+                T s_val;
 
-                dim_type off = idx * sStrides[conv_dim];
-
-                T s_val = T(0);
-                if (isJValid && (idx>=0 && idx<sDims[conv_dim])) {
-                    // we have already offseted the convolving
-                    // dimension, we just need to offset the j offset
-                    // to reach corresponding 2d element
-                    s_val = iptr[s_joff+off];
+                if (conv_dim==0) {
+                    dim_type offi = ci - f;
+                    bool isCIValid = offi>=0 && offi<sDims[0];
+                    bool isCJValid = cj>=0 && cj<sDims[1];
+                    s_val = (isCJValid && isCIValid ? iptr[cj*sDims[0]+offi] : scalar<T>(0));
+                } else {
+                    dim_type offj = cj - f;
+                    bool isCIValid = ci>=0 && ci<sDims[0];
+                    bool isCJValid = offj>=0 && offj<sDims[1];
+                    s_val = (isCJValid && isCIValid ? iptr[offj*sDims[0]+ci] : scalar<T>(0));
                 }
 
-                accum += accType(s_val * fptr[w*fStride]);
+                accum += accType(s_val * f_val);
             }
-            optr[joff+ioff] = T(accum);
+            optr[iOff+jOff] = T(accum);
         }
     }
 }
@@ -253,18 +249,15 @@ Array<T> convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> co
     auto rfDims   = r_filter.dims();
     auto sStrides = signal.strides();
 
-
     dim_type cflen = (dim_type)cfDims.elements();
     dim_type rflen = (dim_type)rfDims.elements();
 
-    dim4 tDims(sDims[0], sDims[1], sDims[2], sDims[3]);
-    dim4 oDims(sDims[0], sDims[1], sDims[2], sDims[3]);
-
-    //FIXME: This needs to go inside expand
-    tDims[0] += cflen - 1;
+    dim4 tDims = sDims;
+    dim4 oDims = sDims;
 
     if (expand) {
         // separable convolve only does ONE2ONE and standard batch(MANY2ONE)
+        tDims[0] += cflen - 1;
         oDims[0] += cflen - 1;
         oDims[1] += rflen - 1;
     }
@@ -274,14 +267,12 @@ Array<T> convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> co
     auto tStrides = temp.strides();
     auto oStrides = out.strides();
 
-
     for (dim_type b=0; b<oDims[2]; ++b) {
         T const *iptr = signal.get()+ b*sStrides[2];
         T *tptr = temp.get() + b*tStrides[2];
         T *optr = out.get()  + b*oStrides[2];
 
-        // FIXME: This need not be true
-        convolve2_separable<T, accT, 0, true>(tptr, iptr, c_filter.get(),
+        convolve2_separable<T, accT, 0, expand>(tptr, iptr, c_filter.get(),
                                                 tDims, sDims, sDims, cflen,
                                                 tStrides, sStrides, c_filter.strides()[0]);
 

--- a/src/backend/cuda/convolve.cpp
+++ b/src/backend/cuda/convolve.cpp
@@ -53,17 +53,20 @@ Array<T> convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> co
     const dim4 cfDims   = c_filter.dims();
     const dim4 rfDims   = r_filter.dims();
 
+    const dim_type cfLen= cfDims.elements();
+    const dim_type rfLen= rfDims.elements();
+
     const dim4 sDims = signal.dims();
-    dim4 oDims(1);
+    dim4 tDims = sDims;
+    dim4 oDims = sDims;
+
     if (expand) {
-        oDims[0] = sDims[0]+cfDims.elements() - 1;
-        oDims[1] = sDims[1]+rfDims.elements() - 1;
-        oDims[2] = sDims[2];
-    } else {
-        oDims = sDims;
+        tDims[0] += cfLen - 1;
+        oDims[0] += cfLen - 1;
+        oDims[1] += rfLen - 1;
     }
 
-    Array<T> temp= createEmptyArray<T>(oDims);
+    Array<T> temp= createEmptyArray<T>(tDims);
     Array<T> out = createEmptyArray<T>(oDims);
 
     kernel::convolve2<T, accT, 0, expand>(temp, signal, c_filter);

--- a/src/backend/cuda/kernel/convolve_separable.cu
+++ b/src/backend/cuda/kernel/convolve_separable.cu
@@ -116,7 +116,7 @@ void conv2Helper(dim3 blks, dim3 thrds, Param<T> out, CParam<T> sig, dim_type nB
 template<typename T, typename accType, dim_type conv_dim, bool expand>
 void convolve2(Param<T> out, CParam<T> signal, CParam<T> filter)
 {
-    dim_type fLen = filter.strides[3] * filter.dims[3];
+    dim_type fLen = filter.dims[0] * filter.dims[1] * filter.dims[2] * filter.dims[3];
     if(fLen > kernel::MAX_SCONV_FILTER_LEN) {
         // call upon fft
         CUDA_NOT_SUPPORTED();

--- a/src/backend/opencl/convolve_separable.cpp
+++ b/src/backend/opencl/convolve_separable.cpp
@@ -76,16 +76,16 @@ Array<T> convolve2(Array<T> const& signal, Array<T> const& c_filter, Array<T> co
     }
 
     const dim4 sDims = signal.dims();
-    dim4 oDims(1);
+    dim4 tDims = sDims;
+    dim4 oDims = sDims;
+
     if (expand) {
-        oDims[0] = sDims[0] + cflen - 1;
-        oDims[1] = sDims[1] + rflen - 1;
-        oDims[2] = sDims[2];
-    } else {
-        oDims = sDims;
+        tDims[0] += cflen - 1;
+        oDims[0] += cflen - 1;
+        oDims[1] += rflen - 1;
     }
 
-    Array<T> temp= createEmptyArray<T>(oDims);
+    Array<T> temp= createEmptyArray<T>(tDims);
     Array<T> out = createEmptyArray<T>(oDims);
 
     conv2Helper<T, accT, 0, expand>(temp, signal, c_filter, cflen);


### PR DESCRIPTION
* Corrected cpu implementation to work on expanded layout only
  in appropriate cases
* Changed temporary buffer dimensions that in turn
  has been effecting performance. This change has been done in
  both cuda and opencl backends