### PR TITLE
Send error messages to error files for OSX

### DIFF
--- a/CMakeModules/osx_install/cpu_scripts/postinstall
+++ b/CMakeModules/osx_install/cpu_scripts/postinstall
@@ -3,7 +3,7 @@
 set -e
 set -o pipefail
 
-err_file=/tmp/AFInstaller.err
+err_file=/tmp/AFInstallerCPU.err
 brew=/usr/local/bin/brew
 
 if [ ! -f $brew ]; then
@@ -20,5 +20,5 @@ if [ -z $user ]; then
     exit 1
 fi
 
-su $user -c "$brew tap homebrew/versions"
-su $user -c "$brew install fftw glfw3 fontconfig"
+su $user -c "$brew tap homebrew/versions" 2> $err_file
+su $user -c "$brew install fftw glfw3 fontconfig" 2> $err_file

--- a/CMakeModules/osx_install/cuda_scripts/postinstall
+++ b/CMakeModules/osx_install/cuda_scripts/postinstall
@@ -19,5 +19,5 @@ if [ -z $user ]; then
     exit 1
 fi
 
-su $user -c "$brew tap homebrew/versions"
-su $user -c "$brew install glfw3 fontconfig"
+su $user -c "$brew tap homebrew/versions" 2> $err_file
+su $user -c "$brew install glfw3 fontconfig" 2> $err_file

--- a/CMakeModules/osx_install/opencl_scripts/postinstall
+++ b/CMakeModules/osx_install/opencl_scripts/postinstall
@@ -19,5 +19,5 @@ if [ -z $user ]; then
     exit 1
 fi
 
-su $user -c "$brew tap homebrew/versions"
-su $user -c "$brew install glfw3 fontconfig"
+su $user -c "$brew tap homebrew/versions" 2> $err_file
+su $user -c "$brew install glfw3 fontconfig" 2> $err_file


### PR DESCRIPTION
[skip ci]

This fix will send any error messages encountered in the post install script phase to the error files located in the /tmp folder. This will be useful for debugging install errors for OSX.