### PR TITLE
Link against the binary_dir version of forge.

### DIFF
--- a/CMakeModules/build_forge.cmake
+++ b/CMakeModules/build_forge.cmake
@@ -1,8 +1,14 @@
 INCLUDE(ExternalProject)
 
 SET(prefix ${CMAKE_BINARY_DIR}/third_party/forge)
-SET(forge_location "${prefix}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}forge${CMAKE_SHARED_LIBRARY_SUFFIX}")
 
+IF(WIN32)
+    SET(forge_lib_prefix "${prefix}/lib")
+ELSE(WIN32)
+    SET(forge_lib_prefix "${prefix}/src/forge-ext-build/src")
+ENDIF(WIN32)
+
+SET(forge_location "${forge_lib_prefix}/${CMAKE_SHARED_LIBRARY_PREFIX}forge${CMAKE_SHARED_LIBRARY_SUFFIX}")
 IF(CMAKE_VERSION VERSION_LESS 3.2)
     IF(CMAKE_GENERATOR MATCHES "Ninja")
         MESSAGE(WARNING "Building forge with Ninja has known issues with CMake older than 3.2")
@@ -33,11 +39,17 @@ ExternalProject_Add(
     ${byproducts}
     )
 
+ExternalProject_Get_Property(forge-ext binary_dir)
 ExternalProject_Get_Property(forge-ext install_dir)
 ADD_LIBRARY(forge SHARED IMPORTED)
 SET_TARGET_PROPERTIES(forge PROPERTIES IMPORTED_LOCATION ${forge_location})
 IF(WIN32)
-    SET_TARGET_PROPERTIES(forge PROPERTIES IMPORTED_IMPLIB ${prefix}/lib/forge.lib)
+    SET_TARGET_PROPERTIES(forge PROPERTIES IMPORTED_IMPLIB ${forge_lib_prefix}/forge.lib)
+ELSE(WIN32)
+    SET(forge_bindir_location ${binary_dir}/src/${CMAKE_SHARED_LIBRARY_PREFIX}forge${CMAKE_SHARED_LIBRARY_SUFFIX})
+    IF(NOT (${forge_bindir_location} STREQUAL ${forge_location}))
+        MESSAGE(WARNING "Did the forge binary location move? (Have ${forge_bindir_location} vs ${forge_location})")
+    ENDIF()
 ENDIF(WIN32)
 ADD_DEPENDENCIES(forge forge-ext)
 SET(FORGE_INCLUDE_DIRECTORIES ${install_dir}/include)


### PR DESCRIPTION
CMake will strip the RPATH from the forge shared library when installing it,
causing link failures later down the line. Use the non-installed version instead.