### PR TITLE
Fix Clang warnings

### DIFF
--- a/examples/graphics/fractal.cpp
+++ b/examples/graphics/fractal.cpp
@@ -10,13 +10,14 @@
 #include <stdio.h>
 #include <iostream>
 #include <arrayfire.h>
-#include <math.h>
+#include <cmath>
 #include <cstdlib>
 
 #define WIDTH 400 // Width of image
 #define HEIGHT 400 // Width of image
 
 using namespace af;
+using std::abs;
 
 array complex_grid(int width, int height, float zoom, float center[2])
 {

--- a/examples/image_processing/adaptive_thresholding.cpp
+++ b/examples/image_processing/adaptive_thresholding.cpp
@@ -13,6 +13,7 @@
 #include <arrayfire.h>
 
 using namespace af;
+using std::abs;
 
 typedef enum {
     MEAN = 0,

--- a/examples/image_processing/brain_segmentation.cpp
+++ b/examples/image_processing/brain_segmentation.cpp
@@ -23,10 +23,12 @@ const float h_sy_kernel[] = { -1, 0, 1,
     -2, 0, 2,
     -1, 0, 1
 };
-const float h_lp_kernel[] = { -0.5f, -1.0f, -0.5f,
-    -1.0f,  6.0f, -1.0f,
-    -0.5f, -1.0f, -0.5f
-};
+
+// Unused
+//const float h_lp_kernel[] = { -0.5f, -1.0f, -0.5f,
+//    -1.0f,  6.0f, -1.0f,
+//    -0.5f, -1.0f, -0.5f
+//};
 
 array edges_slice(array x)
 {

--- a/examples/image_processing/filters.cpp
+++ b/examples/image_processing/filters.cpp
@@ -151,7 +151,7 @@ array medianfilter(const array &in, int window_width, int window_height)
     return ret_val;
 }
 
-array gaussianblur(const array &in, int window_width, int window_height, int sigma)
+array gaussianblur(const array &in, int window_width, int window_height, double sigma)
 {
     array g = gaussianKernel(window_width, window_height, sigma, sigma);
     return convolve(in, g);

--- a/src/api/c/assign.cpp
+++ b/src/api/c/assign.cpp
@@ -125,7 +125,7 @@ af_err af_assign_seq(af_array *out,
 
         ArrayInfo lInfo = getInfo(lhs);
 
-        if (ndims == 1 && ndims != (dim_t)lInfo.ndims()) {
+        if (ndims == 1 && ndims != lInfo.ndims()) {
             af_array tmp_in, tmp_out;
             AF_CHECK(af_flat(&tmp_in, lhs));
             AF_CHECK(af_assign_seq(&tmp_out, tmp_in, ndims, index, rhs));

--- a/src/api/c/index.cpp
+++ b/src/api/c/index.cpp
@@ -42,7 +42,7 @@ af_err af_index(af_array *result, const af_array in, const unsigned ndims, const
     try {
 
         ArrayInfo iInfo = getInfo(in);
-        if (ndims == 1 && ndims != (dim_t)iInfo.ndims()) {
+        if (ndims == 1 && ndims != iInfo.ndims()) {
             af_array tmp_in;
             AF_CHECK(af_flat(&tmp_in, in));
             AF_CHECK(af_index(result, tmp_in, ndims, index));

--- a/src/backend/opencl/kernel/ireduce.hpp
+++ b/src/backend/opencl/kernel/ireduce.hpp
@@ -281,6 +281,14 @@ namespace kernel
         }
     }
 
+#if defined(__GNUC__) || defined(__GNUG__)
+    /* GCC/G++, Clang/LLVM, Intel ICC */
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wunused-function"
+#else
+    /* Other */
+#endif
+
     template<typename T> double cabs(const T in) { return (double)in; }
     static double cabs(const cfloat in) { return (double)abs(in); }
     static double cabs(const cdouble in) { return (double)abs(in); }
@@ -327,6 +335,12 @@ namespace kernel
         }
     };
 
+#if defined(__GNUC__) || defined(__GNUG__)
+    /* GCC/G++, Clang/LLVM, Intel ICC */
+    #pragma GCC diagnostic pop
+#else
+    /* Other */
+#endif
 
     template<typename T, af_op_t op>
     T ireduce_all(uint *loc, Param in)

--- a/src/backend/opencl/kernel/orb.hpp
+++ b/src/backend/opencl/kernel/orb.hpp
@@ -29,8 +29,24 @@ using cl::LocalSpaceArg;
 using cl::NDRange;
 using std::vector;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#if defined(__clang__)
+    /* Clang/LLVM */
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wsometimes-uninitialized"
+#elif defined(__ICC) || defined(__INTEL_COMPILER)
+    /* Intel ICC/ICPC */
+    // Fix the warning code here, if any
+#elif defined(__GNUC__) || defined(__GNUG__)
+    /* GNU GCC/G++ */
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#elif defined(_MSC_VER)
+    /* Microsoft Visual Studio */
+    #pragma warning( push )
+    #pragma warning( disable : 4700 )
+#else
+    /* Other */
+#endif
 
 namespace opencl
 {
@@ -505,4 +521,19 @@ void orb(unsigned* out_feat,
 } //namespace kernel
 
 } //namespace opencl
-#pragma GCC diagnostic pop
+
+#if defined(__clang__)
+    /* Clang/LLVM */
+    #pragma clang diagnostic pop
+#elif defined(__ICC) || defined(__INTEL_COMPILER)
+    /* Intel ICC/ICPC */
+    // Fix the warning code here, if any
+#elif defined(__GNUC__) || defined(__GNUG__)
+    /* GNU GCC/G++ */
+    #pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+    /* Microsoft Visual Studio */
+    #pragma warning( pop )
+#else
+    /* Other */
+#endif

--- a/src/backend/opencl/magma/magma_helper.cpp
+++ b/src/backend/opencl/magma/magma_helper.cpp
@@ -159,6 +159,14 @@ magma_int_t magma_get_geqrf_nb<magmaDoubleComplex>( magma_int_t m )
     else                return 128;
 }
 
+#if defined(__GNUC__) || defined(__GNUG__)
+    /* GCC/G++, Clang/LLVM, Intel ICC */
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wmissing-braces"
+#else
+    /* Other */
+#endif
+
 template<typename T> T magma_make(double r, double i) { return (T) r; }
 template float magma_make<float>(double r, double i);
 template double magma_make<double>(double r, double i);
@@ -172,3 +180,10 @@ template<> magmaDoubleComplex magma_make<magmaDoubleComplex>(double r, double i)
     magmaDoubleComplex tmp = {r, i};
     return tmp;
 }
+
+#if defined(__GNUC__) || defined(__GNUG__)
+    /* GCC/G++, Clang/LLVM, Intel ICC */
+    #pragma GCC diagnostic pop
+#else
+    /* Other */
+#endif

--- a/src/backend/opencl/math.hpp
+++ b/src/backend/opencl/math.hpp
@@ -17,6 +17,14 @@
 #include "backend.hpp"
 #include "types.hpp"
 
+#if defined(__GNUC__) || defined(__GNUG__)
+    /* GCC/G++, Clang/LLVM, Intel ICC */
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wunused-function"
+#else
+    /* Other */
+#endif
+
 namespace opencl
 {
 
@@ -123,3 +131,10 @@ namespace opencl
     cfloat operator *(cfloat a, cfloat b);
     cdouble operator *(cdouble a, cdouble b);
 }
+
+#if defined(__GNUC__) || defined(__GNUG__)
+    /* GCC/G++, Clang/LLVM, Intel ICC */
+    #pragma GCC diagnostic pop
+#else
+    /* Other */
+#endif

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -23,6 +23,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -22,6 +22,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/bilateral.cpp
+++ b/test/bilateral.cpp
@@ -18,6 +18,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 using af::dim4;
 
 template<typename T, bool isColor>

--- a/test/binary.cpp
+++ b/test/binary.cpp
@@ -14,6 +14,7 @@
 #include <testHelpers.hpp>
 
 using namespace std;
+using std::abs;
 using namespace af;
 
 const int num = 10000;

--- a/test/cholesky_dense.cpp
+++ b/test/cholesky_dense.cpp
@@ -22,6 +22,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/convolve.cpp
+++ b/test/convolve.cpp
@@ -17,6 +17,7 @@
 
 using std::vector;
 using std::string;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/diagonal.cpp
+++ b/test/diagonal.cpp
@@ -14,6 +14,7 @@
 
 using namespace af;
 using std::vector;
+using std::abs;
 
 template<typename T>
 class Diagonal : public ::testing::Test

--- a/test/dot.cpp
+++ b/test/dot.cpp
@@ -18,6 +18,7 @@
 
 using std::vector;
 using std::string;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/fast.cpp
+++ b/test/fast.cpp
@@ -20,6 +20,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 using af::dim4;
 
 typedef struct

--- a/test/fft.cpp
+++ b/test/fft.cpp
@@ -18,6 +18,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/fft_real.cpp
+++ b/test/fft_real.cpp
@@ -18,6 +18,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/fftconvolve.cpp
+++ b/test/fftconvolve.cpp
@@ -17,6 +17,7 @@
 
 using std::vector;
 using std::string;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/getting_started.cpp
+++ b/test/getting_started.cpp
@@ -15,6 +15,7 @@
 
 using namespace af;
 using std::vector;
+using std::abs;
 
 TEST(GettingStarted, SNIPPET_getting_started_gen)
 {

--- a/test/gloh_nonfree.cpp
+++ b/test/gloh_nonfree.cpp
@@ -20,6 +20,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 using af::dim4;
 
 typedef struct

--- a/test/harris.cpp
+++ b/test/harris.cpp
@@ -20,6 +20,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 using af::dim4;
 
 typedef struct

--- a/test/histogram.cpp
+++ b/test/histogram.cpp
@@ -18,6 +18,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 
 template<typename T>
 class Histogram : public ::testing::Test

--- a/test/homography.cpp
+++ b/test/homography.cpp
@@ -20,6 +20,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 using af::dim4;
 
 template<typename T>

--- a/test/inverse_dense.cpp
+++ b/test/inverse_dense.cpp
@@ -22,6 +22,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/lu_dense.cpp
+++ b/test/lu_dense.cpp
@@ -22,6 +22,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/math.cpp
+++ b/test/math.cpp
@@ -14,6 +14,7 @@
 
 using namespace std;
 using namespace af;
+using std::abs;
 
 const int num = 10000;
 const float flt_err = 1e-3;

--- a/test/meanshift.cpp
+++ b/test/meanshift.cpp
@@ -18,6 +18,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 using af::dim4;
 
 template<typename T>

--- a/test/medfilt.cpp
+++ b/test/medfilt.cpp
@@ -17,6 +17,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 
 template<typename T>
 class MedianFilter : public ::testing::Test

--- a/test/morph.cpp
+++ b/test/morph.cpp
@@ -18,6 +18,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 
 template<typename T>
 class Morph : public ::testing::Test

--- a/test/orb.cpp
+++ b/test/orb.cpp
@@ -20,6 +20,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 using af::dim4;
 
 typedef struct

--- a/test/qr_dense.cpp
+++ b/test/qr_dense.cpp
@@ -22,6 +22,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/rank_dense.cpp
+++ b/test/rank_dense.cpp
@@ -22,6 +22,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/resize.cpp
+++ b/test/resize.cpp
@@ -20,6 +20,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/rotate.cpp
+++ b/test/rotate.cpp
@@ -20,6 +20,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/rotate_linear.cpp
+++ b/test/rotate_linear.cpp
@@ -20,6 +20,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/sift_nonfree.cpp
+++ b/test/sift_nonfree.cpp
@@ -20,6 +20,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 using af::dim4;
 
 typedef struct

--- a/test/solve_dense.cpp
+++ b/test/solve_dense.cpp
@@ -22,6 +22,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/susan.cpp
+++ b/test/susan.cpp
@@ -20,6 +20,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 using af::dim4;
 
 typedef struct

--- a/test/svd_dense.cpp
+++ b/test/svd_dense.cpp
@@ -22,6 +22,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/transform.cpp
+++ b/test/transform.cpp
@@ -18,6 +18,7 @@
 
 using std::vector;
 using std::string;
+using std::abs;
 using std::cout;
 using std::endl;
 

--- a/test/translate.cpp
+++ b/test/translate.cpp
@@ -20,6 +20,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/transpose.cpp
+++ b/test/transpose.cpp
@@ -17,6 +17,7 @@
 
 using std::string;
 using std::vector;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 

--- a/test/triangle.cpp
+++ b/test/triangle.cpp
@@ -23,6 +23,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 using af::dim4;

--- a/test/wrap.cpp
+++ b/test/wrap.cpp
@@ -23,6 +23,7 @@ using std::vector;
 using std::string;
 using std::cout;
 using std::endl;
+using std::abs;
 using af::cfloat;
 using af::cdouble;
 


### PR DESCRIPTION
[skip ci]
* Using std::abs instead of abs in tests, examples
* Other minor fixes in tests
* Proper warning push pop for clang

Fixes #1206

Some warnings this fixes:
```
In file included from /var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/kernel/homography.hpp:16:
/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/kernel/ireduce.hpp:285:19: warning: unused function 'cabs' [-Wunused-function]
    static double cabs(const cfloat in) { return (double)abs(in); }
                  ^
/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/kernel/ireduce.hpp:286:19: warning: unused function 'cabs' [-Wunused-function]
    static double cabs(const cdouble in) { return (double)abs(in); }

--------------
In file included from /var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/math.cpp:10:
/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/math.hpp:39:12: warning: unused function 'max' [-Wunused-function]
    cfloat max<cfloat>(cfloat lhs, cfloat rhs)
           ^
/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/math.hpp:45:13: warning: unused function 'max' [-Wunused-function]
    cdouble max<cdouble>(cdouble lhs, cdouble rhs)
            ^
/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/math.hpp:51:12: warning: unused function 'min' [-Wunused-function]
    cfloat min<cfloat>(cfloat lhs, cfloat rhs)
           ^
/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/math.hpp:57:13: warning: unused function 'min' [-Wunused-function]
    cdouble min<cdouble>(cdouble lhs, cdouble rhs)
            ^
/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/math.hpp:69:13: warning: unused function 'scalar' [-Wunused-function]
    cfloat  scalar<cfloat >(double val)
            ^
/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/math.hpp:78:13: warning: unused function 'scalar' [-Wunused-function]
    cdouble scalar<cdouble >(double val)
------------------

In file included from /var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/orb.cpp:17:
/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/kernel/orb.hpp:33:32: warning: unknown warning group '-Wmaybe-uninitialized', ignored [-Wunknown-pragmas]
#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
----------------------

In file included from /var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/orb.cpp:17:
/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/src/backend/opencl/kernel/orb.hpp:33:32: warning: unknown warning group '-Wmaybe-uninitialized', ignored [-Wunknown-pragmas]
#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
--------------------

/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/examples/image_processing/filters.cpp:230:44: warning: implicit conversion from 'double' to 'int' changes value from 0.8 to 0 [-Wliteral-conversion]
        array gb = gaussianblur(hrl, 3, 3, 0.8);
                   ~~~~~~~~~~~~            ^~~
1 warning generated.
/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/examples/image_processing/filters.cpp:230:44: warning: implicit conversion from 'double' to 'int' changes value from 0.8 to 0 [-Wliteral-conversion]
        array gb = gaussianblur(hrl, 3, 3, 0.8);
--------------------

/var/lib/jenkins-slave/workspace/arrayfire-osx/pr-build/examples/image_processing/brain_segmentation.cpp:26:13: warning: unused variable 'h_lp_kernel' [-Wunused-const-variable]
const float h_lp_kernel[] = { -0.5f, -1.0f, -0.5f,
```