### PR TITLE
Tests as standalone project

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,5 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
-PROJECT(arrayfire-examples)
+PROJECT(ArrayFire-Examples)
 
 # Find CUDA and OpenCL
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
@@ -8,10 +8,11 @@ FIND_PACKAGE(OpenCL QUIET)
 
 # If the examples are not being built at the same time as ArrayFire,
 # we need to first find the ArrayFire library
-if(TARGET afcpu OR TARGET afcuda OR TARGET afopencl)
+IF(TARGET afcpu OR TARGET afcuda OR TARGET afopencl OR TARGET af)
     SET(ArrayFire_CPU_FOUND False)
     SET(ArrayFire_CUDA_FOUND False)
     SET(ArrayFire_OpenCL_FOUND False)
+    SET(ArrayFire_Unified_FOUND False)
     SET(ASSETS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../assets")
     IF(NOT EXISTS "${ASSETS_DIR}/LICENSE")
         MESSAGE(STATUS "Assests submodule unavailable. Updating submodules.")
@@ -21,12 +22,12 @@ if(TARGET afcpu OR TARGET afcuda OR TARGET afopencl)
             OUTPUT_QUIET
         )
     ENDIF()
-else()
+ELSE()
     FIND_PACKAGE(ArrayFire REQUIRED)
     INCLUDE_DIRECTORIES(${ArrayFire_INCLUDE_DIRS})
 
     SET(ASSETS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/assets")
-endif()
+ENDIF()
 
 IF(WIN32)
     # Deprecated Errors are Warning 4996 on VS2013.
@@ -71,68 +72,60 @@ FILE(GLOB FILES "*/*.cpp")
 ADD_DEFINITIONS("-DASSETS_DIR=\"${ASSETS_DIR}\"")
 
 # Next we build each example using every backend.
-if(${ArrayFire_CPU_FOUND})  # variable defined by FIND(ArrayFire ...)
-  MESSAGE(STATUS "EXAMPLES: CPU backend is ON.")
-  BUILD_ALL("${FILES}" cpu ${ArrayFire_CPU_LIBRARIES} "")
-elseif(TARGET afcpu)        # variable defined by the ArrayFire build tree
-  MESSAGE(STATUS "EXAMPLES: CPU backend is ON.")
-  BUILD_ALL("${FILES}" cpu afcpu "")
-else()
-  MESSAGE(STATUS "EXAMPLES: CPU backend is OFF. afcpu was not found.")
-endif()
+IF(${ArrayFire_CPU_FOUND})  # variable defined by FIND(ArrayFire ...)
+    MESSAGE(STATUS "EXAMPLES: CPU backend is ON.")
+    BUILD_ALL("${FILES}" cpu ${ArrayFire_CPU_LIBRARIES} "")
+ELSEIF(TARGET afcpu)        # variable defined by the ArrayFire build tree
+    MESSAGE(STATUS "EXAMPLES: CPU backend is ON.")
+    BUILD_ALL("${FILES}" cpu afcpu "")
+ELSE()
+    MESSAGE(STATUS "EXAMPLES: CPU backend is OFF. afcpu was not found.")
+ENDIF()
 
 # Next we build each example using every backend.
-if(${ArrayFire_Unified_FOUND})  # variable defined by FIND(ArrayFire ...)
-  MESSAGE(STATUS "EXAMPLES: UNIFIED backend is ON.")
-  IF(WIN32)
-    BUILD_ALL("${FILES}" unified ${ArrayFire_Unified_LIBRARIES} "")
-  ELSE()
-    BUILD_ALL("${FILES}" unified ${ArrayFire_Unified_LIBRARIES} "dl")
-  ENDIF()
-elseif(TARGET af)        # variable defined by the ArrayFire build tree
-  MESSAGE(STATUS "EXAMPLES: UNIFIED backend is ON.")
-  IF(WIN32)
-      BUILD_ALL("${FILES}" unified af "")
-  ELSE()
-      BUILD_ALL("${FILES}" unified af "dl")
-  ENDIF()
-else()
-  MESSAGE(STATUS "EXAMPLES: UNIFIED backend is OFF. af was not found.")
-endif()
+IF(${ArrayFire_Unified_FOUND})  # variable defined by FIND(ArrayFire ...)
+    MESSAGE(STATUS "EXAMPLES: UNIFIED backend is ON.")
+    BUILD_ALL("${FILES}" unified ${ArrayFire_Unified_LIBRARIES} ${CMAKE_DL_LIBS})
+ELSEIF(TARGET af)        # variable defined by the ArrayFire build tree
+    MESSAGE(STATUS "EXAMPLES: UNIFIED backend is ON.")
+    BUILD_ALL("${FILES}" unified af ${CMAKE_DL_LIBS})
+ELSE()
+    MESSAGE(STATUS "EXAMPLES: UNIFIED backend is OFF. af was not found.")
+ENDIF()
 
-if (${CUDA_FOUND})
-  if(${ArrayFire_CUDA_FOUND})  # variable defined by FIND(ArrayFire ...)
-    FIND_LIBRARY( CUDA_NVVM_LIBRARY
-      NAMES "nvvm"
-      PATH_SUFFIXES "nvvm/lib64" "nvvm/lib"
-      PATHS ${CUDA_TOOLKIT_ROOT_DIR}
-      DOC "CUDA NVVM Library"
-      )
-    MESSAGE(STATUS "EXAMPLES: CUDA backend is ON.")
-    BUILD_ALL("${FILES}" cuda ${ArrayFire_CUDA_LIBRARIES} "${CUDA_CUBLAS_LIBRARIES};${CUDA_LIBRARIES};${CUDA_cusolver_LIBRARY};${CUDA_CUFFT_LIBRARIES};${CUDA_NVVM_LIBRARY};${CUDA_CUDA_LIBRARY}")
-  elseif(TARGET afcuda)        # variable defined by the ArrayFire build tree
-    MESSAGE(STATUS "EXAMPLES: CUDA backend is ON.")
-    BUILD_ALL("${FILES}" cuda afcuda "")
-  else()
-    MESSAGE(STATUS "EXAMPLES: CUDA backend is OFF. afcuda was not found")
-  endif()
-else()
-  MESSAGE(STATUS "EXAMPLES: CUDA backend is OFF. CUDA was not found")
-endif()
+IF (${CUDA_FOUND})
+    IF(${ArrayFire_CUDA_FOUND})  # variable defined by FIND(ArrayFire ...)
+        FIND_LIBRARY( CUDA_NVVM_LIBRARY
+          NAMES "nvvm"
+          PATH_SUFFIXES "nvvm/lib64" "nvvm/lib"
+          PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+          DOC "CUDA NVVM Library"
+          )
+        MESSAGE(STATUS "EXAMPLES: CUDA backend is ON.")
+        BUILD_ALL("${FILES}" cuda ${ArrayFire_CUDA_LIBRARIES} "${CUDA_CUBLAS_LIBRARIES};${CUDA_LIBRARIES};${CUDA_cusolver_LIBRARY};${CUDA_CUFFT_LIBRARIES};${CUDA_NVVM_LIBRARY};${CUDA_CUDA_LIBRARY}")
+    ELSEIF(TARGET afcuda)        # variable defined by the ArrayFire build tree
+        MESSAGE(STATUS "EXAMPLES: CUDA backend is ON.")
+        BUILD_ALL("${FILES}" cuda afcuda "")
+    ELSE()
+        MESSAGE(STATUS "EXAMPLES: CUDA backend is OFF. afcuda was not found")
+    ENDIF()
+ELSE()
+    MESSAGE(STATUS "EXAMPLES: CUDA backend is OFF. CUDA was not found")
+ENDIF()
 
-if (${OpenCL_FOUND})
-  if(${ArrayFire_OpenCL_FOUND})  # variable defined by FIND(ArrayFire ...)
-    MESSAGE(STATUS "EXAMPLES: OPENCL backend is ON.")
-    BUILD_ALL("${FILES}" opencl ${ArrayFire_OpenCL_LIBRARIES} "${OpenCL_LIBRARIES}")
-  elseif(TARGET afopencl)        # variable defined by the ArrayFire build tree
-    MESSAGE(STATUS "EXAMPLES: OPENCL backend is ON.")
-    BUILD_ALL("${FILES}" opencl afopencl ${OpenCL_LIBRARIES})
-  else()
-    MESSAGE(STATUS "EXAMPLES: OPENCL backend is OFF. afopencl was not found")
-  endif()
-else()
-  MESSAGE(STATUS "EXAMPLES: OPENCL backend is OFF. OPENCL was not found")
-endif()
+IF (${OpenCL_FOUND})
+    IF(${ArrayFire_OpenCL_FOUND})  # variable defined by FIND(ArrayFire ...)
+        MESSAGE(STATUS "EXAMPLES: OpenCL backend is ON.")
+        BUILD_ALL("${FILES}" opencl ${ArrayFire_OpenCL_LIBRARIES} "${OpenCL_LIBRARIES}")
+    ELSEIF(TARGET afopencl)        # variable defined by the ArrayFire build tree
+        MESSAGE(STATUS "EXAMPLES: OpenCL backend is ON.")
+        BUILD_ALL("${FILES}" opencl afopencl ${OpenCL_LIBRARIES})
+    ELSE()
+        MESSAGE(STATUS "EXAMPLES: OpenCL backend is OFF. afopencl was not found")
+    ENDIF()
+ELSE()
+    MESSAGE(STATUS "EXAMPLES: OpenCL backend is OFF. OpenCL was not found")
+ENDIF()
 
 INSTALL(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     DESTINATION "${AF_INSTALL_EXAMPLE_DIR}"

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -84,7 +84,11 @@ endif()
 # Next we build each example using every backend.
 if(${ArrayFire_Unified_FOUND})  # variable defined by FIND(ArrayFire ...)
   MESSAGE(STATUS "EXAMPLES: UNIFIED backend is ON.")
-  BUILD_ALL("${FILES}" unified ${ArrayFire_Unified_LIBRARIES} "")
+  IF(WIN32)
+    BUILD_ALL("${FILES}" unified ${ArrayFire_Unified_LIBRARIES} "")
+  ELSE()
+    BUILD_ALL("${FILES}" unified ${ArrayFire_Unified_LIBRARIES} "dl")
+  ENDIF()
 elseif(TARGET af)        # variable defined by the ArrayFire build tree
   MESSAGE(STATUS "EXAMPLES: UNIFIED backend is ON.")
   IF(WIN32)

--- a/examples/unified/basic.cpp
+++ b/examples/unified/basic.cpp
@@ -8,6 +8,7 @@
  ********************************************************/
 
 #include <arrayfire.h>
+#include <cstdio>
 #include <vector>
 #include <algorithm>
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,30 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+PROJECT(ArrayFire-Tests)
 
-REMOVE_DEFINITIONS(-std=c++11)
+# Find CUDA and OpenCL
+SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 FIND_PACKAGE(CUDA QUIET)
 FIND_PACKAGE(OpenCL QUIET)
 
+# If the tests are not being built at the same time as ArrayFire,
+# we need to first find the ArrayFire library
+IF(TARGET afcpu OR TARGET afcuda OR TARGET afopencl OR TARGET af)
+    SET(ArrayFire_CPU_FOUND False)
+    SET(ArrayFire_CUDA_FOUND False)
+    SET(ArrayFire_OpenCL_FOUND False)
+    SET(ArrayFire_Unified_FOUND False)
+ELSE()
+    FIND_PACKAGE(ArrayFire REQUIRED)
+    INCLUDE_DIRECTORIES(${ArrayFire_INCLUDE_DIRS})
+    OPTION(BUILD_NONFREE "Build Tests for nonfree algorithms" OFF)
+    IF(${BUILD_NONFREE}) # Add definition. Not required when building with AF
+        ADD_DEFINITIONS(-DAF_BUILD_SIFT)
+    ENDIF(${BUILD_NONFREE})
+ENDIF()
 
-MACRO(CREATE_TESTS BACKEND LIBNAME GTEST_LIBS OTHER_LIBS)
+REMOVE_DEFINITIONS(-std=c++11)
+
+MACRO(CREATE_TESTS BACKEND AFLIBNAME GTEST_LIBS OTHER_LIBS)
     STRING(TOUPPER ${BACKEND} DEF_NAME)
 
     FOREACH(FILE ${FILES})
@@ -22,7 +41,7 @@ MACRO(CREATE_TESTS BACKEND LIBNAME GTEST_LIBS OTHER_LIBS)
 
         FILE(GLOB TEST_FILE "${FNAME}.cpp" "${FNAME}.c")
         ADD_EXECUTABLE(${TEST_NAME} ${TEST_FILE})
-        TARGET_LINK_LIBRARIES(${TEST_NAME}  PRIVATE  af${LIBNAME}
+        TARGET_LINK_LIBRARIES(${TEST_NAME}  PRIVATE ${AFLIBNAME}
                                             PRIVATE ${THREAD_LIB_FLAG}
                                             PRIVATE ${GTEST_LIBS}
                                             PRIVATE ${OTHER_LIBS})
@@ -45,10 +64,11 @@ ENDIF()
 OPTION(USE_RELATIVE_TEST_DIR "Use relative paths for the test data directory(For continious integration(CI) purposes only)" OFF)
 
 IF(${USE_RELATIVE_TEST_DIR})
-    SET(RELATIVE_TEST_DATA_DIR "./data" CACHE STRING "Relative Test Data Directory")
+    # RELATIVE_TEST_DATA_DIR is a User-visible option with default value of test/data directory
+    SET(RELATIVE_TEST_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/data" CACHE STRING "Relative Test Data Directory")
     SET(TESTDATA_SOURCE_DIR ${RELATIVE_TEST_DATA_DIR})
-ELSE(${USE_RELATIVE_TEST_DIR})
-    SET(TESTDATA_SOURCE_DIR "${CMAKE_SOURCE_DIR}/test/data")
+ELSE(${USE_RELATIVE_TEST_DIR})  # Not using relative test data directory
+    SET(TESTDATA_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/data")
 ENDIF(${USE_RELATIVE_TEST_DIR})
 
 IF (${CMAKE_GENERATOR} STREQUAL "Xcode")
@@ -58,20 +78,20 @@ ELSE (${CMAKE_GENERATOR} STREQUAL "Xcode")
 ENDIF (${CMAKE_GENERATOR} STREQUAL "Xcode")
 
 IF(NOT ${USE_RELATIVE_TEST_DIR})
-# Check if data exists
-IF (EXISTS "${TESTDATA_SOURCE_DIR}" AND IS_DIRECTORY "${TESTDATA_SOURCE_DIR}"
-    AND EXISTS "${TESTDATA_SOURCE_DIR}/README.md")
-    # Test data is available
-    # Do Nothing
-ELSE (EXISTS "${TESTDATA_SOURCE_DIR}" AND IS_DIRECTORY "${TESTDATA_SOURCE_DIR}"
-    AND EXISTS "${TESTDATA_SOURCE_DIR}/README.md")
-    MESSAGE(STATUS "Test submodules unavailable. Updating submodules.")
-    EXECUTE_PROCESS(
-        COMMAND git submodule update --init --recursive
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        OUTPUT_QUIET
-    )
-ENDIF()
+    # Check if data exists
+    IF (EXISTS "${TESTDATA_SOURCE_DIR}" AND IS_DIRECTORY "${TESTDATA_SOURCE_DIR}"
+        AND EXISTS "${TESTDATA_SOURCE_DIR}/README.md")
+        # Test data is available
+        # Do Nothing
+    ELSE (EXISTS "${TESTDATA_SOURCE_DIR}" AND IS_DIRECTORY "${TESTDATA_SOURCE_DIR}"
+        AND EXISTS "${TESTDATA_SOURCE_DIR}/README.md")
+        MESSAGE(STATUS "Test submodules unavailable. Updating submodules.")
+        EXECUTE_PROCESS(
+            COMMAND git submodule update --init --recursive
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+            OUTPUT_QUIET
+        )
+    ENDIF()
 ENDIF(NOT ${USE_RELATIVE_TEST_DIR})
 
 OPTION(USE_SYSTEM_GTEST "Use GTEST from system libraries" OFF)
@@ -86,42 +106,89 @@ INCLUDE_DIRECTORIES(${GTEST_INCLUDE_DIRS})
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR})
 FILE(GLOB FILES "*.cpp" "*.c")
 
-IF(${BUILD_CPU})
-    MESSAGE(STATUS "TESTS: CPU backend is ON")
-    CREATE_TESTS(cpu cpu "${GTEST_LIBRARIES}" "")
+# Next we build each example using every backend.
+IF(${ArrayFire_CPU_FOUND})  # variable defined by FIND(ArrayFire ...)
+    MESSAGE(STATUS "TESTS: CPU backend is ON.")
+    CREATE_TESTS(cpu ${ArrayFire_CPU_LIBRARIES} "${GTEST_LIBRARIES}" "")
+ELSEIF(TARGET afcpu)        # variable defined by the ArrayFire build tree
+    MESSAGE(STATUS "TESTS: CPU backend is ON.")
+    CREATE_TESTS(cpu afcpu "${GTEST_LIBRARIES}" "")
 ELSE()
-    MESSAGE(STATUS "TESTS: CPU backend is OFF")
+    MESSAGE(STATUS "TESTS: CPU backend is OFF. afcpu was not found.")
 ENDIF()
 
-IF(${BUILD_CUDA} AND ${CUDA_FOUND})
-    MESSAGE(STATUS "TESTS: CUDA backend is ON")
-    IF("${APPLE}" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CUDA_VERSION_MAJOR} VERSION_LESS 7)
-        CREATE_TESTS(cuda cuda "${GTEST_LIBRARIES_STDLIB}" "")
-        FOREACH(FILE ${FILES})
-            GET_FILENAME_COMPONENT(FNAME ${FILE} NAME_WE)
-            SET(TEST_NAME ${FNAME}_cuda)
-            SET_TARGET_PROPERTIES(${TEST_NAME} PROPERTIES COMPILE_FLAGS -stdlib=libstdc++)
-            SET_TARGET_PROPERTIES(${TEST_NAME} PROPERTIES LINK_FLAGS -stdlib=libstdc++)
-        ENDFOREACH()
-    ELSE("${APPLE}" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CUDA_VERSION_MAJOR} VERSION_LESS 7)
-        CREATE_TESTS(cuda cuda "${GTEST_LIBRARIES}" "")
-    ENDIF("${APPLE}" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CUDA_VERSION_MAJOR} VERSION_LESS 7)
+# Next we build each example using every backend.
+IF(${ArrayFire_Unified_FOUND})  # variable defined by FIND(ArrayFire ...)
+    MESSAGE(STATUS "TESTS: UNIFIED backend is ON.")
+    CREATE_TESTS(unified ${ArrayFire_Unified_LIBRARIES} "${GTEST_LIBRARIES}" "${CMAKE_DL_LIBS}")
+ELSEIF(TARGET af)        # variable defined by the ArrayFire build tree
+    MESSAGE(STATUS "TESTS: UNIFIED backend is ON.")
+    CREATE_TESTS(unified af "${GTEST_LIBRARIES}" "${CMAKE_DL_LIBS}")
 ELSE()
-    MESSAGE(STATUS "TESTS: CUDA backend is OFF")
+    MESSAGE(STATUS "TESTS: UNIFIED backend is OFF. af was not found.")
 ENDIF()
 
-IF(${BUILD_OPENCL} AND ${OpenCL_FOUND})
-    MESSAGE(STATUS "TESTS: OPENCL backend is ON")
-    CREATE_TESTS(opencl opencl "${GTEST_LIBRARIES}" "${OpenCL_LIBRARIES}")
-ELSE()
-    MESSAGE(STATUS "TESTS: OPENCL backend is OFF")
-ENDIF()
+IF (${CUDA_FOUND})
+    IF(${ArrayFire_CUDA_FOUND})  # variable defined by FIND(ArrayFire ...)
+        FIND_LIBRARY( CUDA_NVVM_LIBRARY
+          NAMES "nvvm"
+          PATH_SUFFIXES "nvvm/lib64" "nvvm/lib"
+          PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+          DOC "CUDA NVVM Library"
+          )
+        MESSAGE(STATUS "TESTS: CUDA backend is ON.")
+        # If OSX && CLANG && CUDA < 7
+        IF("${APPLE}" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CUDA_VERSION_MAJOR} VERSION_LESS 7)
+            CREATE_TESTS(cuda ${ArrayFire_CUDA_LIBRARIES} "${GTEST_LIBRARIES_STDLIB}" "${CUDA_CUBLAS_LIBRARIES};${CUDA_LIBRARIES};${CUDA_cusolver_LIBRARY};${CUDA_CUFFT_LIBRARIES};${CUDA_NVVM_LIBRARY};${CUDA_CUDA_LIBRARY}")
 
-IF(${BUILD_UNIFIED})
-    MESSAGE(STATUS "TESTS: Unified backends is ON")
-    IF(WIN32)
-        CREATE_TESTS(unified "" "${GTEST_LIBRARIES}" "")
+            FOREACH(FILE ${FILES})
+                GET_FILENAME_COMPONENT(FNAME ${FILE} NAME_WE)
+                SET(TEST_NAME ${FNAME}_cuda)
+                SET_TARGET_PROPERTIES(${TEST_NAME} PROPERTIES COMPILE_FLAGS -stdlib=libstdc++)
+                SET_TARGET_PROPERTIES(${TEST_NAME} PROPERTIES LINK_FLAGS -stdlib=libstdc++)
+            ENDFOREACH()
+
+        # ELSE OSX && CLANG && CUDA < 7
+        ELSE("${APPLE}" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CUDA_VERSION_MAJOR} VERSION_LESS 7)
+            CREATE_TESTS(cuda ${ArrayFire_CUDA_LIBRARIES} "${GTEST_LIBRARIES}" "${CUDA_CUBLAS_LIBRARIES};${CUDA_LIBRARIES};${CUDA_cusolver_LIBRARY};${CUDA_CUFFT_LIBRARIES};${CUDA_NVVM_LIBRARY};${CUDA_CUDA_LIBRARY}")
+
+        ENDIF("${APPLE}" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CUDA_VERSION_MAJOR} VERSION_LESS 7)
+
+    ELSEIF(TARGET afcuda)        # variable defined by the ArrayFire build tree
+        MESSAGE(STATUS "TESTS: CUDA backend is ON.")
+        # If OSX && CLANG && CUDA < 7
+        IF("${APPLE}" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CUDA_VERSION_MAJOR} VERSION_LESS 7)
+            CREATE_TESTS(cuda afcuda "${GTEST_LIBRARIES_STDLIB}" "${CUDA_CUBLAS_LIBRARIES};${CUDA_LIBRARIES};${CUDA_cusolver_LIBRARY};${CUDA_CUFFT_LIBRARIES};${CUDA_NVVM_LIBRARY};${CUDA_CUDA_LIBRARY}")
+
+            FOREACH(FILE ${FILES})
+                GET_FILENAME_COMPONENT(FNAME ${FILE} NAME_WE)
+                SET(TEST_NAME ${FNAME}_cuda)
+                SET_TARGET_PROPERTIES(${TEST_NAME} PROPERTIES COMPILE_FLAGS -stdlib=libstdc++)
+                SET_TARGET_PROPERTIES(${TEST_NAME} PROPERTIES LINK_FLAGS -stdlib=libstdc++)
+            ENDFOREACH()
+
+        # ELSE OSX && CLANG && CUDA < 7
+        ELSE("${APPLE}" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CUDA_VERSION_MAJOR} VERSION_LESS 7)
+            CREATE_TESTS(cuda afcuda "${GTEST_LIBRARIES}" "${CUDA_CUBLAS_LIBRARIES};${CUDA_LIBRARIES};${CUDA_cusolver_LIBRARY};${CUDA_CUFFT_LIBRARIES};${CUDA_NVVM_LIBRARY};${CUDA_CUDA_LIBRARY}")
+
+        ENDIF("${APPLE}" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CUDA_VERSION_MAJOR} VERSION_LESS 7)
     ELSE()
-        CREATE_TESTS(unified "" "${GTEST_LIBRARIES}" dl)
+        MESSAGE(STATUS "TESTS: CUDA backend is OFF. afcuda was not found")
     ENDIF()
+ELSE()
+    MESSAGE(STATUS "TESTS: CUDA backend is OFF. CUDA was not found")
+ENDIF()
+
+IF (${OpenCL_FOUND})
+    IF(${ArrayFire_OpenCL_FOUND})  # variable defined by FIND(ArrayFire ...)
+        MESSAGE(STATUS "TESTS: OpenCL backend is ON.")
+        CREATE_TESTS(opencl ${ArrayFire_OpenCL_LIBRARIES} "${GTEST_LIBRARIES}" "${OpenCL_LIBRARIES}")
+    ELSEIF(TARGET afopencl)        # variable defined by the ArrayFire build tree
+        MESSAGE(STATUS "TESTS: OpenCL backend is ON.")
+        CREATE_TESTS(opencl afopencl "${GTEST_LIBRARIES}" "${OpenCL_LIBRARIES}")
+    ELSE()
+        MESSAGE(STATUS "TESTS: OpenCL backend is OFF. afopencl was not found")
+    ENDIF()
+ELSE()
+    MESSAGE(STATUS "TESTS: OpenCL backend is OFF. OpenCL was not found")
 ENDIF()

--- a/test/CMakeModules/FindOpenCL.cmake
+++ b/test/CMakeModules/FindOpenCL.cmake
@@ -1,0 +1,190 @@
+#.rst:
+# FindOpenCL
+# ----------
+#
+# Try to find OpenCL
+#
+# Once done this will define::
+#
+#   OpenCL_FOUND          - True if OpenCL was found
+#   OpenCL_INCLUDE_DIRS   - include directories for OpenCL
+#   OpenCL_LIBRARIES      - link against this library to use OpenCL
+#   OpenCL_VERSION_STRING - Highest supported OpenCL version (eg. 1.2)
+#   OpenCL_VERSION_MAJOR  - The major version of the OpenCL implementation
+#   OpenCL_VERSION_MINOR  - The minor version of the OpenCL implementation
+#
+# The module will also define two cache variables::
+#
+#   OpenCL_INCLUDE_DIR    - the OpenCL include directory
+#   OpenCL_LIBRARY        - the path to the OpenCL library
+#
+
+#=============================================================================
+# From CMake 3.2
+# Copyright 2014 Matthaeus G. Chajdas
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+
+# CMake - Cross Platform Makefile Generator
+# Copyright 2000-2014 Kitware, Inc.
+# Copyright 2000-2011 Insight Software Consortium
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+# notice, this list of conditions and the following disclaimer in the
+# documentation and/or other materials provided with the distribution.
+#
+# * Neither the names of Kitware, Inc., the Insight Software Consortium,
+# nor the names of their contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#=============================================================================
+
+function(_FIND_OPENCL_VERSION)
+  include(CheckSymbolExists)
+  include(CMakePushCheckState)
+  set(CMAKE_REQUIRED_QUIET ${OpenCL_FIND_QUIETLY})
+
+  CMAKE_PUSH_CHECK_STATE()
+  foreach(VERSION "2_0" "1_2" "1_1" "1_0")
+    set(CMAKE_REQUIRED_INCLUDES "${OpenCL_INCLUDE_DIR}")
+    if(APPLE)
+      CHECK_SYMBOL_EXISTS(
+        CL_VERSION_${VERSION}
+        "${OpenCL_INCLUDE_DIR}/OpenCL/cl.h"
+        OPENCL_VERSION_${VERSION})
+    else()
+      CHECK_SYMBOL_EXISTS(
+        CL_VERSION_${VERSION}
+        "${OpenCL_INCLUDE_DIR}/CL/cl.h"
+        OPENCL_VERSION_${VERSION})
+    endif()
+
+    if(OPENCL_VERSION_${VERSION})
+      string(REPLACE "_" "." VERSION "${VERSION}")
+      set(OpenCL_VERSION_STRING ${VERSION} PARENT_SCOPE)
+      string(REGEX MATCHALL "[0-9]+" version_components "${VERSION}")
+      list(GET version_components 0 major_version)
+      list(GET version_components 1 minor_version)
+      set(OpenCL_VERSION_MAJOR ${major_version} PARENT_SCOPE)
+      set(OpenCL_VERSION_MINOR ${minor_version} PARENT_SCOPE)
+      break()
+    endif()
+  endforeach()
+  CMAKE_POP_CHECK_STATE()
+endfunction()
+
+find_path(OpenCL_INCLUDE_DIR
+  NAMES
+    CL/cl.h OpenCL/cl.h
+  PATHS
+    ENV "PROGRAMFILES(X86)"
+    ENV NVSDKCOMPUTE_ROOT
+    ENV CUDA_PATH
+    ENV AMDAPPSDKROOT
+    ENV INTELOCLSDKROOT
+    ENV ATISTREAMSDKROOT
+  PATH_SUFFIXES
+    include
+    OpenCL/common/inc
+    "AMD APP/include")
+
+_FIND_OPENCL_VERSION()
+
+if(WIN32)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    find_library(OpenCL_LIBRARY
+      NAMES OpenCL
+      PATHS
+        ENV "PROGRAMFILES(X86)"
+        ENV CUDA_PATH
+        ENV NVSDKCOMPUTE_ROOT
+        ENV AMDAPPSDKROOT
+        ENV INTELOCLSDKROOT
+        ENV ATISTREAMSDKROOT
+      PATH_SUFFIXES
+        "AMD APP/lib/x86"
+        lib/x86
+        lib/Win32
+        OpenCL/common/lib/Win32)
+  elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    find_library(OpenCL_LIBRARY
+      NAMES OpenCL
+      PATHS
+        ENV "PROGRAMFILES(X86)"
+        ENV CUDA_PATH
+        ENV NVSDKCOMPUTE_ROOT
+        ENV AMDAPPSDKROOT
+        ENV INTELOCLSDKROOT
+        ENV ATISTREAMSDKROOT
+      PATH_SUFFIXES
+        "AMD APP/lib/x86_64"
+        lib/x86_64
+        lib/x64
+        OpenCL/common/lib/x64)
+  endif()
+else()
+  find_library(OpenCL_LIBRARY
+    NAMES OpenCL
+    PATHS
+        ENV LD_LIBRARY_PATH
+        ENV AMDAPPSDKROOT
+        ENV INTELOCLSDKROOT
+        ENV CUDA_PATH
+        ENV NVSDKCOMPUTE_ROOT
+        ENV ATISTREAMSDKROOT
+        /usr/lib64
+        /usr/lib
+        /usr/local/lib64
+        /usr/local/lib
+        /sw/lib
+        /opt/local/lib
+    PATH_SUFFIXES
+        "AMD APP/lib/x86_64"
+        lib/x86_64
+        lib/x64
+        lib/
+        lib64/
+        x86_64-linux-gnu
+        arm-linux-gnueabihf
+    )
+endif()
+
+set(OpenCL_LIBRARIES ${OpenCL_LIBRARY})
+set(OpenCL_INCLUDE_DIRS ${OpenCL_INCLUDE_DIR})
+
+#include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+find_package_handle_standard_args(
+  OpenCL
+  FOUND_VAR OpenCL_FOUND
+  REQUIRED_VARS OpenCL_LIBRARY OpenCL_INCLUDE_DIR
+  VERSION_VAR OpenCL_VERSION_STRING)
+
+mark_as_advanced(
+  OpenCL_INCLUDE_DIR
+  OpenCL_LIBRARY)
+

--- a/test/CMakeModules/build_gtest.cmake
+++ b/test/CMakeModules/build_gtest.cmake
@@ -1,14 +1,15 @@
 # Build the gtest libraries
 
 # Check if Google Test exists
-SET(GTEST_SOURCE_DIR "${CMAKE_SOURCE_DIR}/test/gtest")
+SET(GTEST_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/gtest")
+MESSAGE(STATUS ${GTEST_SOURCE_DIR})
 IF(NOT EXISTS "${GTEST_SOURCE_DIR}/README")
-    MESSAGE(WARNING "GTest Source is not available. Tests will not build.")
-    MESSAGE("Did you miss the --recursive option when cloning?")
-    MESSAGE("Run the following commands to correct this:")
-    MESSAGE("git submodule init")
-    MESSAGE("git submodule update")
-    MESSAGE("git submodule foreach git pull origin master")
+    MESSAGE(STATUS "GTest submodules unavailable. Updating submodules.")
+    EXECUTE_PROCESS(
+        COMMAND git submodule update --init --recursive
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_QUIET
+    )
 ENDIF()
 
 if(CMAKE_VERSION VERSION_LESS 3.2 AND CMAKE_GENERATOR MATCHES "Ninja")


### PR DESCRIPTION
Fixes #1108 

Test using
```
cmake arrayfire/test -DArrayFire_DIR=/path/to/af_install/share/ArrayFire/cmake
```

Allows BUILD_NONFREE and USE_RELATIVE_TEST_DIR options as with the previous build action.

Still requires submodules. If not found, will try to init and update them. The expectation is that the source test directory will always be within arrayfire, ie. arrayfire/test.