### PR TITLE
VS 2015 Compilation fixes for OpenCL

### DIFF
--- a/src/backend/opencl/math.hpp
+++ b/src/backend/opencl/math.hpp
@@ -97,13 +97,12 @@ namespace opencl
         return cval;
     }
 
-    template <typename T> T maxval() { return std::numeric_limits<T>::max(); }
-    template <typename T> T minval() { return std::numeric_limits<T>::min(); }
-    template <> STATIC_ float maxval() { return std::numeric_limits<float>::infinity(); }
-    template <> STATIC_ double maxval() { return std::numeric_limits<double>::infinity(); }
-    template <> STATIC_ float minval() { return -std::numeric_limits<float>::infinity(); }
-    template <> STATIC_ double minval() { return -std::numeric_limits<double>::infinity(); }
-
+    template <typename T> STATIC_ T      maxval() { return  std::numeric_limits<T     >::max();      }
+    template <typename T> STATIC_ T      minval() { return  std::numeric_limits<T     >::min();      }
+    template <>           STATIC_ float  maxval() { return  std::numeric_limits<float >::infinity(); }
+    template <>           STATIC_ double maxval() { return  std::numeric_limits<double>::infinity(); }
+    template <>           STATIC_ float  minval() { return -std::numeric_limits<float >::infinity(); }
+    template <>           STATIC_ double minval() { return -std::numeric_limits<double>::infinity(); }
 
     static inline double real(cdouble in)
     {

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -131,12 +131,12 @@ static inline bool compare_default(const Device *ldev, const Device *rdev)
         if (!is_l_curr_type &&  is_r_curr_type) return false;
     }
 
-    // For GPUs, this ensures discreet > integrated
-    auto is_l_integrared = ldev->getInfo<CL_DEVICE_HOST_UNIFIED_MEMORY>();
-    auto is_r_integrared = rdev->getInfo<CL_DEVICE_HOST_UNIFIED_MEMORY>();
+    // For GPUs, this ensures discrete > integrated
+    auto is_l_integrated = ldev->getInfo<CL_DEVICE_HOST_UNIFIED_MEMORY>();
+    auto is_r_integrated = rdev->getInfo<CL_DEVICE_HOST_UNIFIED_MEMORY>();
 
-    if (!is_l_integrared &&  is_r_integrared) return true;
-    if ( is_l_integrared && !is_r_integrared) return false;
+    if (!is_l_integrated &&  is_r_integrated) return true;
+    if ( is_l_integrated && !is_r_integrated) return false;
 
     // At this point, the devices are of same type.
     // Sort based on emperical evidence of preferred platforms
@@ -190,7 +190,7 @@ static inline bool compare_default(const Device *ldev, const Device *rdev)
         if (rres) return false;
     }
 
-    // Default crietria, sort based on memory
+    // Default criteria, sort based on memory
     // Sort based on memory
     auto l_mem = ldev->getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>();
     auto r_mem = rdev->getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>();


### PR DESCRIPTION
Fixes missing static declarations for OpenCL

PS. Will not test on PR on Windows as we do not use VS 2015 for compilation and this has been tested manually.

[skip arrayfire ci]