### PR TITLE
Improvements to OpenCL DeviceManager 

### DIFF
--- a/docs/pages/configuring_arrayfire_environment.md
+++ b/docs/pages/configuring_arrayfire_environment.md
@@ -44,6 +44,37 @@ AF_OPENCL_DEFAULT_DEVICE=1 ./myprogram_opencl
 Note: af::setDevice call in the source code will take precedence over this
 variable.
 
+AF_OPENCL_DEFAULT_DEVICE_TYPE {#af_opencl_default_device_type}
+-------------------------------------------------------------------------------
+
+Use this variable to set the default OpenCL device type. Valid values for this
+variable are: CPU, GPU, ACC (Accelerators).
+
+When set, the first device of the specified type is chosen as default device.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+AF_OPENCL_DEFAULT_DEVICE_TYPE=CPU ./myprogram_opencl
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Note: `AF_OPENCL_DEFAULT_DEVICE`  and af::setDevice takes precedence over this variable.
+
+AF_OPENCL_DEVICE_TYPE {#af_opencl_device_type}
+-------------------------------------------------------------------------------
+
+Use this variable to only choose OpenCL devices of specified type. Valid values for this
+variable are:
+
+- ALL: All OpenCL devices. (Default behavior).
+- CPU: CPU devices only.
+- GPU: GPU devices only.
+- ACC: Accelerator devices only.
+
+When set, the remaining OpenCL device types are ignored by the OpenCL backend.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+AF_OPENCL_DEVICE_TYPE=CPU ./myprogram_opencl
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 AF_DISABLE_GRAPHICS {#af_disable_graphics}
 -------------------------------------------------------------------------------
 

--- a/src/api/c/assign.cpp
+++ b/src/api/c/assign.cpp
@@ -350,10 +350,10 @@ af_err af_assign_gen(af_array *out,
             throw;
         }
         if (is_vector) { AF_CHECK(af_release_array(rhs)); }
+
+        std::swap(*out, output);
     }
     CATCHALL;
-
-    std::swap(*out, output);
 
     return AF_SUCCESS;
 }

--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -39,7 +39,9 @@ af_err af_get_backend_count(unsigned* num_backends)
 
 af_err af_get_available_backends(int* result)
 {
-    *result = getBackend();
+    try {
+        *result = getBackend();
+    } CATCHALL;
     return AF_SUCCESS;
 }
 
@@ -67,7 +69,9 @@ af_err af_init()
 
 af_err af_info()
 {
-    printf("%s", getInfo().c_str());
+    try {
+        printf("%s", getInfo().c_str());
+    } CATCHALL;
     return AF_SUCCESS;
 }
 
@@ -326,7 +330,6 @@ af_err af_free_pinned(void *ptr)
 af_err af_alloc_host(void **ptr, const dim_t bytes)
 {
     try {
-        AF_CHECK(af_init());
         *ptr = malloc(bytes);
     } CATCHALL;
     return AF_SUCCESS;
@@ -335,7 +338,6 @@ af_err af_alloc_host(void **ptr, const dim_t bytes)
 af_err af_free_host(void *ptr)
 {
     try {
-        AF_CHECK(af_init());
         free(ptr);
     } CATCHALL;
     return AF_SUCCESS;
@@ -376,12 +378,16 @@ af_err af_device_mem_info(size_t *alloc_bytes, size_t *alloc_buffers,
 
 af_err af_set_mem_step_size(const size_t step_bytes)
 {
-    detail::setMemStepSize(step_bytes);
+    try{
+        detail::setMemStepSize(step_bytes);
+    } CATCHALL;
     return AF_SUCCESS;
 }
 
 af_err af_get_mem_step_size(size_t *step_bytes)
 {
-    *step_bytes =  detail::getMemStepSize();
+    try {
+        *step_bytes =  detail::getMemStepSize();
+    } CATCHALL;
     return AF_SUCCESS;
 }

--- a/src/api/c/flip.cpp
+++ b/src/api/c/flip.cpp
@@ -74,9 +74,9 @@ af_err af_flip(af_array *result, const af_array in, const unsigned dim)
         case u8:     out = flipArray<uchar>   (in, dim);  break;
         default:    TYPE_ERROR(1, in_type);
         }
+        swap(*result, out);
     }
     CATCHALL
 
-    swap(*result, out);
     return AF_SUCCESS;
 }

--- a/src/api/c/image.cpp
+++ b/src/api/c/image.cpp
@@ -141,9 +141,9 @@ af_err af_create_window(af_window *out, const int width, const int height, const
 
         wnd = new fg::Window(width, height, title, mainWnd);
         wnd->setFont(fgMngr.getFont());
+        *out = reinterpret_cast<af_window>(wnd);
     }
     CATCHALL;
-    *out = reinterpret_cast<af_window>(wnd);
     return AF_SUCCESS;
 #else
     AF_RETURN_ERROR("ArrayFire compiled without graphics support", AF_ERR_NO_GFX);

--- a/src/api/c/imageio.cpp
+++ b/src/api/c/imageio.cpp
@@ -60,14 +60,15 @@ static af_err readImage(af_array *rImage, const uchar* pSrcLine, const int nSrcP
                     pDst0[indx] = (float) *(src + (x * step + FI_RGBA_RED));
                     pDst1[indx] = (float) *(src + (x * step + FI_RGBA_GREEN));
                     pDst2[indx] = (float) *(src + (x * step + FI_RGBA_BLUE));
+                    if (fo_color == 4) pDst3[indx] = (float) *(src + (x * step + FI_RGBA_ALPHA));
                 } else {
                     // Non 8-bit types do not use ordering
                     // See Pixel Access Functions Chapter in FreeImage Doc
-                    pDst0[indx] = (float) *(src + (x * step + FI_RGBA_RED));
-                    pDst1[indx] = (float) *(src + (x * step + FI_RGBA_GREEN));
-                    pDst2[indx] = (float) *(src + (x * step + FI_RGBA_BLUE));
+                    pDst0[indx] = (float) *(src + (x * step + 0));
+                    pDst1[indx] = (float) *(src + (x * step + 1));
+                    pDst2[indx] = (float) *(src + (x * step + 2));
+                    if (fo_color == 4) pDst3[indx] = (float) *(src + (x * step + 3));
                 }
-                if (fo_color == 4) pDst3[indx] = (float) *(src + (x * step + FI_RGBA_ALPHA));
             }
             indx++;
         }
@@ -104,9 +105,9 @@ static af_err readImage(af_array *rImage, const uchar* pSrcLine, const int nSrcP
                 } else {
                     // Non 8-bit types do not use ordering
                     // See Pixel Access Functions Chapter in FreeImage Doc
-                    r = (T) *(src + (x * step + FI_RGBA_RED));
-                    g = (T) *(src + (x * step + FI_RGBA_GREEN));
-                    b = (T) *(src + (x * step + FI_RGBA_BLUE));
+                    r = (T) *(src + (x * step + 0));
+                    g = (T) *(src + (x * step + 1));
+                    b = (T) *(src + (x * step + 2));
                 }
                 pDst[indx] = r * 0.2989f + g * 0.5870f + b * 0.1140f;
             }

--- a/src/api/c/imageio2.cpp
+++ b/src/api/c/imageio2.cpp
@@ -58,14 +58,15 @@ static af_err readImage_t(af_array *rImage, const uchar* pSrcLine, const int nSr
                     pDst0[indx] = (T) *(src + (x * step + FI_RGBA_RED));
                     pDst1[indx] = (T) *(src + (x * step + FI_RGBA_GREEN));
                     pDst2[indx] = (T) *(src + (x * step + FI_RGBA_BLUE));
+                    if (fi_color == 4) pDst3[indx] = (T) *(src + (x * step + FI_RGBA_ALPHA));
                 } else {
                     // Non 8-bit types do not use ordering
                     // See Pixel Access Functions Chapter in FreeImage Doc
-                    pDst0[indx] = (T) *(src + (x * step + FI_RGBA_RED));
-                    pDst1[indx] = (T) *(src + (x * step + FI_RGBA_GREEN));
-                    pDst2[indx] = (T) *(src + (x * step + FI_RGBA_BLUE));
+                    pDst0[indx] = (T) *(src + (x * step + 0));
+                    pDst1[indx] = (T) *(src + (x * step + 1));
+                    pDst2[indx] = (T) *(src + (x * step + 2));
+                    if (fi_color == 4) pDst3[indx] = (T) *(src + (x * step + 3));
                 }
-                if (fi_color == 4) pDst3[indx] = (T) *(src + (x * step + FI_RGBA_ALPHA));
             }
             indx++;
         }
@@ -242,15 +243,16 @@ static void save_t(T* pDstLine, const af_array in, const dim4 dims, uint nDstPit
                     *(pDstLine + x * step + FI_RGBA_RED  ) = (T) pSrc0[indx]; // r -> 0
                     *(pDstLine + x * step + FI_RGBA_GREEN) = (T) pSrc1[indx]; // g -> 1
                     *(pDstLine + x * step + FI_RGBA_BLUE ) = (T) pSrc2[indx]; // b -> 2
+                    if(channels >= 4) *(pDstLine + x * step + FI_RGBA_ALPHA) = (T) pSrc3[indx]; // a
                 } else {
                     // Non 8-bit types do not use ordering
                     // See Pixel Access Functions Chapter in FreeImage Doc
-                    *(pDstLine + x * step + FI_RGBA_RED  ) = (T) pSrc0[indx]; // r -> 0
-                    *(pDstLine + x * step + FI_RGBA_GREEN) = (T) pSrc1[indx]; // g -> 1
-                    *(pDstLine + x * step + FI_RGBA_BLUE ) = (T) pSrc2[indx]; // b -> 2
+                    *(pDstLine + x * step + 0) = (T) pSrc0[indx]; // r -> 0
+                    *(pDstLine + x * step + 1) = (T) pSrc1[indx]; // g -> 1
+                    *(pDstLine + x * step + 2) = (T) pSrc2[indx]; // b -> 2
+                    if(channels >= 4) *(pDstLine + x * step + 3) = (T) pSrc3[indx]; // a
                 }
             }
-            if(channels >= 4) *(pDstLine + x * step + FI_RGBA_ALPHA) = (T) pSrc3[indx]; // a
             ++indx;
         }
         pDstLine = (T*)(((uchar*)pDstLine) - nDstPitch);

--- a/src/api/c/imageio2.cpp
+++ b/src/api/c/imageio2.cpp
@@ -61,9 +61,9 @@ static af_err readImage_t(af_array *rImage, const uchar* pSrcLine, const int nSr
                 } else {
                     // Non 8-bit types do not use ordering
                     // See Pixel Access Functions Chapter in FreeImage Doc
-                    pDst0[indx] = (T) *(src + (x * step + 0));
-                    pDst1[indx] = (T) *(src + (x * step + 1));
-                    pDst2[indx] = (T) *(src + (x * step + 2));
+                    pDst0[indx] = (T) *(src + (x * step + FI_RGBA_RED));
+                    pDst1[indx] = (T) *(src + (x * step + FI_RGBA_GREEN));
+                    pDst2[indx] = (T) *(src + (x * step + FI_RGBA_BLUE));
                 }
                 if (fi_color == 4) pDst3[indx] = (T) *(src + (x * step + FI_RGBA_ALPHA));
             }
@@ -239,15 +239,15 @@ static void save_t(T* pDstLine, const af_array in, const dim4 dims, uint nDstPit
                 *(pDstLine + x * step + FI_RGBA_RED) = (T) pSrc0[indx]; // r -> 0
             } else if(channels >=3) {
                 if((af_dtype) af::dtype_traits<T>::af_type == u8) {
-                    *(pDstLine + x * step + FI_RGBA_BLUE)  = (T) pSrc2[indx]; // b -> 0
+                    *(pDstLine + x * step + FI_RGBA_RED  ) = (T) pSrc0[indx]; // r -> 0
                     *(pDstLine + x * step + FI_RGBA_GREEN) = (T) pSrc1[indx]; // g -> 1
-                    *(pDstLine + x * step + FI_RGBA_RED)   = (T) pSrc0[indx]; // r -> 2
+                    *(pDstLine + x * step + FI_RGBA_BLUE ) = (T) pSrc2[indx]; // b -> 2
                 } else {
                     // Non 8-bit types do not use ordering
                     // See Pixel Access Functions Chapter in FreeImage Doc
-                    *(pDstLine + x * step + 0) = (T) pSrc0[indx]; // r -> 0
-                    *(pDstLine + x * step + 1) = (T) pSrc1[indx]; // g -> 1
-                    *(pDstLine + x * step + 2) = (T) pSrc2[indx]; // b -> 2
+                    *(pDstLine + x * step + FI_RGBA_RED  ) = (T) pSrc0[indx]; // r -> 0
+                    *(pDstLine + x * step + FI_RGBA_GREEN) = (T) pSrc1[indx]; // g -> 1
+                    *(pDstLine + x * step + FI_RGBA_BLUE ) = (T) pSrc2[indx]; // b -> 2
                 }
             }
             if(channels >= 4) *(pDstLine + x * step + FI_RGBA_ALPHA) = (T) pSrc3[indx]; // a

--- a/src/api/c/index.cpp
+++ b/src/api/c/index.cpp
@@ -67,10 +67,10 @@ af_err af_index(af_array *result, const af_array in, const unsigned ndims, const
         case u8:     indexArray<uchar>   (out, in, ndims, index);  break;
         default:    TYPE_ERROR(1, in_type);
         }
+        swap(*result, out);
     }
     CATCHALL
 
-    swap(*result, out);
     return AF_SUCCESS;
 }
 
@@ -127,11 +127,9 @@ af_err af_lookup(af_array *out, const af_array in, const af_array indices, const
             case  u8: output = lookup<uchar   >(in, indices, dim); break;
             default : TYPE_ERROR(1, idxType);
         }
+        std::swap(*out, output);
     }
     CATCHALL;
-
-    std::swap(*out, output);
-
     return AF_SUCCESS;
 }
 

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -110,6 +110,94 @@ void DeviceManager::setContext(int device)
     mActiveCtxId = device;
 }
 
+static inline bool verify_present(std::string pname, const char *ref)
+{
+    return pname.find(ref) != std::string::npos;
+}
+
+static inline bool compare_default(const Device *ldev, const Device *rdev)
+{
+    const cl_device_type device_types[] = {CL_DEVICE_TYPE_GPU,
+                                           CL_DEVICE_TYPE_ACCELERATOR};
+
+    auto l_dev_type = ldev->getInfo<CL_DEVICE_TYPE>();
+    auto r_dev_type = rdev->getInfo<CL_DEVICE_TYPE>();
+
+    // This ensures GPU > ACCELERATOR > CPU
+    for (auto current_type : device_types) {
+        auto is_l_curr_type = l_dev_type == current_type;
+        auto is_r_curr_type = r_dev_type == current_type;
+
+        if ( is_l_curr_type && !is_r_curr_type) return true;
+        if (!is_l_curr_type &&  is_r_curr_type) return false;
+    }
+
+    // For GPUs, this ensures discreet > integrated
+    auto is_l_integrared = ldev->getInfo<CL_DEVICE_HOST_UNIFIED_MEMORY>();
+    auto is_r_integrared = rdev->getInfo<CL_DEVICE_HOST_UNIFIED_MEMORY>();
+
+    if (!is_l_integrared &&  is_r_integrared) return true;
+    if ( is_l_integrared && !is_r_integrared) return false;
+
+    // At this point, the devices are of same type.
+    // Sort based on emperical evidence of preferred platforms
+
+    // Prefer AMD first
+    std::string lPlatName = getPlatformName(*ldev);
+    std::string rPlatName = getPlatformName(*rdev);
+
+    if (l_dev_type == CL_DEVICE_TYPE_GPU &&
+        r_dev_type == CL_DEVICE_TYPE_GPU ) {
+        // If GPU, prefer AMD > NVIDIA > Beignet / Intel > APPLE
+        const char *platforms[] = {"AMD", "NVIDIA", "APPLE", "INTEL", "BEIGNET"};
+
+        for (auto ref_name : platforms) {
+            if ( verify_present(lPlatName, ref_name) &&
+                !verify_present(rPlatName, ref_name)) return true;
+
+            if (!verify_present(lPlatName, ref_name) &&
+                 verify_present(rPlatName, ref_name)) return false;
+        }
+
+        // Intel falls back to compare based on memory
+    } else {
+        // If CPU, prefer Intel > AMD > POCL > APPLE
+        const char *platforms[] = {"INTEL", "AMD", "POCL", "APPLE"};
+
+        for (auto ref_name : platforms) {
+            if ( verify_present(lPlatName, ref_name) &&
+                !verify_present(rPlatName, ref_name)) return true;
+
+            if (!verify_present(lPlatName, ref_name) &&
+                 verify_present(rPlatName, ref_name)) return false;
+        }
+    }
+
+
+    // Compare device compute versions
+
+    {
+        // Check Device OpenCL Version
+        auto lversion =  ldev->getInfo<CL_DEVICE_VERSION>();
+        auto rversion =  rdev->getInfo<CL_DEVICE_VERSION>();
+
+        auto lres = (lversion[7] > rversion[7]) ||
+            ((lversion[7] == rversion[7]) && (lversion[9] > rversion[9]));
+
+        auto rres = (lversion[7] < rversion[7]) ||
+            ((lversion[7] == rversion[7]) && (lversion[9] < rversion[9]));
+
+        if (lres > 0) return true;
+        if (rres < 0) return false;
+    }
+
+    // Default crietria, sort based on memory
+    // Sort based on memory
+    auto l_mem = ldev->getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>();
+    auto r_mem = rdev->getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>();
+    return l_mem >= r_mem;
+}
+
 DeviceManager::DeviceManager()
     : mUserDeviceOffset(0), mActiveCtxId(0), mActiveQId(0)
 {
@@ -117,41 +205,46 @@ DeviceManager::DeviceManager()
         std::vector<cl::Platform>   platforms;
         Platform::get(&platforms);
 
-        cl_device_type DEVC_TYPES[] = {
-            CL_DEVICE_TYPE_GPU,
-#ifndef OS_MAC
-            CL_DEVICE_TYPE_ACCELERATOR,
-            CL_DEVICE_TYPE_CPU
+        // This is all we need because the sort takes care of the order of devices
+#ifdef OS_MAC
+        cl_device_type DEVICE_TYPES = CL_DEVICE_TYPE_GPU;
+#else
+        cl_device_type DEVICE_TYPES = CL_DEVICE_TYPE_ALL;
 #endif
-        };
 
-        unsigned nDevices = 0;
-        for (auto devType : DEVC_TYPES) {
-            for (auto &platform : platforms) {
+        // Iterate through platforms, get all available devices and store them
+        for (auto &platform : platforms) {
+            std::vector<Device> current_devices;
 
-                cl_context_properties cps[3] = {CL_CONTEXT_PLATFORM,
-                    (cl_context_properties)(platform()),
-                    0};
-
-                std::vector<Device> devs;
-                try {
-                    platform.getDevices(devType, &devs);
-                } catch(const cl::Error &err) {
-                    if (err.err() != CL_DEVICE_NOT_FOUND) {
-                        throw;
-                    }
-                }
-
-                for (auto dev : devs) {
-                    nDevices++;
-                    Context *ctx = new Context(dev, cps);
-                    CommandQueue *cq = new CommandQueue(*ctx, dev);
-                    mDevices.push_back(new Device(dev));
-                    mContexts.push_back(ctx);
-                    mQueues.push_back(cq);
-                    mIsGLSharingOn.push_back(false);
+            try {
+                platform.getDevices(DEVICE_TYPES, &current_devices);
+            } catch(const cl::Error &err) {
+                if (err.err() != CL_DEVICE_NOT_FOUND) {
+                    throw;
                 }
             }
+
+            for (auto dev : current_devices) {
+                mDevices.push_back(new Device(dev));
+            }
+        }
+
+        // Sort OpenCL devices based on default criteria
+        std::stable_sort(mDevices.begin(), mDevices.end(), compare_default);
+
+        // Create contexts and queues once the sort is done
+        int nDevices = mDevices.size();
+        for (int i = 0; i < nDevices; i++) {
+            cl_platform_id device_platform = mDevices[i]->getInfo<CL_DEVICE_PLATFORM>();
+            cl_context_properties cps[3] = {CL_CONTEXT_PLATFORM,
+                                            (cl_context_properties)(device_platform),
+                                            0};
+
+            Context *ctx = new Context(*mDevices[i], cps);
+            CommandQueue *cq = new CommandQueue(*ctx, *mDevices[i]);
+            mContexts.push_back(ctx);
+            mQueues.push_back(cq);
+            mIsGLSharingOn.push_back(false);
         }
 
         std::string deviceENV = getEnvVar("AF_OPENCL_DEFAULT_DEVICE");
@@ -204,11 +297,12 @@ static std::string platformMap(std::string &platStr)
     typedef std::map<std::string, std::string> strmap_t;
     static strmap_t platMap;
     if (isFirst) {
-        platMap["NVIDIA CUDA"] = "NVIDIA  ";
-        platMap["Intel(R) OpenCL"] = "INTEL   ";
+        platMap["NVIDIA CUDA"]                         = "NVIDIA  ";
+        platMap["Intel(R) OpenCL"]                     = "INTEL   ";
         platMap["AMD Accelerated Parallel Processing"] = "AMD     ";
-        platMap["Intel Gen OCL Driver"] = "BEIGNET ";
-        platMap["Apple"] = "APPLE   ";
+        platMap["Intel Gen OCL Driver"]                = "BEIGNET ";
+        platMap["Apple"]                               = "APPLE   ";
+        platMap["Portable Computing Language"]         = "POCL    ";
         isFirst = false;
     }
 
@@ -228,38 +322,37 @@ std::string getInfo()
          << " (OpenCL, " << get_system() << ", build " << AF_REVISION << ")" << std::endl;
 
     unsigned nDevices = 0;
-    for (auto context : DeviceManager::getInstance().mContexts) {
-        vector<Device> devices = context->getInfo<CL_CONTEXT_DEVICES>();
+    for(auto &device: DeviceManager::getInstance().mDevices) {
+        const Platform platform(device->getInfo<CL_DEVICE_PLATFORM>());
 
-        for(auto &device:devices) {
-            const Platform platform(device.getInfo<CL_DEVICE_PLATFORM>());
+        string dstr = device->getInfo<CL_DEVICE_NAME>();
 
-            string platStr = platform.getInfo<CL_PLATFORM_NAME>();
-            string dstr = device.getInfo<CL_DEVICE_NAME>();
+        // Remove null termination character from the strings
+        dstr.pop_back();
 
-            // Remove null termination character from the strings
-            platStr.pop_back();
-            dstr.pop_back();
+        bool show_braces = ((unsigned)getActiveDeviceId() == nDevices);
 
-            bool show_braces = ((unsigned)getActiveDeviceId() == nDevices);
-            string id = (show_braces ? string("[") : "-") + std::to_string(nDevices) +
-                        (show_braces ? string("]") : "-");
-            info << id << " " << platformMap(platStr) << ": " << ltrim(dstr) << " ";
+        string id =
+            (show_braces ? string("[") : "-") +
+            std::to_string(nDevices) +
+            (show_braces ? string("]") : "-");
+
+        info << id << " " << getPlatformName(*device) << ": " << ltrim(dstr);
 #ifndef NDEBUG
-            string devVersion = device.getInfo<CL_DEVICE_VERSION>();
-            string driVersion = device.getInfo<CL_DRIVER_VERSION>();
-            devVersion.pop_back();
-            driVersion.pop_back();
-            info << devVersion;
-            info << " Device driver " << driVersion;
-            info << " FP64 Support("
-                 << (device.getInfo<CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE>()>0 ? "True" : "False")
-                 << ")";
+        info << " -- ";
+        string devVersion = device->getInfo<CL_DEVICE_VERSION>();
+        string driVersion = device->getInfo<CL_DRIVER_VERSION>();
+        devVersion.pop_back();
+        driVersion.pop_back();
+        info << devVersion;
+        info << " -- Device driver " << driVersion;
+        info << " -- FP64 Support: "
+             << (device->getInfo<CL_DEVICE_PREFERRED_VECTOR_WIDTH_DOUBLE>()>0 ? "True" : "False")
+             << "";
 #endif
-            info << std::endl;
+        info << std::endl;
 
-            nDevices++;
-        }
+        nDevices++;
     }
     return info.str();
 }
@@ -268,6 +361,8 @@ std::string getPlatformName(const cl::Device &device)
 {
     const Platform platform(device.getInfo<CL_DEVICE_PLATFORM>());
     std::string platStr = platform.getInfo<CL_PLATFORM_NAME>();
+    // Remove null termination character from the strings
+    platStr.pop_back();
     return platformMap(platStr);
 }
 


### PR DESCRIPTION
Sorting for OpenCL devices:
 
1. GPUs > Accelerators > CPUs.

2. IN GPUs:
   a. Discreet preferred to integrated
   b. AMD > NVIDIA > APPLE > Intel / BEIGNET

3. IN CPUs Intel > AMD > POCL > other

4. While everything above is the same:
   a. Higher OpenCL compute version preferred
   b. Higher amount of memory preferred

-------------------------------

Environment flags for choosing the proper device type.

- `AF_OPENCL_DEFAULT_DEVICE_TYPE`: - Setting default device to the first instance of a particular type.

- `AF_OPENCL_DEVICE_TYPE`:  Restrict OpenCL to a particular device type.

[skip ci]