### PR TITLE
Remove unused dtype trait for size_t

### DIFF
--- a/src/backend/opencl/traits.hpp
+++ b/src/backend/opencl/traits.hpp
@@ -31,16 +31,6 @@ struct dtype_traits<cl_double2> {
     static const char* getName() { return "double2"; }
 };
 
-#if !defined(OS_WIN)        // Windows defines size_t as ulong
-template<>
-struct dtype_traits<size_t> {
-    static const char* getName()
-    {
-        return (sizeof(size_t) == 8)  ? "ulong" : "uint";
-    }
-};
-#endif
-
 template<typename T> static bool iscplx() { return false; }
 template<> STATIC_ bool iscplx<cl_float2>() { return true; }
 template<> STATIC_ bool iscplx<cl_double2>() { return true; }


### PR DESCRIPTION
Remove the offending specialization of `dtype_traits<>` for `size_t` which was confirmed by upstream to be unused.

- Fixes #957 