### PR TITLE
Fix missing includes in testsuite.

### DIFF
--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -13,6 +13,8 @@
 #include <vector>
 #include <algorithm>
 #include <limits>
+#include <stdexcept>
+#include <cfloat>
 #include <arrayfire.h>
 #include <af/dim4.hpp>
 #include <af/array.h>


### PR DESCRIPTION
This PR fixes FTBFS errors due to missing includes for `FLT_MAX` and `std::runtime_error` caught when building the project on Ubuntu 14.04.