### PR TITLE
Helper functions in OpenCL to create af::array from cl_mem

### DIFF
--- a/include/af/opencl.h
+++ b/include/af/opencl.h
@@ -12,11 +12,73 @@
 #else
 #include <CL/cl.h>
 #endif
+
 #include <af/defines.h>
+#include <af/array.h>
+#include <af/exception.h>
+#include <af/device.h>
+#include <stdio.h>
 
 namespace afcl
 {
     AFAPI cl_context getContext();
     AFAPI cl_command_queue getQueue();
     AFAPI cl_device_id getDeviceId();
+
+    static inline af::array array(af::dim4 idims, cl_mem buf, af::dtype type)
+    {
+        const unsigned ndims = (unsigned)idims.ndims();
+        const dim_type *dims = idims.get();
+
+        cl_context context;
+        cl_int clerr = clGetMemObjectInfo(buf, CL_MEM_CONTEXT, sizeof(cl_context), &context, NULL);
+        if (clerr != CL_SUCCESS) {
+            throw af::exception("Failed to get context from cl_mem object \"buf\" ");
+        }
+
+        if (context != getContext()) {
+            throw(af::exception("Context mismatch between input \"buf\" and arrayfire"));
+        }
+
+        cl_device_id device;
+        clerr = clGetContextInfo(context, CL_CONTEXT_DEVICES, sizeof(cl_device_id), &device, NULL);
+
+        if (device != getDeviceId()) {
+            throw(af::exception("device mismatch between input \"buf\" and arrayfire"));
+        }
+
+        af_array out;
+        af_err err = af_device_array(&out, buf, ndims, dims, type);
+        if (err != AF_SUCCESS) {
+            throw af::exception("Failed to create device array", __FILE__, __LINE__ - 2, err);
+        }
+
+        return af::array(out);
+    }
+
+    static inline af::array array(dim_type dim0,
+                                  cl_mem buf, af::dtype type)
+    {
+        return afcl::array(af::dim4(dim0), buf, type);
+    }
+
+    static inline af::array array(dim_type dim0, dim_type dim1,
+                                  cl_mem buf, af::dtype type)
+    {
+        return afcl::array(af::dim4(dim0, dim1), buf, type);
+    }
+
+    static inline af::array array(dim_type dim0, dim_type dim1,
+                                  dim_type dim2,
+                                  cl_mem buf, af::dtype type)
+    {
+        return afcl::array(af::dim4(dim0, dim1, dim2), buf, type);
+    }
+
+    static inline af::array array(dim_type dim0, dim_type dim1,
+                                  dim_type dim2, dim_type dim3,
+                                  cl_mem buf, af::dtype type)
+    {
+        return afcl::array(af::dim4(dim0, dim1, dim2, dim3), buf, type);
+    }
 }

--- a/include/af/opencl.h
+++ b/include/af/opencl.h
@@ -25,7 +25,7 @@ namespace afcl
     AFAPI cl_command_queue getQueue();
     AFAPI cl_device_id getDeviceId();
 
-    static inline af::array array(af::dim4 idims, cl_mem buf, af::dtype type)
+    static inline af::array array(af::dim4 idims, cl_mem buf, af::dtype type, bool retain=true)
     {
         const unsigned ndims = (unsigned)idims.ndims();
         const dim_type *dims = idims.get();
@@ -40,38 +40,43 @@ namespace afcl
             throw(af::exception("Context mismatch between input \"buf\" and arrayfire"));
         }
 
+
+        if (retain) clerr = clRetainMemObject(buf);
+
         af_array out;
         af_err err = af_device_array(&out, buf, ndims, dims, type);
-        if (err != AF_SUCCESS) {
-            throw af::exception("Failed to create device array", __FILE__, __LINE__ - 2, err);
+
+        if (err != AF_SUCCESS || clerr != CL_SUCCESS) {
+            if (retain && clerr == CL_SUCCESS) clReleaseMemObject(buf);
+            throw af::exception("Failed to create device array");
         }
 
         return af::array(out);
     }
 
     static inline af::array array(dim_type dim0,
-                                  cl_mem buf, af::dtype type)
+                                  cl_mem buf, af::dtype type, bool retain=true)
     {
-        return afcl::array(af::dim4(dim0), buf, type);
+        return afcl::array(af::dim4(dim0), buf, type, retain);
     }
 
     static inline af::array array(dim_type dim0, dim_type dim1,
-                                  cl_mem buf, af::dtype type)
+                                  cl_mem buf, af::dtype type, bool retain=true)
     {
-        return afcl::array(af::dim4(dim0, dim1), buf, type);
+        return afcl::array(af::dim4(dim0, dim1), buf, type, retain);
     }
 
     static inline af::array array(dim_type dim0, dim_type dim1,
                                   dim_type dim2,
-                                  cl_mem buf, af::dtype type)
+                                  cl_mem buf, af::dtype type, bool retain=true)
     {
-        return afcl::array(af::dim4(dim0, dim1, dim2), buf, type);
+        return afcl::array(af::dim4(dim0, dim1, dim2), buf, type, retain);
     }
 
     static inline af::array array(dim_type dim0, dim_type dim1,
                                   dim_type dim2, dim_type dim3,
-                                  cl_mem buf, af::dtype type)
+                                  cl_mem buf, af::dtype type, bool retain=true)
     {
-        return afcl::array(af::dim4(dim0, dim1, dim2, dim3), buf, type);
+        return afcl::array(af::dim4(dim0, dim1, dim2, dim3), buf, type, retain);
     }
 }

--- a/include/af/opencl.h
+++ b/include/af/opencl.h
@@ -21,11 +21,11 @@
 
 namespace afcl
 {
-    AFAPI cl_context getContext();
-    AFAPI cl_command_queue getQueue();
+    AFAPI cl_context getContext(bool retain = false);
+    AFAPI cl_command_queue getQueue(bool retain = false);
     AFAPI cl_device_id getDeviceId();
 
-    static inline af::array array(af::dim4 idims, cl_mem buf, af::dtype type, bool retain=true)
+    static inline af::array array(af::dim4 idims, cl_mem buf, af::dtype type, bool retain=false)
     {
         const unsigned ndims = (unsigned)idims.ndims();
         const dim_type *dims = idims.get();
@@ -55,27 +55,27 @@ namespace afcl
     }
 
     static inline af::array array(dim_type dim0,
-                                  cl_mem buf, af::dtype type, bool retain=true)
+                                  cl_mem buf, af::dtype type, bool retain=false)
     {
         return afcl::array(af::dim4(dim0), buf, type, retain);
     }
 
     static inline af::array array(dim_type dim0, dim_type dim1,
-                                  cl_mem buf, af::dtype type, bool retain=true)
+                                  cl_mem buf, af::dtype type, bool retain=false)
     {
         return afcl::array(af::dim4(dim0, dim1), buf, type, retain);
     }
 
     static inline af::array array(dim_type dim0, dim_type dim1,
                                   dim_type dim2,
-                                  cl_mem buf, af::dtype type, bool retain=true)
+                                  cl_mem buf, af::dtype type, bool retain=false)
     {
         return afcl::array(af::dim4(dim0, dim1, dim2), buf, type, retain);
     }
 
     static inline af::array array(dim_type dim0, dim_type dim1,
                                   dim_type dim2, dim_type dim3,
-                                  cl_mem buf, af::dtype type, bool retain=true)
+                                  cl_mem buf, af::dtype type, bool retain=false)
     {
         return afcl::array(af::dim4(dim0, dim1, dim2, dim3), buf, type, retain);
     }

--- a/include/af/opencl.h
+++ b/include/af/opencl.h
@@ -40,13 +40,6 @@ namespace afcl
             throw(af::exception("Context mismatch between input \"buf\" and arrayfire"));
         }
 
-        cl_device_id device;
-        clerr = clGetContextInfo(context, CL_CONTEXT_DEVICES, sizeof(cl_device_id), &device, NULL);
-
-        if (device != getDeviceId()) {
-            throw(af::exception("device mismatch between input \"buf\" and arrayfire"));
-        }
-
         af_array out;
         af_err err = af_device_array(&out, buf, ndims, dims, type);
         if (err != AF_SUCCESS) {

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -330,14 +330,18 @@ void sync(int device)
 
 namespace afcl
 {
-    cl_context getContext()
+    cl_context getContext(bool retain)
     {
-        return opencl::getContext()();
+        cl_context ctx = opencl::getContext()();
+        if (retain) clRetainContext(ctx);
+        return ctx;
     }
 
-    cl_command_queue getQueue()
+    cl_command_queue getQueue(bool retain)
     {
-        return opencl::getQueue()();
+        cl_command_queue queue = opencl::getQueue()();
+        if (retain) clRetainCommandQueue(queue);
+        return queue;
     }
 
     cl_device_id getDeviceId()


### PR DESCRIPTION
Example:
```
af::array a = afcl::array(x, y, z, w, buf, f32);
```