### PR TITLE
FEAT: Add CSR <--> COO Conversion in all backends

### DIFF
--- a/src/api/c/sparse.cpp
+++ b/src/api/c/sparse.cpp
@@ -275,6 +275,12 @@ af_err af_sparse_convert_to(af_array *out, const af_array in,
                             const af_storage destStorage)
 {
     try {
+        // Handle dense case
+        const ArrayInfo& info = getInfo(in, false, true);
+        if(!info.isSparse()) {    // If input is dense
+            return af_create_sparse_array_from_dense(out, in, destStorage);
+        }
+
         af_array output = 0;
 
         const SparseArrayBase base = getSparseArrayBase(in);

--- a/src/api/c/sparse.cpp
+++ b/src/api/c/sparse.cpp
@@ -295,19 +295,18 @@ af_array sparseConvertStorage(const af_array in_, const af_storage destStorage)
 af_err af_sparse_convert_to(af_array *out, const af_array in,
                             const af_storage destStorage)
 {
-    // Right now dest_storage can only be AF_STORAGE_DENSE
     try {
         af_array output = 0;
 
         const SparseArrayBase base = getSparseArrayBase(in);
 
-        // Dense not allowed as input -> Should never happen
-        // To convert from dense to type, use the create* functions
-        ARG_ASSERT(1, base.getStorage() != AF_STORAGE_DENSE);
+        // Dense not allowed as input -> Should never happen with SparseArrayBase
+        // CSC is currently not supported
+        ARG_ASSERT(1, base.getStorage() != AF_STORAGE_DENSE
+                   && base.getStorage() != AF_STORAGE_CSC);
 
-        // Right now dest_storage can only be AF_STORAGE_DENSE
-        // TODO: Add support for [CSR, CSC, COO] <-> [CSR, CSC, COO] in backends
-        ARG_ASSERT(1, destStorage != AF_STORAGE_CSC);
+        // Conversion to and from CSC is not supported
+        ARG_ASSERT(2, destStorage != AF_STORAGE_CSC);
 
         if(base.getStorage() == destStorage) {
             // Return a reference

--- a/src/api/c/sparse.cpp
+++ b/src/api/c/sparse.cpp
@@ -183,10 +183,10 @@ af_array createSparseArrayFromDense(
     switch(stype) {
         case AF_STORAGE_CSR:
             return getHandle(sparseConvertDenseToStorage<T, AF_STORAGE_CSR>(in));
-        case AF_STORAGE_CSC:
-            return getHandle(sparseConvertDenseToStorage<T, AF_STORAGE_CSC>(in));
         case AF_STORAGE_COO:
             return getHandle(sparseConvertDenseToStorage<T, AF_STORAGE_COO>(in));
+        case AF_STORAGE_CSC:
+            //return getHandle(sparseConvertDenseToStorage<T, AF_STORAGE_CSC>(in));
         default: AF_ERROR("Storage type is out of range/unsupported", AF_ERR_ARG);
     }
 }
@@ -235,16 +235,11 @@ af_array sparseConvertStorage(const af_array in_, const af_storage destStorage)
 {
     const SparseArray<T> in = getSparseArray<T>(in_);
 
-    // Only destStorage == AF_STORAGE_DENSE is supported
-    // All the other calls are for future when conversions are supported in
-    // the backend
     if(destStorage == AF_STORAGE_DENSE) {
         // Returns a regular af_array, not sparse
         switch(in.getStorage()) {
             case AF_STORAGE_CSR:
                 return getHandle(detail::sparseConvertStorageToDense<T, AF_STORAGE_CSR>(in));
-            case AF_STORAGE_CSC:
-                return getHandle(detail::sparseConvertStorageToDense<T, AF_STORAGE_CSC>(in));
             case AF_STORAGE_COO:
                 return getHandle(detail::sparseConvertStorageToDense<T, AF_STORAGE_COO>(in));
             default:
@@ -255,22 +250,8 @@ af_array sparseConvertStorage(const af_array in_, const af_storage destStorage)
         switch(in.getStorage()) {
             case AF_STORAGE_CSR:
                 return retainSparseHandle<T>(in_);
-            case AF_STORAGE_CSC:
-                return getHandle(detail::sparseConvertStorageToStorage<T, AF_STORAGE_CSR, AF_STORAGE_CSC>(in));
             case AF_STORAGE_COO:
                 return getHandle(detail::sparseConvertStorageToStorage<T, AF_STORAGE_CSR, AF_STORAGE_COO>(in));
-            default:
-                AF_ERROR("Invalid storage type of input array", AF_ERR_ARG);
-        }
-    } else if(destStorage == AF_STORAGE_CSC) {
-        // Returns a sparse af_array
-        switch(in.getStorage()) {
-            case AF_STORAGE_CSR:
-                return getHandle(detail::sparseConvertStorageToStorage<T, AF_STORAGE_CSC, AF_STORAGE_CSR>(in));
-            case AF_STORAGE_CSC:
-                return retainSparseHandle<T>(in_);
-            case AF_STORAGE_COO:
-                return getHandle(detail::sparseConvertStorageToStorage<T, AF_STORAGE_CSC, AF_STORAGE_COO>(in));
             default:
                 AF_ERROR("Invalid storage type of input array", AF_ERR_ARG);
         }
@@ -279,8 +260,6 @@ af_array sparseConvertStorage(const af_array in_, const af_storage destStorage)
         switch(in.getStorage()) {
             case AF_STORAGE_CSR:
                 return getHandle(detail::sparseConvertStorageToStorage<T, AF_STORAGE_COO, AF_STORAGE_CSR>(in));
-            case AF_STORAGE_CSC:
-                return getHandle(detail::sparseConvertStorageToStorage<T, AF_STORAGE_COO, AF_STORAGE_CSC>(in));
             case AF_STORAGE_COO:
                 return retainSparseHandle<T>(in_);
             default:

--- a/src/api/c/sparse.cpp
+++ b/src/api/c/sparse.cpp
@@ -307,7 +307,7 @@ af_err af_sparse_convert_to(af_array *out, const af_array in,
 
         // Right now dest_storage can only be AF_STORAGE_DENSE
         // TODO: Add support for [CSR, CSC, COO] <-> [CSR, CSC, COO] in backends
-        ARG_ASSERT(1, destStorage == AF_STORAGE_DENSE);
+        ARG_ASSERT(1, destStorage != AF_STORAGE_CSC);
 
         if(base.getStorage() == destStorage) {
             // Return a reference

--- a/src/backend/SparseArray.cpp
+++ b/src/backend/SparseArray.cpp
@@ -124,9 +124,9 @@ SparseArray<T> createDeviceDataSparseArray(
         const af::dim4 &_dims, const dim_t nNZ,
         const T * const _values,
         const int * const _rowIdx, const int * const _colIdx,
-        const af::storage _storage)
+        const af::storage _storage, const bool _copy)
 {
-    return SparseArray<T>(_dims, nNZ, _values, _rowIdx, _colIdx, _storage, false);
+    return SparseArray<T>(_dims, nNZ, _values, _rowIdx, _colIdx, _storage, _copy);
 }
 
 template<typename T>
@@ -134,9 +134,9 @@ SparseArray<T> createArrayDataSparseArray(
         const af::dim4 &_dims,
         const Array<T> &_values,
         const Array<int> &_rowIdx, const Array<int> &_colIdx,
-        const af::storage _storage)
+        const af::storage _storage, const bool _copy)
 {
-    return SparseArray<T>(_dims, _values, _rowIdx, _colIdx, _storage, false);
+    return SparseArray<T>(_dims, _values, _rowIdx, _colIdx, _storage, _copy);
 }
 
 template<typename T>
@@ -223,12 +223,12 @@ SparseArray<T>::~SparseArray()
             const af::dim4 &_dims, const dim_t _nNZ,                                                \
             const T * const _values,                                                                \
             const int * const _rowIdx, const int * const _colIdx,                                   \
-            const af::storage _storage);                                                            \
+            const af::storage _storage, const bool _copy);                                          \
     template SparseArray<T> createArrayDataSparseArray<T>(                                          \
             const af::dim4 &_dims,                                                                  \
             const Array<T> &_values,                                                                \
             const Array<int> &_rowIdx, const Array<int> &_colIdx,                                   \
-            const af::storage _storage);                                                            \
+            const af::storage _storage, const bool _copy);                                          \
     template SparseArray<T> *initSparseArray<T>();                                                  \
     template void destroySparseArray<T>(SparseArray<T> *sparse);                                    \
                                                                                                     \

--- a/src/backend/SparseArray.hpp
+++ b/src/backend/SparseArray.hpp
@@ -218,13 +218,13 @@ public:
             const af::dim4 &_dims, const dim_t nNZ,
             const T * const _values,
             const int * const _rowIdx, const int * const _colIdx,
-            const af::storage _storage);
+            const af::storage _storage, const bool _copy);
 
     friend SparseArray<T> createArrayDataSparseArray<T>(
             const af::dim4 &_dims,
             const Array<T> &_values,
             const Array<int> &_rowIdx, const Array<int> &_colIdx,
-            const af::storage _storage);
+            const af::storage _storage, const bool _copy);
 
     friend SparseArray<T> *initSparseArray<T>();
 

--- a/src/backend/cpu/kernel/sparse.hpp
+++ b/src/backend/cpu/kernel/sparse.hpp
@@ -11,6 +11,8 @@
 #include <Array.hpp>
 #include <utility.hpp>
 #include <math.hpp>
+#include <kernel/sort_helper.hpp>
+#include <algorithm>
 
 namespace cpu
 {
@@ -90,6 +92,109 @@ struct csr_dense
                 oPtr[j*stride + i] = v;
             }
         }
+    }
+};
+
+// Modified code from sort helper
+template <typename T>
+using SpKeyIndexPair = std::tuple<int, T, int>; // sorting index, value, other index
+
+template <typename T>
+struct SpKIPCompareK
+{
+    bool operator()(const SpKeyIndexPair<T> &lhs, const SpKeyIndexPair<T> &rhs)
+    {
+        int lhsVal = std::get<0>(lhs);
+        int rhsVal = std::get<0>(rhs);
+        // Always returns ascending
+        return (lhsVal < rhsVal);
+    }
+};
+
+template<typename T>
+struct csr_coo
+{
+    void operator()(Array<T> ovalues, Array<int> orowIdx, Array<int> ocolIdx,
+                    Array<T> const ivalues, Array<int> const irowIdx, Array<int> const icolIdx)
+    {
+        // First calculate the linear index
+        T         * const ovPtr = ovalues.get();
+        int       * const orPtr = orowIdx.get();
+        int       * const ocPtr = ocolIdx.get();
+
+        T   const * const ivPtr = ivalues.get();
+        int const * const irPtr = irowIdx.get();
+        int const * const icPtr = icolIdx.get();
+
+        // Create cordinate form of the row array
+        for(int i = 0; i < (int)irowIdx.elements() - 1; i++) {
+            std::fill_n(orPtr + irPtr[i], irPtr[i + 1] - irPtr[i], i);
+        }
+
+        // Sort the coordinate form using column index
+        // Uses code from sort_by_key kernels
+        typedef SpKeyIndexPair<T> CurrentPair;
+        int size = ovalues.dims()[0];
+        size_t bytes = size * sizeof(CurrentPair);
+        CurrentPair *pairKeyVal = (CurrentPair *)memAlloc<char>(bytes);
+
+        for(int x = 0; x < size; x++) {
+           pairKeyVal[x] = std::make_tuple(icPtr[x], ivPtr[x], orPtr[x]);
+        }
+
+        std::stable_sort(pairKeyVal, pairKeyVal + size, SpKIPCompareK<T>());
+
+        for(int x = 0; x < (int)ovalues.elements(); x++) {
+            ocPtr[x] = std::get<0>(pairKeyVal[x]);
+            ovPtr[x] = std::get<1>(pairKeyVal[x]);
+            orPtr[x] = std::get<2>(pairKeyVal[x]);
+        }
+
+        memFree((char *)pairKeyVal);
+    }
+};
+
+template<typename T>
+struct coo_csr
+{
+    void operator()(Array<T> ovalues, Array<int> orowIdx, Array<int> ocolIdx,
+                    Array<T> const ivalues, Array<int> const irowIdx, Array<int> const icolIdx)
+    {
+        T         * const ovPtr = ovalues.get();
+        int       * const orPtr = orowIdx.get();
+        int       * const ocPtr = ocolIdx.get();
+
+        T   const * const ivPtr = ivalues.get();
+        int const * const irPtr = irowIdx.get();
+        int const * const icPtr = icolIdx.get();
+
+        // Sort the colidx and values based on rowIdx
+        // Uses code from sort_by_key kernels
+        typedef SpKeyIndexPair<T> CurrentPair;
+        int size = ovalues.dims()[0];
+        size_t bytes = size * sizeof(CurrentPair);
+        CurrentPair *pairKeyVal = (CurrentPair *)memAlloc<char>(bytes);
+
+        for(int x = 0; x < size; x++) {
+           pairKeyVal[x] = std::make_tuple(irPtr[x], ivPtr[x], icPtr[x]);
+        }
+
+        std::stable_sort(pairKeyVal, pairKeyVal + size, SpKIPCompareK<T>());
+
+        ovPtr[0] = 0;
+        for(int x = 0; x < (int)ovalues.elements(); x++) {
+            int row  = std::get<0>(pairKeyVal[x]);
+            ovPtr[x] = std::get<1>(pairKeyVal[x]);
+            ocPtr[x] = std::get<2>(pairKeyVal[x]);
+            orPtr[row + 1]++;
+        }
+
+        // Compress row storage
+        for(int x = 1; x < (int)orowIdx.elements(); x++) {
+            orPtr[x] += orPtr[x - 1];
+        }
+
+        memFree((char *)pairKeyVal);
     }
 };
 

--- a/src/backend/cpu/sparse.cpp
+++ b/src/backend/cpu/sparse.cpp
@@ -134,11 +134,11 @@ SparseArray<T> sparseConvertDenseToCOO(const Array<T> &in)
 
     dim_t nNZ = nonZeroIdx.elements();
 
-    Array<int> constNNZ = createValueArray<int>(dim4(nNZ), nNZ);
-    constNNZ.eval();
+    Array<int> constDim = createValueArray<int>(dim4(nNZ), in.dims()[0]);
+    constDim.eval();
 
-    Array<int> rowIdx = arithOp<int, af_mod_t>(nonZeroIdx, constNNZ, nonZeroIdx.dims());
-    Array<int> colIdx = arithOp<int, af_div_t>(nonZeroIdx, constNNZ, nonZeroIdx.dims());
+    Array<int> rowIdx = arithOp<int, af_mod_t>(nonZeroIdx, constDim, nonZeroIdx.dims());
+    Array<int> colIdx = arithOp<int, af_div_t>(nonZeroIdx, constDim, nonZeroIdx.dims());
 
     Array<T> values = copyArray<T>(in);
     values.modDims(dim4(values.elements()));

--- a/src/backend/cuda/sparse.cu
+++ b/src/backend/cuda/sparse.cu
@@ -442,7 +442,7 @@ SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in)
 
             CUSPARSE_CHECK(gthr_func<T>()(
                             getHandle(), nNZ,
-                            cooT.getValues().get(),
+                            in.getValues().get(),
                             cooT.getValues().get(),
                             P, CUSPARSE_INDEX_BASE_ZERO));
 

--- a/src/backend/cuda/sparse.cu
+++ b/src/backend/cuda/sparse.cu
@@ -204,10 +204,10 @@ SparseArray<T> sparseConvertDenseToCOO(const Array<T> &in)
 
     dim_t nNZ = nonZeroIdx.elements();
 
-    Array<int> constNNZ = createValueArray<int>(dim4(nNZ), nNZ);
+    Array<int> constDim = createValueArray<int>(dim4(nNZ), in.dims()[0]);
 
-    Array<int> rowIdx = arithOp<int, af_mod_t>(nonZeroIdx, constNNZ, nonZeroIdx.dims());
-    Array<int> colIdx = arithOp<int, af_div_t>(nonZeroIdx, constNNZ, nonZeroIdx.dims());
+    Array<int> rowIdx = arithOp<int, af_mod_t>(nonZeroIdx, constDim, nonZeroIdx.dims());
+    Array<int> colIdx = arithOp<int, af_div_t>(nonZeroIdx, constDim, nonZeroIdx.dims());
 
     Array<T> values = copyArray<T>(in);
     values.modDims(dim4(values.elements()));

--- a/src/backend/opencl/kernel/csr2coo.cl
+++ b/src/backend/opencl/kernel/csr2coo.cl
@@ -8,10 +8,8 @@
  ********************************************************/
 
 __kernel
-void csr2coo(__global       T   *ovalues,
-             __global       int *orowidx,
+void csr2coo(__global       int *orowidx,
              __global       int *ocolidx,
-             __global const T   *ivalues,
              __global const int *irowidx,
              __global const int *icolidx,
              const int M)
@@ -21,7 +19,6 @@ void csr2coo(__global       T   *ovalues,
         int colStart = irowidx[rowId];
         int colEnd   = irowidx[rowId + 1];
         for (int colId = colStart + lid;  colId < colEnd; colId += THREADS) {
-            //ovalues[colId] = ivalues[colId];
             orowidx[colId] = rowId;
             ocolidx[colId] = icolidx[colId];
         }

--- a/src/backend/opencl/kernel/csr2coo.cl
+++ b/src/backend/opencl/kernel/csr2coo.cl
@@ -1,0 +1,74 @@
+/*******************************************************
+ * Copyright (c) 2016, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+__kernel
+void csr2coo(__global       T   *ovalues,
+             __global       int *orowidx,
+             __global       int *ocolidx,
+             __global const T   *ivalues,
+             __global const int *irowidx,
+             __global const int *icolidx,
+             const int M)
+{
+    int lid = get_local_id(0);
+    for (int rowId = get_group_id(0); rowId < M; rowId += get_num_groups(0)) {
+        int colStart = irowidx[rowId];
+        int colEnd   = irowidx[rowId + 1];
+        for (int colId = colStart + lid;  colId < colEnd; colId += THREADS) {
+            //ovalues[colId] = ivalues[colId];
+            orowidx[colId] = rowId;
+            ocolidx[colId] = icolidx[colId];
+        }
+    }
+}
+
+__kernel
+void swapIndex_kernel(__global       T   *ovalues,
+                      __global       int *oindex,
+                      __global const T   *ivalues,
+                      __global const int *iindex,
+                      __global const int *swapIdx,
+                      const int nNZ)
+{
+    int id = get_global_id(0);
+    if(id >= nNZ) return;
+
+    int idx = swapIdx[id];
+
+    ovalues[id] = ivalues[idx];
+    oindex[id]  = iindex[idx];
+}
+
+__kernel
+void csrReduce_kernel(__global       int *orowIdx,
+                      __global const int *irowIdx,
+                      const int M, const int nNZ)
+{
+    int id = get_global_id(0);
+
+    if(id >= nNZ) return;
+
+    int iRId  = irowIdx[id];
+    int iRId1 = 0;
+    if(id > 0) iRId1 = irowIdx[id - 1];
+
+    if(id == 0) {
+        orowIdx[id] = 0;
+        orowIdx[M]  = nNZ;
+    } else if(iRId1 != iRId) {
+        for(int i = iRId1 + 1; i <= iRId; i++)
+            orowIdx[i] = id;
+    }
+
+    // The last X rows are corner cases if they dont have any values
+    if(id > irowIdx[nNZ - 1] && orowIdx[id] == 0) {
+        orowIdx[id] = nNZ;
+    }
+}
+

--- a/src/backend/opencl/kernel/sparse.hpp
+++ b/src/backend/opencl/kernel/sparse.hpp
@@ -11,6 +11,7 @@
 #include <kernel_headers/coo2dense.hpp>
 #include <kernel_headers/csr2dense.hpp>
 #include <kernel_headers/dense2csr.hpp>
+#include <kernel_headers/csr2coo.hpp>
 #include <program.hpp>
 #include <traits.hpp>
 #include <string>
@@ -24,6 +25,7 @@
 #include "scan_dim.hpp"
 #include "reduce.hpp"
 #include "scan_first.hpp"
+#include "sort_by_key.hpp"
 #include "config.hpp"
 
 using cl::Buffer;
@@ -256,6 +258,198 @@ namespace opencl
                 bufferFree(rd1.data);
                 bufferFree(sd1.data);
             } catch (cl::Error &err) {
+                CL_TO_AF_ERROR(err);
+            }
+        }
+
+        template<typename T>
+        void swapIndex(Param ovalues, Param oindex,
+                       const Param ivalues, const cl::Buffer *iindex,
+                       const Param swapIdx)
+        {
+            try {
+                static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+                static std::map<int, Program*>   swapIndexProgs;
+                static std::map<int, Kernel*>  swapIndexKernels;
+
+                int device = getActiveDeviceId();
+
+                std::call_once( compileFlags[device], [device] () {
+                    std::ostringstream options;
+                    options << " -D T="        << dtype_traits<T>::getName()
+                            << " -D THREADS=256"; // This threads is a dummy for compilation
+                    if (std::is_same<T, double>::value ||
+                        std::is_same<T, cdouble>::value) {
+                        options << " -D USE_DOUBLE";
+                    }
+                    Program prog;
+                    buildProgram(prog, csr2coo_cl, csr2coo_cl_len, options.str());
+                    swapIndexProgs[device]   = new Program(prog);
+                    swapIndexKernels[device] = new Kernel(*swapIndexProgs[device], "swapIndex_kernel");
+                });
+
+                auto swapIndexOp = KernelFunctor<Buffer, Buffer,
+                                                 const Buffer, const Buffer, const Buffer,
+                                                 const int> (*swapIndexKernels[device]);
+
+                static const int threads = 256;
+                NDRange local(threads, 1);
+                NDRange global(divup(ovalues.info.dims[0], threads) * threads, 1, 1);
+
+                swapIndexOp(EnqueueArgs(getQueue(), global, local),
+                            *ovalues.data, *oindex.data,
+                            *ivalues.data, *iindex,
+                            *swapIdx.data, ovalues.info.dims[0]);
+
+                CL_DEBUG_FINISH(getQueue());
+
+            } catch (cl::Error err) {
+                CL_TO_AF_ERROR(err);
+                throw;
+            }
+        }
+
+        template<typename T>
+        void csr2coo(Param ovalues, Param orowIdx, Param ocolIdx,
+                     const Param ivalues, const Param irowIdx, const Param icolIdx,
+                     Param index)
+        {
+            try {
+                const int MAX_GROUPS = 4096;
+                int M = irowIdx.info.dims[0] - 1;
+                //FIXME: This needs to be based non nonzeros per row
+                int threads = 64;
+
+                std::string ref_name =
+                    std::string("csr2coo_") +
+                    std::string(dtype_traits<T>::getName()) +
+                    std::string("_") +
+                    std::to_string(threads);
+
+                int device = getActiveDeviceId();
+                auto idx = kernelCaches[device].find(ref_name);
+                kc_entry_t entry;
+
+                if (idx == kernelCaches[device].end()) {
+
+                    std::ostringstream options;
+                    options << " -D T=" << dtype_traits<T>::getName();
+                    options << " -D THREADS=" << threads;
+
+                    if (std::is_same<T, double>::value ||
+                        std::is_same<T, cdouble>::value) {
+                        options << " -D USE_DOUBLE";
+                    }
+
+                    const char *ker_strs[] = {csr2coo_cl};
+                    const int   ker_lens[] = {csr2coo_cl_len};
+
+                    Program prog;
+                    buildProgram(prog, 1, ker_strs, ker_lens, options.str());
+                    entry.prog = new Program(prog);
+                    entry.ker  = new Kernel(*entry.prog, "csr2coo");
+                } else {
+                    entry = idx->second;
+                }
+
+                cl::Buffer *scratch = bufferAlloc(orowIdx.info.dims[0] * sizeof(int));
+
+                NDRange local(threads, 1);
+                int groups_x = std::min((int)(divup(M, local[0])), MAX_GROUPS);
+                NDRange global(local[0] * groups_x, 1);
+                auto csr2coo_kernel = *entry.ker;
+                auto csr2coo_func = KernelFunctor<Buffer, Buffer, Buffer,
+                                                  const Buffer, const Buffer, const Buffer,
+                                                  int> (csr2coo_kernel);
+
+                csr2coo_func(EnqueueArgs(getQueue(), global, local),
+                               *ovalues.data, *scratch, *ocolIdx.data,
+                               *ivalues.data, *irowIdx.data, *icolIdx.data, M);
+
+                // Now we need to sort this into column major
+                kernel::sort0ByKeyIterative<int, int>(ocolIdx, index, true);
+
+                // Now use index to sort values and rows
+                kernel::swapIndex<T>(ovalues, orowIdx, ivalues, scratch, index);
+
+                CL_DEBUG_FINISH(getQueue());
+
+                bufferFree(scratch);
+
+            } catch(cl::Error err) {
+                CL_TO_AF_ERROR(err);
+            }
+        }
+
+        template<typename T>
+        void coo2csr(Param ovalues, Param orowIdx, Param ocolIdx,
+                     const Param ivalues, const Param irowIdx, const Param icolIdx,
+                     Param index, const int M)
+        {
+            try {
+                cl::Buffer *colCopy = bufferAlloc(icolIdx.info.dims[0] * sizeof(int));
+                getQueue().enqueueCopyBuffer(*icolIdx.data, *colCopy, 0, 0, icolIdx.info.dims[0] * sizeof(int));
+
+                cl::Buffer *rowCopy = bufferAlloc(irowIdx.info.dims[0] * sizeof(int));
+                getQueue().enqueueCopyBuffer(*irowIdx.data, *rowCopy, 0, 0, irowIdx.info.dims[0] * sizeof(int));
+
+                int dims[] = {(int)irowIdx.info.dims[0],
+                              (int)irowIdx.info.dims[1],
+                              (int)irowIdx.info.dims[2],
+                              (int)irowIdx.info.dims[3]
+                             };
+                int strides[] = {(int)irowIdx.info.strides[0],
+                                 (int)irowIdx.info.strides[1],
+                                 (int)irowIdx.info.strides[2],
+                                 (int)irowIdx.info.strides[3]
+                                };
+                Param scP = makeParam((*rowCopy)(), irowIdx.info.offset, dims, strides);
+
+                // Now we need to sort this into column major
+                kernel::sort0ByKeyIterative<int, int>(scP, index, true);
+
+                // Now use index to sort values and rows
+                kernel::swapIndex<T>(ovalues, ocolIdx, ivalues, colCopy, index);
+
+                CL_DEBUG_FINISH(getQueue());
+
+                // Do row compression
+                static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+                static std::map<int, Program*>   csrReduceProgs;
+                static std::map<int, Kernel*>  csrReduceKernels;
+
+                int device = getActiveDeviceId();
+
+                std::call_once( compileFlags[device], [device] () {
+                    std::ostringstream options;
+                    options << " -D T="        << dtype_traits<T>::getName()
+                            << " -D THREADS=256"; // This threads is a dummy for compilation
+                    if (std::is_same<T, double>::value ||
+                        std::is_same<T, cdouble>::value) {
+                        options << " -D USE_DOUBLE";
+                    }
+                    Program prog;
+                    buildProgram(prog, csr2coo_cl, csr2coo_cl_len, options.str());
+                    csrReduceProgs[device]   = new Program(prog);
+                    csrReduceKernels[device] = new Kernel(*csrReduceProgs[device], "csrReduce_kernel");
+                });
+
+                auto csrReduceOp = KernelFunctor<Buffer, const Buffer, const int, const int>
+                                   (*csrReduceKernels[device]);
+
+                static const int threads = 256;
+                NDRange local(threads, 1);
+                NDRange global(divup(irowIdx.info.dims[0], threads) * threads, 1, 1);
+
+                csrReduceOp(EnqueueArgs(getQueue(), global, local),
+                            *orowIdx.data, *rowCopy, M, ovalues.info.dims[0]);
+
+                CL_DEBUG_FINISH(getQueue());
+
+                bufferFree(colCopy);
+                bufferFree(rowCopy);
+
+            } catch(cl::Error err) {
                 CL_TO_AF_ERROR(err);
             }
         }

--- a/src/backend/opencl/kernel/sparse.hpp
+++ b/src/backend/opencl/kernel/sparse.hpp
@@ -303,7 +303,6 @@ namespace opencl
 
             } catch (cl::Error err) {
                 CL_TO_AF_ERROR(err);
-                throw;
             }
         }
 

--- a/src/backend/opencl/kernel/sparse.hpp
+++ b/src/backend/opencl/kernel/sparse.hpp
@@ -292,11 +292,9 @@ namespace opencl
                                                  const Buffer, const Buffer, const Buffer,
                                                  const int> (*swapIndexKernels[device]);
 
-                static const int threads = 256;
-                NDRange local(threads, 1);
-                NDRange global(divup(ovalues.info.dims[0], threads) * threads, 1, 1);
+                NDRange global(ovalues.info.dims[0], 1, 1);
 
-                swapIndexOp(EnqueueArgs(getQueue(), global, local),
+                swapIndexOp(EnqueueArgs(getQueue(), global),
                             *ovalues.data, *oindex.data,
                             *ivalues.data, *iindex,
                             *swapIdx.data, ovalues.info.dims[0]);
@@ -358,13 +356,13 @@ namespace opencl
                 int groups_x = std::min((int)(divup(M, local[0])), MAX_GROUPS);
                 NDRange global(local[0] * groups_x, 1);
                 auto csr2coo_kernel = *entry.ker;
-                auto csr2coo_func = KernelFunctor<Buffer, Buffer, Buffer,
-                                                  const Buffer, const Buffer, const Buffer,
+                auto csr2coo_func = KernelFunctor<Buffer, Buffer,
+                                                  const Buffer, const Buffer,
                                                   int> (csr2coo_kernel);
 
                 csr2coo_func(EnqueueArgs(getQueue(), global, local),
-                               *ovalues.data, *scratch, *ocolIdx.data,
-                               *ivalues.data, *irowIdx.data, *icolIdx.data, M);
+                               *scratch, *ocolIdx.data,
+                               *irowIdx.data, *icolIdx.data, M);
 
                 // Now we need to sort this into column major
                 kernel::sort0ByKeyIterative<int, int>(ocolIdx, index, true);
@@ -437,11 +435,9 @@ namespace opencl
                 auto csrReduceOp = KernelFunctor<Buffer, const Buffer, const int, const int>
                                    (*csrReduceKernels[device]);
 
-                static const int threads = 256;
-                NDRange local(threads, 1);
-                NDRange global(divup(irowIdx.info.dims[0], threads) * threads, 1, 1);
+                NDRange global(irowIdx.info.dims[0], 1, 1);
 
-                csrReduceOp(EnqueueArgs(getQueue(), global, local),
+                csrReduceOp(EnqueueArgs(getQueue(), global),
                             *orowIdx.data, *rowCopy, M, ovalues.info.dims[0]);
 
                 CL_DEBUG_FINISH(getQueue());

--- a/src/backend/opencl/sparse.cpp
+++ b/src/backend/opencl/sparse.cpp
@@ -41,11 +41,11 @@ SparseArray<T> sparseConvertDenseToCOO(const Array<T> &in)
 
     dim_t nNZ = nonZeroIdx.elements();
 
-    Array<int> constNNZ = createValueArray<int>(dim4(nNZ), nNZ);
-    constNNZ.eval();
+    Array<int> constDim = createValueArray<int>(dim4(nNZ), in.dims()[0]);
+    constDim.eval();
 
-    Array<int> rowIdx = arithOp<int, af_mod_t>(nonZeroIdx, constNNZ, nonZeroIdx.dims());
-    Array<int> colIdx = arithOp<int, af_div_t>(nonZeroIdx, constNNZ, nonZeroIdx.dims());
+    Array<int> rowIdx = arithOp<int, af_mod_t>(nonZeroIdx, constDim, nonZeroIdx.dims());
+    Array<int> colIdx = arithOp<int, af_div_t>(nonZeroIdx, constDim, nonZeroIdx.dims());
 
     Array<T> values = copyArray<T>(in);
     values.modDims(dim4(values.elements()));

--- a/src/backend/sparse_helpers.hpp
+++ b/src/backend/sparse_helpers.hpp
@@ -37,14 +37,14 @@ SparseArray<T> createDeviceDataSparseArray(
         const af::dim4 &_dims, const dim_t nNZ,
         const T * const _values,
         const int * const _rowIdx, const int * const _colIdx,
-        const af::storage _storage);
+        const af::storage _storage, const bool _copy = false);
 
 template<typename T>
 SparseArray<T> createArrayDataSparseArray(
         const af::dim4 &_dims,
         const Array<T> &_values,
         const Array<int> &_rowIdx, const Array<int> &_colIdx,
-        const af::storage _storage);
+        const af::storage _storage, const bool _copy = false);
 
 template<typename T>
 SparseArray<T> *initSparseArray();

--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -244,62 +244,57 @@ void sparseConvertTester(const int m, const int n, int factor)
 
     // Create Sparse Array of type src and dest From Dense
     af::array sA = af::sparse(A, src);
-    af::array dA = af::sparse(A, dest);
 
     // Convert src to dest format and dest to src
     af::array s2d = sparseConvertTo(sA, dest);
-    af::array d2s = sparseConvertTo(dA, src);
+
+    // Create the dest type from dense - gold
+    af::array dA = af::sparse(A, dest);
+
+    // Verify nnZ
+    dim_t dNNZ   = sparseGetNNZ(dA);
+    dim_t s2dNNZ = sparseGetNNZ(s2d);
+
+    ASSERT_EQ(dNNZ, s2dNNZ);
+
+    // Verify Types
+    af_storage dType   = sparseGetStorage(dA);
+    af_storage s2dType = sparseGetStorage(s2d);
+
+    ASSERT_EQ(dType, s2dType);
 
     // Get the individual arrays and verify equality
-    af::array sValues = sparseGetValues(sA);
-    af::array sRowIdx = sparseGetRowIdx(sA);
-    af::array sColIdx = sparseGetColIdx(sA);
-    dim_t     sNNZ    = sparseGetNNZ   (sA);
-
     af::array dValues = sparseGetValues(dA);
     af::array dRowIdx = sparseGetRowIdx(dA);
     af::array dColIdx = sparseGetColIdx(dA);
-    dim_t     dNNZ    = sparseGetNNZ   (dA);
 
     af::array s2dValues = sparseGetValues(s2d);
     af::array s2dRowIdx = sparseGetRowIdx(s2d);
     af::array s2dColIdx = sparseGetColIdx(s2d);
-    dim_t     s2dNNZ    = sparseGetNNZ   (s2d);
 
-    af::array d2sValues = sparseGetValues(d2s);
-    af::array d2sRowIdx = sparseGetRowIdx(d2s);
-    af::array d2sColIdx = sparseGetColIdx(d2s);
-    dim_t     d2sNNZ    = sparseGetNNZ   (d2s);
+    // Verify values
+    ASSERT_EQ(0, af::max<double>(af::abs(dValues - s2dValues)));
 
-    ASSERT_EQ(dNNZ, s2dNNZ);
-    ASSERT_EQ(0, af::max<double>(dValues - s2dValues));
+    // Verify row and col indices
     ASSERT_EQ(0, af::max<int   >(dRowIdx - s2dRowIdx));
     ASSERT_EQ(0, af::max<int   >(dColIdx - s2dColIdx));
-
-    ASSERT_EQ(sNNZ, d2sNNZ);
-    ASSERT_EQ(0, af::max<double>(sValues - d2sValues));
-    ASSERT_EQ(0, af::max<int   >(sRowIdx - d2sRowIdx));
-    ASSERT_EQ(0, af::max<int   >(sColIdx - d2sColIdx));
 }
 
-#define CONVERT_TESTS(T, STYPE, DTYPE)                                          \
-    TEST(SPARSE_CONVERT, T##_##STYPE##_##DTYPE##_1)                             \
+#define CONVERT_TESTS_TYPES(T, STYPE, DTYPE, SUFFIX, M, N, F)                   \
+    TEST(SPARSE_CONVERT, T##_##STYPE##_##DTYPE##_##SUFFIX)                      \
     {                                                                           \
-        sparseConvertTester<T, STYPE, DTYPE>(1000, 1000, 5);                    \
+        sparseConvertTester<T, STYPE, DTYPE>(M, N, F);                          \
     }                                                                           \
-    TEST(SPARSE_CONVERT, T##_##STYPE##_##DTYPE##_2)                             \
+    TEST(SPARSE_CONVERT, T##_##DTYPE##_##STYPE##_##SUFFIX)                      \
     {                                                                           \
-        sparseConvertTester<T, STYPE, DTYPE>(512, 512, 1);                      \
-    }                                                                           \
-    TEST(SPARSE_CONVERT, T##_##STYPE##_##DTYPE##_3)                             \
-    {                                                                           \
-        sparseConvertTester<T, STYPE, DTYPE>(512, 1024, 2);                     \
-    }                                                                           \
-    TEST(SPARSE_CONVERT, T##_##STYPE##_##DTYPE##_4)                             \
-    {                                                                           \
-        sparseConvertTester<T, STYPE, DTYPE>(2048, 1024, 10);                   \
+        sparseConvertTester<T, DTYPE, STYPE>(M, N, F);                          \
     }                                                                           \
 
+#define CONVERT_TESTS(T, STYPE, DTYPE)                                          \
+    CONVERT_TESTS_TYPES(T, STYPE, DTYPE, 1, 1000, 1000,  5)                     \
+    CONVERT_TESTS_TYPES(T, STYPE, DTYPE, 2,  512,  512,  1)                     \
+    CONVERT_TESTS_TYPES(T, STYPE, DTYPE, 3,  512, 1024,  2)                     \
+    CONVERT_TESTS_TYPES(T, STYPE, DTYPE, 4, 2048, 1024, 10)                     \
 
 CONVERT_TESTS(float  , AF_STORAGE_CSR, AF_STORAGE_COO)
 CONVERT_TESTS(double , AF_STORAGE_CSR, AF_STORAGE_COO)

--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -246,11 +246,16 @@ void sparseConvertTester(const int m, const int n, int factor)
     af::array sA = af::sparse(A, src);
     af::array dA = af::sparse(A, dest);
 
-    //// Convert src to dest format and dest to src
+    // Convert src to dest format and dest to src
     af::array s2d = sparseConvertTo(sA, dest);
     af::array d2s = sparseConvertTo(dA, src);
 
-    //// Get the individual arrays and verify equality
+    // Get the individual arrays and verify equality
+    af::array sValues = sparseGetValues(sA);
+    af::array sRowIdx = sparseGetRowIdx(sA);
+    af::array sColIdx = sparseGetColIdx(sA);
+    dim_t     sNNZ    = sparseGetNNZ   (sA);
+
     af::array dValues = sparseGetValues(dA);
     af::array dRowIdx = sparseGetRowIdx(dA);
     af::array dColIdx = sparseGetColIdx(dA);
@@ -260,11 +265,6 @@ void sparseConvertTester(const int m, const int n, int factor)
     af::array s2dRowIdx = sparseGetRowIdx(s2d);
     af::array s2dColIdx = sparseGetColIdx(s2d);
     dim_t     s2dNNZ    = sparseGetNNZ   (s2d);
-
-    af::array sValues = sparseGetValues(sA);
-    af::array sRowIdx = sparseGetRowIdx(sA);
-    af::array sColIdx = sparseGetColIdx(sA);
-    dim_t     sNNZ    = sparseGetNNZ   (sA);
 
     af::array d2sValues = sparseGetValues(d2s);
     af::array d2sRowIdx = sparseGetRowIdx(d2s);
@@ -283,9 +283,21 @@ void sparseConvertTester(const int m, const int n, int factor)
 }
 
 #define CONVERT_TESTS(T, STYPE, DTYPE)                                          \
-    TEST(SPARSE_CONVERT, T##_##STYPE##_##DTYPE)                                 \
+    TEST(SPARSE_CONVERT, T##_##STYPE##_##DTYPE##_1)                             \
     {                                                                           \
-        sparseConvertTester<T, STYPE, DTYPE>(10, 10, 5);                        \
+        sparseConvertTester<T, STYPE, DTYPE>(1000, 1000, 5);                    \
+    }                                                                           \
+    TEST(SPARSE_CONVERT, T##_##STYPE##_##DTYPE##_2)                             \
+    {                                                                           \
+        sparseConvertTester<T, STYPE, DTYPE>(512, 512, 1);                      \
+    }                                                                           \
+    TEST(SPARSE_CONVERT, T##_##STYPE##_##DTYPE##_3)                             \
+    {                                                                           \
+        sparseConvertTester<T, STYPE, DTYPE>(512, 1024, 2);                     \
+    }                                                                           \
+    TEST(SPARSE_CONVERT, T##_##STYPE##_##DTYPE##_4)                             \
+    {                                                                           \
+        sparseConvertTester<T, STYPE, DTYPE>(2048, 1024, 10);                   \
     }                                                                           \
 
 

--- a/test/sparse_convert.cpp
+++ b/test/sparse_convert.cpp
@@ -1,0 +1,158 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <gtest/gtest.h>
+#include <arrayfire.h>
+#include <af/dim4.hpp>
+#include <af/defines.h>
+#include <af/traits.hpp>
+#include <vector>
+#include <iostream>
+#include <complex>
+#include <string>
+#include <testHelpers.hpp>
+
+using std::vector;
+using std::string;
+using std::cout;
+using std::endl;
+using std::abs;
+using af::cfloat;
+using af::cdouble;
+
+///////////////////////////////// CPP ////////////////////////////////////
+//
+
+template<typename T>
+af::array makeSparse(af::array A, int factor)
+{
+    A = floor(A * 1000);
+    A = A * ((A % factor) == 0) / 1000;
+    return A;
+}
+
+template<>
+af::array makeSparse<cfloat>(af::array A, int factor)
+{
+    af::array r = real(A);
+    r = floor(r * 1000);
+    r = r * ((r % factor) == 0) / 1000;
+
+    af::array i = r / 2;
+
+    A = af::complex(r, i);
+    return A;
+}
+
+template<>
+af::array makeSparse<cdouble>(af::array A, int factor)
+{
+    af::array r = real(A);
+    r = floor(r * 1000);
+    r = r * ((r % factor) == 0) / 1000;
+
+    af::array i = r / 2;
+
+    A = af::complex(r, i);
+    return A;
+}
+
+template<typename T, af_storage src, af_storage dest>
+void sparseConvertTester(const int m, const int n, int factor)
+{
+    af::deviceGC();
+
+    if (noDoubleTests<T>()) return;
+
+    af::array A = cpu_randu<T>(af::dim4(m, n));
+
+    A = makeSparse<T>(A, factor);
+
+    // Create Sparse Array of type src and dest From Dense
+    af::array sA = af::sparse(A, src);
+
+    // Convert src to dest format and dest to src
+    af::array s2d = sparseConvertTo(sA, dest);
+
+    // Create the dest type from dense - gold
+    af::array dA = af::sparse(A, dest);
+
+    // Verify nnZ
+    dim_t dNNZ   = sparseGetNNZ(dA);
+    dim_t s2dNNZ = sparseGetNNZ(s2d);
+
+    ASSERT_EQ(dNNZ, s2dNNZ);
+
+    // Verify Types
+    af_storage dType   = sparseGetStorage(dA);
+    af_storage s2dType = sparseGetStorage(s2d);
+
+    ASSERT_EQ(dType, s2dType);
+
+    // Get the individual arrays and verify equality
+    af::array dValues = sparseGetValues(dA);
+    af::array dRowIdx = sparseGetRowIdx(dA);
+    af::array dColIdx = sparseGetColIdx(dA);
+
+    af::array s2dValues = sparseGetValues(s2d);
+    af::array s2dRowIdx = sparseGetRowIdx(s2d);
+    af::array s2dColIdx = sparseGetColIdx(s2d);
+
+    // Verify values
+    ASSERT_EQ(0, af::max<double>(af::abs(dValues - s2dValues)));
+
+    // Verify row and col indices
+    ASSERT_EQ(0, af::max<int   >(dRowIdx - s2dRowIdx));
+    ASSERT_EQ(0, af::max<int   >(dColIdx - s2dColIdx));
+}
+
+#define CONVERT_TESTS_TYPES(T, STYPE, DTYPE, SUFFIX, M, N, F)                   \
+    TEST(SPARSE_CONVERT, T##_##STYPE##_##DTYPE##_##SUFFIX)                      \
+    {                                                                           \
+        sparseConvertTester<T, STYPE, DTYPE>(M, N, F);                          \
+    }                                                                           \
+    TEST(SPARSE_CONVERT, T##_##DTYPE##_##STYPE##_##SUFFIX)                      \
+    {                                                                           \
+        sparseConvertTester<T, DTYPE, STYPE>(M, N, F);                          \
+    }                                                                           \
+
+#define CONVERT_TESTS(T, STYPE, DTYPE)                                          \
+    CONVERT_TESTS_TYPES(T, STYPE, DTYPE, 1, 1000, 1000,  5)                     \
+    CONVERT_TESTS_TYPES(T, STYPE, DTYPE, 2,  512,  512,  1)                     \
+    CONVERT_TESTS_TYPES(T, STYPE, DTYPE, 3,  512, 1024,  2)                     \
+    CONVERT_TESTS_TYPES(T, STYPE, DTYPE, 4, 2048, 1024, 10)                     \
+    CONVERT_TESTS_TYPES(T, STYPE, DTYPE, 5,  237, 411,   5)                     \
+
+CONVERT_TESTS(float  , AF_STORAGE_CSR, AF_STORAGE_COO)
+CONVERT_TESTS(double , AF_STORAGE_CSR, AF_STORAGE_COO)
+CONVERT_TESTS(cfloat , AF_STORAGE_CSR, AF_STORAGE_COO)
+CONVERT_TESTS(cdouble, AF_STORAGE_CSR, AF_STORAGE_COO)
+
+#undef CONVERT_TESTS
+#undef CONVERT_TESTS_TYPES
+
+// Test to check failure with CSC
+TEST(SPARSE_CONVERT, CSC_ARG_ERROR)
+{
+    const int m = 100, n = 28, factor = 5;
+
+    af::array A = cpu_randu<float>(af::dim4(m, n));
+
+    A = makeSparse<float>(A, factor);
+
+    // Create Sparse Array of type src and dest From Dense
+    af::array sA = af::sparse(A, AF_STORAGE_CSR);
+
+    // Convert src to dest format and dest to src
+    // Use C-API to catch error
+    af_array out = 0;
+    ASSERT_EQ(AF_ERR_ARG, af_sparse_convert_to(&out, sA.get(), AF_STORAGE_CSC));
+
+    if(out != 0) af_release_array(out);
+}


### PR DESCRIPTION
* Directly convert between `AF_STORAGE_COO` <--> `AF_STORAGE_CSR` using the `sparseConvertTo` function.
  * CPU and OpenCL use native code (no libraries)
  * CUDA uses cusparse
* Fixed a bug in `COO` row/col indices from dense
* Add tests

Fixes CSR <-> COO in #821 

[skip arrayfire ci]
