### PR TITLE
FIX: find_backend(Unified) in build tree ArrayFireConfig.cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,7 @@ ENDIF(FORGE_FOUND AND NOT USE_SYSTEM_FORGE)
 ## configuration to be used from the binary directory directly
 SET(INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 SET(BACKEND_DIR "src/backend/\${lowerbackend}")
+SET(UNIFIED_DIR "src/api/unified")
 CONFIGURE_FILE(
     ${CMAKE_MODULE_PATH}/ArrayFireConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/ArrayFireConfig.cmake
@@ -230,6 +231,7 @@ CONFIGURE_FILE(
 STRING(REGEX REPLACE "[^/]+" ".." reldir "${AF_INSTALL_CMAKE_DIR}")
 SET(INCLUDE_DIR "\${CMAKE_CURRENT_LIST_DIR}/${reldir}/include")
 set(BACKEND_DIR)
+set(UNIFIED_DIR)
 CONFIGURE_FILE(
     ${CMAKE_MODULE_PATH}/ArrayFireConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/Install/ArrayFireConfig.cmake

--- a/CMakeModules/ArrayFireConfig.cmake.in
+++ b/CMakeModules/ArrayFireConfig.cmake.in
@@ -51,7 +51,11 @@
 get_filename_component(ArrayFire_INCLUDE_DIRS "@INCLUDE_DIR@" ABSOLUTE)
 
 macro(find_backend backend libname)
-  set(targetFile ${CMAKE_CURRENT_LIST_DIR}/@BACKEND_DIR@/ArrayFire${backend}.cmake)
+  if (${backend} STREQUAL "Unified")
+    set(targetFile ${CMAKE_CURRENT_LIST_DIR}/@UNIFIED_DIR@/ArrayFire${backend}.cmake)
+  else ()
+    set(targetFile ${CMAKE_CURRENT_LIST_DIR}/@BACKEND_DIR@/ArrayFire${backend}.cmake)
+  endif ()
   if(EXISTS ${targetFile})
     include(${targetFile})
     set(ArrayFire_${backend}_FOUND ON)


### PR DESCRIPTION
The `ArrayFireUnified.cmake` file with the exported Unified backend targets to be imported by `ArrayFireConfig.cmake` file are not found when using the build tree directly because it is located in a different path then the other backend target export files.