### PR TITLE
Fixes to build arrayfire with gcc 6.1.1

### DIFF
--- a/src/api/cpp/features.cpp
+++ b/src/api/cpp/features.cpp
@@ -39,8 +39,9 @@ namespace af
 
     features::~features()
     {
-        if(AF_SUCCESS != af_release_features(feat)) {
-            fprintf(stderr, "Error: Couldn't release af::features: %p\n", this);
+        // THOU SHALL NOT THROW IN DESTRUCTORS
+        if (feat) {
+            af_release_features(feat);
         }
     }
 

--- a/src/api/cpp/graphics.cpp
+++ b/src/api/cpp/graphics.cpp
@@ -44,7 +44,10 @@ Window::Window(const af_window window)
 
 Window::~Window()
 {
-    AF_THROW(af_destroy_window(wnd));
+    // THOU SHALL NOT THROW IN DESTRUCTORS
+    if (wnd) {
+        af_destroy_window(wnd);
+    }
 }
 
 void Window::setPos(const unsigned x, const unsigned y)

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -64,7 +64,14 @@ IF(UNIX)
     # GCC 5.3 and above give errors for mempcy from <string.h>
     # This is a (temporary) fix for that
     IF("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.3.0")
-        ADD_DEFINITIONS(-D_FORCE_INLINES)
+      ADD_DEFINITIONS(-D_FORCE_INLINES)
+    ENDIF()
+
+    # GCC 6.0 and above default to g++14, enabling c++11 features by default
+    # Enabling c++11 with nvcc 7.5 + gcc 6.x doesn't seem to work
+    # Only solution for now is to force use c++03 for gcc 6.x
+    IF("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "6.0.0")
+      SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -std=c++98")
     ENDIF()
 
     # Forcing STRICT ANSI should resolve a bunch of issues that NVIDIA seems to face with GCC compilers.

--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -231,9 +231,10 @@ namespace opencl
         {
             auto func = [=] (void* ptr) {
                 try {
-                    if(ptr != nullptr)
+                    if(ptr != nullptr) {
                         getQueue().enqueueUnmapMemObject(*data, ptr);
                         ptr = nullptr;
+                    }
                 } catch(cl::Error err) {
                     CL_TO_AF_ERROR(err);
                 }

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -233,7 +233,12 @@ CL_KERNEL_TO_H(
 
 # OS Definitions
 IF(UNIX)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pthread -Wno-comment")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -pthread -Wno-comment")
+    # GCC 6.0 and above enable -Wignored-attributes by default causing a lot of warnings
+    # Disable the trigger for gcc >= 6.0.0
+    IF("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "6.0.0")
+        ADD_DEFINITIONS(-Wno-ignored-attributes)
+    ENDIF()
 ENDIF()
 
 INCLUDE("${CMAKE_CURRENT_SOURCE_DIR}/kernel/sort_by_key/CMakeLists.txt")

--- a/src/backend/opencl/fft.cpp
+++ b/src/backend/opencl/fft.cpp
@@ -52,7 +52,8 @@ class clFFTPlanner
             #ifndef OS_WIN
             static bool flag = true;
             if(flag) {
-                CLFFT_CHECK(clfftTeardown());
+                // THOU SHALL NOT THROW IN DESTRUCTORS
+                clfftTeardown();
                 flag = false;
             }
             #endif


### PR DESCRIPTION
- CUDA backend being forced to use c++98