### PR TITLE
API consistency 

### DIFF
--- a/docs/details/algorithm.dox
+++ b/docs/details/algorithm.dox
@@ -49,7 +49,7 @@ Find the maximum values and their locations
 
 
 
-\defgroup reduce_func_alltrue alltrue
+\defgroup reduce_func_all_true alltrue
 
 \ingroup reduce_mat
 
@@ -59,7 +59,7 @@ Find if of all of the values in input are true
 
 
 
-\defgroup reduce_func_anytrue anytrue
+\defgroup reduce_func_any_true anytrue
 
 \ingroup reduce_mat
 

--- a/docs/details/image.dox
+++ b/docs/details/image.dox
@@ -231,7 +231,7 @@ the median value of the pixels covered by the kernel is returned.
 
 =======================================================================
 
-\defgroup image_func_meanshift meanshift
+\defgroup image_func_mean_shift meanshift
 \ingroup imageflt_mat
 
 \brief Meanshift Filter

--- a/docs/details/signal.dox
+++ b/docs/details/signal.dox
@@ -114,7 +114,34 @@ respectively, then the possible batch operations are as follows.
 | [m n p q] | [m n p 1] | Many to One | Output will be 4d array with 3rd dimension length as q - 1 filter applied to q inputs |
 | [m n p q] | [m n p q] | Many to Many| Output will be 4d array with 3rd dimension length as q - q filter applied to q inputs in one-to-one correspondence |
 
+===============================================================================
 
+\defgroup signal_func_fft_convolve fftConvolve
+\ingroup convolve_mat
+
+\brief Convolution using Fast Fourier Transform
+
+\copydoc signal_func_fft_convolve_desc
+
+===============================================================================
+
+\defgroup signal_func_fft_convolve2 fftConvolve2
+\ingroup convolve_mat
+
+\brief 2D Convolution using Fast Fourier Transform
+
+\copydoc signal_func_fft_convolve_desc
+
+===============================================================================
+
+\defgroup signal_func_fft_convolve3 fftConvolve3
+\ingroup convolve_mat
+
+\brief 3D Convolution using Fast Fourier Transform
+
+\copydoc signal_func_fft_convolve_desc
+
+===============================================================================
 
 \defgroup signal_func_fft fft
 \ingroup fft_mat

--- a/examples/financial/monte_carlo_options.cpp
+++ b/examples/financial/monte_carlo_options.cpp
@@ -34,7 +34,7 @@ static ty monte_carlo_barrier(int N, ty K, ty t, ty vol, ty r, ty strike, int st
     array S = product(join(1, s, randmat), 1);
 
     if (use_barrier) {
-        S = S * alltrue(S < B, 1);
+        S = S * allTrue(S < B, 1);
     }
 
     payoff = max(0.0, S - K);

--- a/include/af/algorithm.h
+++ b/include/af/algorithm.h
@@ -74,11 +74,11 @@ namespace af
        \param[in] dim The dimension along which the values are checked to be all true
        \return    result of checking if values along dimension \p dim are all true
 
-       \ingroup reduce_functrue
+       \ingroup reduce_func_all_true
 
        \note \p dim is -1 by default. -1 denotes the first non-signleton dimension.
     */
-    AFAPI array alltrue(const array &in, const int dim = -1);
+    AFAPI array allTrue(const array &in, const int dim = -1);
 
     /**
        C++ Interface for checking any true values in an array
@@ -87,11 +87,11 @@ namespace af
        \param[in] dim The dimension along which the values are checked to be any true
        \return    result of checking if values along dimension \p dim are any true
 
-       \ingroup reduce_func_anytrue
+       \ingroup reduce_func_any_true
 
        \note \p dim is -1 by default. -1 denotes the first non-signleton dimension.
     */
-    AFAPI array anytrue(const array &in, const int dim = -1);
+    AFAPI array anyTrue(const array &in, const int dim = -1);
 
     /**
        C++ Interface for counting non zero values in an array
@@ -152,9 +152,9 @@ namespace af
        \param[in] in is the input array
        \return    true if all values of \p in are true, false otherwise
 
-       \ingroup reduce_func_alltrue
+       \ingroup reduce_func_all_true
     */
-    template<typename T> T alltrue(const array &in);
+    template<typename T> T allTrue(const array &in);
 
     /**
        C++ Interface for checking if any values in an array are true
@@ -162,9 +162,9 @@ namespace af
        \param[in] in is the input array
        \return    true if any values of \p in are true, false otherwise
 
-       \ingroup reduce_func_anytrue
+       \ingroup reduce_func_any_true
     */
-    template<typename T> T anytrue(const array &in);
+    template<typename T> T anyTrue(const array &in);
 
     /**
        C++ Interface for counting total number of non zero values in an array
@@ -324,7 +324,7 @@ namespace af
 
        \ingroup set_func_unique
     */
-    AFAPI array setunique(const array &in, const bool is_sorted=false);
+    AFAPI array setUnique(const array &in, const bool is_sorted=false);
 
     /**
        C++ Interface for performing union of two arrays
@@ -336,7 +336,7 @@ namespace af
 
        \ingroup set_func_union
     */
-    AFAPI array setunion(const array &first, const array &second, const bool is_unique=false);
+    AFAPI array setUnion(const array &first, const array &second, const bool is_unique=false);
 
     /**
        C++ Interface for performing intersect of two arrays
@@ -348,7 +348,7 @@ namespace af
 
        \ingroup set_func_intersect
     */
-    AFAPI array setintersect(const array &first, const array &second, const bool is_unique=false);
+    AFAPI array setIntersect(const array &first, const array &second, const bool is_unique=false);
 }
 #endif
 
@@ -412,9 +412,9 @@ extern "C" {
        \param[in] dim The dimension along which the "and" operation occurs
        \return \ref AF_SUCCESS if the execution completes properly
 
-       \ingroup reduce_func_alltrue
+       \ingroup reduce_func_all_true
     */
-    AFAPI af_err af_alltrue(af_array *out, const af_array in, const int dim);
+    AFAPI af_err af_all_true(af_array *out, const af_array in, const int dim);
 
     /**
        C Interface for checking any true values in an array
@@ -424,9 +424,9 @@ extern "C" {
        \param[in] dim The dimension along which the "or" operation occurs
        \return \ref AF_SUCCESS if the execution completes properly
 
-       \ingroup reduce_func_anytrue
+       \ingroup reduce_func_any_true
     */
-    AFAPI af_err af_anytrue(af_array *out, const af_array in, const int dim);
+    AFAPI af_err af_any_true(af_array *out, const af_array in, const int dim);
 
     /**
        C Interface for counting non zero values in an array
@@ -506,9 +506,9 @@ extern "C" {
 
        \note \p imag is always set to 0.
 
-       \ingroup reduce_func_alltrue
+       \ingroup reduce_func_all_true
     */
-    AFAPI af_err af_alltrue_all(double *real, double *imag, const af_array in);
+    AFAPI af_err af_all_true_all(double *real, double *imag, const af_array in);
 
     /**
        C Interface for checking if any values in an array are true
@@ -520,9 +520,9 @@ extern "C" {
 
        \note \p imag is always set to 0.
 
-       \ingroup reduce_func_anytrue
+       \ingroup reduce_func_any_true
     */
-    AFAPI af_err af_anytrue_all(double *real, double *imag, const af_array in);
+    AFAPI af_err af_any_true_all(double *real, double *imag, const af_array in);
 
     /**
        C Interface for counting total number of non zero values in an array

--- a/include/af/compatible.h
+++ b/include/af/compatible.h
@@ -15,36 +15,52 @@ namespace af
 {
 class array;
 
+DEPRECATED("Use deviceCount instead")
 AFAPI int devicecount();
 
+DEPRECATED("Use deviceGet instead")
 AFAPI int deviceget();
 
+DEPRECATED("Use deviceSet instead")
 AFAPI void deviceset(const int device);
 
+DEPRECATED("Use loadImage instead")
 AFAPI array loadimage(const char* filename, const bool is_color=false);
 
+DEPRECATED("Use saveImage instead")
 AFAPI void saveimage(const char* filename, const array& in);
 
+DEPRECATED("Use gaussianKernel instead")
 AFAPI array gaussiankernel(const int rows, const int cols, const double sig_r = 0, const double sig_c = 0);
 
+DEPRECATED("Use allTrue instead")
 template<typename T> T alltrue(const array &in);
 
+DEPRECATED("Use anyTrue instead")
 template<typename T> T anytrue(const array &in);
 
+DEPRECATED("Use allTrue instead")
 AFAPI array alltrue(const array &in, const int dim = -1);
 
+DEPRECATED("Use anyTrue instead")
 AFAPI array anytrue(const array &in, const int dim = -1);
 
+DEPRECATED("Use setUnique instead")
 AFAPI array setunique(const array &in, const bool is_sorted=false);
 
+DEPRECATED("Use setUnion instead")
 AFAPI array setunion(const array &first, const array &second, const bool is_unique=false);
 
+DEPRECATED("Use setIntersect instead")
 AFAPI array setintersect(const array &first, const array &second, const bool is_unique=false);
 
+DEPRECATED("Use histEqual instead")
 AFAPI array histequal(const array& in, const array& hist);
 
+DEPRECATED("Use colorSpace instead")
 AFAPI array colorspace(const array& image, const CSpace to, const CSpace from);
 
+DEPRECATED("Use deviceInfo instead")
 AFAPI void deviceprop(char* d_name, char* d_platform, char *d_toolkit, char* d_compute);
 
 }

--- a/include/af/compatible.h
+++ b/include/af/compatible.h
@@ -27,6 +27,25 @@ AFAPI void saveimage(const char* filename, const array& in);
 
 AFAPI array gaussiankernel(const int rows, const int cols, const double sig_r = 0, const double sig_c = 0);
 
+template<typename T> T alltrue(const array &in);
+
+template<typename T> T anytrue(const array &in);
+
+AFAPI array alltrue(const array &in, const int dim = -1);
+
+AFAPI array anytrue(const array &in, const int dim = -1);
+
+AFAPI array setunique(const array &in, const bool is_sorted=false);
+
+AFAPI array setunion(const array &first, const array &second, const bool is_unique=false);
+
+AFAPI array setintersect(const array &first, const array &second, const bool is_unique=false);
+
+AFAPI array histequal(const array& in, const array& hist);
+
+AFAPI array colorspace(const array& image, const CSpace to, const CSpace from);
+
+AFAPI void deviceprop(char* d_name, char* d_platform, char *d_toolkit, char* d_compute);
 
 }
 #endif

--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -28,12 +28,14 @@
     #define snprintf sprintf_s
     #define STATIC_ static
     #define SIZE_T_FRMT_SPECIFIER "%Iu"
+    #define DEPRECATED(msg) __declspec(deprecated( msg ))
 #else
     #define AFAPI   __attribute__((visibility("default")))
     #include <stdbool.h>
     #define __PRETTY_FUNCTION__ __func__
     #define STATIC_ inline
     #define SIZE_T_FRMT_SPECIFIER "%zu"
+    #define DEPRECATED(msg) __attribute__((deprecated( msg )))
 #endif
 
 // Known 64-bit x86 and ARM architectures use long long

--- a/include/af/device.h
+++ b/include/af/device.h
@@ -29,16 +29,16 @@ namespace af
     */
 
     /**
-       \defgroup device_func_prop deviceprop
+       \defgroup device_func_prop deviceInfo
 
-       Get device properties
+       Get device information
 
        @{
 
        \ingroup arrayfire_func
        \ingroup device_mat
     */
-    AFAPI void deviceprop(char* d_name, char* d_platform, char *d_toolkit, char* d_compute);
+    AFAPI void deviceInfo(char* d_name, char* d_platform, char *d_toolkit, char* d_compute);
     /**
        @}
     */
@@ -227,9 +227,9 @@ extern "C" {
     AFAPI af_err af_init();
 
     /**
-       \ingroup device_func_prop
+       \ingroup device_func_info
     */
-    AFAPI af_err af_deviceprop(char* d_name, char* d_platform, char *d_toolkit, char* d_compute);
+    AFAPI af_err af_device_info(char* d_name, char* d_platform, char *d_toolkit, char* d_compute);
 
     /**
        \ingroup device_func_count

--- a/include/af/image.h
+++ b/include/af/image.h
@@ -201,7 +201,7 @@ AFAPI array histogram(const array &in, const unsigned nbins, const double minval
 AFAPI array histogram(const array &in, const unsigned nbins);
 
 /**
-    C++ Interface for meanshift
+    C++ Interface for mean shift
 
     \param[in]  in array is the input image
     \param[in]  spatial_sigma is the spatial variance paramter that decides the filter window
@@ -210,9 +210,9 @@ AFAPI array histogram(const array &in, const unsigned nbins);
     \param[in]  is_color indicates if the input \p in is color image or grayscale
     \return     the processed image
 
-    \ingroup image_func_meanshift
+    \ingroup image_func_mean_shift
 */
-AFAPI array meanshift(const array& in, const float spatial_sigma, const float chromatic_sigma, const unsigned iter, const bool is_color=false);
+AFAPI array meanShift(const array& in, const float spatial_sigma, const float chromatic_sigma, const unsigned iter, const bool is_color=false);
 
 /**
     C++ Interface for median filter
@@ -244,7 +244,7 @@ AFAPI array medfilt(const array& in, const dim_t wind_length = 3, const dim_t wi
 AFAPI array dilate(const array& in, const array& mask);
 
 /**
-    C++ Interface for 3d image dilation
+    C++ Interface for 3D image dilation
 
     \param[in]  in array is the input volume
     \param[in]  mask is the neighborhood delta volume
@@ -252,7 +252,7 @@ AFAPI array dilate(const array& in, const array& mask);
 
     \ingroup image_func_dilate3d
 */
-AFAPI array dilate3d(const array& in, const array& mask);
+AFAPI array dilate3(const array& in, const array& mask);
 
 /**
     C++ Interface for image erosion (min filter)
@@ -276,7 +276,7 @@ AFAPI array erode(const array& in, const array& mask);
 
     \ingroup image_func_erode3d
 */
-AFAPI array erode3d(const array& in, const array& mask);
+AFAPI array erode3(const array& in, const array& mask);
 
 /**
     C++ Interface for getting regions in an image
@@ -448,7 +448,7 @@ AFAPI array rgb2hsv(const array& in);
 
    \ingroup image_func_colorspace
  */
-AFAPI array colorspace(const array& image, const CSpace to, const CSpace from);
+AFAPI array colorSpace(const array& image, const CSpace to, const CSpace from);
 
 }
 #endif
@@ -640,7 +640,7 @@ extern "C" {
 
         \ingroup image_func_dilate3d
     */
-    AFAPI af_err af_dilate3d(af_array *out, const af_array in, const af_array mask);
+    AFAPI af_err af_dilate3(af_array *out, const af_array in, const af_array mask);
 
     /**
         C Interface for image erosion (min filter)
@@ -668,7 +668,7 @@ extern "C" {
 
         \ingroup image_func_erode3d
     */
-    AFAPI af_err af_erode3d(af_array *out, const af_array in, const af_array mask);
+    AFAPI af_err af_erode3(af_array *out, const af_array in, const af_array mask);
 
     /**
         C Interface for bilateral filter
@@ -697,9 +697,9 @@ extern "C" {
         \return     \ref AF_SUCCESS if the filter is applied successfully,
         otherwise an appropriate error code is returned.
 
-        \ingroup image_func_meanshift
+        \ingroup image_func_mean_shift
     */
-    AFAPI af_err af_meanshift(af_array *out, const af_array in, const float spatial_sigma, const float chromatic_sigma, const unsigned iter, const bool is_color);
+    AFAPI af_err af_mean_shift(af_array *out, const af_array in, const float spatial_sigma, const float chromatic_sigma, const unsigned iter, const bool is_color);
 
     /**
         C Interface for median filter
@@ -769,8 +769,8 @@ extern "C" {
     /**
        C Interface for converting RGB to gray
 
-       \param[out] out is an array in target colorspace
-       \param[in]  in is an array in the RGB colorspace
+       \param[out] out is an array in target color space
+       \param[in]  in is an array in the RGB color space
        \param[in]  rPercent is percentage of red channel value contributing to grayscale intensity
        \param[in]  gPercent is percentage of green channel value contributing to grayscale intensity
        \param[in]  bPercent is percentage of blue channel value contributing to grayscale intensity
@@ -786,8 +786,8 @@ extern "C" {
     /**
        C Interface for converting gray to RGB
 
-       \param[out] out is an array in target colorspace
-       \param[in]  in is an array in the Grayscale colorspace
+       \param[out] out is an array in target color space
+       \param[in]  in is an array in the Grayscale color space
        \param[in]  rFactor is percentage of intensity value contributing to red channel
        \param[in]  gFactor is percentage of intensity value contributing to green channel
        \param[in]  bFactor is percentage of intensity value contributing to blue channel
@@ -835,8 +835,8 @@ extern "C" {
     /**
        C Interface for converting HSV to RGB
 
-       \param[out] out is an array in the RGB colorspace
-       \param[in]  in is an array in the HSV colorspace
+       \param[out] out is an array in the RGB color space
+       \param[in]  in is an array in the HSV color space
        \return     \ref AF_SUCCESS if the color transformation is successful,
        otherwise an appropriate error code is returned.
 
@@ -849,8 +849,8 @@ extern "C" {
     /**
        C Interface for converting RGB to HSV
 
-       \param[out] out is an array in the HSV colorspace
-       \param[in]  in is an array in the RGB colorspace
+       \param[out] out is an array in the HSV color space
+       \param[in]  in is an array in the RGB color space
        \return     \ref AF_SUCCESS if the color transformation is successful,
        otherwise an appropriate error code is returned.
 
@@ -861,13 +861,13 @@ extern "C" {
     AFAPI af_err af_rgb2hsv(af_array* out, const af_array in);
 
     /**
-       C Interface wrapper for colorspace conversion
+       C Interface wrapper for color space conversion
 
-       \param[out] out is an array in target colorspace \param[in]  image is
+       \param[out] out is an array in target color space \param[in]  image is
        the input array
 
-       \param[in]  to is the target array colorspace \param[in]
-       from is the input array colorspace
+       \param[in]  to is the target array color space \param[in]
+       from is the input array color space
 
        \return     \ref AF_SUCCESS if the color transformation is successful,
        otherwise an appropriate error code
@@ -879,7 +879,7 @@ extern "C" {
 
        \ingroup image_func_colorspace
     */
-    AFAPI af_err af_colorspace(af_array *out, const af_array image, const af_cspace_t to, const af_cspace_t from);
+    AFAPI af_err af_color_space(af_array *out, const af_array image, const af_cspace_t to, const af_cspace_t from);
 
 #ifdef __cplusplus
 }

--- a/include/af/image.h
+++ b/include/af/image.h
@@ -395,7 +395,7 @@ AFAPI array gray2rgb(const array& in, const float rFactor=1.0, const float gFact
 
    \ingroup image_func_histequal
  */
-AFAPI array histequal(const array& in, const array& hist);
+AFAPI array histEqual(const array& in, const array& hist);
 
 /**
    C++ Interface for generating gausian kernels
@@ -813,7 +813,7 @@ extern "C" {
 
        \ingroup image_func_histequal
     */
-    AFAPI af_err af_histequal(af_array *out, const af_array in, const af_array hist);
+    AFAPI af_err af_hist_equal(af_array *out, const af_array in, const af_array hist);
 
     /**
        C Interface generating gaussian kernels

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -396,9 +396,9 @@ AFAPI array convolve3(const array& signal, const array& filter, const convMode m
    \param[in]  mode indicates if the convolution should be expanded or not(where output size equals input).
    \return     the convolved array
 
-   \ingroup signal_func_fftconvolve
+   \ingroup signal_func_fft_convolve
  */
-AFAPI array fftconvolve(const array& signal, const array& filter, const convMode mode=AF_CONV_DEFAULT);
+AFAPI array fftConvolve(const array& signal, const array& filter, const convMode mode=AF_CONV_DEFAULT);
 
 /**
    C++ Interface for convolution on one dimensional data
@@ -408,9 +408,9 @@ AFAPI array fftconvolve(const array& signal, const array& filter, const convMode
    \param[in]  mode indicates if the convolution should be expanded or not(where output size equals input).
    \return     the convolved array
 
-   \ingroup signal_func_fftconvolve1
+   \ingroup signal_func_fft_convolve1
  */
-AFAPI array fftconvolve1(const array& signal, const array& filter, const convMode mode=AF_CONV_DEFAULT);
+AFAPI array fftConvolve1(const array& signal, const array& filter, const convMode mode=AF_CONV_DEFAULT);
 
 /**
    C++ Interface for convolution on two dimensional data
@@ -420,9 +420,9 @@ AFAPI array fftconvolve1(const array& signal, const array& filter, const convMod
    \param[in]  mode indicates if the convolution should be expanded or not(where output size equals input).
    \return     the convolved array
 
-   \ingroup signal_func_fftconvolve2
+   \ingroup signal_func_fft_convolve2
  */
-AFAPI array fftconvolve2(const array& signal, const array& filter, const convMode mode=AF_CONV_DEFAULT);
+AFAPI array fftConvolve2(const array& signal, const array& filter, const convMode mode=AF_CONV_DEFAULT);
 
 /**
    C++ Interface for convolution on three dimensional data
@@ -434,7 +434,7 @@ AFAPI array fftconvolve2(const array& signal, const array& filter, const convMod
 
    \ingroup signal_func_fftconvolve3
  */
-AFAPI array fftconvolve3(const array& signal, const array& filter, const convMode mode=AF_CONV_DEFAULT);
+AFAPI array fftConvolve3(const array& signal, const array& filter, const convMode mode=AF_CONV_DEFAULT);
 
 /**
    C++ Interface for finite impulse response  filter
@@ -672,9 +672,9 @@ AFAPI af_err af_convolve2_sep(af_array *out, const af_array col_filter, const af
    \return     \ref AF_SUCCESS if the convolution is successful,
                otherwise an appropriate error code is returned.
 
-   \ingroup signal_func_fftconvolve1
+   \ingroup signal_func_fft_convolve1
  */
-AFAPI af_err af_fftconvolve1(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode);
+AFAPI af_err af_fft_convolve1(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode);
 
 /**
    C Interface for FFT-based convolution on two dimensional data
@@ -686,9 +686,9 @@ AFAPI af_err af_fftconvolve1(af_array *out, const af_array signal, const af_arra
    \return     \ref AF_SUCCESS if the convolution is successful,
                otherwise an appropriate error code is returned.
 
-   \ingroup signal_func_fftconvolve2
+   \ingroup signal_func_fft_convolve2
  */
-AFAPI af_err af_fftconvolve2(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode);
+AFAPI af_err af_fft_convolve2(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode);
 
 /**
    C Interface for FFT-based convolution on three dimensional data
@@ -700,9 +700,9 @@ AFAPI af_err af_fftconvolve2(af_array *out, const af_array signal, const af_arra
    \return     \ref AF_SUCCESS if the convolution is successful,
                otherwise an appropriate error code is returned.
 
-   \ingroup signal_func_fftconvolve3
+   \ingroup signal_func_fft_convolve3
  */
-AFAPI af_err af_fftconvolve3(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode);
+AFAPI af_err af_fft_convolve3(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode);
 
 /**
    C++ Interface for finite impulse response  filter

--- a/src/api/c/colorspace.cpp
+++ b/src/api/c/colorspace.cpp
@@ -11,7 +11,7 @@
 #include <af/image.h>
 #include <err_common.hpp>
 
-af_err af_colorspace(af_array *out, const af_array image, const af_cspace_t to, const af_cspace_t from)
+af_err af_color_space(af_array *out, const af_array image, const af_cspace_t to, const af_cspace_t from)
 {
     bool hsv2rgb  = (from==AF_HSV  && to==AF_RGB );
     bool rgb2hsv  = (from==AF_RGB  && to==AF_HSV );

--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -174,7 +174,7 @@ af_err af_convolve1(af_array *out, const af_array signal, const af_array filter,
 {
     try {
         if (isFreqDomain<1>(signal, filter, domain))
-            return af_fftconvolve1(out, signal, filter, mode);
+            return af_fft_convolve1(out, signal, filter, mode);
     } CATCHALL;
 
     if (mode == AF_CONV_EXPAND)
@@ -187,7 +187,7 @@ af_err af_convolve2(af_array *out, const af_array signal, const af_array filter,
 {
     try {
         if (isFreqDomain<2>(signal, filter, domain))
-            return af_fftconvolve2(out, signal, filter, mode);
+            return af_fft_convolve2(out, signal, filter, mode);
     } CATCHALL;
 
     if (mode == AF_CONV_EXPAND)
@@ -200,7 +200,7 @@ af_err af_convolve3(af_array *out, const af_array signal, const af_array filter,
 {
     try {
         if (isFreqDomain<3>(signal, filter, domain))
-            return af_fftconvolve3(out, signal, filter, mode);
+            return af_fft_convolve3(out, signal, filter, mode);
     } CATCHALL;
 
     if (mode == AF_CONV_EXPAND)

--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -36,7 +36,7 @@ af_err af_info()
     return AF_SUCCESS;
 }
 
-af_err af_deviceprop(char* d_name, char* d_platform, char *d_toolkit, char* d_compute)
+af_err af_device_info(char* d_name, char* d_platform, char *d_toolkit, char* d_compute)
 {
     try {
         devprop(d_name, d_platform, d_toolkit, d_compute);

--- a/src/api/c/fftconvolve.cpp
+++ b/src/api/c/fftconvolve.cpp
@@ -109,7 +109,7 @@ af_array fftconvcplx(const af_array signal, const af_array filter, bool expand,
 }
 
 template<dim_t baseDim>
-af_err fftconvolve(af_array *out, const af_array signal, const af_array filter, const bool expand)
+af_err fft_convolve(af_array *out, const af_array signal, const af_array filter, const bool expand)
 {
     try {
         ArrayInfo sInfo = getInfo(signal);
@@ -143,17 +143,17 @@ af_err fftconvolve(af_array *out, const af_array signal, const af_array filter, 
     return AF_SUCCESS;
 }
 
-af_err af_fftconvolve1(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode)
+af_err af_fft_convolve1(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode)
 {
-    return fftconvolve<1>(out, signal, filter, mode == AF_CONV_EXPAND);
+    return fft_convolve<1>(out, signal, filter, mode == AF_CONV_EXPAND);
 }
 
-af_err af_fftconvolve2(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode)
+af_err af_fft_convolve2(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode)
 {
-    return fftconvolve<2>(out, signal, filter, mode == AF_CONV_EXPAND);
+    return fft_convolve<2>(out, signal, filter, mode == AF_CONV_EXPAND);
 }
 
-af_err af_fftconvolve3(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode)
+af_err af_fft_convolve3(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode)
 {
-    return fftconvolve<3>(out, signal, filter, mode == AF_CONV_EXPAND);
+    return fft_convolve<3>(out, signal, filter, mode == AF_CONV_EXPAND);
 }

--- a/src/api/c/histeq.cpp
+++ b/src/api/c/histeq.cpp
@@ -23,7 +23,7 @@
 using namespace detail;
 
 template<typename T, typename hType>
-static af_array histequal(const af_array& in, const af_array& hist)
+static af_array hist_equal(const af_array& in, const af_array& hist)
 {
     const Array<T> input = getArray<T>(in);
 
@@ -59,7 +59,7 @@ static af_array histequal(const af_array& in, const af_array& hist)
     return getHandle<T>(result);
 }
 
-af_err af_histequal(af_array *out, const af_array in, const af_array hist)
+af_err af_hist_equal(af_array *out, const af_array in, const af_array hist)
 {
     try {
         ArrayInfo dataInfo = getInfo(in);
@@ -72,11 +72,11 @@ af_err af_histequal(af_array *out, const af_array in, const af_array hist)
 
         af_array output = 0;
         switch(dataType) {
-            case f64: output = histequal<double, uint>(in, hist); break;
-            case f32: output = histequal<float , uint>(in, hist); break;
-            case s32: output = histequal<int   , uint>(in, hist); break;
-            case u32: output = histequal<uint  , uint>(in, hist); break;
-            case u8 : output = histequal<uchar , uint>(in, hist); break;
+            case f64: output = hist_equal<double, uint>(in, hist); break;
+            case f32: output = hist_equal<float , uint>(in, hist); break;
+            case s32: output = hist_equal<int   , uint>(in, hist); break;
+            case u32: output = hist_equal<uint  , uint>(in, hist); break;
+            case u8 : output = hist_equal<uchar , uint>(in, hist); break;
             default : TYPE_ERROR(1, dataType);
         }
         std::swap(*out,output);

--- a/src/api/c/meanshift.cpp
+++ b/src/api/c/meanshift.cpp
@@ -19,13 +19,13 @@ using af::dim4;
 using namespace detail;
 
 template<typename T, bool is_color>
-static inline af_array meanshift(const af_array &in, const float &s_sigma, const float &c_sigma, const unsigned iter)
+static inline af_array mean_shift(const af_array &in, const float &s_sigma, const float &c_sigma, const unsigned iter)
 {
     return getHandle(meanshift<T, is_color>(getArray<T>(in), s_sigma, c_sigma, iter));
 }
 
 template<bool is_color>
-af_err meanshift(af_array *out, const af_array in, const float s_sigma, const float c_sigma, const unsigned iter)
+af_err mean_shift(af_array *out, const af_array in, const float s_sigma, const float c_sigma, const unsigned iter)
 {
     try {
         ARG_ASSERT(2, (s_sigma>=0));
@@ -41,12 +41,12 @@ af_err meanshift(af_array *out, const af_array in, const float s_sigma, const fl
 
         af_array output;
         switch(type) {
-            case f32: output = meanshift<float , is_color>(in, s_sigma, c_sigma, iter); break;
-            case f64: output = meanshift<double, is_color>(in, s_sigma, c_sigma, iter); break;
-            case b8 : output = meanshift<char  , is_color>(in, s_sigma, c_sigma, iter); break;
-            case s32: output = meanshift<int   , is_color>(in, s_sigma, c_sigma, iter); break;
-            case u32: output = meanshift<uint  , is_color>(in, s_sigma, c_sigma, iter); break;
-            case u8 : output = meanshift<uchar , is_color>(in, s_sigma, c_sigma, iter); break;
+            case f32: output = mean_shift<float , is_color>(in, s_sigma, c_sigma, iter); break;
+            case f64: output = mean_shift<double, is_color>(in, s_sigma, c_sigma, iter); break;
+            case b8 : output = mean_shift<char  , is_color>(in, s_sigma, c_sigma, iter); break;
+            case s32: output = mean_shift<int   , is_color>(in, s_sigma, c_sigma, iter); break;
+            case u32: output = mean_shift<uint  , is_color>(in, s_sigma, c_sigma, iter); break;
+            case u8 : output = mean_shift<uchar , is_color>(in, s_sigma, c_sigma, iter); break;
             default : TYPE_ERROR(1, type);
         }
         std::swap(*out,output);
@@ -56,10 +56,10 @@ af_err meanshift(af_array *out, const af_array in, const float s_sigma, const fl
     return AF_SUCCESS;
 }
 
-af_err af_meanshift(af_array *out, const af_array in, const float spatial_sigma, const float chromatic_sigma, const unsigned iter, const bool is_color)
+af_err af_mean_shift(af_array *out, const af_array in, const float spatial_sigma, const float chromatic_sigma, const unsigned iter, const bool is_color)
 {
     if (is_color)
-        return meanshift<true >(out, in, spatial_sigma, chromatic_sigma, iter);
+        return mean_shift<true >(out, in, spatial_sigma, chromatic_sigma, iter);
     else
-        return meanshift<false>(out, in, spatial_sigma, chromatic_sigma, iter);
+        return mean_shift<false>(out, in, spatial_sigma, chromatic_sigma, iter);
 }

--- a/src/api/c/morph.cpp
+++ b/src/api/c/morph.cpp
@@ -109,12 +109,12 @@ af_err af_erode(af_array *out, const af_array in, const af_array mask)
     return morph<false>(out,in,mask);
 }
 
-af_err af_dilate3d(af_array *out, const af_array in, const af_array mask)
+af_err af_dilate3(af_array *out, const af_array in, const af_array mask)
 {
     return morph3d<true>(out,in,mask);
 }
 
-af_err af_erode3d(af_array *out, const af_array in, const af_array mask)
+af_err af_erode3(af_array *out, const af_array in, const af_array mask)
 {
     return morph3d<false>(out,in,mask);
 }

--- a/src/api/c/reduce.cpp
+++ b/src/api/c/reduce.cpp
@@ -164,12 +164,12 @@ af_err af_count(af_array *out, const af_array in, const int dim)
     return reduce_type<af_notzero_t, uint>(out, in, dim);
 }
 
-af_err af_alltrue(af_array *out, const af_array in, const int dim)
+af_err af_all_true(af_array *out, const af_array in, const int dim)
 {
     return reduce_type<af_and_t, uchar>(out, in, dim);
 }
 
-af_err af_anytrue(af_array *out, const af_array in, const int dim)
+af_err af_any_true(af_array *out, const af_array in, const int dim)
 {
     return reduce_type<af_or_t, uchar>(out, in, dim);
 }
@@ -327,12 +327,12 @@ af_err af_count_all(double *real, double *imag, const af_array in)
     return reduce_all_type<af_notzero_t, uint>(real, imag, in);
 }
 
-af_err af_alltrue_all(double *real, double *imag, const af_array in)
+af_err af_all_true_all(double *real, double *imag, const af_array in)
 {
     return reduce_all_type<af_and_t, uchar>(real, imag, in);
 }
 
-af_err af_anytrue_all(double *real, double *imag, const af_array in)
+af_err af_any_true_all(double *real, double *imag, const af_array in)
 {
     return reduce_all_type<af_or_t, uchar>(real, imag, in);
 }

--- a/src/api/cpp/colorspace.cpp
+++ b/src/api/cpp/colorspace.cpp
@@ -15,10 +15,10 @@
 namespace af
 {
 
-array colorspace(const array& image, const CSpace to, const CSpace from)
+array colorSpace(const array& image, const CSpace to, const CSpace from)
 {
     af_array temp = 0;
-    AF_THROW(af_colorspace(&temp, image.get(), to ,from));
+    AF_THROW(af_color_space(&temp, image.get(), to ,from));
     return array(temp);
 }
 

--- a/src/api/cpp/colorspace.cpp
+++ b/src/api/cpp/colorspace.cpp
@@ -9,11 +9,17 @@
 
 #include <af/defines.h>
 #include <af/image.h>
+#include <af/compatible.h>
 #include <af/array.h>
 #include "error.hpp"
 
 namespace af
 {
+
+array colorspace(const array& image, const CSpace to, const CSpace from)
+{
+    return colorSpace(image, to, from);
+}
 
 array colorSpace(const array& image, const CSpace to, const CSpace from)
 {

--- a/src/api/cpp/device.cpp
+++ b/src/api/cpp/device.cpp
@@ -19,6 +19,10 @@ namespace af
         AF_THROW(af_info());
     }
 
+    void deviceprop(char* d_name, char* d_platform, char *d_toolkit, char* d_compute)
+    {
+        deviceInfo(d_name, d_platform, d_toolkit, d_compute);
+    }
     void deviceInfo(char* d_name, char* d_platform, char *d_toolkit, char* d_compute)
     {
         AF_THROW(af_device_info(d_name, d_platform, d_toolkit, d_compute));

--- a/src/api/cpp/device.cpp
+++ b/src/api/cpp/device.cpp
@@ -19,9 +19,9 @@ namespace af
         AF_THROW(af_info());
     }
 
-    void deviceprop(char* d_name, char* d_platform, char *d_toolkit, char* d_compute)
+    void deviceInfo(char* d_name, char* d_platform, char *d_toolkit, char* d_compute)
     {
-        AF_THROW(af_deviceprop(d_name, d_platform, d_toolkit, d_compute));
+        AF_THROW(af_device_info(d_name, d_platform, d_toolkit, d_compute));
     }
 
     int getDeviceCount()

--- a/src/api/cpp/fftconvolve.cpp
+++ b/src/api/cpp/fftconvolve.cpp
@@ -15,37 +15,37 @@
 namespace af
 {
 
-array fftconvolve(const array& signal, const array& filter, const convMode mode)
+array fftConvolve(const array& signal, const array& filter, const convMode mode)
 {
     unsigned sN = signal.numdims();
     unsigned fN = filter.numdims();
 
     switch(std::min(sN,fN)) {
-        case 1:  return fftconvolve1(signal, filter, mode);
-        case 2:  return fftconvolve2(signal, filter, mode);
-        case 3:  return fftconvolve3(signal, filter, mode);
-        default: return fftconvolve3(signal, filter, mode);
+        case 1:  return fftConvolve1(signal, filter, mode);
+        case 2:  return fftConvolve2(signal, filter, mode);
+        case 3:  return fftConvolve3(signal, filter, mode);
+        default: return fftConvolve3(signal, filter, mode);
     }
 }
 
-array fftconvolve1(const array& signal, const array& filter, const convMode mode)
+array fftConvolve1(const array& signal, const array& filter, const convMode mode)
 {
     af_array out = 0;
-    AF_THROW(af_fftconvolve1(&out, signal.get(), filter.get(), mode));
+    AF_THROW(af_fft_convolve1(&out, signal.get(), filter.get(), mode));
     return array(out);
 }
 
-array fftconvolve2(const array& signal, const array& filter, const convMode mode)
+array fftConvolve2(const array& signal, const array& filter, const convMode mode)
 {
     af_array out = 0;
-    AF_THROW(af_fftconvolve2(&out, signal.get(), filter.get(), mode));
+    AF_THROW(af_fft_convolve2(&out, signal.get(), filter.get(), mode));
     return array(out);
 }
 
-array fftconvolve3(const array& signal, const array& filter, const convMode mode)
+array fftConvolve3(const array& signal, const array& filter, const convMode mode)
 {
     af_array out = 0;
-    AF_THROW(af_fftconvolve3(&out, signal.get(), filter.get(), mode));
+    AF_THROW(af_fft_convolve3(&out, signal.get(), filter.get(), mode));
     return array(out);
 }
 

--- a/src/api/cpp/histogram.cpp
+++ b/src/api/cpp/histogram.cpp
@@ -29,10 +29,10 @@ array histogram(const array &in, const unsigned nbins)
     return array(out);
 }
 
-array histequal(const array& in, const array& hist)
+array histEqual(const array& in, const array& hist)
 {
     af_array temp = 0;
-    AF_THROW(af_histequal(&temp, in.get(), hist.get()));
+    AF_THROW(af_hist_equal(&temp, in.get(), hist.get()));
     return array(temp);
 }
 

--- a/src/api/cpp/histogram.cpp
+++ b/src/api/cpp/histogram.cpp
@@ -9,6 +9,7 @@
 
 #include <af/image.h>
 #include <af/algorithm.h>
+#include <af/compatible.h>
 #include <af/array.h>
 #include "error.hpp"
 
@@ -29,6 +30,7 @@ array histogram(const array &in, const unsigned nbins)
     return array(out);
 }
 
+array histequal(const array& in, const array& hist) { return histEqual(in, hist); }
 array histEqual(const array& in, const array& hist)
 {
     af_array temp = 0;

--- a/src/api/cpp/meanshift.cpp
+++ b/src/api/cpp/meanshift.cpp
@@ -14,10 +14,10 @@
 namespace af
 {
 
-array meanshift(const array& in, const float spatial_sigma, const float chromatic_sigma, const unsigned iter, const bool is_color)
+array meanShift(const array& in, const float spatial_sigma, const float chromatic_sigma, const unsigned iter, const bool is_color)
 {
     af_array out = 0;
-    AF_THROW(af_meanshift(&out, in.get(), spatial_sigma, chromatic_sigma, iter, is_color));
+    AF_THROW(af_mean_shift(&out, in.get(), spatial_sigma, chromatic_sigma, iter, is_color));
     return array(out);
 }
 

--- a/src/api/cpp/morph.cpp
+++ b/src/api/cpp/morph.cpp
@@ -21,10 +21,10 @@ array dilate(const array& in, const array& mask)
     return array(out);
 }
 
-array dilate3d(const array& in, const array& mask)
+array dilate3(const array& in, const array& mask)
 {
     af_array out = 0;
-    AF_THROW(af_dilate3d(&out, in.get(), mask.get()));
+    AF_THROW(af_dilate3(&out, in.get(), mask.get()));
     return array(out);
 }
 
@@ -35,10 +35,10 @@ array erode(const array& in, const array& mask)
     return array(out);
 }
 
-array erode3d(const array& in, const array& mask)
+array erode3(const array& in, const array& mask)
 {
     af_array out = 0;
-    AF_THROW(af_erode3d(&out, in.get(), mask.get()));
+    AF_THROW(af_erode3(&out, in.get(), mask.get()));
     return array(out);
 }
 

--- a/src/api/cpp/reduce.cpp
+++ b/src/api/cpp/reduce.cpp
@@ -9,6 +9,7 @@
 
 #include <af/array.h>
 #include <af/algorithm.h>
+#include <af/compatible.h>
 #include "error.hpp"
 #include "common.hpp"
 
@@ -42,6 +43,8 @@ namespace af
         return array(out);
     }
 
+    // 2.1 compatibility
+    array alltrue(const array &in, const int dim) { return allTrue(in, dim); }
     array allTrue(const array &in, const int dim)
     {
         af_array out = 0;
@@ -49,6 +52,8 @@ namespace af
         return array(out);
     }
 
+    // 2.1 compatibility
+    array anytrue(const array &in, const int dim) { return anyTrue(in, dim); }
     array anyTrue(const array &in, const int dim)
     {
         af_array out = 0;
@@ -81,23 +86,23 @@ namespace af
         idx = array(loc);
     }
 
-#define INSTANTIATE_REAL(fnC, fnCPP, T)                             \
+#define INSTANTIATE_REAL(fnC, fnCPP, T)                     \
     template<> AFAPI                                        \
-    T fnCPP(const array &in)                                   \
+    T fnCPP(const array &in)                                \
     {                                                       \
         double rval, ival;                                  \
-        AF_THROW(af_##fnC##_all(&rval, &ival, in.get()));    \
+        AF_THROW(af_##fnC##_all(&rval, &ival, in.get()));   \
         return (T)(rval);                                   \
     }                                                       \
 
 
-#define INSTANTIATE_CPLX(fnC, fnCPP, T, Tr)                         \
+#define INSTANTIATE_CPLX(fnC, fnCPP, T, Tr)                 \
     template<> AFAPI                                        \
-    T fnCPP(const array &in)                                   \
+    T fnCPP(const array &in)                                \
     {                                                       \
         double rval, ival;                                  \
-        AF_THROW(af_##fnC##_all(&rval, &ival, in.get()));    \
-        T out((Tr)rval, (Tr)ival);                       \
+        AF_THROW(af_##fnC##_all(&rval, &ival, in.get()));   \
+        T out((Tr)rval, (Tr)ival);                          \
         return out;                                         \
     }                                                       \
 
@@ -130,6 +135,33 @@ namespace af
 #undef INSTANTIATE_REAL
 #undef INSTANTIATE_CPLX
 
+#define INSTANTIATE_COMPAT(fnCPP, fnCompat, T)              \
+    template<> AFAPI                                        \
+    T fnCompat(const array &in)                             \
+    {                                                       \
+        return fnCPP<T>(in);                                      \
+    }
+
+#define INSTANTIATE(fnCPP, fnCompat)                            \
+    INSTANTIATE_COMPAT(fnCPP, fnCompat, float)                  \
+    INSTANTIATE_COMPAT(fnCPP, fnCompat, double)                 \
+    INSTANTIATE_COMPAT(fnCPP, fnCompat, int)                    \
+    INSTANTIATE_COMPAT(fnCPP, fnCompat, unsigned)               \
+    INSTANTIATE_COMPAT(fnCPP, fnCompat, long)                   \
+    INSTANTIATE_COMPAT(fnCPP, fnCompat, unsigned long)          \
+    INSTANTIATE_COMPAT(fnCPP, fnCompat, long long)              \
+    INSTANTIATE_COMPAT(fnCPP, fnCompat, unsigned long long)     \
+    INSTANTIATE_COMPAT(fnCPP, fnCompat, char)                   \
+    INSTANTIATE_COMPAT(fnCPP, fnCompat, unsigned char)          \
+    INSTANTIATE_COMPAT(fnCPP, fnCompat, af_cfloat)              \
+    INSTANTIATE_COMPAT(fnCPP, fnCompat, af_cdouble)             \
+
+    INSTANTIATE(allTrue, alltrue)
+    INSTANTIATE(anyTrue, anytrue)
+
+#undef INSTANTIATE
+#undef INSTANTIATE_COMPAT
+
 #define INSTANTIATE_REAL(fn, T)                                 \
     template<> AFAPI                                            \
     void fn(T *val, unsigned *idx, const array &in)             \
@@ -146,7 +178,7 @@ namespace af
     {                                                           \
         double rval, ival;                                      \
         AF_THROW(af_i##fn##_all(&rval, &ival, idx, in.get()));  \
-        *val = T((Tr)rval, (Tr)ival);                            \
+        *val = T((Tr)rval, (Tr)ival);                           \
     }                                                           \
 
 #define INSTANTIATE(fn)                         \

--- a/src/api/cpp/reduce.cpp
+++ b/src/api/cpp/reduce.cpp
@@ -42,17 +42,17 @@ namespace af
         return array(out);
     }
 
-    array alltrue(const array &in, const int dim)
+    array allTrue(const array &in, const int dim)
     {
         af_array out = 0;
-        AF_THROW(af_alltrue(&out, in.get(), getFNSD(dim, in.dims())));
+        AF_THROW(af_all_true(&out, in.get(), getFNSD(dim, in.dims())));
         return array(out);
     }
 
-    array anytrue(const array &in, const int dim)
+    array anyTrue(const array &in, const int dim)
     {
         af_array out = 0;
-        AF_THROW(af_anytrue(&out, in.get(), getFNSD(dim, in.dims())));
+        AF_THROW(af_any_true(&out, in.get(), getFNSD(dim, in.dims())));
         return array(out);
     }
 
@@ -81,50 +81,50 @@ namespace af
         idx = array(loc);
     }
 
-#define INSTANTIATE_REAL(fn, T)                             \
+#define INSTANTIATE_REAL(fnC, fnCPP, T)                             \
     template<> AFAPI                                        \
-    T fn(const array &in)                                   \
+    T fnCPP(const array &in)                                   \
     {                                                       \
         double rval, ival;                                  \
-        AF_THROW(af_##fn##_all(&rval, &ival, in.get()));    \
+        AF_THROW(af_##fnC##_all(&rval, &ival, in.get()));    \
         return (T)(rval);                                   \
     }                                                       \
 
 
-#define INSTANTIATE_CPLX(fn, T, Tr)                         \
+#define INSTANTIATE_CPLX(fnC, fnCPP, T, Tr)                         \
     template<> AFAPI                                        \
-    T fn(const array &in)                                   \
+    T fnCPP(const array &in)                                   \
     {                                                       \
         double rval, ival;                                  \
-        AF_THROW(af_##fn##_all(&rval, &ival, in.get()));    \
+        AF_THROW(af_##fnC##_all(&rval, &ival, in.get()));    \
         T out((Tr)rval, (Tr)ival);                       \
         return out;                                         \
     }                                                       \
 
-#define INSTANTIATE(fn)                         \
-    INSTANTIATE_REAL(fn, float)                 \
-    INSTANTIATE_REAL(fn, double)                \
-    INSTANTIATE_REAL(fn, int)                   \
-    INSTANTIATE_REAL(fn, unsigned)              \
-    INSTANTIATE_REAL(fn, long)                  \
-    INSTANTIATE_REAL(fn, unsigned long)         \
-    INSTANTIATE_REAL(fn, long long)             \
-    INSTANTIATE_REAL(fn, unsigned long long)    \
-    INSTANTIATE_REAL(fn, char)                  \
-    INSTANTIATE_REAL(fn, unsigned char)         \
-    INSTANTIATE_CPLX(fn, af_cfloat, float)      \
-    INSTANTIATE_CPLX(fn, af_cdouble, double)    \
+#define INSTANTIATE(fnC, fnCPP)                         \
+    INSTANTIATE_REAL(fnC, fnCPP, float)                 \
+    INSTANTIATE_REAL(fnC, fnCPP, double)                \
+    INSTANTIATE_REAL(fnC, fnCPP, int)                   \
+    INSTANTIATE_REAL(fnC, fnCPP, unsigned)              \
+    INSTANTIATE_REAL(fnC, fnCPP, long)                  \
+    INSTANTIATE_REAL(fnC, fnCPP, unsigned long)         \
+    INSTANTIATE_REAL(fnC, fnCPP, long long)             \
+    INSTANTIATE_REAL(fnC, fnCPP, unsigned long long)    \
+    INSTANTIATE_REAL(fnC, fnCPP, char)                  \
+    INSTANTIATE_REAL(fnC, fnCPP, unsigned char)         \
+    INSTANTIATE_CPLX(fnC, fnCPP, af_cfloat, float)      \
+    INSTANTIATE_CPLX(fnC, fnCPP, af_cdouble, double)    \
 
-    INSTANTIATE(sum)
-    INSTANTIATE(product)
-    INSTANTIATE(min)
-    INSTANTIATE(max)
-    INSTANTIATE(alltrue)
-    INSTANTIATE(anytrue)
-    INSTANTIATE(count)
+    INSTANTIATE(sum, sum)
+    INSTANTIATE(product, product)
+    INSTANTIATE(min, min)
+    INSTANTIATE(max, max)
+    INSTANTIATE(all_true, allTrue)
+    INSTANTIATE(any_true, anyTrue)
+    INSTANTIATE(count, count)
 
-    INSTANTIATE_REAL(alltrue, bool);
-    INSTANTIATE_REAL(anytrue, bool);
+    INSTANTIATE_REAL(all_true, allTrue, bool);
+    INSTANTIATE_REAL(any_true, anyTrue, bool);
 
 #undef INSTANTIATE
 #undef INSTANTIATE_REAL

--- a/src/api/cpp/set.cpp
+++ b/src/api/cpp/set.cpp
@@ -14,6 +14,11 @@
 namespace af
 {
 
+array setunique(const array &in, const bool is_sorted)
+{
+    return setUnique(in, is_sorted);
+}
+
 array setUnique(const array &in, const bool is_sorted)
 {
     af_array out = 0;
@@ -21,11 +26,21 @@ array setUnique(const array &in, const bool is_sorted)
     return array(out);
 }
 
+array setunion(const array &first, const array &second, const bool is_unique)
+{
+    return setUnion(first, second, is_unique);
+}
+
 array setUnion(const array &first, const array &second, const bool is_unique)
 {
     af_array out = 0;
     AF_THROW(af_set_union(&out, first.get(), second.get(), is_unique));
     return array(out);
+}
+
+array setintersect(const array &first, const array &second, const bool is_unique)
+{
+    return setIntersect(first, second, is_unique);
 }
 
 array setIntersect(const array &first, const array &second, const bool is_unique)

--- a/src/api/cpp/set.cpp
+++ b/src/api/cpp/set.cpp
@@ -14,21 +14,21 @@
 namespace af
 {
 
-array setunique(const array &in, const bool is_sorted)
+array setUnique(const array &in, const bool is_sorted)
 {
     af_array out = 0;
     AF_THROW(af_set_unique(&out, in.get(), is_sorted));
     return array(out);
 }
 
-array setunion(const array &first, const array &second, const bool is_unique)
+array setUnion(const array &first, const array &second, const bool is_unique)
 {
     af_array out = 0;
     AF_THROW(af_set_union(&out, first.get(), second.get(), is_unique));
     return array(out);
 }
 
-array setintersect(const array &first, const array &second, const bool is_unique)
+array setIntersect(const array &first, const array &second, const bool is_unique)
 {
     af_array out = 0;
     AF_THROW(af_set_intersect(&out, first.get(), second.get(), is_unique));

--- a/test/fftconvolve.cpp
+++ b/test/fftconvolve.cpp
@@ -73,9 +73,9 @@ void fftconvolveTest(string pTestFile, bool expand)
 
     af_conv_mode mode = expand ? AF_CONV_EXPAND : AF_CONV_DEFAULT;
     switch(baseDim) {
-        case 1: ASSERT_EQ(AF_SUCCESS, af_fftconvolve1(&outArray, signal, filter, mode)); break;
-        case 2: ASSERT_EQ(AF_SUCCESS, af_fftconvolve2(&outArray, signal, filter, mode)); break;
-        case 3: ASSERT_EQ(AF_SUCCESS, af_fftconvolve3(&outArray, signal, filter, mode)); break;
+        case 1: ASSERT_EQ(AF_SUCCESS, af_fft_convolve1(&outArray, signal, filter, mode)); break;
+        case 2: ASSERT_EQ(AF_SUCCESS, af_fft_convolve2(&outArray, signal, filter, mode)); break;
+        case 3: ASSERT_EQ(AF_SUCCESS, af_fft_convolve3(&outArray, signal, filter, mode)); break;
     }
 
     vector<T> currGoldBar = tests[0];
@@ -136,7 +136,7 @@ void fftconvolveTestLarge(int sDim, int fDim, int sBatch, int fBatch, bool expan
     array signal = randu(signalDims, (af_dtype) af::dtype_traits<T>::af_type);
     array filter = randu(filterDims, (af_dtype) af::dtype_traits<T>::af_type);
 
-    array out = fftconvolve(signal, filter, expand ? AF_CONV_EXPAND : AF_CONV_DEFAULT);
+    array out = fftConvolve(signal, filter, expand ? AF_CONV_EXPAND : AF_CONV_DEFAULT);
 
     array gold;
     switch(baseDim) {
@@ -393,7 +393,7 @@ TEST(FFTConvolve1, CPP)
     af::array filter(numDims[1], &(in[1].front()));
     //filter dims = [4 1 1 1]
 
-    af::array output = fftconvolve1(signal, filter, AF_CONV_EXPAND);
+    af::array output = fftConvolve1(signal, filter, AF_CONV_EXPAND);
     //output dims = [32 1 1 1] - same as input since expand(3rd argument is false)
     //None of the dimensions > 1 has lenght > 1, so no batch mode is activated.
     //![ex_image_convolve1]
@@ -430,7 +430,7 @@ TEST(FFTConvolve2, CPP)
     af::array filter(numDims[1], &(in[1].front()));
     //filter dims = [5 5 2 1]
 
-    af::array output = fftconvolve2(signal, filter, AF_CONV_EXPAND);
+    af::array output = fftConvolve2(signal, filter, AF_CONV_EXPAND);
     //output dims = [15 17 1 1] - same as input since expand(3rd argument is false)
     //however, notice that the 3rd dimension of filter is > 1.
     //So, one to many batch mode will be activated automatically
@@ -470,7 +470,7 @@ TEST(FFTConvolve3, CPP)
     af::array filter(numDims[1], &(in[1].front()));
     //filter dims = [4 2 3 2]
 
-    af::array output = fftconvolve3(signal, filter, AF_CONV_EXPAND);
+    af::array output = fftConvolve3(signal, filter, AF_CONV_EXPAND);
     //output dims = [10 11 2 2] - same as input since expand(3rd argument is false)
     //however, notice that the 4th dimension is > 1 for both signal
     //and the filter, therefore many to many batch mode will be
@@ -526,7 +526,7 @@ TEST(FFTConvolve, Docs_Unified_Wrapper)
     //e [2 2 1 1]
     //     1.0000     1.0000
     //     1.0000     1.0000
-    array f = fftconvolve(d, e);
+    array f = fftConvolve(d, e);
     //af_print(f);
     //f [5 5 1 1]
     //     2.0000     2.0000     2.0000     2.0000     1.0000
@@ -568,7 +568,7 @@ TEST(FFTConvolve, Docs_Unified_Wrapper)
     //    0.5000     0.5000
     //    0.5000     0.5000
 
-    array i = fftconvolve(g, h);
+    array i = fftConvolve(g, h);
     //af_print(i);
     //i [4 4 4 1]
     //    4.0000     4.0000     4.0000     2.0000

--- a/test/histogram.cpp
+++ b/test/histogram.cpp
@@ -221,7 +221,7 @@ TEST(Histogram, SNIPPET_histequal)
 
     // input after histogram equalization or normalization
     // based on histogram provided
-    array eq_out = histequal(hist_in, hist_out);
+    array eq_out = histEqual(hist_in, hist_out);
     // eq_out = { 1.5, 4.5,  1.5, 1.5, 4.5, 4.5, 6.0, 7.5, 4.5 }
     //! [ex_image_histequal]
 

--- a/test/imageio.cpp
+++ b/test/imageio.cpp
@@ -148,7 +148,7 @@ TEST(ImageIO, SavePNGCPP) {
     saveImage("SaveCPP.png", input);
     af::array out = af::loadImage("SaveCPP.png", true);
 
-    ASSERT_FALSE(af::anytrue<bool>(out - input));
+    ASSERT_FALSE(af::anyTrue<bool>(out - input));
 }
 
 TEST(ImageIO, SaveBMPCPP) {
@@ -164,7 +164,7 @@ TEST(ImageIO, SaveBMPCPP) {
     saveImage("SaveCPP.bmp", input);
     af::array out = af::loadImage("SaveCPP.bmp", true);
 
-    ASSERT_FALSE(af::anytrue<bool>(out - input));
+    ASSERT_FALSE(af::anyTrue<bool>(out - input));
 }
 
 #endif // WITH_FREEIMAGE

--- a/test/meanshift.cpp
+++ b/test/meanshift.cpp
@@ -43,7 +43,7 @@ TYPED_TEST(Meanshift, InvalidArgs)
     af::dim4 dims = af::dim4(100,1,1,1);
     ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<TypeParam>::af_type));
-    ASSERT_EQ(AF_ERR_SIZE, af_meanshift(&outArray, inArray, 0.12f, 0.34f, 5, true));
+    ASSERT_EQ(AF_ERR_SIZE, af_mean_shift(&outArray, inArray, 0.12f, 0.34f, 5, true));
     ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
 }
 
@@ -78,7 +78,7 @@ void meanshiftTest(string pTestFile)
         ASSERT_EQ(AF_SUCCESS, af_load_image(&goldArray, outFiles[testId].c_str(), isColor));
         ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems, goldArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_meanshift(&outArray, inArray, 2.25f, 25.56f, 5, isColor));
+        ASSERT_EQ(AF_SUCCESS, af_mean_shift(&outArray, inArray, 2.25f, 25.56f, 5, isColor));
 
         T * outData = new T[nElems];
         ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
@@ -137,7 +137,7 @@ TEST(Meanshift, Color_CPP)
         af::array img   = af::loadImage(inFiles[testId].c_str(), true);
         af::array gold  = af::loadImage(outFiles[testId].c_str(), true);
         dim_t nElems = gold.elements();
-        af::array output= af::meanshift(img, 2.25f, 25.56f, 5, true);
+        af::array output= af::meanShift(img, 2.25f, 25.56f, 5, true);
 
         float * outData = new float[nElems];
         output.host((void*)outData);

--- a/test/morph.cpp
+++ b/test/morph.cpp
@@ -57,13 +57,13 @@ void morphTest(string pTestFile)
 
     if (isDilation) {
         if (isVolume)
-            ASSERT_EQ(AF_SUCCESS, af_dilate3d(&outArray, inArray, maskArray));
+            ASSERT_EQ(AF_SUCCESS, af_dilate3(&outArray, inArray, maskArray));
         else
             ASSERT_EQ(AF_SUCCESS, af_dilate(&outArray, inArray, maskArray));
     }
     else {
         if (isVolume)
-            ASSERT_EQ(AF_SUCCESS, af_erode3d(&outArray, inArray, maskArray));
+            ASSERT_EQ(AF_SUCCESS, af_erode3(&outArray, inArray, maskArray));
         else
             ASSERT_EQ(AF_SUCCESS, af_erode(&outArray, inArray, maskArray));
     }
@@ -302,9 +302,9 @@ void morph3DMaskTest(void)
                 mdims.ndims(), mdims.get(), (af_dtype) af::dtype_traits<T>::af_type));
 
     if (isDilation)
-        ASSERT_EQ(AF_ERR_SIZE, af_dilate3d(&outArray, inArray, maskArray));
+        ASSERT_EQ(AF_ERR_SIZE, af_dilate3(&outArray, inArray, maskArray));
     else
-        ASSERT_EQ(AF_ERR_SIZE, af_erode3d(&outArray, inArray, maskArray));
+        ASSERT_EQ(AF_ERR_SIZE, af_erode3(&outArray, inArray, maskArray));
 
     ASSERT_EQ(AF_SUCCESS, af_release_array(maskArray));
 
@@ -315,9 +315,9 @@ void morph3DMaskTest(void)
                 mdims.ndims(), mdims.get(), (af_dtype) af::dtype_traits<T>::af_type));
 
     if (isDilation)
-        ASSERT_EQ(AF_ERR_SIZE, af_dilate3d(&outArray, inArray, maskArray));
+        ASSERT_EQ(AF_ERR_SIZE, af_dilate3(&outArray, inArray, maskArray));
     else
-        ASSERT_EQ(AF_ERR_SIZE, af_erode3d(&outArray, inArray, maskArray));
+        ASSERT_EQ(AF_ERR_SIZE, af_erode3(&outArray, inArray, maskArray));
 
     ASSERT_EQ(AF_SUCCESS, af_release_array(maskArray));
 

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -133,21 +133,21 @@ REDUCE_TESTS(max, cdouble , cdouble, cdouble);
 REDUCE_TESTS(max, unsigned, unsigned  , unsigned  );
 REDUCE_TESTS(max, uchar   , unsigned char, unsigned char);
 
-REDUCE_TESTS(anytrue, float   , float     , unsigned char);
-REDUCE_TESTS(anytrue, double  , double    , unsigned char);
-REDUCE_TESTS(anytrue, int     , int       , unsigned char);
-REDUCE_TESTS(anytrue, cfloat  , cfloat , unsigned char);
-REDUCE_TESTS(anytrue, cdouble , cdouble, unsigned char);
-REDUCE_TESTS(anytrue, unsigned, unsigned  , unsigned char);
-REDUCE_TESTS(anytrue, uchar   , unsigned char, unsigned char);
+REDUCE_TESTS(any_true, float   , float     , unsigned char);
+REDUCE_TESTS(any_true, double  , double    , unsigned char);
+REDUCE_TESTS(any_true, int     , int       , unsigned char);
+REDUCE_TESTS(any_true, cfloat  , cfloat , unsigned char);
+REDUCE_TESTS(any_true, cdouble , cdouble, unsigned char);
+REDUCE_TESTS(any_true, unsigned, unsigned  , unsigned char);
+REDUCE_TESTS(any_true, uchar   , unsigned char, unsigned char);
 
-REDUCE_TESTS(alltrue, float   , float     , unsigned char);
-REDUCE_TESTS(alltrue, double  , double    , unsigned char);
-REDUCE_TESTS(alltrue, int     , int       , unsigned char);
-REDUCE_TESTS(alltrue, cfloat  , cfloat , unsigned char);
-REDUCE_TESTS(alltrue, cdouble , cdouble, unsigned char);
-REDUCE_TESTS(alltrue, unsigned, unsigned  , unsigned char);
-REDUCE_TESTS(alltrue, uchar   , unsigned char, unsigned char);
+REDUCE_TESTS(all_true, float   , float     , unsigned char);
+REDUCE_TESTS(all_true, double  , double    , unsigned char);
+REDUCE_TESTS(all_true, int     , int       , unsigned char);
+REDUCE_TESTS(all_true, cfloat  , cfloat , unsigned char);
+REDUCE_TESTS(all_true, cdouble , cdouble, unsigned char);
+REDUCE_TESTS(all_true, unsigned, unsigned  , unsigned char);
+REDUCE_TESTS(all_true, uchar   , unsigned char, unsigned char);
 
 REDUCE_TESTS(count, float   , float     , unsigned);
 REDUCE_TESTS(count, double  , double    , unsigned);
@@ -184,8 +184,8 @@ typedef af::array (*ReductionOp)(const af::array&, const int);
 using af::sum;
 using af::min;
 using af::max;
-using af::alltrue;
-using af::anytrue;
+using af::allTrue;
+using af::anyTrue;
 using af::count;
 
 template<typename Ti, typename To, ReductionOp reduce>
@@ -239,8 +239,8 @@ void cppReduceTest(string pTestFile)
 CPP_REDUCE_TESTS(sum, float, float);
 CPP_REDUCE_TESTS(min, float, float);
 CPP_REDUCE_TESTS(max, float, float);
-CPP_REDUCE_TESTS(anytrue, float, unsigned char);
-CPP_REDUCE_TESTS(alltrue, float, unsigned char);
+CPP_REDUCE_TESTS(anyTrue, float, unsigned char);
+CPP_REDUCE_TESTS(allTrue, float, unsigned char);
 CPP_REDUCE_TESTS(count, float, unsigned);
 
 TEST(Reduce, Test_Product_Global)
@@ -377,13 +377,13 @@ TYPED_TEST(Reduce, Test_All_Global)
         vector<TypeParam> h_vals(num, (TypeParam)true);
         array a(2, num/2, &h_vals.front());
 
-        TypeParam res = af::alltrue<TypeParam>(a);
+        TypeParam res = af::allTrue<TypeParam>(a);
         typed_assert_eq((TypeParam)true, res, false);
 
         h_vals[3] = false;
         a = array(2, num/2, &h_vals.front());
 
-        res = af::alltrue<TypeParam>(a);
+        res = af::allTrue<TypeParam>(a);
         typed_assert_eq((TypeParam)false, res, false);
     }
 
@@ -394,7 +394,7 @@ TYPED_TEST(Reduce, Test_All_Global)
         h_vals[i] = false;
         array a(2, num/2, &h_vals.front());
 
-        TypeParam res = af::alltrue<TypeParam>(a);
+        TypeParam res = af::allTrue<TypeParam>(a);
         typed_assert_eq((TypeParam)false, res, false);
 
         h_vals[i] = true;
@@ -411,13 +411,13 @@ TYPED_TEST(Reduce, Test_Any_Global)
         vector<TypeParam> h_vals(num, (TypeParam)false);
         array a(2, num/2, &h_vals.front());
 
-        TypeParam res = af::anytrue<TypeParam>(a);
+        TypeParam res = af::anyTrue<TypeParam>(a);
         typed_assert_eq((TypeParam)false, res, false);
 
         h_vals[3] = true;
         a = array(2, num/2, &h_vals.front());
 
-        res = af::anytrue<TypeParam>(a);
+        res = af::anyTrue<TypeParam>(a);
         typed_assert_eq((TypeParam)true, res, false);
     }
 
@@ -428,7 +428,7 @@ TYPED_TEST(Reduce, Test_Any_Global)
         h_vals[i] = true;
         array a(2, num/2, &h_vals.front());
 
-        TypeParam res = af::anytrue<TypeParam>(a);
+        TypeParam res = af::anyTrue<TypeParam>(a);
         typed_assert_eq((TypeParam)true, res, false);
 
         h_vals[i] = false;


### PR DESCRIPTION
Updated the function names to be consistent across the library.

Fixes: #713 

_Possible additions_:
Add the deprecate flags for the older versions? This will throw a warning if the older versions are used guiding the user to use the newer versions.