### PR TITLE
Ensure functions in err_common.cpp are not missing

### DIFF
--- a/src/api/c/err_common.cpp
+++ b/src/api/c/err_common.cpp
@@ -7,6 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <af/exception.h>
 #include <err_common.hpp>
 #include <type_util.hpp>
 #include <string>


### PR DESCRIPTION
Ensure af_get_last_error and af_err_to_string are exported by including the public header.
The header that declares this function as AFAPI (af/exception.h) was not included in err_common.cpp so the symbols were not visible in the compiled library.