### PR TITLE
BUGFIX: Correct input arrays validation in convolve fns

### DIFF
--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -40,7 +40,7 @@ AF_BATCH_KIND identifyBatchKind(const dim4 &sDims, const dim4 &fDims)
     dim_t sn = sDims.ndims();
     dim_t fn = fDims.ndims();
 
-    if (sn==baseDim && fn==baseDim)
+    if ((sn==baseDim && fn==baseDim) || (sn==baseDim-1 && fn==baseDim-1))
         return AF_BATCH_NONE;
     else if (sn==baseDim && (fn>baseDim && fn<=4))
         return AF_BATCH_RHS;
@@ -74,6 +74,8 @@ af_err convolve(af_array *out, const af_array signal, const af_array filter)
 
         AF_BATCH_KIND convBT = identifyBatchKind<baseDim>(sdims, fdims);
 
+        ARG_ASSERT(1, (sdims.ndims()>=1));
+        ARG_ASSERT(2, (fdims.ndims()>=1));
         ARG_ASSERT(1, (convBT != AF_BATCH_UNSUPPORTED && convBT != AF_BATCH_DIFF));
 
         af_array output;

--- a/test/convolve.cpp
+++ b/test/convolve.cpp
@@ -668,3 +668,25 @@ TEST(GFOR, convolve2_MM)
         ASSERT_EQ(max<double>(abs(c_ii - b_ii)) < 1E-5, true);
     }
 }
+
+TEST(Convolve, UnitLengthLastDimension)
+{
+    try {
+        af::array x = af::constant(1, 3, 3, 1, 1);
+        af::array y = af::constant(2, 2, 2, 1, 1);
+        af::array z = af::convolve2(x, y, AF_CONV_EXPAND);
+        af::array w = af::convolve3(x, y, AF_CONV_EXPAND);
+        ASSERT_EQ(z.elements(), w.elements());
+
+        std::vector<float> zHost(z.elements());
+        std::vector<float> wHost(w.elements());
+        z.host((void*)zHost.data());
+        w.host((void*)wHost.data());
+
+        for (uint i=0; i<zHost.size(); ++i) {
+            ASSERT_EQ(std::fabs(zHost[i]-wHost[i]) < 1E-5, true);
+        }
+    } catch (af::exception &e) {
+        std::cout << "What is : " << e.what() << ", Code is "<< e.err() << std::endl;
+    }
+}


### PR DESCRIPTION
Fixes #1442 

Earlier to this change, if an n-1 dimensional array and filter were
provided as inputs to af_convolve(n) function, it used to error out
as it expected the nth dimension of arrays to be >1.

After this change, there is no such restriction. For example,
2d arrays passed onto af_convolve3 should give same output as
passing them to af_convolve2. Have added a test checking the same.