### PR TITLE
Add support for BLAS symbol renaming

### DIFF
--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -102,18 +102,55 @@ ELSE(${UNIX}) #Windows
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 ENDIF()
 
-ADD_LIBRARY(afcpu SHARED
-           ${cpu_headers}
-           ${cpu_sources}
-           ${backend_headers}
-           ${backend_sources}
-           ${c_headers}
-           ${c_sources}
-           ${cpp_sources})
 
-TARGET_LINK_LIBRARIES(afcpu PRIVATE ${FreeImage_LIBS}
+IF(DEFINED BLAS_SYM_FILE)
+  ADD_LIBRARY(afcpu_static STATIC
+              ${cpu_headers}
+              ${cpu_sources}
+              ${backend_headers}
+              ${backend_sources})
+
+  ADD_LIBRARY(afcpu SHARED
+              ${c_headers}
+              ${c_sources}
+              ${cpp_sources})
+
+  IF(FORGE_FOUND)
+    ADD_DEPENDENCIES(afcpu_static forge)
+  ENDIF()
+
+  IF(APPLE)
+    SET_TARGET_PROPERTIES(afcpu_static
+        PROPERTIES LINK_FLAGS -Wl,-exported_symbols_list,${BLAS_SYM_FILE})
+    TARGET_LINK_LIBRARIES(afcpu PUBLIC $<TARGET_FILE:afcpu_static>)
+  ELSE(APPLE)
+    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/afcpu_static.renamed
+      COMMAND objcopy --redefine-syms ${BLAS_SYM_FILE} $<TARGET_FILE:afcpu_static> ${CMAKE_BINARY_DIR}/afcpu_static.renamed
+      DEPENDS $<TARGET_FILE:afcpu_static>)
+      TARGET_LINK_LIBRARIES(afcpu PUBLIC ${CMAKE_BINARY_DIR}/afcpu_static.renamed)
+  ENDIF(APPLE)
+
+ELSE(DEFINED BLAS_SYM_FILE)
+
+  ADD_LIBRARY(afcpu SHARED
+              ${cpu_headers}
+              ${cpu_sources}
+              ${backend_headers}
+              ${backend_sources}
+              ${c_headers}
+              ${c_sources}
+              ${cpp_sources})
+
+ENDIF(DEFINED BLAS_SYM_FILE)
+
+TARGET_LINK_LIBRARIES(afcpu
+                            PRIVATE ${FreeImage_LIBS}
                             PRIVATE ${CBLAS_LIBRARIES}
                             PRIVATE ${FFTW_LIBRARIES})
+
+IF(FORGE_FOUND)
+  ADD_DEPENDENCIES(afcpu forge)
+ENDIF()
 
 IF(LAPACK_FOUND)
    TARGET_LINK_LIBRARIES(afcpu  PRIVATE ${LAPACK_LIBRARIES})

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -169,33 +169,78 @@ ELSE(${UNIX}) #Windows
     SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /bigobj")
 ENDIF()
 
+IF(DEFINED BLAS_SYM_FILE)
 
-ADD_LIBRARY(afopencl SHARED
-            ${opencl_headers}
-            ${opencl_sources}
-            ${jit_sources}
-            ${kernel_headers}
-            ${opencl_kernels}
-            ${kernel_sources}
-            ${conv_ker_headers}
-            ${conv_ker_sources}
-            ${backend_headers}
-            ${backend_sources}
-            ${c_sources}
-            ${c_headers}
-            ${cpp_sources}
-            ${magma_sources}
-            ${magma_headers}
-            )
+    ADD_LIBRARY(afopencl_static STATIC
+                ${opencl_headers}
+                ${opencl_sources}
+                ${jit_sources}
+                ${kernel_headers}
+                ${opencl_kernels}
+                ${kernel_sources}
+                ${conv_ker_headers}
+                ${conv_ker_sources}
+                ${backend_headers}
+                ${backend_sources}
+                ${magma_sources}
+                ${magma_headers})
+
+    ADD_LIBRARY(afopencl SHARED
+               ${c_headers}
+               ${c_sources}
+               ${cpp_sources})
+
+
+    IF(FORGE_FOUND)
+        ADD_DEPENDENCIES(afopencl_static forge)
+    ENDIF()
+
+    IF(APPLE)
+    SET_TARGET_PROPERTIES(afopencl_static
+        PROPERTIES LINK_FLAGS -Wl,-exported_symbols_list,${BLAS_SYM_FILE})
+    TARGET_LINK_LIBRARIES(afopencl PUBLIC $<TARGET_FILE:afopencl_static>)
+    ELSE(APPLE)
+    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/afopencl_static.renamed
+      COMMAND objcopy --redefine-syms ${BLAS_SYM_FILE} $<TARGET_FILE:afopencl_static> ${CMAKE_BINARY_DIR}/afopencl_static.renamed
+      DEPENDS $<TARGET_FILE:afopencl_static>)
+      TARGET_LINK_LIBRARIES(afopencl PUBLIC ${CMAKE_BINARY_DIR}/afopencl_static.renamed)
+    ENDIF(APPLE)
+
+
+ELSE(DEFINED BLAS_SYM_FILE)
+
+    ADD_LIBRARY(afopencl SHARED
+                ${opencl_headers}
+                ${opencl_sources}
+                ${jit_sources}
+                ${kernel_headers}
+                ${opencl_kernels}
+                ${kernel_sources}
+                ${conv_ker_headers}
+                ${conv_ker_sources}
+                ${backend_headers}
+                ${backend_sources}
+                ${c_headers}
+                ${c_sources}
+                ${cpp_sources}
+                ${magma_sources}
+                ${magma_headers})
+
+ENDIF()
 
 ADD_DEPENDENCIES(afopencl ${cl_kernel_targets})
 
-TARGET_LINK_LIBRARIES(afopencl  PRIVATE ${OpenCL_LIBRARIES}
+TARGET_LINK_LIBRARIES(afopencl
+                                PRIVATE ${OpenCL_LIBRARIES}
                                 PRIVATE ${FreeImage_LIBS}
                                 PRIVATE ${CLBLAS_LIBRARIES}
                                 PRIVATE ${CLFFT_LIBRARIES}
                                 PRIVATE ${CMAKE_DL_LIBS}
                                 PRIVATE ${Boost_LIBRARIES})
+
+IF(FORGE_FOUND)
+    ADD_DEPENDENCIES(afopencl forge)
+ENDIF()
 
 IF(LAPACK_FOUND)
    TARGET_LINK_LIBRARIES(afopencl   PRIVATE ${LAPACK_LIBRARIES})


### PR DESCRIPTION
OpenBLAS (and potentially other BLASes), generate a symbol rename file to
move symbols out of a namespace where they might conflict with other BLASes
(if the right options are set). Teach ArrayFire to make use of this file
to be able to still link against that library.