### PR TITLE
Remove usage of max() in fftconvolve()

### DIFF
--- a/src/backend/cuda/kernel/fftconvolve.hpp
+++ b/src/backend/cuda/kernel/fftconvolve.hpp
@@ -393,7 +393,8 @@ void fftconvolve(Param<T> out,
         CUFFT_CHECK(cufftExecC2C(plan, (cufftComplex*)packed.ptr,
                                  (cufftComplex*)packed.ptr, CUFFT_FORWARD));
 
-    dim_type mul_elem = max(sig_packed_elem, filter_packed_elem) / 2;
+    dim_type mul_elem = (sig_packed_elem < filter_packed_elem) ?
+                        filter_packed_elem / 2 : sig_packed_elem / 2;
     blocks = dim3(divup(mul_elem, threads.x));
 
     // Multiply filter and signal FFT arrays

--- a/src/backend/opencl/kernel/fftconvolve.hpp
+++ b/src/backend/opencl/kernel/fftconvolve.hpp
@@ -198,7 +198,8 @@ void fftconvolve(Param out,
                                           0, NULL, NULL, &((*packed.data)()),
                                           NULL, NULL));
 
-        dim_type mul_elem = std::max(sig_packed_elem, filter_packed_elem) / 2;
+        dim_type mul_elem = (sig_packed_elem < filter_packed_elem) ?
+                            filter_packed_elem / 2 : sig_packed_elem / 2;
         blocks = divup(mul_elem, THREADS);
         global = NDRange(blocks * THREADS);
 


### PR DESCRIPTION
Should fix building issues on Windows