### PR TITLE
Fixes to getMappedPtr in OpenCL backend

### DIFF
--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -227,8 +227,10 @@ namespace opencl
             try {
                 if(ptr == nullptr) {
                     ptr = (T*)getQueue().enqueueMapBuffer(*const_cast<cl::Buffer*>(get()),
-                            true, CL_MAP_READ|CL_MAP_WRITE,
-                            getOffset(), getDataDims().elements() * sizeof(T));
+                                                          true, CL_MAP_READ|CL_MAP_WRITE,
+                                                          getOffset(),
+                                                          (getDataDims().elements() - getOffset())
+                                                          * sizeof(T));
                 }
             } catch(cl::Error err) {
                 CL_TO_AF_ERROR(err);

--- a/src/backend/opencl/err_opencl.hpp
+++ b/src/backend/opencl/err_opencl.hpp
@@ -23,8 +23,8 @@
         char opencl_err_msg[1024];                              \
         snprintf(opencl_err_msg,                                \
                  sizeof(opencl_err_msg),                        \
-                 "OpenCL Error: %s when calling %s",            \
-                 getErrorMessage(ERR.err()).c_str(),            \
+                 "OpenCL Error (%d): %s when calling %s",       \
+                 ERR.err(), getErrorMessage(ERR.err()).c_str(), \
                  ERR.what());                                   \
         if (ERR.err() == CL_MEM_OBJECT_ALLOCATION_FAILURE) {    \
             AF_ERROR(opencl_err_msg, AF_ERR_NO_MEM);            \


### PR DESCRIPTION
- Also changed CL_TO_AF_ERROR to display OpenCL error number

[skip ci]