### PR TITLE
CMake fixes for Xcode generator

### DIFF
--- a/CMakeModules/build_forge.cmake
+++ b/CMakeModules/build_forge.cmake
@@ -2,13 +2,31 @@ INCLUDE(ExternalProject)
 
 SET(prefix ${CMAKE_BINARY_DIR}/third_party/forge)
 
+IF(CMAKE_GENERATOR MATCHES "Xcode") # TODO: Also for "Visual Studio"?
+    # FIXME: Cannot use $<CONFIG> generator expression here because add_custom_command
+    #        does not yet support it for the OUTPUT argument, see also:
+    #        - Old "duplicate":   https://cmake.org/Bug/view.php?id=12877
+    #        - Old issue tracker: https://cmake.org/Bug/view.php?id=13840
+    #        - New issue tracker: https://gitlab.kitware.com/cmake/cmake/issues/13840
+    #        In the meantime, use CMAKE_BUILD_TYPE if set by user, assuming that it
+    #        is the primary build configuration used. Otherwise, default to Release.
+    IF(CMAKE_BUILD_TYPE)
+        SET(forge_lib_config ${CMAKE_BUILD_TYPE})
+    ELSE()
+        SET(forge_lib_config Release)
+    ENDIF()
+    SET(forge_lib_infix "/${forge_lib_config}")
+ELSE()
+    SET(forge_lib_config "$<CONFIG>")
+    SET(forge_lib_infix)
+ENDIF()
 IF(WIN32)
     SET(forge_lib_prefix "${prefix}/lib")
 ELSE(WIN32)
     SET(forge_lib_prefix "${prefix}/src/forge-ext-build/src")
 ENDIF(WIN32)
 
-SET(forge_location "${forge_lib_prefix}/${CMAKE_SHARED_LIBRARY_PREFIX}forge${CMAKE_SHARED_LIBRARY_SUFFIX}")
+SET(forge_location "${forge_lib_prefix}${forge_lib_infix}/${CMAKE_SHARED_LIBRARY_PREFIX}forge${CMAKE_SHARED_LIBRARY_SUFFIX}")
 IF(CMAKE_VERSION VERSION_LESS 3.2)
     IF(CMAKE_GENERATOR MATCHES "Ninja")
         MESSAGE(WARNING "Building forge with Ninja has known issues with CMake older than 3.2")
@@ -36,6 +54,7 @@ ExternalProject_Add(
     -DGLFW_ROOT_DIR:STRING=${GLFW_ROOT_DIR}
     -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
     -DBUILD_EXAMPLES:BOOL=OFF
+    BUILD_COMMAND ${CMAKE_COMMAND} --build . --config ${forge_lib_config}
     ${byproducts}
     )
 
@@ -46,7 +65,7 @@ SET_TARGET_PROPERTIES(forge PROPERTIES IMPORTED_LOCATION ${forge_location})
 IF(WIN32)
     SET_TARGET_PROPERTIES(forge PROPERTIES IMPORTED_IMPLIB ${forge_lib_prefix}/forge.lib)
 ELSE(WIN32)
-    SET(forge_bindir_location ${binary_dir}/src/${CMAKE_SHARED_LIBRARY_PREFIX}forge${CMAKE_SHARED_LIBRARY_SUFFIX})
+    SET(forge_bindir_location ${binary_dir}/src${forge_lib_infix}/${CMAKE_SHARED_LIBRARY_PREFIX}forge${CMAKE_SHARED_LIBRARY_SUFFIX})
     IF(NOT (${forge_bindir_location} STREQUAL ${forge_location}))
         MESSAGE(WARNING "Did the forge binary location move? (Have ${forge_bindir_location} vs ${forge_location})")
     ENDIF()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -139,11 +139,13 @@ ELSE(${USE_RELATIVE_TEST_DIR})  # Not using relative test data directory
     SET(TESTDATA_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/data")
 ENDIF(${USE_RELATIVE_TEST_DIR})
 
-IF (${CMAKE_GENERATOR} STREQUAL "Xcode")
+# Workaround for Xcode generator escaping issue, see
+# - https://cmake.org/cmake/help/v3.5/release/3.5.html#deprecated-and-removed-features
+IF (CMAKE_VERSION VERSION_LESS 3.5 AND ${CMAKE_GENERATOR} STREQUAL "Xcode")
     ADD_DEFINITIONS("-D TEST_DIR=\"\\\\\"${TESTDATA_SOURCE_DIR}\\\\\"\"")
-ELSE (${CMAKE_GENERATOR} STREQUAL "Xcode")
+ELSE (CMAKE_VERSION VERSION_LESS 3.5 AND ${CMAKE_GENERATOR} STREQUAL "Xcode")
     ADD_DEFINITIONS("-D TEST_DIR=\"\\\"${TESTDATA_SOURCE_DIR}\\\"\"")
-ENDIF (${CMAKE_GENERATOR} STREQUAL "Xcode")
+ENDIF (CMAKE_VERSION VERSION_LESS 3.5 AND ${CMAKE_GENERATOR} STREQUAL "Xcode")
 
 IF(NOT ${USE_RELATIVE_TEST_DIR})
     # Check if data exists


### PR DESCRIPTION
Disclaimer: Fixes the build issue with Xcode generator. Have not tested Makefile generator.
- [x] Test if non-IDE build still works.

* Closes #1492 - FIX: xforge-ext library file path when build with Xcode
* Closes #1494 - Fix escape character issues with Xcode generator.