### PR TITLE
(OpenCL) Change path of clBLAS/FFT builds, (CUDA) Create stream when device is active

### DIFF
--- a/CMakeModules/build_clBLAS.cmake
+++ b/CMakeModules/build_clBLAS.cmake
@@ -12,7 +12,7 @@ ELSE()
 ENDIF()
 
 ExternalProject_Add(
-    clBLAS-external
+    clBLAS-ext
     GIT_REPOSITORY https://github.com/arrayfire/clBLAS.git
     GIT_TAG 102c832825e8e4d60ad73ca97e95668463294068
     PREFIX "${prefix}"
@@ -33,10 +33,10 @@ ExternalProject_Add(
     ${byproducts}
     )
 
-ExternalProject_Get_Property(clBLAS-external install_dir)
+ExternalProject_Get_Property(clBLAS-ext install_dir)
 ADD_LIBRARY(clBLAS IMPORTED STATIC)
 SET_TARGET_PROPERTIES(clBLAS PROPERTIES IMPORTED_LOCATION ${clBLAS_location})
-ADD_DEPENDENCIES(clBLAS clBLAS-external)
+ADD_DEPENDENCIES(clBLAS clBLAS-ext)
 SET(CLBLAS_INCLUDE_DIRS ${install_dir}/include)
 SET(CLBLAS_LIBRARIES clBLAS)
 SET(CLBLAS_FOUND ON)

--- a/CMakeModules/build_clFFT.cmake
+++ b/CMakeModules/build_clFFT.cmake
@@ -12,7 +12,7 @@ ELSE()
 ENDIF()
 
 ExternalProject_Add(
-    clFFT-external
+    clFFT-ext
     GIT_REPOSITORY https://github.com/arrayfire/clFFT.git
     GIT_TAG 1597f0f35a644789c7ad77efe79014236cca2fab
     PREFIX "${prefix}"
@@ -34,10 +34,10 @@ ExternalProject_Add(
     ${byproducts}
     )
 
-ExternalProject_Get_Property(clFFT-external install_dir)
+ExternalProject_Get_Property(clFFT-ext install_dir)
 ADD_LIBRARY(clFFT IMPORTED STATIC)
 SET_TARGET_PROPERTIES(clFFT PROPERTIES IMPORTED_LOCATION ${clFFT_location})
-ADD_DEPENDENCIES(clFFT clFFT-external)
+ADD_DEPENDENCIES(clFFT clFFT-ext)
 SET(CLFFT_INCLUDE_DIRS ${install_dir}/include)
 SET(CLFFT_LIBRARIES clFFT)
 SET(CLFFT_FOUND ON)

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -332,10 +332,10 @@ DeviceManager::DeviceManager()
 
     sortDevices();
 
-    for(int i = 0; i < nDevices; i++) {
-        setActiveDevice(i, cuDevices[i].nativeId);
-        CUDA_CHECK(cudaStreamCreate(&streams[i]));
-    }
+    // Initialize all streams to 0.
+    // Streams will be created in setActiveDevice()
+    for(int i = 0; i < (int)MAX_DEVICES; i++)
+        streams[i] = (cudaStream_t)0;
 
     const char* deviceENV = getenv("AF_CUDA_DEFAULT_DEVICE");
     if(!deviceENV) {
@@ -381,6 +381,11 @@ int DeviceManager::setActiveDevice(int device, int nId)
         if(nId == -1) nId = getDeviceNativeId(device);
         CUDA_CHECK(cudaSetDevice(nId));
         activeDev = device;
+
+        if(!streams[device]) {
+            CUDA_CHECK(cudaStreamCreate(&streams[device]));
+        }
+
         return old;
     }
 }

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -289,7 +289,17 @@ int getDeviceIdFromNativeId(int nativeId)
 
 cudaStream_t getStream(int device)
 {
-    return DeviceManager::getInstance().streams[device];
+    cudaStream_t str = DeviceManager::getInstance().streams[device];
+    // if the stream has not yet been initialized, ie. the device has not been
+    // set to active at least once (cuz that's where the stream is created)
+    // then set the device, get the stream, reset the device to current
+    if(!str) {
+        int active_dev = DeviceManager::getInstance().activeDev;
+        setDevice(device);
+        str = DeviceManager::getInstance().streams[device];
+        setDevice(active_dev);
+    }
+    return str;
 }
 
 int setDevice(int device)


### PR DESCRIPTION
* Shorten clBLAS/FFT-external to clBLAS/FFT-ext. This is because windows has a 246/260 characted limit on the paths it can build. This is causing issues.

* Creating streams for all devices at the start is not useful and increased the init time (~800ms/device). So create the stream only when the device is set to active the first time.