### PR TITLE
Fix of OpenCL backend's ugly memory leak

### DIFF
--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -280,6 +280,7 @@ namespace opencl
 
         cl::Buffer& buf = *arr.get();
 
+        clRetainMemObject((cl_mem)(data));
         cl::Buffer data_buf = cl::Buffer((cl_mem)(data));
 
         getQueue().enqueueCopyBuffer(data_buf, buf,

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -278,11 +278,11 @@ namespace opencl
             arr = createEmptyArray<T>(arr.dims());
         }
 
-        cl::Buffer buf = *arr.get();
+        cl::Buffer& buf = *arr.get();
 
-        const cl::Buffer *data_buf = new cl::Buffer((cl_mem)(data));
+        cl::Buffer data_buf = cl::Buffer((cl_mem)(data));
 
-        getQueue().enqueueCopyBuffer(*data_buf, buf,
+        getQueue().enqueueCopyBuffer(data_buf, buf,
                                      0, (size_t)arr.getOffset(),
                                      bytes);
 


### PR DESCRIPTION
This fixes that serious memory leak in OpenCL backend, and gets rid of unnecessary CLBuffer referencing.

- Fixes #735 