### PR TITLE
Avoid instantiating templates for sort direction

### DIFF
--- a/src/api/c/median.cpp
+++ b/src/api/c/median.cpp
@@ -51,7 +51,7 @@ static double median(const af_array& in)
     double mid      = (nElems + 1) / 2;
     af_seq mdSpan[1]= {af_make_seq(mid-1, mid, 1)};
 
-    Array<T> sortedArr = sort<T, true>(input, 0);
+    Array<T> sortedArr = sort<T>(input, 0, true);
 
     af_array sarrHandle = getHandle<T>(sortedArr);
 
@@ -89,7 +89,7 @@ static af_array median(const af_array& in, const dim_t dim)
         return getHandle<T>(result);
     }
 
-    Array<T> sortedIn   = sort<T, true>(input, dim);
+    Array<T> sortedIn   = sort<T>(input, dim, true);
 
     int dimLength = input.dims()[dim];
     double mid    = (dimLength + 1) / 2;

--- a/src/api/c/sort.cpp
+++ b/src/api/c/sort.cpp
@@ -28,11 +28,7 @@ template<typename T>
 static inline af_array sort(const af_array in, const unsigned dim, const bool isAscending)
 {
     const Array<T> &inArray = getArray<T>(in);
-    if(isAscending) {
-        return getHandle(sort<T, 1>(inArray, dim));
-    } else {
-        return getHandle(sort<T, 0>(inArray, dim));
-    }
+    return getHandle(sort<T>(inArray, dim, isAscending));
 }
 
 af_err af_sort(af_array *out, const af_array in, const unsigned dim, const bool isAscending)
@@ -75,11 +71,7 @@ static inline void sort_index(af_array *val, af_array *idx, const af_array in,
     Array<T> valArray = createEmptyArray<T>(af::dim4());
     Array<uint> idxArray = createEmptyArray<uint>(af::dim4());
 
-    if(isAscending) {
-        sort_index<T, 1>(valArray, idxArray, inArray, dim);
-    } else {
-        sort_index<T, 0>(valArray, idxArray, inArray, dim);
-    }
+    sort_index<T>(valArray, idxArray, inArray, dim, isAscending);
     *val = getHandle(valArray);
     *idx = getHandle(idxArray);
 }
@@ -127,11 +119,7 @@ static inline void sort_by_key(af_array *okey, af_array *oval, const af_array ik
     Array<Tk> okeyArray = createEmptyArray<Tk>(af::dim4());
     Array<Tv> ovalArray = createEmptyArray<Tv>(af::dim4());
 
-    if(isAscending) {
-        sort_by_key<Tk, Tv, 1>(okeyArray, ovalArray, ikeyArray, ivalArray, dim);
-    } else {
-        sort_by_key<Tk, Tv, 0>(okeyArray, ovalArray, ikeyArray, ivalArray, dim);
-    }
+    sort_by_key<Tk, Tv>(okeyArray, ovalArray, ikeyArray, ivalArray, dim, isAscending);
     *okey = getHandle(okeyArray);
     *oval = getHandle(ovalArray);
 }

--- a/src/backend/cpu/harris.cpp
+++ b/src/backend/cpu/harris.cpp
@@ -95,7 +95,7 @@ unsigned harris(Array<float> &x_out, Array<float> &y_out, Array<float> &resp_out
         Array<unsigned> harris_idx = createEmptyArray<unsigned>(dim4(corners_found));
 
         // Sort Harris responses
-        sort_index<float, false>(harris_sorted, harris_idx, respCorners, 0);
+        sort_index<float>(harris_sorted, harris_idx, respCorners, 0, false);
 
         x_out = createEmptyArray<float>(dim4(corners_out));
         y_out = createEmptyArray<float>(dim4(corners_out));

--- a/src/backend/cpu/kernel/sort.hpp
+++ b/src/backend/cpu/kernel/sort.hpp
@@ -21,8 +21,8 @@ namespace kernel
 {
 
 // Based off of http://stackoverflow.com/a/12399290
-template<typename T, bool isAscending>
-void sort0Iterative(Array<T> val)
+template<typename T>
+void sort0Iterative(Array<T> val, bool isAscending)
 {
     // initialize original index locations
     T *val_ptr = val.get();

--- a/src/backend/cpu/kernel/sort_by_key.hpp
+++ b/src/backend/cpu/kernel/sort_by_key.hpp
@@ -16,14 +16,14 @@ namespace cpu
 namespace kernel
 {
 
-template<typename Tk, typename Tv, bool isAscending>
-void sort0ByKeyIterative(Array<Tk> okey, Array<Tv> oval);
+template<typename Tk, typename Tv>
+void sort0ByKeyIterative(Array<Tk> okey, Array<Tv> oval, bool isAscending);
 
-template<typename Tk, typename Tv, bool isAscending>
-void sortByKeyBatched(Array<Tk> okey, Array<Tv> oval, const int dim);
+template<typename Tk, typename Tv>
+void sortByKeyBatched(Array<Tk> okey, Array<Tv> oval, const int dim, bool isAscending);
 
-template<typename Tk, typename Tv, bool isAscending>
-void sort0ByKey(Array<Tk> okey, Array<Tv> oval);
+template<typename Tk, typename Tv>
+void sort0ByKey(Array<Tk> okey, Array<Tv> oval, bool isAscending);
 
 }
 }

--- a/src/backend/cpu/kernel/sort_by_key/sort_by_key_impl.cpp
+++ b/src/backend/cpu/kernel/sort_by_key/sort_by_key_impl.cpp
@@ -15,7 +15,6 @@ namespace cpu
 {
 namespace kernel
 {
-    INSTANTIATE1(TYPE,true)
-    INSTANTIATE1(TYPE,false)
+    INSTANTIATE1(TYPE)
 }
 }

--- a/src/backend/cpu/orb.cpp
+++ b/src/backend/cpu/orb.cpp
@@ -158,7 +158,7 @@ unsigned orb(Array<float> &x, Array<float> &y,
         Array<float> harris_sorted = createEmptyArray<float>(af::dim4());
         Array<unsigned> harris_idx = createEmptyArray<unsigned>(af::dim4());
 
-        sort_index<float, false>(harris_sorted, harris_idx, score_harris, 0);
+        sort_index<float>(harris_sorted, harris_idx, score_harris, 0, false);
         getQueue().sync();
 
         usable_feat = std::min(usable_feat, lvl_best[i]);

--- a/src/backend/cpu/set.cpp
+++ b/src/backend/cpu/set.cpp
@@ -33,7 +33,7 @@ Array<T> setUnique(const Array<T> &in,
 
     Array<T> out = createEmptyArray<T>(af::dim4());
     if (is_sorted) out = copyArray<T>(in);
-    else           out = sort<T, 1>(in, 0);
+    else           out = sort<T>(in, 0, true);
 
     // Need to sync old jobs since we need to
     // operator on pointers directly in std::unique

--- a/src/backend/cpu/sort.hpp
+++ b/src/backend/cpu/sort.hpp
@@ -11,6 +11,6 @@
 
 namespace cpu
 {
-    template<typename T, bool isAscending>
-    Array<T> sort(const Array<T> &in, const unsigned dim);
+    template<typename T>
+    Array<T> sort(const Array<T> &in, const unsigned dim, bool isAscending);
 }

--- a/src/backend/cpu/sort_by_key.cpp
+++ b/src/backend/cpu/sort_by_key.cpp
@@ -19,9 +19,9 @@
 namespace cpu
 {
 
-template<typename Tk, typename Tv, bool isAscending>
+template<typename Tk, typename Tv>
 void sort_by_key(Array<Tk> &okey, Array<Tv> &oval,
-           const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim)
+                 const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim, bool isAscending)
 {
     ikey.eval();
     ival.eval();
@@ -30,10 +30,10 @@ void sort_by_key(Array<Tk> &okey, Array<Tv> &oval,
     oval = copyArray<Tv>(ival);
 
     switch(dim) {
-        case 0: getQueue().enqueue(kernel::sort0ByKey<Tk, Tv, isAscending>, okey, oval); break;
-        case 1: getQueue().enqueue(kernel::sortByKeyBatched<Tk, Tv, isAscending>, okey, oval, 1); break;
-        case 2: getQueue().enqueue(kernel::sortByKeyBatched<Tk, Tv, isAscending>, okey, oval, 2); break;
-        case 3: getQueue().enqueue(kernel::sortByKeyBatched<Tk, Tv, isAscending>, okey, oval, 3); break;
+        case 0: getQueue().enqueue(kernel::sort0ByKey<Tk, Tv>, okey, oval, isAscending); break;
+        case 1:
+        case 2:
+        case 3: getQueue().enqueue(kernel::sortByKeyBatched<Tk, Tv>, okey, oval, dim, isAscending); break;
         default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
     }
 
@@ -57,11 +57,9 @@ void sort_by_key(Array<Tk> &okey, Array<Tv> &oval,
 
 #define INSTANTIATE(Tk, Tv)                                             \
     template void                                                       \
-    sort_by_key<Tk, Tv, true>(Array<Tk> &okey, Array<Tv> &oval,         \
-                              const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim); \
-    template void                                                       \
-    sort_by_key<Tk, Tv,false>(Array<Tk> &okey, Array<Tv> &oval,         \
-                              const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim); \
+    sort_by_key<Tk, Tv>(Array<Tk> &okey, Array<Tv> &oval,               \
+                        const Array<Tk> &ikey, const Array<Tv> &ival,   \
+                        const uint dim, bool isAscending);
 
 #define INSTANTIATE1(Tk)       \
     INSTANTIATE(Tk, float)     \

--- a/src/backend/cpu/sort_by_key.hpp
+++ b/src/backend/cpu/sort_by_key.hpp
@@ -11,7 +11,7 @@
 
 namespace cpu
 {
-    template<typename Tk, typename Tv, bool isAscending>
+    template<typename Tk, typename Tv>
     void sort_by_key(Array<Tk> &okey, Array<Tv> &oval,
-               const Array<Tk> &ikey, const Array<Tv> &ival, const unsigned dim);
+                     const Array<Tk> &ikey, const Array<Tv> &ival, const unsigned dim, bool isAscending);
 }

--- a/src/backend/cpu/sort_index.cpp
+++ b/src/backend/cpu/sort_index.cpp
@@ -22,8 +22,8 @@
 namespace cpu
 {
 
-template<typename T, bool isAscending>
-void sort_index(Array<T> &okey, Array<uint> &oval, const Array<T> &in, const uint dim)
+template<typename T>
+void sort_index(Array<T> &okey, Array<uint> &oval, const Array<T> &in, const uint dim, bool isAscending)
 {
     in.eval();
 
@@ -33,10 +33,10 @@ void sort_index(Array<T> &okey, Array<uint> &oval, const Array<T> &in, const uin
     oval.eval();
 
     switch(dim) {
-        case 0: getQueue().enqueue(kernel::sort0ByKey<T, uint, isAscending>, okey, oval); break;
-        case 1: getQueue().enqueue(kernel::sortByKeyBatched<T, uint, isAscending>, okey, oval, 1); break;
-        case 2: getQueue().enqueue(kernel::sortByKeyBatched<T, uint, isAscending>, okey, oval, 2); break;
-        case 3: getQueue().enqueue(kernel::sortByKeyBatched<T, uint, isAscending>, okey, oval, 3); break;
+        case 0: getQueue().enqueue(kernel::sort0ByKey<T, uint>, okey, oval, isAscending); break;
+        case 1:
+        case 2:
+        case 3: getQueue().enqueue(kernel::sortByKeyBatched<T, uint>, okey, oval, dim, isAscending); break;
         default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
     }
 
@@ -59,10 +59,8 @@ void sort_index(Array<T> &okey, Array<uint> &oval, const Array<T> &in, const uin
 }
 
 #define INSTANTIATE(T)                                                  \
-    template void sort_index<T, true>(Array<T> &val, Array<uint> &idx, const Array<T> &in, \
-                                      const uint dim);                  \
-    template void sort_index<T,false>(Array<T> &val, Array<uint> &idx, const Array<T> &in, \
-                                      const uint dim);                  \
+    template void sort_index<T>(Array<T> &val, Array<uint> &idx, const Array<T> &in, \
+                                      const uint dim, bool isAscending);
 
 INSTANTIATE(float)
 INSTANTIATE(double)

--- a/src/backend/cpu/sort_index.hpp
+++ b/src/backend/cpu/sort_index.hpp
@@ -11,6 +11,6 @@
 
 namespace cpu
 {
-    template<typename T, bool isAscending>
-    void sort_index(Array<T> &val, Array<unsigned> &idx, const Array<T> &in, const unsigned dim);
+    template<typename T>
+    void sort_index(Array<T> &val, Array<unsigned> &idx, const Array<T> &in, const unsigned dim, bool isAscending);
 }

--- a/src/backend/cuda/kernel/harris.hpp
+++ b/src/backend/cuda/kernel/harris.hpp
@@ -340,7 +340,7 @@ void harris(unsigned* corners_out,
         kernel::range<uint>(harris_idx, 0);
 
         // Sort Harris responses
-        sort0ByKey<float, uint, false>(harris_responses, harris_idx);
+        sort0ByKey<float, uint>(harris_responses, harris_idx, false);
 
         *x_out = memAlloc<float>(*corners_out);
         *y_out = memAlloc<float>(*corners_out);

--- a/src/backend/cuda/kernel/homography.hpp
+++ b/src/backend/cuda/kernel/homography.hpp
@@ -617,7 +617,7 @@ int computeH(
     if (htype == AF_HOMOGRAPHY_LMEDS) {
         // TODO: Improve this sorting, if the number of iterations is
         // sufficiently large, this can be *very* slow
-        kernel::sort0<float, true>(err);
+        kernel::sort0<float>(err, true);
 
         unsigned minIdx;
         float minMedian;

--- a/src/backend/cuda/kernel/orb.hpp
+++ b/src/backend/cuda/kernel/orb.hpp
@@ -398,7 +398,7 @@ void orb(unsigned* out_feat,
         kernel::range<uint>(harris_idx, 0);
 
         // Sort features according to Harris responses
-        kernel::sort0ByKey<float, uint, false>(harris_sorted, harris_idx);
+        kernel::sort0ByKey<float, uint>(harris_sorted, harris_idx, false);
 
         feat_pyr[i] = std::min(feat_pyr[i], lvl_best[i]);
 

--- a/src/backend/cuda/kernel/sort.hpp
+++ b/src/backend/cuda/kernel/sort.hpp
@@ -23,8 +23,8 @@ namespace cuda
         ///////////////////////////////////////////////////////////////////////////
         // Wrapper functions
         ///////////////////////////////////////////////////////////////////////////
-        template<typename T, bool isAscending>
-        void sort0Iterative(Param<T> val)
+        template<typename T>
+        void sort0Iterative(Param<T> val, bool isAscending)
         {
             thrust::device_ptr<T> val_ptr = thrust::device_pointer_cast(val.ptr);
 
@@ -47,8 +47,8 @@ namespace cuda
             POST_LAUNCH_CHECK();
         }
 
-        template<typename T, bool isAscending, int dim>
-        void sortBatched(Param<T> pVal)
+        template<typename T, int dim>
+        void sortBatched(Param<T> pVal, bool isAscending)
         {
             af::dim4 inDims;
             for(int i = 0; i < 4; i++)
@@ -124,15 +124,15 @@ namespace cuda
             memFree(key);
         }
 
-        template<typename T, bool isAscending>
-        void sort0(Param<T> val)
+        template<typename T>
+        void sort0(Param<T> val, bool isAscending)
         {
             int higherDims =  val.dims[1] * val.dims[2] * val.dims[3];
             // TODO Make a better heurisitic
             if(higherDims > 10)
-                sortBatched<T, isAscending, 0>(val);
+              sortBatched<T, 0>(val, isAscending);
             else
-                kernel::sort0Iterative<T, isAscending>(val);
+              kernel::sort0Iterative<T>(val, isAscending);
         }
     }
 }

--- a/src/backend/cuda/kernel/sort_by_key.hpp
+++ b/src/backend/cuda/kernel/sort_by_key.hpp
@@ -17,14 +17,14 @@ namespace cuda
 {
     namespace kernel
     {
-        template<typename Tk, typename Tv, bool isAscending>
-        void sort0ByKeyIterative(Param<Tk> okey, Param<Tv> oval);
+        template<typename Tk, typename Tv>
+        void sort0ByKeyIterative(Param<Tk> okey, Param<Tv> oval, bool isAscending);
 
-        template<typename Tk, typename Tv, bool isAscending>
-        void sortByKeyBatched(Param<Tk> pKey, Param<Tv> pVal, const int dim);
+        template<typename Tk, typename Tv>
+        void sortByKeyBatched(Param<Tk> pKey, Param<Tv> pVal, const int dim, bool isAscending);
 
-        template<typename Tk, typename Tv, bool isAscending>
-        void sort0ByKey(Param<Tk> okey, Param<Tv> oval);
+        template<typename Tk, typename Tv>
+        void sort0ByKey(Param<Tk> okey, Param<Tv> oval, bool isAscending);
 
     }
 }

--- a/src/backend/cuda/kernel/sort_by_key/CMakeLists.txt
+++ b/src/backend/cuda/kernel/sort_by_key/CMakeLists.txt
@@ -4,9 +4,6 @@ FOREACH(STR ${FILESTRINGS})
     IF(${STR} MATCHES "// SBK_TYPES")
         STRING(REPLACE "// SBK_TYPES:" "" TEMP ${STR})
         STRING(REPLACE " " ";" SBK_TYPES ${TEMP})
-    ELSEIF(${STR} MATCHES "// SBK_DIRS:")
-        STRING(REPLACE "// SBK_DIRS:" "" TEMP ${STR})
-        STRING(REPLACE " " ";" SBK_DIRS ${TEMP})
     ELSEIF(${STR} MATCHES "// SBK_INSTS:")
         STRING(REPLACE "// SBK_INSTS:" "" TEMP ${STR})
         STRING(REPLACE " " ";" SBK_INSTS ${TEMP})
@@ -14,16 +11,14 @@ FOREACH(STR ${FILESTRINGS})
 ENDFOREACH()
 
 FOREACH(SBK_TYPE ${SBK_TYPES})
-    FOREACH(SBK_DIR ${SBK_DIRS})
-        FOREACH(SBK_INST ${SBK_INSTS})
-            CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/kernel/sort_by_key/sort_by_key_impl.cu.in"
-            "${CMAKE_CURRENT_BINARY_DIR}/sort_by_key/sort_by_key_impl_${SBK_TYPE}_${SBK_DIR}_${SBK_INST}.cu")
-            ADD_CUSTOM_COMMAND(
-              OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/sort_by_key/sort_by_key_impl_${SBK_TYPE}_${SBK_DIR}_${SBK_INST}.cu"
-              COMMAND  ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/sort_by_key/sort_by_key_impl_${SBK_TYPE}_${SBK_DIR}_${SBK_INST}.cu"
-              DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/kernel/sort_by_key_impl.hpp")
-        ENDFOREACH(SBK_INST ${SBK_INSTS})
-    ENDFOREACH(SBK_DIR ${SBK_DIRS})
+    FOREACH(SBK_INST ${SBK_INSTS})
+        CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/kernel/sort_by_key/sort_by_key_impl.cu.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/sort_by_key/sort_by_key_impl_${SBK_TYPE}_${SBK_INST}.cu")
+        ADD_CUSTOM_COMMAND(
+          OUTPUT  "${CMAKE_CURRENT_BINARY_DIR}/sort_by_key/sort_by_key_impl_${SBK_TYPE}_${SBK_INST}.cu"
+          COMMAND  ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/sort_by_key/sort_by_key_impl_${SBK_TYPE}_${SBK_INST}.cu"
+          DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/kernel/sort_by_key_impl.hpp")
+    ENDFOREACH(SBK_INST ${SBK_INSTS})
 ENDFOREACH(SBK_TYPE ${SBK_TYPES})
 
 FILE(GLOB sort_by_key_sources

--- a/src/backend/cuda/kernel/sort_by_key/sort_by_key_impl.cu.in
+++ b/src/backend/cuda/kernel/sort_by_key/sort_by_key_impl.cu.in
@@ -19,6 +19,6 @@ namespace cuda
 {
 namespace kernel
 {
-    INSTANTIATE@SBK_INST@(@SBK_TYPE@, @SBK_DIR@)
+    INSTANTIATE@SBK_INST@(@SBK_TYPE@)
 }
 }

--- a/src/backend/cuda/sort.cu
+++ b/src/backend/cuda/sort.cu
@@ -18,15 +18,15 @@
 
 namespace cuda
 {
-    template<typename T, bool isAscending>
-    Array<T> sort(const Array<T> &in, const unsigned dim)
+    template<typename T>
+    Array<T> sort(const Array<T> &in, const unsigned dim, bool isAscending)
     {
         Array<T> out = copyArray<T>(in);
         switch(dim) {
-            case 0: kernel::sort0<T, isAscending>(out); break;
-            case 1: kernel::sortBatched<T, isAscending, 1>(out); break;
-            case 2: kernel::sortBatched<T, isAscending, 2>(out); break;
-            case 3: kernel::sortBatched<T, isAscending, 3>(out); break;
+            case 0: kernel::sort0<T>(out, isAscending); break;
+            case 1: kernel::sortBatched<T, 1>(out, isAscending); break;
+            case 2: kernel::sortBatched<T, 2>(out, isAscending); break;
+            case 3: kernel::sortBatched<T, 3>(out, isAscending); break;
             default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
         }
 
@@ -45,10 +45,9 @@ namespace cuda
         }
         return out;
     }
-
+  
 #define INSTANTIATE(T)                                                  \
-    template Array<T> sort<T, true>(const Array<T> &in, const unsigned dim); \
-    template Array<T>  sort<T,false>(const Array<T> &in, const unsigned dim); \
+    template Array<T> sort<T>(const Array<T> &in, const unsigned dim, bool isAscending);
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cuda/sort.hpp
+++ b/src/backend/cuda/sort.hpp
@@ -11,6 +11,6 @@
 
 namespace cuda
 {
-    template<typename T, bool isAscending>
-    Array<T> sort(const Array<T> &in, const unsigned dim);
+    template<typename T>
+    Array<T> sort(const Array<T> &in, const unsigned dim, bool isAscending);
 }

--- a/src/backend/cuda/sort_by_key.cu
+++ b/src/backend/cuda/sort_by_key.cu
@@ -18,18 +18,18 @@
 
 namespace cuda
 {
-    template<typename Tk, typename Tv, bool isAscending>
+    template<typename Tk, typename Tv>
     void sort_by_key(Array<Tk> &okey, Array<Tv> &oval,
-               const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim)
+                     const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim, bool isAscending)
     {
         okey = copyArray<Tk>(ikey);
         oval = copyArray<Tv>(ival);
 
         switch(dim) {
-            case 0: kernel::sort0ByKey<Tk, Tv, isAscending>(okey, oval); break;
-            case 1: kernel::sortByKeyBatched<Tk, Tv, isAscending>(okey, oval, 1); break;
-            case 2: kernel::sortByKeyBatched<Tk, Tv, isAscending>(okey, oval, 2); break;
-            case 3: kernel::sortByKeyBatched<Tk, Tv, isAscending>(okey, oval, 3); break;
+            case 0: kernel::sort0ByKey<Tk, Tv>(okey, oval, isAscending); break;
+            case 1:
+            case 2:
+            case 3: kernel::sortByKeyBatched<Tk, Tv>(okey, oval, dim, isAscending); break;
             default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
         }
 
@@ -52,10 +52,8 @@ namespace cuda
     }
 
 #define INSTANTIATE(Tk, Tv)                                                         \
-    template void sort_by_key<Tk, Tv, true >(Array<Tk> &okey, Array<Tv> &oval,      \
-                const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim);      \
-    template void sort_by_key<Tk, Tv, false>(Array<Tk> &okey, Array<Tv> &oval,      \
-                const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim);      \
+    template void sort_by_key<Tk, Tv>(Array<Tk> &okey, Array<Tv> &oval,      \
+                                      const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim, bool);
 
 #define INSTANTIATE1(Tk    ) \
     INSTANTIATE(Tk, float  ) \

--- a/src/backend/cuda/sort_by_key.hpp
+++ b/src/backend/cuda/sort_by_key.hpp
@@ -11,7 +11,7 @@
 
 namespace cuda
 {
-    template<typename Tk, typename Tv, bool isAscending>
+    template<typename Tk, typename Tv>
     void sort_by_key(Array<Tk> &okey, Array<Tv> &oval,
-               const Array<Tk> &ikey, const Array<Tv> &ival, const unsigned dim);
+                     const Array<Tk> &ikey, const Array<Tv> &ival, const unsigned dim, bool isAscending);
 }

--- a/src/backend/cuda/sort_index.cu
+++ b/src/backend/cuda/sort_index.cu
@@ -19,18 +19,18 @@
 
 namespace cuda
 {
-    template<typename T, bool isAscending>
-    void sort_index(Array<T> &okey, Array<uint> &oval, const Array<T> &in, const uint dim)
+    template<typename T>
+    void sort_index(Array<T> &okey, Array<uint> &oval, const Array<T> &in, const uint dim, bool isAscending)
     {
         okey = copyArray<T>(in);
         oval = range<uint>(in.dims(), dim);
         oval.eval();
 
         switch(dim) {
-            case 0: kernel::sort0ByKey<T, uint, isAscending>(okey, oval); break;
-            case 1: kernel::sortByKeyBatched<T, uint, isAscending>(okey, oval, 1); break;
-            case 2: kernel::sortByKeyBatched<T, uint, isAscending>(okey, oval, 2); break;
-            case 3: kernel::sortByKeyBatched<T, uint, isAscending>(okey, oval, 3); break;
+            case 0: kernel::sort0ByKey<T, uint>(okey, oval, isAscending); break;
+            case 1:
+            case 2:
+            case 3: kernel::sortByKeyBatched<T, uint>(okey, oval, dim, isAscending); break;
             default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
         }
 
@@ -53,10 +53,8 @@ namespace cuda
     }
 
 #define INSTANTIATE(T)                                                  \
-    template void sort_index<T, true>(Array<T> &val, Array<uint> &idx, const Array<T> &in, \
-                                      const uint dim);                  \
-    template void sort_index<T,false>(Array<T> &val, Array<uint> &idx, const Array<T> &in, \
-                                      const uint dim);                  \
+    template void sort_index<T>(Array<T> &val, Array<uint> &idx, const Array<T> &in, \
+                                      const uint dim,bool isAscending);
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/cuda/sort_index.hpp
+++ b/src/backend/cuda/sort_index.hpp
@@ -11,6 +11,6 @@
 
 namespace cuda
 {
-    template<typename T, bool isAscending>
-    void sort_index(Array<T> &val, Array<unsigned> &idx, const Array<T> &in, const unsigned dim);
+    template<typename T>
+    void sort_index(Array<T> &val, Array<unsigned> &idx, const Array<T> &in, const unsigned dim, bool isAscending);
 }

--- a/src/backend/opencl/kernel/harris.hpp
+++ b/src/backend/opencl/kernel/harris.hpp
@@ -289,7 +289,7 @@ void harris(unsigned* corners_out,
             kernel::range<uint>(harris_idx, 0);
 
             // Sort Harris responses
-            kernel::sort0ByKey<float, uint, false>(harris_resp, harris_idx);
+            kernel::sort0ByKey<float, uint>(harris_resp, harris_idx, false);
 
             x_out.data = bufferAlloc(*corners_out * sizeof(float));
             y_out.data = bufferAlloc(*corners_out * sizeof(float));

--- a/src/backend/opencl/kernel/homography.hpp
+++ b/src/backend/opencl/kernel/homography.hpp
@@ -145,7 +145,7 @@ int computeH(
         if (htype == AF_HOMOGRAPHY_LMEDS) {
             // TODO: Improve this sorting, if the number of iterations is
             // sufficiently large, this can be *very* slow
-            kernel::sort0<float, true>(err);
+            kernel::sort0<float>(err, true);
 
             unsigned minIdx;
             float minMedian;

--- a/src/backend/opencl/kernel/orb.hpp
+++ b/src/backend/opencl/kernel/orb.hpp
@@ -307,7 +307,7 @@ void orb(unsigned* out_feat,
             d_harris_idx.data = bufferAlloc((d_harris_idx.info.dims[0]) * sizeof(unsigned));
             kernel::range<uint>(d_harris_idx, 0);
 
-            kernel::sort0ByKey<float, uint, false>(d_harris_sorted, d_harris_idx);
+            kernel::sort0ByKey<float, uint>(d_harris_sorted, d_harris_idx, false);
 
             cl::Buffer* d_x_lvl = bufferAlloc(usable_feat * sizeof(float));
             cl::Buffer* d_y_lvl = bufferAlloc(usable_feat * sizeof(float));

--- a/src/backend/opencl/kernel/sort.hpp
+++ b/src/backend/opencl/kernel/sort.hpp
@@ -41,8 +41,8 @@ namespace opencl
 {
     namespace kernel
     {
-        template<typename T, bool isAscending>
-        void sort0Iterative(Param val)
+        template<typename T>
+        void sort0Iterative(Param val, bool isAscending)
         {
             try {
                 compute::command_queue c_queue(getQueue()());
@@ -79,8 +79,8 @@ namespace opencl
             }
         }
 
-        template<typename T, bool isAscending, int dim>
-        void sortBatched(Param pVal)
+        template<typename T, int dim>
+        void sortBatched(Param pVal, bool isAscending)
         {
             try{
                 af::dim4 inDims;
@@ -157,15 +157,15 @@ namespace opencl
             }
         }
 
-        template<typename T, bool isAscending>
-        void sort0(Param val)
+        template<typename T>
+        void sort0(Param val, bool isAscending)
         {
             int higherDims =  val.info.dims[1] * val.info.dims[2] * val.info.dims[3];
             // TODO Make a better heurisitic
             if(higherDims > 10)
-                sortBatched<T, isAscending, 0>(val);
+                sortBatched<T, 0>(val, isAscending);
             else
-                kernel::sort0Iterative<T, isAscending>(val);
+                kernel::sort0Iterative<T>(val, isAscending);
         }
     }
 }

--- a/src/backend/opencl/kernel/sort_by_key.hpp
+++ b/src/backend/opencl/kernel/sort_by_key.hpp
@@ -17,13 +17,13 @@ namespace opencl
 {
     namespace kernel
     {
-        template<typename Tk, typename Tv, bool isAscending>
-        void sort0ByKeyIterative(Param pKey, Param pVal);
+        template<typename Tk, typename Tv>
+        void sort0ByKeyIterative(Param pKey, Param pVal, bool isAscending);
 
-        template<typename Tk_, typename Tv_, bool isAscending>
-        void sortByKeyBatched(Param pKey, Param pVal, const int dim);
+        template<typename Tk_, typename Tv_>
+        void sortByKeyBatched(Param pKey, Param pVal, const int dim, bool isAscending);
 
-        template<typename Tk, typename Tv, bool isAscending>
-        void sort0ByKey(Param pKey, Param pVal);
+        template<typename Tk, typename Tv>
+        void sort0ByKey(Param pKey, Param pVal, bool isAscending);
     }
 }

--- a/src/backend/opencl/kernel/sort_by_key/sort_by_key_impl.cpp
+++ b/src/backend/opencl/kernel/sort_by_key/sort_by_key_impl.cpp
@@ -15,7 +15,6 @@ namespace opencl
 {
 namespace kernel
 {
-    INSTANTIATE1(TYPE,true)
-    INSTANTIATE1(TYPE,false)
+    INSTANTIATE1(TYPE)
 }
 }

--- a/src/backend/opencl/kernel/sort_by_key_impl.hpp
+++ b/src/backend/opencl/kernel/sort_by_key_impl.hpp
@@ -192,8 +192,8 @@ namespace opencl
             }
         }
 
-        template<typename Tk, typename Tv, bool isAscending>
-        void sort0ByKeyIterative(Param pKey, Param pVal)
+        template<typename Tk, typename Tv>
+        void sort0ByKeyIterative(Param pKey, Param pVal, bool isAscending)
         {
             try {
                 compute::command_queue c_queue(getQueue()());
@@ -232,8 +232,8 @@ namespace opencl
             }
         }
 
-        template<typename Tk_, typename Tv_, bool isAscending>
-        void sortByKeyBatched(Param pKey, Param pVal, const int dim)
+        template<typename Tk_, typename Tv_>
+        void sortByKeyBatched(Param pKey, Param pVal, const int dim, bool isAscending)
         {
             typedef type_t<Tk_> Tk;
             typedef type_t<Tv_> Tv;
@@ -335,35 +335,35 @@ namespace opencl
             }
         }
 
-        template<typename Tk, typename Tv, bool isAscending>
-        void sort0ByKey(Param pKey, Param pVal)
+        template<typename Tk, typename Tv>
+        void sort0ByKey(Param pKey, Param pVal, bool isAscending)
         {
             int higherDims =  pKey.info.dims[1] * pKey.info.dims[2] * pKey.info.dims[3];
             // TODO Make a better heurisitic
             if(higherDims > 5)
-                kernel::sortByKeyBatched<Tk, Tv, isAscending>(pKey, pVal, 0);
+                kernel::sortByKeyBatched<Tk, Tv>(pKey, pVal, 0, isAscending);
             else
-                kernel::sort0ByKeyIterative<Tk, Tv, isAscending>(pKey, pVal);
+                kernel::sort0ByKeyIterative<Tk, Tv>(pKey, pVal, isAscending);
         }
 
-#define INSTANTIATE(Tk, Tv, dr)                                                         \
-    template void sort0ByKey<Tk, Tv, dr>(Param okey, Param oval);                       \
-    template void sort0ByKeyIterative<Tk, Tv, dr>(Param okey, Param oval);              \
-    template void sortByKeyBatched<Tk, Tv, dr>(Param okey, Param oval, const int dim);
+#define INSTANTIATE(Tk, Tv)                                                         \
+  template void sort0ByKey<Tk, Tv>(Param okey, Param oval, bool isAscending);        \
+  template void sort0ByKeyIterative<Tk, Tv>(Param okey, Param oval, bool isAscending); \
+  template void sortByKeyBatched<Tk, Tv>(Param okey, Param oval, const int dim, bool isAscending);
 
-#define INSTANTIATE1(Tk    , dr) \
-    INSTANTIATE(Tk, float  , dr) \
-    INSTANTIATE(Tk, double , dr) \
-    INSTANTIATE(Tk, cfloat , dr) \
-    INSTANTIATE(Tk, cdouble, dr) \
-    INSTANTIATE(Tk, int    , dr) \
-    INSTANTIATE(Tk, uint   , dr) \
-    INSTANTIATE(Tk, short  , dr) \
-    INSTANTIATE(Tk, ushort , dr) \
-    INSTANTIATE(Tk, char   , dr) \
-    INSTANTIATE(Tk, uchar  , dr) \
-    INSTANTIATE(Tk, intl   , dr) \
-    INSTANTIATE(Tk, uintl  , dr)
+#define INSTANTIATE1(Tk    ) \
+    INSTANTIATE(Tk, float  ) \
+    INSTANTIATE(Tk, double ) \
+    INSTANTIATE(Tk, cfloat ) \
+    INSTANTIATE(Tk, cdouble) \
+    INSTANTIATE(Tk, int    ) \
+    INSTANTIATE(Tk, uint   ) \
+    INSTANTIATE(Tk, short  ) \
+    INSTANTIATE(Tk, ushort ) \
+    INSTANTIATE(Tk, char   ) \
+    INSTANTIATE(Tk, uchar  ) \
+    INSTANTIATE(Tk, intl   ) \
+    INSTANTIATE(Tk, uintl  )
     }
 }
 

--- a/src/backend/opencl/sort.cpp
+++ b/src/backend/opencl/sort.cpp
@@ -18,16 +18,16 @@
 
 namespace opencl
 {
-    template<typename T, bool isAscending>
-    Array<T> sort(const Array<T> &in, const unsigned dim)
+    template<typename T>
+    Array<T> sort(const Array<T> &in, const unsigned dim, bool isAscending)
     {
         try {
             Array<T> out = copyArray<T>(in);
             switch(dim) {
-                case 0: kernel::sort0<T, isAscending>(out); break;
-                case 1: kernel::sortBatched<T, isAscending, 1>(out); break;
-                case 2: kernel::sortBatched<T, isAscending, 2>(out); break;
-                case 3: kernel::sortBatched<T, isAscending, 3>(out); break;
+                case 0: kernel::sort0<T>(out, isAscending); break;
+                case 1: kernel::sortBatched<T, 1>(out, isAscending); break;
+                case 2: kernel::sortBatched<T, 2>(out, isAscending); break;
+                case 3: kernel::sortBatched<T, 3>(out, isAscending); break;
                 default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
             }
 
@@ -51,8 +51,7 @@ namespace opencl
     }
 
 #define INSTANTIATE(T)                                                  \
-    template Array<T> sort<T, true>(const Array<T> &in, const unsigned dim); \
-    template Array<T> sort<T,false>(const Array<T> &in, const unsigned dim); \
+    template Array<T> sort<T>(const Array<T> &in, const unsigned dim, bool isAscending);
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/opencl/sort.hpp
+++ b/src/backend/opencl/sort.hpp
@@ -11,6 +11,6 @@
 
 namespace opencl
 {
-    template<typename T, bool isAscending>
-    Array<T> sort(const Array<T> &in, const unsigned dim);
+    template<typename T>
+    Array<T> sort(const Array<T> &in, const unsigned dim, bool isAscending);
 }

--- a/src/backend/opencl/sort_by_key.cpp
+++ b/src/backend/opencl/sort_by_key.cpp
@@ -18,19 +18,19 @@
 
 namespace opencl
 {
-    template<typename Tk, typename Tv, bool isAscending>
+    template<typename Tk, typename Tv>
     void sort_by_key(Array<Tk> &okey, Array<Tv> &oval,
-               const Array<Tk> &ikey, const Array<Tv> &ival, const unsigned dim)
+                     const Array<Tk> &ikey, const Array<Tv> &ival, const unsigned dim, bool isAscending)
     {
         try {
             okey = copyArray<Tk>(ikey);
             oval = copyArray<Tv>(ival);
 
             switch(dim) {
-                case 0: kernel::sort0ByKey<Tk, Tv, isAscending>(okey, oval); break;
-                case 1: kernel::sortByKeyBatched<Tk, Tv, isAscending>(okey, oval, 1); break;
-                case 2: kernel::sortByKeyBatched<Tk, Tv, isAscending>(okey, oval, 2); break;
-                case 3: kernel::sortByKeyBatched<Tk, Tv, isAscending>(okey, oval, 3); break;
+                case 0: kernel::sort0ByKey<Tk, Tv>(okey, oval, isAscending); break;
+                case 1:
+                case 2:
+                case 3: kernel::sortByKeyBatched<Tk, Tv>(okey, oval, dim, isAscending); break;
                 default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
             }
 
@@ -56,10 +56,9 @@ namespace opencl
     }
 
 #define INSTANTIATE(Tk, Tv)                                                         \
-    template void sort_by_key<Tk, Tv, true >(Array<Tk> &okey, Array<Tv> &oval,      \
-                const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim);      \
-    template void sort_by_key<Tk, Tv, false>(Array<Tk> &okey, Array<Tv> &oval,      \
-                const Array<Tk> &ikey, const Array<Tv> &ival, const uint dim);      \
+    template void sort_by_key<Tk, Tv>(Array<Tk> &okey, Array<Tv> &oval,             \
+                                      const Array<Tk> &ikey, const Array<Tv> &ival, \
+                                      const uint dim, bool isAscending);
 
 #define INSTANTIATE1(Tk    ) \
     INSTANTIATE(Tk, float  ) \
@@ -76,15 +75,14 @@ namespace opencl
     INSTANTIATE(Tk, uintl  )
 
 
-INSTANTIATE1(float )
-INSTANTIATE1(double)
-INSTANTIATE1(int   )
-INSTANTIATE1(uint  )
-INSTANTIATE1(short )
-INSTANTIATE1(ushort)
-INSTANTIATE1(char  )
-INSTANTIATE1(uchar )
-INSTANTIATE1(intl  )
-INSTANTIATE1(uintl )
-
+  INSTANTIATE1(float )
+  INSTANTIATE1(double)
+  INSTANTIATE1(int   )
+  INSTANTIATE1(uint  )
+  INSTANTIATE1(short )
+  INSTANTIATE1(ushort)
+  INSTANTIATE1(char  )
+  INSTANTIATE1(uchar )
+  INSTANTIATE1(intl  )
+  INSTANTIATE1(uintl )
 }

--- a/src/backend/opencl/sort_by_key.hpp
+++ b/src/backend/opencl/sort_by_key.hpp
@@ -11,7 +11,7 @@
 
 namespace opencl
 {
-    template<typename Tk, typename Tv, bool isAscending>
+    template<typename Tk, typename Tv>
     void sort_by_key(Array<Tk> &okey, Array<Tv> &oval,
-               const Array<Tk> &ikey, const Array<Tv> &ival, const unsigned dim);
+                     const Array<Tk> &ikey, const Array<Tv> &ival, const unsigned dim, bool isAscending);
 }

--- a/src/backend/opencl/sort_index.cpp
+++ b/src/backend/opencl/sort_index.cpp
@@ -19,8 +19,8 @@
 
 namespace opencl
 {
-    template<typename T, bool isAscending>
-    void sort_index(Array<T> &okey, Array<uint> &oval, const Array<T> &in, const uint dim)
+    template<typename T>
+    void sort_index(Array<T> &okey, Array<uint> &oval, const Array<T> &in, const uint dim, bool isAscending)
     {
         try {
             // okey contains values, oval contains indices
@@ -29,10 +29,10 @@ namespace opencl
             oval.eval();
 
             switch(dim) {
-                case 0: kernel::sort0ByKey<T, uint, isAscending>(okey, oval); break;
-                case 1: kernel::sortByKeyBatched<T, uint, isAscending>(okey, oval, 1); break;
-                case 2: kernel::sortByKeyBatched<T, uint, isAscending>(okey, oval, 2); break;
-                case 3: kernel::sortByKeyBatched<T, uint, isAscending>(okey, oval, 3); break;
+                case 0: kernel::sort0ByKey<T, uint>(okey, oval, isAscending); break;
+                case 1:
+                case 2:
+                case 3: kernel::sortByKeyBatched<T, uint>(okey, oval, dim, isAscending); break;
                 default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
             }
 
@@ -58,10 +58,9 @@ namespace opencl
     }
 
 #define INSTANTIATE(T)                                                  \
-    template void sort_index<T, true>(Array<T> &val, Array<uint> &idx, const Array<T> &in, \
-                                      const uint dim);                  \
-    template void sort_index<T,false>(Array<T> &val, Array<uint> &idx, const Array<T> &in, \
-                                      const uint dim);                  \
+  template void sort_index<T>(Array<T> &val, Array<uint> &idx,          \
+                              const Array<T> &in, const uint dim,       \
+                              bool isAscending);
 
     INSTANTIATE(float)
     INSTANTIATE(double)

--- a/src/backend/opencl/sort_index.hpp
+++ b/src/backend/opencl/sort_index.hpp
@@ -11,6 +11,6 @@
 
 namespace opencl
 {
-    template<typename T, bool isAscending>
-    void sort_index(Array<T> &val, Array<unsigned> &idx, const Array<T> &in, const unsigned dim);
+    template<typename T>
+    void sort_index(Array<T> &val, Array<unsigned> &idx, const Array<T> &in, const unsigned dim, bool isAscending);
 }


### PR DESCRIPTION
This PR moves the isAscending template parameter into the function parameter. This should reduce the compile times and binary sizes. It should also not impact the performance of the operation.