### PR TITLE
Fixes for CUDA computes for 6x

### DIFF
--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -61,7 +61,7 @@ MACRO(SET_COMPUTE VERSION)
 ENDMACRO(SET_COMPUTE)
 
 # Iterate over compute versions. Create variables and enable computes if needed
-FOREACH(VER 20 30 32 35 37 50 52 53)
+FOREACH(VER 20 30 32 35 37 50 52 53 60 61 62)
     OPTION(CUDA_COMPUTE_${VER} "CUDA Compute Capability ${VER}" OFF)
     MARK_AS_ADVANCED(CUDA_COMPUTE_${VER})
     IF(${CUDA_COMPUTE_${VER}})

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -53,6 +53,9 @@ static inline int compute2cores(int major, int minor)
         { 0x50, 128 },
         { 0x52, 128 },
         { 0x53, 128 },
+        { 0x60, 128 },
+        { 0x61, 64  },
+        { 0x62, 128 },
         {   -1, -1  },
     };
 


### PR DESCRIPTION
These fixes should have really been made with the CUDA 8 branch but somehow got missed. So in reality, compute_6x was never getting compiled.

Ref #1485 