### PR TITLE
Preparing for release with CUDA 8

### DIFF
--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -44,12 +44,12 @@ LIST(LENGTH COMPUTES_DETECTED_LIST COMPUTES_LEN)
 IF(${COMPUTES_LEN} EQUAL 0 AND ${FALLBACK})
     MESSAGE(STATUS "You can use -DCOMPUTES_DETECTED_LIST=\"AB;XY\" (semicolon separated list of CUDA Compute versions to enable the specified computes")
     MESSAGE(STATUS "Individual compute versions flags are also available under CMake Advance options")
-    LIST(APPEND COMPUTES_DETECTED_LIST "20" "30" "50")
+    LIST(APPEND COMPUTES_DETECTED_LIST "30" "50")
     IF(${CUDA_VERSION_MAJOR} GREATER 7) # Enable 60 only if CUDA 8 or greater
-        MESSAGE(STATUS "No computes detected. Fall back to 20, 30, 50, 60")
+        MESSAGE(STATUS "No computes detected. Fall back to 30, 50, 60")
         LIST(APPEND COMPUTES_DETECTED_LIST "60")
     ELSE(${CUDA_VERSION_MAJOR} GREATER 7)
-        MESSAGE(STATUS "No computes detected. Fall back to 20, 30, 50")
+        LIST(APPEND COMPUTES_DETECTED_LIST "20")
     ENDIF(${CUDA_VERSION_MAJOR} GREATER 7)
 ENDIF()
 
@@ -85,8 +85,8 @@ IF(${CUDA_VERSION_MAJOR} LESS 8)
       )
         MESSAGE(FATAL_ERROR
                 "CUDA Compute 6x was enabled.\
-                CUDA Compute 6x (Pascal) GPUs require CUDA 8 or greater.\
-                Your CUDA Version is ${CUDA_VERSION}."
+                 CUDA Compute 6x (Pascal) GPUs require CUDA 8 or greater.\
+                 Your CUDA Version is ${CUDA_VERSION}."
                 )
     ENDIF()
 ENDIF(${CUDA_VERSION_MAJOR} LESS 8)

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -294,7 +294,12 @@ LIST(LENGTH COMPUTE_VERSIONS COMPUTE_COUNT)
 IF(${COMPUTE_COUNT} EQUAL 1)
     SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} ${CUDA_GENERATE_CODE}")
 ELSE()
-    SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -arch sm_20")
+    # Use -arch sm_30 if CUDA 8 or greater and compute_20 not defined
+    IF(CUDA_COMPUTE_20 OR ${CUDA_VERSION_MAJOR} LESS 8)
+        SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -arch sm_20")
+    ELSE()
+        SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -arch sm_30")
+    ENDIF()
 ENDIF()
 
 # PUSH/POP --keep-device-functions flag. Only available in CUDA 8 or newer

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -327,7 +327,8 @@ void compute_to_libdevice_table(const char **buffer, size_t *bc_buffer_len, int 
         *buffer        = compute_30_bc;
         *bc_buffer_len = compute_30_bc_len;
     } else {
-        AF_ERROR("Invalid Compute for libdevice", AF_ERR_INTERNAL);
+        *buffer        = compute_30_bc;
+        *bc_buffer_len = compute_30_bc_len;
     }
 }
 


### PR DESCRIPTION
This PR does the following:
* If CUDA 8 is being used, `CUDA_COMPUTE_20` is no longer in the default computes list. This can be enabled using `cmake -DCUDA_COMPUTE_20=ON`
  * For CUDA versions older than 8, 20, 30, 50 is the default compute selection.
* If CUDA 8 is being used and `CUDA_COMPUTE_20` if OFF, then the default compute version of PTX compilation will be 30 in case of multiple compute devices being present. The behavior when a single compute is found remains the same.
* For libdevice, check the compute version of the device and select the appropriate header.

The compute 2x deprecation follows CUDA 8's deprecation of computes 2.x.

[skip arrayfire ci]