### PR TITLE
Fixed build warnings

### DIFF
--- a/include/af/opencl.h
+++ b/include/af/opencl.h
@@ -75,6 +75,7 @@ namespace afcl
         cl_command_queue queue;
         af_err err = afcl_get_queue(&queue, retain);
         if (err != AF_SUCCESS) throw af::exception("Failed to get OpenCL command queue from arrayfire");
+        return queue;
     }
 
     /**

--- a/src/backend/cuda/kernel/fftconvolve.hpp
+++ b/src/backend/cuda/kernel/fftconvolve.hpp
@@ -320,6 +320,9 @@ void complexMultiplyHelper(Param<T> out,
             complexMultiply<convT, MANY2MANY><<<blocks, threads>>>
                 (sig_packed, sig_packed, filter_packed, mul_elem);
             break;
+        case CONVOLVE_UNSUPPORTED_BATCH_MODE:
+        default:
+            break;
     }
     POST_LAUNCH_CHECK();
 }


### PR DESCRIPTION
* Missing switch case on CUDA fftconvolve;
* Missing return statement on OpenCL getQueue().