### PR TITLE
CMake fixes

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -101,6 +101,7 @@ ENDIF()
 
 IF (${CUDA_FOUND})
     IF(${ArrayFire_CUDA_FOUND})  # variable defined by FIND(ArrayFire ...)
+        # Find NVVM
         FIND_LIBRARY( CUDA_NVVM_LIBRARY
           NAMES "nvvm"
           PATH_SUFFIXES "nvvm/lib64" "nvvm/lib"
@@ -108,6 +109,26 @@ IF (${CUDA_FOUND})
           DOC "CUDA NVVM Library"
           )
         MARK_AS_ADVANCED(CUDA_NVVM_LIBRARY)
+
+        # If CUDA_CUDA_LIBRARY is not found, check for Stub in CUDA Toolkit
+        IF(NOT CUDA_CUDA_LIBRARY)
+            MESSAGE(SEND_ERROR "CMake CUDA Variable CUDA_CUDA_LIBRARY Not found.")
+            MESSAGE("CUDA Driver Library (libcuda.so/libcuda.dylib/cuda.lib) cannot be found.")
+            FIND_FILE(CUDA_CUDA_LIBRARY_STUB
+                      NAMES "libcuda.so" "libcuda.dylib" "cuda.lib"
+                      PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+                      PATH_SUFFIXES "lib64" "lib64/stubs" "lib" "lib/stubs" "lib/x64" "lib/Win32"
+                      DOC "CUDA Library STUB"
+                     )
+            IF(CUDA_CUDA_LIBRARY_STUB)
+                MESSAGE("You can use the library stub available in the CUDA Toolkit: ${CUDA_CUDA_LIBRARY_STUB}")
+                MESSAGE("Run the following commands (Linux) to set it up:")
+                MESSAGE("ln -s ${CUDA_CUDA_LIBRARY_STUB} /usr/lib/libcuda.so.1")
+                MESSAGE("ln -s /usr/lib/libcuda.so.1 /usr/lib/libcuda.so")
+            ENDIF()
+            MESSAGE(FATAL_ERROR "Ending CMake configuration because of missing CUDA_CUDA_LIBRARY")
+        ENDIF(NOT CUDA_CUDA_LIBRARY)
+
         OPTION(BUILD_CUDA "Build ArrayFire Examples for CUDA backend" ON)
         BUILD_ALL("${FILES}" cuda ${ArrayFire_CUDA_LIBRARIES} "${CUDA_CUBLAS_LIBRARIES};${CUDA_LIBRARIES};${CUDA_cusolver_LIBRARY};${CUDA_CUFFT_LIBRARIES};${CUDA_NVVM_LIBRARY};${CUDA_CUDA_LIBRARY}")
     ELSEIF(TARGET afcuda)        # variable defined by the ArrayFire build tree

--- a/src/api/c/imageio.cpp
+++ b/src/api/c/imageio.cpp
@@ -149,7 +149,9 @@ af_err af_load_image(af_array *out, const char* filename, const bool isColor)
 
         int flags = 0;
         if(fif == FIF_JPEG) flags = flags | JPEG_ACCURATE;
+#ifdef JPEG_GREYSCALE
         if(fif == FIF_JPEG && !isColor) flags = flags | JPEG_GREYSCALE;
+#endif
 
         // check that the plugin has reading capabilities ...
         FIBITMAP* pBitmap = NULL;

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -31,8 +31,7 @@ ENDIF()
 LIST(LENGTH COMPUTES_DETECTED_LIST COMPUTES_LEN)
 IF(${COMPUTES_LEN} EQUAL 0 AND ${FALLBACK})
     MESSAGE(STATUS "No computes detected. Fall back to 20, 30, 50")
-    MESSAGE(STATUS "You can use -DCOMPUTES_DETECTED_LIST=\"AB;XY\" (semicolon
-    separated list of CUDA Compute versions to enable the specified computes")
+    MESSAGE(STATUS "You can use -DCOMPUTES_DETECTED_LIST=\"AB;XY\" (semicolon separated list of CUDA Compute versions to enable the specified computes")
     MESSAGE(STATUS "Individual compute versions flags are also available under CMake Advance options")
     LIST(APPEND COMPUTES_DETECTED_LIST "20" "30" "50")
 ENDIF()
@@ -331,6 +330,24 @@ macro(MY_CUDA_ADD_LIBRARY cuda_target)
     )
 
 endmacro()
+
+IF(NOT CUDA_CUDA_LIBRARY)
+    MESSAGE(SEND_ERROR "CMake CUDA Variable CUDA_CUDA_LIBRARY Not found.")
+    MESSAGE("CUDA Driver Library (libcuda.so/libcuda.dylib/cuda.lib) cannot be found.")
+    FIND_FILE(CUDA_CUDA_LIBRARY_STUB
+              NAMES "libcuda.so" "libcuda.dylib" "cuda.lib"
+              PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+              PATH_SUFFIXES "lib64" "lib64/stubs" "lib" "lib/stubs" "lib/x64" "lib/Win32"
+              DOC "CUDA Library STUB"
+             )
+    IF(CUDA_CUDA_LIBRARY_STUB)
+        MESSAGE("You can use the library stub available in the CUDA Toolkit: ${CUDA_CUDA_LIBRARY_STUB}")
+        MESSAGE("Run the following commands (Linux) to set it up:")
+        MESSAGE("ln -s ${CUDA_CUDA_LIBRARY_STUB} /usr/lib/libcuda.so.1")
+        MESSAGE("ln -s /usr/lib/libcuda.so.1 /usr/lib/libcuda.so")
+    ENDIF()
+    MESSAGE(FATAL_ERROR "Ending CMake configuration because of missing CUDA_CUDA_LIBRARY")
+ENDIF(NOT CUDA_CUDA_LIBRARY)
 
 MY_CUDA_ADD_LIBRARY(afcuda SHARED
                 ${cuda_headers}

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -31,6 +31,9 @@ ENDIF()
 LIST(LENGTH COMPUTES_DETECTED_LIST COMPUTES_LEN)
 IF(${COMPUTES_LEN} EQUAL 0 AND ${FALLBACK})
     MESSAGE(STATUS "No computes detected. Fall back to 20, 30, 50")
+    MESSAGE(STATUS "You can use -DCOMPUTES_DETECTED_LIST=\"AB;XY\" (semicolon
+    separated list of CUDA Compute versions to enable the specified computes")
+    MESSAGE(STATUS "Individual compute versions flags are also available under CMake Advance options")
     LIST(APPEND COMPUTES_DETECTED_LIST "20" "30" "50")
 ENDIF()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -189,6 +189,7 @@ ENDIF()
 # CUDA Backend
 IF (${CUDA_FOUND})
     IF(${ArrayFire_CUDA_FOUND})  # variable defined by FIND(ArrayFire ...)
+        # Find NVVM
         FIND_LIBRARY( CUDA_NVVM_LIBRARY
           NAMES "nvvm"
           PATH_SUFFIXES "nvvm/lib64" "nvvm/lib"
@@ -196,6 +197,26 @@ IF (${CUDA_FOUND})
           DOC "CUDA NVVM Library"
           )
         MARK_AS_ADVANCED(CUDA_NVVM_LIBRARY)
+
+        # If CUDA_CUDA_LIBRARY is not found, check for Stub in CUDA Toolkit
+        IF(NOT CUDA_CUDA_LIBRARY)
+            MESSAGE(SEND_ERROR "CMake CUDA Variable CUDA_CUDA_LIBRARY Not found.")
+            MESSAGE("CUDA Driver Library (libcuda.so/libcuda.dylib/cuda.lib) cannot be found.")
+            FIND_FILE(CUDA_CUDA_LIBRARY_STUB
+                      NAMES "libcuda.so" "libcuda.dylib" "cuda.lib"
+                      PATHS ${CUDA_TOOLKIT_ROOT_DIR}
+                      PATH_SUFFIXES "lib64" "lib64/stubs" "lib" "lib/stubs" "lib/x64" "lib/Win32"
+                      DOC "CUDA Library STUB"
+                     )
+            IF(CUDA_CUDA_LIBRARY_STUB)
+                MESSAGE("You can use the library stub available in the CUDA Toolkit: ${CUDA_CUDA_LIBRARY_STUB}")
+                MESSAGE("Run the following commands (Linux) to set it up:")
+                MESSAGE("ln -s ${CUDA_CUDA_LIBRARY_STUB} /usr/lib/libcuda.so.1")
+                MESSAGE("ln -s /usr/lib/libcuda.so.1 /usr/lib/libcuda.so")
+            ENDIF()
+            MESSAGE(FATAL_ERROR "Ending CMake configuration because of missing CUDA_CUDA_LIBRARY")
+        ENDIF(NOT CUDA_CUDA_LIBRARY)
+
         # If OSX && CLANG && CUDA < 7
         IF("${APPLE}" AND ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CUDA_VERSION_MAJOR} VERSION_LESS 7)
             OPTION(BUILD_CUDA "Build ArrayFire Tests for CUDA backend" ON)


### PR DESCRIPTION
* Fixes #1363 : Print message when libcuda is not found and check for libcuda in CUDA toolkit. From what I have seen this is a problem only on Linux. On OSX and Windows, libcuda.dylib and cuda.lib are installed in the CUDA Toolkit itself.
* Fixes #1362 : Adding messages when compute detection fails and default computes are used.
* Fixes #1360 : Check if JPEG_GREYSCALE is available.