### PR TITLE
Double precision checks in testing

### DIFF
--- a/test/constant.cpp
+++ b/test/constant.cpp
@@ -20,6 +20,7 @@ using namespace af;
 #define CONSTANT_TESTS(TY, VAL)                         \
     TEST(ConstantTests, Test_##TY)                      \
     {                                                   \
+        if (noDoubleTests<TY>()) return;                \
         const int num = 1000;                           \
         TY val = VAL;                                   \
         dtype dty = (dtype) dtype_traits<TY>::af_type;  \

--- a/test/hsv_rgb.cpp
+++ b/test/hsv_rgb.cpp
@@ -19,7 +19,7 @@ using std::vector;
 
 TEST(hsv_rgb, InvalidArray)
 {
-    vector<double> in(100, 1);
+    vector<float> in(100, 1);
 
     af::dim4 dims(100);
     af::array input(dims, &(in.front()));

--- a/test/match_template.cpp
+++ b/test/match_template.cpp
@@ -35,6 +35,7 @@ template<typename T>
 void matchTemplateTest(string pTestFile, af_match_type pMatchType)
 {
     typedef typename std::conditional<std::is_same<T, double>::value, double, float>::type outType;
+    if (noDoubleTests<T>()) return;
 
     vector<af::dim4>  numDims;
     vector<vector<T>>      in;

--- a/test/mean.cpp
+++ b/test/mean.cpp
@@ -51,6 +51,7 @@ template<typename T, dim_type dim>
 void meanDimTest(string pFileName)
 {
     typedef meanOutType<T> outType;
+    if (noDoubleTests<T>()) return;
 
     vector<af::dim4>      numDims;
     vector<vector<int>>        in;
@@ -125,6 +126,8 @@ template<typename T>
 void testCPPMean(T const_value, af::dim4 dims)
 {
     typedef meanOutType<T> outType;
+    if (noDoubleTests<T>()) return;
+
     using af::array;
     using af::mean;
 

--- a/test/var.cpp
+++ b/test/var.cpp
@@ -74,6 +74,7 @@ void testCPPVar(T const_value, af::dim4 dims)
 
 TEST(Var, CPP_f64)
 {
+    if (noDoubleTests<cdouble>()) return;
     testCPPVar<double>(2.1, af::dim4(10, 10, 1, 1));
 }
 
@@ -109,5 +110,6 @@ TEST(Var, CPP_cfloat)
 
 TEST(Var, CPP_cdouble)
 {
+    if (noDoubleTests<cdouble>()) return;
     testCPPVar<cdouble>(cdouble(2.1), af::dim4(10, 10, 1, 1));
 }


### PR DESCRIPTION
Double precision support was not being checked in: 

* constant
* hsv_rgb
* match_template
* mean
* var