### PR TITLE
Revert to setting chart axes limits automatically

### DIFF
--- a/CMakeModules/build_forge.cmake
+++ b/CMakeModules/build_forge.cmake
@@ -42,13 +42,13 @@ ELSE()
     SET(byproducts BYPRODUCTS ${forge_location})
 ENDIF()
 
-SET(FORGE_VERSION 0.9.0)
+SET(FORGE_VERSION 0.9.1)
 
 # FIXME Tag forge correctly during release
 ExternalProject_Add(
     forge-ext
     GIT_REPOSITORY https://github.com/arrayfire/forge.git
-    GIT_TAG v${FORGE_VERSION}
+    GIT_TAG devel
     PREFIX "${prefix}"
     INSTALL_DIR "${prefix}"
     UPDATE_COMMAND ""

--- a/examples/graphics/field.cpp
+++ b/examples/graphics/field.cpp
@@ -25,9 +25,6 @@ int main(int argc, char *argv[])
 
         myWindow.grid(1, 2);
 
-        myWindow(0, 0).setAxesLimits(MINIMUM, MAXIMUM, MINIMUM, MAXIMUM);
-        myWindow(0, 1).setAxesLimits(MINIMUM, MAXIMUM, MINIMUM, MAXIMUM);
-
         array dataRange = seq(MINIMUM, MAXIMUM, STEP);
 
         array x = tile(dataRange, 1, dataRange.dims(0));

--- a/examples/graphics/histogram.cpp
+++ b/examples/graphics/histogram.cpp
@@ -24,8 +24,6 @@ int main(int argc, char *argv[])
         array img = loadImage(ASSETS_DIR"/examples/images/arrow.jpg", false);
         array hist_out = histogram(img, 256, 0, 255);
 
-        float freq_max = max<float>(hist_out);
-        myWindow.setAxesLimits(0, 255, 0, freq_max);
         myWindow.setAxesTitles("Bins", "Frequency");
         myWindow.setPos(480, 0);
 

--- a/examples/graphics/plot2d.cpp
+++ b/examples/graphics/plot2d.cpp
@@ -29,8 +29,6 @@ int main(int argc, char *argv[])
         array noise = randn(X.dims(0))/5.f;
 
         myWindow.grid(2, 1);
-        myWindow(0, 0).setAxesLimits(-2 * af::Pi, 2 * af::Pi, -1, 1, true);
-        myWindow(1, 0).setAxesLimits(-2 * af::Pi, 2 * af::Pi, -1.25, 1.25, true);
 
         for (double val=0; !myWindow.close(); ) {
 

--- a/examples/graphics/plot3.cpp
+++ b/examples/graphics/plot3.cpp
@@ -32,8 +32,6 @@ int main(int argc, char *argv[])
             X = max(min(X, 1.0), -1.0);
             Y = max(min(Y, 1.0), -1.0);
 
-            myWindow.setAxesLimits(X, Y, Z);
-
             //Pts can be passed in as a matrix in the form n x 3, 3 x n
             //or in the flattened xyz-triplet array with size 3n x 1
             myWindow.plot(X, Y, Z);

--- a/examples/graphics/surface.cpp
+++ b/examples/graphics/surface.cpp
@@ -28,7 +28,6 @@ int main(int argc, char *argv[])
         const array y = iota(dim4(1, N), dim4(N, 1)) / M - 1;
 
         static float t=0;
-        myWindow.setAxesLimits(-1.0, 1.0, -1.0, 1.0, -10.0, 10.0);
         while(!myWindow.close()) {
             t+=0.07;
             array z = 10*x*-abs(y) * cos(x*x*(y+t))+sin(y*(x+t))-1.5;

--- a/examples/image_processing/binary_thresholding.cpp
+++ b/examples/image_processing/binary_thresholding.cpp
@@ -76,18 +76,12 @@ int main(int argc, char **argv)
         array smooth = convolve(bimodal, gaussianKernel(5, 5));
         array smoothHist = histogram(smooth, 256, 0, 255);
 
-        unsigned bimodHist_freq_max = max<unsigned>(bimodHist);
-        unsigned smoothHist_freq_max = max<unsigned>(smoothHist);
-
         af::Window wnd(1536, 1024, "Binary Thresholding Algorithms");
         std::cout << "Press ESC while the window is in focus to proceed to exit" << std::endl;
 
         wnd.grid(3, 3);
-        wnd(0, 1).setAxesLimits(0, 255, 0, bimodHist_freq_max, true);
         wnd(0, 1).setAxesTitles("Bins", "Frequency");
-        wnd(1, 1).setAxesLimits(0, 255, 0, bimodHist_freq_max, true);
         wnd(1, 1).setAxesTitles("Bins", "Frequency");
-        wnd(2, 1).setAxesLimits(0, 255, 0, smoothHist_freq_max, true);
         wnd(2, 1).setAxesTitles("Bins", "Frequency");
         while (!wnd.close()) {
             wnd(0, 0).image(bimodal / 255, "Input Image");

--- a/examples/image_processing/edge.cpp
+++ b/examples/image_processing/edge.cpp
@@ -80,8 +80,6 @@ void edge()
     array sobelFilter   = edge(in, 2);
     array hst = histogram(in, 256, 0, 255);
 
-    float freq_max = max<float>(hst);
-    myWindow2.setAxesLimits(0, 255, 0, freq_max);
     myWindow2.setAxesTitles("Bins", "Frequency");
 
     while(!myWindow.close() && !myWindow2.close()) {

--- a/examples/pde/swe.cpp
+++ b/examples/pde/swe.cpp
@@ -87,8 +87,6 @@ static void swe(bool console)
             array hist_out = histogram(normalize(eta, m_eta), 15);
 
             (*win)(0, 1).setAxesLimits(0, hist_out.elements(), 0, max<float>(hist_out));
-            (*win)(1, 0).setAxesLimits(range(up.dims(1)), vp.col(0));
-            (*win)(1, 1).setAxesLimits(eta.col(0), up.col(0), vp.col(0));
 
             (*win)(0,0).image(normalize(eta, m_eta));
             (*win)(0,1).hist(hist_out, 0, 1, "Normalized Pressure Distribution");

--- a/src/api/c/graphics_common.cpp
+++ b/src/api/c/graphics_common.cpp
@@ -428,7 +428,7 @@ bool ForgeManager::getChartAxesOverride(forge::Chart* chart)
 {
     ChartAxesOverrideIter iter = mChartAxesOverrideMap.find(chart);
     if (iter == mChartAxesOverrideMap.end()) {
-        AF_ERROR("Chart Not Found!", AF_ERR_ARG);
+        AF_ERROR("Chart Not Found!", AF_ERR_INTERNAL);
     }
     return mChartAxesOverrideMap[chart];
 }
@@ -437,7 +437,7 @@ void ForgeManager::setChartAxesOverride(forge::Chart* chart, bool flag)
 {
     ChartAxesOverrideIter iter = mChartAxesOverrideMap.find(chart);
     if (iter == mChartAxesOverrideMap.end()) {
-        AF_ERROR("Chart Not Found!", AF_ERR_ARG);
+        AF_ERROR("Chart Not Found!", AF_ERR_INTERNAL);
     }
     mChartAxesOverrideMap[chart] = flag;
 }

--- a/src/api/c/graphics_common.cpp
+++ b/src/api/c/graphics_common.cpp
@@ -116,6 +116,61 @@ void makeContextCurrent(forge::Window *window)
     CheckGL("End makeContextCurrent");
 }
 
+// dir -> true = round up, false = round down
+double step_round(const double in, const bool dir)
+{
+    if(in == 0) return 0;
+
+    static const double __log2 = log10(2);
+    static const double __log4 = log10(4);
+    static const double __log6 = log10(6);
+    static const double __log8 = log10(8);
+
+    // log_in is of the form "s abc.xyz", where
+    // s is either + or -; + indicates abs(in) >= 1 and - indicates 0 < abs(in) < 1 (log10(1) is +0)
+    const double sign   = in < 0 ? -1 : 1;
+    const double log_in = std::log10(std::fabs(in));
+    const double mag    = std::pow(10, std::floor(log_in)) * sign;  // Number of digits either left or right of 0
+    const double dec    = std::log10(in / mag); // log of the fraction
+
+    // This means in is of the for 10^n
+    if(dec == 0) return in;
+
+    // For negative numbers, -ve round down = +ve round up and vice versa
+    bool op_dir = in > 0 ? dir : !dir;
+
+    double mult = 1;
+
+    // Round up
+    if(op_dir) {
+        if(dec <= __log2) {
+            mult = 2;
+        } else if(dec <= __log4) {
+            mult = 4;
+        } else if(dec <= __log6) {
+            mult = 6;
+        } else if(dec <= __log8) {
+            mult = 8;
+        } else {
+            mult = 10;
+        }
+    } else {    // Round down
+        if(dec < __log2) {
+            mult = 1;
+        } else if(dec < __log4) {
+            mult = 2;
+        } else if(dec < __log6) {
+            mult = 4;
+        } else if(dec < __log8) {
+            mult = 6;
+        } else {
+            mult = 8;
+        }
+    }
+
+    return mag * mult;
+}
+
 namespace graphics
 {
 

--- a/src/api/c/graphics_common.hpp
+++ b/src/api/c/graphics_common.hpp
@@ -70,6 +70,9 @@ typedef std::map<const forge::Window*, ChartVec_t> ChartMap_t;
 typedef ChartVec_t::iterator ChartVecIter;
 typedef ChartMap_t::iterator ChartMapIter;
 
+// Keeps track of which charts have manually assigned axes limits
+typedef std::map<forge::Chart*, bool> ChartAxesOverride_t;
+typedef ChartAxesOverride_t::iterator ChartAxesOverrideIter;
 
 /**
  * ForgeManager class follows a single pattern. Any user of this class, has
@@ -92,7 +95,8 @@ class ForgeManager
         SurfaceMap_t        mSfcMap;
         VectorFieldMap_t    mVcfMap;
 
-        ChartMap_t      mChartMap;
+        ChartMap_t          mChartMap;
+        ChartAxesOverride_t mChartAxesOverrideMap;
 
     public:
         static ForgeManager& getInstance();
@@ -116,6 +120,9 @@ class ForgeManager
         forge::Histogram*   getHistogram    (forge::Chart* chart, int nBins, forge::dtype type);
         forge::Surface*     getSurface      (forge::Chart* chart, int nX, int nY, forge::dtype type);
         forge::VectorField* getVectorField  (forge::Chart* chart, int nPoints, forge::dtype type);
+
+        bool getChartAxesOverride(forge::Chart* chart);
+        void setChartAxesOverride(forge::Chart* chart, bool flag = true);
 
     protected:
         ForgeManager() {}

--- a/src/api/c/graphics_common.hpp
+++ b/src/api/c/graphics_common.hpp
@@ -37,6 +37,8 @@ forge::MarkerType getFGMarker(const af_marker_type af_marker);
 
 void makeContextCurrent(forge::Window *window);
 
+double step_round(const double in, const bool dir);
+
 namespace graphics
 {
 

--- a/src/api/c/hist.cpp
+++ b/src/api/c/hist.cpp
@@ -47,6 +47,31 @@ forge::Chart* setup_histogram(const forge::Window* const window,
     // Set histogram bar colors to orange
     hist->setColor(0.929f, 0.486f, 0.2745f, 1.0f);
 
+    // If chart axes limits do not have a manual override
+    // then compute and set axes limits
+    if(!fgMngr.getChartAxesOverride(chart)) {
+        float xMin, xMax, yMin, yMax;
+        chart->getAxesLimits(&xMin, &xMax, &yMin, &yMax);
+        T freqMax = detail::reduce_all<af_max_t, T, T>(histogramInput);
+
+        if(xMin == 0 && xMax == 0 && yMin == 0 && yMax == 0) {
+            // No previous limits. Set without checking
+            xMin = step_round(minval, false);
+            xMax = step_round(maxval, true);
+            yMax = step_round(freqMax, true);
+            // For histogram, always set yMin to 0.
+            yMin = 0;
+        } else {
+            if(xMin > minval)  xMin = step_round(minval, false);
+            if(xMax < maxval)  xMax = step_round(maxval, true);
+            if(yMax < freqMax) yMax = step_round(freqMax, true);
+            // For histogram, always set yMin to 0.
+            yMin = 0;
+        }
+
+        chart->setAxesLimits(xMin, xMax, yMin, yMax);
+    }
+
     copy_histogram<T>(histogramInput, hist);
 
     return chart;

--- a/src/api/c/plot.cpp
+++ b/src/api/c/plot.cpp
@@ -64,6 +64,43 @@ forge::Chart* setup_plot(const forge::Window* const window, const af_array in_,
     // ArrayFire LOGO Orange shade
     plot->setColor(0.929f, 0.529f, 0.212f, 1.0);
 
+    // If chart axes limits do not have a manual override
+    // then compute and set axes limits
+    if(!fgMngr.getChartAxesOverride(chart)) {
+        float cmin[3], cmax[3];
+        T     dmin[3], dmax[3];
+        chart->getAxesLimits(&cmin[0], &cmax[0], &cmin[1], &cmax[1], &cmin[2], &cmax[2]);
+        copyData(dmin, reduce<af_min_t, T, T>(in, 1));
+        copyData(dmax, reduce<af_max_t, T, T>(in, 1));
+
+        if(cmin[0] == 0 && cmax[0] == 0
+        && cmin[1] == 0 && cmax[1] == 0
+        && cmin[2] == 0 && cmax[2] == 0) {
+            // No previous limits. Set without checking
+            cmin[0] = step_round(dmin[0], false);
+            cmax[0] = step_round(dmax[0], true);
+            cmin[1] = step_round(dmin[1], false);
+            cmax[1] = step_round(dmax[1], true);
+            if(order == 3) cmin[2] = step_round(dmin[2], false);
+            if(order == 3) cmax[2] = step_round(dmax[2], true);
+        } else {
+            if(cmin[0] > dmin[0])       cmin[0] = step_round(dmin[0], false);
+            if(cmax[0] < dmax[0])       cmax[0] = step_round(dmax[0], true);
+            if(cmin[1] > dmin[1])       cmin[1] = step_round(dmin[1], false);
+            if(cmax[1] < dmax[1])       cmax[1] = step_round(dmax[1], true);
+            if(order == 3) {
+                if(cmin[2] > dmin[2])   cmin[2] = step_round(dmin[2], false);
+                if(cmax[2] < dmax[2])   cmax[2] = step_round(dmax[2], true);
+            }
+        }
+
+        if(order == 2) {
+            chart->setAxesLimits(cmin[0], cmax[0], cmin[1], cmax[1]);
+        } else if(order == 3) {
+            chart->setAxesLimits(cmin[0], cmax[0], cmin[1], cmax[1], cmin[2], cmax[2]);
+        }
+    }
+
     copy_plot<T>(in, plot);
 
     return chart;

--- a/src/api/c/surface.cpp
+++ b/src/api/c/surface.cpp
@@ -81,6 +81,41 @@ forge::Chart* setup_surface(const forge::Window* const window,
 
     surface->setColor(0.0, 1.0, 0.0, 1.0);
 
+    // If chart axes limits do not have a manual override
+    // then compute and set axes limits
+    if(!fgMngr.getChartAxesOverride(chart)) {
+        float cmin[3], cmax[3];
+        T     dmin[3], dmax[3];
+        chart->getAxesLimits(&cmin[0], &cmax[0], &cmin[1], &cmax[1], &cmin[2], &cmax[2]);
+        dmin[0] = reduce_all<af_min_t, T, T>(xIn);
+        dmax[0] = reduce_all<af_max_t, T, T>(xIn);
+        dmin[1] = reduce_all<af_min_t, T, T>(yIn);
+        dmax[1] = reduce_all<af_max_t, T, T>(yIn);
+        dmin[2] = reduce_all<af_min_t, T, T>(zIn);
+        dmax[2] = reduce_all<af_max_t, T, T>(zIn);
+
+        if(cmin[0] == 0 && cmax[0] == 0
+        && cmin[1] == 0 && cmax[1] == 0
+        && cmin[2] == 0 && cmax[2] == 0) {
+            // No previous limits. Set without checking
+            cmin[0] = step_round(dmin[0], false);
+            cmax[0] = step_round(dmax[0], true);
+            cmin[1] = step_round(dmin[1], false);
+            cmax[1] = step_round(dmax[1], true);
+            cmin[2] = step_round(dmin[2], false);
+            cmax[2] = step_round(dmax[2], true);
+        } else {
+            if(cmin[0] > dmin[0]) cmin[0] = step_round(dmin[0], false);
+            if(cmax[0] < dmax[0]) cmax[0] = step_round(dmax[0], true);
+            if(cmin[1] > dmin[1]) cmin[1] = step_round(dmin[1], false);
+            if(cmax[1] < dmax[1]) cmax[1] = step_round(dmax[1], true);
+            if(cmin[2] > dmin[2]) cmin[2] = step_round(dmin[2], false);
+            if(cmax[2] < dmax[2]) cmax[2] = step_round(dmax[2], true);
+        }
+
+        chart->setAxesLimits(cmin[0], cmax[0], cmin[1], cmax[1], cmin[2], cmax[2]);
+    }
+
     copy_surface<T>(Z, surface);
 
     return chart;

--- a/src/api/c/window.cpp
+++ b/src/api/c/window.cpp
@@ -137,61 +137,6 @@ af_err af_grid(const af_window wind, const int rows, const int cols)
 #endif
 }
 
-// dir -> true = round up, false = round down
-double step_round(const double in, const bool dir)
-{
-    if(in == 0) return 0;
-
-    static const double __log2 = log10(2);
-    static const double __log4 = log10(4);
-    static const double __log6 = log10(6);
-    static const double __log8 = log10(8);
-
-    // log_in is of the form "s abc.xyz", where
-    // s is either + or -; + indicates abs(in) >= 1 and - indicates 0 < abs(in) < 1 (log10(1) is +0)
-    const double sign   = in < 0 ? -1 : 1;
-    const double log_in = std::log10(std::fabs(in));
-    const double mag    = std::pow(10, std::floor(log_in)) * sign;  // Number of digits either left or right of 0
-    const double dec    = std::log10(in / mag); // log of the fraction
-
-    // This means in is of the for 10^n
-    if(dec == 0) return in;
-
-    // For negative numbers, -ve round down = +ve round up and vice versa
-    bool op_dir = in > 0 ? dir : !dir;
-
-    double mult = 1;
-
-    // Round up
-    if(op_dir) {
-        if(dec <= __log2) {
-            mult = 2;
-        } else if(dec <= __log4) {
-            mult = 4;
-        } else if(dec <= __log6) {
-            mult = 6;
-        } else if(dec <= __log8) {
-            mult = 8;
-        } else {
-            mult = 10;
-        }
-    } else {    // Round down
-        if(dec < __log2) {
-            mult = 1;
-        } else if(dec < __log4) {
-            mult = 2;
-        } else if(dec < __log6) {
-            mult = 4;
-        } else if(dec < __log8) {
-            mult = 6;
-        } else {
-            mult = 8;
-        }
-    }
-
-    return mag * mult;
-}
-
 af_err af_set_axes_limits_compute(const af_window wind,
                                   const af_array x, const af_array y, const af_array z,
                                   const bool exact, const af_cell* const props)

--- a/src/api/c/window.cpp
+++ b/src/api/c/window.cpp
@@ -187,6 +187,7 @@ af_err af_set_axes_limits_compute(const af_window wind,
             zmax = step_round(zmax, true );
         }
 
+        fgMngr.setChartAxesOverride(chart);
         chart->setAxesLimits(xmin, xmax, ymin, ymax, zmin, zmax);
     }
     CATCHALL;
@@ -235,6 +236,7 @@ af_err af_set_axes_limits_2d(const af_window wind,
             _ymax = step_round(_ymax, true );
         }
 
+        fgMngr.setChartAxesOverride(chart);
         chart->setAxesLimits(_xmin, _xmax, _ymin, _ymax);
     }
     CATCHALL;
@@ -288,6 +290,7 @@ af_err af_set_axes_limits_3d(const af_window wind,
             _zmax = step_round(_zmax, true );
         }
 
+        fgMngr.setChartAxesOverride(chart);
         chart->setAxesLimits(_xmin, _xmax, _ymin, _ymax, _zmin, _zmax);
     }
     CATCHALL;


### PR DESCRIPTION
* The axes limits will always be the minimum/maximum of the current and new limit.
* The user can still set limits from API calls
  * If the user sets a limit from the API call, then the automatic limit setting will be disabled.
* This PR requires https://github.com/arrayfire/forge/pull/120

TODO:
Update the forge build tag to a version once the version tag is created in Forge.