### PR TITLE
Fix bin2cpp null termination

### DIFF
--- a/CMakeModules/CLKernelToH.cmake
+++ b/CMakeModules/CLKernelToH.cmake
@@ -28,7 +28,7 @@ include(CMakeParseArguments)
 set(BIN2CPP_PROGRAM "bin2cpp")
 
 function(CL_KERNEL_TO_H)
-    cmake_parse_arguments(RTCS "" "VARNAME;EXTENSION;OUTPUT_DIR;TARGETS;NAMESPACE;BINARY;EOF" "SOURCES" ${ARGN})
+    cmake_parse_arguments(RTCS "" "VARNAME;EXTENSION;OUTPUT_DIR;TARGETS;NAMESPACE;BINARY;NULLTERM" "SOURCES" ${ARGN})
 
     set(_output_files "")
     foreach(_input_file ${RTCS_SOURCES})
@@ -42,6 +42,9 @@ function(CL_KERNEL_TO_H)
         if(${RTCS_BINARY})
             set(_binary "--binary")
         endif(${RTCS_BINARY})
+        if(${RTCS_NULLTERM})
+            set(_nullterm "--nullterm")
+        endif(${RTCS_NULLTERM})
 
         string(REPLACE "." "_" var_name ${var_name})
 
@@ -53,7 +56,7 @@ function(CL_KERNEL_TO_H)
             DEPENDS ${_input_file} ${BIN2CPP_PROGRAM}
             COMMAND ${CMAKE_COMMAND} -E make_directory "${_output_path}"
             COMMAND ${CMAKE_COMMAND} -E echo "\\#include \\<${_path}/${_name_we}.hpp\\>"  >>"${_output_file}"
-            COMMAND ${BIN2CPP_PROGRAM} --file ${_name} --namespace ${_namespace} --output ${_output_file} --name ${var_name} ${_binary} --eof ${RTCS_EOF}
+            COMMAND ${BIN2CPP_PROGRAM} --file ${_name} --namespace ${_namespace} --output ${_output_file} --name ${var_name} ${_binary} ${_nullterm}
             WORKING_DIRECTORY "${_path}"
             COMMENT "Compiling ${_input_file} to C++ source"
         )

--- a/CMakeModules/bin2cpp.cpp
+++ b/CMakeModules/bin2cpp.cpp
@@ -23,6 +23,7 @@ xxd but adds support for namespaces.
 | --output      | output file (If no output is specified then it prints to stdout   |
 | --type        | Type of variable (default: char)                                  |
 | --binary      | If the file contents are in binary form                           |
+| --nullterm    | Add a null character to the end of the file                       |
 | --namespace   | A space seperated list of namespaces                              |
 | --formatted   | Tabs for formatting                                               |
 | --version     | Prints my name                                                    |
@@ -49,6 +50,7 @@ namespace blah {
 
 static bool formatted;
 static bool binary = false;
+static bool nullterm = false;
 
 void add_tabs(const int level ){
     if(formatted) {
@@ -67,7 +69,6 @@ parse_options(const vector<string>& args) {
     options["--file"]       = "";
     options["--output"]     = "";
     options["--namespace"]  = "";
-    options["--eof"]        = "0";
 
     //Parse Arguments
     string curr_opt;
@@ -78,6 +79,9 @@ parse_options(const vector<string>& args) {
         }
         else if(arg == "--binary") {
             binary = true;
+        }
+        else if(arg == "--nullterm") {
+            nullterm = true;
         }
         else if(arg == "--formatted") {
             formatted = true;
@@ -167,7 +171,7 @@ int main(int argc, const char * const * const argv)
         }
     }
 
-    if (options["--eof"].c_str()[0] == '1') {
+    if (nullterm) {
         // Add end of file character
         cout << "0x0";
         char_cnt++;

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -327,7 +327,7 @@ CL_KERNEL_TO_H(
     OUTPUT_DIR ${ptx_headers}
     TARGETS ptx_targets
     NAMESPACE "cuda"
-    EOF "1"
+    NULLTERM TRUE
     )
 
 SET(libdevice_bc "")
@@ -363,7 +363,6 @@ IF (${libdevice_bc_len} GREATER 0)
     TARGETS libdevice_targets
     NAMESPACE "cuda"
     BINARY TRUE
-    EOF "1"
     )
 
   MESSAGE(STATUS "LIBDEVICE found.")

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -230,7 +230,6 @@ CL_KERNEL_TO_H(
     OUTPUT_DIR ${cl_kernel_headers}
     TARGETS cl_kernel_targets
     NAMESPACE "opencl"
-    EOF "0"
     )
 
 # OS Definitions


### PR DESCRIPTION
It was affecting ptx files as they were failing to compile.
CUDA cuLinkAddData requires the string to be NULL Terminated.

[skip arrayfire ci]