### PR TITLE
[WIP] Dockerized ArrayFire

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,63 @@
+FROM nvidia/cuda
+
+RUN apt-get update && apt-get install -y software-properties-common && \
+    add-apt-repository ppa:george-edison55/cmake-3.x && \
+    apt-add-repository -y ppa:keithw/glfw3 && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        clinfo \
+        cmake \
+        git \
+        libboost-all-dev \
+        libfftw3-dev \
+        libfontconfig1-dev \
+        libfreeimage-dev \
+        libglfw3-dev \
+        liblapack-dev \
+        liblapacke-dev \
+        libopenblas-dev \
+        ocl-icd-opencl-dev \
+        opencl-headers \
+        wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# Setting up symlinks for libcuda and OpenCL ICD
+RUN ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/lib/libcuda.so.1 && \
+    ln -s /usr/lib/libcuda.so.1 /usr/lib/libcuda.so && \
+    mkdir -p /etc/OpenCL/vendors && \
+    echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd && \
+    echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+
+# AF_DISABLE_GRAPHICS - Environment variable to disable graphics at
+# runtime due to lack of graphics support by docker - visit
+# http://arrayfire.org/docs/configuring_environment.htm#af_disable_graphics
+# for more information
+ENV AF_PATH=/opt/arrayfire AF_DISABLE_GRAPHICS=1
+ARG COMPILE_GRAPHICS=OFF
+WORKDIR /root
+RUN git clone --recursive https://github.com/arrayfire/arrayfire.git && \
+    cd arrayfire && mkdir build && cd build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX=/opt/arrayfire-3 \
+             -DCMAKE_BUILD_TYPE=Release \
+             -DBUILD_CPU=ON \
+             -DBUILD_CUDA=ON \
+             -DBUILD_OPENCL=ON \
+             -DBUILD_UNIFIED=ON \
+             -DBUILD_GRAPHICS=${COMPILE_GRAPHICS} \
+             -DBUILD_NONFREE=OFF \
+             -DBUILD_EXAMPLES=ON \
+             -DBUILD_TEST=ON \
+             -DBUILD_DOCS=OFF \
+             -DINSTALL_FORGE_DEV=ON \
+             -DUSE_FREEIMAGE_STATIC=OFF && \
+             # -DCOMPUTES_DETECTED_LIST="30;35;37;50;52;60" \
+    make -j8 && make install && \
+    mkdir -p ${AF_PATH} && ln -s /opt/arrayfire-3/* ${AF_PATH}/ && \
+    echo "${AF_PATH}/lib" >> /etc/ld.so.conf.d/arrayfire.conf && \
+    echo "/usr/local/cuda/nvvm/lib64" >> /etc/ld.so.conf.d/arrayfire.conf && \
+    ldconfig
+
+WORKDIR /root/arrayfire


### PR DESCRIPTION
This PR Dockerizes ArrayFire using Nvidia's Ubuntu 14.04 CUDA 8 image.

Initial tests indicate all backends are working.

NOTE: Users will need to use the [`nvidia-docker`](https://github.com/NVIDIA/nvidia-docker) binary.