### PR TITLE
Updating the cl.hpp version

### DIFF
--- a/src/backend/opencl/cl.hpp
+++ b/src/backend/opencl/cl.hpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2008-2013 The Khronos Group Inc.
+ * Copyright (c) 2008-2015 The Khronos Group Inc.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and/or associated documentation files (the
@@ -33,14 +33,14 @@
  *       Bruce Merry, February 2013.
  *       Tom Deakin and Simon McIntosh-Smith, July 2013
  *   
- *   \version 1.2.6
- *   \date August 2013
+ *   \version 1.2.7
+ *   \date January 2015
  *
  *   Optional extension support
  *
  *         cl
  *         cl_ext_device_fission
- *                #define USE_CL_DEVICE_FISSION
+ *				#define USE_CL_DEVICE_FISSION
  */
 
 /*! \mainpage
@@ -147,22 +147,17 @@
 
 #ifdef _WIN32
 
-#include <windows.h>
 #include <malloc.h>
-#include <iterator>
-#include <intrin.h>
 
-#if defined(__CL_ENABLE_EXCEPTIONS)
-#include <exception>
-#endif // #if defined(__CL_ENABLE_EXCEPTIONS)
-
-#pragma push_macro("max")
-#undef max
 #if defined(USE_DX_INTEROP)
 #include <CL/cl_d3d10.h>
 #include <CL/cl_dx9_media_sharing.h>
 #endif
 #endif // _WIN32
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif // _MSC_VER
 
 // 
 #if defined(USE_CL_DEVICE_FISSION)
@@ -170,13 +165,23 @@
 #endif
 
 #if defined(__APPLE__) || defined(__MACOSX)
-#include <OpenGL/OpenGL.h>
 #include <OpenCL/opencl.h>
-#include <libkern/OSAtomic.h>
 #else
-#include <GL/gl.h>
 #include <CL/opencl.h>
 #endif // !__APPLE__
+
+#if (_MSC_VER >= 1700) || (__cplusplus >= 201103L)
+#define CL_HPP_RVALUE_REFERENCES_SUPPORTED
+#define CL_HPP_CPP11_ATOMICS_SUPPORTED
+#include <atomic>
+#endif
+
+#if (__cplusplus >= 201103L)
+#define CL_HPP_NOEXCEPT noexcept
+#else
+#define CL_HPP_NOEXCEPT
+#endif
+
 
 // To avoid accidentally taking ownership of core OpenCL types
 // such as cl_kernel constructors are made explicit
@@ -202,6 +207,11 @@
 
 #include <utility>
 #include <limits>
+#include <iterator>
+
+#if defined(__CL_ENABLE_EXCEPTIONS)
+#include <exception>
+#endif // #if defined(__CL_ENABLE_EXCEPTIONS)
 
 #if !defined(__NO_STD_VECTOR)
 #include <vector>
@@ -211,11 +221,8 @@
 #include <string>
 #endif 
 
-#if defined(linux) || defined(__APPLE__) || defined(__MACOSX)
+#if defined(__ANDROID__) || defined(linux) || defined(__APPLE__) || defined(__MACOSX)
 #include <alloca.h>
-
-#include <emmintrin.h>
-#include <xmmintrin.h>
 #endif // linux
 
 #include <cstring>
@@ -389,7 +396,7 @@ static inline cl_int errHandler (cl_int err, const char * errStr = NULL)
 #define __BUILD_PROGRAM_ERR                 __ERR_STR(clBuildProgram)
 #if defined(CL_VERSION_1_2)
 #define __COMPILE_PROGRAM_ERR                  __ERR_STR(clCompileProgram)
-
+#define __LINK_PROGRAM_ERR                  __ERR_STR(clLinkProgram)
 #endif // #if defined(CL_VERSION_1_2)
 #define __CREATE_KERNELS_IN_PROGRAM_ERR     __ERR_STR(clCreateKernelsInProgram)
 
@@ -546,7 +553,7 @@ public:
         } 
         else {
             char *newString = new char[n + 1];
-            int copySize = n;
+            ::size_t copySize = n;
             if( size_ < n ) {
                 copySize = size_;
             }
@@ -676,7 +683,7 @@ typedef cl::string STRING_CLASS;
  *  \param N maximum size of the vector.
  */
 template <typename T, unsigned int N = __MAX_DEFAULT_VECTOR_SIZE>
-class CL_EXT_PREFIX__VERSION_1_1_DEPRECATED vector CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
+class CL_EXT_PREFIX__VERSION_1_1_DEPRECATED vector
 {
 private:
     T data_[N];
@@ -718,7 +725,7 @@ public:
      */
     void push_back (const T& x)
     { 
-        if (size() < N) {    
+        if (size() < N) {
             new (&data_[size_]) T(x);
             size_++;
         } else {
@@ -739,7 +746,7 @@ public:
             detail::errHandler(CL_MEM_OBJECT_ALLOCATION_FAILURE, __VECTOR_CAPACITY_ERR);
         }
     }
-  
+
     /*! \brief Constructs with a value copied from another.
      *
      *  \param vec the vector to copy.
@@ -747,7 +754,7 @@ public:
     vector(const vector<T, N>& vec) : 
         size_(vec.size_)
     {
-        if (size_ != 0) {    
+        if (size_ != 0) {
             assign(vec.begin(), vec.end());
         }
     } 
@@ -779,12 +786,12 @@ public:
             return *this;
         }
 
-        if (rhs.size_ != 0) {    
+        if (rhs.size_ != 0) {	
             assign(rhs.begin(), rhs.end());
         } else {
             clear();
         }
-    
+
         return *this;
     }
 
@@ -828,6 +835,28 @@ public:
     unsigned int capacity () const
     {
         return N;
+    }
+
+    //! \brief Resizes the vector to the given size
+    void resize(unsigned int newSize, T fill = T())
+    {
+        if (newSize > N)
+        {
+            detail::errHandler(CL_MEM_OBJECT_ALLOCATION_FAILURE, __VECTOR_CAPACITY_ERR);
+        }
+        else
+        {
+            while (size_ < newSize)
+            {
+                new (&data_[size_]) T(fill);
+                size_++;
+            }
+            while (size_ > newSize)
+            {
+                --size_;
+                data_[size_].~T();
+            }
+        }
     }
 
     /*! \brief Returns a reference to a given element.
@@ -1006,7 +1035,7 @@ public:
     {
         return data_[size_-1];
     }
-};  
+} CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED;
 #endif // #if !defined(__USE_DEV_VECTOR) && !defined(__NO_STD_VECTOR)
 
 
@@ -1021,25 +1050,39 @@ namespace detail {
     /*
      * Compare and exchange primitives are needed for handling of defaults
     */
+
+#ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
+    inline int compare_exchange(std::atomic<int> * dest, int exchange, int comparand)
+#else // !CL_HPP_CPP11_ATOMICS_SUPPORTED
     inline int compare_exchange(volatile int * dest, int exchange, int comparand)
+#endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
     {
-#ifdef _WIN32
-        return (int)(InterlockedCompareExchange(
-           (volatile long*)dest, 
-           (long)exchange, 
-           (long)comparand));
-#elif defined(__APPLE__) || defined(__MACOSX)
-        return OSAtomicOr32Orig((uint32_t)exchange, (volatile uint32_t*)dest);
-#else // !_WIN32 || defined(__APPLE__) || defined(__MACOSX)
+#ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
+        std::atomic_compare_exchange_strong(dest, &comparand, exchange);
+        return comparand;
+#elif _MSC_VER
+        return (int)(_InterlockedCompareExchange(
+            (volatile long*)dest,
+            (long)exchange,
+            (long)comparand));
+#else // !_MSC_VER && !CL_HPP_CPP11_ATOMICS_SUPPORTED
         return (__sync_val_compare_and_swap(
-            dest, 
-            comparand, 
+            dest,
+            comparand,
             exchange));
-#endif // !_WIN32
+#endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
     }
 
-    inline void fence() { _mm_mfence(); }
-}; // namespace detail
+    inline void fence() {
+#ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+#elif _MSC_VER // !CL_HPP_CPP11_ATOMICS_SUPPORTED
+        _ReadWriteBarrier();
+#else // !_MSC_VER && !CL_HPP_CPP11_ATOMICS_SUPPORTED
+        __sync_synchronize();
+#endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
+    }
+} // namespace detail
 
     
 /*! \brief class used to interface between C++ and
@@ -1169,13 +1212,16 @@ inline cl_int getInfoHelper(Func f, cl_uint name, STRING_CLASS* param, long)
         return err;
     }
 
-    char* value = (char*) alloca(required);
-    err = f(name, required, value, NULL);
+    // std::string has a constant data member
+    // a char vector does not
+    VECTOR_CLASS<char> value(required);
+    err = f(name, required, value.data(), NULL);
     if (err != CL_SUCCESS) {
         return err;
     }
-
-    *param = value;
+    if (param) {
+        param->assign(value.begin(), value.end());
+    }
     return CL_SUCCESS;
 }
 
@@ -1294,7 +1340,7 @@ inline cl_int getInfoHelper(Func f, cl_uint name, T* param, int, typename T::cl_
     F(cl_event_info, CL_EVENT_COMMAND_QUEUE, cl::CommandQueue) \
     F(cl_event_info, CL_EVENT_COMMAND_TYPE, cl_command_type) \
     F(cl_event_info, CL_EVENT_REFERENCE_COUNT, cl_uint) \
-    F(cl_event_info, CL_EVENT_COMMAND_EXECUTION_STATUS, cl_uint) \
+    F(cl_event_info, CL_EVENT_COMMAND_EXECUTION_STATUS, cl_int) \
     \
     F(cl_profiling_info, CL_PROFILING_COMMAND_QUEUED, cl_ulong) \
     F(cl_profiling_info, CL_PROFILING_COMMAND_SUBMIT, cl_ulong) \
@@ -1675,7 +1721,7 @@ static cl_uint getVersion(const char *versionInfo)
         ++index;
     }
     ++index;
-    while(versionInfo[index] != ' ' ) {
+    while(versionInfo[index] != ' ' &&  versionInfo[index] != '\0') {
         lowVersion *= 10;
         lowVersion += versionInfo[index]-'0';
         ++index;
@@ -1739,13 +1785,35 @@ public:
         if (object_ != NULL) { detail::errHandler(retain(), __RETAIN_ERR); }
     }
 
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    Wrapper(Wrapper<cl_type>&& rhs) CL_HPP_NOEXCEPT
+    {
+        object_ = rhs.object_;
+        rhs.object_ = NULL;
+    }
+#endif
+
     Wrapper<cl_type>& operator = (const Wrapper<cl_type>& rhs)
     {
-        if (object_ != NULL) { detail::errHandler(release(), __RELEASE_ERR); }
-        object_ = rhs.object_;
-        if (object_ != NULL) { detail::errHandler(retain(), __RETAIN_ERR); }
+        if (this != &rhs) {
+            if (object_ != NULL) { detail::errHandler(release(), __RELEASE_ERR); }
+            object_ = rhs.object_;
+            if (object_ != NULL) { detail::errHandler(retain(), __RETAIN_ERR); }
+        }
         return *this;
     }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    Wrapper<cl_type>& operator = (Wrapper<cl_type>&& rhs)
+    {
+        if (this != &rhs) {
+            if (object_ != NULL) { detail::errHandler(release(), __RELEASE_ERR); }
+            object_ = rhs.object_;
+            rhs.object_ = NULL;
+        }
+        return *this;
+    }
+#endif
 
     Wrapper<cl_type>& operator = (const cl_type &rhs)
     {
@@ -1817,14 +1885,40 @@ public:
         if (object_ != NULL) { detail::errHandler(retain(), __RETAIN_ERR); }
     }
 
-    Wrapper<cl_type>& operator = (const Wrapper<cl_type>& rhs)
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    Wrapper(Wrapper<cl_type>&& rhs) CL_HPP_NOEXCEPT
     {
-        if (object_ != NULL) { detail::errHandler(release(), __RELEASE_ERR); }
         object_ = rhs.object_;
         referenceCountable_ = rhs.referenceCountable_;
-        if (object_ != NULL) { detail::errHandler(retain(), __RETAIN_ERR); }
+        rhs.object_ = NULL;
+        rhs.referenceCountable_ = false;
+    }
+#endif
+
+    Wrapper<cl_type>& operator = (const Wrapper<cl_type>& rhs)
+    {
+        if (this != &rhs) {
+            if (object_ != NULL) { detail::errHandler(release(), __RELEASE_ERR); }
+            object_ = rhs.object_;
+            referenceCountable_ = rhs.referenceCountable_;
+            if (object_ != NULL) { detail::errHandler(retain(), __RETAIN_ERR); }
+        }
         return *this;
     }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    Wrapper<cl_type>& operator = (Wrapper<cl_type>&& rhs)
+    {
+        if (this != &rhs) {
+            if (object_ != NULL) { detail::errHandler(release(), __RELEASE_ERR); }
+            object_ = rhs.object_;
+            referenceCountable_ = rhs.referenceCountable_;
+            rhs.object_ = NULL;
+            rhs.referenceCountable_ = false;
+        }
+        return *this;
+    }
+#endif
 
     Wrapper<cl_type>& operator = (const cl_type &rhs)
     {
@@ -1910,35 +2004,17 @@ public:
     //! \brief Default constructor - initializes to NULL.
     Device() : detail::Wrapper<cl_type>() { }
 
-    /*! \brief Copy constructor.
-     * 
-     *  This simply copies the device ID value, which is an inexpensive operation.
-     */
-    Device(const Device& device) : detail::Wrapper<cl_type>(device) { }
-
     /*! \brief Constructor from cl_device_id.
      * 
      *  This simply copies the device ID value, which is an inexpensive operation.
      */
-    Device(const cl_device_id &device) : detail::Wrapper<cl_type>(device) { }
+    __CL_EXPLICIT_CONSTRUCTORS Device(const cl_device_id &device) : detail::Wrapper<cl_type>(device) { }
 
     /*! \brief Returns the first device on the default context.
      *
      *  \see Context::getDefault()
      */
     static Device getDefault(cl_int * err = NULL);
-
-    /*! \brief Assignment operator from Device.
-     * 
-     *  This simply copies the device ID value, which is an inexpensive operation.
-     */
-    Device& operator = (const Device& rhs)
-    {
-        if (this != &rhs) {
-            detail::Wrapper<cl_type>::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment operator from cl_device_id.
      * 
@@ -1949,6 +2025,36 @@ public:
         detail::Wrapper<cl_type>::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Device(const Device& dev) : detail::Wrapper<cl_type>(dev) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Device& operator = (const Device &dev)
+    {
+        detail::Wrapper<cl_type>::operator=(dev);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Device(Device&& dev) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(dev)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Device& operator = (Device &&dev)
+    {
+        detail::Wrapper<cl_type>::operator=(std::move(dev));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
     //! \brief Wrapper for clGetDeviceInfo().
     template <typename T>
@@ -2051,29 +2157,11 @@ public:
     //! \brief Default constructor - initializes to NULL.
     Platform() : detail::Wrapper<cl_type>()  { }
 
-    /*! \brief Copy constructor.
-     * 
-     *  This simply copies the platform ID value, which is an inexpensive operation.
-     */
-    Platform(const Platform& platform) : detail::Wrapper<cl_type>(platform) { }
-
     /*! \brief Constructor from cl_platform_id.
      * 
      *  This simply copies the platform ID value, which is an inexpensive operation.
      */
-    Platform(const cl_platform_id &platform) : detail::Wrapper<cl_type>(platform) { }
-
-    /*! \brief Assignment operator from Platform.
-     * 
-     *  This simply copies the platform ID value, which is an inexpensive operation.
-     */
-    Platform& operator = (const Platform& rhs)
-    {
-        if (this != &rhs) {
-            detail::Wrapper<cl_type>::operator=(rhs);
-        }
-        return *this;
-    }
+    __CL_EXPLICIT_CONSTRUCTORS Platform(const cl_platform_id &platform) : detail::Wrapper<cl_type>(platform) { }
 
     /*! \brief Assignment operator from cl_platform_id.
      * 
@@ -2284,6 +2372,7 @@ public:
             if (errResult != NULL) {
                 *errResult = err;
             }
+            return Platform();
         }
 
         cl_platform_id* ids = (cl_platform_id*) alloca(
@@ -2292,13 +2381,14 @@ public:
 
         if (err != CL_SUCCESS) {
             detail::errHandler(err, __GET_PLATFORM_IDS_ERR);
+            if (errResult != NULL) {
+                *errResult = err;
+            }
+            return Platform();
         }
 
-        if (errResult != NULL) {
-            *errResult = err;
-        }
         
-        return ids[0];
+        return Platform(ids[0]);
     }
 
     static Platform getDefault( 
@@ -2347,16 +2437,15 @@ class Context
     : public detail::Wrapper<cl_context>
 {
 private:
+
+#ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
+    static std::atomic<int> default_initialized_;
+#else // !CL_HPP_CPP11_ATOMICS_SUPPORTED
     static volatile int default_initialized_;
+#endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
     static Context default_;
     static volatile cl_int default_error_;
 public:
-    /*! \brief Destructor.
-     *
-     *  This calls clReleaseContext() on the value held by this instance.
-     */
-    ~Context() { }
-
     /*! \brief Constructs a context including a list of specified devices.
      *
      *  Wraps clCreateContext().
@@ -2434,7 +2523,7 @@ public:
     {
         cl_int error;
 
-#if !defined(__APPLE__) || !defined(__MACOS)
+#if !defined(__APPLE__) && !defined(__MACOS)
         cl_context_properties prop[4] = {CL_CONTEXT_PLATFORM, 0, 0, 0 };
 
         if (properties == NULL) {
@@ -2502,6 +2591,36 @@ public:
         }
     }
 
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Context(const Context& ctx) : detail::Wrapper<cl_type>(ctx) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Context& operator = (const Context &ctx)
+    {
+        detail::Wrapper<cl_type>::operator=(ctx);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Context(Context&& ctx) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(ctx)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Context& operator = (Context &&ctx)
+    {
+        detail::Wrapper<cl_type>::operator=(std::move(ctx));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+
     /*! \brief Returns a singleton context including all devices of CL_DEVICE_TYPE_DEFAULT.
      *
      *  \note All calls to this function return the same cl_context as the first.
@@ -2557,31 +2676,12 @@ public:
     //! \brief Default constructor - initializes to NULL.
     Context() : detail::Wrapper<cl_type>() { }
 
-    /*! \brief Copy constructor.
-     * 
-     *  This calls clRetainContext() on the parameter's cl_context.
-     */
-    Context(const Context& context) : detail::Wrapper<cl_type>(context) { }
-
     /*! \brief Constructor from cl_context - takes ownership.
      * 
      *  This effectively transfers ownership of a refcount on the cl_context
      *  into the new Context object.
      */
     __CL_EXPLICIT_CONSTRUCTORS Context(const cl_context& context) : detail::Wrapper<cl_type>(context) { }
-
-    /*! \brief Assignment operator from Context.
-     * 
-     *  This calls clRetainContext() on the parameter and clReleaseContext() on
-     *  the previous value held by this instance.
-     */
-    Context& operator = (const Context& rhs)
-    {
-        if (this != &rhs) {
-            detail::Wrapper<cl_type>::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment operator from cl_context - takes ownership.
      * 
@@ -2662,7 +2762,7 @@ inline Device Device::getDefault(cl_int * err)
     Device device;
 
     Context context = Context::getDefault(&error);
-    detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
+    detail::errHandler(error, __CREATE_CONTEXT_ERR);
 
     if (error != CL_SUCCESS) {
         if (err != NULL) {
@@ -2681,14 +2781,22 @@ inline Device Device::getDefault(cl_int * err)
 
 
 #ifdef _WIN32
+#ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
+__declspec(selectany) std::atomic<int> Context::default_initialized_;
+#else // !CL_HPP_CPP11_ATOMICS_SUPPORTED
 __declspec(selectany) volatile int Context::default_initialized_ = __DEFAULT_NOT_INITIALIZED;
+#endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
 __declspec(selectany) Context Context::default_;
 __declspec(selectany) volatile cl_int Context::default_error_ = CL_SUCCESS;
-#else
+#else // !_WIN32
+#ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
+__attribute__((weak)) std::atomic<int> Context::default_initialized_;
+#else // !CL_HPP_CPP11_ATOMICS_SUPPORTED
 __attribute__((weak)) volatile int Context::default_initialized_ = __DEFAULT_NOT_INITIALIZED;
+#endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
 __attribute__((weak)) Context Context::default_;
 __attribute__((weak)) volatile cl_int Context::default_error_ = CL_SUCCESS;
-#endif
+#endif // !_WIN32
 
 /*! \brief Class interface for cl_event.
  *
@@ -2701,45 +2809,20 @@ __attribute__((weak)) volatile cl_int Context::default_error_ = CL_SUCCESS;
 class Event : public detail::Wrapper<cl_event>
 {
 public:
-    /*! \brief Destructor.
-     *
-     *  This calls clReleaseEvent() on the value held by this instance.
-     */
-    ~Event() { }
- 
     //! \brief Default constructor - initializes to NULL.
     Event() : detail::Wrapper<cl_type>() { }
-
-    /*! \brief Copy constructor.
-     * 
-     *  This calls clRetainEvent() on the parameter's cl_event.
-     */
-    Event(const Event& event) : detail::Wrapper<cl_type>(event) { }
 
     /*! \brief Constructor from cl_event - takes ownership.
      * 
      *  This effectively transfers ownership of a refcount on the cl_event
      *  into the new Event object.
      */
-    Event(const cl_event& event) : detail::Wrapper<cl_type>(event) { }
+    __CL_EXPLICIT_CONSTRUCTORS Event(const cl_event& event) : detail::Wrapper<cl_type>(event) { }
 
     /*! \brief Assignment operator from cl_event - takes ownership.
      *
      *  This effectively transfers ownership of a refcount on the rhs and calls
      *  clReleaseEvent() on the value previously held by this instance.
-     */
-    Event& operator = (const Event& rhs)
-    {
-        if (this != &rhs) {
-            detail::Wrapper<cl_type>::operator=(rhs);
-        }
-        return *this;
-    }
-
-    /*! \brief Assignment operator from cl_event.
-     * 
-     *  This calls clRetainEvent() on the parameter and clReleaseEvent() on
-     *  the previous value held by this instance.
      */
     Event& operator = (const cl_event& rhs)
     {
@@ -2811,7 +2894,7 @@ public:
      */
     cl_int setCallback(
         cl_int type,
-        void (CL_CALLBACK * pfn_notify)(cl_event, cl_int, void *),        
+        void (CL_CALLBACK * pfn_notify)(cl_event, cl_int, void *),		
         void * user_data = NULL)
     {
         return detail::errHandler(
@@ -2833,7 +2916,7 @@ public:
     {
         return detail::errHandler(
             ::clWaitForEvents(
-                (cl_uint) events.size(), (cl_event*)&events.front()),
+                (cl_uint) events.size(), (events.size() > 0) ? (cl_event*)&events.front() : NULL),
             __WAIT_FOR_EVENTS_ERR);
     }
 };
@@ -2868,18 +2951,6 @@ public:
     //! \brief Default constructor - initializes to NULL.
     UserEvent() : Event() { }
 
-    //! \brief Copy constructor - performs shallow copy.
-    UserEvent(const UserEvent& event) : Event(event) { }
-
-    //! \brief Assignment Operator - performs shallow copy.
-    UserEvent& operator = (const UserEvent& rhs)
-    {
-        if (this != &rhs) {
-            Event::operator=(rhs);
-        }
-        return *this;
-    }
-
     /*! \brief Sets the execution status of a user event object.
      *
      *  Wraps clSetUserEventStatus().
@@ -2902,7 +2973,7 @@ WaitForEvents(const VECTOR_CLASS<Event>& events)
 {
     return detail::errHandler(
         ::clWaitForEvents(
-            (cl_uint) events.size(), (cl_event*)&events.front()),
+            (cl_uint) events.size(), (events.size() > 0) ? (cl_event*)&events.front() : NULL),
         __WAIT_FOR_EVENTS_ERR);
 }
 
@@ -2917,21 +2988,8 @@ WaitForEvents(const VECTOR_CLASS<Event>& events)
 class Memory : public detail::Wrapper<cl_mem>
 {
 public:
- 
-    /*! \brief Destructor.
-     *
-     *  This calls clReleaseMemObject() on the value held by this instance.
-     */
-    ~Memory() {}
-
     //! \brief Default constructor - initializes to NULL.
     Memory() : detail::Wrapper<cl_type>() { }
-
-    /*! \brief Copy constructor - performs shallow copy.
-     * 
-     *  This calls clRetainMemObject() on the parameter's cl_mem.
-     */
-    Memory(const Memory& memory) : detail::Wrapper<cl_type>(memory) { }
 
     /*! \brief Constructor from cl_mem - takes ownership.
      * 
@@ -2939,19 +2997,6 @@ public:
      *  into the new Memory object.
      */
     __CL_EXPLICIT_CONSTRUCTORS Memory(const cl_mem& memory) : detail::Wrapper<cl_type>(memory) { }
-
-    /*! \brief Assignment operator from Memory.
-     * 
-     *  This calls clRetainMemObject() on the parameter and clReleaseMemObject()
-     *  on the previous value held by this instance.
-     */
-    Memory& operator = (const Memory& rhs)
-    {
-        if (this != &rhs) {
-            detail::Wrapper<cl_type>::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment operator from cl_mem - takes ownership.
      *
@@ -2963,6 +3008,36 @@ public:
         detail::Wrapper<cl_type>::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Memory(const Memory& mem) : detail::Wrapper<cl_type>(mem) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Memory& operator = (const Memory &mem)
+    {
+        detail::Wrapper<cl_type>::operator=(mem);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Memory(Memory&& mem) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(mem)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Memory& operator = (Memory &&mem)
+    {
+        detail::Wrapper<cl_type>::operator=(std::move(mem));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
     //! \brief Wrapper for clGetMemObjectInfo().
     template <typename T>
@@ -3002,7 +3077,7 @@ public:
      *  value - not the Memory class instance.
      */
     cl_int setDestructorCallback(
-        void (CL_CALLBACK * pfn_notify)(cl_mem, void *),        
+        void (CL_CALLBACK * pfn_notify)(cl_mem, void *),		
         void * user_data = NULL)
     {
         return detail::errHandler(
@@ -3148,32 +3223,22 @@ public:
     Buffer(const Context &context, IteratorType startIterator, IteratorType endIterator,
         bool readOnly, bool useHostPtr = false, cl_int* err = NULL);
 
+    /*!
+    * \brief Construct a Buffer from a host container via iterators using a specified queue.
+    * If useHostPtr is specified iterators must represent contiguous data.
+    */
+    template< typename IteratorType >
+    Buffer(const CommandQueue &queue, IteratorType startIterator, IteratorType endIterator,
+        bool readOnly, bool useHostPtr = false, cl_int* err = NULL);
+
     //! \brief Default constructor - initializes to NULL.
     Buffer() : Memory() { }
-
-    /*! \brief Copy constructor - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Buffer(const Buffer& buffer) : Memory(buffer) { }
 
     /*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
     __CL_EXPLICIT_CONSTRUCTORS Buffer(const cl_mem& buffer) : Memory(buffer) { }
-
-    /*! \brief Assignment from Buffer - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Buffer& operator = (const Buffer& rhs)
-    {
-        if (this != &rhs) {
-            Memory::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment from cl_mem - performs shallow copy.
      *
@@ -3184,6 +3249,36 @@ public:
         Memory::operator=(rhs);
         return *this;
     }
+    
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Buffer(const Buffer& buf) : Memory(buf) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Buffer& operator = (const Buffer &buf)
+    {
+        Memory::operator=(buf);
+        return *this;
+    }
+    
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Buffer(Buffer&& buf) CL_HPP_NOEXCEPT : Memory(std::move(buf)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Buffer& operator = (Buffer &&buf)
+    {
+        Memory::operator=(std::move(buf));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
 #if defined(CL_VERSION_1_1)
     /*! \brief Creates a new buffer object from this.
@@ -3211,7 +3306,7 @@ public:
         }
 
         return result;
-    }        
+    }		
 #endif
 };
 
@@ -3274,29 +3369,11 @@ public:
     //! \brief Default constructor - initializes to NULL.
     BufferD3D10() : Buffer() { }
 
-    /*! \brief Copy constructor - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    BufferD3D10(const BufferD3D10& buffer) : Buffer(buffer) { }
-
     /*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
     __CL_EXPLICIT_CONSTRUCTORS BufferD3D10(const cl_mem& buffer) : Buffer(buffer) { }
-
-    /*! \brief Assignment from BufferD3D10 - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    BufferD3D10& operator = (const BufferD3D10& rhs)
-    {
-        if (this != &rhs) {
-            Buffer::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment from cl_mem - performs shallow copy.
      *
@@ -3307,6 +3384,36 @@ public:
         Buffer::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+    * Required for MSVC.
+    */
+    BufferD3D10(const BufferD3D10& buf) : Buffer(buf) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+    * Required for MSVC.
+    */
+    BufferD3D10& operator = (const BufferD3D10 &buf)
+    {
+        Buffer::operator=(buf);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+    * Required for MSVC.
+    */
+    BufferD3D10(BufferD3D10&& buf) CL_HPP_NOEXCEPT : Buffer(std::move(buf)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+    * Required for MSVC.
+    */
+    BufferD3D10& operator = (BufferD3D10 &&buf)
+    {
+        Buffer::operator=(std::move(buf));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 #endif
 
@@ -3329,7 +3436,7 @@ public:
     BufferGL(
         const Context& context,
         cl_mem_flags flags,
-        GLuint bufobj,
+        cl_GLuint bufobj,
         cl_int * err = NULL)
     {
         cl_int error;
@@ -3348,29 +3455,11 @@ public:
     //! \brief Default constructor - initializes to NULL.
     BufferGL() : Buffer() { }
 
-    /*! \brief Copy constructor - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    BufferGL(const BufferGL& buffer) : Buffer(buffer) { }
-
     /*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
     __CL_EXPLICIT_CONSTRUCTORS BufferGL(const cl_mem& buffer) : Buffer(buffer) { }
-
-    /*! \brief Assignment from BufferGL - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    BufferGL& operator = (const BufferGL& rhs)
-    {
-        if (this != &rhs) {
-            Buffer::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment from cl_mem - performs shallow copy.
      *
@@ -3382,93 +3471,40 @@ public:
         return *this;
     }
 
-    //! \brief Wrapper for clGetGLObjectInfo().
-    cl_int getObjectInfo(
-        cl_gl_object_type *type,
-        GLuint * gl_object_name)
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+    * Required for MSVC.
+    */
+    BufferGL(const BufferGL& buf) : Buffer(buf) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+    * Required for MSVC.
+    */
+    BufferGL& operator = (const BufferGL &buf)
     {
-        return detail::errHandler(
-            ::clGetGLObjectInfo(object_,type,gl_object_name),
-            __GET_GL_OBJECT_INFO_ERR);
-    }
-};
-
-/*! \brief Class interface for GL Render Buffer Memory Objects.
- *
- *  This is provided to facilitate interoperability with OpenGL.
- * 
- *  See Memory for details about copy semantics, etc.
- * 
- *  \see Memory
- */
-class BufferRenderGL : public Buffer
-{
-public:
-    /*! \brief Constructs a BufferRenderGL in a specified context, from a given
-     *         GL Renderbuffer.
-     *
-     *  Wraps clCreateFromGLRenderbuffer().
-     */
-    BufferRenderGL(
-        const Context& context,
-        cl_mem_flags flags,
-        GLuint bufobj,
-        cl_int * err = NULL)
-    {
-        cl_int error;
-        object_ = ::clCreateFromGLRenderbuffer(
-            context(),
-            flags,
-            bufobj,
-            &error);
-
-        detail::errHandler(error, __CREATE_GL_RENDER_BUFFER_ERR);
-        if (err != NULL) {
-            *err = error;
-        }
-    }
-
-    //! \brief Default constructor - initializes to NULL.
-    BufferRenderGL() : Buffer() { }
-
-    /*! \brief Copy constructor - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    BufferRenderGL(const BufferGL& buffer) : Buffer(buffer) { }
-
-    /*! \brief Constructor from cl_mem - takes ownership.
-     *
-     *  See Memory for further details.
-     */
-    __CL_EXPLICIT_CONSTRUCTORS BufferRenderGL(const cl_mem& buffer) : Buffer(buffer) { }
-
-    /*! \brief Assignment from BufferGL - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    BufferRenderGL& operator = (const BufferRenderGL& rhs)
-    {
-        if (this != &rhs) {
-            Buffer::operator=(rhs);
-        }
+        Buffer::operator=(buf);
         return *this;
     }
 
-    /*! \brief Assignment from cl_mem - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    BufferRenderGL& operator = (const cl_mem& rhs)
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+    * Required for MSVC.
+    */
+    BufferGL(BufferGL&& buf) CL_HPP_NOEXCEPT : Buffer(std::move(buf)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+    * Required for MSVC.
+    */
+    BufferGL& operator = (BufferGL &&buf)
     {
-        Buffer::operator=(rhs);
+        Buffer::operator=(std::move(buf));
         return *this;
     }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
     //! \brief Wrapper for clGetGLObjectInfo().
     cl_int getObjectInfo(
         cl_gl_object_type *type,
-        GLuint * gl_object_name)
+        cl_GLuint * gl_object_name)
     {
         return detail::errHandler(
             ::clGetGLObjectInfo(object_,type,gl_object_name),
@@ -3488,29 +3524,11 @@ protected:
     //! \brief Default constructor - initializes to NULL.
     Image() : Memory() { }
 
-    /*! \brief Copy constructor - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Image(const Image& image) : Memory(image) { }
-
     /*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
     __CL_EXPLICIT_CONSTRUCTORS Image(const cl_mem& image) : Memory(image) { }
-
-    /*! \brief Assignment from Image - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Image& operator = (const Image& rhs)
-    {
-        if (this != &rhs) {
-            Memory::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment from cl_mem - performs shallow copy.
      *
@@ -3521,6 +3539,36 @@ protected:
         Memory::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image(const Image& img) : Memory(img) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image& operator = (const Image &img)
+    {
+        Memory::operator=(img);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image(Image&& img) CL_HPP_NOEXCEPT : Memory(std::move(img)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image& operator = (Image &&img)
+    {
+        Memory::operator=(std::move(img));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
 public:
     //! \brief Wrapper for clGetImageInfo().
@@ -3593,29 +3641,11 @@ public:
     //! \brief Default constructor - initializes to NULL.
     Image1D() { }
 
-    /*! \brief Copy constructor - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Image1D(const Image1D& image1D) : Image(image1D) { }
-
     /*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
     __CL_EXPLICIT_CONSTRUCTORS Image1D(const cl_mem& image1D) : Image(image1D) { }
-
-    /*! \brief Assignment from Image1D - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Image1D& operator = (const Image1D& rhs)
-    {
-        if (this != &rhs) {
-            Image::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment from cl_mem - performs shallow copy.
      *
@@ -3626,6 +3656,36 @@ public:
         Image::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image1D(const Image1D& img) : Image(img) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image1D& operator = (const Image1D &img)
+    {
+        Image::operator=(img);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image1D(Image1D&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image1D& operator = (Image1D &&img)
+    {
+        Image::operator=(std::move(img));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 
 /*! \class Image1DBuffer
@@ -3666,23 +3726,43 @@ public:
 
     Image1DBuffer() { }
 
-    Image1DBuffer(const Image1DBuffer& image1D) : Image(image1D) { }
-
     __CL_EXPLICIT_CONSTRUCTORS Image1DBuffer(const cl_mem& image1D) : Image(image1D) { }
-
-    Image1DBuffer& operator = (const Image1DBuffer& rhs)
-    {
-        if (this != &rhs) {
-            Image::operator=(rhs);
-        }
-        return *this;
-    }
 
     Image1DBuffer& operator = (const cl_mem& rhs)
     {
         Image::operator=(rhs);
         return *this;
     }
+    
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image1DBuffer(const Image1DBuffer& img) : Image(img) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image1DBuffer& operator = (const Image1DBuffer &img)
+    {
+        Image::operator=(img);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image1DBuffer(Image1DBuffer&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image1DBuffer& operator = (Image1DBuffer &&img)
+    {
+        Image::operator=(std::move(img));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 
 /*! \class Image1DArray
@@ -3727,23 +3807,43 @@ public:
 
     Image1DArray() { }
 
-    Image1DArray(const Image1DArray& imageArray) : Image(imageArray) { }
-
     __CL_EXPLICIT_CONSTRUCTORS Image1DArray(const cl_mem& imageArray) : Image(imageArray) { }
-
-    Image1DArray& operator = (const Image1DArray& rhs)
-    {
-        if (this != &rhs) {
-            Image::operator=(rhs);
-        }
-        return *this;
-    }
 
     Image1DArray& operator = (const cl_mem& rhs)
     {
         Image::operator=(rhs);
         return *this;
     }
+    
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image1DArray(const Image1DArray& img) : Image(img) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image1DArray& operator = (const Image1DArray &img)
+    {
+        Image::operator=(img);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image1DArray(Image1DArray&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image1DArray& operator = (Image1DArray &&img)
+    {
+        Image::operator=(std::move(img));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 #endif // #if defined(CL_VERSION_1_2)
 
@@ -3829,29 +3929,11 @@ public:
     //! \brief Default constructor - initializes to NULL.
     Image2D() { }
 
-    /*! \brief Copy constructor - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Image2D(const Image2D& image2D) : Image(image2D) { }
-
     /*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
     __CL_EXPLICIT_CONSTRUCTORS Image2D(const cl_mem& image2D) : Image(image2D) { }
-
-    /*! \brief Assignment from Image2D - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Image2D& operator = (const Image2D& rhs)
-    {
-        if (this != &rhs) {
-            Image::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment from cl_mem - performs shallow copy.
      *
@@ -3862,6 +3944,36 @@ public:
         Image::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image2D(const Image2D& img) : Image(img) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image2D& operator = (const Image2D &img)
+    {
+        Image::operator=(img);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image2D(Image2D&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image2D& operator = (Image2D &&img)
+    {
+        Image::operator=(std::move(img));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 
 
@@ -3886,9 +3998,9 @@ public:
     Image2DGL(
         const Context& context,
         cl_mem_flags flags,
-        GLenum target,
-        GLint  miplevel,
-        GLuint texobj,
+        cl_GLenum target,
+        cl_GLint  miplevel,
+        cl_GLuint texobj,
         cl_int * err = NULL)
     {
         cl_int error;
@@ -3910,29 +4022,11 @@ public:
     //! \brief Default constructor - initializes to NULL.
     Image2DGL() : Image2D() { }
 
-    /*! \brief Copy constructor - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Image2DGL(const Image2DGL& image) : Image2D(image) { }
-
     /*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
     __CL_EXPLICIT_CONSTRUCTORS Image2DGL(const cl_mem& image) : Image2D(image) { }
-
-    /*! \brief Assignment from Image2DGL - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Image2DGL& operator = (const Image2DGL& rhs)
-    {
-        if (this != &rhs) {
-            Image2D::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment from cl_mem - performs shallow copy.
      *
@@ -3943,6 +4037,36 @@ public:
         Image2D::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image2DGL(const Image2DGL& img) : Image2D(img) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image2DGL& operator = (const Image2DGL &img)
+    {
+        Image2D::operator=(img);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image2DGL(Image2DGL&& img) CL_HPP_NOEXCEPT : Image2D(std::move(img)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image2DGL& operator = (Image2DGL &&img)
+    {
+        Image2D::operator=(std::move(img));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 #endif // #if !defined(CL_VERSION_1_2)
 
@@ -3993,23 +4117,43 @@ public:
 
     Image2DArray() { }
 
-    Image2DArray(const Image2DArray& imageArray) : Image(imageArray) { }
-
     __CL_EXPLICIT_CONSTRUCTORS Image2DArray(const cl_mem& imageArray) : Image(imageArray) { }
-
-    Image2DArray& operator = (const Image2DArray& rhs)
-    {
-        if (this != &rhs) {
-            Image::operator=(rhs);
-        }
-        return *this;
-    }
 
     Image2DArray& operator = (const cl_mem& rhs)
     {
         Image::operator=(rhs);
         return *this;
     }
+    
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image2DArray(const Image2DArray& img) : Image(img) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image2DArray& operator = (const Image2DArray &img)
+    {
+        Image::operator=(img);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image2DArray(Image2DArray&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image2DArray& operator = (Image2DArray &&img)
+    {
+        Image::operator=(std::move(img));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 #endif // #if defined(CL_VERSION_1_2)
 
@@ -4097,31 +4241,13 @@ public:
     }
 
     //! \brief Default constructor - initializes to NULL.
-    Image3D() { }
-
-    /*! \brief Copy constructor - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Image3D(const Image3D& image3D) : Image(image3D) { }
+    Image3D() : Image() { }
 
     /*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
     __CL_EXPLICIT_CONSTRUCTORS Image3D(const cl_mem& image3D) : Image(image3D) { }
-
-    /*! \brief Assignment from Image3D - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Image3D& operator = (const Image3D& rhs)
-    {
-        if (this != &rhs) {
-            Image::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment from cl_mem - performs shallow copy.
      *
@@ -4132,6 +4258,36 @@ public:
         Image::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image3D(const Image3D& img) : Image(img) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image3D& operator = (const Image3D &img)
+    {
+        Image::operator=(img);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image3D(Image3D&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image3D& operator = (Image3D &&img)
+    {
+        Image::operator=(std::move(img));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 
 #if !defined(CL_VERSION_1_2)
@@ -4154,9 +4310,9 @@ public:
     Image3DGL(
         const Context& context,
         cl_mem_flags flags,
-        GLenum target,
-        GLint  miplevel,
-        GLuint texobj,
+        cl_GLenum target,
+        cl_GLint  miplevel,
+        cl_GLuint texobj,
         cl_int * err = NULL)
     {
         cl_int error;
@@ -4177,29 +4333,11 @@ public:
     //! \brief Default constructor - initializes to NULL.
     Image3DGL() : Image3D() { }
 
-    /*! \brief Copy constructor - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Image3DGL(const Image3DGL& image) : Image3D(image) { }
-
     /*! \brief Constructor from cl_mem - takes ownership.
      *
      *  See Memory for further details.
      */
     __CL_EXPLICIT_CONSTRUCTORS Image3DGL(const cl_mem& image) : Image3D(image) { }
-
-    /*! \brief Assignment from Image3DGL - performs shallow copy.
-     *
-     *  See Memory for further details.
-     */
-    Image3DGL& operator = (const Image3DGL& rhs)
-    {
-        if (this != &rhs) {
-            Image3D::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment from cl_mem - performs shallow copy.
      *
@@ -4210,6 +4348,36 @@ public:
         Image3D::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image3DGL(const Image3DGL& img) : Image3D(img) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image3DGL& operator = (const Image3DGL &img)
+    {
+        Image3D::operator=(img);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image3DGL(Image3DGL&& img) CL_HPP_NOEXCEPT : Image3D(std::move(img)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Image3DGL& operator = (Image3DGL &&img)
+    {
+        Image3D::operator=(std::move(img));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 #endif // #if !defined(CL_VERSION_1_2)
 
@@ -4226,9 +4394,9 @@ public:
     ImageGL(
         const Context& context,
         cl_mem_flags flags,
-        GLenum target,
-        GLint  miplevel,
-        GLuint texobj,
+        cl_GLenum target,
+        cl_GLint  miplevel,
+        cl_GLuint texobj,
         cl_int * err = NULL)
     {
         cl_int error;
@@ -4248,25 +4416,177 @@ public:
 
     ImageGL() : Image() { }
 
-    ImageGL(const ImageGL& image) : Image(image) { }
-
     __CL_EXPLICIT_CONSTRUCTORS ImageGL(const cl_mem& image) : Image(image) { }
-
-    ImageGL& operator = (const ImageGL& rhs)
-    {
-        if (this != &rhs) {
-            Image::operator=(rhs);
-        }
-        return *this;
-    }
 
     ImageGL& operator = (const cl_mem& rhs)
     {
         Image::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    ImageGL(const ImageGL& img) : Image(img) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    ImageGL& operator = (const ImageGL &img)
+    {
+        Image::operator=(img);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    ImageGL(ImageGL&& img) CL_HPP_NOEXCEPT : Image(std::move(img)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    ImageGL& operator = (ImageGL &&img)
+    {
+        Image::operator=(std::move(img));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 };
 #endif // #if defined(CL_VERSION_1_2)
+
+/*! \brief Class interface for GL Render Buffer Memory Objects.
+*
+*  This is provided to facilitate interoperability with OpenGL.
+*
+*  See Memory for details about copy semantics, etc.
+*
+*  \see Memory
+*/
+class BufferRenderGL : 
+#if defined(CL_VERSION_1_2)
+    public ImageGL
+#else // #if defined(CL_VERSION_1_2)
+    public Image2DGL
+#endif //#if defined(CL_VERSION_1_2)
+{
+public:
+    /*! \brief Constructs a BufferRenderGL in a specified context, from a given
+    *         GL Renderbuffer.
+    *
+    *  Wraps clCreateFromGLRenderbuffer().
+    */
+    BufferRenderGL(
+        const Context& context,
+        cl_mem_flags flags,
+        cl_GLuint bufobj,
+        cl_int * err = NULL)
+    {
+        cl_int error;
+        object_ = ::clCreateFromGLRenderbuffer(
+            context(),
+            flags,
+            bufobj,
+            &error);
+
+        detail::errHandler(error, __CREATE_GL_RENDER_BUFFER_ERR);
+        if (err != NULL) {
+            *err = error;
+        }
+    }
+
+    //! \brief Default constructor - initializes to NULL.
+#if defined(CL_VERSION_1_2)
+    BufferRenderGL() : ImageGL() {};
+#else // #if defined(CL_VERSION_1_2)
+    BufferRenderGL() : Image2DGL() {};
+#endif //#if defined(CL_VERSION_1_2)
+
+    /*! \brief Constructor from cl_mem - takes ownership.
+    *
+    *  See Memory for further details.
+    */
+#if defined(CL_VERSION_1_2)
+    __CL_EXPLICIT_CONSTRUCTORS BufferRenderGL(const cl_mem& buffer) : ImageGL(buffer) { }
+#else // #if defined(CL_VERSION_1_2)
+    __CL_EXPLICIT_CONSTRUCTORS BufferRenderGL(const cl_mem& buffer) : Image2DGL(buffer) { }
+#endif //#if defined(CL_VERSION_1_2)
+
+
+    /*! \brief Assignment from cl_mem - performs shallow copy.
+    *
+    *  See Memory for further details.
+    */
+    BufferRenderGL& operator = (const cl_mem& rhs)
+    {
+#if defined(CL_VERSION_1_2)
+        ImageGL::operator=(rhs);
+#else // #if defined(CL_VERSION_1_2)
+        Image2DGL::operator=(rhs);
+#endif //#if defined(CL_VERSION_1_2)
+        
+        return *this;
+    }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+    * Required for MSVC.
+    */
+#if defined(CL_VERSION_1_2)
+    BufferRenderGL(const BufferRenderGL& buf) : ImageGL(buf) {}
+#else // #if defined(CL_VERSION_1_2)
+    BufferRenderGL(const BufferRenderGL& buf) : Image2DGL(buf) {}
+#endif //#if defined(CL_VERSION_1_2)
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+    * Required for MSVC.
+    */
+    BufferRenderGL& operator = (const BufferRenderGL &rhs)
+    {
+#if defined(CL_VERSION_1_2)
+        ImageGL::operator=(rhs);
+#else // #if defined(CL_VERSION_1_2)
+        Image2DGL::operator=(rhs);
+#endif //#if defined(CL_VERSION_1_2)
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+    * Required for MSVC.
+    */
+#if defined(CL_VERSION_1_2)
+    BufferRenderGL(BufferRenderGL&& buf) CL_HPP_NOEXCEPT : ImageGL(std::move(buf)) {}
+#else // #if defined(CL_VERSION_1_2)
+    BufferRenderGL(BufferRenderGL&& buf) CL_HPP_NOEXCEPT : Image2DGL(std::move(buf)) {}
+#endif //#if defined(CL_VERSION_1_2)
+    
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+    * Required for MSVC.
+    */
+    BufferRenderGL& operator = (BufferRenderGL &&buf)
+    {
+#if defined(CL_VERSION_1_2)
+        ImageGL::operator=(std::move(buf));
+#else // #if defined(CL_VERSION_1_2)
+        Image2DGL::operator=(std::move(buf));
+#endif //#if defined(CL_VERSION_1_2)
+        
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+
+    //! \brief Wrapper for clGetGLObjectInfo().
+    cl_int getObjectInfo(
+        cl_gl_object_type *type,
+        cl_GLuint * gl_object_name)
+    {
+        return detail::errHandler(
+            ::clGetGLObjectInfo(object_, type, gl_object_name),
+            __GET_GL_OBJECT_INFO_ERR);
+    }
+};
 
 /*! \brief Class interface for cl_sampler.
  *
@@ -4279,12 +4599,6 @@ public:
 class Sampler : public detail::Wrapper<cl_sampler>
 {
 public:
-    /*! \brief Destructor.
-     *
-     *  This calls clReleaseSampler() on the value held by this instance.
-     */
-    ~Sampler() { }
-
     //! \brief Default constructor - initializes to NULL.
     Sampler() { }
 
@@ -4313,31 +4627,12 @@ public:
         }
     }
 
-    /*! \brief Copy constructor - performs shallow copy.
-     * 
-     *  This calls clRetainSampler() on the parameter's cl_sampler.
-     */
-    Sampler(const Sampler& sampler) : detail::Wrapper<cl_type>(sampler) { }
-
     /*! \brief Constructor from cl_sampler - takes ownership.
      * 
      *  This effectively transfers ownership of a refcount on the cl_sampler
      *  into the new Sampler object.
      */
-    Sampler(const cl_sampler& sampler) : detail::Wrapper<cl_type>(sampler) { }
-
-    /*! \brief Assignment operator from Sampler.
-     * 
-     *  This calls clRetainSampler() on the parameter and clReleaseSampler()
-     *  on the previous value held by this instance.
-     */
-    Sampler& operator = (const Sampler& rhs)
-    {
-        if (this != &rhs) {
-            detail::Wrapper<cl_type>::operator=(rhs);
-        }
-        return *this;
-    }
+    __CL_EXPLICIT_CONSTRUCTORS Sampler(const cl_sampler& sampler) : detail::Wrapper<cl_type>(sampler) { }
 
     /*! \brief Assignment operator from cl_sampler - takes ownership.
      *
@@ -4349,6 +4644,36 @@ public:
         detail::Wrapper<cl_type>::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Sampler(const Sampler& sam) : detail::Wrapper<cl_type>(sam) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Sampler& operator = (const Sampler &sam)
+    {
+        detail::Wrapper<cl_type>::operator=(sam);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Sampler(Sampler&& sam) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(sam)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Sampler& operator = (Sampler &&sam)
+    {
+        detail::Wrapper<cl_type>::operator=(std::move(sam));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
     //! \brief Wrapper for clGetSamplerInfo().
     template <typename T>
@@ -4442,14 +4767,14 @@ template <typename T>
 struct KernelArgumentHandler
 {
     static ::size_t size(const T&) { return sizeof(T); }
-    static T* ptr(T& value) { return &value; }
+    static const T* ptr(const T& value) { return &value; }
 };
 
 template <>
 struct KernelArgumentHandler<LocalSpaceArg>
 {
     static ::size_t size(const LocalSpaceArg& value) { return value.size_; }
-    static void* ptr(LocalSpaceArg&) { return NULL; }
+    static const void* ptr(const LocalSpaceArg&) { return NULL; }
 };
 
 } 
@@ -4493,20 +4818,8 @@ class Kernel : public detail::Wrapper<cl_kernel>
 public:
     inline Kernel(const Program& program, const char* name, cl_int* err = NULL);
 
-    /*! \brief Destructor.
-     *
-     *  This calls clReleaseKernel() on the value held by this instance.
-     */
-    ~Kernel() { }
-
     //! \brief Default constructor - initializes to NULL.
     Kernel() { }
-
-    /*! \brief Copy constructor - performs shallow copy.
-     * 
-     *  This calls clRetainKernel() on the parameter's cl_kernel.
-     */
-    Kernel(const Kernel& kernel) : detail::Wrapper<cl_type>(kernel) { }
 
     /*! \brief Constructor from cl_kernel - takes ownership.
      * 
@@ -4514,19 +4827,6 @@ public:
      *  into the new Kernel object.
      */
     __CL_EXPLICIT_CONSTRUCTORS Kernel(const cl_kernel& kernel) : detail::Wrapper<cl_type>(kernel) { }
-
-    /*! \brief Assignment operator from Kernel.
-     * 
-     *  This calls clRetainKernel() on the parameter and clReleaseKernel()
-     *  on the previous value held by this instance.
-     */
-    Kernel& operator = (const Kernel& rhs)
-    {
-        if (this != &rhs) {
-            detail::Wrapper<cl_type>::operator=(rhs);
-        }
-        return *this;
-    }
 
     /*! \brief Assignment operator from cl_kernel - takes ownership.
      *
@@ -4538,6 +4838,36 @@ public:
         detail::Wrapper<cl_type>::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Kernel(const Kernel& kernel) : detail::Wrapper<cl_type>(kernel) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Kernel& operator = (const Kernel &kernel)
+    {
+        detail::Wrapper<cl_type>::operator=(kernel);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Kernel(Kernel&& kernel) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(kernel)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Kernel& operator = (Kernel &&kernel)
+    {
+        detail::Wrapper<cl_type>::operator=(std::move(kernel));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
     template <typename T>
     cl_int getInfo(cl_kernel_info name, T* param) const
@@ -4607,7 +4937,7 @@ public:
     }
 
     template <typename T>
-    cl_int setArg(cl_uint index, T value)
+    cl_int setArg(cl_uint index, const T &value)
     {
         return detail::errHandler(
             ::clSetKernelArg(
@@ -4618,7 +4948,7 @@ public:
             __SET_KERNEL_ARGS_ERR);
     }
 
-    cl_int setArg(cl_uint index, ::size_t size, void* argPtr)
+    cl_int setArg(cl_uint index, ::size_t size, const void* argPtr)
     {
         return detail::errHandler(
             ::clSetKernelArg(object_, index, size, argPtr),
@@ -4789,7 +5119,7 @@ public:
         object_ = ::clCreateProgramWithBinary(
             context(), (cl_uint) devices.size(),
             deviceIDs,
-            lengths, images, binaryStatus != NULL
+            lengths, images, (binaryStatus != NULL && numDevices > 0)
                ? &binaryStatus->front()
                : NULL, &error);
 
@@ -4836,23 +5166,43 @@ public:
 
     Program() { }
 
-    Program(const Program& program) : detail::Wrapper<cl_type>(program) { }
-
     __CL_EXPLICIT_CONSTRUCTORS Program(const cl_program& program) : detail::Wrapper<cl_type>(program) { }
-
-    Program& operator = (const Program& rhs)
-    {
-        if (this != &rhs) {
-            detail::Wrapper<cl_type>::operator=(rhs);
-        }
-        return *this;
-    }
 
     Program& operator = (const cl_program& rhs)
     {
         detail::Wrapper<cl_type>::operator=(rhs);
         return *this;
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Program(const Program& program) : detail::Wrapper<cl_type>(program) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    Program& operator = (const Program &program)
+    {
+        detail::Wrapper<cl_type>::operator=(program);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Program(Program&& program) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(program)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    Program& operator = (Program &&program)
+    {
+        detail::Wrapper<cl_type>::operator=(std::move(program));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
     cl_int build(
         const VECTOR_CLASS<Device>& devices,
@@ -4988,11 +5338,14 @@ inline Program linkProgram(
     void* data = NULL,
     cl_int* err = NULL) 
 {
-    cl_int err_local = CL_SUCCESS;
+    cl_int error_local = CL_SUCCESS;
 
     cl_program programs[2] = { input1(), input2() };
 
-    Context ctx = input1.getInfo<CL_PROGRAM_CONTEXT>();
+    Context ctx = input1.getInfo<CL_PROGRAM_CONTEXT>(&error_local);
+    if(error_local!=CL_SUCCESS) {
+        detail::errHandler(error_local, __LINK_PROGRAM_ERR);
+    }
 
     cl_program prog = ::clLinkProgram(
         ctx(),
@@ -5003,11 +5356,11 @@ inline Program linkProgram(
         programs,
         notifyFptr,
         data,
-        &err_local);
+        &error_local);
 
-    detail::errHandler(err_local,__COMPILE_PROGRAM_ERR);
+    detail::errHandler(error_local,__COMPILE_PROGRAM_ERR);
     if (err != NULL) {
-        *err = err_local;
+        *err = error_local;
     }
 
     return Program(prog);
@@ -5020,7 +5373,7 @@ inline Program linkProgram(
     void* data = NULL,
     cl_int* err = NULL) 
 {
-    cl_int err_local = CL_SUCCESS;
+    cl_int error_local = CL_SUCCESS;
 
     cl_program * programs = (cl_program*) alloca(inputPrograms.size() * sizeof(cl_program));
 
@@ -5030,8 +5383,15 @@ inline Program linkProgram(
         }
     } 
 
+    Context ctx;
+    if(inputPrograms.size() > 0) {
+        ctx = inputPrograms[0].getInfo<CL_PROGRAM_CONTEXT>(&error_local);
+        if(error_local!=CL_SUCCESS) {
+            detail::errHandler(error_local, __LINK_PROGRAM_ERR);
+        }
+    }
     cl_program prog = ::clLinkProgram(
-        Context::getDefault()(),
+        ctx(),
         0,
         NULL,
         options,
@@ -5039,11 +5399,11 @@ inline Program linkProgram(
         programs,
         notifyFptr,
         data,
-        &err_local);
+        &error_local);
 
-    detail::errHandler(err_local,__COMPILE_PROGRAM_ERR);
+    detail::errHandler(error_local,__COMPILE_PROGRAM_ERR);
     if (err != NULL) {
-        *err = err_local;
+        *err = error_local;
     }
 
     return Program(prog);
@@ -5089,7 +5449,11 @@ inline Kernel::Kernel(const Program& program, const char* name, cl_int* err)
 class CommandQueue : public detail::Wrapper<cl_command_queue>
 {
 private:
+#ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
+    static std::atomic<int> default_initialized_;
+#else // !CL_HPP_CPP11_ATOMICS_SUPPORTED
     static volatile int default_initialized_;
+#endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
     static CommandQueue default_;
     static volatile cl_int default_error_;
 public:
@@ -5100,7 +5464,7 @@ public:
         cl_int error;
 
         Context context = Context::getDefault(&error);
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
+        detail::errHandler(error, __CREATE_CONTEXT_ERR);
 
         if (error != CL_SUCCESS) {
             if (err != NULL) {
@@ -5131,7 +5495,7 @@ public:
         VECTOR_CLASS<cl::Device> devices;
         error = context.getInfo(CL_CONTEXT_DEVICES, &devices);
 
-        detail::errHandler(error, __CREATE_COMMAND_QUEUE_ERR);
+        detail::errHandler(error, __CREATE_CONTEXT_ERR);
 
         if (error != CL_SUCCESS)
         {
@@ -5166,6 +5530,36 @@ public:
             *err = error;
         }
     }
+
+    /*! \brief Copy constructor to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    CommandQueue(const CommandQueue& queue) : detail::Wrapper<cl_type>(queue) {}
+
+    /*! \brief Copy assignment to forward copy to the superclass correctly.
+     * Required for MSVC.
+     */
+    CommandQueue& operator = (const CommandQueue &queue)
+    {
+        detail::Wrapper<cl_type>::operator=(queue);
+        return *this;
+    }
+
+#if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
+    /*! \brief Move constructor to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    CommandQueue(CommandQueue&& queue) CL_HPP_NOEXCEPT : detail::Wrapper<cl_type>(std::move(queue)) {}
+
+    /*! \brief Move assignment to forward move to the superclass correctly.
+     * Required for MSVC.
+     */
+    CommandQueue& operator = (CommandQueue &&queue)
+    {
+        detail::Wrapper<cl_type>::operator=(std::move(queue));
+        return *this;
+    }
+#endif // #if defined(CL_HPP_RVALUE_REFERENCES_SUPPORTED)
 
     static CommandQueue getDefault(cl_int * err = NULL) 
     {
@@ -5230,17 +5624,7 @@ public:
 
     CommandQueue() { }
 
-    CommandQueue(const CommandQueue& commandQueue) : detail::Wrapper<cl_type>(commandQueue) { }
-
-    CommandQueue(const cl_command_queue& commandQueue) : detail::Wrapper<cl_type>(commandQueue) { }
-
-    CommandQueue& operator = (const CommandQueue& rhs)
-    {
-        if (this != &rhs) {
-            detail::Wrapper<cl_type>::operator=(rhs);
-        }
-        return *this;
-    }
+    __CL_EXPLICIT_CONSTRUCTORS CommandQueue(const cl_command_queue& commandQueue) : detail::Wrapper<cl_type>(commandQueue) { }
 
     CommandQueue& operator = (const cl_command_queue& rhs)
     {
@@ -5739,18 +6123,22 @@ public:
         Event* event = NULL,
         cl_int* err = NULL) const
     {
+        cl_event tmp;
         cl_int error;
         void * result = ::clEnqueueMapBuffer(
             object_, buffer(), blocking, flags, offset, size,
             (events != NULL) ? (cl_uint) events->size() : 0,
             (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-            (cl_event*) event,
+            (event != NULL) ? &tmp : NULL,
             &error);
 
         detail::errHandler(error, __ENQUEUE_MAP_BUFFER_ERR);
         if (err != NULL) {
             *err = error;
         }
+        if (event != NULL && error == CL_SUCCESS)
+            *event = tmp;
+
         return result;
     }
 
@@ -5766,6 +6154,7 @@ public:
         Event* event = NULL,
         cl_int* err = NULL) const
     {
+        cl_event tmp;
         cl_int error;
         void * result = ::clEnqueueMapImage(
             object_, buffer(), blocking, flags,
@@ -5773,13 +6162,15 @@ public:
             row_pitch, slice_pitch,
             (events != NULL) ? (cl_uint) events->size() : 0,
             (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
-            (cl_event*) event,
+            (event != NULL) ? &tmp : NULL,
             &error);
 
         detail::errHandler(error, __ENQUEUE_MAP_IMAGE_ERR);
         if (err != NULL) {
               *err = error;
         }
+        if (event != NULL && error == CL_SUCCESS)
+            *event = tmp;
         return result;
     }
 
@@ -5972,7 +6363,7 @@ public:
                 object_, userFptr, args.first, args.second,
                 (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
                 mems,
-                (mem_locs != NULL) ? (const void **) &mem_locs->front() : NULL,
+                (mem_locs != NULL && mem_locs->size() > 0) ? (const void **) &mem_locs->front() : NULL,
                 (events != NULL) ? (cl_uint) events->size() : 0,
                 (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
                 (event != NULL) ? &tmp : NULL),
@@ -5991,9 +6382,17 @@ public:
     CL_EXT_PREFIX__VERSION_1_1_DEPRECATED 
     cl_int enqueueMarker(Event* event = NULL) const CL_EXT_SUFFIX__VERSION_1_1_DEPRECATED
     {
-        return detail::errHandler(
-            ::clEnqueueMarker(object_, (cl_event*) event),
+        cl_event tmp;
+        cl_int err = detail::errHandler(
+            ::clEnqueueMarker(
+                object_, 
+                (event != NULL) ? &tmp : NULL),
             __ENQUEUE_MARKER_ERR);
+
+        if (event != NULL && err == CL_SUCCESS)
+            *event = tmp;
+
+        return err;
     }
 
     CL_EXT_PREFIX__VERSION_1_1_DEPRECATED
@@ -6003,7 +6402,7 @@ public:
             ::clEnqueueWaitForEvents(
                 object_,
                 (cl_uint) events.size(),
-                (const cl_event*) &events.front()),
+                events.size() > 0 ? (const cl_event*) &events.front() : NULL),
             __ENQUEUE_WAIT_FOR_EVENTS_ERR);
     }
 #endif // #if defined(CL_VERSION_1_1)
@@ -6018,7 +6417,7 @@ public:
              ::clEnqueueAcquireGLObjects(
                  object_,
                  (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                 (mem_objects != NULL) ? (const cl_mem *) &mem_objects->front(): NULL,
+                 (mem_objects != NULL && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): NULL,
                  (events != NULL) ? (cl_uint) events->size() : 0,
                  (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
                  (event != NULL) ? &tmp : NULL),
@@ -6040,7 +6439,7 @@ public:
              ::clEnqueueReleaseGLObjects(
                  object_,
                  (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                 (mem_objects != NULL) ? (const cl_mem *) &mem_objects->front(): NULL,
+                 (mem_objects != NULL && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): NULL,
                  (events != NULL) ? (cl_uint) events->size() : 0,
                  (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
                  (event != NULL) ? &tmp : NULL),
@@ -6083,7 +6482,7 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
              pfn_clEnqueueAcquireD3D10ObjectsKHR(
                  object_,
                  (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                 (mem_objects != NULL) ? (const cl_mem *) &mem_objects->front(): NULL,
+                 (mem_objects != NULL && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): NULL,
                  (events != NULL) ? (cl_uint) events->size() : 0,
                  (events != NULL) ? (cl_event*) &events->front() : NULL,
                  (event != NULL) ? &tmp : NULL),
@@ -6116,9 +6515,9 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
             pfn_clEnqueueReleaseD3D10ObjectsKHR(
                 object_,
                 (mem_objects != NULL) ? (cl_uint) mem_objects->size() : 0,
-                (mem_objects != NULL) ? (const cl_mem *) &mem_objects->front(): NULL,
+                (mem_objects != NULL && mem_objects->size() > 0) ? (const cl_mem *) &mem_objects->front(): NULL,
                 (events != NULL) ? (cl_uint) events->size() : 0,
-                (events != NULL) ? (cl_event*) &events->front() : NULL,
+                (events != NULL && events->size() > 0) ? (cl_event*) &events->front() : NULL,
                 (event != NULL) ? &tmp : NULL),
             __ENQUEUE_RELEASE_GL_ERR);
 
@@ -6154,14 +6553,22 @@ typedef CL_API_ENTRY cl_int (CL_API_CALL *PFN_clEnqueueReleaseD3D10ObjectsKHR)(
 };
 
 #ifdef _WIN32
+#ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
+__declspec(selectany) std::atomic<int> CommandQueue::default_initialized_;
+#else // !CL_HPP_CPP11_ATOMICS_SUPPORTED
 __declspec(selectany) volatile int CommandQueue::default_initialized_ = __DEFAULT_NOT_INITIALIZED;
+#endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
 __declspec(selectany) CommandQueue CommandQueue::default_;
 __declspec(selectany) volatile cl_int CommandQueue::default_error_ = CL_SUCCESS;
-#else
+#else // !_WIN32
+#ifdef CL_HPP_CPP11_ATOMICS_SUPPORTED
+__attribute__((weak)) std::atomic<int> CommandQueue::default_initialized_;
+#else // !CL_HPP_CPP11_ATOMICS_SUPPORTED
 __attribute__((weak)) volatile int CommandQueue::default_initialized_ = __DEFAULT_NOT_INITIALIZED;
+#endif // !CL_HPP_CPP11_ATOMICS_SUPPORTED
 __attribute__((weak)) CommandQueue CommandQueue::default_;
 __attribute__((weak)) volatile cl_int CommandQueue::default_error_ = CL_SUCCESS;
-#endif
+#endif // !_WIN32
 
 template< typename IteratorType >
 Buffer::Buffer(
@@ -6206,6 +6613,54 @@ Buffer::Buffer(
             *err = error;
         }
 
+        error = cl::copy(queue, startIterator, endIterator, *this);
+        detail::errHandler(error, __CREATE_BUFFER_ERR);
+        if (err != NULL) {
+            *err = error;
+        }
+    }
+}
+
+template< typename IteratorType >
+Buffer::Buffer(
+    const CommandQueue &queue,
+    IteratorType startIterator,
+    IteratorType endIterator,
+    bool readOnly,
+    bool useHostPtr,
+    cl_int* err)
+{
+    typedef typename std::iterator_traits<IteratorType>::value_type DataType;
+    cl_int error;
+
+    cl_mem_flags flags = 0;
+    if (readOnly) {
+        flags |= CL_MEM_READ_ONLY;
+    }
+    else {
+        flags |= CL_MEM_READ_WRITE;
+    }
+    if (useHostPtr) {
+        flags |= CL_MEM_USE_HOST_PTR;
+    }
+
+    ::size_t size = sizeof(DataType)*(endIterator - startIterator);
+
+    Context context = queue.getInfo<CL_QUEUE_CONTEXT>();
+
+    if (useHostPtr) {
+        object_ = ::clCreateBuffer(context(), flags, size, static_cast<DataType*>(&*startIterator), &error);
+    }
+    else {
+        object_ = ::clCreateBuffer(context(), flags, size, 0, &error);
+    }
+
+    detail::errHandler(error, __CREATE_BUFFER_ERR);
+    if (err != NULL) {
+        *err = error;
+    }
+
+    if (!useHostPtr) {
         error = cl::copy(queue, startIterator, endIterator, *this);
         detail::errHandler(error, __CREATE_BUFFER_ERR);
         if (err != NULL) {
@@ -7022,73 +7477,73 @@ public:
 
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19,
-    typename T20,
-    typename T21,
-    typename T22,
-    typename T23,
-    typename T24,
-    typename T25,
-    typename T26,
-    typename T27,
-    typename T28,
-    typename T29,
-    typename T30,
-    typename T31>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19,
+	typename T20,
+	typename T21,
+	typename T22,
+	typename T23,
+	typename T24,
+	typename T25,
+	typename T26,
+	typename T27,
+	typename T28,
+	typename T29,
+	typename T30,
+	typename T31>
 struct functionImplementation_
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        T26,
-        T27,
-        T28,
-        T29,
-        T30,
-        T31> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		T26,
+		T27,
+		T28,
+		T29,
+		T30,
+		T31> FunctorType;
 
     FunctorType functor_;
 
@@ -7103,218 +7558,218 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        T26,
-        T27,
-        T28,
-        T29,
-        T30,
-        T31);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		T26,
+		T27,
+		T28,
+		T29,
+		T30,
+		T31);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19,
-        T20 arg20,
-        T21 arg21,
-        T22 arg22,
-        T23 arg23,
-        T24 arg24,
-        T25 arg25,
-        T26 arg26,
-        T27 arg27,
-        T28 arg28,
-        T29 arg29,
-        T30 arg30,
-        T31 arg31)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19,
-            arg20,
-            arg21,
-            arg22,
-            arg23,
-            arg24,
-            arg25,
-            arg26,
-            arg27,
-            arg28,
-            arg29,
-            arg30,
-            arg31);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19,
+		T20 arg20,
+		T21 arg21,
+		T22 arg22,
+		T23 arg23,
+		T24 arg24,
+		T25 arg25,
+		T26 arg26,
+		T27 arg27,
+		T28 arg28,
+		T29 arg29,
+		T30 arg30,
+		T31 arg31)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19,
+			arg20,
+			arg21,
+			arg22,
+			arg23,
+			arg24,
+			arg25,
+			arg26,
+			arg27,
+			arg28,
+			arg29,
+			arg30,
+			arg31);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19,
-    typename T20,
-    typename T21,
-    typename T22,
-    typename T23,
-    typename T24,
-    typename T25,
-    typename T26,
-    typename T27,
-    typename T28,
-    typename T29,
-    typename T30>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19,
+	typename T20,
+	typename T21,
+	typename T22,
+	typename T23,
+	typename T24,
+	typename T25,
+	typename T26,
+	typename T27,
+	typename T28,
+	typename T29,
+	typename T30>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    T23,
-    T24,
-    T25,
-    T26,
-    T27,
-    T28,
-    T29,
-    T30,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	T19,
+	T20,
+	T21,
+	T22,
+	T23,
+	T24,
+	T25,
+	T26,
+	T27,
+	T28,
+	T29,
+	T30,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        T26,
-        T27,
-        T28,
-        T29,
-        T30,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		T26,
+		T27,
+		T28,
+		T29,
+		T30,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -7329,214 +7784,214 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        T26,
-        T27,
-        T28,
-        T29,
-        T30);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		T26,
+		T27,
+		T28,
+		T29,
+		T30);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19,
-        T20 arg20,
-        T21 arg21,
-        T22 arg22,
-        T23 arg23,
-        T24 arg24,
-        T25 arg25,
-        T26 arg26,
-        T27 arg27,
-        T28 arg28,
-        T29 arg29,
-        T30 arg30)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19,
-            arg20,
-            arg21,
-            arg22,
-            arg23,
-            arg24,
-            arg25,
-            arg26,
-            arg27,
-            arg28,
-            arg29,
-            arg30);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19,
+		T20 arg20,
+		T21 arg21,
+		T22 arg22,
+		T23 arg23,
+		T24 arg24,
+		T25 arg25,
+		T26 arg26,
+		T27 arg27,
+		T28 arg28,
+		T29 arg29,
+		T30 arg30)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19,
+			arg20,
+			arg21,
+			arg22,
+			arg23,
+			arg24,
+			arg25,
+			arg26,
+			arg27,
+			arg28,
+			arg29,
+			arg30);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19,
-    typename T20,
-    typename T21,
-    typename T22,
-    typename T23,
-    typename T24,
-    typename T25,
-    typename T26,
-    typename T27,
-    typename T28,
-    typename T29>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19,
+	typename T20,
+	typename T21,
+	typename T22,
+	typename T23,
+	typename T24,
+	typename T25,
+	typename T26,
+	typename T27,
+	typename T28,
+	typename T29>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    T23,
-    T24,
-    T25,
-    T26,
-    T27,
-    T28,
-    T29,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	T19,
+	T20,
+	T21,
+	T22,
+	T23,
+	T24,
+	T25,
+	T26,
+	T27,
+	T28,
+	T29,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        T26,
-        T27,
-        T28,
-        T29,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		T26,
+		T27,
+		T28,
+		T29,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -7551,210 +8006,210 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        T26,
-        T27,
-        T28,
-        T29);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		T26,
+		T27,
+		T28,
+		T29);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19,
-        T20 arg20,
-        T21 arg21,
-        T22 arg22,
-        T23 arg23,
-        T24 arg24,
-        T25 arg25,
-        T26 arg26,
-        T27 arg27,
-        T28 arg28,
-        T29 arg29)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19,
-            arg20,
-            arg21,
-            arg22,
-            arg23,
-            arg24,
-            arg25,
-            arg26,
-            arg27,
-            arg28,
-            arg29);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19,
+		T20 arg20,
+		T21 arg21,
+		T22 arg22,
+		T23 arg23,
+		T24 arg24,
+		T25 arg25,
+		T26 arg26,
+		T27 arg27,
+		T28 arg28,
+		T29 arg29)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19,
+			arg20,
+			arg21,
+			arg22,
+			arg23,
+			arg24,
+			arg25,
+			arg26,
+			arg27,
+			arg28,
+			arg29);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19,
-    typename T20,
-    typename T21,
-    typename T22,
-    typename T23,
-    typename T24,
-    typename T25,
-    typename T26,
-    typename T27,
-    typename T28>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19,
+	typename T20,
+	typename T21,
+	typename T22,
+	typename T23,
+	typename T24,
+	typename T25,
+	typename T26,
+	typename T27,
+	typename T28>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    T23,
-    T24,
-    T25,
-    T26,
-    T27,
-    T28,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	T19,
+	T20,
+	T21,
+	T22,
+	T23,
+	T24,
+	T25,
+	T26,
+	T27,
+	T28,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        T26,
-        T27,
-        T28,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		T26,
+		T27,
+		T28,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -7769,206 +8224,206 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        T26,
-        T27,
-        T28);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		T26,
+		T27,
+		T28);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19,
-        T20 arg20,
-        T21 arg21,
-        T22 arg22,
-        T23 arg23,
-        T24 arg24,
-        T25 arg25,
-        T26 arg26,
-        T27 arg27,
-        T28 arg28)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19,
-            arg20,
-            arg21,
-            arg22,
-            arg23,
-            arg24,
-            arg25,
-            arg26,
-            arg27,
-            arg28);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19,
+		T20 arg20,
+		T21 arg21,
+		T22 arg22,
+		T23 arg23,
+		T24 arg24,
+		T25 arg25,
+		T26 arg26,
+		T27 arg27,
+		T28 arg28)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19,
+			arg20,
+			arg21,
+			arg22,
+			arg23,
+			arg24,
+			arg25,
+			arg26,
+			arg27,
+			arg28);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19,
-    typename T20,
-    typename T21,
-    typename T22,
-    typename T23,
-    typename T24,
-    typename T25,
-    typename T26,
-    typename T27>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19,
+	typename T20,
+	typename T21,
+	typename T22,
+	typename T23,
+	typename T24,
+	typename T25,
+	typename T26,
+	typename T27>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    T23,
-    T24,
-    T25,
-    T26,
-    T27,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	T19,
+	T20,
+	T21,
+	T22,
+	T23,
+	T24,
+	T25,
+	T26,
+	T27,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        T26,
-        T27,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		T26,
+		T27,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -7983,202 +8438,202 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        T26,
-        T27);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		T26,
+		T27);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19,
-        T20 arg20,
-        T21 arg21,
-        T22 arg22,
-        T23 arg23,
-        T24 arg24,
-        T25 arg25,
-        T26 arg26,
-        T27 arg27)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19,
-            arg20,
-            arg21,
-            arg22,
-            arg23,
-            arg24,
-            arg25,
-            arg26,
-            arg27);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19,
+		T20 arg20,
+		T21 arg21,
+		T22 arg22,
+		T23 arg23,
+		T24 arg24,
+		T25 arg25,
+		T26 arg26,
+		T27 arg27)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19,
+			arg20,
+			arg21,
+			arg22,
+			arg23,
+			arg24,
+			arg25,
+			arg26,
+			arg27);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19,
-    typename T20,
-    typename T21,
-    typename T22,
-    typename T23,
-    typename T24,
-    typename T25,
-    typename T26>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19,
+	typename T20,
+	typename T21,
+	typename T22,
+	typename T23,
+	typename T24,
+	typename T25,
+	typename T26>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    T23,
-    T24,
-    T25,
-    T26,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	T19,
+	T20,
+	T21,
+	T22,
+	T23,
+	T24,
+	T25,
+	T26,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        T26,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		T26,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -8193,198 +8648,198 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        T26);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		T26);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19,
-        T20 arg20,
-        T21 arg21,
-        T22 arg22,
-        T23 arg23,
-        T24 arg24,
-        T25 arg25,
-        T26 arg26)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19,
-            arg20,
-            arg21,
-            arg22,
-            arg23,
-            arg24,
-            arg25,
-            arg26);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19,
+		T20 arg20,
+		T21 arg21,
+		T22 arg22,
+		T23 arg23,
+		T24 arg24,
+		T25 arg25,
+		T26 arg26)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19,
+			arg20,
+			arg21,
+			arg22,
+			arg23,
+			arg24,
+			arg25,
+			arg26);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19,
-    typename T20,
-    typename T21,
-    typename T22,
-    typename T23,
-    typename T24,
-    typename T25>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19,
+	typename T20,
+	typename T21,
+	typename T22,
+	typename T23,
+	typename T24,
+	typename T25>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    T23,
-    T24,
-    T25,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	T19,
+	T20,
+	T21,
+	T22,
+	T23,
+	T24,
+	T25,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -8399,194 +8854,194 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        T25);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		T25);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19,
-        T20 arg20,
-        T21 arg21,
-        T22 arg22,
-        T23 arg23,
-        T24 arg24,
-        T25 arg25)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19,
-            arg20,
-            arg21,
-            arg22,
-            arg23,
-            arg24,
-            arg25);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19,
+		T20 arg20,
+		T21 arg21,
+		T22 arg22,
+		T23 arg23,
+		T24 arg24,
+		T25 arg25)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19,
+			arg20,
+			arg21,
+			arg22,
+			arg23,
+			arg24,
+			arg25);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19,
-    typename T20,
-    typename T21,
-    typename T22,
-    typename T23,
-    typename T24>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19,
+	typename T20,
+	typename T21,
+	typename T22,
+	typename T23,
+	typename T24>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    T23,
-    T24,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	T19,
+	T20,
+	T21,
+	T22,
+	T23,
+	T24,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -8601,190 +9056,190 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        T24);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		T24);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19,
-        T20 arg20,
-        T21 arg21,
-        T22 arg22,
-        T23 arg23,
-        T24 arg24)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19,
-            arg20,
-            arg21,
-            arg22,
-            arg23,
-            arg24);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19,
+		T20 arg20,
+		T21 arg21,
+		T22 arg22,
+		T23 arg23,
+		T24 arg24)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19,
+			arg20,
+			arg21,
+			arg22,
+			arg23,
+			arg24);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19,
-    typename T20,
-    typename T21,
-    typename T22,
-    typename T23>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19,
+	typename T20,
+	typename T21,
+	typename T22,
+	typename T23>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    T23,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	T19,
+	T20,
+	T21,
+	T22,
+	T23,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -8799,186 +9254,186 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        T23);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		T23);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19,
-        T20 arg20,
-        T21 arg21,
-        T22 arg22,
-        T23 arg23)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19,
-            arg20,
-            arg21,
-            arg22,
-            arg23);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19,
+		T20 arg20,
+		T21 arg21,
+		T22 arg22,
+		T23 arg23)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19,
+			arg20,
+			arg21,
+			arg22,
+			arg23);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19,
-    typename T20,
-    typename T21,
-    typename T22>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19,
+	typename T20,
+	typename T21,
+	typename T22>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    T22,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	T19,
+	T20,
+	T21,
+	T22,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -8993,182 +9448,182 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        T22);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		T22);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19,
-        T20 arg20,
-        T21 arg21,
-        T22 arg22)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19,
-            arg20,
-            arg21,
-            arg22);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19,
+		T20 arg20,
+		T21 arg21,
+		T22 arg22)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19,
+			arg20,
+			arg21,
+			arg22);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19,
-    typename T20,
-    typename T21>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19,
+	typename T20,
+	typename T21>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    T21,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	T19,
+	T20,
+	T21,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -9183,178 +9638,178 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        T21);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		T21);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19,
-        T20 arg20,
-        T21 arg21)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19,
-            arg20,
-            arg21);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19,
+		T20 arg20,
+		T21 arg21)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19,
+			arg20,
+			arg21);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19,
-    typename T20>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19,
+	typename T20>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    T20,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	T19,
+	T20,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -9369,174 +9824,174 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        T20);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		T20);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19,
-        T20 arg20)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19,
-            arg20);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19,
+		T20 arg20)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19,
+			arg20);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18,
-    typename T19>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18,
+	typename T19>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    T19,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	T19,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -9551,170 +10006,170 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        T19);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		T19);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18,
-        T19 arg19)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18,
-            arg19);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18,
+		T19 arg19)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18,
+			arg19);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17,
-    typename T18>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17,
+	typename T18>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    T18,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	T18,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -9729,166 +10184,166 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        T18);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		T18);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17,
-        T18 arg18)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17,
-            arg18);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17,
+		T18 arg18)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17,
+			arg18);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16,
-    typename T17>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16,
+	typename T17>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    T17,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	T17,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -9903,162 +10358,162 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        T17);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		T17);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16,
-        T17 arg17)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16,
-            arg17);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16,
+		T17 arg17)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16,
+			arg17);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15,
-    typename T16>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15,
+	typename T16>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    T16,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	T16,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -10073,158 +10528,158 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        T16);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		T16);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15,
-        T16 arg16)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15,
-            arg16);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15,
+		T16 arg16)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15,
+			arg16);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14,
-    typename T15>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14,
+	typename T15>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    T15,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	T15,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -10239,154 +10694,154 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        T15);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		T15);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14,
-        T15 arg15)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14,
-            arg15);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14,
+		T15 arg15)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14,
+			arg15);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13,
-    typename T14>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13,
+	typename T14>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    T14,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	T14,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -10401,150 +10856,150 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        T14);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		T14);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13,
-        T14 arg14)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13,
-            arg14);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13,
+		T14 arg14)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13,
+			arg14);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12,
-    typename T13>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12,
+	typename T13>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    T13,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	T13,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -10559,146 +11014,146 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        T13);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		T13);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12,
-        T13 arg13)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12,
-            arg13);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12,
+		T13 arg13)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12,
+			arg13);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11,
-    typename T12>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11,
+	typename T12>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    T12,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	T12,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -10713,142 +11168,142 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        T12);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		T12);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11,
-        T12 arg12)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11,
-            arg12);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11,
+		T12 arg12)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11,
+			arg12);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10,
-    typename T11>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10,
+	typename T11>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    T11,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	T11,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -10863,138 +11318,138 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        T11);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		T11);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10,
-        T11 arg11)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10,
-            arg11);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10,
+		T11 arg11)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10,
+			arg11);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9,
-    typename T10>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9,
+	typename T10>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    T10,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	T10,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -11009,134 +11464,134 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        T10);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		T10);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9,
-        T10 arg10)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9,
-            arg10);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9,
+		T10 arg10)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9,
+			arg10);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8,
-    typename T9>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8,
+	typename T9>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    T9,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	T9,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -11151,130 +11606,130 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        T9);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		T9);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8,
-        T9 arg9)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8,
-            arg9);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8,
+		T9 arg9)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8,
+			arg9);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7,
-    typename T8>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7,
+	typename T8>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    T8,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	T8,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -11289,126 +11744,126 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        T8);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		T8);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7,
-        T8 arg8)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7,
-            arg8);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7,
+		T8 arg8)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7,
+			arg8);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6,
-    typename T7>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6,
+	typename T7>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    T7,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	T7,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -11423,122 +11878,122 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        T7);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		T7);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6,
-        T7 arg7)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6,
-            arg7);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6,
+		T7 arg7)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6,
+			arg7);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5,
-    typename T6>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5,
+	typename T6>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    T6,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	T6,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -11553,118 +12008,118 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        T6);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		T6);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5,
-        T6 arg6)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5,
-            arg6);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5,
+		T6 arg6)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5,
+			arg6);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4,
-    typename T5>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4,
+	typename T5>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    T5,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	T5,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -11679,114 +12134,114 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        T5);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		T5);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4,
-        T5 arg5)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4,
-            arg5);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4,
+		T5 arg5)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4,
+			arg5);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3,
-    typename T4>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3,
+	typename T4>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    T4,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	T4,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        T4,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		T4,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -11801,110 +12256,110 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3,
-        T4);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3,
+		T4);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3,
-        T4 arg4)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3,
-            arg4);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3,
+		T4 arg4)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3,
+			arg4);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2,
-    typename T3>
+	typename T0,
+	typename T1,
+	typename T2,
+	typename T3>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    T3,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	T3,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        T3,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		T3,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -11919,106 +12374,106 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2,
-        T3);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2,
+		T3);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2,
-        T3 arg3)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2,
-            arg3);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2,
+		T3 arg3)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2,
+			arg3);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1,
-    typename T2>
+	typename T0,
+	typename T1,
+	typename T2>
 struct functionImplementation_
-<    T0,
-    T1,
-    T2,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	T2,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        T2,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		T2,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -12033,102 +12488,102 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1,
-        T2);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1,
+		T2);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1,
-        T2 arg2)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1,
-            arg2);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1,
+		T2 arg2)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1,
+			arg2);
+	}
 
 
 };
 
 template<
-    typename T0,
-    typename T1>
+	typename T0,
+	typename T1>
 struct functionImplementation_
-<    T0,
-    T1,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	T1,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        T1,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		T1,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -12143,98 +12598,98 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0,
-        T1);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0,
+		T1);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0,
-        T1 arg1)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0,
-            arg1);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0,
+		T1 arg1)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0,
+			arg1);
+	}
 
 
 };
 
 template<
-    typename T0>
+	typename T0>
 struct functionImplementation_
-<    T0,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType,
-    NullType>
+<	T0,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType,
+	NullType>
 {
-    typedef detail::KernelFunctorGlobal<
-        T0,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType,
-        NullType> FunctorType;
+	typedef detail::KernelFunctorGlobal<
+		T0,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType,
+		NullType> FunctorType;
 
     FunctorType functor_;
 
@@ -12249,22 +12704,22 @@ struct functionImplementation_
             
     }
 
-    //! \brief Return type of the functor
-    typedef Event result_type;
+	//! \brief Return type of the functor
+	typedef Event result_type;
 
-    //! \brief Function signature of kernel functor with no event dependency.
-    typedef Event type_(
-        const EnqueueArgs&,
-        T0);
+	//! \brief Function signature of kernel functor with no event dependency.
+	typedef Event type_(
+		const EnqueueArgs&,
+		T0);
 
-    Event operator()(
-        const EnqueueArgs& enqueueArgs,
-        T0 arg0)
-    {
-        return functor_(
-            enqueueArgs,
-            arg0);
-    }
+	Event operator()(
+		const EnqueueArgs& enqueueArgs,
+		T0 arg0)
+	{
+		return functor_(
+			enqueueArgs,
+			arg0);
+	}
 
 
 };
@@ -12443,10 +12898,9 @@ public:
 #undef __DEFAULT_BEING_INITIALIZED 
 #undef __DEFAULT_INITIALIZED
 
-} // namespace cl
+#undef CL_HPP_RVALUE_REFERENCES_SUPPORTED
+#undef CL_HPP_NOEXCEPT
 
-#ifdef _WIN32
-#pragma pop_macro("max")
-#endif // _WIN32
+} // namespace cl
 
 #endif // CL_HPP_

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -405,7 +405,7 @@ void DeviceManager::markDeviceForInterop(const int device, const fg::Window* wHa
             }
 
             // call forge to get OpenGL sharing context and details
-            cl::Platform plat = mDevices[device]->getInfo<CL_DEVICE_PLATFORM>();
+            cl::Platform plat(mDevices[device]->getInfo<CL_DEVICE_PLATFORM>());
 #ifdef OS_MAC
             CGLContextObj cgl_current_ctx = CGLGetCurrentContext();
             CGLShareGroupObj cgl_share_group = CGLGetShareGroup(cgl_current_ctx);

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -222,7 +222,7 @@ std::string getInfo()
         vector<Device> devices = context->getInfo<CL_CONTEXT_DEVICES>();
 
         for(auto &device:devices) {
-            const Platform &platform = device.getInfo<CL_DEVICE_PLATFORM>();
+            const Platform platform(device.getInfo<CL_DEVICE_PLATFORM>());
             string platStr = platform.getInfo<CL_PLATFORM_NAME>();
             bool show_braces = ((unsigned)getActiveDeviceId() == nDevices);
             string dstr = device.getInfo<CL_DEVICE_NAME>();
@@ -247,7 +247,7 @@ std::string getInfo()
 
 std::string getPlatformName(const cl::Device &device)
 {
-    const Platform &platform = device.getInfo<CL_DEVICE_PLATFORM>();
+    const Platform platform(device.getInfo<CL_DEVICE_PLATFORM>());
     std::string platStr = platform.getInfo<CL_PLATFORM_NAME>();
     return platformMap(platStr);
 }
@@ -302,7 +302,7 @@ void devprop(char* d_name, char* d_platform, char *d_toolkit, char* d_compute)
         vector<Device> devices = context->getInfo<CL_CONTEXT_DEVICES>();
 
         for (auto &device : devices) {
-            const Platform &platform = device.getInfo<CL_DEVICE_PLATFORM>();
+            const Platform platform(device.getInfo<CL_DEVICE_PLATFORM>());
             string platStr = platform.getInfo<CL_PLATFORM_NAME>();
 
             if (currActiveDevId == nDevices) {


### PR DESCRIPTION
This PR allows to build ArrayFire on both `i386` and `amd64` architectures using the latest Khronos OpenCL headers.