### PR TITLE
Automatically enable and build CUDA and OpenCL backends by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,13 +13,13 @@ OPTION(BUILD_GTEST "Download gtest and check for updates. Necessary if you chang
 
 OPTION(BUILD_CPU "Build ArrayFire with a CPU backend" ON)
 
-FIND_PACKAGE(CUDA)
+FIND_PACKAGE(CUDA QUIET)
 IF(${CUDA_FOUND})
     SET(BUILD_CUDA ON CACHE BOOL "")
 ENDIF(${CUDA_FOUND})
 OPTION(BUILD_CUDA "Build ArrayFire with a CUDA backend" OFF)
 
-FIND_PACKAGE(OpenCL)
+FIND_PACKAGE(OpenCL QUIET)
 IF(${OpenCL_FOUND})
     SET(BUILD_OPENCL ON CACHE BOOL "")
 ENDIF(${OpenCL_FOUND})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,26 @@ PROJECT(ARRAYFIRE)
 
 SET_PROPERTY(GLOBAL PROPERTY USE_FOLDERS ON)
 
+SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
+INCLUDE(${CMAKE_MODULE_PATH}/UploadCoveralls.cmake)
+INCLUDE(AFInstallDirs)
+
 OPTION(BUILD_TEST "Build Tests" ON)
 OPTION(BUILD_EXAMPLES "Build Examples" ON)
 OPTION(BUILD_GTEST "Download gtest and check for updates. Necessary if you change compilers" ON)
 
 OPTION(BUILD_CPU "Build ArrayFire with a CPU backend" ON)
+
+FIND_PACKAGE(CUDA)
+IF(${CUDA_FOUND})
+    SET(BUILD_CUDA ON CACHE BOOL "")
+ENDIF(${CUDA_FOUND})
 OPTION(BUILD_CUDA "Build ArrayFire with a CUDA backend" OFF)
+
+FIND_PACKAGE(OpenCL)
+IF(${OpenCL_FOUND})
+    SET(BUILD_OPENCL ON CACHE BOOL "")
+ENDIF(${OpenCL_FOUND})
 OPTION(BUILD_OPENCL "Build ArrayFire with a OpenCL backend" OFF)
 
 OPTION(BUILD_GRAPHICS "Build ArrayFire with Forge Graphics" ON)
@@ -23,10 +37,6 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
       "MinSizeRel" "RelWithDebInfo")
 endif()
-
-SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
-INCLUDE(${CMAKE_MODULE_PATH}/UploadCoveralls.cmake)
-INCLUDE(AFInstallDirs)
 
 FIND_PACKAGE(FreeImage)
 IF(FREEIMAGE_FOUND)


### PR DESCRIPTION
Note, this changes the default behavior of ArrayFire's build system in that it will automatically build the OpenCL and CUDA backends if the respective packages are detected. Individual backends may be disabled by specifying -DBUILD_OPENCL=OFF or -DBUILD_CUDA=OFF at CMake time.

The build instructions portion of the wiki will need to be updated once this patch is merged into the devel branch. We should also notify the package maintainers of this change.