### PR TITLE
Fix pedantic compiler warning.

### DIFF
--- a/include/af/array.h
+++ b/include/af/array.h
@@ -607,24 +607,24 @@ namespace af
     AFAPI array operator op(const cfloat&, const array&);               \
     AFAPI array operator op(const cdouble&, const array&);              \
 
-    BIN_OP(+ );
-    BIN_OP(- );
-    BIN_OP(* );
-    BIN_OP(/ );
-    BIN_OP(==);
-    BIN_OP(!=);
-    BIN_OP(< );
-    BIN_OP(<=);
-    BIN_OP(> );
-    BIN_OP(>=);
-    BIN_OP(&&);
-    BIN_OP(||);
-    BIN_OP(% );
-    BIN_OP(& );
-    BIN_OP(| );
-    BIN_OP(^ );
-    BIN_OP(<<);
-    BIN_OP(>>);
+    BIN_OP(+ )
+    BIN_OP(- )
+    BIN_OP(* )
+    BIN_OP(/ )
+    BIN_OP(==)
+    BIN_OP(!=)
+    BIN_OP(< )
+    BIN_OP(<=)
+    BIN_OP(> )
+    BIN_OP(>=)
+    BIN_OP(&&)
+    BIN_OP(||)
+    BIN_OP(% )
+    BIN_OP(& )
+    BIN_OP(| )
+    BIN_OP(^ )
+    BIN_OP(<<)
+    BIN_OP(>>)
 
 #undef BIN_OP
 

--- a/include/af/data.h
+++ b/include/af/data.h
@@ -28,19 +28,19 @@ namespace af
                          const dim_type d1, const dim_type d2,      \
                          const dim_type d3, dtype ty=TY);           \
 
-    CONSTANT(double             , f32);
-    CONSTANT(float              , f32);
-    CONSTANT(int                , f32);
-    CONSTANT(unsigned           , f32);
-    CONSTANT(char               , f32);
-    CONSTANT(unsigned char      , f32);
-    CONSTANT(cfloat             , c32);
-    CONSTANT(cdouble            , c64);
-    CONSTANT(long               , s64);
-    CONSTANT(unsigned long      , u64);
-    CONSTANT(long long          , s64);
-    CONSTANT(unsigned long long , u64);
-    CONSTANT(bool               ,  b8);
+    CONSTANT(double             , f32)
+    CONSTANT(float              , f32)
+    CONSTANT(int                , f32)
+    CONSTANT(unsigned           , f32)
+    CONSTANT(char               , f32)
+    CONSTANT(unsigned char      , f32)
+    CONSTANT(cfloat             , c32)
+    CONSTANT(cdouble            , c64)
+    CONSTANT(long               , s64)
+    CONSTANT(unsigned long      , u64)
+    CONSTANT(long long          , s64)
+    CONSTANT(unsigned long long , u64)
+    CONSTANT(bool               ,  b8)
 
 #undef CONSTANT
 


### PR DESCRIPTION
Several macros in the ArrayFire headers are followed by semicolons, generating pedantic compiler warnings.