### PR TITLE
Cusolver svd

### DIFF
--- a/examples/lin_algebra/svd.cpp
+++ b/examples/lin_algebra/svd.cpp
@@ -1,0 +1,51 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <arrayfire.h>
+#include <cstdio>
+#include <cstdlib>
+
+using namespace af;
+
+int main(int argc, char* argv[])
+{
+    try {
+        // Select a device and display arrayfire info
+        int device = argc > 1 ? atoi(argv[1]) : 0;
+        af::setDevice(device);
+        af::info();
+
+        float h_buffer[] = {1, 4, 2, 5, 3, 6 };  // host array
+        array in(2, 3, h_buffer);                        // copy host data to device
+        print("in", in);
+
+        array s;
+        array u;
+        array vt;
+        printf("Running svd");
+        svd(s, u, vt, in);
+        print("in", in);
+        print("s", s);
+        print("u", u);
+        print("vt", vt);
+
+    } catch (af::exception& e) {
+        fprintf(stderr, "%s\n", e.what());
+        throw;
+    }
+
+#ifdef WIN32  // pause in Windows
+    if (!(argc == 2 && argv[1][0] == '-')) {
+        printf("hit [enter]...");
+        fflush(stdout);
+        getchar();
+    }
+#endif
+    return 0;
+}

--- a/include/af/lapack.h
+++ b/include/af/lapack.h
@@ -14,6 +14,29 @@
 #ifdef __cplusplus
 namespace af
 {
+    /**
+       C++ Interface for SVD decomposition
+
+       \param[out] s is the output array containing the diagonal values of sigma, (singular values of the input matrix))
+       \param[out] u is the output array containing U
+       \param[out] vt is the output array containing V^H
+       \param[in] in is the input matrix
+
+       \ingroup lapack_factor_func_svd
+    */
+    AFAPI void svd(array &s, array &u, array &vt, const array &in);
+
+    /**
+       C++ Interface for SVD decomposition
+
+       \param[out] s is the output array containing the diagonal values of sigma, (singular values of the input matrix))
+       \param[out] u is the output array containing U
+       \param[out] vt is the output array containing V^H
+       \param[inout] in is the input matrix and will contain random data after this operation
+
+       \ingroup lapack_factor_func_svd
+    */
+    AFAPI void svdInPlace(array &s, array &u, array &vt, array &in);
 
     /**
        C++ Interface for LU decomposition in packed format
@@ -216,6 +239,30 @@ namespace af
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+    /**
+       C Interface for SVD decomposition
+
+       \param[out] s is the output array containing the diagonal values of sigma, (singular values of the input matrix))
+       \param[out] u is the output array containing U
+       \param[out] vt is the output array containing V^H
+       \param[in] in is the input matrix
+
+       \ingroup lapack_factor_func_svd
+    */
+    AFAPI af_err af_svd(af_array *s, af_array *u, af_array *vt, const af_array in);
+
+    /**
+       C Interface for SVD decomposition
+
+       \param[out] s is the output array containing the diagonal values of sigma, (singular values of the input matrix))
+       \param[out] u is the output array containing U
+       \param[out] vt is the output array containing V^H
+       \param[inout] in is the input matrix that will contain random data after this operation
+
+       \ingroup lapack_factor_func_svd
+    */
+    AFAPI af_err af_svd_inplace(af_array *s, af_array *u, af_array *vt, af_array in);
 
     /**
        C Interface for LU decomposition

--- a/src/api/c/svd.cpp
+++ b/src/api/c/svd.cpp
@@ -1,0 +1,119 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <af/dim4.hpp>
+#include <af/array.h>
+#include <af/lapack.h>
+
+#include <af/util.h>
+
+#include <af/defines.h>
+
+#include <err_common.hpp>
+
+#include <backend.hpp>
+
+#include <Array.hpp>
+
+#include <handle.hpp>
+
+#include <svd.hpp>
+
+using namespace detail;
+
+template <typename T>
+static inline void svd(af_array *s, af_array *u, af_array *vt, const af_array in)
+{
+    ArrayInfo info = getInfo(in);  // ArrayInfo is the base class which
+    af::dim4 dims = info.dims();
+    int M = dims[0];
+    int N = dims[1];
+
+    //Allocate output arrays
+    Array<T> sA = createEmptyArray<T>(af::dim4(min(M, N)));
+    Array<T> uA = createEmptyArray<T>(af::dim4(M, M));
+    Array<T> vtA = createEmptyArray<T>(af::dim4(N, N));
+
+    svd<T>(sA, uA, vtA, getArray<T>(in));
+
+    *s = getHandle(sA);
+    *u = getHandle(uA);
+    *vt = getHandle(vtA);
+}
+
+template <typename T>
+static inline void svdInPlace(af_array *s, af_array *u, af_array *vt, af_array in){
+    ArrayInfo info = getInfo(in);  // ArrayInfo is the base class which
+    af::dim4 dims = info.dims();
+    int M = dims[0];
+    int N = dims[1];
+
+    //Allocate output arrays
+    Array<T> sA = createEmptyArray<T>(af::dim4(min(M, N)));
+    Array<T> uA = createEmptyArray<T>(af::dim4(M, M));
+    Array<T> vtA = createEmptyArray<T>(af::dim4(N, N));
+
+    svdInPlace<T>(sA, uA, vtA, getWritableArray<T>(in));
+
+    *s = getHandle(sA);
+    *u = getHandle(uA);
+    *vt = getHandle(vtA);
+}
+
+af_err af_svd(af_array *s, af_array *u, af_array *vt, const af_array in)
+{
+    try {
+        ArrayInfo info = getInfo(in);
+
+        af::dim4 dims = info.dims();
+
+        ARG_ASSERT(2, (dims.ndims() >= 0 && dims.ndims() <= 3));
+
+        af_dtype type = info.getType();
+
+        switch (type) {
+            case f64:
+                svd<double>(s, u, vt, in);
+                break;
+            case f32:
+                svd<float>(s, u, vt, in);
+                break;
+            default:
+                TYPE_ERROR(1, type);
+        }
+    }
+    CATCHALL;
+    return AF_SUCCESS;
+}
+
+af_err af_svd_inplace(af_array *s, af_array *u, af_array *vt, af_array in)
+{
+    try {
+        ArrayInfo info = getInfo(in);
+
+        af::dim4 dims = info.dims();
+
+        ARG_ASSERT(2, (dims.ndims() >= 0 && dims.ndims() <= 3));
+
+        af_dtype type = info.getType();
+
+        switch (type) {
+            case f64:
+                svdInPlace<double>(s, u, vt, in);
+                break;
+            case f32:
+                svdInPlace<float>(s, u, vt, in);
+                break;
+            default:
+                TYPE_ERROR(1, type);
+        }
+    }
+    CATCHALL;
+    return AF_SUCCESS;
+}

--- a/src/api/cpp/lapack.cpp
+++ b/src/api/cpp/lapack.cpp
@@ -13,6 +13,24 @@
 
 namespace af
 {
+    void svd(array &s, array &u, array &vt, const array &in)
+    {
+        af_array sl = 0, ul = 0, vtl = 0;
+        AF_THROW(af_svd(&sl, &ul, &vtl, in.get()));
+        s = array(sl);
+        u = array(ul);
+        vt = array(vtl);
+    }
+
+    void svdInPlace(array &s, array &u, array &vt, array &in)
+    {
+        af_array sl = 0, ul = 0, vtl = 0;
+        AF_THROW(af_svd_inplace(&sl, &ul, &vtl, in.get()));
+        s = array(sl);
+        u = array(ul);
+        vt = array(vtl);
+    }
+
     void lu(array &out, array &pivot, const array &in, const bool is_lapack_piv)
     {
         out = in.copy();

--- a/src/backend/cpu/svd.cpp
+++ b/src/backend/cpu/svd.cpp
@@ -1,0 +1,84 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Array.hpp>
+#include <svd.hpp>
+#include <err_common.hpp>
+
+#include <err_cpu.hpp>
+
+#define INSTANTIATE_SVD(T)                                                               \
+    template void svd<T>(Array<T> & s, Array<T> & u, Array<T> & vt, const Array<T> &in); \
+    template void svdInPlace<T>(Array<T> & s, Array<T> & u, Array<T> & vt, Array<T> &in);
+
+#if defined(WITH_CPU_LINEAR_ALGEBRA)
+#include <lapack_helper.hpp>
+#include <copy.hpp>
+
+namespace cpu
+{
+
+    #define SVD_FUNC_DEF( FUNC )                                     \
+    template<typename T> FUNC##_func_def<T> FUNC##_func();
+
+    #define SVD_FUNC( FUNC, TYPE, PREFIX )                           \
+    template<> FUNC##_func_def<TYPE>     FUNC##_func<TYPE>()         \
+    { return & LAPACK_NAME(PREFIX##FUNC); }
+
+    template<typename T>
+    using gesdd_func_def = int (*)(ORDER_TYPE, char jobz, int m, int n, T* in,
+                                     int ldin, T* s, T* u, int ldu,
+                                     T* vt, int ldvt);
+
+    SVD_FUNC_DEF( gesdd )
+    SVD_FUNC(gesdd, float, s)
+    SVD_FUNC(gesdd, double, d)
+
+    template <typename T>
+    void svdInPlace(Array<T> &s, Array<T> &u, Array<T> &vt, Array<T> &in)
+    {
+        dim4 iDims = in.dims();
+        int M = iDims[0];
+        int N = iDims[1];
+
+        gesdd_func<T>()(AF_LAPACK_COL_MAJOR, 'A', M, N, in.get(), in.strides()[1],
+                        s.get(), u.get(), u.strides()[1], vt.get(), vt.strides()[1]);
+    }
+
+    template <typename T>
+    void svd(Array<T> &s, Array<T> &u, Array<T> &vt, const Array<T> &in)
+    {
+        Array<T> in_copy = copyArray<T>(in);
+        svdInPlace(s, u, vt, in_copy);
+    }
+}
+
+#else
+
+namespace cpu
+{
+    template <typename T>
+    void svd(Array<T> &s, Array<T> &u, Array<T> &vt, const Array<T> &in)
+    {
+        AF_ERROR("Linear Algebra is disabled on CPU", AF_ERR_NOT_CONFIGURED);
+    }
+
+    template <typename T>
+    void svdInPlace(Array<T> &s, Array<T> &u, Array<T> &vt, Array<T> &in)
+    {
+        AF_ERROR("Linear Algebra is disabled on CPU", AF_ERR_NOT_CONFIGURED);
+    }
+}
+
+#endif
+
+namespace cpu {
+    INSTANTIATE_SVD(float)
+    INSTANTIATE_SVD(double)
+}

--- a/src/backend/cpu/svd.hpp
+++ b/src/backend/cpu/svd.hpp
@@ -1,0 +1,20 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <af/util.h>
+#include <Array.hpp>
+
+namespace cpu
+{
+    template <typename T>
+    void svd(Array<T> &s, Array<T> &u, Array<T> &vt, const Array<T> &in);
+
+    template <typename T>
+    void svdInPlace(Array<T> &s, Array<T> &u, Array<T> &vt, Array<T> &in);
+}

--- a/src/backend/cuda/svd.cu
+++ b/src/backend/cuda/svd.cu
@@ -1,0 +1,143 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <svd.hpp>
+#include <err_common.hpp>
+
+#if defined(WITH_CUDA_LINEAR_ALGEBRA)
+
+#include <cusolverDnManager.hpp>
+#include "transpose.hpp"
+#include <memory.hpp>
+#include <copy.hpp>
+#include <math.hpp>
+#include <err_common.hpp>
+
+namespace cuda
+{
+    using cusolver::getDnHandle;
+
+    template <typename T>
+    struct gesvd_func_def_t {
+        typedef cusolverStatus_t (*gesvd_func_def)(cusolverDnHandle_t, char, char, int,
+                                                   int, T *, int, T *, T *, int, T *, int,
+                                                   T *, int, T *, int *);
+    };
+
+    template<typename T>
+    struct gesvd_buf_func_def_t {
+        typedef cusolverStatus_t (*gesvd_buf_func_def)(cusolverDnHandle_t, int, int,
+                                                       int *);
+    };
+
+#define SVD_FUNC_DEF(FUNC)                                                              \
+    template <typename T>                                                               \
+    typename FUNC##_func_def_t<T>::FUNC##_func_def FUNC##_func();                       \
+                                                                                        \
+    template<typename T>                                                                \
+    typename FUNC##_buf_func_def_t<T>::FUNC##_buf_func_def                              \
+    FUNC##_buf_func();
+
+#define SVD_FUNC(FUNC, TYPE, PREFIX)                                                    \
+    template <>                                                                         \
+    typename FUNC##_func_def_t<TYPE>::FUNC##_func_def FUNC##_func<TYPE>()               \
+    {                                                                                   \
+        return (FUNC##_func_def_t<TYPE>::FUNC##_func_def) & cusolverDn##PREFIX##FUNC;   \
+    }                                                                                   \
+                                                                                        \
+    template<> typename FUNC##_buf_func_def_t<TYPE>::FUNC##_buf_func_def                \
+    FUNC##_buf_func<TYPE>()                                                             \
+    {                                                                                   \
+        return (FUNC##_buf_func_def_t<TYPE>::FUNC##_buf_func_def) &                     \
+               cusolverDn##PREFIX##FUNC##_bufferSize;                                   \
+    }
+
+    SVD_FUNC_DEF(gesvd)
+    SVD_FUNC(gesvd, float, S)
+    SVD_FUNC(gesvd, double, D)
+//SVD_FUNC(gesvd , cfloat , C)
+//SVD_FUNC(gesvd , cdouble, Z)
+
+    template <typename T>
+    void svdInPlace(Array<T> &s, Array<T> &u, Array<T> &vt, Array<T> &in)
+    {
+        dim4 iDims = in.dims();
+        int M = iDims[0];
+        int N = iDims[1];
+
+        // cuSolver(cuda 7.0) doesn't have support for M<N
+        bool flip_and_transpose = M < N;
+
+        if (flip_and_transpose) {
+            std::swap(M, N);
+            std::swap(vt, u);
+        }
+
+        int lwork = 0;
+        CUSOLVER_CHECK(gesvd_buf_func<T>()(getDnHandle(), M, N, &lwork));
+        T *lWorkspace = memAlloc<T>(lwork);
+        //complex numbers would need rWorkspace
+        //T *rWorkspace = memAlloc<T>(lwork);
+
+        int *info = memAlloc<int>(1);
+
+        if (flip_and_transpose) {
+            transpose_inplace(in, true);
+            CUSOLVER_CHECK(gesvd_func<T>()(getDnHandle(), 'A', 'A', M, N, in.get(),
+                                           M, s.get(), u.get(), M, vt.get(), N,
+                                           lWorkspace, lwork, NULL, info));
+            std::swap(u, vt);
+            transpose_inplace(vt, true);
+        } else {
+            Array<T> inCopy = copyArray<T>(in);
+            CUSOLVER_CHECK(gesvd_func<T>()(getDnHandle(), 'A', 'A', M, N, in.get(),
+                                           M, s.get(), u.get(), M, vt.get(), N,
+                                           lWorkspace, lwork, NULL, info));
+        }
+        memFree(info);
+        memFree(lWorkspace);
+        //memFree(rWorkspace);
+    }
+
+    template <typename T>
+    void svd(Array<T> &s, Array<T> &u, Array<T> &vt, const Array<T> &in)
+    {
+        Array<T> inCopy = copyArray<T>(in);
+        svdInPlace(s, u, vt, inCopy);
+    }
+
+#define INSTANTIATE_SVD(T)                                                              \
+    template void svd<T>(Array<T> &s, Array<T> &u, Array<T> &vt, const Array<T> &in);   \
+    template void svdInPlace<T>(Array<T> &s, Array<T> &u, Array<T> &vt, Array<T> &in);   \
+
+    INSTANTIATE_SVD(float)
+    //INSTANTIATE_SVD(cfloat)
+    INSTANTIATE_SVD(double)
+    //INSTANTIATE_SVD(cdouble)
+}
+
+#else
+namespace cuda
+{
+    template <typename T>
+    void svd(Array<T> &s, Array<T> &u, Array<T> &vt, const Array<T> &in)
+    {
+        AF_ERROR("CUDA cusolver not available. Linear Algebra is disabled",
+                 AF_ERR_NOT_CONFIGURED);
+    }
+
+#define INSTANTIATE_SVD(T)                                                              \
+    template void svd<T>(Array<T> &s, Array<T> &u, Array<T> &vt, const Array<T> &in);   \
+
+    INSTANTIATE_SVD(float)
+    //INSTANTIATE_SVD(cfloat)
+    INSTANTIATE_SVD(double)
+    //INSTANTIATE_SVD(cdouble)
+}
+#endif

--- a/src/backend/cuda/svd.hpp
+++ b/src/backend/cuda/svd.hpp
@@ -1,0 +1,20 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <af/array.h>
+#include <Array.hpp>
+
+namespace cuda
+{
+    template <typename T>
+    void svd(Array<T> &s, Array<T> &u, Array<T> &vt, const Array<T> &in);
+
+    template <typename T>
+    void svdInPlace(Array<T> &s, Array<T> &u, Array<T> &vt, Array<T> &in);
+}

--- a/src/backend/opencl/svd.cpp
+++ b/src/backend/opencl/svd.cpp
@@ -1,0 +1,40 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Array.hpp>
+
+#include <svd.hpp>          // opencl backend function header
+
+#include <err_opencl.hpp>               // error check functions and Macros
+                                        // specific to opencl backend
+
+namespace opencl
+{
+
+template<typename T>
+void svd(Array<T> &s, Array<T> &u, Array<T> &vt, const Array<T> &in)
+{
+    OPENCL_NOT_SUPPORTED();
+}
+
+template<typename T>
+void svdInPlace(Array<T> &s, Array<T> &u, Array<T> &vt, Array<T> &in)
+{
+    OPENCL_NOT_SUPPORTED();
+}
+
+
+#define INSTANTIATE(T)                                                                  \
+    template void svd(Array<T> &s, Array<T> &u, Array<T> &vt, const Array<T> &in)       \
+    template void svdInPlace(Array<T> &s, Array<T> &u, Array<T> &vt, Array<T> &in)
+
+INSTANTIATE(float)
+INSTANTIATE(double)
+
+}

--- a/src/backend/opencl/svd.hpp
+++ b/src/backend/opencl/svd.hpp
@@ -1,0 +1,20 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Array.hpp>
+
+namespace opencl
+{
+    template<typename T>
+    void svd(Array<T> &s, Array<T> &u, Array<T> &vt, const Array<T> &in);
+
+    template<typename T>
+    void svdInPlace(Array<T> &s, Array<T> &u, Array<T> &vt, Array<T> &in);
+}
+


### PR DESCRIPTION
@pavanky 
As requested in #862 

Unfortunately
```-DBUILD_OPENCL=ON``` results in linking errors like
```
/home/richy/Projects/arrayfire/build/third_party/clFFT/src/clFFT-external/src/examples/fft1d.c:66: undefined reference to `clfftInitSetupData'
collect2: error: ld returned 1 exit status
```
As the error is present in current develop I'll open the PR anyway.

