### PR TITLE
Handle empty arrays in a variety of functions

### DIFF
--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -55,6 +55,11 @@ af_err af_approx1(af_array *out, const af_array in, const af_array pos,
                       (pdims[1] == idims[1] && pdims[2] == idims[2] && pdims[3] == idims[3]));
         ARG_ASSERT(3, (method == AF_INTERP_LINEAR || method == AF_INTERP_NEAREST));
 
+        if(idims.ndims() == 0 || pdims.ndims() ==  0) {
+            dim_t my_dims[] = { 0, 0, 0, 0 };
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, itype);
+        }
+
         af_array output;
 
         switch(itype) {
@@ -97,6 +102,11 @@ af_err af_approx2(af_array *out, const af_array in, const af_array pos0, const a
         DIM_ASSERT(2, (pdims[2] == 1        && pdims[3] == 1) ||
                       (pdims[2] == idims[2] && pdims[3] == idims[3]));
         ARG_ASSERT(3, (method == AF_INTERP_LINEAR || method == AF_INTERP_NEAREST));
+
+        if(idims.ndims() == 0 || pdims.ndims() ==  0 || qdims.ndims() == 0) {
+            dim_t my_dims[] = { 0, 0, 0, 0 };
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, itype);
+        }
 
         af_array output;
 

--- a/src/api/c/array.cpp
+++ b/src/api/c/array.cpp
@@ -123,6 +123,11 @@ af_err af_copy_array(af_array *out, const af_array in)
         ArrayInfo info = getInfo(in);
         const af_dtype type = info.getType();
 
+        if(info.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, type);
+        }
+
         af_array res;
         switch(type) {
         case f32:   res = copyArray<float   >(in); break;

--- a/src/api/c/assign.cpp
+++ b/src/api/c/assign.cpp
@@ -206,7 +206,6 @@ af_err af_assign_gen(af_array *out,
     spanner.isSeq = true;
 
     try {
-        ARG_ASSERT(2, (ndims>0));
         ARG_ASSERT(3, (indexs!=NULL));
 
         int track = 0;
@@ -233,6 +232,15 @@ af_err af_assign_gen(af_array *out,
         af_dtype lhsType= lInfo.getType();
         af_dtype rhsType= rInfo.getType();
 
+        if(rhsDims.ndims() == 0) {
+            return af_retain_array(out, lhs);
+        }
+
+        if(lhsDims.ndims() == 0) {
+            dim_t my_dims[] = { 0, 0, 0, 0 };
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, lhsType);
+        }
+
         ARG_ASSERT(2, (ndims == 1) || (ndims == (dim_t)lInfo.ndims()));
 
         if (ndims == 1 && ndims != (dim_t)lInfo.ndims()) {
@@ -246,7 +254,6 @@ af_err af_assign_gen(af_array *out,
         }
 
         ARG_ASSERT(1, (lhsType==rhsType));
-        ARG_ASSERT(3, (rhsDims.ndims()>0));
         ARG_ASSERT(1, (lhsDims.ndims()>=rhsDims.ndims()));
         ARG_ASSERT(2, (lhsDims.ndims()>=ndims));
 

--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -332,6 +332,11 @@ static af_err af_bitwise(af_array *out, const af_array lhs, const af_array rhs, 
 
         dim4 odims = getOutDims(linfo.dims(), rinfo.dims(), batchMode);
 
+        if(odims.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, type);
+        }
+
         af_array res;
         switch (type) {
         case s32: res = bitOp<int    , op>(lhs, rhs, odims); break;

--- a/src/api/c/blas.cpp
+++ b/src/api/c/blas.cpp
@@ -105,6 +105,9 @@ af_err af_dot(      af_array *out,
         af_dtype lhs_type = lhsInfo.getType();
         af_dtype rhs_type = rhsInfo.getType();
 
+        if(lhsInfo.ndims() == 0) {
+            return af_retain_array(out, lhs);
+        }
         if (lhsInfo.ndims() > 1 ||
             rhsInfo.ndims() > 1) {
             AF_ERROR("dot can not be used in batch mode", AF_ERR_BATCH);

--- a/src/api/c/cast.cpp
+++ b/src/api/c/cast.cpp
@@ -48,6 +48,13 @@ static af_array cast(const af_array in, const af_dtype type)
 af_err af_cast(af_array *out, const af_array in, const af_dtype type)
 {
     try {
+        const ArrayInfo info = getInfo(in);
+        dim4 idims = info.dims();
+        if(idims.elements() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, type);
+        }
+
         af_array res = cast(in, type);
         std::swap(*out, res);
     }

--- a/src/api/c/cholesky.cpp
+++ b/src/api/c/cholesky.cpp
@@ -45,6 +45,11 @@ af_err af_cholesky(af_array *out, int *info, const af_array in, const bool is_up
         ARG_ASSERT(2, i_info.isFloating());                  // Only floating and complex types
         DIM_ASSERT(1, i_info.dims()[0] == i_info.dims()[1]); // Only square matrices
 
+        if(i_info.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, type);
+        }
+
         af_array output;
         switch(type) {
             case f32: output = cholesky<float  >(info, in, is_upper);  break;
@@ -73,6 +78,10 @@ af_err af_cholesky_inplace(int *info, af_array in, const bool is_upper)
 
         ARG_ASSERT(1, i_info.isFloating()); // Only floating and complex types
         DIM_ASSERT(1, i_info.dims()[0] == i_info.dims()[1]); // Only square matrices
+
+        if(i_info.ndims() == 0) {
+            return AF_SUCCESS;
+        }
 
         int out;
 

--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -72,6 +72,10 @@ af_err convolve(af_array *out, const af_array signal, const af_array filter)
         dim4 sdims = sInfo.dims();
         dim4 fdims = fInfo.dims();
 
+        if(fdims.ndims() == 0 || sdims.ndims() ==  0) {
+            return af_retain_array(out, signal);
+        }
+
         AF_BATCH_KIND convBT = identifyBatchKind<baseDim>(sdims, fdims);
 
         ARG_ASSERT(1, (convBT != AF_BATCH_UNSUPPORTED && convBT != AF_BATCH_DIFF));

--- a/src/api/c/data.cpp
+++ b/src/api/c/data.cpp
@@ -98,7 +98,13 @@ af_err af_constant_complex(af_array *result, const double real, const double ima
         af_array out;
         AF_CHECK(af_init());
 
-        dim4 d = verifyDims(ndims, dims);
+        dim4 d(1, 1, 1, 1);
+        if(ndims <= 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(result, AF_MAX_DIMS, my_dims, type);
+        } else {
+            d = verifyDims(ndims, dims);
+        }
 
         switch (type) {
         case c32: out = createCplx<cfloat , float >(d, real, imag); break;
@@ -119,7 +125,13 @@ af_err af_constant_long(af_array *result, const intl val,
         af_array out;
         AF_CHECK(af_init());
 
-        dim4 d = verifyDims(ndims, dims);
+        dim4 d(1, 1, 1, 1);
+        if(ndims <= 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(result, AF_MAX_DIMS, my_dims, s64);
+        } else {
+            d = verifyDims(ndims, dims);
+        }
 
         out = getHandle(createValueArray<intl>(d, val));
 
@@ -136,7 +148,13 @@ af_err af_constant_ulong(af_array *result, const uintl val,
         af_array out;
         AF_CHECK(af_init());
 
-        dim4 d = verifyDims(ndims, dims);
+        dim4 d(1, 1, 1, 1);
+        if(ndims <= 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(result, AF_MAX_DIMS, my_dims, u64);
+        } else {
+            d = verifyDims(ndims, dims);
+        }
         out = getHandle(createValueArray<uintl>(d, val));
 
         std::swap(*result, out);
@@ -169,7 +187,13 @@ af_err af_randu(af_array *out, const unsigned ndims, const dim_t * const dims, c
         af_array result;
         AF_CHECK(af_init());
 
-        dim4 d = verifyDims(ndims, dims);
+        dim4 d(1, 1, 1, 1);
+        if(ndims <= 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, type);
+        } else {
+            d = verifyDims(ndims, dims);
+        }
 
         switch(type) {
         case f32:   result = randu_<float  >(d);    break;
@@ -198,7 +222,13 @@ af_err af_randn(af_array *out, const unsigned ndims, const dim_t * const dims, c
         af_array result;
         AF_CHECK(af_init());
 
-        dim4 d = verifyDims(ndims, dims);
+        dim4 d(1, 1, 1, 1);
+        if(ndims <= 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, type);
+        } else {
+            d = verifyDims(ndims, dims);
+        }
 
         switch(type) {
         case f32:   result = randn_<float  >(d);    break;
@@ -278,7 +308,13 @@ af_err af_range(af_array *result, const unsigned ndims, const dim_t * const dims
         af_array out;
         AF_CHECK(af_init());
 
-        dim4 d = verifyDims(ndims, dims);
+        dim4 d(1, 1, 1, 1);
+        if(ndims <= 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(result, AF_MAX_DIMS, my_dims, type);
+        } else {
+            d = verifyDims(ndims, dims);
+        }
 
         switch(type) {
         case f32:   out = range_<float  >(d, seq_dim); break;
@@ -439,7 +475,13 @@ af_array triangle(const af_array in, bool is_unit_diag)
 af_err af_lower(af_array *out, const af_array in, bool is_unit_diag)
 {
     try {
-        af_dtype type = getInfo(in).getType();
+        ArrayInfo info = getInfo(in);
+        af_dtype type = info.getType();
+
+        if(info.ndims() == 0) {
+            return af_retain_array(out, in);
+        }
+
         af_array res;
         switch(type) {
         case f32: res = triangle<float   , false>(in, is_unit_diag); break;
@@ -465,7 +507,13 @@ af_err af_lower(af_array *out, const af_array in, bool is_unit_diag)
 af_err af_upper(af_array *out, const af_array in, bool is_unit_diag)
 {
     try {
-        af_dtype type = getInfo(in).getType();
+        ArrayInfo info = getInfo(in);
+        af_dtype type = info.getType();
+
+        if(info.ndims() == 0) {
+            return af_retain_array(out, in);
+        }
+
         af_array res;
         switch(type) {
         case f32: res = triangle<float   , true>(in, is_unit_diag); break;

--- a/src/api/c/data.cpp
+++ b/src/api/c/data.cpp
@@ -28,7 +28,6 @@
 
 using af::dim4;
 using namespace detail;
-using namespace std;
 
 dim4 verifyDims(const unsigned ndims, const dim_t * const dims)
 {
@@ -54,7 +53,14 @@ af_err af_constant(af_array *result, const double value,
         af_array out;
         AF_CHECK(af_init());
 
-        dim4 d = verifyDims(ndims, dims);
+        dim4 d(1, 1, 1, 1);
+        if(ndims <= 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(result, AF_MAX_DIMS, my_dims, type);
+        } else {
+            d = verifyDims(ndims, dims);
+        }
+
 
         switch(type) {
         case f32:   out = createHandleFromValue<float  >(d, value); break;
@@ -229,6 +235,11 @@ af_err af_identity(af_array *out, const unsigned ndims, const dim_t * const dims
         af_array result;
         AF_CHECK(af_init());
 
+        if(ndims == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, type);
+        }
+
         dim4 d = verifyDims(ndims, dims);
 
         switch(type) {
@@ -301,6 +312,11 @@ af_err af_iota(af_array *result, const unsigned ndims, const dim_t * const dims,
         af_array out;
         AF_CHECK(af_init());
 
+        if(ndims == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(result, AF_MAX_DIMS, my_dims, type);
+        }
+
         DIM_ASSERT(1, ndims > 0 && ndims <= 4);
         DIM_ASSERT(3, t_ndims > 0 && t_ndims <= 4);
 
@@ -345,6 +361,12 @@ af_err af_diag_create(af_array *out, const af_array in, const int num)
         af_dtype type = in_info.getType();
 
         af_array result;
+
+        if(in_info.dims()[0] == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, type);
+        }
+
         switch(type) {
         case f32:   result = diagCreate<float  >(in, num);    break;
         case c32:   result = diagCreate<cfloat >(in, num);    break;
@@ -372,8 +394,14 @@ af_err af_diag_extract(af_array *out, const af_array in, const int num)
 
     try {
         ArrayInfo in_info = getInfo(in);
-        DIM_ASSERT(1, in_info.ndims() >= 2);
         af_dtype type = in_info.getType();
+
+        if(in_info.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, type);
+        }
+
+        DIM_ASSERT(1, in_info.ndims() >= 2);
 
         af_array result;
         switch(type) {

--- a/src/api/c/det.cpp
+++ b/src/api/c/det.cpp
@@ -29,6 +29,11 @@ T det(const af_array a)
 
     const int num = A.dims()[0];
 
+    if(num == 0) {
+        T res = scalar<T>(1.0);
+        return res;
+    }
+
     std::vector<T> hD(num);
     std::vector<int> hP(num);
 

--- a/src/api/c/diff.cpp
+++ b/src/api/c/diff.cpp
@@ -40,6 +40,11 @@ af_err af_diff1(af_array *out, const af_array in, const int dim)
         af_dtype type = info.getType();
 
         af::dim4 in_dims = info.dims();
+        if(in_dims[dim] < 2) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, type);
+        }
+
         DIM_ASSERT(1, in_dims[dim] >= 2);
 
         af_array output;
@@ -77,6 +82,10 @@ af_err af_diff2(af_array *out, const af_array in, const int dim)
         af_dtype type = info.getType();
 
         af::dim4 in_dims = info.dims();
+        if(in_dims[dim] < 3) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, type);
+        }
         DIM_ASSERT(1, in_dims[dim] >= 3);
 
         af_array output;

--- a/src/api/c/fft.cpp
+++ b/src/api/c/fft.cpp
@@ -33,6 +33,10 @@ static af_err fft(af_array *out, const af_array in, const double norm_factor, co
         af_dtype type  = info.getType();
         af::dim4 dims  = info.dims();
 
+        if(dims.ndims() == 0) {
+            return af_retain_array(out, in);
+        }
+
         DIM_ASSERT(1, (dims.ndims()>=rank));
 
         af_array output;
@@ -104,6 +108,9 @@ static af_err fft_inplace(af_array in, const double norm_factor)
         af_dtype type  = info.getType();
         af::dim4 dims  = info.dims();
 
+        if(dims.ndims() == 0) {
+            return AF_SUCCESS;
+        }
         DIM_ASSERT(1, (dims.ndims()>=rank));
 
         switch(type) {
@@ -163,6 +170,9 @@ static af_err fft_r2c(af_array *out, const af_array in, const double norm_factor
         af_dtype type  = info.getType();
         af::dim4 dims  = info.dims();
 
+        if(dims.ndims() == 0) {
+            return af_retain_array(out, in);
+        }
         DIM_ASSERT(1, (dims.ndims()>=rank));
 
         af_array output;
@@ -215,6 +225,9 @@ static af_err fft_c2r(af_array *out, const af_array in, const double norm_factor
         af_dtype type  = info.getType();
         af::dim4 idims  = info.dims();
 
+        if(idims.ndims() == 0) {
+            return af_retain_array(out, in);
+        }
         DIM_ASSERT(1, (idims.ndims()>=rank));
 
         dim4 odims = idims;

--- a/src/api/c/histogram.cpp
+++ b/src/api/c/histogram.cpp
@@ -35,6 +35,10 @@ af_err af_histogram(af_array *out, const af_array in,
         ArrayInfo info = getInfo(in);
         af_dtype type  = info.getType();
 
+        if(info.ndims() == 0) {
+            return af_retain_array(out, in);
+        }
+
         af_array output;
         switch(type) {
             case f32: output = histogram<float , uint>(in, nbins, minval, maxval, info.isLinear()); break;

--- a/src/api/c/hsv_rgb.cpp
+++ b/src/api/c/hsv_rgb.cpp
@@ -38,6 +38,11 @@ af_err convert(af_array* out, const af_array& in)
         af_dtype iType = info.getType();
         af::dim4 inputDims = info.dims();
 
+        if(info.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, iType);
+        }
+
         ARG_ASSERT(1, (inputDims.ndims() >= 3));
 
         af_array output = 0;

--- a/src/api/c/iir.cpp
+++ b/src/api/c/iir.cpp
@@ -65,6 +65,10 @@ af_err af_iir(af_array *y, const af_array b, const af_array a, const af_array x)
         dim4 bdims = binfo.dims();
         dim4 xdims = xinfo.dims();
 
+        if(xinfo.ndims() == 0) {
+            return af_retain_array(y, x);
+        }
+
         if (xinfo.ndims() > 1) {
             if (binfo.ndims() > 1) {
                 for (int i = 1; i < 3; i++) {

--- a/src/api/c/index.cpp
+++ b/src/api/c/index.cpp
@@ -161,6 +161,15 @@ af_err af_index_gen(af_array *out, const af_array in, const dim_t ndims, const a
         ARG_ASSERT(3, (indexs!=NULL));
 
         ArrayInfo iInfo = getInfo(in);
+
+        dim4 iDims = iInfo.dims();
+        af_dtype inType = getInfo(in).getType();
+
+        if(iDims.ndims() <= 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, inType);
+        }
+
         if (ndims == 1 && ndims != (dim_t)iInfo.ndims()) {
             af_array tmp_in;
             AF_CHECK(af_flat(&tmp_in, in));
@@ -205,14 +214,6 @@ af_err af_index_gen(af_array *out, const af_array in, const dim_t ndims, const a
                 // just copy the index to local variable
                 idxrs[i] = indexs[i];
             }
-        }
-
-        dim4 iDims = iInfo.dims();
-        af_dtype inType = getInfo(in).getType();
-
-        if(iDims.ndims() <= 0) {
-            dim_t my_dims[] = {0, 0, 0, 0};
-            return af_create_handle(out, AF_MAX_DIMS, my_dims, inType);
         }
 
         switch(inType) {

--- a/src/api/c/index.cpp
+++ b/src/api/c/index.cpp
@@ -107,6 +107,10 @@ af_err af_lookup(af_array *out, const af_array in, const af_array indices, const
 
         ArrayInfo idxInfo= getInfo(indices);
 
+        if(idxInfo.ndims() == 0) {
+            return af_retain_array(out, indices);
+        }
+
         ARG_ASSERT(2, idxInfo.isVector() || idxInfo.isScalar());
 
         af_dtype idxType = idxInfo.getType();
@@ -204,10 +208,13 @@ af_err af_index_gen(af_array *out, const af_array in, const dim_t ndims, const a
         }
 
         dim4 iDims = iInfo.dims();
-
-        ARG_ASSERT(1, (iDims.ndims()>0));
-
         af_dtype inType = getInfo(in).getType();
+
+        if(iDims.ndims() <= 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, inType);
+        }
+
         switch(inType) {
             case c64: output = genIndex<cdouble>(in, idxrs); break;
             case f64: output = genIndex<double >(in, idxrs); break;

--- a/src/api/c/inverse.cpp
+++ b/src/api/c/inverse.cpp
@@ -45,6 +45,10 @@ af_err af_inverse(af_array *out, const af_array in, const af_mat_prop options)
 
         af_array output;
 
+        if(i_info.ndims() == 0) {
+            return af_retain_array(out, in);
+        }
+
         switch(type) {
             case f32: output = inverse<float  >(in);  break;
             case f64: output = inverse<double >(in);  break;

--- a/src/api/c/join.cpp
+++ b/src/api/c/join.cpp
@@ -46,6 +46,14 @@ af_err af_join(af_array *out, const int dim, const af_array first, const af_arra
 
         ARG_ASSERT(1, dim >= 0 && dim < 4);
         ARG_ASSERT(2, finfo.getType() == sinfo.getType());
+        if(sinfo.elements() == 0) {
+            return af_retain_array(out, first);
+        }
+
+        if(finfo.elements() == 0) {
+            return af_retain_array(out, second);
+        }
+
         DIM_ASSERT(2, sinfo.elements() > 0);
         DIM_ASSERT(3, finfo.elements() > 0);
 

--- a/src/api/c/lu.cpp
+++ b/src/api/c/lu.cpp
@@ -53,6 +53,14 @@ af_err af_lu(af_array *lower, af_array *upper, af_array *pivot, const af_array i
 
         ARG_ASSERT(3, i_info.isFloating());                       // Only floating and complex types
 
+        if(i_info.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            AF_CHECK(af_create_handle(lower, AF_MAX_DIMS, my_dims, type));
+            AF_CHECK(af_create_handle(upper, AF_MAX_DIMS, my_dims, type));
+            AF_CHECK(af_create_handle(pivot, AF_MAX_DIMS, my_dims, type));
+            return AF_SUCCESS;
+        }
+
         switch(type) {
             case f32: lu<float  >(lower, upper, pivot, in);  break;
             case f64: lu<double >(lower, upper, pivot, in);  break;
@@ -78,6 +86,11 @@ af_err af_lu_inplace(af_array *pivot, af_array in, const bool is_lapack_piv)
         }
 
         ARG_ASSERT(1, i_info.isFloating()); // Only floating and complex types
+
+        if(i_info.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(pivot, AF_MAX_DIMS, my_dims, type);
+        }
 
         af_array out;
 

--- a/src/api/c/median.cpp
+++ b/src/api/c/median.cpp
@@ -28,6 +28,7 @@ static double median(const af_array& in)
 {
     dim_t nElems = getInfo(in).elements();
     dim4 dims(nElems, 1, 1, 1);
+    ARG_ASSERT(0, nElems > 0);
 
     af_array temp = 0;
     AF_CHECK(af_moddims(&temp, in, 1, dims.get()));
@@ -154,6 +155,8 @@ af_err af_median_all(double *realVal, double *imagVal, const af_array in)
     try {
         ArrayInfo info = getInfo(in);
         af_dtype type = info.getType();
+
+        ARG_ASSERT(2, info.ndims() > 0);
         switch(type) {
             case f64: *realVal = median<double>(in); break;
             case f32: *realVal = median<float >(in); break;
@@ -176,6 +179,8 @@ af_err af_median(af_array* out, const af_array in, const dim_t dim)
 
         af_array output = 0;
         ArrayInfo info = getInfo(in);
+
+        ARG_ASSERT(1, info.ndims() > 0);
         af_dtype type = info.getType();
         switch(type) {
             case f64: output = median<double>(in, dim); break;

--- a/src/api/c/moddims.cpp
+++ b/src/api/c/moddims.cpp
@@ -53,6 +53,9 @@ af_err af_moddims(af_array *out, const af_array in,
                   const unsigned ndims, const dim_t * const dims)
 {
     try {
+        if(ndims == 0) {
+            return af_retain_array(out, in);
+        }
         ARG_ASSERT(2, ndims >= 1);
         ARG_ASSERT(3, dims != NULL);
 

--- a/src/api/c/norm.cpp
+++ b/src/api/c/norm.cpp
@@ -138,6 +138,8 @@ af_err af_norm(double *out, const af_array in,
 
         *out = 0;
 
+        if(i_info.ndims() == 0) { return AF_SUCCESS; }
+
         switch(i_type) {
         case f32: *out = norm<float  >(in, type, p, q);  break;
         case f64: *out = norm<double >(in, type, p, q);  break;

--- a/src/api/c/qr.cpp
+++ b/src/api/c/qr.cpp
@@ -50,6 +50,14 @@ af_err af_qr(af_array *q, af_array *r, af_array *tau, const af_array in)
 
         af_dtype type = i_info.getType();
 
+        if(i_info.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            AF_CHECK(af_create_handle(q,   AF_MAX_DIMS, my_dims, type));
+            AF_CHECK(af_create_handle(r,   AF_MAX_DIMS, my_dims, type));
+            AF_CHECK(af_create_handle(tau, AF_MAX_DIMS, my_dims, type));
+            return AF_SUCCESS;
+        }
+
         ARG_ASSERT(3, i_info.isFloating());                       // Only floating and complex types
 
         switch(type) {
@@ -77,6 +85,11 @@ af_err af_qr_inplace(af_array *tau, af_array in)
         af_dtype type = i_info.getType();
 
         ARG_ASSERT(1, i_info.isFloating()); // Only floating and complex types
+
+        if(i_info.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(tau, AF_MAX_DIMS, my_dims, type);
+        }
 
         af_array out;
 

--- a/src/api/c/rank.cpp
+++ b/src/api/c/rank.cpp
@@ -60,6 +60,10 @@ af_err af_rank(uint *out, const af_array in, const double tol)
         ARG_ASSERT(1, i_info.isFloating());                       // Only floating and complex types
 
         uint output;
+        if(i_info.ndims() == 0) {
+            output = 0;
+            return AF_SUCCESS;
+        }
 
         switch(type) {
             case f32: output = rank<float  >(in, tol);  break;

--- a/src/api/c/reduce.cpp
+++ b/src/api/c/reduce.cpp
@@ -81,8 +81,7 @@ static af_err reduce_common(af_array *out, const af_array in, const int dim)
         const ArrayInfo in_info = getInfo(in);
 
         if (dim >= (int)in_info.ndims()) {
-            *out = retain(in);
-            return AF_SUCCESS;
+            return af_retain_array(out, in);
         }
 
         af_dtype type = in_info.getType();
@@ -246,6 +245,7 @@ static af_err reduce_all_common(double *real_val, double *imag_val, const af_arr
         const ArrayInfo in_info = getInfo(in);
         af_dtype type = in_info.getType();
 
+        ARG_ASSERT(2, in_info.ndims() > 0);
         ARG_ASSERT(0, real_val != NULL);
         *real_val = 0;
         if (!imag_val) *imag_val = 0;
@@ -399,6 +399,7 @@ static af_err ireduce_common(af_array *val, af_array *idx, const af_array in, co
         ARG_ASSERT(2, dim <  4);
 
         const ArrayInfo in_info = getInfo(in);
+        ARG_ASSERT(2, in_info.ndims() > 0);
 
         if (dim >= (int)in_info.ndims()) {
             *val = retain(in);
@@ -457,6 +458,7 @@ static af_err ireduce_all_common(double *real_val, double *imag_val,
         const ArrayInfo in_info = getInfo(in);
         af_dtype type = in_info.getType();
 
+        ARG_ASSERT(3, in_info.ndims() > 0);
         ARG_ASSERT(0, real_val != NULL);
         *real_val = 0;
         if (!imag_val) *imag_val = 0;

--- a/src/api/c/reorder.cpp
+++ b/src/api/c/reorder.cpp
@@ -30,6 +30,10 @@ af_err af_reorder(af_array *out, const af_array in, const af::dim4 &rdims)
         ArrayInfo info = getInfo(in);
         af_dtype type = info.getType();
 
+        if(info.elements() == 0) {
+            return af_retain_array(out, in);
+        }
+
         DIM_ASSERT(1, info.elements() > 0);
 
         // Check that dimensions are not repeated

--- a/src/api/c/replace.cpp
+++ b/src/api/c/replace.cpp
@@ -35,6 +35,10 @@ af_err af_replace(af_array a, const af_array cond, const af_array b)
         ArrayInfo binfo = getInfo(b);
         ArrayInfo cinfo = getInfo(cond);
 
+        if(cinfo.ndims() == 0) {
+            return AF_SUCCESS;
+        }
+
         ARG_ASSERT(2, ainfo.getType() == binfo.getType());
         ARG_ASSERT(1, cinfo.getType() == b8);
 

--- a/src/api/c/rgb_gray.cpp
+++ b/src/api/c/rgb_gray.cpp
@@ -110,7 +110,10 @@ af_err convert(af_array* out, const af_array in, const float r, const float g, c
         af::dim4 inputDims = info.dims();
 
         // 2D is not required.
-        ARG_ASSERT(1, info.elements() > 0);
+        if(info.elements() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, iType);
+        }
 
         // If RGB is input, then assert 3 channels
         // else 1 channel

--- a/src/api/c/rotate.cpp
+++ b/src/api/c/rotate.cpp
@@ -49,6 +49,9 @@ af_err af_rotate(af_array *out, const af_array in, const float theta,
                       method == AF_INTERP_BILINEAR ||
                       method == AF_INTERP_LOWER);
 
+        if(idims.elements() == 0) {
+            return af_retain_array(out, in);
+        }
         DIM_ASSERT(1, idims.elements() > 0);
 
         af::dim4 odims(odims0, odims1, idims[2], idims[3]);

--- a/src/api/c/select.cpp
+++ b/src/api/c/select.cpp
@@ -36,6 +36,10 @@ af_err af_select(af_array *out, const af_array cond, const af_array a, const af_
         ArrayInfo binfo = getInfo(b);
         ArrayInfo cinfo = getInfo(cond);
 
+        if(cinfo.ndims() == 0) {
+            return af_retain_array(out, cond);
+        }
+
         ARG_ASSERT(2, ainfo.getType() == binfo.getType());
         ARG_ASSERT(1, cinfo.getType() == b8);
 

--- a/src/api/c/set.cpp
+++ b/src/api/c/set.cpp
@@ -29,6 +29,9 @@ af_err af_set_unique(af_array *out, const af_array in, const bool is_sorted)
     try {
 
         ArrayInfo in_info = getInfo(in);
+        if(in_info.isEmpty()) {
+            return af_retain_array(out, in);
+        }
         ARG_ASSERT(1, in_info.isVector());
         af_dtype type = in_info.getType();
 
@@ -67,6 +70,15 @@ af_err af_set_union(af_array *out, const af_array first, const af_array second, 
         ArrayInfo first_info = getInfo(first);
         ArrayInfo second_info = getInfo(second);
 
+        af_array res;
+        if(first_info.isEmpty()) {
+            return af_retain_array(out, second);
+        }
+
+        if(second_info.isEmpty()) {
+            return af_retain_array(out, first);
+        }
+
         ARG_ASSERT(1, first_info.isVector());
         ARG_ASSERT(1, second_info.isVector());
 
@@ -75,7 +87,6 @@ af_err af_set_union(af_array *out, const af_array first, const af_array second, 
 
         ARG_ASSERT(1, first_type == second_type);
 
-        af_array res;
         switch(first_type) {
         case f32: res = setUnion<float  >(first, second, is_unique); break;
         case f64: res = setUnion<double >(first, second, is_unique); break;
@@ -108,6 +119,15 @@ af_err af_set_intersect(af_array *out, const af_array first, const af_array seco
 
         ArrayInfo first_info = getInfo(first);
         ArrayInfo second_info = getInfo(second);
+
+        //TODO: fix for set intersect from union
+        if(first_info.isEmpty()) {
+            return af_retain_array(out, first);
+        }
+
+        if(second_info.isEmpty()) {
+            return af_retain_array(out, second);
+        }
 
         ARG_ASSERT(1, first_info.isVector());
         ARG_ASSERT(1, second_info.isVector());

--- a/src/api/c/shift.cpp
+++ b/src/api/c/shift.cpp
@@ -29,6 +29,9 @@ af_err af_shift(af_array *out, const af_array in, const int sdims[4])
         ArrayInfo info = getInfo(in);
         af_dtype type = info.getType();
 
+        if(info.ndims() == 0) {
+            return af_retain_array(out, in);
+        }
         DIM_ASSERT(1, info.elements() > 0);
 
         af_array output;

--- a/src/api/c/solve.cpp
+++ b/src/api/c/solve.cpp
@@ -51,6 +51,11 @@ af_err af_solve(af_array *out, const af_array a, const af_array b, const af_mat_
         DIM_ASSERT(1, bdims[2] == adims[2]);
         DIM_ASSERT(1, bdims[3] == adims[3]);
 
+        if(a_info.ndims() == 0 || b_info.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, a_type);
+        }
+
         bool is_triangle_solve = (options & AF_MAT_LOWER) || (options & AF_MAT_UPPER);
 
         if (options != AF_MAT_NONE && !is_triangle_solve) {
@@ -116,6 +121,11 @@ af_err af_solve_lu(af_array *out, const af_array a,
         DIM_ASSERT(1, bdims[0] == adims[0]);
         DIM_ASSERT(1, bdims[2] == adims[2]);
         DIM_ASSERT(1, bdims[3] == adims[3]);
+
+        if(a_info.ndims() == 0 || b_info.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(out, AF_MAX_DIMS, my_dims, a_type);
+        }
 
         if (options != AF_MAT_NONE) {
             AF_ERROR("Using this property is not yet supported in solveLU", AF_ERR_NOT_SUPPORTED);

--- a/src/api/c/sort.cpp
+++ b/src/api/c/sort.cpp
@@ -41,6 +41,9 @@ af_err af_sort(af_array *out, const af_array in, const unsigned dim, const bool 
         ArrayInfo info = getInfo(in);
         af_dtype type = info.getType();
 
+        if(info.elements() == 0) {
+            return af_retain_array(out, in);
+        }
         DIM_ASSERT(1, info.elements() > 0);
 
         af_array val;
@@ -90,7 +93,12 @@ af_err af_sort_index(af_array *out, af_array *indices, const af_array in, const 
         ArrayInfo info = getInfo(in);
         af_dtype type = info.getType();
 
-        DIM_ASSERT(2, info.elements() > 0);
+        if(info.elements() <= 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            AF_CHECK(af_create_handle(out,     AF_MAX_DIMS, my_dims, type));
+            AF_CHECK(af_create_handle(indices, AF_MAX_DIMS, my_dims, type));
+            return AF_SUCCESS;
+        }
 
         af_array val;
         af_array idx;
@@ -172,8 +180,13 @@ af_err af_sort_by_key(af_array *out_keys, af_array *out_values,
 
         ArrayInfo vinfo = getInfo(values);
 
-        DIM_ASSERT(3, kinfo.elements() > 0);
         DIM_ASSERT(4, kinfo.dims() == vinfo.dims());
+        if(kinfo.elements() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            AF_CHECK(af_create_handle(out_keys,   AF_MAX_DIMS, my_dims, ktype));
+            AF_CHECK(af_create_handle(out_values, AF_MAX_DIMS, my_dims, ktype));
+            return AF_SUCCESS;
+        }
 
         TYPE_ASSERT(kinfo.isReal());
 

--- a/src/api/c/svd.cpp
+++ b/src/api/c/svd.cpp
@@ -73,6 +73,14 @@ af_err af_svd(af_array *u, af_array *s, af_array *vt, const af_array in)
         ARG_ASSERT(3, (dims.ndims() >= 0 && dims.ndims() <= 3));
         af_dtype type = info.getType();
 
+        if(dims.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            AF_CHECK(af_create_handle(u, AF_MAX_DIMS, my_dims, type));
+            AF_CHECK(af_create_handle(s, AF_MAX_DIMS, my_dims, type));
+            AF_CHECK(af_create_handle(vt, AF_MAX_DIMS, my_dims, type));
+            return AF_SUCCESS;
+        }
+
         switch (type) {
         case f64:
             svd<double>(s, u, vt, in);
@@ -102,8 +110,16 @@ af_err af_svd_inplace(af_array *u, af_array *s, af_array *vt, af_array in)
 
         DIM_ASSERT(3, dims[0] <= dims[1]);
         ARG_ASSERT(3, (dims.ndims() >= 0 && dims.ndims() <= 3));
-
         af_dtype type = info.getType();
+
+        if(dims.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            AF_CHECK(af_create_handle(u, AF_MAX_DIMS, my_dims, type));
+            AF_CHECK(af_create_handle(s, AF_MAX_DIMS, my_dims, type));
+            AF_CHECK(af_create_handle(vt, AF_MAX_DIMS, my_dims, type));
+            return AF_SUCCESS;
+        }
+
 
         switch (type) {
         case f64:

--- a/src/api/c/tile.cpp
+++ b/src/api/c/tile.cpp
@@ -55,6 +55,9 @@ af_err af_tile(af_array *out, const af_array in, const af::dim4 &tileDims)
         ArrayInfo info = getInfo(in);
         af_dtype type = info.getType();
 
+        if(info.ndims() == 0) {
+            return af_retain_array(out, in);
+        }
         DIM_ASSERT(1, info.dims().elements() > 0);
         DIM_ASSERT(2, tileDims.elements() > 0);
 

--- a/src/api/c/transpose.cpp
+++ b/src/api/c/transpose.cpp
@@ -33,6 +33,10 @@ af_err af_transpose(af_array *out, af_array in, const bool conjugate)
         af_dtype type = info.getType();
         af::dim4 dims = info.dims();
 
+        if (dims.elements() == 0) {
+            return af_retain_array(out, in);
+        }
+
         if (dims[0]==1 || dims[1]==1) {
             af::dim4 outDims(dims[1],dims[0],dims[2],dims[3]);
             if(conjugate) {

--- a/src/api/c/where.cpp
+++ b/src/api/c/where.cpp
@@ -29,7 +29,14 @@ static inline af_array where(const af_array in)
 af_err af_where(af_array *idx, const af_array in)
 {
     try {
-        af_dtype type = getInfo(in).getType();
+        ArrayInfo i_info = getInfo(in);
+        af_dtype type = i_info.getType();
+
+        if(i_info.ndims() == 0) {
+            dim_t my_dims[] = {0, 0, 0, 0};
+            return af_create_handle(idx, AF_MAX_DIMS, my_dims, u32);
+        }
+
         af_array res;
         switch(type) {
         case f32: res = where<float  >(in); break;

--- a/src/api/cpp/histogram.cpp
+++ b/src/api/cpp/histogram.cpp
@@ -26,6 +26,9 @@ array histogram(const array &in, const unsigned nbins, const double minval, cons
 array histogram(const array &in, const unsigned nbins)
 {
     af_array out = 0;
+    if(in.numdims() == 0) {
+        return in;
+    }
     AF_THROW(af_histogram(&out, in.get(), nbins, min<double>(in), max<double>(in)));
     return array(out);
 }

--- a/src/backend/cuda/index.cu
+++ b/src/backend/cuda/index.cu
@@ -60,6 +60,7 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[])
     }
 
     Array<T> out = createEmptyArray<T>(oDims);
+    if(oDims.elements() == 0) { return out; }
 
     kernel::index<T>(out, in, p);
 

--- a/src/backend/opencl/index.cpp
+++ b/src/backend/opencl/index.cpp
@@ -63,6 +63,7 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[])
     }
 
     Array<T> out = createEmptyArray<T>(oDims);
+    if(oDims.elements() == 0) { return out; }
 
     kernel::index<T>(out, in, p, bPtrs);
 

--- a/test/constant.cpp
+++ b/test/constant.cpp
@@ -130,10 +130,10 @@ void IdentityCPPError() {
         array out = af::identity(num, 0, 10, dty);
     }
     catch(const af::exception &ex) {
-        SUCCEED();
+        FAIL() << "Incorrectly thrown 0-length exception";
         return;
     }
-    FAIL() << "Failed to throw an exception";
+    SUCCEED();
 }
 
 TYPED_TEST(Constant, basicCPP)

--- a/test/empty.cpp
+++ b/test/empty.cpp
@@ -10,11 +10,9 @@
 #include <gtest/gtest.h>
 #include <arrayfire.h>
 #include <cstdio>
-#include <iostream>
 #include <cstdlib>
 
 using namespace af;
-using namespace std;
 
 template<typename T>
 class Array : public ::testing::Test
@@ -129,8 +127,8 @@ TEST(Array, TestEmptyLinAlg) {
     ASSERT_EQ( det<float>(constant(0,0)), 1);
     ASSERT_EQ( det<cfloat>(constant(0,0)).real, 1);
     ASSERT_EQ( det<cdouble>(constant(0,0)).real, 1);
-    ASSERT_EQ( norm(constant(0,0)), 0);
-    ASSERT_EQ( rank(constant(0,0)), 0);
+    ASSERT_EQ( af::norm(constant(0,0)), 0);
+    ASSERT_EQ( af::rank(constant(0,0)), 0);
     array tau_qr, arr = constant(0,0);
     qrInPlace(tau_qr, arr);
     ASSERT_EQ(tau_qr.numdims(), 0);
@@ -240,7 +238,7 @@ TEST(Array, TestEmptyVecOp) {
 TEST(Array, TestEmptyArrMod) {
     ASSERT_EQ(diag(constant(0,0)).numdims(), 0);
     ASSERT_EQ(diag(constant(0,0), true).numdims(), 0);
-    ASSERT_EQ(identity(0).numdims(), 0);
+    ASSERT_EQ(af::identity(0).numdims(), 0);
     ASSERT_EQ(iota(dim4(0)).numdims(), 0);
     ASSERT_EQ(lower(constant(0,0)).numdims(), 0);
     ASSERT_EQ(upper(constant(0,0)).numdims(), 0);

--- a/test/empty.cpp
+++ b/test/empty.cpp
@@ -1,0 +1,284 @@
+/*******************************************************
+ * Copyright (c) 2016, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <gtest/gtest.h>
+#include <arrayfire.h>
+#include <cstdio>
+#include <iostream>
+#include <cstdlib>
+
+using namespace af;
+using namespace std;
+
+template<typename T>
+class Array : public ::testing::Test
+{
+
+};
+
+TEST(Array, TestEmptyAssignment) {
+    array A = randu(5, f32);
+    array C = constant(0,0);
+    array B = A(isNaN(A));
+    A(isNaN(A)) = C;
+    ASSERT_EQ(B.numdims(), 0);
+    ASSERT_EQ(A.numdims(), 1);
+    ASSERT_EQ(lookup(constant(1,9), constant(0,0)).numdims(), 0);
+}
+
+TEST(Array, TestEmptySigProc) {
+    ASSERT_EQ(convolve(constant(1,1), constant(0,0)).numdims(), 1);
+    ASSERT_EQ(convolve(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(convolve2(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(convolve3(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(iir(constant(0,0), constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(approx1(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(approx1(constant(0,0), seq(0,10)).numdims(), 0);
+    ASSERT_EQ(approx2(constant(0,0), constant(0,0),  constant(0,0)).numdims(), 0);
+    ASSERT_EQ(approx2(constant(0,0), seq(0,10), seq(0,10)).numdims(), 0);
+}
+
+TEST(Array, TestEmptySet) {
+    ASSERT_EQ(setIntersect(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(setUnique(constant(0,0)).numdims(), 0);
+    array A = randu(5, f32);
+    array B = constant(0, 0);
+    ASSERT_EQ(setUnion(A, B).elements(), 5);
+    ASSERT_EQ(setUnion(B, A).elements(), 5);
+}
+
+TEST(Array, TestEmptyOperators) {
+    ASSERT_EQ((constant(0,0) +  constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) && constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) -  constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) &  constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) |  constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) ^  constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) << constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) >> constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) /  constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) == constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) <= constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) >= constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) >  constant(0,0)).numdims(), 0);
+    ASSERT_EQ((constant(0,0) <  constant(0,0)).numdims(), 0);
+    ASSERT_EQ(-constant(0,0).numdims(), 0 );
+    ASSERT_EQ((!constant(0,0)).numdims(), 0 );
+    ASSERT_EQ((constant(0,0) != constant(0,0)).numdims(), 0 );
+    ASSERT_EQ((constant(0,0) += 1).numdims(), 0 );
+    ASSERT_EQ((constant(0,0) -= 1).numdims(), 0 );
+    ASSERT_EQ((constant(0,0) *= 1).numdims(), 0 );
+    ASSERT_EQ((constant(0,0) /= 1).numdims(), 0 );
+    ASSERT_EQ((constant(0,0) || constant(0,0)).numdims(), 0 );
+    ASSERT_EQ((constant(0,0) %  constant(0,0)).numdims(), 0 );
+    ASSERT_EQ((constant(0,0) *  constant(0,0)).numdims(), 0 );
+}
+
+TEST(Array, TestEmptyFFT) {
+    array arr = constant(0,0);
+    fftInPlace(arr);
+    ASSERT_EQ(arr.numdims(), 0);
+    fft2InPlace(arr);
+    ASSERT_EQ(arr.numdims(), 0);
+    fft3InPlace(arr);
+    ASSERT_EQ(arr.numdims(), 0);
+    ifftInPlace(arr);
+    ASSERT_EQ(arr.numdims(), 0);
+    ifft2InPlace(arr);
+    ASSERT_EQ(arr.numdims(), 0);
+    ifft3InPlace(arr);
+    ASSERT_EQ(arr.numdims(), 0);
+
+    ASSERT_EQ((fft(constant(0,0))).numdims(), 0);
+    ASSERT_EQ((fftNorm(constant(0,0), 0.5)).numdims(), 0);
+    ASSERT_EQ((fft2(constant(0,0))).numdims(), 0);
+    ASSERT_EQ((fft2Norm(constant(0,0), 0.5)).numdims(), 0);
+    ASSERT_EQ((fft3(constant(0,0))).numdims(), 0);
+    ASSERT_EQ((fft3Norm(constant(0,0), 0.5)).numdims(), 0);
+    ASSERT_EQ((fftC2R<1>(constant(0,0))).numdims(), 0);
+    ASSERT_EQ((fftR2C<1>(constant(0,0))).numdims(), 0);
+    ASSERT_EQ((fftC2R<2>(constant(0,0))).numdims(), 0);
+    ASSERT_EQ((fftR2C<2>(constant(0,0))).numdims(), 0);
+    ASSERT_EQ((fftC2R<3>(constant(0,0))).numdims(), 0);
+    ASSERT_EQ((fftR2C<3>(constant(0,0))).numdims(), 0);
+    ASSERT_EQ((ifft(constant(0,0))).numdims(), 0);
+    ASSERT_EQ((ifftNorm(constant(0,0), 0.5)).numdims(), 0);
+    ASSERT_EQ((ifft2(constant(0,0))).numdims(), 0);
+    ASSERT_EQ((ifft2Norm(constant(0,0), 0.5)).numdims(), 0);
+    ASSERT_EQ((ifft3(constant(0,0))).numdims(), 0);
+    ASSERT_EQ((ifft3Norm(constant(0,0), 0.5)).numdims(), 0);
+}
+
+TEST(Array, TestEmptyDiff) {
+    ASSERT_EQ(diff1(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(diff1(constant(1,1)).numdims(), 0);
+    ASSERT_EQ(diff1(constant(1,2)).numdims(), 1);
+    ASSERT_EQ(diff2(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(diff2(constant(1,1)).numdims(), 0);
+    ASSERT_EQ(diff2(constant(1,2)).numdims(), 0);
+    ASSERT_EQ(diff2(constant(1,3)).numdims(), 1);
+}
+
+TEST(Array, TestEmptyLinAlg) {
+    ASSERT_EQ( det<float>(constant(0,0)), 1);
+    ASSERT_EQ( det<cfloat>(constant(0,0)).real, 1);
+    ASSERT_EQ( det<cdouble>(constant(0,0)).real, 1);
+    ASSERT_EQ( norm(constant(0,0)), 0);
+    ASSERT_EQ( rank(constant(0,0)), 0);
+    array tau_qr, arr = constant(0,0);
+    qrInPlace(tau_qr, arr);
+    ASSERT_EQ(tau_qr.numdims(), 0);
+
+
+    array out_qr;
+    qr(out_qr, tau_qr, constant(0,0));
+    ASSERT_EQ(out_qr.numdims(), 0);
+    ASSERT_EQ(tau_qr.numdims(), 0);
+    ASSERT_EQ(solve(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(solveLU(constant(0,0), constant(0,0), constant(0,0)).numdims(), 0);
+
+    array out_lu, piv_lu;
+    lu(out_lu, piv_lu, constant(0,0));
+    ASSERT_EQ(out_lu.numdims(), 0);
+    ASSERT_EQ(piv_lu.numdims(), 0);
+
+    array low_lu, up_lu;
+    lu(low_lu, up_lu, piv_lu, constant(0,0));
+    ASSERT_EQ(low_lu.numdims(), 0);
+    ASSERT_EQ(up_lu.numdims(), 0);
+    ASSERT_EQ(piv_lu.numdims(), 0);
+
+    luInPlace(piv_lu, arr, true);
+    ASSERT_EQ(piv_lu.numdims(), 0);
+    ASSERT_EQ(arr.numdims(), 0);
+
+    array u, s, v;
+    svd(u,s,v, constant(0,0));
+    svdInPlace(u,s,v, arr);
+    ASSERT_EQ(dot(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(transpose(constant(0,0)).numdims(), 0);
+    choleskyInPlace(arr);
+    ASSERT_EQ(arr.numdims(), 0);
+    array out;
+    cholesky(out, constant(0,0));
+    ASSERT_EQ(out.numdims(), 0);
+}
+
+TEST(Array, TestEmptyMath) {
+    ASSERT_EQ(acos(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(acosh(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(abs(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(asin(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(asinh(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(atan(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(atan2(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(atanh(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(cos(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(cosh(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(log(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(log10(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(log1p(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(sin(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(sinh(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(tan(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(tanh(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(sqrt(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(real(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(imag(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(conjg(constant(0,0)).numdims(), 0);
+    //ASSERT_EQ(complex(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(erf(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(erfc(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(exp(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(expm1(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(cbrt(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(ceil(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(factorial(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(lgamma(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(pow(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(root(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(tgamma(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(arg(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(floor(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(hypot(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(rem(constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(round(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(sign(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(trunc(constant(0,0)).numdims(), 0);
+}
+
+TEST(Array, TestEmptyVecOp) {
+    ASSERT_EQ(accum(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(allTrue(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(anyTrue(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(count(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(where(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(max(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(min(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(product(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(sum(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(sort(constant(0,0)).numdims(), 0);
+
+    array skeys, svals;
+    sort(skeys, svals, constant(0,0), constant(0,0));
+    ASSERT_EQ(skeys.numdims(), 0);
+    ASSERT_EQ(svals.numdims(), 0);
+
+
+    array sout, sind;
+    sort(sout, sind, constant(0,0));
+    ASSERT_EQ(sout.numdims(), 0);
+    ASSERT_EQ(sind.numdims(), 0);
+}
+
+TEST(Array, TestEmptyArrMod) {
+    ASSERT_EQ(diag(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(diag(constant(0,0), true).numdims(), 0);
+    ASSERT_EQ(identity(0).numdims(), 0);
+    ASSERT_EQ(iota(dim4(0)).numdims(), 0);
+    ASSERT_EQ(lower(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(upper(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(constant(0,0).as(u8).numdims(), 0);
+    ASSERT_EQ(isNaN(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(isInf(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(iszero(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(flat(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(flip(constant(0,0), 0).numdims(), 0);
+    ASSERT_EQ(join(0, constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(join(0, randu(3), constant(0,0)).elements(), 3);
+    ASSERT_EQ(join(0, constant(0,0), randn(3)).elements(), 3);
+    ASSERT_EQ(moddims(constant(0,0), dim4(0)).numdims(), 0);
+    ASSERT_EQ(reorder(constant(0,0),0).numdims(), 0);
+    ASSERT_EQ(select(constant(0,0), constant(0,0), constant(0,0)).numdims(), 0);
+    ASSERT_EQ(shift(constant(0,0), 1).numdims(), 0);
+    ASSERT_EQ(tile(constant(0,0), 1).numdims(), 0);
+
+    array arr = constant(0,0);
+    replace(arr, constant(0,0), constant(0,0));
+    ASSERT_EQ(arr.numdims(), 0);
+
+}
+
+TEST(Array, TestEmptyImage) {
+    ASSERT_EQ(histogram(constant(0,0) , 1).numdims(), 0);
+    ASSERT_EQ(hsv2rgb(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(gray2rgb(constant(0,0)).numdims(), 0);
+    ASSERT_EQ(rotate(constant(0,0),0).numdims(), 0);
+
+    af_array h, hout;
+    dim_t ds[1];
+    af_constant (&h, 0, 0, ds, f32);
+    af_histogram(&hout, h, 10, 0.0, 1.0);
+
+    unsigned nd; af_get_numdims(&nd, h);
+    ASSERT_EQ(nd, 0);
+    af_get_numdims(&nd, hout);
+    ASSERT_EQ(nd, 0);
+}
+

--- a/test/moddims.cpp
+++ b/test/moddims.cpp
@@ -136,7 +136,7 @@ void moddimsArgsTest(string pTestFile)
     af::dim4 newDims(1);
     newDims[0] = dims[1];
     newDims[1] = dims[0]*dims[2];
-    ASSERT_EQ(AF_ERR_ARG, af_moddims(&outArray,inArray,0,newDims.get()));
+    ASSERT_EQ(AF_SUCCESS, af_moddims(&outArray,inArray,0,newDims.get()));
     ASSERT_EQ(AF_ERR_ARG, af_moddims(&outArray,inArray,newDims.ndims(),NULL));
 
     ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));


### PR DESCRIPTION
Allows indexing with empty arrays . Also handles weird cases such as `af::det( [ ] ) = 1` 

- Fixes https://github.com/arrayfire/arrayfire/issues/799