### PR TITLE
optimize morph by pre-computing the mask linear offsets

### DIFF
--- a/src/backend/cpu/kernel/morph.hpp
+++ b/src/backend/cpu/kernel/morph.hpp
@@ -12,62 +12,73 @@
 #include <Array.hpp>
 #include <utility.hpp>
 #include <ops.hpp>
+#include <cassert>
 
 namespace cpu
 {
 namespace kernel
 {
 
+
+template<typename T>
+void getOffsets(const af::dim4& strides, const Array<T>& mask, std::vector<dim_t>& offsets)
+{
+    const af::dim4 fstrides = mask.strides();
+    const T * filter = mask.get();
+    const dim_t dim0 = mask.dims()[0], dim1 = mask.dims()[1];
+    const dim_t R0 = dim0/2;
+    const dim_t R1 = dim1/2;
+
+    offsets.reserve(mask.elements());
+    for (dim_t j = 0; j < dim1; ++j) {
+	for (dim_t i = 0; i < dim0; ++i) {
+	    if (filter[ getIdx(fstrides, i, j) ] > (T)0) {
+		dim_t offset = (j - R1) * strides[1] + (i - R0) * strides[0];
+		offsets.push_back(offset);
+	    }
+	}
+    }
+}
+
+    
 template<typename T, bool IsDilation>
 void morph(Array<T> out, Array<T> const in, Array<T> const mask)
 {
     const af::dim4 ostrides = out.strides();
     const af::dim4 istrides = in.strides();
-    const af::dim4 fstrides = mask.strides();
     const af::dim4 dims     = in.dims();
-    const af::dim4 window   = mask.dims();
+
+    assert(dims[0] == out.dims()[0]);
+    assert(dims[1] == out.dims()[1]);
+    assert(dims[2] == out.dims()[2]);
+    assert(dims[3] == out.dims()[3]);
+
     T* outData          = out.get();
     const T*   inData   = in.get();
-    const T*   filter   = mask.get();
-    const dim_t R0      = window[0]/2;
-    const dim_t R1      = window[1]/2;
 
     T init = IsDilation ? Binary<T, af_max_t>().init() : Binary<T, af_min_t>().init();
 
+    dim_t batchNumElements = dims[0] * dims[1];
+    std::vector<dim_t> offsets;
+    getOffsets(istrides, mask, offsets);
+
     for(dim_t b3=0; b3<dims[3]; ++b3) {
         for(dim_t b2=0; b2<dims[2]; ++b2) {
-            // either channels or batch is handled by outer most loop
-            for(dim_t j=0; j<dims[1]; ++j) {
-                // j steps along 2nd dimension
-                for(dim_t i=0; i<dims[0]; ++i) {
-                    // i steps along 1st dimension
-                    T filterResult = init;
-
-                    // wj,wi steps along 2nd & 1st dimensions of filter window respectively
-                    for(dim_t wj=0; wj<window[1]; wj++) {
-                        for(dim_t wi=0; wi<window[0]; wi++) {
-
-                            dim_t offj = j+wj-R1;
-                            dim_t offi = i+wi-R0;
-
-                            T maskValue = filter[ getIdx(fstrides, wi, wj) ];
-
-                            if ((maskValue > (T)0) && offi>=0 && offj>=0 && offi<dims[0] && offj<dims[1]) {
-
-                                T inValue   = inData[ getIdx(istrides, offi, offj) ];
-
-                                if (IsDilation)
-                                    filterResult = std::max(filterResult, inValue);
-                                else
-                                    filterResult = std::min(filterResult, inValue);
-                            }
-
-                        } // window 1st dimension loop ends here
-                    } // filter window loop ends here
-
-                    outData[ getIdx(ostrides, i, j) ] = filterResult;
-                } //1st dimension loop ends here
-            } // 2nd dimension loop ends here
+	    for (dim_t n = 0; n < batchNumElements; ++n) {
+		T filterResult = init;
+		for (size_t oi = 0; oi < offsets.size(); ++oi) {
+		    dim_t x = n + offsets[oi];
+		    if (x >= 0 && x < batchNumElements) {
+			T inValue = inData[x];
+			if (IsDilation) {
+			    filterResult = std::max(filterResult, inValue);
+			} else {
+			    filterResult = std::min(filterResult, inValue);
+			}
+		    }
+		}
+		outData[n] = filterResult;
+	    }
 
             // next iteration will be next batch if any
             outData += ostrides[2];

--- a/src/backend/cpu/kernel/pad.hpp
+++ b/src/backend/cpu/kernel/pad.hpp
@@ -128,7 +128,6 @@ Array<T> createCroppedArray(const Array<T>& in, const af::dim4 cropSizes, const 
     getCropInfo(inOffsets, outDims, in.dims(), cropSizes, direction);
 
     Array<T> out = createEmptyArray<T>(outDims);
-    out.eval();
     cropArray(out, in, cropSizes, direction);
     return out;
 }

--- a/src/backend/cpu/kernel/pad.hpp
+++ b/src/backend/cpu/kernel/pad.hpp
@@ -1,0 +1,137 @@
+/*******************************************************
+ * Copyright (c) 2015, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+#include <Array.hpp>
+#include <cassert>
+#include <cstring>
+
+namespace cpu
+{
+namespace kernel
+{
+
+enum PadDirection {
+    PRE,
+    POST,
+    BOTH
+};
+
+void getPadInfo(af::dim4& outOffsets, af::dim4& outDims, af::dim4 const & inDims, const af::dim4 padSizes, const PadDirection direction[4]) {
+    for (int n = 0; n < 4; n++) {
+        switch (direction[n]) {
+        case PRE:
+            outOffsets[n] = padSizes[n];
+            outDims[n] = inDims[n] + padSizes[n];
+            break;
+        case POST:
+            outOffsets[n] = 0;
+            outDims[n] = inDims[n] + padSizes[n];
+            break;
+        case BOTH:
+            outOffsets[n] = padSizes[n];
+            outDims[n] = inDims[n] + 2*padSizes[n];
+            break;
+        }
+    }
+}
+
+template<typename T>
+void padArray(T * outData, af::dim4 const & outStrides, af::dim4 const & outOffsets, const T * inData, af::dim4 const & inDims, af::dim4 const & inStrides) {
+    for (dim_t l = 0; l < inDims[3]; ++l) {
+        for (dim_t k = 0; k < inDims[2]; ++k) {
+            for (dim_t j = 0; j < inDims[1]; ++j) {
+                dim_t outOffset = getIdx(outStrides, outOffsets[0], j + outOffsets[1], k + outOffsets[2], l + outOffsets[3]);
+                dim_t inOffset = getIdx(inStrides, 0, j, k, l);
+                memcpy(outData + outOffset, inData + inOffset, sizeof(T) * inDims[0]);
+            }
+        }
+    }
+}
+
+template<typename T>
+void padArray(Array<T>& out, const Array<T>& in, const af::dim4 padSizes, const PadDirection direction[4]) {
+    af::dim4 outOffsets, outDims;
+    getPadInfo(outOffsets, outDims, in.dims(), padSizes, direction);
+    assert(outDims[0] == out.dims()[0]);
+    assert(outDims[1] == out.dims()[1]);
+    assert(outDims[2] == out.dims()[2]);
+    assert(outDims[3] == out.dims()[3]);
+
+    padArray(out.get(), out.strides(), outOffsets, in.get(), in.dims(), in.strides());
+}
+
+template<typename T>
+Array<T> createPaddedArray(const Array<T>& in, const af::dim4 padSizes, T padValue, const PadDirection direction[4]) {
+    af::dim4 outOffsets, outDims;
+    getPadInfo(outOffsets, outDims, in.dims(), padSizes, direction);
+
+    Array<T> out = createEmptyArray<T>(outDims);
+    std::fill(out.get(), out.get() + out.elements(), padValue);
+    padArray(out, in, padSizes, direction);
+    return out;
+}
+
+void getCropInfo(af::dim4& inOffsets, af::dim4& outDims, af::dim4 const & inDims, const af::dim4 cropSizes, const PadDirection direction[4]) {
+    for (int n = 0; n < 4; n++) {
+        switch (direction[n]) {
+        case PRE:
+            inOffsets[n] = cropSizes[n];
+            outDims[n] = inDims[n] - cropSizes[n];
+            break;
+        case POST:
+            inOffsets[n] = 0;
+            outDims[n] = inDims[n] - cropSizes[n];
+            break;
+        case BOTH:
+            inOffsets[n] = cropSizes[n];
+            outDims[n] = inDims[n] - 2*cropSizes[n];
+            break;
+        }
+    }
+}
+
+template<typename T>
+void cropArray(T * outData, af::dim4 const & outDims, af::dim4 const & outStrides, const T * inData, af::dim4 const & inOffsets, af::dim4 const & inStrides) {
+    for (dim_t l = 0; l < outDims[3]; ++l) {
+        for (dim_t k = 0; k < outDims[2]; ++k) {
+            for (dim_t j = 0; j < outDims[1]; ++j) {
+                dim_t inOffset = getIdx(inStrides, inOffsets[0], j + inOffsets[1], k + inOffsets[2], l + inOffsets[3]);
+                dim_t outOffset = getIdx(outStrides, 0, j, k, l);
+                memcpy(outData + outOffset, inData + inOffset, sizeof(T) * outDims[0]);
+            }
+        }
+    }
+}
+
+template<typename T>
+void cropArray(Array<T>& out, const Array<T>& in, const af::dim4 cropSizes, const PadDirection direction[4]) {
+    af::dim4 inOffsets, outDims;
+    getCropInfo(inOffsets, outDims, in.dims(), cropSizes, direction);
+    assert(outDims[0] == out.dims()[0]);
+    assert(outDims[1] == out.dims()[1]);
+    assert(outDims[2] == out.dims()[2]);
+    assert(outDims[3] == out.dims()[3]);
+
+    cropArray(out.get(), outDims, out.strides(), in.get(), inOffsets, in.strides());
+}
+
+template<typename T>
+Array<T> createCroppedArray(const Array<T>& in, const af::dim4 cropSizes, const PadDirection direction[4]) {
+    af::dim4 inOffsets, outDims;
+    getCropInfo(inOffsets, outDims, in.dims(), cropSizes, direction);
+
+    Array<T> out = createEmptyArray<T>(outDims);
+    out.eval();
+    cropArray(out, in, cropSizes, direction);
+    return out;
+}
+
+}
+}


### PR DESCRIPTION
As discussed in https://github.com/arrayfire/arrayfire/pull/1547#issuecomment-241145933, this patch is to optimize the algorithm for `erode` and `dilate`. Before this patch, the following code took about 110 seconds, while after the patch it takes about 4 seconds.

```
in = randn(3000, 3000);
filter = constant(1, 21, 21);
dilate(in, filter);
```

This change assumes that the input and output arrays have the same dimensions, which allows to use the linear indexing for both input and output batches. The way `morph` is currently being used for `erode` and `dilate`, this assumption is definitely satisfied.

Only the 2D version of morph is implemented here, mainly to show the idea.
