### PR TITLE
CUDA Kernels: Use ints instead of dim_t in index calculations

### DIFF
--- a/src/backend/cuda/kernel/approx.hpp
+++ b/src/backend/cuda/kernel/approx.hpp
@@ -27,13 +27,13 @@ namespace cuda
         ///////////////////////////////////////////////////////////////////////////
         template<typename Ty, typename Tp>
         __device__ inline static
-        void core_nearest1(const dim_t idx, const dim_t idy, const dim_t idz, const dim_t idw,
+        void core_nearest1(const int idx, const int idy, const int idz, const int idw,
                            Param<Ty> out, CParam<Ty> in, CParam<Tp> pos,
                            const float offGrid, const bool pBatch)
         {
-            const dim_t omId = idw * out.strides[3] + idz * out.strides[2]
+            const int omId = idw * out.strides[3] + idz * out.strides[2]
                              + idy * out.strides[1] + idx;
-            dim_t pmId = idx;
+            int pmId = idx;
             if(pBatch) pmId += idw * pos.strides[3] + idz * pos.strides[2] + idy * pos.strides[1];
 
             const Tp x = pos.ptr[pmId];
@@ -42,8 +42,8 @@ namespace cuda
                 return;
             }
 
-            dim_t ioff = idw * in.strides[3] + idz * in.strides[2] + idy * in.strides[1];
-            const dim_t iMem = round(x) + ioff;
+            int ioff = idw * in.strides[3] + idz * in.strides[2] + idy * in.strides[1];
+            const int iMem = round(x) + ioff;
 
             Ty yt = in.ptr[iMem];
             out.ptr[omId] = yt;
@@ -51,14 +51,14 @@ namespace cuda
 
         template<typename Ty, typename Tp>
         __device__ inline static
-        void core_nearest2(const dim_t idx, const dim_t idy, const dim_t idz, const dim_t idw,
+        void core_nearest2(const int idx, const int idy, const int idz, const int idw,
                            Param<Ty> out, CParam<Ty> in,
                            CParam<Tp> pos, CParam<Tp> qos, const float offGrid, const bool pBatch)
         {
-            const dim_t omId = idw * out.strides[3] + idz * out.strides[2]
+            const int omId = idw * out.strides[3] + idz * out.strides[2]
                              + idy * out.strides[1] + idx;
-            dim_t pmId = idy * pos.strides[1] + idx;
-            dim_t qmId = idy * qos.strides[1] + idx;
+            int pmId = idy * pos.strides[1] + idx;
+            int qmId = idy * qos.strides[1] + idx;
             if(pBatch) {
                 pmId += idw * pos.strides[3] + idz * pos.strides[2];
                 qmId += idw * qos.strides[3] + idz * qos.strides[2];
@@ -70,8 +70,8 @@ namespace cuda
                 return;
             }
 
-            const dim_t grid_x = round(x), grid_y = round(y); // nearest grid
-            const dim_t imId = idw * in.strides[3] + idz * in.strides[2]
+            const int grid_x = round(x), grid_y = round(y); // nearest grid
+            const int imId = idw * in.strides[3] + idz * in.strides[2]
                           + grid_y * in.strides[1] + grid_x;
 
             Ty val = in.ptr[imId];
@@ -83,13 +83,13 @@ namespace cuda
         ///////////////////////////////////////////////////////////////////////////
         template<typename Ty, typename Tp>
         __device__ inline static
-        void core_linear1(const dim_t idx, const dim_t idy, const dim_t idz, const dim_t idw,
+        void core_linear1(const int idx, const int idy, const int idz, const int idw,
                           Param<Ty> out, CParam<Ty> in, CParam<Tp> pos,
                           const float offGrid, const bool pBatch)
         {
-            const dim_t omId = idw * out.strides[3] + idz * out.strides[2]
+            const int omId = idw * out.strides[3] + idz * out.strides[2]
                              + idy * out.strides[1] + idx;
-            dim_t pmId = idx;
+            int pmId = idx;
             if(pBatch) pmId += idw * pos.strides[3] + idz * pos.strides[2] + idy * pos.strides[1];
 
             const Tp pVal = pos.ptr[pmId];
@@ -98,10 +98,10 @@ namespace cuda
                 return;
             }
 
-            const dim_t grid_x = floor(pVal);  // nearest grid
+            const int grid_x = floor(pVal);  // nearest grid
             const Tp off_x = pVal - grid_x; // fractional offset
 
-            dim_t ioff = idw * in.strides[3] + idz * in.strides[2] + idy * in.strides[1] + grid_x;
+            int ioff = idw * in.strides[3] + idz * in.strides[2] + idy * in.strides[1] + grid_x;
 
             // Check if pVal and pVal + 1 are both valid indices
             bool cond = (pVal < in.dims[0] - 1);
@@ -117,14 +117,14 @@ namespace cuda
 
         template<typename Ty, typename Tp>
         __device__ inline static
-        void core_linear2(const dim_t idx, const dim_t idy, const dim_t idz, const dim_t idw,
+        void core_linear2(const int idx, const int idy, const int idz, const int idw,
                            Param<Ty> out, CParam<Ty> in,
                            CParam<Tp> pos, CParam<Tp> qos, const float offGrid, const bool pBatch)
         {
-            const dim_t omId = idw * out.strides[3] + idz * out.strides[2]
+            const int omId = idw * out.strides[3] + idz * out.strides[2]
                              + idy * out.strides[1] + idx;
-            dim_t pmId = idy * pos.strides[1] + idx;
-            dim_t qmId = idy * qos.strides[1] + idx;
+            int pmId = idy * pos.strides[1] + idx;
+            int qmId = idy * qos.strides[1] + idx;
             if(pBatch) {
                 pmId += idw * pos.strides[3] + idz * pos.strides[2];
                 qmId += idw * qos.strides[3] + idz * qos.strides[2];
@@ -137,10 +137,10 @@ namespace cuda
                 return;
             }
 
-            const dim_t grid_x = floor(x),   grid_y = floor(y);   // nearest grid
+            const int grid_x = floor(x),   grid_y = floor(y);   // nearest grid
             const Tp off_x  = x - grid_x, off_y  = y - grid_y; // fractional offset
 
-            dim_t ioff = idw * in.strides[3] + idz * in.strides[2] + grid_y * in.strides[1] + grid_x;
+            int ioff = idw * in.strides[3] + idz * in.strides[2] + grid_y * in.strides[1] + grid_x;
 
             // Check if pVal and pVal + 1 are both valid indices
             bool condY = (y < in.dims[1] - 1);
@@ -172,14 +172,14 @@ namespace cuda
         template<typename Ty, typename Tp, af_interp_type method>
         __global__
         void approx1_kernel(Param<Ty> out, CParam<Ty> in, CParam<Tp> pos,
-                            const float offGrid, const dim_t blocksMatX, const bool pBatch)
+                            const float offGrid, const int blocksMatX, const bool pBatch)
         {
-            const dim_t idw = blockIdx.y / out.dims[2];
-            const dim_t idz = blockIdx.y - idw * out.dims[2];
+            const int idw = blockIdx.y / out.dims[2];
+            const int idz = blockIdx.y - idw * out.dims[2];
 
-            const dim_t idy = blockIdx.x / blocksMatX;
-            const dim_t blockIdx_x = blockIdx.x - idy * blocksMatX;
-            const dim_t idx = blockIdx_x * blockDim.x + threadIdx.x;
+            const int idy = blockIdx.x / blocksMatX;
+            const int blockIdx_x = blockIdx.x - idy * blocksMatX;
+            const int idx = blockIdx_x * blockDim.x + threadIdx.x;
 
             if (idx >= out.dims[0] || idy >= out.dims[1] ||
                 idz >= out.dims[2] || idw >= out.dims[3])
@@ -201,16 +201,16 @@ namespace cuda
         __global__
         void approx2_kernel(Param<Ty> out, CParam<Ty> in,
                       CParam<Tp> pos, CParam<Tp> qos, const float offGrid,
-                      const dim_t blocksMatX, const dim_t blocksMatY, const bool pBatch)
+                      const int blocksMatX, const int blocksMatY, const bool pBatch)
         {
-            const dim_t idz = blockIdx.x / blocksMatX;
-            const dim_t idw = blockIdx.y / blocksMatY;
+            const int idz = blockIdx.x / blocksMatX;
+            const int idw = blockIdx.y / blocksMatY;
 
-            dim_t blockIdx_x = blockIdx.x - idz * blocksMatX;
-            dim_t blockIdx_y = blockIdx.y - idw * blocksMatY;
+            int blockIdx_x = blockIdx.x - idz * blocksMatX;
+            int blockIdx_y = blockIdx.y - idw * blocksMatY;
 
-            dim_t idx = threadIdx.x + blockIdx_x * blockDim.x;
-            dim_t idy = threadIdx.y + blockIdx_y * blockDim.y;
+            int idx = threadIdx.x + blockIdx_x * blockDim.x;
+            int idy = threadIdx.y + blockIdx_y * blockDim.y;
 
             if (idx >= out.dims[0] || idy >= out.dims[1] ||
                 idz >= out.dims[2] || idw >= out.dims[3])
@@ -236,7 +236,7 @@ namespace cuda
                CParam<Tp> pos, const float offGrid)
         {
             dim3 threads(THREADS, 1, 1);
-            dim_t blocksPerMat = divup(out.dims[0], threads.x);
+            int blocksPerMat = divup(out.dims[0], threads.x);
             dim3 blocks(blocksPerMat * out.dims[1], out.dims[2] * out.dims[3]);
 
             bool pBatch = !(pos.dims[1] == 1 && pos.dims[2] == 1 && pos.dims[3] == 1);
@@ -251,8 +251,8 @@ namespace cuda
                     CParam<Tp> pos, CParam<Tp> qos, const float offGrid)
         {
             dim3 threads(TX, TY, 1);
-            dim_t blocksPerMatX = divup(out.dims[0], threads.x);
-            dim_t blocksPerMatY = divup(out.dims[1], threads.y);
+            int blocksPerMatX = divup(out.dims[0], threads.x);
+            int blocksPerMatY = divup(out.dims[1], threads.y);
             dim3 blocks(blocksPerMatX * out.dims[2], blocksPerMatY * out.dims[3]);
 
             bool pBatch = !(pos.dims[2] == 1 && pos.dims[3] == 1);

--- a/src/backend/opencl/kernel/approx1.cl
+++ b/src/backend/opencl/kernel/approx1.cl
@@ -32,15 +32,15 @@ Ty div(Ty a, Tp b) { a.x = a.x / b; a.y = a.y / b; return a; }
 ///////////////////////////////////////////////////////////////////////////
 // nearest-neighbor resampling
 ///////////////////////////////////////////////////////////////////////////
-void core_nearest1(const dim_t idx, const dim_t idy, const dim_t idz, const dim_t idw,
+void core_nearest1(const int idx, const int idy, const int idz, const int idw,
                    __global       Ty *d_out, const KParam out,
                    __global const Ty *d_in,  const KParam in,
                    __global const Tp *d_pos, const KParam pos,
                    const float offGrid, const bool pBatch)
 {
-    const dim_t omId = idw * out.strides[3] + idz * out.strides[2]
+    const int omId = idw * out.strides[3] + idz * out.strides[2]
                      + idy * out.strides[1] + idx;
-    dim_t pmId = idx;
+    int pmId = idx;
     if(pBatch) pmId += idw * pos.strides[3] + idz * pos.strides[2] + idy * pos.strides[1];
 
     const Tp pVal = d_pos[pmId];
@@ -49,8 +49,8 @@ void core_nearest1(const dim_t idx, const dim_t idy, const dim_t idz, const dim_
         return;
     }
 
-    dim_t ioff = idw * in.strides[3] + idz * in.strides[2] + idy * in.strides[1];
-    const dim_t imId = round(pVal) + ioff;
+    int ioff = idw * in.strides[3] + idz * in.strides[2] + idy * in.strides[1];
+    const int imId = round(pVal) + ioff;
 
     Ty y;
     set(y, d_in[imId]);
@@ -60,15 +60,15 @@ void core_nearest1(const dim_t idx, const dim_t idy, const dim_t idz, const dim_
 ///////////////////////////////////////////////////////////////////////////
 // linear resampling
 ///////////////////////////////////////////////////////////////////////////
-void core_linear1(const dim_t idx, const dim_t idy, const dim_t idz, const dim_t idw,
+void core_linear1(const int idx, const int idy, const int idz, const int idw,
                    __global       Ty *d_out, const KParam out,
                    __global const Ty *d_in,  const KParam in,
                    __global const Tp *d_pos, const KParam pos,
                    const float offGrid, const bool pBatch)
 {
-    const dim_t omId = idw * out.strides[3] + idz * out.strides[2]
+    const int omId = idw * out.strides[3] + idz * out.strides[2]
                      + idy * out.strides[1] + idx;
-    dim_t pmId = idx;
+    int pmId = idx;
     if(pBatch) pmId += idw * pos.strides[3] + idz * pos.strides[2] + idy * pos.strides[1];
 
     const Tp pVal = d_pos[pmId];
@@ -77,10 +77,10 @@ void core_linear1(const dim_t idx, const dim_t idy, const dim_t idz, const dim_t
         return;
     }
 
-    const dim_t grid_x = floor(pVal);  // nearest grid
+    const int grid_x = floor(pVal);  // nearest grid
     const Tp off_x = pVal - grid_x; // fractional offset
 
-    dim_t ioff = idw * in.strides[3] + idz * in.strides[2] + idy * in.strides[1] + grid_x;
+    int ioff = idw * in.strides[3] + idz * in.strides[2] + idy * in.strides[1] + grid_x;
 
     // Check if pVal and pVal + 1 are both valid indices
     bool cond = (pVal < in.dims[0] - 1);
@@ -106,14 +106,14 @@ __kernel
 void approx1_kernel(__global       Ty *d_out, const KParam out,
                     __global const Ty *d_in,  const KParam in,
                     __global const Tp *d_pos, const KParam pos,
-                    const float offGrid, const dim_t blocksMatX, const int pBatch)
+                    const float offGrid, const int blocksMatX, const int pBatch)
 {
-    const dim_t idw = get_group_id(1) / out.dims[2];
-    const dim_t idz = get_group_id(1)  - idw * out.dims[2];
+    const int idw = get_group_id(1) / out.dims[2];
+    const int idz = get_group_id(1)  - idw * out.dims[2];
 
-    const dim_t idy = get_group_id(0) / blocksMatX;
-    const dim_t blockIdx_x = get_group_id(0) - idy * blocksMatX;
-    const dim_t idx = get_local_id(0) + blockIdx_x * get_local_size(0);
+    const int idy = get_group_id(0) / blocksMatX;
+    const int blockIdx_x = get_group_id(0) - idy * blocksMatX;
+    const int idx = get_local_id(0) + blockIdx_x * get_local_size(0);
 
     if(idx >= out.dims[0] ||
        idy >= out.dims[1] ||

--- a/src/backend/opencl/kernel/approx2.cl
+++ b/src/backend/opencl/kernel/approx2.cl
@@ -32,17 +32,17 @@ Ty div(Ty a, Tp b) { a.x = a.x / b; a.y = a.y / b; return a; }
 ///////////////////////////////////////////////////////////////////////////
 // nearest-neighbor resampling
 ///////////////////////////////////////////////////////////////////////////
-void core_nearest2(const dim_t idx, const dim_t idy, const dim_t idz, const dim_t idw,
+void core_nearest2(const int idx, const int idy, const int idz, const int idw,
                    __global       Ty *d_out, const KParam out,
                    __global const Ty *d_in,  const KParam in,
                    __global const Tp *d_pos, const KParam pos,
                    __global const Tp *d_qos, const KParam qos,
                    const float offGrid, const bool pBatch)
 {
-    const dim_t omId = idw * out.strides[3] + idz * out.strides[2]
+    const int omId = idw * out.strides[3] + idz * out.strides[2]
                      + idy * out.strides[1] + idx;
-    dim_t pmId = idy * pos.strides[1] + idx;
-    dim_t qmId = idy * qos.strides[1] + idx;
+    int pmId = idy * pos.strides[1] + idx;
+    int qmId = idy * qos.strides[1] + idx;
     if(pBatch) {
         pmId += idw * pos.strides[3] + idz * pos.strides[2];
         qmId += idw * qos.strides[3] + idz * qos.strides[2];
@@ -54,8 +54,8 @@ void core_nearest2(const dim_t idx, const dim_t idy, const dim_t idz, const dim_
         return;
     }
 
-    const dim_t grid_x = round(x), grid_y = round(y); // nearest grid
-    const dim_t imId = idw * in.strides[3] + idz * in.strides[2]
+    const int grid_x = round(x), grid_y = round(y); // nearest grid
+    const int imId = idw * in.strides[3] + idz * in.strides[2]
                   + grid_y * in.strides[1] + grid_x;
 
     Ty z;
@@ -66,17 +66,17 @@ void core_nearest2(const dim_t idx, const dim_t idy, const dim_t idz, const dim_
 ///////////////////////////////////////////////////////////////////////////
 // linear resampling
 ///////////////////////////////////////////////////////////////////////////
-void core_linear2(const dim_t idx, const dim_t idy, const dim_t idz, const dim_t idw,
+void core_linear2(const int idx, const int idy, const int idz, const int idw,
                   __global       Ty *d_out, const KParam out,
                   __global const Ty *d_in,  const KParam in,
                   __global const Tp *d_pos, const KParam pos,
                   __global const Tp *d_qos, const KParam qos,
                   const float offGrid, const bool pBatch)
 {
-    const dim_t omId = idw * out.strides[3] + idz * out.strides[2]
+    const int omId = idw * out.strides[3] + idz * out.strides[2]
                      + idy * out.strides[1] + idx;
-    dim_t pmId = idy * pos.strides[1] + idx;
-    dim_t qmId = idy * qos.strides[1] + idx;
+    int pmId = idy * pos.strides[1] + idx;
+    int qmId = idy * qos.strides[1] + idx;
     if(pBatch) {
         pmId += idw * pos.strides[3] + idz * pos.strides[2];
         qmId += idw * qos.strides[3] + idz * qos.strides[2];
@@ -88,10 +88,10 @@ void core_linear2(const dim_t idx, const dim_t idy, const dim_t idz, const dim_t
         return;
     }
 
-    const dim_t grid_x = floor(x),   grid_y = floor(y);   // nearest grid
+    const int grid_x = floor(x),   grid_y = floor(y);   // nearest grid
     const Tp off_x  = x - grid_x, off_y  = y - grid_y; // fractional offset
 
-    dim_t ioff = idw * in.strides[3] + idz * in.strides[2] + grid_y * in.strides[1] + grid_x;
+    int ioff = idw * in.strides[3] + idz * in.strides[2] + grid_y * in.strides[1] + grid_x;
 
     // Check if pVal and pVal + 1 are both valid indices
     bool condY = (y < in.dims[1] - 1);
@@ -126,17 +126,17 @@ void approx2_kernel(__global       Ty *d_out, const KParam out,
                     __global const Ty *d_in,  const KParam in,
                     __global const Tp *d_pos, const KParam pos,
                     __global const Tp *d_qos, const KParam qos,
-                    const float offGrid, const dim_t blocksMatX, const dim_t blocksMatY,
+                    const float offGrid, const int blocksMatX, const int blocksMatY,
                     const int pBatch)
 {
-    const dim_t idz = get_group_id(0) / blocksMatX;
-    const dim_t idw = get_group_id(1) / blocksMatY;
+    const int idz = get_group_id(0) / blocksMatX;
+    const int idw = get_group_id(1) / blocksMatY;
 
-    const dim_t blockIdx_x = get_group_id(0) - idz * blocksMatX;
-    const dim_t blockIdx_y = get_group_id(1) - idw * blocksMatY;
+    const int blockIdx_x = get_group_id(0) - idz * blocksMatX;
+    const int blockIdx_y = get_group_id(1) - idw * blocksMatY;
 
-    const dim_t idx = get_local_id(0) + blockIdx_x * get_local_size(0);
-    const dim_t idy = get_local_id(1) + blockIdx_y * get_local_size(1);
+    const int idx = get_local_id(0) + blockIdx_x * get_local_size(0);
+    const int idy = get_local_id(1) + blockIdx_y * get_local_size(1);
 
     if(idx >= out.dims[0] ||
        idy >= out.dims[1] ||

--- a/src/backend/opencl/kernel/unwrap.cl
+++ b/src/backend/opencl/kernel/unwrap.cl
@@ -10,33 +10,33 @@
 __kernel
 void unwrap_kernel(__global T *d_out, const KParam out,
                    __global const T *d_in, const KParam in,
-                   const dim_t wx, const dim_t wy, const dim_t sx, const dim_t sy,
-                   const dim_t px, const dim_t py, const dim_t nx, const dim_t reps)
+                   const int wx, const int wy, const int sx, const int sy,
+                   const int px, const int py, const int nx, const int reps)
 {
     // Compute channel and volume
-    const dim_t w = get_group_id(1) / in.dims[2];
-    const dim_t z = get_group_id(1) - w * in.dims[2]; // get_group_id(1) % in.dims[2];
+    const int w = get_group_id(1) / in.dims[2];
+    const int z = get_group_id(1) - w * in.dims[2]; // get_group_id(1) % in.dims[2];
 
     if(w >= in.dims[3] || z >= in.dims[2])
         return;
 
     // Compute offset for channel and volume
-    const dim_t cOut = w * out.strides[3] + z * out.strides[2];
-    const dim_t cIn  = w *  in.strides[3] + z *  in.strides[2];
+    const int cOut = w * out.strides[3] + z * out.strides[2];
+    const int cIn  = w *  in.strides[3] + z *  in.strides[2];
 
     // Compute the output column index
-    const dim_t id = is_column ?
+    const int id = is_column ?
         (get_group_id(0) * get_local_size(1) + get_local_id(1)) :
         get_global_id(0);
 
     if (id >= (is_column ? out.dims[1] : out.dims[0])) return;
 
     // Compute the starting index of window in x and y of input
-    const dim_t startx = (id % nx) * sx;
-    const dim_t starty = (id / nx) * sy;
+    const int startx = (id % nx) * sx;
+    const int starty = (id / nx) * sy;
 
-    const dim_t spx = startx - px;
-    const dim_t spy = starty - py;
+    const int spx = startx - px;
+    const int spy = starty - py;
 
     // Offset the global pointers to the respective starting indices
     __global       T* optr = d_out + cOut + id * (is_column ? out.strides[1] : 1);
@@ -47,7 +47,7 @@ void unwrap_kernel(__global T *d_out, const KParam out,
     for(int i = 0; i < reps; i++) {
 
         // Compute output index local to column
-        const dim_t outIdx = is_column ?
+        const int outIdx = is_column ?
             (i * get_local_size(0) + get_local_id(0)) :
             (i * get_local_size(1) + get_local_id(1));
 
@@ -55,16 +55,16 @@ void unwrap_kernel(__global T *d_out, const KParam out,
             return;
 
         // Compute input index local to window
-        const dim_t y = outIdx / wx;
-        const dim_t x = outIdx % wx;
+        const int y = outIdx / wx;
+        const int x = outIdx % wx;
 
-        const dim_t xpad = spx + x;
-        const dim_t ypad = spy + y;
+        const int xpad = spx + x;
+        const int ypad = spy + y;
 
         // Copy
         T val = ZERO;
         if(cond || (xpad >= 0 && xpad < in.dims[0] && ypad >= 0 && ypad < in.dims[1])) {
-            const dim_t inIdx = ypad * in.strides[1] + xpad * in.strides[0];
+            const int inIdx = ypad * in.strides[1] + xpad * in.strides[0];
             val = iptr[inIdx];
         }
 

--- a/src/backend/opencl/kernel/wrap.cl
+++ b/src/backend/opencl/kernel/wrap.cl
@@ -10,21 +10,21 @@
 __kernel
 void wrap_kernel(__global T *optr, KParam out,
                  __global T *iptr, KParam in,
-                 const dim_t wx, const dim_t wy,
-                 const dim_t sx, const dim_t sy,
-                 const dim_t px, const dim_t py,
-                 const dim_t nx, const dim_t ny,
-                 dim_t groups_x,
-                 dim_t groups_y)
+                 const int wx, const int wy,
+                 const int sx, const int sy,
+                 const int px, const int py,
+                 const int nx, const int ny,
+                 int groups_x,
+                 int groups_y)
 {
-    dim_t idx2 = get_group_id(0) / groups_x;
-    dim_t idx3 = get_group_id(1) / groups_y;
+    int idx2 = get_group_id(0) / groups_x;
+    int idx3 = get_group_id(1) / groups_y;
 
-    dim_t groupId_x = get_group_id(0) - idx2 * groups_x;
-    dim_t groupId_y = get_group_id(1) - idx3 * groups_y;
+    int groupId_x = get_group_id(0) - idx2 * groups_x;
+    int groupId_y = get_group_id(1) - idx3 * groups_y;
 
-    dim_t oidx0 = get_local_id(0) + get_local_size(0) * groupId_x;
-    dim_t oidx1 = get_local_id(1) + get_local_size(1) * groupId_y;
+    int oidx0 = get_local_id(0) + get_local_size(0) * groupId_x;
+    int oidx1 = get_local_id(1) + get_local_size(1) * groupId_y;
 
     optr += idx2 * out.strides[2] + idx3 * out.strides[3];
     iptr += idx2 *  in.strides[2] + idx3 *  in.strides[3] + in.offset;
@@ -32,30 +32,30 @@ void wrap_kernel(__global T *optr, KParam out,
 
     if (oidx0 >= out.dims[0] || oidx1 >= out.dims[1]) return;
 
-    dim_t pidx0 = oidx0 + px;
-    dim_t pidx1 = oidx1 + py;
+    int pidx0 = oidx0 + px;
+    int pidx1 = oidx1 + py;
 
     // The last time a value appears in the unwrapped index is padded_index / stride
     // Each previous index has the value appear "stride" locations earlier
     // We work our way back from the last index
 
-    const dim_t x_end = min(pidx0 / sx, nx - 1);
-    const dim_t y_end = min(pidx1 / sy, ny - 1);
+    const int x_end = min(pidx0 / sx, nx - 1);
+    const int y_end = min(pidx1 / sy, ny - 1);
 
-    const dim_t x_off = pidx0 - sx * x_end;
-    const dim_t y_off = pidx1 - sy * y_end;
+    const int x_off = pidx0 - sx * x_end;
+    const int y_off = pidx1 - sy * y_end;
 
     T val = ZERO;
-    dim_t idx = 1;
+    int idx = 1;
 
-    for (dim_t y = y_end, yo = y_off; y >= 0 && yo < wy; yo += sy, y--) {
-        dim_t win_end_y = yo * wx;
-        dim_t dim_end_y = y * nx;
+    for (int y = y_end, yo = y_off; y >= 0 && yo < wy; yo += sy, y--) {
+        int win_end_y = yo * wx;
+        int dim_end_y = y * nx;
 
-        for (dim_t x = x_end, xo = x_off; x >= 0 && xo < wx; xo += sx, x--) {
+        for (int x = x_end, xo = x_off; x >= 0 && xo < wx; xo += sx, x--) {
 
-            dim_t win_end = win_end_y + xo;
-            dim_t dim_end = dim_end_y + x;
+            int win_end = win_end_y + xo;
+            int dim_end = dim_end_y + x;
 
             if (is_column) {
                 idx = dim_end * in.strides[1] + win_end;


### PR DESCRIPTION
[skip ci]

Fixes #1410