### PR TITLE
Compilation Fixes

### DIFF
--- a/include/af/image.h
+++ b/include/af/image.h
@@ -114,7 +114,7 @@ AFAPI void deleteImageMem(void *ptr);
 
     \ingroup imageio_func_load
 */
-AFAPI array loadImageT(const char* filename);
+AFAPI array loadImageNative(const char* filename);
 #endif
 
 #if AF_API_VERSION >= 32
@@ -144,7 +144,7 @@ AFAPI array loadImageT(const char* filename);
 
     \ingroup imageio_func_save
 */
-AFAPI void saveImageT(const char* filename, const array& in);
+AFAPI void saveImageNative(const char* filename, const array& in);
 #endif
 
 /**
@@ -758,7 +758,7 @@ extern "C" {
 
         \ingroup imageio_func_load
     */
-    AFAPI af_err af_load_image_t(af_array *out, const char* filename);
+    AFAPI af_err af_load_image_native(af_array *out, const char* filename);
 #endif
 
 #if AF_API_VERSION >= 32
@@ -790,7 +790,7 @@ extern "C" {
 
         \ingroup imageio_func_save
     */
-    AFAPI af_err af_save_image_t(const char* filename, const af_array in);
+    AFAPI af_err af_save_image_native(const char* filename, const af_array in);
 #endif
 
     /**

--- a/src/api/c/imageio2.cpp
+++ b/src/api/c/imageio2.cpp
@@ -100,7 +100,7 @@ FREE_IMAGE_TYPE getFIT(FI_CHANNELS channels, af_dtype type)
 // File IO
 ////////////////////////////////////////////////////////////////////////////////
 // Load image from disk.
-af_err af_load_image_t(af_array *out, const char* filename)
+af_err af_load_image_native(af_array *out, const char* filename)
 {
     try {
         ARG_ASSERT(1, filename != NULL);
@@ -270,7 +270,7 @@ static void save_t(T* pDstLine, const af_array in, const dim4 dims, uint nDstPit
 }
 
 // Save an image to disk.
-af_err af_save_image_t(const char* filename, const af_array in)
+af_err af_save_image_native(const char* filename, const af_array in)
 {
     try {
 
@@ -375,13 +375,13 @@ af_err af_save_image_t(const char* filename, const af_array in)
 #else   // WITH_FREEIMAGE
 #include <af/image.h>
 #include <stdio.h>
-af_err af_load_image_t(af_array *out, const char* filename, const bool isColor)
+af_err af_load_image_native(af_array *out, const char* filename)
 {
     printf("Error: Image IO requires FreeImage. See https://github.com/arrayfire/arrayfire\n");
     return AF_ERR_NOT_CONFIGURED;
 }
 
-af_err af_save_image_t(const char* filename, const af_array in_)
+af_err af_save_image_native(const char* filename, const af_array in)
 {
     printf("Error: Image IO requires FreeImage. See https://github.com/arrayfire/arrayfire\n");
     return AF_ERR_NOT_CONFIGURED;

--- a/src/api/c/surface.cpp
+++ b/src/api/c/surface.cpp
@@ -105,7 +105,7 @@ af_err af_draw_surface(const af_window wind, const af_array xVals, const af_arra
             DIM_ASSERT(1, X_dims == Y_dims);
             DIM_ASSERT(3, Y_dims == S_dims);
         }else{
-            DIM_ASSERT(3, ( X_dims[0] * Y_dims[0] == Sinfo.elements()));
+            DIM_ASSERT(3, ( X_dims[0] * Y_dims[0] == (dim_t)Sinfo.elements()));
         }
 
         fg::Window* window = reinterpret_cast<fg::Window*>(wind);

--- a/src/api/cpp/imageio.cpp
+++ b/src/api/cpp/imageio.cpp
@@ -56,16 +56,16 @@ void deleteImageMem(void* ptr)
     AF_THROW(af_delete_image_memory(ptr));
 }
 
-array loadImageT(const char* filename)
+array loadImageNative(const char* filename)
 {
     af_array out = 0;
-    AF_THROW(af_load_image_t(&out, filename));
+    AF_THROW(af_load_image_native(&out, filename));
     return array(out);
 }
 
-void saveImageT(const char* filename, const array& in)
+void saveImageNative(const char* filename, const array& in)
 {
-    AF_THROW(af_save_image_t(filename, in.get()));
+    AF_THROW(af_save_image_native(filename, in.get()));
 }
 
 }

--- a/src/api/unified/image.cpp
+++ b/src/api/unified/image.cpp
@@ -41,12 +41,12 @@ af_err af_delete_image_memory(void* ptr)
     return CALL(ptr);
 }
 
-af_err af_load_image_t(af_array *out, const char* filename)
+af_err af_load_image_native(af_array *out, const char* filename)
 {
     return CALL(out, filename);
 }
 
-af_err af_save_image_t(const char* filename, const af_array in)
+af_err af_save_image_native(const char* filename, const af_array in)
 {
     return CALL(filename, in);
 }

--- a/src/backend/cuda/kernel/shared.hpp
+++ b/src/backend/cuda/kernel/shared.hpp
@@ -47,6 +47,8 @@ SPECIALIZE(uint)
 SPECIALIZE(short)
 SPECIALIZE(ushort)
 SPECIALIZE(uchar)
+SPECIALIZE(intl)
+SPECIALIZE(uintl)
 
 #undef SPECIALIZE
 


### PR DESCRIPTION
[skip ci]

API Change:
* loadImageT -> loadImageNative
* saveImageT -> saveImageNative
* af_load_image_t -> af_load_image_native
* af_save_image_t -> af_save_image_native

Fixes #1083 
Fix compilation issues and warning.