### PR TITLE
Delegate convolve[3|2] calls to lower dim versions when appropriate

### DIFF
--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -198,6 +198,10 @@ af_err af_convolve2(af_array *out, const af_array signal, const af_array filter,
         if (isFreqDomain<2>(signal, filter, domain))
             return af_fft_convolve2(out, signal, filter, mode);
 
+        if (getInfo(signal).dims().ndims()<2 && getInfo(filter).dims().ndims()<2) {
+            return af_convolve1(out, signal, filter, mode, domain);
+        }
+
         if (mode == AF_CONV_EXPAND)
             return convolve<2, true >(out, signal, filter);
         else
@@ -210,6 +214,10 @@ af_err af_convolve3(af_array *out, const af_array signal, const af_array filter,
     try {
         if (isFreqDomain<3>(signal, filter, domain))
             return af_fft_convolve3(out, signal, filter, mode);
+
+        if (getInfo(signal).dims().ndims()<3 && getInfo(filter).dims().ndims()<3) {
+            return af_convolve2(out, signal, filter, mode, domain);
+        }
 
         if (mode == AF_CONV_EXPAND)
             return convolve<3, true >(out, signal, filter);

--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -195,12 +195,12 @@ af_err af_convolve1(af_array *out, const af_array signal, const af_array filter,
 af_err af_convolve2(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode, af_conv_domain domain)
 {
     try {
-        if (isFreqDomain<2>(signal, filter, domain))
-            return af_fft_convolve2(out, signal, filter, mode);
-
         if (getInfo(signal).dims().ndims()<2 && getInfo(filter).dims().ndims()<2) {
             return af_convolve1(out, signal, filter, mode, domain);
         }
+
+        if (isFreqDomain<2>(signal, filter, domain))
+            return af_fft_convolve2(out, signal, filter, mode);
 
         if (mode == AF_CONV_EXPAND)
             return convolve<2, true >(out, signal, filter);
@@ -212,12 +212,12 @@ af_err af_convolve2(af_array *out, const af_array signal, const af_array filter,
 af_err af_convolve3(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode, af_conv_domain domain)
 {
     try {
-        if (isFreqDomain<3>(signal, filter, domain))
-            return af_fft_convolve3(out, signal, filter, mode);
-
         if (getInfo(signal).dims().ndims()<3 && getInfo(filter).dims().ndims()<3) {
             return af_convolve2(out, signal, filter, mode, domain);
         }
+
+        if (isFreqDomain<3>(signal, filter, domain))
+            return af_fft_convolve3(out, signal, filter, mode);
 
         if (mode == AF_CONV_EXPAND)
             return convolve<3, true >(out, signal, filter);

--- a/src/api/c/fftconvolve.cpp
+++ b/src/api/c/fftconvolve.cpp
@@ -166,10 +166,18 @@ af_err af_fft_convolve1(af_array *out, const af_array signal, const af_array fil
 
 af_err af_fft_convolve2(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode)
 {
-    return fft_convolve<2>(out, signal, filter, mode == AF_CONV_EXPAND);
+    if (getInfo(signal).dims().ndims()<2 && getInfo(filter).dims().ndims()<2) {
+        return fft_convolve<1>(out, signal, filter, mode == AF_CONV_EXPAND);
+    } else {
+        return fft_convolve<2>(out, signal, filter, mode == AF_CONV_EXPAND);
+    }
 }
 
 af_err af_fft_convolve3(af_array *out, const af_array signal, const af_array filter, const af_conv_mode mode)
 {
-    return fft_convolve<3>(out, signal, filter, mode == AF_CONV_EXPAND);
+    if (getInfo(signal).dims().ndims()<3 && getInfo(filter).dims().ndims()<3) {
+        return fft_convolve<2>(out, signal, filter, mode == AF_CONV_EXPAND);
+    } else {
+        return fft_convolve<3>(out, signal, filter, mode == AF_CONV_EXPAND);
+    }
 }


### PR DESCRIPTION
Fixes #1442

af_convolve2 & af_convolve3 will now delegate calls to af_convolve1 &
af_convolve2 respectively, when the input arrays are of lower dimension
than their's.

For example, if the input arrays of af_convolve3 are two dimensional,
the function call will be forwarded to af_convolve2.