### PR TITLE
Fix tests based on optional parts, fix cpu random, meminfo, print

### DIFF
--- a/docs/arrayfire.css
+++ b/docs/arrayfire.css
@@ -190,4 +190,9 @@ div.fragment
     border              :   1px solid #DFDFDF;
 }
 
+pre
+{
+    overflow            : hidden;
+}
+
 /* @end */

--- a/include/af/macros.h
+++ b/include/af/macros.h
@@ -22,15 +22,63 @@
         } while (0);
 #endif
 
-#define MEMINFO(msg) do {                                                               \
+/**
+ * AF_MEM_INFO macro can be used to print the current stats of ArrayFire's memory
+ * manager.
+ *
+ * AF_MEM_INFO print 4 values:
+ *
+ * ---------------------------------------------------
+ *  Name                    | Description
+ * -------------------------|-------------------------
+ *  Allocated Bytes         | Total number of bytes allocated by the memory manager
+ *  Allocated Buffers       | Total number of buffers allocated
+ *  Locked (In Use) Bytes   | Number of bytes that are in use by active arrays
+ *  Locked (In Use) Buffers | Number of buffers that are in use by active arrays
+ * ---------------------------------------------------
+ *
+ *  The `Allocated Bytes` is always a multiple of the memory step size. The
+ *  default step size is 1024 bytes. This means when a buffer is to be
+ *  allocated, the size is always rounded up to a multiple of the step size.
+ *  You can use af::getMemStepSize() to check the current step size and
+ *  af::setMemStepSize() to set a custom resolution size.
+ *
+ *  The `Allocated Buffers` is the number of buffers that use up the allocated
+ *  bytes. This includes buffers currently in scope, as well as buffers marked
+ *  as free, ie, from arrays gone out of scope. The free buffers are available
+ *  for use by new arrays that might be created.
+ *
+ *  The `Locked Bytes` is the number of bytes in use that cannot be
+ *  reallocated at the moment. The difference of Allocated Bytes and Locked
+ *  Bytes is the total bytes available for reallocation.
+ *
+ *  The `Locked Buffers` is the number of buffer in use that cannot be
+ *  reallocated at the moment. The difference of Allocated Buffers and Locked
+ *  Buffers is the number of buffers available for reallocation.
+ *
+ * The AF_MEM_INFO macro can accept a string an argument that is printed to screen
+ *
+ * \param[in] msg (Optional) A message that is printed to screen
+ *
+ * \code
+ *     AF_MEM_INFO("At start");
+ * \endcode
+ *
+ * Output:
+ *
+ *     AF Memory at /workspace/myfile.cpp:41: At Start
+ *     Allocated [ Bytes | Buffers ] = [ 4096 | 4 ]
+ *     In Use    [ Bytes | Buffers ] = [ 2048 | 2 ]
+ */
+#define AF_MEM_INFO(msg) do {                                                           \
     size_t abytes = 0, abuffs = 0, lbytes = 0, lbuffs = 0;                              \
     af_err err = af_device_mem_info(&abytes, &abuffs, &lbytes, &lbuffs);                \
     if(err == AF_SUCCESS) {                                                             \
-        printf("MemInfo at %s:%d: " msg "\n", __FILE__, __LINE__);                      \
+        printf("AF Memory at %s:%d: " msg "\n", __FILE__, __LINE__);                    \
         printf("Allocated [ Bytes | Buffers ] = [ %ld | %ld ]\n", abytes, abuffs);      \
         printf("In Use    [ Bytes | Buffers ] = [ %ld | %ld ]\n", lbytes, lbuffs);      \
     } else {                                                                            \
-        fprintf(stderr, "MemInfo at %s:%d: " msg "\nAF Error %d\n",                     \
+        fprintf(stderr, "AF Memory at %s:%d: " msg "\nAF Error %d\n",                   \
                 __FILE__, __LINE__, err);                                               \
     }                                                                                   \
-} while(0);
+} while(0)

--- a/include/af/macros.h
+++ b/include/af/macros.h
@@ -21,3 +21,16 @@
                  __FILE__, __LINE__, ##__VA_ARGS__);      \
         } while (0);
 #endif
+
+#define MEMINFO(msg) do {                                                               \
+    size_t abytes = 0, abuffs = 0, lbytes = 0, lbuffs = 0;                              \
+    af_err err = af_device_mem_info(&abytes, &abuffs, &lbytes, &lbuffs);                \
+    if(err == AF_SUCCESS) {                                                             \
+        printf("MemInfo at %s:%d: " msg "\n", __FILE__, __LINE__);                      \
+        printf("Allocated [ Bytes | Buffers ] = [ %ld | %ld ]\n", abytes, abuffs);      \
+        printf("In Use    [ Bytes | Buffers ] = [ %ld | %ld ]\n", lbytes, lbuffs);      \
+    } else {                                                                            \
+        fprintf(stderr, "MemInfo at %s:%d: " msg "\nAF Error %d\n",                     \
+                __FILE__, __LINE__, err);                                               \
+    }                                                                                   \
+} while(0);

--- a/src/api/c/print.cpp
+++ b/src/api/c/print.cpp
@@ -64,6 +64,22 @@ static void print(const char *exp, af_array arr, const int precision, std::ostre
     }
 
     const ArrayInfo info = getInfo(arr);
+
+    std::ios_base::fmtflags backup = os.flags();
+
+    os << "[" << info.dims() << "]\n";
+#ifndef NDEBUG
+    os <<"   Offsets: [" << info.offsets() << "]" << std::endl;
+    os <<"   Strides: [" << info.strides() << "]" << std::endl;
+#endif
+
+    // Handle empty array
+    if(info.elements() == 0) {
+        os << "<empty>" << std::endl;
+        os.flags(backup);
+        return;
+    }
+
     vector<T> data(info.elements());
 
     af_array arrT;
@@ -80,14 +96,6 @@ static void print(const char *exp, af_array arr, const int precision, std::ostre
     if(transpose) {
         AF_CHECK(af_release_array(arrT));
     }
-
-    std::ios_base::fmtflags backup = os.flags();
-
-    os << "[" << info.dims() << "]\n";
-#ifndef NDEBUG
-    os <<"   Offsets: [" << info.offsets() << "]" << std::endl;
-    os <<"   Strides: [" << info.strides() << "]" << std::endl;
-#endif
 
     printer(os, &data.front(), infoT, infoT.ndims() - 1, precision);
 

--- a/src/backend/cpu/random.cpp
+++ b/src/backend/cpu/random.cpp
@@ -68,7 +68,7 @@ nrand(GenType &generator)
     return [func] () { return T(func(), func());};
 }
 
-static default_random_engine generator;
+static mt19937 generator;
 static unsigned long long gen_seed = 0;
 static bool is_first = true;
 #define GLOBAL 1

--- a/src/backend/defines.hpp
+++ b/src/backend/defines.hpp
@@ -9,10 +9,6 @@
 
 #pragma once
 
-#include <af/macros.h>
-
-#define MSG AF_MSG
-
 #if defined(_WIN32) || defined(_MSC_VER)
     #define __PRETTY_FUNCTION__ __FUNCSIG__
     #if _MSC_VER < 1900

--- a/test/bilateral.cpp
+++ b/test/bilateral.cpp
@@ -24,6 +24,7 @@ template<typename T, bool isColor>
 void bilateralTest(string pTestFile)
 {
     if (noDoubleTests<T>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>       inDims;
     vector<string>    inFiles;

--- a/test/cholesky_dense.cpp
+++ b/test/cholesky_dense.cpp
@@ -29,6 +29,7 @@ template<typename T>
 void choleskyTester(const int n, double eps, bool is_upper)
 {
     if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
 
     af::dtype ty = (af::dtype)af::dtype_traits<T>::af_type;
 

--- a/test/fast.cpp
+++ b/test/fast.cpp
@@ -72,6 +72,7 @@ template<typename T>
 void fastTest(string pTestFile, bool nonmax)
 {
     if (noDoubleTests<T>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>        inDims;
     vector<string>     inFiles;
@@ -175,6 +176,7 @@ void fastTest(string pTestFile, bool nonmax)
 TEST(FloatFAST, CPP)
 {
     if (noDoubleTests<float>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>        inDims;
     vector<string>     inFiles;

--- a/test/gloh_nonfree.cpp
+++ b/test/gloh_nonfree.cpp
@@ -159,6 +159,7 @@ void glohTest(string pTestFile)
 {
 #ifdef AF_BUILD_SIFT
     if (noDoubleTests<T>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>           inDims;
     vector<string>         inFiles;
@@ -270,6 +271,7 @@ TEST(GLOH, CPP)
 {
 #ifdef AF_BUILD_SIFT
     if (noDoubleTests<float>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>           inDims;
     vector<string>         inFiles;

--- a/test/harris.cpp
+++ b/test/harris.cpp
@@ -63,6 +63,7 @@ template<typename T>
 void harrisTest(string pTestFile, float sigma, unsigned block_size)
 {
     if (noDoubleTests<T>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>        inDims;
     vector<string>     inFiles;
@@ -164,6 +165,7 @@ void harrisTest(string pTestFile, float sigma, unsigned block_size)
 TEST(FloatHarris, CPP)
 {
     if (noDoubleTests<float>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>        inDims;
     vector<string>     inFiles;

--- a/test/homography.cpp
+++ b/test/homography.cpp
@@ -59,6 +59,7 @@ void homographyTest(string pTestFile, const af_homography_type htype,
                     const bool rotate, const float size_ratio)
 {
     if (noDoubleTests<T>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>           inDims;
     vector<string>         inFiles;
@@ -216,6 +217,8 @@ void homographyTest(string pTestFile, const af_homography_type htype,
 //
 TEST(Homography, CPP)
 {
+    if (noImageIOTests()) return;
+
     vector<dim4>           inDims;
     vector<string>         inFiles;
     vector<vector<float> > gold;

--- a/test/imageio.cpp
+++ b/test/imageio.cpp
@@ -41,6 +41,7 @@ TYPED_TEST_CASE(ImageIO, TestTypes);
 void loadImageTest(string pTestFile, string pImageFile, const bool isColor)
 {
     if (noDoubleTests<float>()) return;
+    if (noImageIOTests()) return;
 
     vector<af::dim4> numDims;
 
@@ -98,6 +99,8 @@ TYPED_TEST(ImageIO, ColorSeq)
 
 void loadimageArgsTest(string pImageFile, const bool isColor, af_err err)
 {
+    if (noImageIOTests()) return;
+
     af_array imgArray = 0;
 
     ASSERT_EQ(err, af_load_image(&imgArray, pImageFile.c_str(), isColor));
@@ -119,6 +122,7 @@ TYPED_TEST(ImageIO,InvalidArgsWrongExt)
 TEST(ImageIO, CPP)
 {
     if (noDoubleTests<float>()) return;
+    if (noImageIOTests()) return;
 
     vector<af::dim4> numDims;
 
@@ -145,6 +149,8 @@ TEST(ImageIO, CPP)
 
 TEST(ImageIO, SavePNGCPP) {
 
+    if (noImageIOTests()) return;
+
     af::array input(10, 10, 3, f32);
 
     input(af::span, af::span, af::span) = 0;
@@ -160,6 +166,8 @@ TEST(ImageIO, SavePNGCPP) {
 }
 
 TEST(ImageIO, SaveBMPCPP) {
+
+    if (noImageIOTests()) return;
 
     af::array input(10, 10, 3, f32);
 
@@ -178,6 +186,7 @@ TEST(ImageIO, SaveBMPCPP) {
 TEST(ImageMem, SaveMemPNG)
 {
     if (noDoubleTests<float>()) return;
+    if (noImageIOTests()) return;
 
     af::array img = af::loadImage(string(TEST_DIR"/imageio/color_seq.png").c_str(), true);
 
@@ -193,6 +202,7 @@ TEST(ImageMem, SaveMemPNG)
 TEST(ImageMem, SaveMemJPG1)
 {
     if (noDoubleTests<float>()) return;
+    if (noImageIOTests()) return;
 
     af::array img = af::loadImage(string(TEST_DIR"/imageio/color_seq.png").c_str(), false);
     af::saveImage("color_seq1.jpg", img);
@@ -210,6 +220,7 @@ TEST(ImageMem, SaveMemJPG1)
 TEST(ImageMem, SaveMemJPG3)
 {
     if (noDoubleTests<float>()) return;
+    if (noImageIOTests()) return;
 
     af::array img = af::loadImage(string(TEST_DIR"/imageio/color_seq.png").c_str(), true);
     af::saveImage("color_seq3.jpg", img);
@@ -227,6 +238,7 @@ TEST(ImageMem, SaveMemJPG3)
 TEST(ImageMem, SaveMemBMP)
 {
     if (noDoubleTests<float>()) return;
+    if (noImageIOTests()) return;
 
     af::array img = af::loadImage(string(TEST_DIR"/imageio/color_rand.png").c_str(), true);
 

--- a/test/inverse_dense.cpp
+++ b/test/inverse_dense.cpp
@@ -32,6 +32,7 @@ template<typename T>
 void inverseTester(const int m, const int n, const int k, double eps)
 {
     if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
 #if 1
     af::array A  = cpu_randu<T>(af::dim4(m, n));
 #else

--- a/test/lu_dense.cpp
+++ b/test/lu_dense.cpp
@@ -30,6 +30,7 @@ using af::cdouble;
 TEST(LU, InPlaceSmall)
 {
     if (noDoubleTests<float>()) return;
+    if (noLAPACKTests()) return;
 
     int resultIdx = 0;
 
@@ -67,6 +68,7 @@ TEST(LU, InPlaceSmall)
 TEST(LU, SplitSmall)
 {
     if (noDoubleTests<float>()) return;
+    if (noLAPACKTests()) return;
 
     int resultIdx = 0;
 
@@ -117,6 +119,7 @@ template<typename T>
 void luTester(const int m, const int n, double eps)
 {
     if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
 
 #if 1
     af::array a_orig = cpu_randu<T>(af::dim4(m, n));

--- a/test/meanshift.cpp
+++ b/test/meanshift.cpp
@@ -51,6 +51,7 @@ template<typename T, bool isColor>
 void meanshiftTest(string pTestFile)
 {
     if (noDoubleTests<T>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>       inDims;
     vector<string>    inFiles;
@@ -120,6 +121,7 @@ IMAGE_TESTS(double)
 TEST(Meanshift, Color_CPP)
 {
     if (noDoubleTests<float>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>       inDims;
     vector<string>    inFiles;

--- a/test/medfilt.cpp
+++ b/test/medfilt.cpp
@@ -91,6 +91,7 @@ template<typename T,bool isColor>
 void medfiltImageTest(string pTestFile, dim_t w_len, dim_t w_wid)
 {
     if (noDoubleTests<T>()) return;
+    if (noImageIOTests()) return;
 
     using af::dim4;
 

--- a/test/morph.cpp
+++ b/test/morph.cpp
@@ -121,6 +121,7 @@ template<typename T, bool isDilation, bool isColor>
 void morphImageTest(string pTestFile)
 {
     if (noDoubleTests<T>()) return;
+    if (noImageIOTests()) return;
 
     using af::dim4;
 
@@ -341,6 +342,7 @@ template<typename T, bool isDilation, bool isColor>
 void cppMorphImageTest(string pTestFile)
 {
     if (noDoubleTests<T>()) return;
+    if (noImageIOTests()) return;
 
     using af::dim4;
 

--- a/test/orb.cpp
+++ b/test/orb.cpp
@@ -144,6 +144,7 @@ template<typename T>
 void orbTest(string pTestFile)
 {
     if (noDoubleTests<T>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>             inDims;
     vector<string>           inFiles;
@@ -253,6 +254,7 @@ void orbTest(string pTestFile)
 TEST(ORB, CPP)
 {
     if (noDoubleTests<float>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>             inDims;
     vector<string>           inFiles;

--- a/test/qr_dense.cpp
+++ b/test/qr_dense.cpp
@@ -29,6 +29,7 @@ using af::cdouble;
 TEST(QRFactorized, CPP)
 {
     if (noDoubleTests<float>()) return;
+    if (noLAPACKTests()) return;
 
     int resultIdx = 0;
 
@@ -82,6 +83,7 @@ void qrTester(const int m, const int n, double eps)
 {
     try {
         if (noDoubleTests<T>()) return;
+        if (noLAPACKTests()) return;
 
 #if 1
         af::array in = cpu_randu<T>(af::dim4(m, n));

--- a/test/rank_dense.cpp
+++ b/test/rank_dense.cpp
@@ -43,6 +43,7 @@ template<typename T>
 void rankSmall()
 {
     if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
 
     T ha[] = {1, 4, 7, 2, 5, 8, 3, 6, 20};
     af::array a(3, 3, ha);
@@ -54,6 +55,8 @@ template<typename T>
 void rankBig(const int num)
 {
     if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
+
     af::dtype dt = (af::dtype)af::dtype_traits<T>::af_type;
     af::array a = af::randu(num, num, dt);
     ASSERT_EQ(num, (int)af::rank(a));
@@ -67,6 +70,8 @@ template<typename T>
 void rankLow(const int num)
 {
     if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
+
     af::dtype dt = (af::dtype)af::dtype_traits<T>::af_type;
 
     af::array a = af::randu(3 * num, num, dt);
@@ -97,6 +102,8 @@ template<typename T>
 void detTest()
 {
     if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
+
     af::dtype dt = (af::dtype)af::dtype_traits<T>::af_type;
 
     vector<af::dim4> numDims;

--- a/test/sift_nonfree.cpp
+++ b/test/sift_nonfree.cpp
@@ -159,6 +159,7 @@ void siftTest(string pTestFile, unsigned nLayers, float contrastThr, float edgeT
 {
 #ifdef AF_BUILD_SIFT
     if (noDoubleTests<T>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>           inDims;
     vector<string>         inFiles;
@@ -276,6 +277,7 @@ TEST(SIFT, CPP)
 {
 #ifdef AF_BUILD_SIFT
     if (noDoubleTests<float>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>           inDims;
     vector<string>         inFiles;

--- a/test/solve_dense.cpp
+++ b/test/solve_dense.cpp
@@ -34,6 +34,8 @@ void solveTester(const int m, const int n, const int k, double eps)
     af::deviceGC();
 
     if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
+
 #if 1
     af::array A  = cpu_randu<T>(af::dim4(m, n));
     af::array X0 = cpu_randu<T>(af::dim4(n, k));
@@ -61,6 +63,8 @@ void solveLUTester(const int n, const int k, double eps)
     af::deviceGC();
 
     if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
+
 #if 1
     af::array A  = cpu_randu<T>(af::dim4(n, n));
     af::array X0 = cpu_randu<T>(af::dim4(n, k));
@@ -88,6 +92,8 @@ void solveTriangleTester(const int n, const int k, bool is_upper, double eps)
     af::deviceGC();
 
     if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
+
 #if 1
     af::array A  = cpu_randu<T>(af::dim4(n, n));
     af::array X0 = cpu_randu<T>(af::dim4(n, k));

--- a/test/susan.cpp
+++ b/test/susan.cpp
@@ -63,6 +63,7 @@ template<typename T>
 void susanTest(string pTestFile, float t, float g)
 {
     if (noDoubleTests<T>()) return;
+    if (noImageIOTests()) return;
 
     vector<dim4>        inDims;
     vector<string>     inFiles;

--- a/test/svd_dense.cpp
+++ b/test/svd_dense.cpp
@@ -54,6 +54,7 @@ void svdTest(const int M, const int N)
 {
 
     if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
 
     af::dtype ty = (af::dtype)af::dtype_traits<T>::af_type;
 

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -401,6 +401,26 @@ bool noImageIOTests()
         return false;   // No, let test continue
 }
 
+bool noLAPACKTests()
+{
+    // Run LU
+    af::dim4 dims(5, 5);
+    af_array in = 0, l = 0, u = 0, p= 0;
+    af_randu(&in, dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<float>::af_type);
+
+    af_err err = af_lu(&l, &u, &p, in);
+
+    if(in != 0) af_release_array(in);
+    if(l  != 0) af_release_array(l);
+    if(u  != 0) af_release_array(u);
+    if(p  != 0) af_release_array(p);
+
+    if(err == AF_ERR_NOT_CONFIGURED)
+        return true;    // Yes, disable test
+    else
+        return false;   // No, let test continue
+}
+
 // TODO: perform conversion on device for CUDA and OpenCL
 template<typename T>
 af_err conv_image(af_array *out, af_array in)

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -388,6 +388,19 @@ bool noDoubleTests()
     return ((isTypeDouble && !isDoubleSupported) ? true : false);
 }
 
+bool noImageIOTests()
+{
+    af_array arr = 0;
+    const af_err err = af_load_image(&arr, TEST_DIR"/imageio/color_small.png", true);
+
+    if(arr != 0) af_release_array(arr);
+
+    if(err == AF_ERR_NOT_CONFIGURED)
+        return true;    // Yes, disable test
+    else
+        return false;   // No, let test continue
+}
+
 // TODO: perform conversion on device for CUDA and OpenCL
 template<typename T>
 af_err conv_image(af_array *out, af_array in)


### PR DESCRIPTION
[skip ci]

* Tests imageio and lapack
Fixes #1165 #1167 

* Change default_random_engine to mt19937 in CPU random
Fixes #1170 

* Added AF_MEM_INFO macro
Fixes #1172 

* Handle printing empty arrays
Fixes #1164 

Merges #1166 