### PR TITLE
Batch support along 4th dimension

### DIFF
--- a/docs/details/signal.dox
+++ b/docs/details/signal.dox
@@ -28,9 +28,9 @@ respectively, then the possible batch operations are as follows.
 | Input Signal Dimensions | Filter Signal Dimensions | Batch Mode | Explanation |
 |:-----------------------:|:------------------------:|:----------:|:------------|
 | [m n 1 1] | [m n 1 1] | One to One  | Output will be a single convolve array |
-| [m n 1 1] | [m n 9 1] | One to Many | Output will be 3d array with 2nd dimension length as 9 - 9 filters applied to same input |
-| [m n 9 1] | [m n 1 1] | Many to One | Output will be 3d array with 2nd dimension length as 9 - 1 filter applied to 9 inputs |
-| [m n 9 1] | [m n 9 1] | Many to Many| Output will be 3d array with 2nd dimension length as 9 - 9 filter applied to 9 inputs in one-to-one fashion |
+| [m n 1 1] | [m n p 1] | One to Many | Output will be 3d array with 2nd dimension length as p - p filters applied to same input |
+| [m n p 1] | [m n 1 1] | Many to One | Output will be 3d array with 2nd dimension length as p - 1 filter applied to p inputs |
+| [m n p 1] | [m n p 1] | Many to Many| Output will be 3d array with 2nd dimension length as p - p filter applied to p inputs in one-to-one correspondence |
 
 
 
@@ -74,14 +74,15 @@ factor is calculated internally based on the input data provided.
 \brief Convolution Integral for one dimensional data
 
 \copydoc signal_func_conv_desc
+
 For example, if the input size is m along 0th dimension, then the possible batch operations are as follows.
 
 | Input Signal Dimensions | Filter Signal Dimensions | Batch Mode | Explanation |
 |:-----------------------:|:------------------------:|:----------:|:------------|
 | [m 1 1 1] | [m 1 1 1] | One to One  | Output will be a single convolve array |
-| [m 1 1 1] | [m 4 1 1] | One to Many | Output will be 2d array with 1st dimension length as 4 - 4 filters applied to same input |
-| [m 4 1 1] | [m 1 1 1] | Many to One | Output will be 2d array with 1st dimension length as 4 - 1 filter applied to 4 inputs |
-| [m 4 1 1] | [m 4 1 1] | Many to Many| Output will be 2d array with 1st dimension length as 4 - 4 filter applied to 4 inputs in one-to-one fashion |
+| [m 1 1 1] | [m n 1 1] | One to Many | Output will be 2d array with 1st dimension length as n - n filters applied to same input |
+| [m n 1 1] | [m 1 1 1] | Many to One | Output will be 2d array with 1st dimension length as n - 1 filter applied to n inputs |
+| [m n 1 1] | [m n 1 1] | Many to Many| Output will be 2d array with 1st dimension length as n - n filter applied to n inputs in one-to-one correspondence |
 
 
 
@@ -91,6 +92,7 @@ For example, if the input size is m along 0th dimension, then the possible batch
 \brief Convolution Integral for two dimensional data
 
 \copydoc signal_func_conv_desc
+
 \copydoc signal_func_conv2_batch_desc
 
 
@@ -101,15 +103,16 @@ For example, if the input size is m along 0th dimension, then the possible batch
 \brief Convolution Integral for three dimensional data
 
 \copydoc signal_func_conv_desc
+
 For example, if the signal is three dimensional with m, n & p sizes along the 0th, 1st & 2nd dimensions
 respectively, then the possible batch operations are as follows.
 
 | Input Signal Dimensions | Filter Signal Dimensions | Batch Mode | Explanation |
 |:-----------------------:|:------------------------:|:----------:|:------------|
 | [m n p 1] | [m n p 1] | One to One  | Output will be a single convolve array |
-| [m n p 1] | [m n p 4] | One to Many | Output will be 4d array with 3rd dimension length as 4 - 4 filters applied to same input |
-| [m n p 4] | [m n p 1] | Many to One | Output will be 4d array with 3rd dimension length as 4 - 1 filter applied to 4 inputs |
-| [m n p 4] | [m n p 4] | Many to Many| Output will be 4d array with 3rd dimension length as 4 - 4 filter applied to 4 inputs in one-to-one fashion |
+| [m n p 1] | [m n p q] | One to Many | Output will be 4d array with 3rd dimension length as q - q filters applied to same input |
+| [m n p q] | [m n p 1] | Many to One | Output will be 4d array with 3rd dimension length as q - 1 filter applied to q inputs |
+| [m n p q] | [m n p q] | Many to Many| Output will be 4d array with 3rd dimension length as q - q filter applied to q inputs in one-to-one correspondence |
 
 
 

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -216,6 +216,15 @@ AFAPI array ifft3(const array& in, dim_type odim0=0, dim_type odim1=0, dim_type 
 /**
    C++ Interface for convolution any(one through three) dimensional data
 
+   Example for convolution on one dimensional signal in one to one batch mode
+   \snippet test/convolve.cpp ex_image_convolve_1d
+
+   Example for convolution on two dimensional signal in one to one batch mode
+   \snippet test/convolve.cpp ex_image_convolve_2d
+
+   Example for convolution on three dimensional signal in one to one batch mode
+   \snippet test/convolve.cpp ex_image_convolve_3d
+
    \param[in]  signal is the input signal
    \param[in]  filter is the signal that shall be flipped for the convolution operation
    \param[in]  expand indicates if the convolution should be expanded or not(where output size equals input).
@@ -228,11 +237,16 @@ AFAPI array convolve(const array& signal, const array& filter, bool expand=false
 /**
    C++ Interface for separable convolution on two dimensional data
 
+   \snippet test/convolve.cpp ex_image_conv2_sep
+
    \param[in]  signal is the input signal
    \param[in]  col_filter is the signal that shall be along coloumns
    \param[in]  row_filter is the signal that shall be along rows
    \param[in]  expand indicates if the convolution should be expanded or not(where output size equals input).
    \return     the convolved array
+
+   \note Separable convolution only supports two(ONE-to-ONE and MANY-to-ONE) batch modes from the ones described
+         in the detailed description section.
 
    \ingroup signal_func_convolve
  */
@@ -240,6 +254,8 @@ AFAPI array convolve(const array& col_filter, const array& row_filter, const arr
 
 /**
    C++ Interface for convolution on one dimensional data
+
+   \snippet test/convolve.cpp ex_image_convolve1
 
    \param[in]  signal is the input signal
    \param[in]  filter is the signal that shall be flipped for the convolution operation
@@ -253,6 +269,8 @@ AFAPI array convolve1(const array& signal, const array& filter, bool expand=fals
 /**
    C++ Interface for convolution on two dimensional data
 
+   \snippet test/convolve.cpp ex_image_convolve2
+
    \param[in]  signal is the input signal
    \param[in]  filter is the signal that shall be flipped for the convolution operation
    \param[in]  expand indicates if the convolution should be expanded or not(where output size equals input).
@@ -264,6 +282,8 @@ AFAPI array convolve2(const array& signal, const array& filter, bool expand=fals
 
 /**
    C++ Interface for convolution on three dimensional data
+
+   \snippet test/convolve.cpp ex_image_convolve3
 
    \param[in]  signal is the input signal
    \param[in]  filter is the signal that shall be flipped for the convolution operation
@@ -458,6 +478,9 @@ AFAPI af_err af_convolve3(af_array *out, af_array signal, af_array filter, bool 
    \param[in]  expand indicates if the convolution should be expanded or not(where output size equals input).
    \return     \ref AF_SUCCESS if the convolution is successful,
                otherwise an appropriate error code is returned.
+
+   \note Separable convolution only supports two(ONE-to-ONE and MANY-to-ONE) batch modes from the ones described
+         in the detailed description section.
 
    \ingroup signal_func_convolve
  */

--- a/src/api/c/bilateral.cpp
+++ b/src/api/c/bilateral.cpp
@@ -32,11 +32,7 @@ static af_err bilateral(af_array *out, const af_array &in, const float &s_sigma,
         af_dtype type  = info.getType();
         af::dim4 dims  = info.dims();
 
-        if (isColor) {
-            DIM_ASSERT(1, (dims.ndims()>=3));
-        } else {
-            DIM_ASSERT(1, (dims.ndims()>=2 && dims.ndims()<=3));
-        }
+        DIM_ASSERT(1, (dims.ndims()>=2));
 
         af_array output;
         switch(type) {

--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -97,7 +97,7 @@ af_err convolve2_sep(af_array *out, af_array col_filter, af_array row_filter, af
 
         dim4 signalDims = sInfo.dims();
 
-        ARG_ASSERT(1, (signalDims.ndims()==2 || signalDims.ndims()==3));
+        ARG_ASSERT(1, (signalDims.ndims()>=2));
         ARG_ASSERT(2, cfInfo.isVector());
         ARG_ASSERT(3, rfInfo.isVector());
 

--- a/src/api/c/histogram.cpp
+++ b/src/api/c/histogram.cpp
@@ -30,9 +30,6 @@ af_err af_histogram(af_array *out, const af_array in,
     try {
         ArrayInfo info = getInfo(in);
         af_dtype type  = info.getType();
-        af::dim4 dims  = info.dims();
-
-        DIM_ASSERT(1, (dims.ndims()<=3));
 
         af_array output;
         switch(type) {

--- a/src/api/c/hsv_rgb.cpp
+++ b/src/api/c/hsv_rgb.cpp
@@ -38,7 +38,7 @@ af_err convert(af_array* out, const af_array& in)
         af_dtype iType = info.getType();
         af::dim4 inputDims = info.dims();
 
-        ARG_ASSERT(1, (inputDims.ndims() == 3));
+        ARG_ASSERT(1, (inputDims.ndims() >= 3));
 
         af_array output = 0;
         switch (iType) {

--- a/src/api/c/match_template.cpp
+++ b/src/api/c/match_template.cpp
@@ -48,7 +48,7 @@ af_err af_match_template(af_array *out, const af_array search_img, const af_arra
 
         dim_type sNumDims= sDims.ndims();
         dim_type tNumDims= tDims.ndims();
-        ARG_ASSERT(1, (sNumDims==2 || sNumDims==3));
+        ARG_ASSERT(1, (sNumDims>=2));
         ARG_ASSERT(2, (tNumDims==2));
 
         af_dtype sType = sInfo.getType();

--- a/src/api/c/meanshift.cpp
+++ b/src/api/c/meanshift.cpp
@@ -36,12 +36,8 @@ af_err meanshift(af_array *out, const af_array in, const float s_sigma, const fl
         af_dtype type  = info.getType();
         af::dim4 dims  = info.dims();
 
-        if (is_color) {
-            DIM_ASSERT(1, (dims.ndims()>=3 && dims.ndims()<=4));
-            DIM_ASSERT(1, (dims[2]==3));
-        }
-        else
-            DIM_ASSERT(1, (dims.ndims()>=2 && dims.ndims()<=3));
+        DIM_ASSERT(1, (dims.ndims()>=2));
+        if (is_color) DIM_ASSERT(1, (dims[2]==3));
 
         af_array output;
         switch(type) {

--- a/src/api/c/medfilt.cpp
+++ b/src/api/c/medfilt.cpp
@@ -39,8 +39,8 @@ af_err af_medfilt(af_array *out, const af_array in, dim_type wind_length, dim_ty
         ArrayInfo info = getInfo(in);
         af::dim4 dims  = info.dims();
 
-        dim_type in_ndims = dims.ndims();
-        DIM_ASSERT(1, (in_ndims <= 3 && in_ndims >= 2));
+        dim_type input_ndims = dims.ndims();
+        DIM_ASSERT(1, (input_ndims >= 2));
 
         if (wind_length==1) {
             *out = weakCopy(in);

--- a/src/api/c/morph.cpp
+++ b/src/api/c/morph.cpp
@@ -79,7 +79,7 @@ static af_err morph3d(af_array *out, const af_array &in, const af_array &mask)
         dim_type in_ndims = dims.ndims();
         dim_type mask_ndims = mdims.ndims();
 
-        DIM_ASSERT(1, (in_ndims == 3));
+        DIM_ASSERT(1, (in_ndims >= 3));
         DIM_ASSERT(2, (mask_ndims == 3));
 
         af_array output;

--- a/src/api/c/morph.cpp
+++ b/src/api/c/morph.cpp
@@ -47,7 +47,7 @@ static af_err morph(af_array *out, const af_array &in, const af_array &mask)
         dim_type in_ndims = dims.ndims();
         dim_type mask_ndims = mdims.ndims();
 
-        DIM_ASSERT(1, (in_ndims <= 3 && in_ndims >= 2));
+        DIM_ASSERT(1, (in_ndims >= 2));
         DIM_ASSERT(2, (mask_ndims == 2));
 
         af_array output;

--- a/src/api/c/rgb_gray.cpp
+++ b/src/api/c/rgb_gray.cpp
@@ -29,21 +29,21 @@ static af_array rgb2gray(const af_array& in, const float r, const float g, const
 {
     Array<cType> input = cast<cType>(getArray<T>(in));
     dim4 inputDims = input.dims();
-    dim4 matDims(inputDims[0], inputDims[1], 1 , 1);
+    dim4 matDims(inputDims[0], inputDims[1], 1, inputDims[3]);
 
     Array<cType> rCnst = createValueArray<cType>(matDims, scalar<cType>(r));
     Array<cType> gCnst = createValueArray<cType>(matDims, scalar<cType>(g));
     Array<cType> bCnst = createValueArray<cType>(matDims, scalar<cType>(b));
 
     // extract three channels as three slices
-    af_seq slice1[3] = { af_span, af_span, {0, 0, 1} };
-    af_seq slice2[3] = { af_span, af_span, {1, 1, 1} };
-    af_seq slice3[3] = { af_span, af_span, {2, 2, 1} };
+    af_seq slice1[4] = { af_span, af_span, {0, 0, 1}, af_span };
+    af_seq slice2[4] = { af_span, af_span, {1, 1, 1}, af_span };
+    af_seq slice3[4] = { af_span, af_span, {2, 2, 1}, af_span };
 
     af_array ch1Temp=0, ch2Temp=0, ch3Temp=0;
-    AF_CHECK(af_index(&ch1Temp, in, 3, slice1));
-    AF_CHECK(af_index(&ch2Temp, in, 3, slice2));
-    AF_CHECK(af_index(&ch3Temp, in, 3, slice3));
+    AF_CHECK(af_index(&ch1Temp, in, 4, slice1));
+    AF_CHECK(af_index(&ch2Temp, in, 4, slice2));
+    AF_CHECK(af_index(&ch3Temp, in, 4, slice3));
 
     // r*Slice0
     Array<cType> expr1 = arithOp<cType, af_mul_t>(getArray<cType>(ch1Temp), rCnst, matDims);
@@ -66,22 +66,28 @@ static af_array rgb2gray(const af_array& in, const float r, const float g, const
 template<typename T, typename cType>
 static af_array gray2rgb(const af_array& in, const float r, const float g, const float b)
 {
-    Array<cType> input = cast<cType>(getArray<T>(in));
-    dim4 inputDims = input.dims();
-
     if (r==1.0 && g==1.0 && b==1.0) {
         dim4 tileDims(1, 1, 3, 1);
-        return getHandle(tile(input, tileDims));
+        return getHandle(tile(getArray<T>(in), tileDims));
     }
 
-    dim4 matDims(inputDims[0], inputDims[1], 1 , 1);
+    af_array mod_input = 0;
+    dim4 inputDims = getInfo(in).dims();
+
+    dim4 matDims(inputDims[0], inputDims[1], 1, inputDims[2]*inputDims[3]);
+
+    AF_CHECK(af_moddims(&mod_input, in, matDims.ndims(), matDims.get()));
+    Array<cType> mod_in = cast<cType>(getArray<cType>(mod_input));
+
     Array<cType> rCnst = createValueArray<cType>(matDims, scalar<cType>(r));
     Array<cType> gCnst = createValueArray<cType>(matDims, scalar<cType>(g));
     Array<cType> bCnst = createValueArray<cType>(matDims, scalar<cType>(b));
 
-    Array<cType> expr1 = arithOp<cType, af_mul_t>(input, rCnst, matDims);
-    Array<cType> expr2 = arithOp<cType, af_mul_t>(input, gCnst, matDims);
-    Array<cType> expr3 = arithOp<cType, af_mul_t>(input, bCnst, matDims);
+    Array<cType> expr1 = arithOp<cType, af_mul_t>(mod_in, rCnst, matDims);
+    Array<cType> expr2 = arithOp<cType, af_mul_t>(mod_in, gCnst, matDims);
+    Array<cType> expr3 = arithOp<cType, af_mul_t>(mod_in, bCnst, matDims);
+
+    AF_CHECK(af_destroy_array(mod_input));
 
     // join channels
     Array<cType> expr4 = join<cType, cType>(2, expr1, expr2);
@@ -106,10 +112,8 @@ af_err convert(af_array* out, const af_array in, const float r, const float g, c
         af_dtype iType     = info.getType();
         af::dim4 inputDims = info.dims();
 
-        if (isRGB2GRAY)
-            ARG_ASSERT(1, (inputDims.ndims()==3));
-        else
-            ARG_ASSERT(1, (inputDims.ndims()==2));
+        ARG_ASSERT(1, (inputDims.ndims()>=2));
+        if (isRGB2GRAY) ARG_ASSERT(1, (inputDims[2]==3));
 
         af_array output = 0;
         switch(iType) {

--- a/src/backend/cpu/bilateral.cpp
+++ b/src/backend/cpu/bilateral.cpp
@@ -43,8 +43,6 @@ Array<outType> bilateral(const Array<inType> &in, const float &s_sigma, const fl
     Array<outType> out = createEmptyArray<outType>(dims);
     const dim4 ostrides = out.strides();
 
-    dim_type bCount     = isColor ? dims[3] : dims[2]*dims[3];
-
     outType *outData    = out.get();
     const inType * inData = in.get();
 
@@ -55,41 +53,47 @@ Array<outType> bilateral(const Array<inType> &in, const float &s_sigma, const fl
     const float svar      = space_*space_;
     const float cvar      = color_*color_;
 
-    for(dim_type batchId=0; batchId<bCount; ++batchId) {
-        // batchId for loop handles following batch configurations
-        //  - channels
+    for(dim_type b3=0; b3<dims[3]; ++b3) {
+        // b3 for loop handles following batch configurations
         //  - gfor
         //  - input based batch
-        //      - when input is 3d array for grayscale images
         //      - when input is 4d array for color images
-        for(dim_type j=0; j<dims[1]; ++j) {
-            // j steps along 2nd dimension
-            for(dim_type i=0; i<dims[0]; ++i) {
-                // i steps along 1st dimension
-                outType norm = 0.0;
-                outType res  = 0.0;
-                const outType center = (outType)inData[getIdx(istrides, i, j)];
-                for(dim_type wj=-radius; wj<=radius; ++wj) {
-                    // clamps offsets
-                    dim_type tj = clamp(j+wj, 0, dims[1]-1);
-                    for(dim_type wi=-radius; wi<=radius; ++wi) {
+        for(dim_type b2=0; b2<dims[2]; ++b2) {
+            // b2 for loop handles following batch configurations
+            //  - channels
+            //  - input based batch
+            //      - when input is 3d array for grayscale images
+            for(dim_type j=0; j<dims[1]; ++j) {
+                // j steps along 2nd dimension
+                for(dim_type i=0; i<dims[0]; ++i) {
+                    // i steps along 1st dimension
+                    outType norm = 0.0;
+                    outType res  = 0.0;
+                    const outType center = (outType)inData[getIdx(istrides, i, j)];
+                    for(dim_type wj=-radius; wj<=radius; ++wj) {
                         // clamps offsets
-                        dim_type ti = clamp(i+wi, 0, dims[0]-1);
-                        // proceed
-                        const outType val= (outType)inData[getIdx(istrides, ti, tj)];
-                        const outType gauss_space = (wi*wi+wj*wj)/(-2.0*svar);
-                        const outType gauss_range = ((center-val)*(center-val))/(-2.0*cvar);
-                        const outType weight = std::exp(gauss_space+gauss_range);
-                        norm += weight;
-                        res += val*weight;
-                    }
-                } // filter loop ends here
+                        dim_type tj = clamp(j+wj, 0, dims[1]-1);
+                        for(dim_type wi=-radius; wi<=radius; ++wi) {
+                            // clamps offsets
+                            dim_type ti = clamp(i+wi, 0, dims[0]-1);
+                            // proceed
+                            const outType val= (outType)inData[getIdx(istrides, ti, tj)];
+                            const outType gauss_space = (wi*wi+wj*wj)/(-2.0*svar);
+                            const outType gauss_range = ((center-val)*(center-val))/(-2.0*cvar);
+                            const outType weight = std::exp(gauss_space+gauss_range);
+                            norm += weight;
+                            res += val*weight;
+                        }
+                    } // filter loop ends here
 
-                outData[getIdx(ostrides, i, j)] = res/norm;
-            } //1st dimension loop ends here
-        } //2nd dimension loop ends here
-        outData += ostrides[2];
-        inData  += istrides[2];
+                    outData[getIdx(ostrides, i, j)] = res/norm;
+                } //1st dimension loop ends here
+            } //2nd dimension loop ends here
+            outData += ostrides[2];
+            inData  += istrides[2];
+        }
+        outData += ostrides[3];
+        inData  += istrides[3];
     }
 
     return out;

--- a/src/backend/cpu/bilateral.cpp
+++ b/src/backend/cpu/bilateral.cpp
@@ -43,8 +43,7 @@ Array<outType> bilateral(const Array<inType> &in, const float &s_sigma, const fl
     Array<outType> out = createEmptyArray<outType>(dims);
     const dim4 ostrides = out.strides();
 
-    dim_type bCount     = dims[2];
-    if (isColor) bCount*= dims[3];
+    dim_type bCount     = isColor ? dims[3] : dims[2]*dims[3];
 
     outType *outData    = out.get();
     const inType * inData = in.get();
@@ -57,7 +56,12 @@ Array<outType> bilateral(const Array<inType> &in, const float &s_sigma, const fl
     const float cvar      = color_*color_;
 
     for(dim_type batchId=0; batchId<bCount; ++batchId) {
-        // channels or batch for gray and channel are handled by outer loop
+        // batchId for loop handles following batch configurations
+        //  - channels
+        //  - gfor
+        //  - input based batch
+        //      - when input is 3d array for grayscale images
+        //      - when input is 4d array for color images
         for(dim_type j=0; j<dims[1]; ++j) {
             // j steps along 2nd dimension
             for(dim_type i=0; i<dims[0]; ++i) {

--- a/src/backend/cpu/convolve.cpp
+++ b/src/backend/cpu/convolve.cpp
@@ -267,20 +267,26 @@ Array<T> convolve2(Array<T> const& signal, Array<accT> const& c_filter, Array<ac
     auto tStrides = temp.strides();
     auto oStrides = out.strides();
 
-    dim_type batch = oDims[2]*oDims[3];
+    for (dim_type b3=0; b3<oDims[3]; ++b3) {
 
-    for (dim_type b=0; b<batch; ++b) {
-        T const *iptr = signal.get()+ b*sStrides[2];
-        T *tptr = temp.get() + b*tStrides[2];
-        T *optr = out.get()  + b*oStrides[2];
+        dim_type i_b3Off = b3*sStrides[3];
+        dim_type t_b3Off = b3*tStrides[3];
+        dim_type o_b3Off = b3*oStrides[3];
 
-        convolve2_separable<T, accT, 0, expand>(tptr, iptr, c_filter.get(),
-                                                tDims, sDims, sDims, cflen,
-                                                tStrides, sStrides, c_filter.strides()[0]);
+        for (dim_type b2=0; b2<oDims[2]; ++b2) {
 
-        convolve2_separable<T, accT, 1, expand>(optr, tptr, r_filter.get(),
-                                                oDims, tDims, sDims, rflen,
-                                                oStrides, tStrides, r_filter.strides()[0]);
+            T const *iptr = signal.get()+ b2*sStrides[2] + i_b3Off;
+            T *tptr = temp.get() + b2*tStrides[2] + t_b3Off;
+            T *optr = out.get()  + b2*oStrides[2] + o_b3Off;
+
+            convolve2_separable<T, accT, 0, expand>(tptr, iptr, c_filter.get(),
+                    tDims, sDims, sDims, cflen,
+                    tStrides, sStrides, c_filter.strides()[0]);
+
+            convolve2_separable<T, accT, 1, expand>(optr, tptr, r_filter.get(),
+                    oDims, tDims, sDims, rflen,
+                    oStrides, tStrides, r_filter.strides()[0]);
+        }
     }
 
     return out;

--- a/src/backend/cpu/convolve.cpp
+++ b/src/backend/cpu/convolve.cpp
@@ -267,7 +267,9 @@ Array<T> convolve2(Array<T> const& signal, Array<accT> const& c_filter, Array<ac
     auto tStrides = temp.strides();
     auto oStrides = out.strides();
 
-    for (dim_type b=0; b<oDims[2]; ++b) {
+    dim_type batch = oDims[2]*oDims[3];
+
+    for (dim_type b=0; b<batch; ++b) {
         T const *iptr = signal.get()+ b*sStrides[2];
         T *tptr = temp.get() + b*tStrides[2];
         T *optr = out.get()  + b*oStrides[2];

--- a/src/backend/cpu/histogram.cpp
+++ b/src/backend/cpu/histogram.cpp
@@ -31,7 +31,7 @@ Array<outType> histogram(const Array<inType> &in, const unsigned &nbins, const d
     outType *outData    = out.get();
     const inType* inData= in.get();
 
-    dim_type batchCount = inDims[2];
+    dim_type batchCount = inDims[2] * inDims[3];
     dim_type batchStride= in.strides()[2];
     dim_type numElements= inDims[0]*inDims[1];
 

--- a/src/backend/cpu/histogram.cpp
+++ b/src/backend/cpu/histogram.cpp
@@ -21,39 +21,31 @@ namespace cpu
 template<typename inType, typename outType>
 Array<outType> histogram(const Array<inType> &in, const unsigned &nbins, const double &minval, const double &maxval)
 {
-    const dim4 inDims   = in.dims();
-    dim4 outDims        = dim4(nbins,1,inDims[2],inDims[3]);
+    float step = (maxval - minval)/(float)nbins;
 
-    // create an array with first two dimensions swapped
-    Array<outType> out = createEmptyArray<outType>(outDims);
+    const dim4 inDims  = in.dims();
+    dim4 iStrides      = in.strides();
+    dim4 outDims       = dim4(nbins,1,inDims[2],inDims[3]);
+    Array<outType> out = createValueArray<outType>(outDims, outType(0));
+    dim4 oStrides      = out.strides();
+    dim_type nElems    = inDims[0]*inDims[1];
 
-    // get data pointers for input and output Arrays
     outType *outData    = out.get();
     const inType* inData= in.get();
 
-    dim_type batchCount = inDims[2] * inDims[3];
-    dim_type batchStride= in.strides()[2];
-    dim_type numElements= inDims[0]*inDims[1];
-
-    // set all bin elements to zero
-    outType *temp = outData;
-    for(int batchId = 0; batchId < batchCount; batchId++) {
-        for(int i=0; i < (int)nbins; i++)
-            temp[i] = 0;
-        temp += nbins;
-    }
-
-    float step = (maxval - minval)/(float)nbins;
-
-    for(dim_type batchId = 0; batchId < batchCount; batchId++) {
-        for(dim_type i=0; i<numElements; i++) {
-            int bin = (int)((inData[i] - minval) / step);
-            bin = std::max(bin, 0);
-            bin = std::min(bin, (int)(nbins - 1));
-            outData[bin]++;
+    for(dim_type b3 = 0; b3 < outDims[2]; b3++) {
+        for(dim_type b2 = 0; b2 < outDims[2]; b2++) {
+            for(dim_type i=0; i<nElems; i++) {
+                int bin = (int)((inData[i] - minval) / step);
+                bin = std::max(bin, 0);
+                bin = std::min(bin, (int)(nbins - 1));
+                outData[bin]++;
+            }
+            inData  += iStrides[2];
+            outData += oStrides[2];
         }
-        inData  += batchStride;
-        outData += nbins;
+        inData  += iStrides[3];
+        outData += oStrides[3];
     }
 
     return out;

--- a/src/backend/cpu/match_template.cpp
+++ b/src/backend/cpu/match_template.cpp
@@ -35,7 +35,7 @@ Array<outType> match_template(const Array<inType> &sImg, const Array<inType> &tI
     Array<outType> out = createEmptyArray<outType>(sDims);
     const dim4 oStrides = out.strides();
 
-    const dim_type batchNum = sDims[2];
+    const dim_type batchNum = sDims[2] * sDims[3];
 
     outType tImgMean = outType(0);
     dim_type winNumElements = tImg.elements();

--- a/src/backend/cpu/match_template.cpp
+++ b/src/backend/cpu/match_template.cpp
@@ -35,8 +35,6 @@ Array<outType> match_template(const Array<inType> &sImg, const Array<inType> &tI
     Array<outType> out = createEmptyArray<outType>(sDims);
     const dim4 oStrides = out.strides();
 
-    const dim_type batchNum = sDims[2] * sDims[3];
-
     outType tImgMean = outType(0);
     dim_type winNumElements = tImg.elements();
     bool needMean = mType==AF_ZSAD || mType==AF_LSAD ||
@@ -55,9 +53,11 @@ Array<outType> match_template(const Array<inType> &sImg, const Array<inType> &tI
         tImgMean /= winNumElements;
     }
 
-    for(dim_type b=0; b<batchNum; ++b) {
-        outType * dst      = out.get() + b*oStrides[2];
-        const inType * src = sImg.get() + b*sStrides[2];
+    outType * dst      = out.get();
+    const inType * src = sImg.get();
+
+    for(dim_type b3=0; b3<sDims[3]; ++b3) {
+    for(dim_type b2=0; b2<sDims[2]; ++b2) {
 
         // slide through image window after window
         for(dim_type sj=0; sj<sDim1; sj++) {
@@ -132,6 +132,11 @@ Array<outType> match_template(const Array<inType> &sImg, const Array<inType> &tI
                 dst[ojStride + si] = disparity;
             }
         }
+        src += sStrides[2];
+        dst += oStrides[2];
+    }
+        src += sStrides[3];
+        dst += oStrides[3];
     }
 
     return out;

--- a/src/backend/cpu/meanshift.cpp
+++ b/src/backend/cpu/meanshift.cpp
@@ -32,12 +32,11 @@ Array<T>  meanshift(const Array<T> &in, const float &s_sigma, const float &c_sig
 {
     const dim4 dims     = in.dims();
     const dim4 istrides = in.strides();
-
-    Array<T> out       = createEmptyArray<T>(dims);
+    Array<T> out        = createEmptyArray<T>(dims);
     const dim4 ostrides = out.strides();
 
     const dim_type bIndex   = (is_color ? 3 : 2);
-    const dim_type bCount   = dims[bIndex];
+    const dim_type bCount   = (is_color ? dims[bIndex] : dims[bIndex]*dims[bIndex+1]);
     const dim_type channels = (is_color ? dims[2] : 1);
 
     // clamp spatical and chromatic sigma's
@@ -45,9 +44,12 @@ Array<T>  meanshift(const Array<T> &in, const float &s_sigma, const float &c_sig
     const dim_type radius = std::max((dim_type)(space_ * 1.5f), 1);
     const float cvar      = c_sigma*c_sigma;
 
-    vector<float> means(channels);
-    vector<float> centers(channels);
-    vector<float> tmpclrs(channels);
+    vector<float> means;
+    vector<float> centers;
+    vector<float> tmpclrs;
+    means.reserve(channels);
+    centers.reserve(channels);
+    tmpclrs.reserve(channels);
 
     for(dim_type batchId=0; batchId<bCount; ++batchId) {
 

--- a/src/backend/cpu/medfilt.cpp
+++ b/src/backend/cpu/medfilt.cpp
@@ -25,110 +25,114 @@ Array<T> medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid)
 {
     const dim4 dims     = in.dims();
     const dim4 istrides = in.strides();
-
-    Array<T> out      = createEmptyArray<T>(dims);
-
+    Array<T> out        = createEmptyArray<T>(dims);
     const dim4 ostrides = out.strides();
 
     std::vector<T> wind_vals;
     wind_vals.reserve(w_len*w_wid);
 
-    dim_type batchCount = dims[2] * dims[3];
+    T const * in_ptr = in.get();
+    T * out_ptr = out.get();
 
-    for(dim_type batchId=0; batchId<batchCount; batchId++) {
+    for(dim_type b3=0; b3<dims[3]; b3++) {
 
-        T const * in_ptr = in.get() + batchId*istrides[2];
-        T * out_ptr = out.get() + batchId*ostrides[2];
+        for(dim_type b2=0; b2<dims[2]; b2++) {
 
-        for(dim_type col=0; col<dims[1]; col++) {
+            for(dim_type col=0; col<dims[1]; col++) {
 
-            dim_type ocol_off = col*ostrides[1];
+                dim_type ocol_off = col*ostrides[1];
 
-            for(dim_type row=0; row<dims[0]; row++) {
+                for(dim_type row=0; row<dims[0]; row++) {
 
-                wind_vals.clear();
+                    wind_vals.clear();
 
-                for(dim_type wj=0; wj<w_wid; ++wj) {
+                    for(dim_type wj=0; wj<w_wid; ++wj) {
 
-                    bool isColOff = false;
+                        bool isColOff = false;
 
-                    dim_type im_col = col + wj-w_wid/2;
-                    dim_type im_coff;
-                    switch(pad) {
-                        case AF_ZERO:
-                            im_coff = im_col * istrides[1];
-                            if (im_col < 0 || im_col>=dims[1])
-                                isColOff = true;
-                            break;
-                        case AF_SYMMETRIC:
-                            {
-                                if (im_col < 0) {
-                                    im_col *= -1;
-                                    isColOff = true;
-                                }
-
-                                if (im_col>=dims[1]) {
-                                    im_col = 2*(dims[1]-1) - im_col;
-                                    isColOff = true;
-                                }
-
-                                im_coff = im_col * istrides[1];
-                            }
-                            break;
-                    }
-
-                    for(dim_type wi=0; wi<w_len; ++wi) {
-
-                        bool isRowOff = false;
-
-                        dim_type im_row = row + wi-w_len/2;
-                        dim_type im_roff;
+                        dim_type im_col = col + wj-w_wid/2;
+                        dim_type im_coff;
                         switch(pad) {
                             case AF_ZERO:
-                                im_roff = im_row * istrides[0];
-                                if (im_row < 0 || im_row>=dims[0])
-                                    isRowOff = true;
+                                im_coff = im_col * istrides[1];
+                                if (im_col < 0 || im_col>=dims[1])
+                                    isColOff = true;
                                 break;
                             case AF_SYMMETRIC:
                                 {
-                                    if (im_row < 0) {
-                                        im_row *= -1;
-                                        isRowOff = true;
+                                    if (im_col < 0) {
+                                        im_col *= -1;
+                                        isColOff = true;
                                     }
 
-                                    if (im_row>=dims[0]) {
-                                        im_row = 2*(dims[0]-1) - im_row;
-                                        isRowOff = true;
+                                    if (im_col>=dims[1]) {
+                                        im_col = 2*(dims[1]-1) - im_col;
+                                        isColOff = true;
                                     }
 
-                                    im_roff = im_row * istrides[0];
+                                    im_coff = im_col * istrides[1];
                                 }
                                 break;
                         }
 
-                        if(isRowOff || isColOff) {
+                        for(dim_type wi=0; wi<w_len; ++wi) {
+
+                            bool isRowOff = false;
+
+                            dim_type im_row = row + wi-w_len/2;
+                            dim_type im_roff;
                             switch(pad) {
                                 case AF_ZERO:
-                                    wind_vals.push_back(0);
+                                    im_roff = im_row * istrides[0];
+                                    if (im_row < 0 || im_row>=dims[0])
+                                        isRowOff = true;
                                     break;
                                 case AF_SYMMETRIC:
-                                    wind_vals.push_back(in_ptr[im_coff+im_roff]);
+                                    {
+                                        if (im_row < 0) {
+                                            im_row *= -1;
+                                            isRowOff = true;
+                                        }
+
+                                        if (im_row>=dims[0]) {
+                                            im_row = 2*(dims[0]-1) - im_row;
+                                            isRowOff = true;
+                                        }
+
+                                        im_roff = im_row * istrides[0];
+                                    }
                                     break;
                             }
-                        } else
-                            wind_vals.push_back(in_ptr[im_coff+im_roff]);
+
+                            if(isRowOff || isColOff) {
+                                switch(pad) {
+                                    case AF_ZERO:
+                                        wind_vals.push_back(0);
+                                        break;
+                                    case AF_SYMMETRIC:
+                                        wind_vals.push_back(in_ptr[im_coff+im_roff]);
+                                        break;
+                                }
+                            } else
+                                wind_vals.push_back(in_ptr[im_coff+im_roff]);
+                        }
+                    }
+
+                    std::stable_sort(wind_vals.begin(),wind_vals.end());
+                    dim_type off = wind_vals.size()/2;
+                    if (wind_vals.size()%2==0)
+                        out_ptr[ocol_off+row*ostrides[0]] = (wind_vals[off]+wind_vals[off-1])/2;
+                    else {
+                        out_ptr[ocol_off+row*ostrides[0]] = wind_vals[off];
                     }
                 }
-
-                std::stable_sort(wind_vals.begin(),wind_vals.end());
-                dim_type off = wind_vals.size()/2;
-                if (wind_vals.size()%2==0)
-                    out_ptr[ocol_off+row*ostrides[0]] = (wind_vals[off]+wind_vals[off-1])/2;
-                else {
-                    out_ptr[ocol_off+row*ostrides[0]] = wind_vals[off];
-                }
             }
+            in_ptr  += istrides[2];
+            out_ptr += ostrides[2];
         }
+
+        in_ptr  += istrides[3];
+        out_ptr += ostrides[3];
     }
 
     return out;

--- a/src/backend/cpu/medfilt.cpp
+++ b/src/backend/cpu/medfilt.cpp
@@ -33,7 +33,9 @@ Array<T> medfilt(const Array<T> &in, dim_type w_len, dim_type w_wid)
     std::vector<T> wind_vals;
     wind_vals.reserve(w_len*w_wid);
 
-    for(dim_type batchId=0; batchId<dims[2]; batchId++) {
+    dim_type batchCount = dims[2] * dims[3];
+
+    for(dim_type batchId=0; batchId<batchCount; batchId++) {
 
         T const * in_ptr = in.get() + batchId*istrides[2];
         T * out_ptr = out.get() + batchId*ostrides[2];

--- a/src/backend/cpu/morph.cpp
+++ b/src/backend/cpu/morph.cpp
@@ -37,7 +37,7 @@ Array<T> morph(const Array<T> &in, const Array<T> &mask)
     const dim_type R1     = window[1]/2;
     const dim4 istrides   = in.strides();
     const dim4 fstrides   = mask.strides();
-    const dim_type bCount = dims[2];
+    const dim_type bCount = dims[2] * dims[3];
 
     Array<T> out         = createEmptyArray<T>(dims);
     const dim4 ostrides   = out.strides();

--- a/src/backend/cpu/sobel.cpp
+++ b/src/backend/cpu/sobel.cpp
@@ -24,9 +24,8 @@ namespace cpu
 template<typename Ti, typename To, bool isDX>
 void derivative(To *optr, Ti const *iptr, dim4 const &dims, dim4 const &strides)
 {
-    dim_type bCount = dims[2]*dims[3];
-
-    for(dim_type b=0; b<bCount; ++b) {
+    for(dim_type b3=0; b3<dims[3]; ++b3) {
+    for(dim_type b2=0; b2<dims[2]; ++b2) {
 
         for(dim_type j=0; j<dims[1]; ++j) {
 
@@ -76,6 +75,9 @@ void derivative(To *optr, Ti const *iptr, dim4 const &dims, dim4 const &strides)
 
         optr += strides[2];
         iptr += strides[2];
+    }
+    optr += strides[3];
+    iptr += strides[3];
     }
 }
 

--- a/src/backend/cuda/histogram.cu
+++ b/src/backend/cuda/histogram.cu
@@ -33,14 +33,15 @@ Array<outType> histogram(const Array<inType> &in, const unsigned &nbins, const d
     // create an array to hold min and max values for
     // batch operation handling, this will reduce
     // number of concurrent reads to one single memory location
-    cfloat* h_minmax = new cfloat[dims[2]];
+    dim_type mmNElems= dims[2] * dims[3];
+    cfloat* h_minmax = new cfloat[mmNElems];
 
-    for(dim_type k=0; k<dims[2]; ++k) {
+    for(dim_type k=0; k<mmNElems; ++k) {
         h_minmax[k].x = minval;
         h_minmax[k].y = maxval;
     }
 
-    dim4 minmax_dims(dims[2]*2);
+    dim4 minmax_dims(mmNElems*2);
     Array<cfloat> minmax = createHostDataArray<cfloat>(minmax_dims, h_minmax);
 
     // cleanup the host memory used

--- a/src/backend/cuda/histogram.cu
+++ b/src/backend/cuda/histogram.cu
@@ -27,10 +27,8 @@ Array<outType> histogram(const Array<inType> &in, const unsigned &nbins, const d
     ARG_ASSERT(1, (nbins<=kernel::MAX_BINS));
 
     const dim4 dims     = in.dims();
-    const dim4 istrides = in.strides();
     dim4 outDims        = dim4(nbins, 1, dims[2], dims[3]);
     Array<outType> out  = createValueArray<outType>(outDims, outType(0));
-    const dim4 ostrides = out.strides();
 
     // create an array to hold min and max values for
     // batch operation handling, this will reduce

--- a/src/backend/cuda/kernel/bilateral.hpp
+++ b/src/backend/cuda/kernel/bilateral.hpp
@@ -56,7 +56,7 @@ template<typename inType, typename outType>
 static __global__
 void bilateralKernel(Param<outType> out, CParam<inType> in,
                      float sigma_space, float sigma_color,
-                     dim_type gaussOff, dim_type nonBatchBlkSize)
+                     dim_type gaussOff, dim_type nBBS0, dim_type nBBS1)
 {
     SharedMemory<outType> shared;
     outType *localMem = shared.getPointer();
@@ -70,15 +70,16 @@ void bilateralKernel(Param<outType> out, CParam<inType> in,
     const float variance_space = sigma_space * sigma_space;
 
     // gfor batch offsets
-    unsigned batchId = blockIdx.x / nonBatchBlkSize;
-    const inType* iptr  = (const inType *) in.ptr + (batchId * in.strides[2]);
-    outType*       optr = (outType *     )out.ptr + (batchId * out.strides[2]);
+    unsigned b2 = blockIdx.x / nBBS0;
+    unsigned b3 = blockIdx.y / nBBS1;
+    const inType* iptr  = (const inType *) in.ptr + (b2 * in.strides[2]  + b3 * in.strides[3] );
+    outType*       optr = (outType *     )out.ptr + (b2 * out.strides[2] + b3 * out.strides[3]);
 
     dim_type lx = threadIdx.x;
     dim_type ly = threadIdx.y;
 
-    const dim_type gx = THREADS_X * (blockIdx.x-batchId*nonBatchBlkSize) + lx;
-    const dim_type gy = THREADS_Y * blockIdx.y + ly;
+    const dim_type gx = THREADS_X * (blockIdx.x-b2*nBBS0) + lx;
+    const dim_type gy = THREADS_Y * (blockIdx.y-b3*nBBS1) + ly;
 
     // generate gauss2d spatial variance values for block
     if (lx<window_size && ly<window_size) {
@@ -140,9 +141,8 @@ void bilateral(Param<outType> out, CParam<inType> in, float s_sigma, float c_sig
 
     dim_type blk_x = divup(in.dims[0], THREADS_X);
     dim_type blk_y = divup(in.dims[1], THREADS_Y);
-    dim_type bCount= blk_x * (isColor ? in.dims[3] : in.dims[2]*in.dims[3]);
 
-    dim3 blocks(bCount, blk_y);
+    dim3 blocks(blk_x * in.dims[2], blk_y * in.dims[3]);
 
     // calculate shared memory size
     dim_type radius = (dim_type)std::max(s_sigma * 1.5f, 1.f);
@@ -152,7 +152,7 @@ void bilateral(Param<outType> out, CParam<inType> in, float s_sigma, float c_sig
 
     bilateralKernel<inType, outType>
         <<<blocks, threads, total_shrd_size>>>
-        (out, in, s_sigma, c_sigma, num_shrd_elems, blk_x);
+        (out, in, s_sigma, c_sigma, num_shrd_elems, blk_x, blk_y);
 
     POST_LAUNCH_CHECK();
 }

--- a/src/backend/cuda/kernel/bilateral.hpp
+++ b/src/backend/cuda/kernel/bilateral.hpp
@@ -140,10 +140,7 @@ void bilateral(Param<outType> out, CParam<inType> in, float s_sigma, float c_sig
 
     dim_type blk_x = divup(in.dims[0], THREADS_X);
     dim_type blk_y = divup(in.dims[1], THREADS_Y);
-
-    dim_type bCount = blk_x * in.dims[2];
-    if (isColor)
-        bCount *= in.dims[3];
+    dim_type bCount= blk_x * (isColor ? in.dims[3] : in.dims[2]*in.dims[3]);
 
     dim3 blocks(bCount, blk_y);
 

--- a/src/backend/cuda/kernel/convolve_separable.cu
+++ b/src/backend/cuda/kernel/convolve_separable.cu
@@ -127,7 +127,7 @@ void convolve2(Param<T> out, CParam<T> signal, CParam<accType> filter)
     dim_type blk_x = divup(out.dims[0], threads.x);
     dim_type blk_y = divup(out.dims[1], threads.y);
 
-    dim3 blocks(blk_x*signal.dims[2], blk_y);
+    dim3 blocks(blk_x*signal.dims[2]*signal.dims[3], blk_y);
 
 
    // FIX ME: if the filter array is strided, direct copy of symbols

--- a/src/backend/cuda/kernel/convolve_separable.cu
+++ b/src/backend/cuda/kernel/convolve_separable.cu
@@ -35,7 +35,7 @@ __constant__ char sFilter[2*THREADS_Y*(2*(MAX_SCONV_FILTER_LEN-1)+THREADS_X)*siz
 
 template<typename T, typename accType, dim_type conv_dim, bool expand, dim_type fLen>
 __global__
-void convolve2_separable(Param<T> out, CParam<T> signal, dim_type nBBS)
+void convolve2_separable(Param<T> out, CParam<T> signal, dim_type nBBS0, dim_type nBBS1)
 {
     const dim_type smem_len =   (conv_dim==0 ?
                                 (THREADS_X+2*(fLen-1))* THREADS_Y:
@@ -50,15 +50,16 @@ void convolve2_separable(Param<T> out, CParam<T> signal, dim_type nBBS)
     const dim_type d1      = signal.dims[1];
     const dim_type shrdLen = THREADS_X + (conv_dim==0 ? padding : 0);
 
-    unsigned batchId  = blockIdx.x/nBBS;
-    T *dst            = (T *)out.ptr          + (batchId*out.strides[2]);
-    const T *src      = (const T *)signal.ptr + (batchId*signal.strides[2]);
+    unsigned b2  = blockIdx.x/nBBS0;
+    unsigned b3  = blockIdx.y/nBBS1;
+    T *dst       = (T *)out.ptr          + (b2*out.strides[2] + b3*out.strides[3]);
+    const T *src = (const T *)signal.ptr + (b2*signal.strides[2] + b3*signal.strides[3]);
     const accType *impulse  = (const accType *)sFilter;
 
     dim_type lx = threadIdx.x;
     dim_type ly = threadIdx.y;
-    dim_type ox = THREADS_X * (blockIdx.x-batchId*nBBS) + lx;
-    dim_type oy = THREADS_Y * blockIdx.y + ly;
+    dim_type ox = THREADS_X * (blockIdx.x-b2*nBBS0) + lx;
+    dim_type oy = THREADS_Y * (blockIdx.y-b3*nBBS1) + ly;
     dim_type gx = ox;
     dim_type gy = oy;
 
@@ -108,9 +109,9 @@ void convolve2_separable(Param<T> out, CParam<T> signal, dim_type nBBS)
 }
 
 template<typename T, typename aT, dim_type cDim, bool expand, dim_type f>
-void conv2Helper(dim3 blks, dim3 thrds, Param<T> out, CParam<T> sig, dim_type nBBS)
+void conv2Helper(dim3 blks, dim3 thrds, Param<T> out, CParam<T> sig, dim_type nBBS0, dim_type nBBS1)
 {
-   (convolve2_separable<T, aT, cDim, expand, f>)<<<blks, thrds>>>(out, sig, nBBS);
+   (convolve2_separable<T, aT, cDim, expand, f>)<<<blks, thrds>>>(out, sig, nBBS0, nBBS1);
 }
 
 template<typename T, typename accType, dim_type conv_dim, bool expand>
@@ -127,7 +128,7 @@ void convolve2(Param<T> out, CParam<T> signal, CParam<accType> filter)
     dim_type blk_x = divup(out.dims[0], threads.x);
     dim_type blk_y = divup(out.dims[1], threads.y);
 
-    dim3 blocks(blk_x*signal.dims[2]*signal.dims[3], blk_y);
+    dim3 blocks(blk_x*signal.dims[2], blk_y*signal.dims[3]);
 
 
    // FIX ME: if the filter array is strided, direct copy of symbols
@@ -135,36 +136,36 @@ void convolve2(Param<T> out, CParam<T> signal, CParam<accType> filter)
    CUDA_CHECK(cudaMemcpyToSymbol(kernel::sFilter, filter.ptr, fLen*sizeof(accType), 0, cudaMemcpyDeviceToDevice));
 
     switch(fLen) {
-        case  2: conv2Helper<T, accType, conv_dim, expand,  2>(blocks, threads, out, signal, blk_x); break;
-        case  3: conv2Helper<T, accType, conv_dim, expand,  3>(blocks, threads, out, signal, blk_x); break;
-        case  4: conv2Helper<T, accType, conv_dim, expand,  4>(blocks, threads, out, signal, blk_x); break;
-        case  5: conv2Helper<T, accType, conv_dim, expand,  5>(blocks, threads, out, signal, blk_x); break;
-        case  6: conv2Helper<T, accType, conv_dim, expand,  6>(blocks, threads, out, signal, blk_x); break;
-        case  7: conv2Helper<T, accType, conv_dim, expand,  7>(blocks, threads, out, signal, blk_x); break;
-        case  8: conv2Helper<T, accType, conv_dim, expand,  8>(blocks, threads, out, signal, blk_x); break;
-        case  9: conv2Helper<T, accType, conv_dim, expand,  9>(blocks, threads, out, signal, blk_x); break;
-        case 10: conv2Helper<T, accType, conv_dim, expand, 10>(blocks, threads, out, signal, blk_x); break;
-        case 11: conv2Helper<T, accType, conv_dim, expand, 11>(blocks, threads, out, signal, blk_x); break;
-        case 12: conv2Helper<T, accType, conv_dim, expand, 12>(blocks, threads, out, signal, blk_x); break;
-        case 13: conv2Helper<T, accType, conv_dim, expand, 13>(blocks, threads, out, signal, blk_x); break;
-        case 14: conv2Helper<T, accType, conv_dim, expand, 14>(blocks, threads, out, signal, blk_x); break;
-        case 15: conv2Helper<T, accType, conv_dim, expand, 15>(blocks, threads, out, signal, blk_x); break;
-        case 16: conv2Helper<T, accType, conv_dim, expand, 16>(blocks, threads, out, signal, blk_x); break;
-        case 17: conv2Helper<T, accType, conv_dim, expand, 17>(blocks, threads, out, signal, blk_x); break;
-        case 18: conv2Helper<T, accType, conv_dim, expand, 18>(blocks, threads, out, signal, blk_x); break;
-        case 19: conv2Helper<T, accType, conv_dim, expand, 19>(blocks, threads, out, signal, blk_x); break;
-        case 20: conv2Helper<T, accType, conv_dim, expand, 20>(blocks, threads, out, signal, blk_x); break;
-        case 21: conv2Helper<T, accType, conv_dim, expand, 21>(blocks, threads, out, signal, blk_x); break;
-        case 22: conv2Helper<T, accType, conv_dim, expand, 22>(blocks, threads, out, signal, blk_x); break;
-        case 23: conv2Helper<T, accType, conv_dim, expand, 23>(blocks, threads, out, signal, blk_x); break;
-        case 24: conv2Helper<T, accType, conv_dim, expand, 24>(blocks, threads, out, signal, blk_x); break;
-        case 25: conv2Helper<T, accType, conv_dim, expand, 25>(blocks, threads, out, signal, blk_x); break;
-        case 26: conv2Helper<T, accType, conv_dim, expand, 26>(blocks, threads, out, signal, blk_x); break;
-        case 27: conv2Helper<T, accType, conv_dim, expand, 27>(blocks, threads, out, signal, blk_x); break;
-        case 28: conv2Helper<T, accType, conv_dim, expand, 28>(blocks, threads, out, signal, blk_x); break;
-        case 29: conv2Helper<T, accType, conv_dim, expand, 29>(blocks, threads, out, signal, blk_x); break;
-        case 30: conv2Helper<T, accType, conv_dim, expand, 30>(blocks, threads, out, signal, blk_x); break;
-        case 31: conv2Helper<T, accType, conv_dim, expand, 31>(blocks, threads, out, signal, blk_x); break;
+        case  2: conv2Helper<T, accType, conv_dim, expand,  2>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case  3: conv2Helper<T, accType, conv_dim, expand,  3>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case  4: conv2Helper<T, accType, conv_dim, expand,  4>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case  5: conv2Helper<T, accType, conv_dim, expand,  5>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case  6: conv2Helper<T, accType, conv_dim, expand,  6>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case  7: conv2Helper<T, accType, conv_dim, expand,  7>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case  8: conv2Helper<T, accType, conv_dim, expand,  8>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case  9: conv2Helper<T, accType, conv_dim, expand,  9>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 10: conv2Helper<T, accType, conv_dim, expand, 10>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 11: conv2Helper<T, accType, conv_dim, expand, 11>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 12: conv2Helper<T, accType, conv_dim, expand, 12>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 13: conv2Helper<T, accType, conv_dim, expand, 13>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 14: conv2Helper<T, accType, conv_dim, expand, 14>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 15: conv2Helper<T, accType, conv_dim, expand, 15>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 16: conv2Helper<T, accType, conv_dim, expand, 16>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 17: conv2Helper<T, accType, conv_dim, expand, 17>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 18: conv2Helper<T, accType, conv_dim, expand, 18>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 19: conv2Helper<T, accType, conv_dim, expand, 19>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 20: conv2Helper<T, accType, conv_dim, expand, 20>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 21: conv2Helper<T, accType, conv_dim, expand, 21>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 22: conv2Helper<T, accType, conv_dim, expand, 22>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 23: conv2Helper<T, accType, conv_dim, expand, 23>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 24: conv2Helper<T, accType, conv_dim, expand, 24>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 25: conv2Helper<T, accType, conv_dim, expand, 25>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 26: conv2Helper<T, accType, conv_dim, expand, 26>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 27: conv2Helper<T, accType, conv_dim, expand, 27>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 28: conv2Helper<T, accType, conv_dim, expand, 28>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 29: conv2Helper<T, accType, conv_dim, expand, 29>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 30: conv2Helper<T, accType, conv_dim, expand, 30>(blocks, threads, out, signal, blk_x, blk_y); break;
+        case 31: conv2Helper<T, accType, conv_dim, expand, 31>(blocks, threads, out, signal, blk_x, blk_y); break;
         default: CUDA_NOT_SUPPORTED();
     }
 

--- a/src/backend/cuda/kernel/histogram.hpp
+++ b/src/backend/cuda/kernel/histogram.hpp
@@ -32,23 +32,24 @@ template<typename inType, typename outType>
 static __global__
 void histogramKernel(Param<outType> out, CParam<inType> in,
                      const cfloat *d_minmax, dim_type len,
-                     dim_type nbins, dim_type blk_x)
+                     dim_type nbins, dim_type nBBS)
 {
     SharedMemory<outType> shared;
     outType * shrdMem = shared.getPointer();
 
-    // offset minmax array to account for batch ops
-    d_minmax += blockIdx.y;
-
     // offset input and output to account for batch ops
-    const inType *iptr  =  in.ptr + blockIdx.y *  in.strides[2];
-    outType      *optr  = out.ptr + blockIdx.y * out.strides[2];
+    unsigned b2 = blockIdx.x / nBBS;
+    const inType *iptr  =  in.ptr + b2 *  in.strides[2] + blockIdx.y *  in.strides[3];
+    outType      *optr  = out.ptr + b2 * out.strides[2] + blockIdx.y * out.strides[3];
 
-    int start = blockIdx.x * THRD_LOAD * blockDim.x + threadIdx.x;
+    int start = (blockIdx.x-b2*nBBS) * THRD_LOAD * blockDim.x + threadIdx.x;
     int end   = minimum((start + THRD_LOAD * blockDim.x), len);
 
     __shared__ float min;
     __shared__ float step;
+
+    // offset minmax array to account for batch ops
+    d_minmax += (b2 * blockIdx.x + blockIdx.y);
 
     if (threadIdx.x == 0) {
         float2 minmax = *d_minmax;
@@ -77,16 +78,17 @@ template<typename inType, typename outType>
 void histogram(Param<outType> out, CParam<inType> in, cfloat *d_minmax, dim_type nbins)
 {
     dim3 threads(kernel::THREADS_X, 1);
-    dim_type numElements = in.dims[0] * in.dims[1];
-    dim_type blk_x       = divup(numElements, THRD_LOAD*THREADS_X);
-    dim_type batchCount  = in.dims[2] * in.dims[3];
 
-    dim3 blocks(blk_x, batchCount);
+    dim_type nElems = in.dims[0] * in.dims[1];
+    dim_type blk_x  = divup(nElems, THRD_LOAD*THREADS_X);
+
+    dim3 blocks(blk_x * in.dims[2], in.dims[3]);
+
     dim_type smem_size = nbins * sizeof(outType);
 
     histogramKernel<inType, outType>
         <<<blocks, threads, smem_size>>>
-        (out, in, d_minmax, numElements, nbins, blk_x);
+        (out, in, d_minmax, nElems, nbins, blk_x);
 
     POST_LAUNCH_CHECK();
 }

--- a/src/backend/cuda/kernel/histogram.hpp
+++ b/src/backend/cuda/kernel/histogram.hpp
@@ -77,9 +77,10 @@ template<typename inType, typename outType>
 void histogram(Param<outType> out, CParam<inType> in, cfloat *d_minmax, dim_type nbins)
 {
     dim3 threads(kernel::THREADS_X, 1);
-    dim_type numElements= in.dims[0] * in.dims[1];
-    dim_type blk_x = divup(numElements, THRD_LOAD*THREADS_X);
-    dim_type batchCount = in.dims[2];
+    dim_type numElements = in.dims[0] * in.dims[1];
+    dim_type blk_x       = divup(numElements, THRD_LOAD*THREADS_X);
+    dim_type batchCount  = in.dims[2] * in.dims[3];
+
     dim3 blocks(blk_x, batchCount);
     dim_type smem_size = nbins * sizeof(outType);
 

--- a/src/backend/cuda/kernel/match_template.hpp
+++ b/src/backend/cuda/kernel/match_template.hpp
@@ -131,7 +131,7 @@ void matchTemplate(Param<outType> out, CParam<inType> srch, CParam<inType> tmplt
     dim_type blk_x = divup(srch.dims[0], threads.x);
     dim_type blk_y = divup(srch.dims[1], threads.y);
 
-    dim3 blocks(blk_x*srch.dims[2], blk_y);
+    dim3 blocks(blk_x*srch.dims[2]*srch.dims[3], blk_y);
 
     matchTemplate<inType, outType, mType, needMean> <<< blocks, threads >>> (out, srch, tmplt, blk_x);
 

--- a/src/backend/cuda/kernel/meanshift.hpp
+++ b/src/backend/cuda/kernel/meanshift.hpp
@@ -52,11 +52,11 @@ void load2ShrdMem(T * shrd, const T * in,
         shrd[lIdx(lx, ly, shrdStride, 1)+ch*schStride] = in[lIdx(gx_, gy_, inStride1, inStride0)+ch*ichStride];
 }
 
-template<typename T, dim_type channels, dim_type batchIndex>
+template<typename T, dim_type channels>
 static __global__
 void meanshiftKernel(Param<T> out, CParam<T> in,
                      float space_, dim_type radius, float cvar,
-                     uint iter, dim_type nonBatchBlkSize)
+                     uint iter, dim_type nBBS0, dim_type nBBS1)
 {
     SharedMemory<T> shared;
     T * shrdMem = shared.getPointer();
@@ -68,18 +68,19 @@ void meanshiftKernel(Param<T> out, CParam<T> in,
     // the variable ichStride will only effect when we have >1
     // channels. in the other cases, the expression in question
     // will not use the variable
-    const dim_type ichStride   = in.strides[batchIndex-1];
+    const dim_type ichStride   = in.strides[2];
 
     // gfor batch offsets
-    unsigned batchId = blockIdx.x / nonBatchBlkSize;
-    const T* iptr    = (const T *) in.ptr + (batchId *  in.strides[batchIndex]);
-    T*       optr    = (T *      )out.ptr + (batchId * out.strides[batchIndex]);
+    unsigned b2 = blockIdx.x / nBBS0;
+    unsigned b3 = blockIdx.y / nBBS1;
+    const T* iptr = (const T *) in.ptr + (b2 *  in.strides[2] + b3 *  in.strides[3]);
+    T*       optr = (T *      )out.ptr + (b2 * out.strides[2] + b3 * out.strides[3]);
 
     const dim_type lx = threadIdx.x;
     const dim_type ly = threadIdx.y;
 
-    const dim_type gx = blockDim.x * (blockIdx.x-batchId*nonBatchBlkSize) + lx;
-    const dim_type gy = blockDim.y * blockIdx.y + ly;
+    const dim_type gx = blockDim.x * (blockIdx.x-b2*nBBS0) + lx;
+    const dim_type gy = blockDim.y * (blockIdx.y-b3*nBBS1) + ly;
 
     dim_type gx2 = gx + blockDim.x;
     dim_type gy2 = gy + blockDim.y;
@@ -196,11 +197,10 @@ void meanshift(Param<T> out, CParam<T> in, float s_sigma, float c_sigma, uint it
     dim_type blk_x = divup(in.dims[0], THREADS_X);
     dim_type blk_y = divup(in.dims[1], THREADS_Y);
 
-    const dim_type bIndex   = (is_color ? 3 : 2);
-    const dim_type bCount   = (is_color ? in.dims[bIndex] : in.dims[bIndex]*in.dims[bIndex+1]);
-    const dim_type channels = (is_color ? in.dims[2] : 1);
+    const dim_type bCount   = (is_color ? 1 : in.dims[2]);
+    const dim_type channels = (is_color ? in.dims[2] : 1); // this has to be 3 for color images
 
-    dim3 blocks(blk_x * bCount, blk_y);
+    dim3 blocks(blk_x * bCount, blk_y * in.dims[3]);
 
     // clamp spatical and chromatic sigma's
     float space_     = std::min(11.5f, s_sigma);
@@ -210,9 +210,9 @@ void meanshift(Param<T> out, CParam<T> in, float s_sigma, float c_sigma, uint it
     size_t shrd_size = channels*(threads.x + padding)*(threads.y+padding)*sizeof(T);
 
     if (is_color)
-        (meanshiftKernel<T, 3, 3>) <<<blocks, threads, shrd_size>>>(out, in, space_, radius, cvar, iter, blk_x);
+        (meanshiftKernel<T, 3>) <<<blocks, threads, shrd_size>>>(out, in, space_, radius, cvar, iter, blk_x, blk_y);
     else
-        (meanshiftKernel<T, 1, 2>) <<<blocks, threads, shrd_size>>>(out, in, space_, radius, cvar, iter, blk_x);
+        (meanshiftKernel<T, 1>) <<<blocks, threads, shrd_size>>>(out, in, space_, radius, cvar, iter, blk_x, blk_y);
 
     POST_LAUNCH_CHECK();
 }

--- a/src/backend/cuda/kernel/meanshift.hpp
+++ b/src/backend/cuda/kernel/meanshift.hpp
@@ -197,7 +197,7 @@ void meanshift(Param<T> out, CParam<T> in, float s_sigma, float c_sigma, uint it
     dim_type blk_y = divup(in.dims[1], THREADS_Y);
 
     const dim_type bIndex   = (is_color ? 3 : 2);
-    const dim_type bCount   = in.dims[bIndex];
+    const dim_type bCount   = (is_color ? in.dims[bIndex] : in.dims[bIndex]*in.dims[bIndex+1]);
     const dim_type channels = (is_color ? in.dims[2] : 1);
 
     dim3 blocks(blk_x * bCount, blk_y);

--- a/src/backend/cuda/kernel/medfilt.hpp
+++ b/src/backend/cuda/kernel/medfilt.hpp
@@ -208,7 +208,7 @@ void medfilt(Param<T> out, CParam<T> in, dim_type w_len, dim_type w_wid)
     dim_type blk_x = divup(in.dims[0], threads.x);
     dim_type blk_y = divup(in.dims[1], threads.y);
 
-    dim3 blocks(blk_x*in.dims[2], blk_y);
+    dim3 blocks(blk_x*in.dims[2]*in.dims[3], blk_y);
 
     switch(w_len) {
         case  3: (medfilt<T, pad,  3,  3>)<<<blocks, threads>>>(out, in, blk_x); break;

--- a/src/backend/cuda/kernel/medfilt.hpp
+++ b/src/backend/cuda/kernel/medfilt.hpp
@@ -66,7 +66,7 @@ void load2ShrdMem(T * shrd, const T * in,
 
 template<typename T, af_pad_type pad, unsigned w_len, unsigned w_wid>
 __global__
-void medfilt(Param<T> out, CParam<T> in, dim_type nonBatchBlkSize)
+void medfilt(Param<T> out, CParam<T> in, dim_type nBBS0, dim_type nBBS1)
 {
     __shared__ T shrdMem[(THREADS_X+w_len-1)*(THREADS_Y+w_wid-1)];
 
@@ -76,17 +76,18 @@ void medfilt(Param<T> out, CParam<T> in, dim_type nonBatchBlkSize)
     const dim_type shrdLen = blockDim.x + padding;
 
     // batch offsets
-    unsigned batchId = blockIdx.x / nonBatchBlkSize;
-    const T* iptr    = (const T *) in.ptr + (batchId *  in.strides[2]);
-    T*       optr    = (T *      )out.ptr + (batchId * out.strides[2]);
+    unsigned b2 = blockIdx.x / nBBS0;
+    unsigned b3 = blockIdx.y / nBBS1;
+    const T* iptr    = (const T *) in.ptr + (b2 *  in.strides[2] + b3 *  in.strides[3]);
+    T*       optr    = (T *      )out.ptr + (b2 * out.strides[2] + b3 * out.strides[3]);
 
     // local neighborhood indices
     dim_type lx = threadIdx.x;
     dim_type ly = threadIdx.y;
 
     // global indices
-    dim_type gx = blockDim.x * (blockIdx.x-batchId*nonBatchBlkSize) + lx;
-    dim_type gy = blockDim.y * blockIdx.y + ly;
+    dim_type gx = blockDim.x * (blockIdx.x-b2*nBBS0) + lx;
+    dim_type gy = blockDim.y * (blockIdx.y-b3*nBBS1) + ly;
 
     // offset values for pulling image to local memory
     dim_type lx2 = lx + blockDim.x;
@@ -208,16 +209,16 @@ void medfilt(Param<T> out, CParam<T> in, dim_type w_len, dim_type w_wid)
     dim_type blk_x = divup(in.dims[0], threads.x);
     dim_type blk_y = divup(in.dims[1], threads.y);
 
-    dim3 blocks(blk_x*in.dims[2]*in.dims[3], blk_y);
+    dim3 blocks(blk_x*in.dims[2], blk_y*in.dims[3]);
 
     switch(w_len) {
-        case  3: (medfilt<T, pad,  3,  3>)<<<blocks, threads>>>(out, in, blk_x); break;
-        case  5: (medfilt<T, pad,  5,  5>)<<<blocks, threads>>>(out, in, blk_x); break;
-        case  7: (medfilt<T, pad,  7,  7>)<<<blocks, threads>>>(out, in, blk_x); break;
-        case  9: (medfilt<T, pad,  9,  9>)<<<blocks, threads>>>(out, in, blk_x); break;
-        case 11: (medfilt<T, pad, 11, 11>)<<<blocks, threads>>>(out, in, blk_x); break;
-        case 13: (medfilt<T, pad, 13, 13>)<<<blocks, threads>>>(out, in, blk_x); break;
-        case 15: (medfilt<T, pad, 15, 15>)<<<blocks, threads>>>(out, in, blk_x); break;
+        case  3: (medfilt<T, pad,  3,  3>)<<<blocks, threads>>>(out, in, blk_x, blk_y); break;
+        case  5: (medfilt<T, pad,  5,  5>)<<<blocks, threads>>>(out, in, blk_x, blk_y); break;
+        case  7: (medfilt<T, pad,  7,  7>)<<<blocks, threads>>>(out, in, blk_x, blk_y); break;
+        case  9: (medfilt<T, pad,  9,  9>)<<<blocks, threads>>>(out, in, blk_x, blk_y); break;
+        case 11: (medfilt<T, pad, 11, 11>)<<<blocks, threads>>>(out, in, blk_x, blk_y); break;
+        case 13: (medfilt<T, pad, 13, 13>)<<<blocks, threads>>>(out, in, blk_x, blk_y); break;
+        case 15: (medfilt<T, pad, 15, 15>)<<<blocks, threads>>>(out, in, blk_x, blk_y); break;
     }
 
     POST_LAUNCH_CHECK();

--- a/src/backend/cuda/kernel/morph.hpp
+++ b/src/backend/cuda/kernel/morph.hpp
@@ -297,7 +297,7 @@ void morph(Param<T> out, CParam<T> in, dim_type windLen)
     dim_type blk_x = divup(in.dims[0], THREADS_X);
     dim_type blk_y = divup(in.dims[1], THREADS_Y);
     // launch batch * blk_x blocks along x dimension
-    dim3 blocks(blk_x * in.dims[2], blk_y);
+    dim3 blocks(blk_x * in.dims[2] * in.dims[3], blk_y);
 
     // calculate shared memory size
     int halo      = windLen/2;

--- a/src/backend/cuda/morph3d_impl.hpp
+++ b/src/backend/cuda/morph3d_impl.hpp
@@ -31,10 +31,6 @@ Array<T> morph3d(const Array<T> &in, const Array<T> &mask)
     if (mdims[0] > 7)
         AF_ERROR("Upto 7x7x7 kernels are only supported in CUDA backend", AF_ERR_SIZE);
 
-    if (in.dims()[3] > 1)
-        AF_ERROR("Batch not supported for volumetic morph operations in CUDA backend",
-                 AF_ERR_NOT_SUPPORTED);
-
     Array<T> out       = createEmptyArray<T>(in.dims());
 
     CUDA_CHECK(cudaMemcpyToSymbol(kernel::cFilter, mask.get(),

--- a/src/backend/opencl/histogram.cpp
+++ b/src/backend/opencl/histogram.cpp
@@ -36,14 +36,15 @@ Array<outType> histogram(const Array<inType> &in, const unsigned &nbins, const d
     // create an array to hold min and max values for
     // batch operation handling, this will reduce
     // number of concurrent reads to one single memory location
-    cfloat* h_minmax = new cfloat[dims[2]];
+    dim_type mmNElems= dims[2] * dims[3];
+    cfloat* h_minmax = new cfloat[mmNElems];
 
-    for(dim_type k=0; k<dims[2]; ++k) {
+    for(dim_type k=0; k<mmNElems; ++k) {
         h_minmax[k].s[0] = minval;
         h_minmax[k].s[1] = maxval;
     }
 
-    dim4 minmax_dims(dims[2]*2);
+    dim4 minmax_dims(mmNElems*2);
     Array<cfloat> minmax = createHostDataArray<cfloat>(minmax_dims, h_minmax);
 
     // cleanup the host memory used

--- a/src/backend/opencl/kernel/bilateral.hpp
+++ b/src/backend/opencl/kernel/bilateral.hpp
@@ -75,10 +75,7 @@ void bilateral(Param out, const Param in, float s_sigma, float c_sigma)
 
         dim_type blk_x = divup(in.info.dims[0], THREADS_X);
         dim_type blk_y = divup(in.info.dims[1], THREADS_Y);
-
-        dim_type bCount= blk_x * in.info.dims[2];
-        if (isColor)
-            bCount *= in.info.dims[3];
+        dim_type bCount= blk_x * (isColor ? in.info.dims[3] : in.info.dims[2] * in.info.dims[3]);
 
         NDRange global(bCount*THREADS_X, blk_y*THREADS_Y);
 

--- a/src/backend/opencl/kernel/bilateral.hpp
+++ b/src/backend/opencl/kernel/bilateral.hpp
@@ -68,16 +68,16 @@ void bilateral(Param out, const Param in, float s_sigma, float c_sigma)
                                        LocalSpaceArg,
                                        LocalSpaceArg,
                                        float, float,
-                                       dim_type, dim_type
+                                       dim_type, dim_type, dim_type
                                       >(*bilKernels[device]);
 
         NDRange local(THREADS_X, THREADS_Y);
 
         dim_type blk_x = divup(in.info.dims[0], THREADS_X);
         dim_type blk_y = divup(in.info.dims[1], THREADS_Y);
-        dim_type bCount= blk_x * (isColor ? in.info.dims[3] : in.info.dims[2] * in.info.dims[3]);
 
-        NDRange global(bCount*THREADS_X, blk_y*THREADS_Y);
+        NDRange global(blk_x*in.info.dims[2]*THREADS_X,
+                       blk_y*in.info.dims[3]*THREADS_Y);
 
         // calculate local memory size
         dim_type radius = (dim_type)std::max(s_sigma * 1.5f, 1.f);
@@ -88,7 +88,7 @@ void bilateral(Param out, const Param in, float s_sigma, float c_sigma)
                     *out.data, out.info, *in.data, in.info,
                     cl::Local(num_shrd_elems*sizeof(outType)),
                     cl::Local(num_gauss_elems*sizeof(outType)),
-                    s_sigma, c_sigma, num_shrd_elems, blk_x);
+                    s_sigma, c_sigma, num_shrd_elems, blk_x, blk_y);
 
         CL_DEBUG_FINISH(getQueue());
     } catch (cl::Error err) {

--- a/src/backend/opencl/kernel/convolve_separable.hpp
+++ b/src/backend/opencl/kernel/convolve_separable.hpp
@@ -74,21 +74,23 @@ void convolve2(Param out, const Param signal, const Param filter)
                     convKernels[device] = new Kernel(*convProgs[device], "convolve");
                 });
 
-        auto convOp = make_kernel<Buffer, KParam, Buffer, KParam, Buffer, dim_type>(*convKernels[device]);
+        auto convOp = make_kernel<Buffer, KParam, Buffer, KParam, Buffer,
+                                  dim_type, dim_type>(*convKernels[device]);
 
         NDRange local(THREADS_X, THREADS_Y);
 
         dim_type blk_x = divup(out.info.dims[0], THREADS_X);
         dim_type blk_y = divup(out.info.dims[1], THREADS_Y);
 
-        NDRange global(blk_x*signal.info.dims[2]*signal.info.dims[3]*THREADS_X, blk_y*THREADS_Y);
+        NDRange global(blk_x*signal.info.dims[2]*THREADS_X,
+                       blk_y*signal.info.dims[3]*THREADS_Y);
 
         cl::Buffer *mBuff = bufferAlloc(fLen*sizeof(accType));
         // FIX ME: if the filter array is strided, direct might cause issues
         getQueue().enqueueCopyBuffer(*filter.data, *mBuff, 0, 0, fLen*sizeof(accType));
 
         convOp(EnqueueArgs(getQueue(), global, local),
-               *out.data, out.info, *signal.data, signal.info, *mBuff, blk_x);
+               *out.data, out.info, *signal.data, signal.info, *mBuff, blk_x, blk_y);
 
         bufferFree(mBuff);
     } catch (cl::Error err) {

--- a/src/backend/opencl/kernel/convolve_separable.hpp
+++ b/src/backend/opencl/kernel/convolve_separable.hpp
@@ -81,7 +81,7 @@ void convolve2(Param out, const Param signal, const Param filter)
         dim_type blk_x = divup(out.info.dims[0], THREADS_X);
         dim_type blk_y = divup(out.info.dims[1], THREADS_Y);
 
-        NDRange global(blk_x*signal.info.dims[2]*THREADS_X, blk_y*THREADS_Y);
+        NDRange global(blk_x*signal.info.dims[2]*signal.info.dims[3]*THREADS_X, blk_y*THREADS_Y);
 
         cl::Buffer *mBuff = bufferAlloc(fLen*sizeof(accType));
         // FIX ME: if the filter array is strided, direct might cause issues

--- a/src/backend/opencl/kernel/histogram.hpp
+++ b/src/backend/opencl/kernel/histogram.hpp
@@ -68,7 +68,7 @@ void histogram(Param out, const Param in, const Param minmax, dim_type nbins)
 
         dim_type blk_x       = divup(numElements, THRD_LOAD*THREADS_X);
 
-        dim_type batchCount  = in.info.dims[2];
+        dim_type batchCount  = in.info.dims[2] * in.info.dims[3];
 
         NDRange global(blk_x*THREADS_X, batchCount);
 

--- a/src/backend/opencl/kernel/matchTemplate.cl
+++ b/src/backend/opencl/kernel/matchTemplate.cl
@@ -14,12 +14,14 @@ void matchTemplate(global outType * out,
                     KParam          sInfo,
                     global const inType * tmplt,
                     KParam          tInfo,
-                    dim_type        nBBS)
+                    dim_type        nBBS0,
+                    dim_type        nBBS1)
 {
-    unsigned batchId = get_group_id(0) / nBBS;
+    unsigned b2 = get_group_id(0) / nBBS0;
+    unsigned b3 = get_group_id(1) / nBBS1;
 
-    dim_type gx = get_local_id(0) + (get_group_id(0) - batchId*nBBS) * get_local_size(0);
-    dim_type gy = get_local_id(1) + get_group_id(1) * get_local_size(1);
+    dim_type gx = get_local_id(0) + (get_group_id(0) - b2*nBBS0) * get_local_size(0);
+    dim_type gy = get_local_id(1) + (get_group_id(1) - b3*nBBS1)* get_local_size(1);
 
     if (gx < sInfo.dims[0] && gy < sInfo.dims[1]) {
 
@@ -43,8 +45,8 @@ void matchTemplate(global outType * out,
             tImgMean /= winNumElems;
         }
 
-        global const inType* sptr  = srch + (batchId * sInfo.strides[2]);
-        global outType* optr       = out  + (batchId * oInfo.strides[2]);
+        global const inType* sptr  = srch + (b2 * sInfo.strides[2] + b3 * sInfo.strides[3] + sInfo.offset);
+        global outType* optr       = out  + (b2 * oInfo.strides[2] + b3 * oInfo.strides[3]);
 
         // mean for window
         // this variable will be used based on MATCH_T value

--- a/src/backend/opencl/kernel/match_template.hpp
+++ b/src/backend/opencl/kernel/match_template.hpp
@@ -75,15 +75,15 @@ void matchTemplate(Param out, const Param srch, const Param tmplt)
         dim_type blk_x = divup(srch.info.dims[0], THREADS_X);
         dim_type blk_y = divup(srch.info.dims[1], THREADS_Y);
 
-        NDRange global(blk_x * srch.info.dims[2] * srch.info.dims[3] * THREADS_X, blk_y * THREADS_Y);
+        NDRange global(blk_x * srch.info.dims[2] * THREADS_X, blk_y * srch.info.dims[3] * THREADS_Y);
 
         auto matchImgOp = make_kernel<Buffer, KParam,
                                        Buffer, KParam,
                                        Buffer, KParam,
-                                       dim_type> (*mtKernels[device]);
+                                       dim_type, dim_type> (*mtKernels[device]);
 
         matchImgOp(EnqueueArgs(getQueue(), global, local),
-                    *out.data, out.info, *srch.data, srch.info, *tmplt.data, tmplt.info, blk_x);
+                    *out.data, out.info, *srch.data, srch.info, *tmplt.data, tmplt.info, blk_x, blk_y);
 
         CL_DEBUG_FINISH(getQueue());
     } catch (cl::Error err) {

--- a/src/backend/opencl/kernel/match_template.hpp
+++ b/src/backend/opencl/kernel/match_template.hpp
@@ -75,7 +75,7 @@ void matchTemplate(Param out, const Param srch, const Param tmplt)
         dim_type blk_x = divup(srch.info.dims[0], THREADS_X);
         dim_type blk_y = divup(srch.info.dims[1], THREADS_Y);
 
-        NDRange global(blk_x * srch.info.dims[2] * THREADS_X, blk_y * THREADS_Y);
+        NDRange global(blk_x * srch.info.dims[2] * srch.info.dims[3] * THREADS_X, blk_y * THREADS_Y);
 
         auto matchImgOp = make_kernel<Buffer, KParam,
                                        Buffer, KParam,

--- a/src/backend/opencl/kernel/meanshift.hpp
+++ b/src/backend/opencl/kernel/meanshift.hpp
@@ -63,10 +63,10 @@ void meanshift(Param out, const Param in, float s_sigma, float c_sigma, uint ite
 
         auto meanshiftOp = make_kernel<Buffer, KParam,
                                        Buffer, KParam,
-                                       LocalSpaceArg, dim_type,
+                                       LocalSpaceArg,
                                        dim_type, float,
                                        dim_type, float,
-                                       unsigned, dim_type
+                                       unsigned, dim_type, dim_type
                                       >(*msKernels[device]);
 
         NDRange local(THREADS_X, THREADS_Y);
@@ -74,12 +74,10 @@ void meanshift(Param out, const Param in, float s_sigma, float c_sigma, uint ite
         dim_type blk_x = divup(in.info.dims[0], THREADS_X);
         dim_type blk_y = divup(in.info.dims[1], THREADS_Y);
 
-        const dim_type bIndex   = (is_color ? 3 : 2);
-        const dim_type bCount   = (is_color ? in.info.dims[bIndex] :
-                                              in.info.dims[bIndex]*in.info.dims[bIndex+1]);
+        const dim_type bCount   = (is_color ? 1 : in.info.dims[2]);
         const dim_type channels = (is_color ? in.info.dims[2] : 1);
 
-        NDRange global(bCount*blk_x*THREADS_X, blk_y*THREADS_Y);
+        NDRange global(bCount*blk_x*THREADS_X, in.info.dims[3]*blk_y*THREADS_Y);
 
         // clamp spatical and chromatic sigma's
         float space_     = std::min(11.5f, s_sigma);
@@ -90,8 +88,8 @@ void meanshift(Param out, const Param in, float s_sigma, float c_sigma, uint ite
 
         meanshiftOp(EnqueueArgs(getQueue(), global, local),
                     *out.data, out.info, *in.data, in.info,
-                    cl::Local(loc_size), bIndex, channels,
-                    space_, radius, cvar, iter, blk_x);
+                    cl::Local(loc_size), channels,
+                    space_, radius, cvar, iter, blk_x, blk_y);
 
         CL_DEBUG_FINISH(getQueue());
     } catch (cl::Error err) {

--- a/src/backend/opencl/kernel/meanshift.hpp
+++ b/src/backend/opencl/kernel/meanshift.hpp
@@ -75,7 +75,8 @@ void meanshift(Param out, const Param in, float s_sigma, float c_sigma, uint ite
         dim_type blk_y = divup(in.info.dims[1], THREADS_Y);
 
         const dim_type bIndex   = (is_color ? 3 : 2);
-        const dim_type bCount   = in.info.dims[bIndex];
+        const dim_type bCount   = (is_color ? in.info.dims[bIndex] :
+                                              in.info.dims[bIndex]*in.info.dims[bIndex+1]);
         const dim_type channels = (is_color ? in.info.dims[2] : 1);
 
         NDRange global(bCount*blk_x*THREADS_X, blk_y*THREADS_Y);

--- a/src/backend/opencl/kernel/medfilt.hpp
+++ b/src/backend/opencl/kernel/medfilt.hpp
@@ -74,7 +74,8 @@ void medfilt(Param out, const Param in)
         dim_type blk_x = divup(in.info.dims[0], THREADS_X);
         dim_type blk_y = divup(in.info.dims[1], THREADS_Y);
 
-        NDRange global(blk_x * in.info.dims[2] * THREADS_X, blk_y * THREADS_Y);
+        NDRange global(blk_x * in.info.dims[2] * in.info.dims[3] * THREADS_X,
+                       blk_y * THREADS_Y);
 
         auto medfiltOp = make_kernel<Buffer, KParam,
                                      Buffer, KParam,

--- a/src/backend/opencl/kernel/medfilt.hpp
+++ b/src/backend/opencl/kernel/medfilt.hpp
@@ -74,18 +74,18 @@ void medfilt(Param out, const Param in)
         dim_type blk_x = divup(in.info.dims[0], THREADS_X);
         dim_type blk_y = divup(in.info.dims[1], THREADS_Y);
 
-        NDRange global(blk_x * in.info.dims[2] * in.info.dims[3] * THREADS_X,
-                       blk_y * THREADS_Y);
+        NDRange global(blk_x * in.info.dims[2] * THREADS_X,
+                       blk_y * in.info.dims[3] * THREADS_Y);
 
         auto medfiltOp = make_kernel<Buffer, KParam,
                                      Buffer, KParam,
                                      cl::LocalSpaceArg,
-                                     dim_type> (*mfKernels[device]);
+                                     dim_type, dim_type> (*mfKernels[device]);
 
         size_t loc_size = (THREADS_X+w_len-1)*(THREADS_Y+w_wid-1)*sizeof(T);
 
         medfiltOp(EnqueueArgs(getQueue(), global, local),
-                    *out.data, out.info, *in.data, in.info, cl::Local(loc_size), blk_x);
+                    *out.data, out.info, *in.data, in.info, cl::Local(loc_size), blk_x, blk_y);
 
         CL_DEBUG_FINISH(getQueue());
     } catch (cl::Error err) {

--- a/src/backend/opencl/kernel/morph.cl
+++ b/src/backend/opencl/kernel/morph.cl
@@ -34,24 +34,25 @@ void morph(__global T *              out,
            KParam                  iInfo,
            __constant const T *   d_filt,
            __local T *          localMem,
-           dim_type nonBatchBlkSize)
+           dim_type nBBS0, dim_type nBBS1)
 {
     const dim_type halo   = windLen/2;
     const dim_type padding= 2*halo;
     const dim_type shrdLen= get_local_size(0) + padding + 1;
 
     // gfor batch offsets
-    dim_type batchId    = get_group_id(0) / nonBatchBlkSize;
-    in  += (batchId * iInfo.strides[2] + iInfo.offset);
-    out += (batchId * oInfo.strides[2]);
+    dim_type b2 = get_group_id(0) / nBBS0;
+    dim_type b3 = get_group_id(1) / nBBS1;
+    in  += (b2 * iInfo.strides[2] + b3 * iInfo.strides[3] + iInfo.offset);
+    out += (b2 * oInfo.strides[2] + b3 * oInfo.strides[3]);
 
     // local neighborhood indices
     const dim_type lx = get_local_id(0);
     const dim_type ly = get_local_id(1);
 
     // global indices
-    dim_type gx = get_local_size(0) * (get_group_id(0)-batchId*nonBatchBlkSize) + lx;
-    dim_type gy = get_local_size(1) * get_group_id(1) + ly;
+    dim_type gx = get_local_size(0) * (get_group_id(0)-b2*nBBS0) + lx;
+    dim_type gy = get_local_size(1) * (get_group_id(1)-b3*nBBS1) + ly;
 
     // offset values for pulling image to local memory
     dim_type lx2      = lx + get_local_size(0);

--- a/src/backend/opencl/kernel/morph.hpp
+++ b/src/backend/opencl/kernel/morph.hpp
@@ -79,7 +79,7 @@ void morph(Param         out,
         dim_type blk_x = divup(in.info.dims[0], THREADS_X);
         dim_type blk_y = divup(in.info.dims[1], THREADS_Y);
         // launch batch * blk_x blocks along x dimension
-        NDRange global(blk_x * THREADS_X * in.info.dims[2],
+        NDRange global(blk_x * THREADS_X * in.info.dims[2] * in.info.dims[3],
                 blk_y * THREADS_Y);
 
         // copy mask/filter to constant memory

--- a/src/backend/opencl/kernel/morph.hpp
+++ b/src/backend/opencl/kernel/morph.hpp
@@ -135,7 +135,7 @@ void morph3d(Param       out,
 
         auto morphOp = make_kernel<Buffer, KParam,
                                    Buffer, KParam,
-                                   Buffer, cl::LocalSpaceArg
+                                   Buffer, cl::LocalSpaceArg, dim_type
                                   >(*morKernels[device]);
 
         NDRange local(CUBE_X, CUBE_Y, CUBE_Z);
@@ -144,9 +144,9 @@ void morph3d(Param       out,
         dim_type blk_y = divup(in.info.dims[1], CUBE_Y);
         dim_type blk_z = divup(in.info.dims[2], CUBE_Z);
         // launch batch * blk_x blocks along x dimension
-        NDRange global(blk_x * CUBE_X,
-                blk_y * CUBE_Y,
-                blk_z * CUBE_Z);
+        NDRange global(blk_x * CUBE_X * in.info.dims[3],
+                       blk_y * CUBE_Y,
+                       blk_z * CUBE_Z);
 
         // copy mask/filter to constant memory
         cl_int se_size   = sizeof(T)*windLen*windLen*windLen;
@@ -162,7 +162,7 @@ void morph3d(Param       out,
 
         morphOp(EnqueueArgs(getQueue(), global, local),
                 *out.data, out.info, *in.data, in.info,
-                *mBuff, cl::Local(locSize*sizeof(T)));
+                *mBuff, cl::Local(locSize*sizeof(T)), blk_x);
 
         bufferFree(mBuff);
         CL_DEBUG_FINISH(getQueue());

--- a/src/backend/opencl/kernel/morph.hpp
+++ b/src/backend/opencl/kernel/morph.hpp
@@ -71,7 +71,7 @@ void morph(Param         out,
         auto morphOp = make_kernel<Buffer, KParam,
                                    Buffer, KParam,
                                    Buffer, cl::LocalSpaceArg,
-                                   dim_type
+                                   dim_type, dim_type
                                   >(*morKernels[device]);
 
         NDRange local(THREADS_X, THREADS_Y);
@@ -79,8 +79,8 @@ void morph(Param         out,
         dim_type blk_x = divup(in.info.dims[0], THREADS_X);
         dim_type blk_y = divup(in.info.dims[1], THREADS_Y);
         // launch batch * blk_x blocks along x dimension
-        NDRange global(blk_x * THREADS_X * in.info.dims[2] * in.info.dims[3],
-                blk_y * THREADS_Y);
+        NDRange global(blk_x * THREADS_X * in.info.dims[2],
+                       blk_y * THREADS_Y * in.info.dims[3]);
 
         // copy mask/filter to constant memory
         cl_int se_size   = sizeof(T)*windLen*windLen;
@@ -95,7 +95,7 @@ void morph(Param         out,
 
         morphOp(EnqueueArgs(getQueue(), global, local),
                 *out.data, out.info, *in.data, in.info, *mBuff,
-                cl::Local(locSize*sizeof(T)), blk_x);
+                cl::Local(locSize*sizeof(T)), blk_x, blk_y);
 
         bufferFree(mBuff);
 

--- a/src/backend/opencl/kernel/sobel.cl
+++ b/src/backend/opencl/kernel/sobel.cl
@@ -23,22 +23,23 @@ void sobel3x3(global To * dx, KParam dxInfo,
               global To * dy, KParam dyInfo,
               global const Ti * in, KParam iInfo,
               local        Ti * localMem,
-              dim_type nBBS)
+              dim_type nBBS0, dim_type nBBS1)
 {
     const dim_type radius  = 1;
     const dim_type padding = 2*radius;
     const dim_type shrdLen = get_local_size(0) + padding;
 
-    unsigned batchId = get_group_id(0) / nBBS;
-    global const Ti* iptr = in + (batchId * iInfo.strides[2] + iInfo.offset);
-    global To*      dxptr = dx + (batchId * dxInfo.strides[2]);
-    global To*      dyptr = dy + (batchId * dyInfo.strides[2]);
+    unsigned b2 = get_group_id(0) / nBBS0;
+    unsigned b3 = get_group_id(1) / nBBS1;
+    global const Ti* iptr = in + (b2 * iInfo.strides[2]  + b3 * iInfo.strides[3] + iInfo.offset);
+    global To*      dxptr = dx + (b2 * dxInfo.strides[2] + b3 * dxInfo.strides[3]);
+    global To*      dyptr = dy + (b2 * dyInfo.strides[2] + b3 * dyInfo.strides[3]);
 
     dim_type lx = get_local_id(0);
     dim_type ly = get_local_id(1);
 
-    dim_type gx = get_local_size(0) * (get_group_id(0)-batchId*nBBS) + lx;
-    dim_type gy = get_local_size(1) * get_group_id(1) + ly;
+    dim_type gx = get_local_size(0) * (get_group_id(0)-b2*nBBS0) + lx;
+    dim_type gy = get_local_size(1) * (get_group_id(1)-b3*nBBS1) + ly;
 
     dim_type lx2 = lx + get_local_size(0);
     dim_type ly2 = ly + get_local_size(1);

--- a/src/backend/opencl/kernel/sobel.hpp
+++ b/src/backend/opencl/kernel/sobel.hpp
@@ -65,20 +65,20 @@ void sobel(Param dx, Param dy, const Param in)
         dim_type blk_x = divup(in.info.dims[0], THREADS_X);
         dim_type blk_y = divup(in.info.dims[1], THREADS_Y);
 
-        NDRange global(blk_x * in.info.dims[2] * in.info.dims[3] * THREADS_X,
-                       blk_y * THREADS_Y);
+        NDRange global(blk_x * in.info.dims[2] * THREADS_X,
+                       blk_y * in.info.dims[3] * THREADS_Y);
 
         auto sobelOp = make_kernel<Buffer, KParam,
                                    Buffer, KParam,
                                    Buffer, KParam,
                                    cl::LocalSpaceArg,
-                                   dim_type> (*sobKernels[device]);
+                                   dim_type, dim_type> (*sobKernels[device]);
 
         size_t loc_size = (THREADS_X+ker_size-1)*(THREADS_Y+ker_size-1)*sizeof(Ti);
 
         sobelOp(EnqueueArgs(getQueue(), global, local),
                     *dx.data, dx.info, *dy.data, dy.info,
-                    *in.data, in.info, cl::Local(loc_size), blk_x);
+                    *in.data, in.info, cl::Local(loc_size), blk_x, blk_y);
 
         CL_DEBUG_FINISH(getQueue());
     } catch (cl::Error err) {

--- a/src/backend/opencl/morph3d_impl.hpp
+++ b/src/backend/opencl/morph3d_impl.hpp
@@ -36,10 +36,7 @@ Array<T> morph3d(const Array<T> &in, const Array<T> &mask)
     if (mdims[0]>7)
         AF_ERROR("Upto 7x7x7 kernels are only supported in opencl currently", AF_ERR_SIZE);
 
-    const dim4 dims     = in.dims();
-    if (dims[3]>1)
-        AF_ERROR("Batch not supported for volumetic morphological operations", AF_ERR_NOT_SUPPORTED);
-
+    const dim4 dims= in.dims();
     Array<T> out   = createEmptyArray<T>(dims);
 
     switch(mdims[0]) {

--- a/test/bilateral.cpp
+++ b/test/bilateral.cpp
@@ -143,15 +143,8 @@ TYPED_TEST(BilateralOnData, InvalidArgs)
     af_array inArray   = 0;
     af_array outArray  = 0;
 
-    // check for gray scale bilateral
-    af::dim4 dims(5,5,2,2);
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
-                dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<TypeParam>::af_type));
-    ASSERT_EQ(AF_ERR_SIZE, af_bilateral(&outArray, inArray, 0.12f, 0.34f, false));
-    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
-
     // check for color image bilateral
-    dims = af::dim4(100,1,1,1);
+    af::dim4 dims = af::dim4(100,1,1,1);
     ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<TypeParam>::af_type));
     ASSERT_EQ(AF_ERR_SIZE, af_bilateral(&outArray, inArray, 0.12f, 0.34f, true));

--- a/test/histogram.cpp
+++ b/test/histogram.cpp
@@ -32,26 +32,6 @@ typedef ::testing::Types<float, double, int, uint, char, uchar> TestTypes;
 // register the type list
 TYPED_TEST_CASE(Histogram, TestTypes);
 
-TYPED_TEST(Histogram,InvalidArgs)
-{
-    if (noDoubleTests<TypeParam>()) return;
-
-    af::dim4            dims(1);
-    vector<TypeParam>   in(100,1);
-
-    af_array inArray   = 0;
-    af_array outArray  = 0;
-
-    // square test file is 100x100 originally
-    // use new dimensions for this argument
-    // unit test
-    af::dim4 newDims(5,5,2,2);
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(), newDims.ndims(), newDims.get(), (af_dtype) af::dtype_traits<TypeParam>::af_type));
-
-    ASSERT_EQ(AF_ERR_SIZE, af_histogram(&outArray,inArray,256,0,255));
-    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
-}
-
 template<typename inType, typename outType>
 void histTest(string pTestFile, unsigned nbins, double minval, double maxval)
 {

--- a/test/meanshift.cpp
+++ b/test/meanshift.cpp
@@ -40,15 +40,7 @@ TYPED_TEST(Meanshift, InvalidArgs)
     af_array inArray   = 0;
     af_array outArray  = 0;
 
-    // check for gray scale Meanshift
-    af::dim4 dims(5,5,2,2);
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
-                dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<TypeParam>::af_type));
-    ASSERT_EQ(AF_ERR_SIZE, af_meanshift(&outArray, inArray, 0.12f, 0.34f, 5, false));
-    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
-
-    // check for color image Meanshift
-    dims = af::dim4(100,1,1,1);
+    af::dim4 dims = af::dim4(100,1,1,1);
     ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<TypeParam>::af_type));
     ASSERT_EQ(AF_ERR_SIZE, af_meanshift(&outArray, inArray, 0.12f, 0.34f, 5, true));

--- a/test/medfilt.cpp
+++ b/test/medfilt.cpp
@@ -143,18 +143,8 @@ void medfiltInputTest(void)
 
     vector<T>   in(100, 1);
 
-    // Check for 4D inputs
-    af::dim4 dims(5, 5, 2, 2);
-
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
-                dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<T>::af_type));
-
-    ASSERT_EQ(AF_ERR_SIZE, af_medfilt(&outArray, inArray, 1, 1, AF_ZERO));
-
-    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
-
     // Check for 1D inputs
-    dims = af::dim4(100, 1, 1, 1);
+    af::dim4 dims = af::dim4(100, 1, 1, 1);
 
     ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<T>::af_type));

--- a/test/morph.cpp
+++ b/test/morph.cpp
@@ -194,25 +194,12 @@ void morphInputTest(void)
     vector<T>   in(100,1);
     vector<T>   mask(9,1);
 
-    // Check for 4D inputs
-    af::dim4 dims(5,5,2,2);
+    // Check for 1D inputs
+    af::dim4 dims = af::dim4(100,1,1,1);
     af::dim4 mdims(3,3,1,1);
 
     ASSERT_EQ(AF_SUCCESS, af_create_array(&maskArray, &mask.front(),
                 mdims.ndims(), mdims.get(), (af_dtype) af::dtype_traits<T>::af_type));
-
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
-                dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<T>::af_type));
-
-    if (isDilation)
-        ASSERT_EQ(AF_ERR_SIZE, af_dilate(&outArray, inArray, maskArray));
-    else
-        ASSERT_EQ(AF_ERR_SIZE, af_erode(&outArray, inArray, maskArray));
-
-    ASSERT_EQ(AF_SUCCESS, af_destroy_array(inArray));
-
-    // Check for 1D inputs
-    dims = af::dim4(100,1,1,1);
 
     ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<T>::af_type));


### PR DESCRIPTION
gfor requires batch support along 4th dimension. This merge adds
the required support for the following functions

- `convolve` - separable convolution
- `morph`
- `bilateral`
- `meanshift`
- `histogram`
- `medfilt`
- `matchTemplate`
- `sobel`
- `rgb2hsv`
- `hsv2rgb`
- `rgb2gray`
- `gray2rgb`

Related to #302 

This also has documentation update for convolve.