### PR TITLE
correct cmake args for local example compile

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -40,7 +40,7 @@ the directory which contains the `ArrayFireConfig.cmake` as an argument to the
 if you were to install ArrayFire to the `local` directory within your home
 folder, the invocation of `cmake` above would be replaced with the following:
 
-    cmake -DArrayFire_ROOT=~/local/share/ArrayFire/ ..
+    cmake -DArrayFire_DIR=$HOME/local/share/ArrayFire/cmake ..
     
 ### Support and Contact Info
 


### PR DESCRIPTION
The suggested cmake invocation for a local arrayfire installation only worked when utilizing `ArrayFire_DIR` as opposed to `ArrayFire_ROOT` and also by specifying the explicit directory containing the referred cmake file. cmake was version 3.5.2 -- perhaps a versioning issue?