### PR TITLE
Fixes to compile with icc

### DIFF
--- a/src/api/c/assign.cpp
+++ b/src/api/c/assign.cpp
@@ -29,6 +29,7 @@ using std::swap;
 template<typename T>
 Array<T> modDims(const Array<T>& in, const af::dim4 &newDims);
 
+
 template<typename Tout, typename Tin>
 static
 void assign(Array<Tout> &out, const unsigned &ndims, const af_seq *index, const Array<Tin> &in_)

--- a/src/api/c/moddims.cpp
+++ b/src/api/c/moddims.cpp
@@ -36,6 +36,19 @@ Array<T> modDims(const Array<T>& in, const af::dim4 &newDims)
     return Out;
 }
 
+template Array<float> modDims(const Array<float> &in, const af::dim4 &newDims);
+template Array<double> modDims(const Array<double> &in, const af::dim4 &newDims);
+template Array<cfloat> modDims(const Array<cfloat> &in, const af::dim4 &newDims);
+template Array<cdouble> modDims(const Array<cdouble> &in, const af::dim4 &newDims);
+template Array<int> modDims(const Array<int> &in, const af::dim4 &newDims);
+template Array<uint> modDims(const Array<uint> &in, const af::dim4 &newDims);
+template Array<intl> modDims(const Array<intl> &in, const af::dim4 &newDims);
+template Array<uintl> modDims(const Array<uintl> &in, const af::dim4 &newDims);
+template Array<short> modDims(const Array<short> &in, const af::dim4 &newDims);
+template Array<ushort> modDims(const Array<ushort> &in, const af::dim4 &newDims);
+template Array<uchar> modDims(const Array<uchar> &in, const af::dim4 &newDims);
+template Array<char> modDims(const Array<char> &in, const af::dim4 &newDims);
+
 af_err af_moddims(af_array *out, const af_array in,
                   const unsigned ndims, const dim_t * const dims)
 {

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -277,6 +277,7 @@ namespace cuda
     template       Array<T>::Array(af::dim4 dims, const T * const in_data, \
                                    bool is_device, bool copy_device);   \
     template       Array<T>::~Array        ();                          \
+    template       Node_ptr Array<T>::getNode() const;             \
     template       void Array<T>::eval();                               \
     template       void Array<T>::eval() const;                         \
     template       void      writeHostDataArray<T>    (Array<T> &arr, const T * const data, const size_t bytes); \

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -320,6 +320,7 @@ namespace opencl
     template       Array<T>  createNodeArray<T>       (const dim4 &size, JIT::Node_ptr node); \
     template       Array<T>::Array(af::dim4 dims, cl_mem mem, size_t src_offset, bool copy); \
     template       Array<T>::~Array        ();                          \
+    template       Node_ptr Array<T>::getNode() const;             \
     template       void Array<T>::eval();                               \
     template       void Array<T>::eval() const;                         \
     template       void      writeHostDataArray<T>    (Array<T> &arr, const T * const data, const size_t bytes); \


### PR DESCRIPTION
Fixes #1255 

1) Fix link errors to modDims() in src/api/c/assign.cpp by instantiating `modDims()` in src/api/c/moddims.cpp for various types.

2) Added missing function getNode() in INSTANTIATE macro in
src/backend/cuda/Array.cpp and src/backend/opencl/Array.cpp