### PR TITLE
PERF: min/max operations on CPU

### DIFF
--- a/src/backend/cpu/math.hpp
+++ b/src/backend/cpu/math.hpp
@@ -14,6 +14,9 @@
 #include "types.hpp"
 #include <af/defines.h>
 
+using std::is_integral;
+using std::enable_if;
+
 namespace cpu
 {
     template<typename T> static inline T abs(T val) { return std::abs(val); }
@@ -24,11 +27,25 @@ namespace cpu
     size_t abs(size_t val);
 #endif
 
-    template<typename T> static inline T min(T lhs, T rhs) { return std::min(lhs, rhs); }
+    template<typename T>
+    static inline typename enable_if<is_integral<T>::value, T>::type
+    min(T lhs, T rhs) { return lhs ^ ((lhs ^ rhs) & -(rhs < lhs)); }
+
+    template<typename T>
+    static inline typename enable_if<!is_integral<T>::value, T>::type
+    min(T lhs, T rhs) { return std::min(lhs, rhs); }
+
     cfloat min(cfloat lhs, cfloat rhs);
     cdouble min(cdouble lhs, cdouble rhs);
 
-    template<typename T> static inline T max(T lhs, T rhs) { return std::max(lhs, rhs); }
+    template<typename T>
+    static inline typename enable_if<is_integral<T>::value, T>::type
+    max(T lhs, T rhs) { return lhs ^ ((lhs ^ rhs) & -(rhs > lhs)); }
+
+    template<typename T>
+    static inline typename enable_if<!is_integral<T>::value, T>::type
+    max(T lhs, T rhs) { return std::max(lhs, rhs); }
+
     cfloat max(cfloat lhs, cfloat rhs);
     cdouble max(cdouble lhs, cdouble rhs);
 


### PR DESCRIPTION
Replace std::min/std::max for integral types. This could probably work on floats with some work.

~20% increase on min/max