### PR TITLE
fix gtest build with ninja and simplify gtest external project

### DIFF
--- a/CMakeModules/build_gtest.cmake
+++ b/CMakeModules/build_gtest.cmake
@@ -1,4 +1,20 @@
 # Build the gtest libraries
+
+# Check if Google Test exists
+SET(GTEST_SOURCE_DIR "${CMAKE_SOURCE_DIR}/test/gtest")
+IF(NOT EXISTS "${GTEST_SOURCE_DIR}/README")
+    MESSAGE(WARNING "GTest Source is not available. Tests will not build.")
+    MESSAGE("Did you miss the --recursive option when cloning?")
+    MESSAGE("Run the following commands to correct this:")
+    MESSAGE("git submodule init")
+    MESSAGE("git submodule update")
+    MESSAGE("git submodule foreach git pull origin master")
+ENDIF()
+
+if(CMAKE_VERSION VERSION_LESS 3.2 AND CMAKE_GENERATOR MATCHES "Ninja")
+    message(WARNING "Building GTest with Ninja has known issues with CMake older than 3.2")
+endif()
+
 include(ExternalProject)
 
 # Set the build type if it isn't already
@@ -7,21 +23,38 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 # Set default ExternalProject root directory
-set_directory_properties(PROPERTIES EP_PREFIX "${CMAKE_BINARY_DIR}/third_party")
+set(prefix "${CMAKE_BINARY_DIR}/third_party/gtest")
+# the binary dir must be know before creating the external project in order
+# to pass the byproducts
+set(binary_dir "${prefix}/src/googletest-build")
+
+set(GTEST_LIBRARIES gtest gtest_main)
+
+set(byproducts)
+foreach(lib ${GTEST_LIBRARIES})
+    set(${lib}_location
+        ${binary_dir}/${CMAKE_CFG_INTDIR}/${CMAKE_STATIC_LIBRARY_PREFIX}${lib}${CMAKE_STATIC_LIBRARY_SUFFIX})
+    list(APPEND byproducts ${${lib}_location})
+endforeach()
 
 # Add gtest
 ExternalProject_Add(
     googletest
+    # URL http://googletest.googlecode.com/files/gtest-1.7.0.zip
+    # URL_MD5 2d6ec8ccdf5c46b05ba54a9fd1d130d7
     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../test/gtest"
+    PREFIX ${prefix}
+    BINARY_DIR ${binary_dir}
     TIMEOUT 10
     CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-               -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=DebugLibs
-               -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=ReleaseLibs
-               -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELWITHDEBINFO:PATH=ReleaseLibs
-               -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_MINSIZEREL:PATH=ReleaseLibs
                -Dgtest_force_shared_crt=ON
                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+               -DCMAKE_CXX_FLAGS_DEBUG=${CMAKE_CXX_FLAGS_DEBUG}
+               -DCMAKE_CXX_FLAGS_MINSIZEREL=${CMAKE_CXX_FLAGS_MINSIZEREL}
+               -DCMAKE_CXX_FLAGS_RELEASE=${CMAKE_CXX_FLAGS_RELEASE}
+               -DCMAKE_CXX_FLAGS_RELWITHDEBINFO=${CMAKE_CXX_FLAGS_RELWITHDEBINFO}
+    BUILD_BYPRODUCTS ${byproducts}
     # Disable install step
     INSTALL_COMMAND ""
     # Wrap download, configure and build steps in a script to log output
@@ -30,6 +63,13 @@ ExternalProject_Add(
     LOG_CONFIGURE 0
     LOG_BUILD 0)
 
+foreach(lib ${GTEST_LIBRARIES})
+    add_library(${lib} IMPORTED STATIC)
+    add_dependencies(${lib} googletest)
+    set_target_properties(${lib} PROPERTIES IMPORTED_LOCATION ${${lib}_location})
+endforeach()
+
 # Specify include dir
 ExternalProject_Get_Property(googletest source_dir)
-include_directories("${source_dir}/include")
+set(GTEST_INCLUDE_DIRS ${source_dir}/include)
+set(GTEST_FOUND ON)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,15 +9,9 @@ MACRO(CREATE_TESTS BACKEND)
 
         ADD_TEST(Test_${TEST_NAME} ${TEST_NAME})
         ADD_EXECUTABLE(${TEST_NAME} ${FNAME}.cpp)
-        IF (${BUILD_GTEST} AND NOT ${USE_SYSTEM_GTEST})
-            ADD_DEPENDENCIES(${TEST_NAME} googletest)
-        ENDIF()
         TARGET_LINK_LIBRARIES(${TEST_NAME}  af${BACKEND}
                       ${THREAD_LIB_FLAG}
-                      optimized ${GTEST_RELEASE_LIB}
-                      optimized ${GTEST_RELEASE_MAIN_LIB}
-                      debug ${GTEST_DEBUG_LIB}
-                      debug ${GTEST_DEBUG_MAIN_LIB})
+                      ${GTEST_LIBRARIES})
         SET_TARGET_PROPERTIES(${TEST_NAME} PROPERTIES COMPILE_FLAGS -DAF_${DEF_NAME})
     ENDFOREACH()
 
@@ -31,43 +25,11 @@ ELSE()
 ENDIF()
 
 IF(${USE_SYSTEM_GTEST})
-
     FIND_PACKAGE(GTest REQUIRED)
-
-    SET(GTEST_RELEASE_LIB "${GTEST_LIBRARIES}")
-    SET(GTEST_RELEASE_MAIN_LIB "${GTEST_MAIN_LIBRARIES}")
-
-    SET(GTEST_DEBUG_LIB "${GTEST_LIBRARIES}")
-    SET(GTEST_DEBUG_MAIN_LIB "${GTEST_MAIN_LIBRARIES}")
-
 ELSE()
-
-    IF(${BUILD_GTEST})
-
-      INCLUDE("${CMAKE_MODULE_PATH}/build_gtest.cmake")
-        ExternalProject_Get_Property(googletest SOURCE_DIR BINARY_DIR)
-
-        SET(GTEST_BINARY_DIR "${BINARY_DIR}")
-        SET(GTEST_SOURCE_DIR "${SOURCE_DIR}")
-
-    ELSE()
-
-        SET(GTEST_SOURCE_DIR "${CMAKE_BINARY_DIR}/third_party/src/googletest")
-        SET(GTEST_BINARY_DIR "${CMAKE_BINARY_DIR}/third_party/src/googletest-build")
-
-    ENDIF()
-
-    SET(GTEST_INCLUDE_DIRS         "${GTEST_SOURCE_DIR}/include")
-    SET(GTEST_RELEASE_LIBRARY_DIRS "${GTEST_BINARY_DIR}/ReleaseLibs")
-    SET(GTEST_DEBUG_LIBRARY_DIRS   "${GTEST_BINARY_DIR}/DebugLibs")
-
-    SET(GTEST_RELEASE_LIB "${GTEST_RELEASE_LIBRARY_DIRS}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    SET(GTEST_RELEASE_MAIN_LIB "${GTEST_RELEASE_LIBRARY_DIRS}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}")
-
-    SET(GTEST_DEBUG_LIB "${GTEST_DEBUG_LIBRARY_DIRS}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX}")
-    SET(GTEST_DEBUG_MAIN_LIB "${GTEST_DEBUG_LIBRARY_DIRS}/${CMAKE_STATIC_LIBRARY_PREFIX}gtest_main${CMAKE_STATIC_LIBRARY_SUFFIX}")
-
+    INCLUDE("${CMAKE_MODULE_PATH}/build_gtest.cmake")
 ENDIF()
+INCLUDE_DIRECTORIES(${GTEST_INCLUDE_DIRS})
 
 SET(TESTDATA_SOURCE_DIR "${CMAKE_SOURCE_DIR}/test/data")
 ADD_DEFINITIONS("-D TEST_DIR=\"\\\"${TESTDATA_SOURCE_DIR}\\\"\"")
@@ -87,22 +49,7 @@ ELSE (EXISTS "${TESTDATA_SOURCE_DIR}" AND IS_DIRECTORY "${TESTDATA_SOURCE_DIR}"
     MESSAGE("git submodule foreach git pull origin master")
 ENDIF()
 
-# Check if Google Test exists
-SET(GTEST_SOURCE_DIR "${CMAKE_SOURCE_DIR}/test/gtest")
-IF (EXISTS "${GTEST_SOURCE_DIR}" AND IS_DIRECTORY "${GTEST_SOURCE_DIR}"
-    AND EXISTS "${GTEST_SOURCE_DIR}/README")
-    # GTest source is available
-    # Do Nothing
-ELSE (EXISTS "${GTEST_SOURCE_DIR}" AND IS_DIRECTORY "${GTEST_SOURCE_DIR}"
-    AND EXISTS "${GTEST_SOURCE_DIR}/README")
-    MESSAGE(WARNING "GTest Source is not available. Tests will not build.")
-    MESSAGE("Did you miss the --recursive option when cloning?")
-    MESSAGE("Run the following commands to correct this:")
-    MESSAGE("git submodule init")
-    MESSAGE("git submodule update")
-    MESSAGE("git submodule foreach git pull origin master")
-ENDIF()
-
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 FILE(GLOB FILES "*.cpp")
 
 IF(${BUILD_CPU})
@@ -116,7 +63,3 @@ ENDIF()
 IF(${BUILD_OPENCL})
     CREATE_TESTS(opencl)
 ENDIF()
-
-INCLUDE_DIRECTORIES(
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-    ${GTEST_INCLUDE_DIRS})


### PR DESCRIPTION
build with ninja fixed with cmake 3.2's BUILD_BYPRODUCTS external project option

gtest external project code simplified by using imported libraries and
${CMAKE_CFG_INTDIR} to find the right lib path with MSVC

also pass the build flags to the C++ compiler

most of the code comes from https://github.com/glehmann/gtest-external