### PR TITLE
Prevent inclusion of <sys/sysctl.h> on gnu hurd.

### DIFF
--- a/src/backend/host_memory.cpp
+++ b/src/backend/host_memory.cpp
@@ -16,7 +16,7 @@
 #include <sys/types.h>
 #include <sys/param.h>
 
-#if defined(BSD)
+#if defined(BSD) && !defined(__gnu_hurd__)
 #include <sys/sysctl.h>
 #endif
 


### PR DESCRIPTION
According to the current [build log](https://buildd.debian.org/status/fetch.php?pkg=arrayfire&arch=hurd-i386&ver=3.3.1%2Bdfsg1-1&stamp=1459100721), `<sys/sysctl.h>` get included when compiled on the gnu-hurd architecture although it should not be. This commit adds the necessary guard to prevent this.