### PR TITLE
CPU Fallback for CUDA LAPACK API for CUDA <= 6.5

### DIFF
--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -69,22 +69,30 @@ ENDIF()
 ADD_DEFINITIONS(-DAF_CUDA)
 
 IF(${CUDA_VERSION_MAJOR} LESS 7)
-    ## Try to use CPU side lapack
-    IF(APPLE)
-        FIND_PACKAGE(LAPACK)
-    ELSE(APPLE) # Linux and Windows
-        FIND_PACKAGE(LAPACKE)
-    ENDIF(APPLE)
+    # Use CPU Lapack as fallback?
+    OPTION(CUDA_LAPACK_CPU_FALLBACK "Use CPU LAPACK as fallback for CUDA LAPACK when CUDA is 6.5 or older" OFF)
+    MARK_AS_ADVANCED(CUDA_LAPACK_CPU_FALLBACK)
 
-    IF(NOT LAPACK_FOUND)
+    IF(${CUDA_LAPACK_CPU_FALLBACK})
+        ## Try to use CPU side lapack
+        IF(APPLE)
+            FIND_PACKAGE(LAPACK)
+        ELSE(APPLE) # Linux and Windows
+            FIND_PACKAGE(LAPACKE)
+        ENDIF(APPLE)
+
+        IF(NOT LAPACK_FOUND)
+            MESSAGE(STATUS "CUDA Version ${CUDA_VERSION_STRING} does not contain cuSolve library. Linear Algebra will not be available.")
+        ELSE(NOT LAPACK_FOUND)
+            MESSAGE(STATUS "CUDA Version ${CUDA_VERSION_STRING} does not contain cuSolve library. But CPU LAPACK libraries are available. Will fallback to using host side code.")
+            ADD_DEFINITIONS(-DWITH_CPU_LINEAR_ALGEBRA)
+        ENDIF()
+    ELSE()
         MESSAGE(STATUS "CUDA Version ${CUDA_VERSION_STRING} does not contain cuSolve library. Linear Algebra will not be available.")
-    ELSE(NOT LAPACK_FOUND)
-        MESSAGE(STATUS "CUDA Version ${CUDA_VERSION_STRING} does not contain cuSolve library. But CPU LAPACK libraries are available. Will fallback to using host side code.")
-        SET(CUDA_LAPACK_CPU_FALLBACK ON)
-        ADD_DEFINITIONS(-DWITH_CPU_LINEAR_ALGEBRA)
     ENDIF()
     IF(CMAKE_VERSION VERSION_LESS 3.2)
         SET(CUDA_cusolver_LIBRARY)
+        MARK_AS_ADVANCED(CUDA_cusolver_LIBRARY)
     ENDIF(CMAKE_VERSION VERSION_LESS 3.2)
 ELSE(${CUDA_VERSION_MAJOR} LESS 7)
     MESSAGE(STATUS "CUDA cusolver library available in CUDA Version ${CUDA_VERSION_STRING}")

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -69,7 +69,20 @@ ENDIF()
 ADD_DEFINITIONS(-DAF_CUDA)
 
 IF(${CUDA_VERSION_MAJOR} LESS 7)
-    MESSAGE(STATUS "CUDA Version ${CUDA_VERSION_STRING} does not contain cuSolve library. Linear Algebra will not be available." )
+    ## Try to use CPU side lapack
+    IF(APPLE)
+        FIND_PACKAGE(LAPACK)
+    ELSE(APPLE) # Linux and Windows
+        FIND_PACKAGE(LAPACKE)
+    ENDIF(APPLE)
+
+    IF(NOT LAPACK_FOUND)
+        MESSAGE(STATUS "CUDA Version ${CUDA_VERSION_STRING} does not contain cuSolve library. Linear Algebra will not be available.")
+    ELSE(NOT LAPACK_FOUND)
+        MESSAGE(STATUS "CUDA Version ${CUDA_VERSION_STRING} does not contain cuSolve library. But CPU LAPACK libraries are available. Will fallback to using host side code.")
+        SET(CUDA_LAPACK_CPU_FALLBACK ON)
+        ADD_DEFINITIONS(-DWITH_CPU_LINEAR_ALGEBRA)
+    ENDIF()
     IF(CMAKE_VERSION VERSION_LESS 3.2)
         SET(CUDA_cusolver_LIBRARY)
     ENDIF(CMAKE_VERSION VERSION_LESS 3.2)
@@ -97,6 +110,10 @@ INCLUDE_DIRECTORIES(
     ${CUDA_NVVM_INCLUDE_DIR}
     )
 
+IF(CUDA_LAPACK_CPU_FALLBACK)
+  INCLUDE_DIRECTORIES(${LAPACK_INCLUDE_DIR})
+ENDIF()
+
 FILE(GLOB cuda_headers
      "*.hpp"
      "*.h")
@@ -120,6 +137,16 @@ SOURCE_GROUP(backend\\cuda\\Headers FILES ${cuda_headers})
 SOURCE_GROUP(backend\\cuda\\Sources FILES ${cuda_sources})
 SOURCE_GROUP(backend\\cuda\\JIT FILES ${jit_sources})
 SOURCE_GROUP(backend\\cuda\\kernel\\Headers FILES ${kernel_headers})
+
+IF(CUDA_LAPACK_CPU_FALLBACK)
+    FILE(GLOB cpu_lapack_sources
+        "cpu_lapack/*.cpp")
+    FILE(GLOB cpu_lapack_headers
+        "cpu_lapack/*.hpp")
+
+    SOURCE_GROUP(backend\\cuda\\cpu_lapack\\Headers FILES ${cpu_lapack_headers})
+    SOURCE_GROUP(backend\\cuda\\cpu_lapack\\Sources FILES ${cpu_lapack_sources})
+ENDIF()
 
 FILE(GLOB backend_headers
     "../*.hpp"
@@ -256,6 +283,8 @@ MY_CUDA_ADD_LIBRARY(afcuda SHARED
                 ${cuda_sources}
                 ${jit_sources}
                 ${kernel_headers}
+                ${cpu_lapack_headers}
+                ${cpu_lapack_sources}
                 ${backend_headers}
                 ${backend_sources}
                 ${c_headers}
@@ -275,6 +304,10 @@ TARGET_LINK_LIBRARIES(afcuda    PRIVATE ${CUDA_CUBLAS_LIBRARIES}
 
 IF(FORGE_FOUND)
     TARGET_LINK_LIBRARIES(afcuda PRIVATE ${FORGE_LIBRARIES})
+ENDIF()
+
+IF(CUDA_LAPACK_CPU_FALLBACK)
+  TARGET_LINK_LIBRARIES(afcuda PRIVATE ${LAPACK_LIBRARIES})
 ENDIF()
 
 SET_TARGET_PROPERTIES(afcuda PROPERTIES

--- a/src/backend/cuda/cholesky.cu
+++ b/src/backend/cuda/cholesky.cu
@@ -148,6 +148,34 @@ INSTANTIATE_CH(double)
 INSTANTIATE_CH(cdouble)
 }
 
+#elif defined(WITH_CPU_LINEAR_ALGEBRA)
+#include <cpu_lapack/cpu_cholesky.hpp>
+namespace cuda
+{
+
+template<typename T>
+Array<T> cholesky(int *info, const Array<T> &in, const bool is_upper)
+{
+    return cpu::cholesky(info, in, is_upper);
+}
+
+template<typename T>
+int cholesky_inplace(Array<T> &in, const bool is_upper)
+{
+    return cpu::cholesky_inplace(in, is_upper);
+}
+
+#define INSTANTIATE_CH(T)                                                                   \
+    template int cholesky_inplace<T>(Array<T> &in, const bool is_upper);                    \
+    template Array<T> cholesky<T>   (int *info, const Array<T> &in, const bool is_upper);
+
+INSTANTIATE_CH(float)
+INSTANTIATE_CH(cfloat)
+INSTANTIATE_CH(double)
+INSTANTIATE_CH(cdouble)
+
+}
+
 #else
 namespace cuda
 {

--- a/src/backend/cuda/cpu_lapack/cpu_cholesky.cpp
+++ b/src/backend/cuda/cpu_lapack/cpu_cholesky.cpp
@@ -7,11 +7,10 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include <cholesky.hpp>
-#include <err_common.hpp>
-
 #if defined(WITH_CPU_LINEAR_ALGEBRA)
 
+#include <cpu_lapack/cpu_cholesky.hpp>
+#include <err_common.hpp>
 #include <af/dim4.hpp>
 #include <handle.hpp>
 #include <copy.hpp>

--- a/src/backend/cuda/cpu_lapack/cpu_cholesky.cpp
+++ b/src/backend/cuda/cpu_lapack/cpu_cholesky.cpp
@@ -1,0 +1,110 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <cholesky.hpp>
+#include <err_common.hpp>
+
+#if defined(WITH_CPU_LINEAR_ALGEBRA)
+
+#include <af/dim4.hpp>
+#include <handle.hpp>
+#include <copy.hpp>
+#include <iostream>
+#include <cassert>
+
+#include <cpu_lapack/cpu_triangle.hpp>
+#include "lapack_helper.hpp"
+
+namespace cuda
+{
+namespace cpu
+{
+
+template<typename T>
+using potrf_func_def = int (*)(ORDER_TYPE, char,
+                               int,
+                               T*, int);
+
+#define CH_FUNC_DEF( FUNC )                                     \
+template<typename T> FUNC##_func_def<T> FUNC##_func();
+
+
+#define CH_FUNC( FUNC, TYPE, PREFIX )                           \
+template<> FUNC##_func_def<TYPE>     FUNC##_func<TYPE>()        \
+{ return & LAPACK_NAME(PREFIX##FUNC); }
+
+CH_FUNC_DEF( potrf )
+CH_FUNC(potrf , float  , s)
+CH_FUNC(potrf , double , d)
+CH_FUNC(potrf , cfloat , c)
+CH_FUNC(potrf , cdouble, z)
+
+template<typename T>
+Array<T> cholesky(int *info, const Array<T> &in, const bool is_upper)
+{
+    dim4 iDims = in.dims();
+    int N = iDims[0];
+
+    char uplo = 'L';
+    if(is_upper)
+        uplo = 'U';
+
+    T *inPtr = pinnedAlloc<T>(in.elements());
+    copyData(inPtr, in);
+
+    *info = potrf_func<T>()(AF_LAPACK_COL_MAJOR, uplo,
+                            N, inPtr, in.strides()[1]);
+
+    if (is_upper) triangle<T, true , false>(inPtr, inPtr, in.dims(), in.strides(), in.strides());
+    else          triangle<T, false, false>(inPtr, inPtr, in.dims(), in.strides(), in.strides());
+
+    Array<T> out = createHostDataArray<T>(in.dims(), inPtr);
+
+    pinnedFree(inPtr);
+
+    return out;
+}
+
+template<typename T>
+int cholesky_inplace(Array<T> &in, const bool is_upper)
+{
+    dim4 iDims = in.dims();
+    int N = iDims[0];
+
+    char uplo = 'L';
+    if(is_upper)
+        uplo = 'U';
+
+    T *inPtr = pinnedAlloc<T>(in.elements());
+    copyData(inPtr, in);
+
+    int info = potrf_func<T>()(AF_LAPACK_COL_MAJOR, uplo,
+                               N, inPtr, in.strides()[1]);
+
+    writeHostDataArray<T>(in, inPtr, in.elements() * sizeof(T));
+
+    pinnedFree(inPtr);
+
+    return info;
+}
+
+#define INSTANTIATE_CH(T)                                                                   \
+    template int cholesky_inplace<T>(Array<T> &in, const bool is_upper);                    \
+    template Array<T> cholesky<T>   (int *info, const Array<T> &in, const bool is_upper);   \
+
+
+INSTANTIATE_CH(float)
+INSTANTIATE_CH(cfloat)
+INSTANTIATE_CH(double)
+INSTANTIATE_CH(cdouble)
+
+}
+}
+
+#endif

--- a/src/backend/cuda/cpu_lapack/cpu_cholesky.hpp
+++ b/src/backend/cuda/cpu_lapack/cpu_cholesky.hpp
@@ -1,0 +1,22 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Array.hpp>
+
+namespace cuda
+{
+namespace cpu
+{
+    template<typename T>
+    Array<T> cholesky(int *info, const Array<T> &in, const bool is_upper);
+
+    template<typename T>
+    int cholesky_inplace(Array<T> &in, const bool is_upper);
+}
+}

--- a/src/backend/cuda/cpu_lapack/cpu_inverse.cpp
+++ b/src/backend/cuda/cpu_lapack/cpu_inverse.cpp
@@ -1,0 +1,92 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#if defined(WITH_CPU_LINEAR_ALGEBRA)
+
+#include <inverse.hpp>
+#include <err_common.hpp>
+
+#include <af/dim4.hpp>
+#include <handle.hpp>
+#include <identity.hpp>
+#include <copy.hpp>
+#include <iostream>
+#include <cassert>
+
+#include "lapack_helper.hpp"
+#include <cpu_lapack/cpu_lu.hpp>
+#include <cpu_lapack/cpu_solve.hpp>
+
+namespace cuda
+{
+namespace cpu
+{
+
+template<typename T>
+using getri_func_def = int (*)(ORDER_TYPE, int,
+                               T *, int,
+                               const int *);
+
+#define INV_FUNC_DEF( FUNC )                                        \
+template<typename T> FUNC##_func_def<T> FUNC##_func();
+
+#define INV_FUNC( FUNC, TYPE, PREFIX )                              \
+template<> FUNC##_func_def<TYPE>     FUNC##_func<TYPE>()            \
+{ return & LAPACK_NAME(PREFIX##FUNC); }
+
+INV_FUNC_DEF( getri )
+INV_FUNC(getri , float  , s)
+INV_FUNC(getri , double , d)
+INV_FUNC(getri , cfloat , c)
+INV_FUNC(getri , cdouble, z)
+
+template<typename T>
+Array<T> inverse(const Array<T> &in)
+{
+    int M = in.dims()[0];
+    int N = in.dims()[1];
+
+    if (M != N) {
+        Array<T> I = identity<T>(in.dims());
+        return cpu::solve(in, I);
+    }
+
+    Array<T> A = copyArray<T>(in);
+
+    Array<int> pivot = lu_inplace<T>(A, false);
+
+    T *aPtr = pinnedAlloc<T>(A.elements());
+    int *pPtr = pinnedAlloc<int>(pivot.elements());
+    copyData(aPtr, A);
+    copyData(pPtr, pivot);
+
+    getri_func<T>()(AF_LAPACK_COL_MAJOR, M,
+                    aPtr, A.strides()[1],
+                    pPtr);
+
+    writeHostDataArray<T>(A, aPtr, A.elements() * sizeof(T));
+
+    pinnedFree(aPtr);
+    pinnedFree(pPtr);
+
+    return A;
+}
+
+#define INSTANTIATE(T)                                                                   \
+    template Array<T> inverse<T> (const Array<T> &in);
+
+INSTANTIATE(float)
+INSTANTIATE(cfloat)
+INSTANTIATE(double)
+INSTANTIATE(cdouble)
+
+}
+}
+
+#endif

--- a/src/backend/cuda/cpu_lapack/cpu_inverse.hpp
+++ b/src/backend/cuda/cpu_lapack/cpu_inverse.hpp
@@ -1,0 +1,19 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Array.hpp>
+
+namespace cuda
+{
+namespace cpu
+{
+    template<typename T>
+    Array<T> inverse(const Array<T> &in);
+}
+}

--- a/src/backend/cuda/cpu_lapack/cpu_lu.cpp
+++ b/src/backend/cuda/cpu_lapack/cpu_lu.cpp
@@ -7,10 +7,10 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#if defined(WITH_CPU_LINEAR_ALGEBRA)
+
 #include <cpu_lapack/cpu_lu.hpp>
 #include <err_common.hpp>
-
-#if defined(WITH_CPU_LINEAR_ALGEBRA)
 
 #include <af/dim4.hpp>
 #include <handle.hpp>

--- a/src/backend/cuda/cpu_lapack/cpu_lu.cpp
+++ b/src/backend/cuda/cpu_lapack/cpu_lu.cpp
@@ -1,0 +1,197 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <cpu_lapack/cpu_lu.hpp>
+#include <err_common.hpp>
+
+#if defined(WITH_CPU_LINEAR_ALGEBRA)
+
+#include <af/dim4.hpp>
+#include <handle.hpp>
+#include <iostream>
+#include <cassert>
+#include <err_cuda.hpp>
+
+#include "lapack_helper.hpp"
+
+namespace cuda
+{
+namespace cpu
+{
+
+template<typename T>
+using getrf_func_def = int (*)(ORDER_TYPE, int, int,
+                               T*, int,
+                               int*);
+
+#define LU_FUNC_DEF( FUNC )                                     \
+template<typename T> FUNC##_func_def<T> FUNC##_func();
+
+
+#define LU_FUNC( FUNC, TYPE, PREFIX )                           \
+template<> FUNC##_func_def<TYPE>     FUNC##_func<TYPE>()        \
+{ return & LAPACK_NAME(PREFIX##FUNC); }
+
+LU_FUNC_DEF( getrf )
+LU_FUNC(getrf , float  , s)
+LU_FUNC(getrf , double , d)
+LU_FUNC(getrf , cfloat , c)
+LU_FUNC(getrf , cdouble, z)
+
+template<typename T>
+void lu_split(T *l, T *u, const T *i,
+        const dim4 ldm, const dim4 udm, const dim4 idm,
+        const dim4 lst, const dim4 ust, const dim4 ist)
+{
+    for(dim_t ow = 0; ow < idm[3]; ow++) {
+        const dim_t lW = ow * lst[3];
+        const dim_t uW = ow * ust[3];
+        const dim_t iW = ow * ist[3];
+
+        for(dim_t oz = 0; oz < idm[2]; oz++) {
+            const dim_t lZW = lW + oz * lst[2];
+            const dim_t uZW = uW + oz * ust[2];
+            const dim_t iZW = iW + oz * ist[2];
+
+            for(dim_t oy = 0; oy < idm[1]; oy++) {
+                const dim_t lYZW = lZW + oy * lst[1];
+                const dim_t uYZW = uZW + oy * ust[1];
+                const dim_t iYZW = iZW + oy * ist[1];
+
+                for(dim_t ox = 0; ox < idm[0]; ox++) {
+                    const dim_t lMem = lYZW + ox;
+                    const dim_t uMem = uYZW + ox;
+                    const dim_t iMem = iYZW + ox;
+                    if(ox > oy) {
+                        if(oy < ldm[1])
+                            l[lMem] = i[iMem];
+                        if(ox < udm[0])
+                            u[uMem] = scalar<T>(0);
+                    } else if (oy > ox) {
+                        if(oy < ldm[1])
+                            l[lMem] = scalar<T>(0);
+                        if(ox < udm[0])
+                            u[uMem] = i[iMem];
+                    } else if(ox == oy) {
+                        if(oy < ldm[1])
+                            l[lMem] = scalar<T>(1.0);
+                        if(ox < udm[0])
+                            u[uMem] = i[iMem];
+                    }
+                }
+            }
+        }
+    }
+}
+
+void convertPivot(int **pivot, int out_sz, dim_t d0)
+{
+    int* p = pinnedAlloc<int>(out_sz);
+    for(int i = 0; i < out_sz; i++)
+        p[i] = i;
+
+    for(int j = 0; j < (int)d0; j++) {
+        // 1 indexed in pivot
+        std::swap(p[j], p[(*pivot)[j] - 1]);
+    }
+
+    pinnedFree(*pivot);
+    *pivot = p;
+}
+
+template<typename T>
+void lu(Array<T> &lower, Array<T> &upper, Array<int> &pivot, const Array<T> &in)
+{
+    dim4 iDims = in.dims();
+    int M = iDims[0];
+    int N = iDims[1];
+
+    Array<T> in_copy = copyArray<T>(in);
+
+    //////////////////////////////////////////
+    // LU inplace
+    int *pivotPtr  = pinnedAlloc<int>(min(M, N));
+    T   *inPtr     = pinnedAlloc<T>  (in_copy.elements());
+    copyData(inPtr, in);
+
+    getrf_func<T>()(AF_LAPACK_COL_MAJOR, M, N,
+                    inPtr, in_copy.strides()[1],
+                    pivotPtr);
+
+    convertPivot(&pivotPtr, M, min(M, N));
+
+    pivot = createHostDataArray<int>(af::dim4(M), pivotPtr);
+    //////////////////////////////////////////
+
+    // SPLIT into lower and upper
+    dim4 ldims(M, min(M, N));
+    dim4 udims(min(M, N), N);
+
+    T *lowerPtr = pinnedAlloc<T>(ldims.elements());
+    T *upperPtr = pinnedAlloc<T>(udims.elements());
+
+    dim4 lst(1, ldims[0], ldims[0] * ldims[1], ldims[0] * ldims[1] * ldims[2]);
+    dim4 ust(1, udims[0], udims[0] * udims[1], udims[0] * udims[1] * udims[2]);
+
+    lu_split<T>(lowerPtr, upperPtr, inPtr, ldims, udims, iDims,
+                lst, ust, in_copy.strides());
+
+    lower = createHostDataArray<T>(ldims, lowerPtr);
+    upper = createHostDataArray<T>(udims, upperPtr);
+
+    lower.eval();
+    upper.eval();
+
+    pinnedFree(lowerPtr);
+    pinnedFree(upperPtr);
+    pinnedFree(pivotPtr);
+    pinnedFree(inPtr);
+}
+
+template<typename T>
+Array<int> lu_inplace(Array<T> &in, const bool convert_pivot)
+{
+    dim4 iDims = in.dims();
+    int M = iDims[0];
+    int N = iDims[1];
+
+    int *pivotPtr  = pinnedAlloc<int>(min(M, N));
+    T   *inPtr     = pinnedAlloc<T>  (in.elements());
+    copyData(inPtr, in);
+
+    getrf_func<T>()(AF_LAPACK_COL_MAJOR, M, N,
+                    inPtr, in.strides()[1],
+                    pivotPtr);
+
+    if(convert_pivot) convertPivot(&pivotPtr, M, min(M, N));
+
+    writeHostDataArray<T>(in, inPtr, in.elements() * sizeof(T));
+    Array<int> pivot = createHostDataArray<int>(af::dim4(M), pivotPtr);
+
+    pivot.eval();
+
+    pinnedFree(inPtr);
+    pinnedFree(pivotPtr);
+
+    return pivot;
+}
+
+#define INSTANTIATE_LU(T)                                                                           \
+    template Array<int> lu_inplace<T>(Array<T> &in, const bool convert_pivot);                      \
+    template void lu<T>(Array<T> &lower, Array<T> &upper, Array<int> &pivot, const Array<T> &in);
+
+INSTANTIATE_LU(float)
+INSTANTIATE_LU(cfloat)
+INSTANTIATE_LU(double)
+INSTANTIATE_LU(cdouble)
+
+}
+}
+
+#endif

--- a/src/backend/cuda/cpu_lapack/cpu_lu.hpp
+++ b/src/backend/cuda/cpu_lapack/cpu_lu.hpp
@@ -1,0 +1,22 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Array.hpp>
+
+namespace cuda
+{
+namespace cpu
+{
+    template<typename T>
+    void lu(Array<T> &lower, Array<T> &upper, Array<int> &pivot, const Array<T> &in);
+
+    template<typename T>
+    Array<int> lu_inplace(Array<T> &in, const bool convert_pivot = true);
+}
+}

--- a/src/backend/cuda/cpu_lapack/cpu_qr.cpp
+++ b/src/backend/cuda/cpu_lapack/cpu_qr.cpp
@@ -7,11 +7,10 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include <qr.hpp>
-#include <err_common.hpp>
-
 #if defined(WITH_CPU_LINEAR_ALGEBRA)
 
+#include <cpu_lapack/cpu_qr.hpp>
+#include <err_common.hpp>
 #include <af/dim4.hpp>
 #include <handle.hpp>
 #include <copy.hpp>

--- a/src/backend/cuda/cpu_lapack/cpu_qr.cpp
+++ b/src/backend/cuda/cpu_lapack/cpu_qr.cpp
@@ -17,8 +17,8 @@
 #include <copy.hpp>
 #include <iostream>
 #include <cassert>
-#include <triangle.hpp>
 
+#include <cpu_lapack/cpu_triangle.hpp>
 #include "lapack_helper.hpp"
 
 namespace cuda
@@ -62,38 +62,6 @@ GQR_FUNC(gqr , float  , sorgqr)
 GQR_FUNC(gqr , double , dorgqr)
 GQR_FUNC(gqr , cfloat , cungqr)
 GQR_FUNC(gqr , cdouble, zungqr)
-
-template<typename T, bool is_upper, bool is_unit_diag>
-void triangle(T *o, const T *i, const dim4 odm, const dim4 ost, const dim4 ist)
-{
-    for(dim_t ow = 0; ow < odm[3]; ow++) {
-        const dim_t oW = ow * ost[3];
-        const dim_t iW = ow * ist[3];
-
-        for(dim_t oz = 0; oz < odm[2]; oz++) {
-            const dim_t oZW = oW + oz * ost[2];
-            const dim_t iZW = iW + oz * ist[2];
-
-            for(dim_t oy = 0; oy < odm[1]; oy++) {
-                const dim_t oYZW = oZW + oy * ost[1];
-                const dim_t iYZW = iZW + oy * ist[1];
-
-                for(dim_t ox = 0; ox < odm[0]; ox++) {
-                    const dim_t oMem = oYZW + ox;
-                    const dim_t iMem = iYZW + ox;
-
-                    bool cond = is_upper ? (oy >= ox) : (oy <= ox);
-                    bool do_unit_diag = (is_unit_diag && ox == oy);
-                    if(cond) {
-                        o[oMem] = do_unit_diag ? scalar<T>(1) : i[iMem];
-                    } else {
-                        o[oMem] = scalar<T>(0);
-                    }
-                }
-            }
-        }
-    }
-}
 
 template<typename T>
 void qr(Array<T> &q, Array<T> &r, Array<T> &t, const Array<T> &in)

--- a/src/backend/cuda/cpu_lapack/cpu_qr.cpp
+++ b/src/backend/cuda/cpu_lapack/cpu_qr.cpp
@@ -1,0 +1,193 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <qr.hpp>
+#include <err_common.hpp>
+
+#if defined(WITH_CPU_LINEAR_ALGEBRA)
+
+#include <af/dim4.hpp>
+#include <handle.hpp>
+#include <copy.hpp>
+#include <iostream>
+#include <cassert>
+#include <triangle.hpp>
+
+#include "lapack_helper.hpp"
+
+namespace cuda
+{
+namespace cpu
+{
+
+template<typename T>
+using geqrf_func_def = int (*)(ORDER_TYPE, int, int,
+                               T*, int,
+                               T*);
+
+template<typename T>
+using gqr_func_def = int (*)(ORDER_TYPE, int, int, int,
+                             T*, int,
+                             const T*);
+
+#define QR_FUNC_DEF( FUNC )                                         \
+template<typename T> FUNC##_func_def<T> FUNC##_func();
+
+
+#define QR_FUNC( FUNC, TYPE, PREFIX )                               \
+template<> FUNC##_func_def<TYPE>     FUNC##_func<TYPE>()            \
+{ return & LAPACK_NAME(PREFIX##FUNC); }
+
+QR_FUNC_DEF( geqrf )
+QR_FUNC(geqrf , float  , s)
+QR_FUNC(geqrf , double , d)
+QR_FUNC(geqrf , cfloat , c)
+QR_FUNC(geqrf , cdouble, z)
+
+#define GQR_FUNC_DEF( FUNC )                                         \
+template<typename T> FUNC##_func_def<T> FUNC##_func();
+
+#define GQR_FUNC( FUNC, TYPE, PREFIX )                               \
+template<> FUNC##_func_def<TYPE>     FUNC##_func<TYPE>()             \
+{ return & LAPACK_NAME(PREFIX); }
+
+GQR_FUNC_DEF( gqr )
+GQR_FUNC(gqr , float  , sorgqr)
+GQR_FUNC(gqr , double , dorgqr)
+GQR_FUNC(gqr , cfloat , cungqr)
+GQR_FUNC(gqr , cdouble, zungqr)
+
+template<typename T, bool is_upper, bool is_unit_diag>
+void triangle(T *o, const T *i, const dim4 odm, const dim4 ost, const dim4 ist)
+{
+    for(dim_t ow = 0; ow < odm[3]; ow++) {
+        const dim_t oW = ow * ost[3];
+        const dim_t iW = ow * ist[3];
+
+        for(dim_t oz = 0; oz < odm[2]; oz++) {
+            const dim_t oZW = oW + oz * ost[2];
+            const dim_t iZW = iW + oz * ist[2];
+
+            for(dim_t oy = 0; oy < odm[1]; oy++) {
+                const dim_t oYZW = oZW + oy * ost[1];
+                const dim_t iYZW = iZW + oy * ist[1];
+
+                for(dim_t ox = 0; ox < odm[0]; ox++) {
+                    const dim_t oMem = oYZW + ox;
+                    const dim_t iMem = iYZW + ox;
+
+                    bool cond = is_upper ? (oy >= ox) : (oy <= ox);
+                    bool do_unit_diag = (is_unit_diag && ox == oy);
+                    if(cond) {
+                        o[oMem] = do_unit_diag ? scalar<T>(1) : i[iMem];
+                    } else {
+                        o[oMem] = scalar<T>(0);
+                    }
+                }
+            }
+        }
+    }
+}
+
+template<typename T>
+void qr(Array<T> &q, Array<T> &r, Array<T> &t, const Array<T> &in)
+{
+    dim4 iDims = in.dims();
+    int M = iDims[0];
+    int N = iDims[1];
+
+    dim4 padDims(M, max(M, N));
+    q = padArray<T, T>(in, padDims, scalar<T>(0));
+    q.resetDims(iDims);
+
+    dim4 qdims = q.dims();
+
+    T *tPtr = NULL;
+    T *qPtr = NULL;
+    int nT = 0;
+    {
+        ///////////////////////////////////////////////
+        // QR Inplace on q
+        int M_ = qdims[0];
+        int N_ = qdims[1];
+        nT = min(M_, N_);
+
+        tPtr = pinnedAlloc<T>(nT);
+        qPtr = pinnedAlloc<T>(padDims.elements());
+        q.resetDims(padDims);
+        copyData(qPtr, q);
+        q.resetDims(iDims);
+
+        geqrf_func<T>()(AF_LAPACK_COL_MAJOR, M, N,
+                        qPtr, M,
+                        tPtr);
+        ///////////////////////////////////////////////
+    }
+
+    // SPLIT into q and r
+    dim4 rdims(M, N);
+    T *rPtr = pinnedAlloc<T>(rdims.elements());
+
+    dim4 rst(1, rdims[0], rdims[0] * rdims[1], rdims[0] * rdims[1] * rdims[2]);
+
+    triangle<T, true, false>(rPtr, qPtr, rdims, rst, q.strides());
+
+    gqr_func<T>()(AF_LAPACK_COL_MAJOR,
+                  M, M, min(M, N),
+                  qPtr, q.strides()[1],
+                  tPtr);
+
+    q.resetDims(dim4(M, M));
+
+    t = createHostDataArray<T>(af::dim4(nT), tPtr);
+    r = createHostDataArray<T>(rdims, rPtr);
+    writeHostDataArray<T>(q, qPtr, q.elements() * sizeof(T));
+
+    pinnedFree(tPtr);
+    pinnedFree(rPtr);
+    pinnedFree(qPtr);
+}
+
+template<typename T>
+Array<T> qr_inplace(Array<T> &in)
+{
+    dim4 iDims = in.dims();
+    int M = iDims[0];
+    int N = iDims[1];
+
+    T *tPtr  = pinnedAlloc<T>(min(M, N));
+    T *inPtr = pinnedAlloc<T>(in.elements());
+    copyData(inPtr, in);
+
+    geqrf_func<T>()(AF_LAPACK_COL_MAJOR, M, N,
+                    inPtr, in.strides()[1],
+                    tPtr);
+
+    writeHostDataArray<T>(in, inPtr, in.elements() * sizeof(T));
+    Array<T> t = createHostDataArray<T>(af::dim4(min(M, N)), tPtr);
+
+    pinnedFree(inPtr);
+    pinnedFree(tPtr);
+
+    return t;
+}
+
+#define INSTANTIATE_QR(T)                                                                           \
+    template Array<T> qr_inplace<T>(Array<T> &in);                                                \
+    template void qr<T>(Array<T> &q, Array<T> &r, Array<T> &t, const Array<T> &in);
+
+INSTANTIATE_QR(float)
+INSTANTIATE_QR(cfloat)
+INSTANTIATE_QR(double)
+INSTANTIATE_QR(cdouble)
+
+}
+}
+
+#endif

--- a/src/backend/cuda/cpu_lapack/cpu_qr.hpp
+++ b/src/backend/cuda/cpu_lapack/cpu_qr.hpp
@@ -1,0 +1,22 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Array.hpp>
+
+namespace cuda
+{
+namespace cpu
+{
+    template<typename T>
+    void qr(Array<T> &q, Array<T> &r, Array<T> &t, const Array<T> &in);
+
+    template<typename T>
+    Array<T> qr_inplace(Array<T> &in);
+}
+}

--- a/src/backend/cuda/cpu_lapack/cpu_solve.cpp
+++ b/src/backend/cuda/cpu_lapack/cpu_solve.cpp
@@ -1,0 +1,206 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#if defined(WITH_CPU_LINEAR_ALGEBRA)
+
+#include <cpu_lapack/cpu_solve.hpp>
+#include <err_common.hpp>
+
+#include <af/dim4.hpp>
+#include <handle.hpp>
+#include <iostream>
+#include <cassert>
+#include <err_cuda.hpp>
+
+#include "lapack_helper.hpp"
+
+namespace cuda
+{
+namespace cpu
+{
+
+template<typename T>
+using gesv_func_def = int (*)(ORDER_TYPE, int, int,
+                              T *, int,
+                              int *,
+                              T *, int);
+
+template<typename T>
+using gels_func_def = int (*)(ORDER_TYPE, char,
+                              int, int, int,
+                              T *, int,
+                              T *, int);
+
+template<typename T>
+using getrs_func_def = int (*)(ORDER_TYPE, char,
+                               int, int,
+                               const T *, int,
+                               const int *,
+                               T *, int);
+
+template<typename T>
+using trtrs_func_def = int (*)(ORDER_TYPE,
+                               char, char, char,
+                               int, int,
+                               const T *, int,
+                               T *, int);
+
+
+#define SOLVE_FUNC_DEF( FUNC )                                      \
+template<typename T> FUNC##_func_def<T> FUNC##_func();
+
+
+#define SOLVE_FUNC( FUNC, TYPE, PREFIX )                            \
+template<> FUNC##_func_def<TYPE>     FUNC##_func<TYPE>()            \
+{ return & LAPACK_NAME(PREFIX##FUNC); }
+
+SOLVE_FUNC_DEF( gesv )
+SOLVE_FUNC(gesv , float  , s)
+SOLVE_FUNC(gesv , double , d)
+SOLVE_FUNC(gesv , cfloat , c)
+SOLVE_FUNC(gesv , cdouble, z)
+
+SOLVE_FUNC_DEF( gels )
+SOLVE_FUNC(gels , float  , s)
+SOLVE_FUNC(gels , double , d)
+SOLVE_FUNC(gels , cfloat , c)
+SOLVE_FUNC(gels , cdouble, z)
+
+SOLVE_FUNC_DEF( getrs )
+SOLVE_FUNC(getrs , float  , s)
+SOLVE_FUNC(getrs , double , d)
+SOLVE_FUNC(getrs , cfloat , c)
+SOLVE_FUNC(getrs , cdouble, z)
+
+SOLVE_FUNC_DEF( trtrs )
+SOLVE_FUNC(trtrs , float  , s)
+SOLVE_FUNC(trtrs , double , d)
+SOLVE_FUNC(trtrs , cfloat , c)
+SOLVE_FUNC(trtrs , cdouble, z)
+
+template<typename T>
+Array<T> solveLU(const Array<T> &A, const Array<int> &pivot,
+                 const Array<T> &b, const af_mat_prop options)
+{
+    int N = A.dims()[0];
+    int NRHS = b.dims()[1];
+
+    T *aPtr = pinnedAlloc<T>(A.elements());
+    T *bPtr = pinnedAlloc<T>(b.elements());
+    int *pPtr = pinnedAlloc<int>(pivot.elements());
+
+    copyData(aPtr, A);
+    copyData(bPtr, b);
+    copyData(pPtr, pivot);
+
+    getrs_func<T>()(AF_LAPACK_COL_MAJOR, 'N',
+                    N, NRHS,
+                    aPtr, A.strides()[1],
+                    pPtr,
+                    bPtr, b.strides()[1]);
+
+    Array<T> B = createHostDataArray<T>(b.dims(), bPtr);
+
+    pinnedFree(aPtr);
+    pinnedFree(bPtr);
+    pinnedFree(pPtr);
+
+    return B;
+}
+
+template<typename T>
+Array<T> triangleSolve(const Array<T> &A, const Array<T> &b, const af_mat_prop options)
+{
+    int N = b.dims()[0];
+    int NRHS = b.dims()[1];
+
+    T *aPtr = pinnedAlloc<T>(A.elements());
+    T *bPtr = pinnedAlloc<T>(b.elements());
+    copyData(aPtr, A);
+    copyData(bPtr, b);
+
+    trtrs_func<T>()(AF_LAPACK_COL_MAJOR,
+                    options & AF_MAT_UPPER ? 'U' : 'L',
+                    'N', // transpose flag
+                    options & AF_MAT_DIAG_UNIT ? 'U' : 'N',
+                    N, NRHS,
+                    aPtr, A.strides()[1],
+                    bPtr, b.strides()[1]);
+
+    Array<T> B = createHostDataArray<T>(b.dims(), bPtr);
+
+    pinnedFree(aPtr);
+    pinnedFree(bPtr);
+
+    return B;
+}
+
+
+template<typename T>
+Array<T> solve(const Array<T> &a, const Array<T> &b, const af_mat_prop options)
+{
+
+    if (options & AF_MAT_UPPER ||
+        options & AF_MAT_LOWER) {
+        return triangleSolve<T>(a, b, options);
+    }
+
+    int M = a.dims()[0];
+    int N = a.dims()[1];
+    int K = b.dims()[1];
+
+    Array<T> B = padArray<T, T>(b, dim4(max(M, N), K), scalar<T>(0));
+
+    T *aPtr = pinnedAlloc<T>(a.elements());
+    T *bPtr = pinnedAlloc<T>(B.elements());
+    copyData(aPtr, a);
+    copyData(bPtr, B);
+
+    if(M == N) {
+        int *pivotPtr  = pinnedAlloc<int>(N);
+        gesv_func<T>()(AF_LAPACK_COL_MAJOR, N, K,
+                       aPtr, a.strides()[1],
+                       pivotPtr,
+                       bPtr, B.strides()[1]);
+        pinnedFree(pivotPtr);
+
+        writeHostDataArray<T>(B, bPtr, B.elements() * sizeof(T));
+    } else {
+        int sM = a.strides()[1];
+        int sN = a.strides()[2] / sM;
+
+        gels_func<T>()(AF_LAPACK_COL_MAJOR, 'N',
+                       M, N, K,
+                       aPtr, a.strides()[1],
+                       bPtr, max(sM, sN));
+        writeHostDataArray<T>(B, bPtr, B.elements() * sizeof(T));
+        B.resetDims(dim4(N, K));
+    }
+
+    pinnedFree(aPtr);
+    pinnedFree(bPtr);
+
+    return B;
+}
+
+#define INSTANTIATE_SOLVE(T)                                            \
+    template Array<T> solve<T>(const Array<T> &a, const Array<T> &b,    \
+                               const af_mat_prop options);              \
+    template Array<T> solveLU<T>(const Array<T> &A, const Array<int> &pivot, \
+                                 const Array<T> &b, const af_mat_prop options); \
+
+INSTANTIATE_SOLVE(float)
+INSTANTIATE_SOLVE(cfloat)
+INSTANTIATE_SOLVE(double)
+INSTANTIATE_SOLVE(cdouble)
+
+}
+}
+
+#endif

--- a/src/backend/cuda/cpu_lapack/cpu_solve.hpp
+++ b/src/backend/cuda/cpu_lapack/cpu_solve.hpp
@@ -1,0 +1,23 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Array.hpp>
+
+namespace cuda
+{
+namespace cpu
+{
+    template<typename T>
+    Array<T> solve(const Array<T> &a, const Array<T> &b, const af_mat_prop options = AF_MAT_NONE);
+
+    template<typename T>
+    Array<T> solveLU(const Array<T> &a, const Array<int> &pivot,
+                     const Array<T> &b, const af_mat_prop options = AF_MAT_NONE);
+}
+}

--- a/src/backend/cuda/cpu_lapack/cpu_svd.cpp
+++ b/src/backend/cuda/cpu_lapack/cpu_svd.cpp
@@ -1,0 +1,153 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#if defined(WITH_CPU_LINEAR_ALGEBRA)
+#include <cpu_lapack/cpu_svd.hpp>
+
+#include <Array.hpp>
+#include <svd.hpp>
+#include <err_common.hpp>
+#include <copy.hpp>
+
+#include "lapack_helper.hpp"
+
+namespace cuda
+{
+namespace cpu
+{
+
+#define SVD_FUNC_DEF( FUNC )                                            \
+    template<typename T,typename Tr> svd_func_def<T, Tr> svd_func();
+
+#define SVD_FUNC( FUNC, T, Tr, PREFIX )                     \
+    template<> svd_func_def<T, Tr>     svd_func<T, Tr>()    \
+    { return & LAPACK_NAME(PREFIX##FUNC); }
+
+#if defined(USE_MKL) || defined(__APPLE__)
+
+    template<typename T, typename Tr>
+    using svd_func_def = int (*)(ORDER_TYPE,
+                                 char jobz,
+                                 int m, int n,
+                                 T* in, int ldin,
+                                 Tr* s,
+                                 T* u, int ldu,
+                                 T* vt, int ldvt);
+
+    SVD_FUNC_DEF( gesdd )
+    SVD_FUNC(gesdd, float  , float , s)
+    SVD_FUNC(gesdd, double , double, d)
+    SVD_FUNC(gesdd, cfloat , float , c)
+    SVD_FUNC(gesdd, cdouble, double, z)
+
+#else   // Atlas causes memory freeing issues with using gesdd
+
+    template<typename T, typename Tr>
+    using svd_func_def = int (*)(ORDER_TYPE,
+                                 char jobu, char jobvt,
+                                 int m, int n,
+                                 T* in, int ldin,
+                                 Tr* s,
+                                 T* u, int ldu,
+                                 T* vt, int ldvt,
+                                 Tr *superb);
+
+    SVD_FUNC_DEF( gesvd )
+    SVD_FUNC(gesvd, float  , float , s)
+    SVD_FUNC(gesvd, double , double, d)
+    SVD_FUNC(gesvd, cfloat , float , c)
+    SVD_FUNC(gesvd, cdouble, double, z)
+
+#endif
+
+    template <typename T, typename Tr>
+    void svdInPlace(Array<Tr> &s, Array<T> &u, Array<T> &vt, Array<T> &in)
+    {
+        dim4 iDims = in.dims();
+        int M = iDims[0];
+        int N = iDims[1];
+
+        // S, U, Vt are empty. Simply write to them
+        Tr *sPtr = pinnedAlloc<Tr>(s.elements());
+        T  *uPtr = pinnedAlloc<T >(u.elements());
+        T  *vPtr = pinnedAlloc<T >(vt.elements());
+        T  *iPtr = pinnedAlloc<T >(in.elements());
+
+        copyData(sPtr, s);
+        copyData(uPtr, u);
+        copyData(vPtr, vt);
+        copyData(iPtr, in);
+
+#if defined(USE_MKL) || defined(__APPLE__)
+        svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', M, N, iPtr, in.strides()[1],
+                          sPtr, uPtr, u.strides()[1], vPtr, vt.strides()[1]);
+#else
+        std::vector<Tr> superb(std::min(M, N));
+        svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', 'A', M, N, iPtr, in.strides()[1],
+                          sPtr, uPtr, u.strides()[1], vPtr, vt.strides()[1], &superb[0]);
+#endif
+        writeHostDataArray(s , sPtr, s.elements()  * sizeof(Tr));
+        writeHostDataArray(u , uPtr, u.elements()  * sizeof(T ));
+        writeHostDataArray(vt, vPtr, vt.elements() * sizeof(T ));
+        writeHostDataArray(in, iPtr, in.elements() * sizeof(T ));
+
+        pinnedFree(sPtr);
+        pinnedFree(uPtr);
+        pinnedFree(vPtr);
+        pinnedFree(iPtr);
+    }
+
+    template <typename T, typename Tr>
+    void svd(Array<Tr> &s, Array<T> &u, Array<T> &vt, const Array<T> &in)
+    {
+        dim4 iDims = in.dims();
+        int M = iDims[0];
+        int N = iDims[1];
+
+        // S, U, Vt are empty. Simply write to them
+        Tr *sPtr = pinnedAlloc<Tr>(s.elements());
+        T  *uPtr = pinnedAlloc<T >(u.elements());
+        T  *vPtr = pinnedAlloc<T >(vt.elements());
+        T  *iPtr = pinnedAlloc<T >(in.elements());
+
+        copyData(sPtr, s);
+        copyData(uPtr, u);
+        copyData(vPtr, vt);
+        copyData(iPtr, in);
+
+#if defined(USE_MKL) || defined(__APPLE__)
+        svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', M, N, iPtr, in.strides()[1],
+                          sPtr, uPtr, u.strides()[1], vPtr, vt.strides()[1]);
+#else
+        std::vector<Tr> superb(std::min(M, N));
+        svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', 'A', M, N, iPtr, in.strides()[1],
+                          sPtr, uPtr, u.strides()[1], vPtr, vt.strides()[1], &superb[0]);
+#endif
+        writeHostDataArray(s , sPtr, s.elements()  * sizeof(Tr));
+        writeHostDataArray(u , uPtr, u.elements()  * sizeof(T ));
+        writeHostDataArray(vt, vPtr, vt.elements() * sizeof(T ));
+
+        pinnedFree(sPtr);
+        pinnedFree(uPtr);
+        pinnedFree(vPtr);
+        pinnedFree(iPtr);
+    }
+
+#define INSTANTIATE_SVD(T, Tr)                                          \
+    template void svd<T, Tr>(Array<Tr> & s, Array<T> & u, Array<T> & vt, const Array<T> &in); \
+    template void svdInPlace<T, Tr>(Array<Tr> & s, Array<T> & u, Array<T> & vt, Array<T> &in);
+
+    INSTANTIATE_SVD(float  , float )
+    INSTANTIATE_SVD(double , double)
+    INSTANTIATE_SVD(cfloat , float )
+    INSTANTIATE_SVD(cdouble, double)
+}
+}
+
+#endif

--- a/src/backend/cuda/cpu_lapack/cpu_svd.hpp
+++ b/src/backend/cuda/cpu_lapack/cpu_svd.hpp
@@ -1,0 +1,22 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Array.hpp>
+
+namespace cuda
+{
+namespace cpu
+{
+    template<typename T, typename Tr>
+    void svd(Array<Tr> &s, Array<T> &u, Array<T> &vt, const Array<T> &in);
+
+    template<typename T, typename Tr>
+    void svdInPlace(Array<Tr> &s, Array<T> &u, Array<T> &vt, Array<T> &in);
+}
+}

--- a/src/backend/cuda/cpu_lapack/cpu_triangle.hpp
+++ b/src/backend/cuda/cpu_lapack/cpu_triangle.hpp
@@ -1,0 +1,52 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#ifndef CPU_LAPACK_TRIANGLE
+#define CPU_LAPACK_TRIANGLE
+namespace cuda
+{
+namespace cpu
+{
+
+template<typename T, bool is_upper, bool is_unit_diag>
+void triangle(T *o, const T *i, const dim4 odm, const dim4 ost, const dim4 ist)
+{
+    for(dim_t ow = 0; ow < odm[3]; ow++) {
+        const dim_t oW = ow * ost[3];
+        const dim_t iW = ow * ist[3];
+
+        for(dim_t oz = 0; oz < odm[2]; oz++) {
+            const dim_t oZW = oW + oz * ost[2];
+            const dim_t iZW = iW + oz * ist[2];
+
+            for(dim_t oy = 0; oy < odm[1]; oy++) {
+                const dim_t oYZW = oZW + oy * ost[1];
+                const dim_t iYZW = iZW + oy * ist[1];
+
+                for(dim_t ox = 0; ox < odm[0]; ox++) {
+                    const dim_t oMem = oYZW + ox;
+                    const dim_t iMem = iYZW + ox;
+
+                    bool cond = is_upper ? (oy >= ox) : (oy <= ox);
+                    bool do_unit_diag = (is_unit_diag && ox == oy);
+                    if(cond) {
+                        o[oMem] = do_unit_diag ? scalar<T>(1) : i[iMem];
+                    } else {
+                        o[oMem] = scalar<T>(0);
+                    }
+                }
+            }
+        }
+    }
+}
+
+}
+}
+
+#endif

--- a/src/backend/cuda/cpu_lapack/lapack_helper.hpp
+++ b/src/backend/cuda/cpu_lapack/lapack_helper.hpp
@@ -1,0 +1,35 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#ifndef AFCPU_LAPACK
+#define AFCPU_LAPACK
+
+#include <types.hpp>
+
+#define lapack_complex_float cuda::cfloat
+#define lapack_complex_double cuda::cdouble
+#define LAPACK_PREFIX LAPACKE_
+#define ORDER_TYPE int
+#define AF_LAPACK_COL_MAJOR LAPACK_COL_MAJOR
+#define LAPACK_NAME(fn) LAPACKE_##fn
+
+#ifdef __APPLE__
+#include <Accelerate/Accelerate.h>
+#include <lapacke.hpp>
+#undef AF_LAPACK_COL_MAJOR
+#define AF_LAPACK_COL_MAJOR 0
+#else
+#ifdef USE_MKL
+#include<mkl_lapacke.h>
+#else // NETLIB LAPACKE
+#include<lapacke.h>
+#endif
+#endif
+
+#endif

--- a/src/backend/cuda/inverse.cu
+++ b/src/backend/cuda/inverse.cu
@@ -36,6 +36,28 @@ INSTANTIATE(cdouble)
 
 }
 
+#elif defined(WITH_CPU_LINEAR_ALGEBRA)
+#include <cpu_lapack/cpu_inverse.hpp>
+
+namespace cuda
+{
+
+template<typename T>
+Array<T> inverse(const Array<T> &in)
+{
+    return cpu::inverse(in);
+}
+
+#define INSTANTIATE(T)                                                                   \
+    template Array<T> inverse<T> (const Array<T> &in);
+
+INSTANTIATE(float)
+INSTANTIATE(cfloat)
+INSTANTIATE(double)
+INSTANTIATE(cdouble)
+
+}
+
 #else
 namespace cuda
 {

--- a/src/backend/cuda/lu.cu
+++ b/src/backend/cuda/lu.cu
@@ -166,6 +166,36 @@ INSTANTIATE_LU(double)
 INSTANTIATE_LU(cdouble)
 }
 
+#elif defined(WITH_CPU_LINEAR_ALGEBRA)
+////////////////////////////////////////////////////////////////////////////////
+// For versions earlier than CUDA 7, use CPU fallback
+////////////////////////////////////////////////////////////////////////////////
+#include <cpu_lapack/cpu_lu.hpp>
+
+namespace cuda
+{
+template<typename T>
+void lu(Array<T> &lower, Array<T> &upper, Array<int> &pivot, const Array<T> &in)
+{
+    return cpu::lu(lower, upper, pivot, in);
+}
+
+template<typename T>
+Array<int> lu_inplace(Array<T> &in, const bool convert_pivot)
+{
+    return cpu::lu_inplace(in, convert_pivot);
+}
+
+#define INSTANTIATE_LU(T)                                                                           \
+    template Array<int> lu_inplace<T>(Array<T> &in, const bool convert_pivot);                      \
+    template void lu<T>(Array<T> &lower, Array<T> &upper, Array<int> &pivot, const Array<T> &in);
+
+INSTANTIATE_LU(float)
+INSTANTIATE_LU(cfloat)
+INSTANTIATE_LU(double)
+INSTANTIATE_LU(cdouble)
+}
+
 #else
 namespace cuda
 {

--- a/src/backend/cuda/qr.cu
+++ b/src/backend/cuda/qr.cu
@@ -219,6 +219,35 @@ INSTANTIATE_QR(double)
 INSTANTIATE_QR(cdouble)
 }
 
+#elif defined(WITH_CPU_LINEAR_ALGEBRA)
+#include <cpu_lapack/cpu_qr.hpp>
+
+namespace cuda
+{
+
+template<typename T>
+void qr(Array<T> &q, Array<T> &r, Array<T> &t, const Array<T> &in)
+{
+    return cpu::qr(q, r, t, in);
+}
+
+template<typename T>
+Array<T> qr_inplace(Array<T> &in)
+{
+    return cpu::qr_inplace(in);
+}
+
+#define INSTANTIATE_QR(T)                                                                           \
+    template Array<T> qr_inplace<T>(Array<T> &in);                                                \
+    template void qr<T>(Array<T> &q, Array<T> &r, Array<T> &t, const Array<T> &in);
+
+INSTANTIATE_QR(float)
+INSTANTIATE_QR(cfloat)
+INSTANTIATE_QR(double)
+INSTANTIATE_QR(cdouble)
+
+}
+
 #else
 namespace cuda
 {

--- a/src/backend/cuda/solve.cu
+++ b/src/backend/cuda/solve.cu
@@ -384,6 +384,37 @@ INSTANTIATE_SOLVE(cdouble)
 
 }
 
+#elif defined(WITH_CPU_LINEAR_ALGEBRA)
+#include<cpu_lapack/cpu_solve.hpp>
+
+namespace cuda
+{
+
+template<typename T>
+Array<T> solveLU(const Array<T> &A, const Array<int> &pivot,
+                 const Array<T> &b, const af_mat_prop options)
+{
+    return cpu::solveLU(A, pivot, b, options);
+}
+
+template<typename T>
+Array<T> solve(const Array<T> &a, const Array<T> &b, const af_mat_prop options)
+{
+    return cpu::solve(a, b, options);
+}
+
+#define INSTANTIATE_SOLVE(T)                                            \
+    template Array<T> solve<T>(const Array<T> &a, const Array<T> &b,    \
+                               const af_mat_prop options);              \
+    template Array<T> solveLU<T>(const Array<T> &A, const Array<int> &pivot, \
+                                 const Array<T> &b, const af_mat_prop options); \
+
+INSTANTIATE_SOLVE(float)
+INSTANTIATE_SOLVE(cfloat)
+INSTANTIATE_SOLVE(double)
+INSTANTIATE_SOLVE(cdouble)
+}
+
 #else
 namespace cuda
 {

--- a/src/backend/cuda/svd.cu
+++ b/src/backend/cuda/svd.cu
@@ -17,13 +17,12 @@
 #include <math.hpp>
 #include <err_common.hpp>
 
-namespace cuda
-{
-
 #if defined(WITH_CUDA_LINEAR_ALGEBRA)
 
 #include <cusolverDnManager.hpp>
 
+namespace cuda
+{
     using cusolver::getDnHandle;
 
     template<typename T>
@@ -124,8 +123,32 @@ SVD_SPECIALIZE(cdouble, double, Z);
             transpose_inplace(u, true);
         }
     }
+}
+#elif defined(WITH_CPU_LINEAR_ALGEBRA)
+
+#include <cpu_lapack/cpu_svd.hpp>
+
+namespace cuda
+{
+
+template<typename T, typename Tr>
+void svd(Array<Tr> &s, Array<T> &u, Array<T> &vt, const Array<T> &in)
+{
+    return cpu::svd<T, Tr>(s, u, vt, in);
+}
+
+template<typename T, typename Tr>
+void svdInPlace(Array<Tr> &s, Array<T> &u, Array<T> &vt, Array<T> &in)
+{
+    return cpu::svdInPlace<T, Tr>(s, u, vt, in);
+}
+
+}
 
 #else
+
+namespace cuda
+{
 
 template<typename T, typename Tr>
 void svd(Array<Tr> &s, Array<T> &u, Array<T> &vt, const Array<T> &in)
@@ -141,7 +164,12 @@ void svdInPlace(Array<Tr> &s, Array<T> &u, Array<T> &vt, Array<T> &in)
              AF_ERR_NOT_CONFIGURED);
 }
 
+}
+
 #endif
+
+namespace cuda
+{
 
 #define INSTANTIATE(T, Tr)                                              \
     template void svd<T, Tr>(Array<Tr> &s, Array<T> &u, Array<T> &vt, const Array<T> &in); \

--- a/test/solve_dense.cpp
+++ b/test/solve_dense.cpp
@@ -31,6 +31,8 @@ using af::cdouble;
 template<typename T>
 void solveTester(const int m, const int n, const int k, double eps)
 {
+    af::deviceGC();
+
     if (noDoubleTests<T>()) return;
 #if 1
     af::array A  = cpu_randu<T>(af::dim4(m, n));
@@ -56,6 +58,8 @@ void solveTester(const int m, const int n, const int k, double eps)
 template<typename T>
 void solveLUTester(const int n, const int k, double eps)
 {
+    af::deviceGC();
+
     if (noDoubleTests<T>()) return;
 #if 1
     af::array A  = cpu_randu<T>(af::dim4(n, n));
@@ -81,6 +85,8 @@ void solveLUTester(const int n, const int k, double eps)
 template<typename T>
 void solveTriangleTester(const int n, const int k, bool is_upper, double eps)
 {
+    af::deviceGC();
+
     if (noDoubleTests<T>()) return;
 #if 1
     af::array A  = cpu_randu<T>(af::dim4(n, n));


### PR DESCRIPTION
Adds fallback CPU capability for CUDA lapack functions who's implementations were disabled for versions of CUDA prior to 7.0.