### PR TITLE
Add support for s64 and u64 arrays

### DIFF
--- a/src/api/c/where.cpp
+++ b/src/api/c/where.cpp
@@ -38,6 +38,8 @@ af_err af_where(af_array *idx, const af_array in)
         case c64: res = where<cdouble>(in); break;
         case s32: res = where<int    >(in); break;
         case u32: res = where<uint   >(in); break;
+        case s64: res = where<intl   >(in); break;
+        case u64: res = where<uintl  >(in); break;
         case u8 : res = where<uchar  >(in); break;
         case b8 : res = where<char   >(in); break;
         default:

--- a/src/backend/cpu/where.cpp
+++ b/src/backend/cpu/where.cpp
@@ -68,6 +68,8 @@ namespace cpu
     INSTANTIATE(char   )
     INSTANTIATE(int    )
     INSTANTIATE(uint   )
+    INSTANTIATE(intl   )
+    INSTANTIATE(uintl  )
     INSTANTIATE(uchar  )
 
 }

--- a/src/backend/cuda/where.cu
+++ b/src/backend/cuda/where.cu
@@ -39,6 +39,8 @@ namespace cuda
     INSTANTIATE(char   )
     INSTANTIATE(int    )
     INSTANTIATE(uint   )
+    INSTANTIATE(intl   )
+    INSTANTIATE(uintl  )
     INSTANTIATE(uchar  )
 
 }

--- a/src/backend/opencl/where.cpp
+++ b/src/backend/opencl/where.cpp
@@ -42,6 +42,8 @@ namespace opencl
     INSTANTIATE(char   )
     INSTANTIATE(int    )
     INSTANTIATE(uint   )
+    INSTANTIATE(intl   )
+    INSTANTIATE(uintl  )
     INSTANTIATE(uchar  )
 
 }


### PR DESCRIPTION
Currently calling af::where() using an s64 or u64 array as first argument causes:
```Error(11): Function does not support this data type```
This pull request fixes that.

Also the return array has type u32, which is going to be a problem with large arrays. That should be looked into at some point, maybe sooner than later.
