### PR TITLE
Search for GLEWmx in default paths too

### DIFF
--- a/CMakeModules/FindGLEWmx.cmake
+++ b/CMakeModules/FindGLEWmx.cmake
@@ -55,7 +55,6 @@ ELSE (WIN32)
         /sw/lib
         /opt/local/lib
         ${GLEW_ROOT_DIR}/lib
-        NO_DEFAULT_PATH
         DOC "The GLEWmx library")
 
     SET(PX ${CMAKE_STATIC_LIBRARY_PREFIX})
@@ -72,7 +71,6 @@ ELSE (WIN32)
         /sw/lib
         /opt/local/lib
         ${GLEW_ROOT_DIR}/lib
-        NO_DEFAULT_PATH
         DOC "The GLEWmx library")
     UNSET(PX)
     UNSET(SX)


### PR DESCRIPTION
Is there a reason the search needs to be limited to those specific locations? CMake now can't find the GLEW I installed under $HOME (even though I added it to CMAKE_SYSTEM_PREFIX_PATH).