### PR TITLE
Add AF_DISABLE_GRAPHICS to disable OpenCL window creation on init

### DIFF
--- a/src/api/c/graphics_common.cpp
+++ b/src/api/c/graphics_common.cpp
@@ -124,11 +124,15 @@ fg::Window* ForgeManager::getMainWindow(const bool dontCreate)
     static bool flag = true;
     static fg::Window* wnd = NULL;
 
-    if (flag && !dontCreate) {
-	    wnd = new fg::Window(WIDTH, HEIGHT, "ArrayFire", NULL, true);
-	    CheckGL("End ForgeManager::getMainWindow");
-	    flag = false;
-    };
+    // Define AF_DISABLE_GRAPHICS with any value to disable initialization
+    const char* noGraphicsENV = getenv("AF_DISABLE_GRAPHICS");
+    if(!noGraphicsENV) { // If AF_DISABLE_GRAPHICS is not defined
+        if (flag && !dontCreate) {
+            wnd = new fg::Window(WIDTH, HEIGHT, "ArrayFire", NULL, true);
+            CheckGL("End ForgeManager::getMainWindow");
+            flag = false;
+        };
+    }
     return wnd;
 }
 

--- a/src/api/cpp/graphics.cpp
+++ b/src/api/cpp/graphics.cpp
@@ -79,7 +79,7 @@ void Window::show()
 
 bool Window::close()
 {
-    bool temp;
+    bool temp = true;
     AF_THROW(af_is_window_closed(&temp, get()));
     return temp;
 }

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -162,12 +162,16 @@ DeviceManager::DeviceManager()
     /* loop over devices and replace contexts with
      * OpenGL shared contexts whereever applicable */
 #if defined(WITH_GRAPHICS)
-    try {
-        int devCount = mDevices.size();
-        fg::Window* wHandle = graphics::ForgeManager::getInstance().getMainWindow();
-        for(int i=0; i<devCount; ++i)
-            markDeviceForInterop(i, wHandle);
-    } catch (...) {
+    // Define AF_DISABLE_GRAPHICS with any value to disable initialization
+    const char* noGraphicsENV = getenv("AF_DISABLE_GRAPHICS");
+    if(!noGraphicsENV) { // If AF_DISABLE_GRAPHICS is not defined
+        try {
+            int devCount = mDevices.size();
+            fg::Window* wHandle = graphics::ForgeManager::getInstance().getMainWindow();
+            for(int i=0; i<devCount; ++i)
+                markDeviceForInterop(i, wHandle);
+        } catch (...) {
+        }
     }
 #endif
 }


### PR DESCRIPTION
* Disables windows creation which disables all other graphics calls
* This disables the initial windows creation for OpenGL-OpenCL context sharing.
* Any future window creation calls will only throw warnings
* This is only a hack to disable the creation that may give segmentation
  faults on some machines (the problem/solution are still unknown)