### PR TITLE
explicitly instantiate void* type for array::device<void>()

### DIFF
--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -1003,6 +1003,13 @@ af::dtype implicit_dtype(af::dtype scalar_type, af::dtype array_type)
 
 #undef INSTANTIATE
 
+    template<> AFAPI void* array::device() const
+    {
+        void *ptr = NULL;
+        AF_THROW(af_get_device_ptr(&ptr, get()));
+        return (void *)ptr;
+    }
+
 
 // array_proxy instanciations
 #define TEMPLATE_MEM_FUNC(TYPE, RETURN_TYPE, FUNC)      \


### PR DESCRIPTION
Fixes issue #1503