### PR TITLE
Revert "use scoped_array instead of scoped_ptr when managing array resources"

### DIFF
--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -45,10 +45,10 @@
 #include <vector>
 #include <nvvm.h>
 #include <boost/functional/hash.hpp>
-#include <boost/scoped_array.hpp>
+#include <boost/scoped_ptr.hpp>
 
 using std::vector;
-using boost::scoped_array;
+using boost::scoped_ptr;
 
 namespace cuda
 {
@@ -409,7 +409,7 @@ static char *irToPtx(string IR, size_t *ptx_size)
         size_t log_size = 0;
         nvvmGetProgramLogSize(prog, &log_size);
         printf("%ld, %zu\n", IR.size(), log_size);
-        scoped_array<char> log(new char[log_size]);
+        scoped_ptr<char> log(new char[log_size]);
         nvvmGetProgramLog(prog, log.get());
         printf("LOG:\n%s\n%s", log.get(), IR.c_str());
         NVVM_CHECK(comp_res, "Failed to compile program");
@@ -463,7 +463,7 @@ char linkError[size];
 static kc_entry_t compileKernel(const char *ker_name, string jit_ker)
 {
     size_t ptx_size;
-    scoped_array<const char> ptx(irToPtx(jit_ker, &ptx_size));
+    scoped_ptr<const char> ptx(irToPtx(jit_ker, &ptx_size));
 
     CUlinkState linkState;
 

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -16,9 +16,9 @@
 #include <debug_cuda.hpp>
 #include "config.hpp"
 #include <memory.hpp>
-#include <boost/scoped_array.hpp>
+#include <boost/scoped_ptr.hpp>
 
-using boost::scoped_array;
+using boost::scoped_ptr;
 
 namespace cuda
 {
@@ -486,8 +486,8 @@ namespace kernel
             tlptr = memAlloc<uint>(tmp_elements);
             ireduce_first_launcher<T, op, true>(tmp, tlptr, in, NULL, blocks_x, blocks_y, threads_x);
 
-            scoped_array<T>       h_ptr(new T[tmp_elements]);
-            scoped_array<uint>    h_lptr(new uint[tmp_elements]);
+            scoped_ptr<T>       h_ptr(new T[tmp_elements]);
+            scoped_ptr<uint>    h_lptr(new uint[tmp_elements]);
             T*      h_ptr_raw = h_ptr.get();
             uint*   h_lptr_raw = h_lptr.get();
 
@@ -520,7 +520,7 @@ namespace kernel
             return Op.m_val;
         } else {
 
-            scoped_array<T> h_ptr(new T[in_elements]);
+            scoped_ptr<T> h_ptr(new T[in_elements]);
             T* h_ptr_raw = h_ptr.get();
             CUDA_CHECK(cudaMemcpyAsync(h_ptr_raw, in.ptr, in_elements * sizeof(T),
                        cudaMemcpyDeviceToHost, cuda::getStream(cuda::getActiveDeviceId())));

--- a/src/backend/cuda/kernel/orb.hpp
+++ b/src/backend/cuda/kernel/orb.hpp
@@ -17,10 +17,10 @@
 #include "sort_by_key.hpp"
 #include "range.hpp"
 
-#include <boost/scoped_array.hpp>
+#include <boost/scoped_ptr.hpp>
 
 using std::vector;
-using boost::scoped_array;
+using boost::scoped_ptr;
 
 namespace cuda
 {
@@ -344,7 +344,7 @@ void orb(unsigned* out_feat,
     Param<convAccT> gauss_filter;
     if (blur_img) {
         unsigned gauss_len = 9;
-        scoped_array<convAccT> h_gauss(new convAccT[gauss_len]);
+        scoped_ptr<convAccT> h_gauss(new convAccT[gauss_len]);
         gaussian1D(h_gauss.get(), gauss_len, 2.f);
         gauss_filter.dims[0] = gauss_len;
         gauss_filter.strides[0] = 1;

--- a/src/backend/cuda/kernel/reduce.hpp
+++ b/src/backend/cuda/kernel/reduce.hpp
@@ -16,9 +16,9 @@
 #include <debug_cuda.hpp>
 #include "config.hpp"
 #include <memory.hpp>
-#include <boost/scoped_array.hpp>
+#include <boost/scoped_ptr.hpp>
 
-using boost::scoped_array;
+using boost::scoped_ptr;
 
 namespace cuda
 {
@@ -410,7 +410,7 @@ namespace kernel
             reduce_first_launcher<Ti, To, op>(tmp, in, blocks_x, blocks_y, threads_x,
                                               change_nan, nanval);
 
-            scoped_array<To> h_ptr(new To[tmp_elements]);
+            scoped_ptr<To> h_ptr(new To[tmp_elements]);
             To* h_ptr_raw = h_ptr.get();
 
             CUDA_CHECK(cudaMemcpyAsync(h_ptr_raw, tmp.ptr, tmp_elements * sizeof(To),
@@ -428,7 +428,7 @@ namespace kernel
 
         } else {
 
-            scoped_array<Ti> h_ptr(new Ti[in_elements]);
+            scoped_ptr<Ti> h_ptr(new Ti[in_elements]);
             Ti* h_ptr_raw = h_ptr.get();
             CUDA_CHECK(cudaMemcpyAsync(h_ptr_raw, in.ptr, in_elements * sizeof(Ti),
                        cudaMemcpyDeviceToHost, cuda::getStream(cuda::getActiveDeviceId())));


### PR DESCRIPTION
Reverts arrayfire/arrayfire#1634