### PR TITLE
Fix race condition in reduce_first_kernel.

### DIFF
--- a/src/backend/cuda/kernel/reduce.hpp
+++ b/src/backend/cuda/kernel/reduce.hpp
@@ -226,6 +226,7 @@ namespace kernel
                 assign_vol(val2, s_ptr_vol + n);
                 tmp = reduce(val1, val2);
                 assign_vol(s_ptr_vol, tmp);
+                __syncthreads();
             }
         }
     }


### PR DESCRIPTION
I believe this fix should resolve issue #625.  It seems that a `__syncthreads()` was missing.