### PR TITLE
BUGFIX: added type check for tests on opencl backend

### DIFF
--- a/test/hsv_rgb.cpp
+++ b/test/hsv_rgb.cpp
@@ -19,7 +19,7 @@ using std::vector;
 
 TEST(hsv_rgb, InvalidArray)
 {
-    vector<double> in(100, 1);
+    vector<float> in(100, 1);
 
     af::dim4 dims(100);
     af::array input(dims, &(in.front()));

--- a/test/mean.cpp
+++ b/test/mean.cpp
@@ -50,6 +50,8 @@ using meanOutType = typename std::conditional<std::is_same<T, cdouble>::value,
 template<typename T, dim_type dim>
 void meanDimTest(string pFileName)
 {
+    if (noDoubleTests<T>()) return;
+
     typedef meanOutType<T> outType;
 
     vector<af::dim4>      numDims;
@@ -124,6 +126,8 @@ TYPED_TEST(Mean, Dim2HyperCube)
 template<typename T>
 void testCPPMean(T const_value, af::dim4 dims)
 {
+    if (noDoubleTests<T>()) return;
+
     typedef meanOutType<T> outType;
     using af::array;
     using af::mean;

--- a/test/var.cpp
+++ b/test/var.cpp
@@ -37,6 +37,8 @@ using varOutType = typename std::conditional<std::is_same<T, char>::value,
 template<typename T>
 void testCPPVar(T const_value, af::dim4 dims)
 {
+    if (noDoubleTests<T>()) return;
+
     typedef varOutType<T> outType;
     using af::array;
     using af::var;


### PR DESCRIPTION
double type will fail the tests on hardware where it is
not supported. I forgot to add this check earlier in the
files which are changed in this commit.