### PR TITLE
Fixes to and reorganization of OSX Installer

### DIFF
--- a/CMakeModules/osx_install/OSXInstaller.cmake
+++ b/CMakeModules/osx_install/OSXInstaller.cmake
@@ -8,8 +8,62 @@ SET(BIN2CPP_PROGRAM "bin2cpp")
 
 SET(OSX_INSTALL_DIR ${CMAKE_MODULE_PATH}/osx_install)
 
+################################################################################
+## Create Directory Structure
+################################################################################
+SET(OSX_TEMP "${CMAKE_BINARY_DIR}/osx_install_files")
+
+FILE(GLOB COMMONLIB "${CMAKE_INSTALL_PREFIX}/${AF_INSTALL_LIB_DIR}/libforge*.dylib")
+FILE(GLOB COMMONCMAKE "${CMAKE_INSTALL_PREFIX}/${AF_INSTALL_CMAKE_DIR}/ArrayFireConfig*.cmake")
+
+MACRO(OSX_INSTALL_SETUP BACKEND LIB)
+    FILE(GLOB ${BACKEND}LIB "${CMAKE_INSTALL_PREFIX}/${AF_INSTALL_LIB_DIR}/lib${LIB}*.dylib")
+    FILE(GLOB ${BACKEND}CMAKE "${CMAKE_INSTALL_PREFIX}/${AF_INSTALL_CMAKE_DIR}/ArrayFire${BACKEND}*.cmake")
+
+    ADD_CUSTOM_TARGET(OSX_INSTALL_SETUP_${BACKEND})
+    FOREACH(SRC ${${BACKEND}LIB} ${COMMONLIB} ${${BACKEND}CMAKE} ${COMMONCMAKE})
+        FILE(RELATIVE_PATH SRC_REL ${CMAKE_INSTALL_PREFIX} ${SRC})
+        ADD_CUSTOM_COMMAND(TARGET OSX_INSTALL_SETUP_${BACKEND} PRE_BUILD
+                           COMMAND ${CMAKE_COMMAND} -E copy
+                           ${SRC} "${OSX_TEMP}/${BACKEND}/${SRC_REL}"
+                           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                           COMMENT "Copying ${BACKEND} files to temporary OSX Install Dir"
+                           )
+    ENDFOREACH()
+ENDMACRO(OSX_INSTALL_SETUP)
+
+OSX_INSTALL_SETUP(CPU afcpu)
+OSX_INSTALL_SETUP(CUDA afcuda)
+OSX_INSTALL_SETUP(OpenCL afopencl)
+OSX_INSTALL_SETUP(Unified af)
+
+# Headers
+ADD_CUSTOM_TARGET(OSX_INSTALL_SETUP_INCLUDE
+                  COMMAND ${CMAKE_COMMAND} -E copy_directory
+                  ${CMAKE_INSTALL_PREFIX}/include "${OSX_TEMP}/include"
+                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                  COMMENT "Copying header files to temporary OSX Install Dir"
+                  )
+
+# Examples
+ADD_CUSTOM_TARGET(OSX_INSTALL_SETUP_EXAMPLES
+                  COMMAND ${CMAKE_COMMAND} -E copy_directory
+                  "${CMAKE_INSTALL_PREFIX}/share/ArrayFire/examples" "${OSX_TEMP}/examples"
+                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                  COMMENT "Copying examples files to temporary OSX Install Dir"
+                  )
+
+# Documentation
+ADD_CUSTOM_TARGET(OSX_INSTALL_SETUP_DOC
+                  COMMAND ${CMAKE_COMMAND} -E copy_directory
+                  "${CMAKE_INSTALL_PREFIX}/share/ArrayFire/doc" "${OSX_TEMP}/doc"
+                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+                  COMMENT "Copying documentation files to temporary OSX Install Dir"
+                  )
+################################################################################
+
 FUNCTION(PKG_BUILD)
-    CMAKE_PARSE_ARGUMENTS(ARGS "" "INSTALL_LOCATION;IDENTIFIER;PATH_TO_FILES;PKG_NAME;TARGETS;SCRIPT_DIR" "FILTERS" ${ARGN})
+    CMAKE_PARSE_ARGUMENTS(ARGS "" "DEPENDS;INSTALL_LOCATION;IDENTIFIER;PATH_TO_FILES;PKG_NAME;TARGETS;SCRIPT_DIR" "FILTERS" ${ARGN})
 
     FOREACH(filter ${ARGS_FILTERS})
         LIST(APPEND  FILTER_LIST --filter ${filter})
@@ -70,50 +124,61 @@ ENDFUNCTION(PRODUCT_BUILD)
 
 
 PKG_BUILD(  PKG_NAME        ArrayFireCPU
-            DEPENDS         afcpu
+            DEPENDS         OSX_INSTALL_SETUP_CPU
             TARGETS         cpu_package
-            INSTALL_LOCATION /usr/local/lib
+            INSTALL_LOCATION /usr/local
             SCRIPT_DIR      ${OSX_INSTALL_DIR}/cpu_scripts
             IDENTIFIER      com.arrayfire.pkg.arrayfire.cpu.lib
-            PATH_TO_FILES   package/lib
+            PATH_TO_FILES   ${OSX_TEMP}/CPU
             FILTERS         opencl cuda unified)
 
 PKG_BUILD(  PKG_NAME        ArrayFireCUDA
-            DEPENDS         afcuda
+            DEPENDS         OSX_INSTALL_SETUP_CUDA
             TARGETS         cuda_package
-            INSTALL_LOCATION /usr/local/lib
+            INSTALL_LOCATION /usr/local
             SCRIPT_DIR      ${OSX_INSTALL_DIR}/cuda_scripts
             IDENTIFIER      com.arrayfire.pkg.arrayfire.cuda.lib
-            PATH_TO_FILES   package/lib
+            PATH_TO_FILES   ${OSX_TEMP}/CUDA
             FILTERS         cpu opencl unified)
 
 PKG_BUILD(  PKG_NAME        ArrayFireOPENCL
-            DEPENDS         afopencl
+            DEPENDS         OSX_INSTALL_SETUP_OpenCL
             TARGETS         opencl_package
-            INSTALL_LOCATION /usr/local/lib
+            INSTALL_LOCATION /usr/local
             IDENTIFIER      com.arrayfire.pkg.arrayfire.opencl.lib
-            PATH_TO_FILES   package/lib
+            PATH_TO_FILES   ${OSX_TEMP}/OpenCL
             FILTERS         cpu cuda unified)
 
 PKG_BUILD(  PKG_NAME        ArrayFireUNIFIED
-            DEPENDS         af
+            DEPENDS         OSX_INSTALL_SETUP_Unified
             TARGETS         unified_package
-            INSTALL_LOCATION /usr/local/lib
+            INSTALL_LOCATION /usr/local
             IDENTIFIER      com.arrayfire.pkg.arrayfire.unified.lib
-            PATH_TO_FILES   package/lib
+            PATH_TO_FILES   ${OSX_TEMP}/Unified
             FILTERS         cpu cuda opencl)
 
 PKG_BUILD(  PKG_NAME        ArrayFireHeaders
+            DEPENDS         OSX_INSTALL_SETUP_INCLUDE
             TARGETS         header_package
             INSTALL_LOCATION /usr/local/include
             IDENTIFIER      com.arrayfire.pkg.arrayfire.inc
-            PATH_TO_FILES   package/include)
+            PATH_TO_FILES   ${OSX_TEMP}/include)
 
-PKG_BUILD(  PKG_NAME        ArrayFireExtra
-            TARGETS         extra_package
-            INSTALL_LOCATION /usr/local/share
-            IDENTIFIER      com.arrayfire.pkg.arrayfire.extra
-            PATH_TO_FILES   package/share)
+PKG_BUILD(  PKG_NAME        ArrayFireExamples
+            DEPENDS         OSX_INSTALL_SETUP_EXAMPLES
+            TARGETS         examples_package
+            INSTALL_LOCATION /usr/local/share/ArrayFire/examples
+            IDENTIFIER      com.arrayfire.pkg.arrayfire.examples
+            PATH_TO_FILES   ${OSX_TEMP}/examples
+            FILTERS         cmake)
 
-PRODUCT_BUILD(DEPENDS ${cpu_package} ${cuda_package} ${opencl_package} ${unified_package} ${header_package} ${extra_package})
+PKG_BUILD(  PKG_NAME        ArrayFireDoc
+            DEPENDS         OSX_INSTALL_SETUP_DOC
+            TARGETS         doc_package
+            INSTALL_LOCATION /usr/local/share/ArrayFire/doc
+            IDENTIFIER      com.arrayfire.pkg.arrayfire.doc
+            PATH_TO_FILES   ${OSX_TEMP}/doc
+            FILTERS         cmake)
+
+PRODUCT_BUILD(DEPENDS ${cpu_package} ${cuda_package} ${opencl_package} ${unified_package} ${header_package} ${examples_package} ${doc_package})
 

--- a/CMakeModules/osx_install/distribution.dist
+++ b/CMakeModules/osx_install/distribution.dist
@@ -17,7 +17,8 @@
     <pkg-ref id="com.arrayfire.arrayfire.opencl.lib"    version="${AF_VERSION}" onConclusion="none">ArrayFireOPENCL.pkg</pkg-ref>
     <pkg-ref id="com.arrayfire.arrayfire.unified.lib"   version="${AF_VERSION}" onConclusion="none">ArrayFireUNIFIED.pkg</pkg-ref>
     <pkg-ref id="com.arrayfire.arrayfire.inc"           version="${AF_VERSION}" onConclusion="none">ArrayFireHeaders.pkg</pkg-ref>
-    <pkg-ref id="com.arrayfire.arrayfire.extra"         version="${AF_VERSION}" onConclusion="none">ArrayFireExtra.pkg</pkg-ref>
+    <pkg-ref id="com.arrayfire.arrayfire.examples"      version="${AF_VERSION}" onConclusion="none">ArrayFireExamples.pkg</pkg-ref>
+    <pkg-ref id="com.arrayfire.arrayfire.doc"           version="${AF_VERSION}" onConclusion="none">ArrayFireDoc.pkg</pkg-ref>
     <options customize="always" require-scripts="false"/>
     <choices-outline>
         <line choice="libs">
@@ -27,26 +28,27 @@
             <line choice="com.arrayfire.arrayfire.unified.lib"/>
         </line>
         <line choice="com.arrayfire.arrayfire.inc"/>
-        <line choice="com.arrayfire.arrayfire.extra"/>
+        <line choice="com.arrayfire.arrayfire.examples"/>
+        <line choice="com.arrayfire.arrayfire.doc"/>
     </choices-outline>
     <choice id="libs" title="ArrayFire Libraries" visible="true" />
-    <choice title="CPU Libraries"
+    <choice title="ArrayFire CPU Libraries. Also installs the corresponding CMake config files."
             description="ArrayFire targeting CPUs."
             id="cpu_lib" visible="true" enabled="true">
         <pkg-ref id="com.arrayfire.arrayfire.cpu.lib"/>
     </choice>
     <choice title="CUDA Libraries"
-            description="ArrayFire which targets the CUDA platform. This platform allows you to to take advantage of the CUDA enabled GPUs to run ArrayFire code."
+            description="ArrayFire which targets the CUDA platform. This platform allows you to to take advantage of the CUDA enabled GPUs to run ArrayFire code. Also installs the corresponding CMake config files."
             id="cuda_lib" visible="true" enabled="true">
         <pkg-ref id="com.arrayfire.arrayfire.cuda.lib"/>
     </choice>
     <choice title="OpenCL Libraries"
-            description="ArrayFire which targets the OpenCL platform. This platform allows you to use the ArrayFire library which targets OpenCL devices. NOTE: Currently ArrayFire does not support OpenCL for the Intel CPU on Apple."
+            description="ArrayFire which targets the OpenCL platform. This platform allows you to use the ArrayFire library which targets OpenCL devices. Also installs the corresponding CMake config files. NOTE: Currently ArrayFire does not support OpenCL for the Intel CPU on Apple."
             id="opencl_lib" visible="true" enabled="true">
         <pkg-ref id="com.arrayfire.arrayfire.opencl.lib"/>
     </choice>
     <choice title="Unified Library"
-            description="This library will allow you to choose the platform(cpu, cuda, opencl) at runtime. NOTE: This option requires the other platforms to work properly"
+            description="This library will allow you to choose the platform(cpu, cuda, opencl) at runtime. Also installs the corresponding CMake config files. NOTE: This option requires the other platforms to work properly"
             id="com.arrayfire.arrayfire.unified.lib"
             selected="CheckBackendSelected()"
             visible="true"
@@ -56,7 +58,10 @@
     <choice title="ArrayFire Headers" description="ArrayFire Headers" id="com.arrayfire.arrayfire.inc" visible="true" enabled="true">
         <pkg-ref id="com.arrayfire.arrayfire.inc"/>
     </choice>
-    <choice title="Extras" description="Extra files include documentation, examples, and cmake scripts to find and use ArrayFire with cmake," id="com.arrayfire.arrayfire.extra" visible="true" enabled="true">
-        <pkg-ref id="com.arrayfire.arrayfire.extra"/>
+    <choice title="Examples" description="ArrayFire Examples" id="com.arrayfire.arrayfire.examples" visible="true" enabled="true">
+        <pkg-ref id="com.arrayfire.arrayfire.examples"/>
+    </choice>
+    <choice title="Documentation" description="ArrayFire Documentation" id="com.arrayfire.arrayfire.doc" visible="true" enabled="true">
+        <pkg-ref id="com.arrayfire.arrayfire.doc"/>
     </choice>
 </installer-gui-script>

--- a/CMakeModules/osx_install/distribution.dist
+++ b/CMakeModules/osx_install/distribution.dist
@@ -19,6 +19,7 @@
     <pkg-ref id="com.arrayfire.arrayfire.inc"           version="${AF_VERSION}" onConclusion="none">ArrayFireHeaders.pkg</pkg-ref>
     <pkg-ref id="com.arrayfire.arrayfire.examples"      version="${AF_VERSION}" onConclusion="none">ArrayFireExamples.pkg</pkg-ref>
     <pkg-ref id="com.arrayfire.arrayfire.doc"           version="${AF_VERSION}" onConclusion="none">ArrayFireDoc.pkg</pkg-ref>
+    <pkg-ref id="com.arrayfire.arrayfire.libcommon"     version="${AF_VERSION}" onConclusion="none">ArrayFireCommon.pkg</pkg-ref>
     <options customize="always" require-scripts="false"/>
     <choices-outline>
         <line choice="libs">
@@ -26,14 +27,15 @@
             <line choice="cuda_lib"/>
             <line choice="opencl_lib"/>
             <line choice="com.arrayfire.arrayfire.unified.lib"/>
+            <line choice="com.arrayfire.arrayfire.libcommon"/>
         </line>
         <line choice="com.arrayfire.arrayfire.inc"/>
         <line choice="com.arrayfire.arrayfire.examples"/>
         <line choice="com.arrayfire.arrayfire.doc"/>
     </choices-outline>
     <choice id="libs" title="ArrayFire Libraries" visible="true" />
-    <choice title="ArrayFire CPU Libraries. Also installs the corresponding CMake config files."
-            description="ArrayFire targeting CPUs."
+    <choice title="CPU Libraries"
+            description="ArrayFire targeting CPUs. Also installs the corresponding CMake config files."
             id="cpu_lib" visible="true" enabled="true">
         <pkg-ref id="com.arrayfire.arrayfire.cpu.lib"/>
     </choice>
@@ -54,6 +56,14 @@
             visible="true"
             enabled="CheckBackendSelected()">
         <pkg-ref id="com.arrayfire.arrayfire.unified.lib"/>
+    </choice>
+    <choice title="Library Common"
+            description="Installs Forge and ArrayFireConfig.cmake files"
+            id="com.arrayfire.arrayfire.libcommon"
+            selected="CheckBackendSelected()"
+            visible="false"
+            enabled="CheckBackendSelected()">
+        <pkg-ref id="com.arrayfire.arrayfire.libcommon"/>
     </choice>
     <choice title="ArrayFire Headers" description="ArrayFire Headers" id="com.arrayfire.arrayfire.inc" visible="true" enabled="true">
         <pkg-ref id="com.arrayfire.arrayfire.inc"/>

--- a/CMakeModules/osx_install/readme.html
+++ b/CMakeModules/osx_install/readme.html
@@ -5,18 +5,9 @@
     <ul>
         <li> Libraries will be installed in <code>/usr/local/lib</code> </li>
         <li> Headers will be installed in <code>/usr/local/include</code> </li>
-        <li> Docs and other files will be installed in <code>/usr/local/share</code> </li>
+        <li> Examples, documentation and CMake config files will be installed in <code>/usr/local/share</code> </li>
     </ul>
-
-    <h2> Major Updates </h2>
-    <ul>
-        <li> ArrayFire is now open source</li>
-        <li> Major changes to the visualization library</li>
-        <li> Introducing handle based C API</li>
-        <li> New backend: CPU fallback available for systems without GPUs</li>
-        <li> Dense linear algebra functions available for all backends</li>
-        <li> Support for 64 bit integers</li>
-    </ul>
+    <p> For complete list of updates, visit <a href="http://www.arrayfire.com/docs/releasenotes.htm">ArrayFire Release Notes</a></p>
 
 </body>
 </html>


### PR DESCRIPTION
* ArrayFire<Backend>.config and forge are now installed with the library component
* ArrayFireConfig.cmake files are installed by all repos
* Examples and Documentation and now independent components
* No changes to install paths
* When make osx_installer is called, it creates a new directory called
  osx_install_files which are then used to generate the installers
* osx_installer target depends on make install being called first

Fixes #1223 
[skip ci]