### PR TITLE
Visual Studio Multiprocess Compilation options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,13 @@ IF(UNIX)
     ENDIF()
 ELSE(${UNIX}) #Windows
     ADD_DEFINITIONS(-DOS_WIN -DNOMINMAX)
+    IF(MSVC)
+        # MP is multiprocess compilation. Gm- disables minimal rebuilds
+        # http://stackoverflow.com/questions/6172205/how-can-i-do-a-parallel-build-in-visual-studio-2010vvvvvvvv
+        # http://www.kitware.com/blog/home/post/434
+        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP /Gm-")
+        SET(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} /MP /Gm-")
+    ENDIF(MSVC)
 ENDIF()
 
 # Architechture Definitions

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -33,8 +33,10 @@ ENDIF()
 IF(WIN32)
     # Deprecated Errors are Warning 4996 on VS2013.
     # https://msdn.microsoft.com/en-us/library/ttcz0bys.aspx
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /we4996")
-    SET(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} /we4996")
+    IF(MSVC)
+        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /we4996")
+        SET(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} /we4996")
+    ENDIF(MSVC)
 ELSE(WIN32)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=deprecated-declarations")
     SET(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -Werror=deprecated-declarations")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -33,8 +33,8 @@ ENDIF()
 IF(WIN32)
     # Deprecated Errors are Warning 4996 on VS2013.
     # https://msdn.microsoft.com/en-us/library/ttcz0bys.aspx
-    SET(CMAKE_CXX_FLAGS "/we4996")
-    SET(CMAKE_C_FLAGS   "/we4996")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /we4996")
+    SET(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} /we4996")
 ELSE(WIN32)
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=deprecated-declarations")
     SET(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -Werror=deprecated-declarations")

--- a/src/backend/cuda/kernel/identity.hpp
+++ b/src/backend/cuda/kernel/identity.hpp
@@ -23,14 +23,14 @@ namespace kernel
     __global__
     static void identity_kernel(Param<T> out, int blocks_x, int blocks_y)
     {
-        unsigned idz = blockIdx.x / blocks_x;
-        unsigned idw = blockIdx.y / blocks_y;
+        const dim_t idz = blockIdx.x / blocks_x;
+        const dim_t idw = blockIdx.y / blocks_y;
 
-        unsigned blockIdx_x = blockIdx.x - idz * blocks_x;
-        unsigned blockIdx_y = blockIdx.y - idw * blocks_y;
+        const dim_t blockIdx_x = blockIdx.x - idz * blocks_x;
+        const dim_t blockIdx_y = blockIdx.y - idw * blocks_y;
 
-        unsigned idx = threadIdx.x + blockIdx_x * blockDim.x;
-        unsigned idy = threadIdx.y + blockIdx_y * blockDim.y;
+        const dim_t idx = threadIdx.x + blockIdx_x * blockDim.x;
+        const dim_t idy = threadIdx.y + blockIdx_y * blockDim.y;
 
         if(idx >= out.dims[0] ||
            idy >= out.dims[1] ||
@@ -38,8 +38,11 @@ namespace kernel
            idw >= out.dims[3])
             return;
 
+        const T one  = scalar<T>(1);
+        const T zero = scalar<T>(0);
+
         T *ptr = out.ptr + idz * out.strides[2] + idw * out.strides[3];
-        T val = (idx == idy) ? scalar<T>(1) : scalar<T>(0);
+        T val = (idx == idy) ? one : zero;
         ptr[idx + idy * out.strides[1]] = val;
     }
 


### PR DESCRIPTION
[skip ci]

On CI, we run multi process builds using msbuild.exe options.
This PR is to test whether adding the MP option makes the builds any faster.