### PR TITLE
FEAT Add fallback to CUDA OpenGL Interop

### DIFF
--- a/src/backend/cuda/hist_graphics.cu
+++ b/src/backend/cuda/hist_graphics.cu
@@ -21,23 +21,35 @@ namespace cuda
 template<typename T>
 void copy_histogram(const Array<T> &data, const fg::Histogram* hist)
 {
-    const T *d_P = data.get();
+    if(InteropManager::checkGraphicsInteropCapability()) {
+        const T *d_P = data.get();
 
-    InteropManager& intrpMngr = InteropManager::getInstance();
+        InteropManager& intrpMngr = InteropManager::getInstance();
 
-    cudaGraphicsResource *cudaVBOResource = intrpMngr.getBufferResource(hist);
-    // Map resource. Copy data to VBO. Unmap resource.
-    size_t num_bytes = hist->size();
-    T* d_vbo = NULL;
-    cudaGraphicsMapResources(1, &cudaVBOResource, 0);
-    cudaGraphicsResourceGetMappedPointer((void **)&d_vbo, &num_bytes, cudaVBOResource);
-    cudaMemcpyAsync(d_vbo, d_P, num_bytes, cudaMemcpyDeviceToDevice,
-                    cuda::getStream(cuda::getActiveDeviceId()));
-    cudaGraphicsUnmapResources(1, &cudaVBOResource, 0);
+        cudaGraphicsResource *cudaVBOResource = intrpMngr.getBufferResource(hist);
+        // Map resource. Copy data to VBO. Unmap resource.
+        size_t num_bytes = hist->size();
+        T* d_vbo = NULL;
+        cudaGraphicsMapResources(1, &cudaVBOResource, 0);
+        cudaGraphicsResourceGetMappedPointer((void **)&d_vbo, &num_bytes, cudaVBOResource);
+        cudaMemcpyAsync(d_vbo, d_P, num_bytes, cudaMemcpyDeviceToDevice,
+                        cuda::getStream(cuda::getActiveDeviceId()));
+        cudaGraphicsUnmapResources(1, &cudaVBOResource, 0);
 
-    CheckGL("After cuda resource copy");
+        CheckGL("After cuda resource copy");
 
-    POST_LAUNCH_CHECK();
+        POST_LAUNCH_CHECK();
+    } else {
+        CheckGL("Begin CUDA fallback-resource copy");
+        glBindBuffer(GL_ARRAY_BUFFER, hist->vbo());
+        GLubyte* ptr = (GLubyte*)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        if (ptr) {
+            CUDA_CHECK(cudaMemcpy(ptr, data.get(), hist->size(), cudaMemcpyDeviceToHost));
+            glUnmapBuffer(GL_ARRAY_BUFFER);
+        }
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        CheckGL("End CUDA fallback-resource copy");
+    }
 }
 
 #define INSTANTIATE(T)  \

--- a/src/backend/cuda/image.cu
+++ b/src/backend/cuda/image.cu
@@ -26,22 +26,35 @@ namespace cuda
 template<typename T>
 void copy_image(const Array<T> &in, const fg::Image* image)
 {
-    InteropManager& intrpMngr = InteropManager::getInstance();
+    if(InteropManager::checkGraphicsInteropCapability()) {
+        InteropManager& intrpMngr = InteropManager::getInstance();
 
-    cudaGraphicsResource *cudaPBOResource = intrpMngr.getBufferResource(image);
+        cudaGraphicsResource *cudaPBOResource = intrpMngr.getBufferResource(image);
 
-    const T *d_X = in.get();
-    // Map resource. Copy data to PBO. Unmap resource.
-    size_t num_bytes;
-    T* d_pbo = NULL;
-    cudaGraphicsMapResources(1, &cudaPBOResource, 0);
-    cudaGraphicsResourceGetMappedPointer((void **)&d_pbo, &num_bytes, cudaPBOResource);
-    cudaMemcpyAsync(d_pbo, d_X, num_bytes, cudaMemcpyDeviceToDevice,
-                    cuda::getStream(cuda::getActiveDeviceId()));
-    cudaGraphicsUnmapResources(1, &cudaPBOResource, 0);
+        const T *d_X = in.get();
+        // Map resource. Copy data to PBO. Unmap resource.
+        size_t num_bytes;
+        T* d_pbo = NULL;
+        cudaGraphicsMapResources(1, &cudaPBOResource, 0);
+        cudaGraphicsResourceGetMappedPointer((void **)&d_pbo, &num_bytes, cudaPBOResource);
+        cudaMemcpyAsync(d_pbo, d_X, num_bytes, cudaMemcpyDeviceToDevice,
+                        cuda::getStream(cuda::getActiveDeviceId()));
+        cudaGraphicsUnmapResources(1, &cudaPBOResource, 0);
 
-    POST_LAUNCH_CHECK();
-    CheckGL("After cuda resource copy");
+        POST_LAUNCH_CHECK();
+        CheckGL("After cuda resource copy");
+    } else {
+        CheckGL("Begin CUDA fallback-resource copy");
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, image->pbo());
+        glBufferData(GL_PIXEL_UNPACK_BUFFER, image->size(), 0, GL_STREAM_DRAW);
+        GLubyte* ptr = (GLubyte*)glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY);
+        if (ptr) {
+            CUDA_CHECK(cudaMemcpy(ptr, in.get(), image->size(), cudaMemcpyDeviceToHost));
+            glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);
+        }
+        glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+        CheckGL("End CUDA fallback-resource copy");
+    }
 }
 
 #define INSTANTIATE(T)      \

--- a/src/backend/cuda/interopManager.cu
+++ b/src/backend/cuda/interopManager.cu
@@ -134,6 +134,28 @@ cudaGraphicsResource* InteropManager::getBufferResource(const fg::Surface* key)
     return interop_maps[device][key_value];
 }
 
+bool InteropManager::checkGraphicsInteropCapability()
+{
+    static bool run_once = true;
+    static bool capable  = true;
+
+    if(run_once) {
+        unsigned int pCudaEnabledDeviceCount = 0;
+        int pCudaGraphicsEnabledDeviceIds = 0;
+        cudaGetLastError(); // Reset Errors
+        cudaError_t err = cudaGLGetDevices(&pCudaEnabledDeviceCount, &pCudaGraphicsEnabledDeviceIds, getDeviceCount(), cudaGLDeviceListAll);
+        if(err == 63) { // OS Support Failure - Happens when devices are only Tesla
+            capable = false;
+            printf("Warning: No CUDA Device capable of CUDA-OpenGL. CUDA-OpenGL Interop will use CPU fallback.\n");
+            printf("Corresponding CUDA Error (%d): %s.\n", err, cudaGetErrorString(err));
+            printf("This may happen if all CUDA Devices are in TCC Mode and/or not connected to a display.\n");
+        }
+        cudaGetLastError(); // Reset Errors
+        run_once = false;
+    }
+    return capable;
+}
+
 }
 
 #endif

--- a/src/backend/cuda/interopManager.hpp
+++ b/src/backend/cuda/interopManager.hpp
@@ -37,6 +37,8 @@ class InteropManager
 
     public:
         static InteropManager& getInstance();
+        static bool checkGraphicsInteropCapability();
+
         ~InteropManager();
         cudaGraphicsResource* getBufferResource(const fg::Image* handle);
         cudaGraphicsResource* getBufferResource(const fg::Plot* handle);

--- a/src/backend/cuda/plot3.cu
+++ b/src/backend/cuda/plot3.cu
@@ -26,23 +26,35 @@ namespace cuda
 template<typename T>
 void copy_plot3(const Array<T> &P, fg::Plot3* plot3)
 {
-    const T *d_P = P.get();
+    if(InteropManager::checkGraphicsInteropCapability()) {
+        const T *d_P = P.get();
 
-    InteropManager& intrpMngr = InteropManager::getInstance();
+        InteropManager& intrpMngr = InteropManager::getInstance();
 
-    cudaGraphicsResource *cudaVBOResource = intrpMngr.getBufferResource(plot3);
-    // Map resource. Copy data to VBO. Unmap resource.
-    size_t num_bytes = plot3->size();
-    T* d_vbo = NULL;
-    cudaGraphicsMapResources(1, &cudaVBOResource, 0);
-    cudaGraphicsResourceGetMappedPointer((void **)&d_vbo, &num_bytes, cudaVBOResource);
-    cudaMemcpyAsync(d_vbo, d_P, num_bytes, cudaMemcpyDeviceToDevice,
-               cuda::getStream(cuda::getActiveDeviceId()));
-    cudaGraphicsUnmapResources(1, &cudaVBOResource, 0);
+        cudaGraphicsResource *cudaVBOResource = intrpMngr.getBufferResource(plot3);
+        // Map resource. Copy data to VBO. Unmap resource.
+        size_t num_bytes = plot3->size();
+        T* d_vbo = NULL;
+        cudaGraphicsMapResources(1, &cudaVBOResource, 0);
+        cudaGraphicsResourceGetMappedPointer((void **)&d_vbo, &num_bytes, cudaVBOResource);
+        cudaMemcpyAsync(d_vbo, d_P, num_bytes, cudaMemcpyDeviceToDevice,
+                cuda::getStream(cuda::getActiveDeviceId()));
+        cudaGraphicsUnmapResources(1, &cudaVBOResource, 0);
 
-    CheckGL("After cuda resource copy");
+        CheckGL("After cuda resource copy");
 
-    POST_LAUNCH_CHECK();
+        POST_LAUNCH_CHECK();
+    } else {
+        CheckGL("Begin CUDA fallback-resource copy");
+        glBindBuffer(GL_ARRAY_BUFFER, plot3->vbo());
+        GLubyte* ptr = (GLubyte*)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        if (ptr) {
+            CUDA_CHECK(cudaMemcpy(ptr, P.get(), plot3->size(), cudaMemcpyDeviceToHost));
+            glUnmapBuffer(GL_ARRAY_BUFFER);
+        }
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        CheckGL("End CUDA fallback-resource copy");
+    }
 }
 
 #define INSTANTIATE(T)  \

--- a/src/backend/cuda/surface.cu
+++ b/src/backend/cuda/surface.cu
@@ -26,23 +26,35 @@ namespace cuda
 template<typename T>
 void copy_surface(const Array<T> &P, fg::Surface* surface)
 {
-    const T *d_P = P.get();
+    if(InteropManager::checkGraphicsInteropCapability()) {
+        const T *d_P = P.get();
 
-    InteropManager& intrpMngr = InteropManager::getInstance();
+        InteropManager& intrpMngr = InteropManager::getInstance();
 
-    cudaGraphicsResource *cudaVBOResource = intrpMngr.getBufferResource(surface);
-    // Map resource. Copy data to VBO. Unmap resource.
-    size_t num_bytes = surface->size();
-    T* d_vbo = NULL;
-    cudaGraphicsMapResources(1, &cudaVBOResource, 0);
-    cudaGraphicsResourceGetMappedPointer((void **)&d_vbo, &num_bytes, cudaVBOResource);
-    cudaMemcpyAsync(d_vbo, d_P, num_bytes, cudaMemcpyDeviceToDevice,
-               cuda::getStream(cuda::getActiveDeviceId()));
-    cudaGraphicsUnmapResources(1, &cudaVBOResource, 0);
+        cudaGraphicsResource *cudaVBOResource = intrpMngr.getBufferResource(surface);
+        // Map resource. Copy data to VBO. Unmap resource.
+        size_t num_bytes = surface->size();
+        T* d_vbo = NULL;
+        cudaGraphicsMapResources(1, &cudaVBOResource, 0);
+        cudaGraphicsResourceGetMappedPointer((void **)&d_vbo, &num_bytes, cudaVBOResource);
+        cudaMemcpyAsync(d_vbo, d_P, num_bytes, cudaMemcpyDeviceToDevice,
+                cuda::getStream(cuda::getActiveDeviceId()));
+        cudaGraphicsUnmapResources(1, &cudaVBOResource, 0);
 
-    CheckGL("After cuda resource copy");
+        CheckGL("After cuda resource copy");
 
-    POST_LAUNCH_CHECK();
+        POST_LAUNCH_CHECK();
+    } else {
+        CheckGL("Begin CUDA fallback-resource copy");
+        glBindBuffer(GL_ARRAY_BUFFER, surface->vbo());
+        GLubyte* ptr = (GLubyte*)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        if (ptr) {
+            CUDA_CHECK(cudaMemcpy(ptr, P.get(), surface->size(), cudaMemcpyDeviceToHost));
+            glUnmapBuffer(GL_ARRAY_BUFFER);
+        }
+        glBindBuffer(GL_ARRAY_BUFFER, 0);
+        CheckGL("End CUDA fallback-resource copy");
+    }
 }
 
 #define INSTANTIATE(T)  \


### PR DESCRIPTION
This comes into play when devices are not graphics capable but OpenGL is
available.

On Windows, when all devices are in TCC mode or not connected to display, CUDA
throws an error `CUDA Error (63): OS call failed or operation not supported on this OS`.

On Linux, if all devices are in TCC mode, the graphics part will still run as
long as OpenGL is available.

The checking function uses the [cudaGLGetDevices](http://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__OPENGL.html#group__CUDART__OPENGL_1g3471ecaa5b827c94f2c55ab51fde1751).
This function returns
* Linux: `cudaErrorNoDevices (38)` if all the devices are in TCC mode
* OSX: This function is not supported and returns `cudaErrorNotSupported (71)`.
There is no need for fallback in these cases.

Fixes #1402 