### PR TITLE
BUGFIX: Fixes to index and array_proxy classes when using c++11

### DIFF
--- a/docs/details/index.dox
+++ b/docs/details/index.dox
@@ -4,7 +4,7 @@
 
 \defgroup index_func_index index
 
-\brief lookup values on array based on sequences
+\brief lookup values on array based on sequences and/or arrays
 
 \ingroup index_mat
 

--- a/include/af/index.h
+++ b/include/af/index.h
@@ -293,10 +293,12 @@ extern "C" {
     ///
     /// \brief Create an quadruple of af_index_t array
     ///
+    /// \snippet test/index.cpp ex_index_util_0
+    ///
     /// \param[out] indexers pointer to location where quadruple af_index_t array is created
     /// \returns \ref af_err error code
     ///
-    /// \ingroup index_func_util
+    /// \ingroup index_func_index
     ///
     AFAPI af_err af_create_indexers(af_index_t** indexers);
 #endif
@@ -305,12 +307,14 @@ extern "C" {
     ///
     /// \brief set \p dim to given indexer af_array \p idx
     ///
+    /// \snippet test/index.cpp ex_index_util_0
+    ///
     /// \param[in] indexer pointer to location where quadruple af_index_t array was created
     /// \param[in] idx is the af_array indexer for given dimension \p dim
     /// \param[in] dim is the dimension to be indexed
     /// \returns \ref af_err error code
     ///
-    /// \ingroup index_func_util
+    /// \ingroup index_func_index
     ///
     AFAPI af_err af_set_array_indexer(af_index_t* indexer, const af_array idx, const dim_t dim);
 #endif
@@ -319,12 +323,17 @@ extern "C" {
     ///
     /// \brief set \p dim to given indexer af_array \p idx
     ///
+    /// This function is similar to \ref af_set_array_indexer in terms of functionality except
+    /// that this version accepts object of type \ref af_seq instead of \ref af_array.
+    ///
+    /// \snippet test/index.cpp ex_index_util_0
+    ///
     /// \param[in] indexer pointer to location where quadruple af_index_t array was created
     /// \param[in] idx is the af_seq indexer for given dimension \p dim
     /// \param[in] dim is the dimension to be indexed
     /// \param[in] is_batch indicates if the sequence based indexing is inside a batch operation
     ///
-    /// \ingroup index_func_util
+    /// \ingroup index_func_index
     ///
     AFAPI af_err af_set_seq_indexer(af_index_t* indexer, const af_seq* idx,
                                   const dim_t dim, const bool is_batch);
@@ -334,6 +343,10 @@ extern "C" {
     ///
     /// \brief set \p dim to given indexer af_array \p idx
     ///
+    ///  This function is alternative to \ref af_set_seq_indexer where instead of passing
+    ///  in an already prepared \ref af_seq object, you pass the arguments necessary for
+    ///  creating an af_seq directly.
+    ///
     /// \param[in] indexer pointer to location where quadruple af_index_t array was created
     /// \param[in] begin is the beginning index of along dimension \p dim
     /// \param[in] end is the beginning index of along dimension \p dim
@@ -342,7 +355,7 @@ extern "C" {
     /// \param[in] is_batch indicates if the sequence based indexing is inside a batch operation
     /// \returns \ref af_err error code
     ///
-    /// \ingroup index_func_util
+    /// \ingroup index_func_index
     ///
     AFAPI af_err af_set_seq_param_indexer(af_index_t* indexer,
                                         const double begin, const double end, const double step,
@@ -353,10 +366,12 @@ extern "C" {
     ///
     /// \brief Release's the memory resource used by the quadruple af_index_t array
     ///
+    /// \snippet test/index.cpp ex_index_util_0
+    ///
     /// \param[in] indexers is pointer to location where quadruple af_index_t array is created
     //  \returns \ref af_err error code
     ///
-    /// \ingroup index_func_util
+    /// \ingroup index_func_index
     ///
     AFAPI af_err af_release_indexers(af_index_t* indexers);
 #endif

--- a/src/api/c/index.cpp
+++ b/src/api/c/index.cpp
@@ -241,6 +241,11 @@ af_err af_create_indexers(af_index_t** indexers)
 {
     try {
         af_index_t* out = new af_index_t[4];
+        for (int i=0; i<4; ++i) {
+            out[i].idx.seq = af_span;
+            out[i].isSeq = true;
+            out[i].isBatch = false;
+        }
         std::swap(*indexers, out);
     }
     CATCHALL;

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -539,6 +539,7 @@ namespace af
     array::array_proxy&
     af::array::array_proxy::operator=(array_proxy &&other) {
         array out = other;
+        other.impl = nullptr;
         return *this = out;
     }
 #endif

--- a/src/api/cpp/index.cpp
+++ b/src/api/cpp/index.cpp
@@ -80,8 +80,10 @@ index::index(const af::index& idx0) {
 }
 
 index::~index() {
-    if (!impl.isSeq)
+    if (!impl.isSeq && impl.idx.arr)
         af_release_array(impl.idx.arr);
+
+
 }
 
 index & index::operator=(const index& idx0) {
@@ -97,10 +99,12 @@ index & index::operator=(const index& idx0) {
 #if __cplusplus > 199711L
 index::index(index &&idx0) {
     impl = idx0.impl;
+    idx0.impl.idx.arr = nullptr;
 }
 
 index& index::operator=(index &&idx0) {
     impl = idx0.impl;
+    idx0.impl.idx.arr = nullptr;
     return *this;
 }
 #endif

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -495,6 +495,64 @@ TYPED_TEST(Indexing, 3D_to_1D)
     DimCheckND<TypeParam>(this->continuous3d_to_1d, TEST_DIR"/index/Continuous3Dto1D.test", 3);
 }
 
+
+TEST(Index, Docs_Util_C_API)
+{
+    //![ex_index_util_0]
+    af_index_t* indexers = 0;
+    af_err err = af_create_indexers(&indexers); // Memory is allocated on heap by the callee
+    // by default all the indexers span all the elements along the given dimension
+
+    //Create array
+    af_array a;
+    unsigned ndims = 2;
+    dim_t dim[] = {10,10};
+    af_randu(&a, ndims, dim, f32);
+
+    //Create index array
+    af_array idx;
+    unsigned n = 1;
+    dim_t d[] = {5};
+    af_range(&idx, n, d, 0, s32);
+
+    af_print_array(a);
+    af_print_array(idx);
+
+    //create array indexer
+    err = af_set_array_indexer(indexers, idx, 1);
+
+    //index with indexers
+    af_array out;
+    af_index_gen(&out, a, 2, indexers); // number of indexers should be two since
+                                        // we have set only second af_index_t
+    if (err != AF_SUCCESS) {
+        printf("Failed in af_index_gen: %d\n", err);
+        throw;
+    }
+    af_print_array(out);
+    af_release_array(out);
+
+    af_seq zeroIndices = af_make_seq(0.0, 9.0, 2.0);
+
+    err = af_set_seq_indexer(indexers, &zeroIndices, 0, false);
+
+    af_print_array(a);
+    af_print_array(out);
+
+    err = af_index_gen(&out, a, 2, indexers);
+    if (err != AF_SUCCESS) {
+        printf("Failed in af_index_gen: %d\n", err);
+        throw;
+    }
+    af_print_array(out);
+
+    af_release_indexers(indexers);
+    af_release_array(a);
+    af_release_array(idx);
+    af_release_array(out);
+    //![ex_index_util_0]
+}
+
 //////////////////////////////// CPP ////////////////////////////////
 TEST(Indexing2D, ColumnContiniousCPP)
 {


### PR DESCRIPTION
Fixes a bug in move constructor for index and array_proxy