### PR TITLE
Allow building against 64bit index OpenBlas

### DIFF
--- a/src/backend/cpu/blas.cpp
+++ b/src/backend/cpu/blas.cpp
@@ -26,29 +26,30 @@ namespace cpu
 
 template<typename T, typename BT>
 using cptr_type     =   typename conditional<   is_complex<T>::value,
-                                                const void *,
+                                                const BT *,
                                                 const T*>::type;
 template<typename T, typename BT>
 using ptr_type     =    typename conditional<   is_complex<T>::value,
-                                                void *,
+                                                BT *,
                                                 T*>::type;
 template<typename T, typename BT>
 using scale_type   =    typename conditional<   is_complex<T>::value,
-                                                const void *,
+                                                const BT *,
                                                 const T>::type;
+
 template<typename T, typename BT>
 using gemm_func_def = void (*)( const CBLAS_ORDER, const CBLAS_TRANSPOSE, const CBLAS_TRANSPOSE,
-                                const int, const int, const int,
-                                scale_type<T, BT>, cptr_type<T, BT>, const int,
-                                cptr_type<T, BT>, const int,
-                                scale_type<T, BT>, ptr_type<T, BT>, const int);
+                                const blasint, const blasint, const blasint,
+                                scale_type<T, BT>, cptr_type<T, BT>, const blasint,
+                                cptr_type<T, BT>, const blasint,
+                                scale_type<T, BT>, ptr_type<T, BT>, const blasint);
 
 template<typename T, typename BT>
 using gemv_func_def = void (*)( const CBLAS_ORDER, const CBLAS_TRANSPOSE,
-                                const int, const int,
-                                scale_type<T, BT>, cptr_type<T, BT>, const int,
-                                cptr_type<T, BT>, const int,
-                                scale_type<T, BT>, ptr_type<T, BT>, const int);
+                                const blasint, const blasint,
+                                scale_type<T, BT>, cptr_type<T, BT>, const blasint,
+                                cptr_type<T, BT>, const blasint,
+                                scale_type<T, BT>, ptr_type<T, BT>, const blasint);
 
 #define BLAS_FUNC_DEF( FUNC )                                                      \
 template<typename T, typename BT> FUNC##_func_def<T, BT> FUNC##_func();
@@ -59,7 +60,7 @@ template<> FUNC##_func_def<TYPE, BASE_TYPE>     FUNC##_func<TYPE, BASE_TYPE>()  
 { return &cblas_##PREFIX##FUNC; }
 
 BLAS_FUNC_DEF( gemm )
-#ifdef OS_WIN
+#if defined(OS_WIN) || defined(IS_OPENBLAS)
 BLAS_FUNC(gemm , float   , float  , s)
 BLAS_FUNC(gemm , double  , double , d)
 BLAS_FUNC(gemm , cfloat  , float  , c)
@@ -72,7 +73,7 @@ BLAS_FUNC(gemm , cdouble ,   void, z)
 #endif
 
 BLAS_FUNC_DEF(gemv)
-#ifdef OS_WIN
+#if defined(OS_WIN) || defined(IS_OPENBLAS)
 BLAS_FUNC(gemv , float   ,  float , s)
 BLAS_FUNC(gemv , double  ,  double, d)
 BLAS_FUNC(gemv , cfloat  ,  float , c)
@@ -112,8 +113,8 @@ toCblasTranspose(af_mat_prop opt)
 using namespace std;
 
 
-#ifdef OS_WIN
-#define BT af::dtype_traits<T>::base_type
+#if defined(OS_WIN) || defined(IS_OPENBLAS)
+#define BT typename af::dtype_traits<T>::base_type
 #define REINTERPRET_CAST(PTR_TYPE, X) reinterpret_cast<PTR_TYPE>((X))
 #else
 template<typename T> struct cblas_types;

--- a/src/backend/cpu/blas.cpp
+++ b/src/backend/cpu/blas.cpp
@@ -60,7 +60,7 @@ template<> FUNC##_func_def<TYPE, BASE_TYPE>     FUNC##_func<TYPE, BASE_TYPE>()  
 { return &cblas_##PREFIX##FUNC; }
 
 BLAS_FUNC_DEF( gemm )
-#if defined(OS_WIN) || defined(IS_OPENBLAS)
+#if (defined(OS_WIN) && !defined(USE_MKL)) || defined(IS_OPENBLAS)
 BLAS_FUNC(gemm , float   , float  , s)
 BLAS_FUNC(gemm , double  , double , d)
 BLAS_FUNC(gemm , cfloat  , float  , c)
@@ -73,7 +73,7 @@ BLAS_FUNC(gemm , cdouble ,   void, z)
 #endif
 
 BLAS_FUNC_DEF(gemv)
-#if defined(OS_WIN) || defined(IS_OPENBLAS)
+#if (defined(OS_WIN) && !defined(USE_MKL)) || defined(IS_OPENBLAS)
 BLAS_FUNC(gemv , float   ,  float , s)
 BLAS_FUNC(gemv , double  ,  double, d)
 BLAS_FUNC(gemv , cfloat  ,  float , c)
@@ -113,7 +113,7 @@ toCblasTranspose(af_mat_prop opt)
 using namespace std;
 
 
-#if defined(OS_WIN) || defined(IS_OPENBLAS)
+#if (defined(OS_WIN) && !defined(USE_MKL)) || defined(IS_OPENBLAS)
 #define BT typename af::dtype_traits<T>::base_type
 #define REINTERPRET_CAST(PTR_TYPE, X) reinterpret_cast<PTR_TYPE>((X))
 #else

--- a/src/backend/cpu/blas.hpp
+++ b/src/backend/cpu/blas.hpp
@@ -23,6 +23,18 @@ extern "C" {
 #endif
 #endif
 
+// TODO: Ask upstream for a more official way to detect it
+#ifdef OPENBLAS_CONST
+#define IS_OPENBLAS
+#endif
+
+// Make sure we get the correct type signature for OpenBLAS
+// OpenBLAS defines blasint as it's index type. Emulate this
+// if we're not dealing with openblas and use it where applicable
+#ifndef IS_OPENBLAS
+typedef int blasint;
+#endif
+
 namespace cpu
 {
 


### PR DESCRIPTION
OpenBLAS can be built with signatures that take a 64bit value as the index type.
When built in this mode blasint is defined to be int64_t, otherwise it is just a
regular int. Since this causes a signature mismatch for those versions of OpenBLAS,
use blasint throughout and provide a fallback typedef for other BLASes.
Also use the OpenBLAS detection to make it use the correct gemm/gemv signature pointer
type. Note that this reverts part of 9be64f05f7236b64949430d4c18ee0421f18bd56, which
I believe was incorrect as it made `BT` pointless. The correct fix would have been
to detect the specific BLAS that was used in the definition below and set the BT to
be `void`.