### PR TITLE
dilate, erode wrong result when the filter center is not set

### DIFF
--- a/src/backend/cpu/kernel/morph.hpp
+++ b/src/backend/cpu/kernel/morph.hpp
@@ -38,7 +38,7 @@ void morph(Array<T> out, Array<T> const in, Array<T> const mask)
                 // j steps along 2nd dimension
                 for(dim_t i=0; i<dims[0]; ++i) {
                     // i steps along 1st dimension
-                    T filterResult = isDilation ? (std::is_integral<T>::value ? std::numeric_limits<T>::lowest() : -std::numeric_limits<T>::infinity())
+                    T filterResult = IsDilation ? (std::is_integral<T>::value ? std::numeric_limits<T>::lowest() : -std::numeric_limits<T>::infinity())
 			: (std::is_integral<T>::value ? std::numeric_limits<T>::max() : std::numeric_limits<T>::infinity());
 
                     // wj,wi steps along 2nd & 1st dimensions of filter window respectively
@@ -98,7 +98,7 @@ void morph3d(Array<T> out, Array<T> const in, Array<T> const mask)
                 // j steps along 2nd dimension
                 for(dim_t i=0; i<dims[0]; ++i) {
                     // i steps along 1st dimension
-                    T filterResult = isDilation ? (std::is_integral<T>::value ? std::numeric_limits<T>::lowest() : -std::numeric_limits<T>::infinity())
+                    T filterResult = IsDilation ? (std::is_integral<T>::value ? std::numeric_limits<T>::lowest() : -std::numeric_limits<T>::infinity())
 			: (std::is_integral<T>::value ? std::numeric_limits<T>::max() : std::numeric_limits<T>::infinity());
 
                     // wk, wj,wi steps along 2nd & 1st dimensions of filter window respectively

--- a/src/backend/cpu/kernel/morph.hpp
+++ b/src/backend/cpu/kernel/morph.hpp
@@ -8,6 +8,7 @@
  ********************************************************/
 
 #pragma once
+#include <limits>
 #include <Array.hpp>
 #include <utility.hpp>
 
@@ -37,7 +38,8 @@ void morph(Array<T> out, Array<T> const in, Array<T> const mask)
                 // j steps along 2nd dimension
                 for(dim_t i=0; i<dims[0]; ++i) {
                     // i steps along 1st dimension
-                    T filterResult = inData[ getIdx(istrides, i, j) ];
+                    T filterResult = isDilation ? (std::is_integral<T>::value ? std::numeric_limits<T>::lowest() : -std::numeric_limits<T>::infinity())
+			: (std::is_integral<T>::value ? std::numeric_limits<T>::max() : std::numeric_limits<T>::infinity());
 
                     // wj,wi steps along 2nd & 1st dimensions of filter window respectively
                     for(dim_t wj=0; wj<window[1]; wj++) {
@@ -96,7 +98,8 @@ void morph3d(Array<T> out, Array<T> const in, Array<T> const mask)
                 // j steps along 2nd dimension
                 for(dim_t i=0; i<dims[0]; ++i) {
                     // i steps along 1st dimension
-                    T filterResult = inData[ getIdx(istrides, i, j, k) ];
+                    T filterResult = isDilation ? (std::is_integral<T>::value ? std::numeric_limits<T>::lowest() : -std::numeric_limits<T>::infinity())
+			: (std::is_integral<T>::value ? std::numeric_limits<T>::max() : std::numeric_limits<T>::infinity());
 
                     // wk, wj,wi steps along 2nd & 1st dimensions of filter window respectively
                     for(dim_t wk=0; wk<window[2]; wk++) {

--- a/src/backend/cuda/kernel/morph.hpp
+++ b/src/backend/cuda/kernel/morph.hpp
@@ -7,6 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <limits>
 #include <backend.hpp>
 #include <dispatch.hpp>
 #include <Param.hpp>
@@ -102,7 +103,8 @@ static __global__ void morphKernel(Param<T> out, CParam<T> in,
     __syncthreads();
 
     const T * d_filt = (const T *)cFilter;
-    T acc = shrdMem[ lIdx(i, j, shrdLen, 1) ];
+    T acc = isDilation ? (std::is_integral<T>::value ? std::numeric_limits<T>::lowest() : -std::numeric_limits<T>::infinity())
+	: (std::is_integral<T>::value ? std::numeric_limits<T>::max() : std::numeric_limits<T>::infinity());
 #pragma unroll
     for(int wj=0; wj<windLen; ++wj) {
         int joff   = wj*windLen;
@@ -196,7 +198,8 @@ static __global__ void morph3DKernel(Param<T> out, CParam<T> in, int nBBS)
     int k  = lz + halo;
 
     const T * d_filt = (const T *)cFilter;
-    T acc = shrdMem[ lIdx3D(i, j, k, shrdArea, shrdLen, 1) ];
+    T acc = isDilation ? (std::is_integral<T>::value ? std::numeric_limits<T>::lowest() : -std::numeric_limits<T>::infinity())
+	: (std::is_integral<T>::value ? std::numeric_limits<T>::max() : std::numeric_limits<T>::infinity());
 #pragma unroll
     for(int wk=0; wk<windLen; ++wk) {
         int koff   = wk*se_area;


### PR DESCRIPTION
The current implementation of `morph` (which is used for `dilate` and `erode` functions) seems to assume that the center of the filter is always set. This happens in [backend/cpu/kernel/morph.hpp:40](https://github.com/arrayfire/arrayfire/blob/devel/src/backend/cpu/kernel/morph.hpp#L40) and [backend/cuda/kernel/morph.hpp:105](https://github.com/arrayfire/arrayfire/blob/devel/src/backend/cuda/kernel/morph.hpp#L105).
In contrast, matlab's `imdilate` and `imerode` makes no such assumption and (for floating types) initializes the value to `Inf` for `erode` and to `-Inf` for `dilate`.
For example in matlab ` imdilate(ones(3, 3), zeros(3, 3))` would return 3x3 all `-Inf`, whereas arrayfire will return 3x3 all 1s.
