### PR TITLE
Requires some knowledge of array_proxy_impl. Fixes #787

### DIFF
--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -558,8 +558,9 @@ namespace af
     {
     }
 
-    af::array::array_proxy::array_proxy(const array_proxy &other) {
-        *impl = *(other.impl);
+    af::array::array_proxy::array_proxy(const array_proxy &other)
+        : impl(new array_proxy_impl(*other.impl->parent, other.impl->indices, other.impl->lin))
+    {
     }
 
 #if __cplusplus > 199711L


### PR DESCRIPTION
This fixes the constructor problems. The current solution requires some knowledge of the internals of array_proxy_impl. A possible alternative solution could be:
```
impl = new array_proxy_impl;
*impl = *other.impl;
```
which might separate a bit more the internals, but would require adding an empty constructor for array_proxy_impl.