### PR TITLE
Add cast support for sparse

### DIFF
--- a/src/api/c/cast.cpp
+++ b/src/api/c/cast.cpp
@@ -47,19 +47,6 @@ static af_array cast(const af_array in, const af_dtype type)
     }
 }
 
-template<typename T>
-static af_array castSparseValues(const af_array in, const af_dtype type)
-{
-    using namespace common;
-    const SparseArray<T> sparse = getSparseArray<T>(in);
-    Array<T> values = castArray<T>(getHandle(sparse.getValues()));
-    return getHandle(createArrayDataSparseArray(sparse.dims(), values,
-                                                sparse.getRowIdx(), sparse.getColIdx(),
-                                                sparse.getStorage()
-                                               )
-                    );
-}
-
 static af_array castSparse(const af_array in, const af_dtype type)
 {
     using namespace common;
@@ -71,10 +58,10 @@ static af_array castSparse(const af_array in, const af_dtype type)
     }
 
     switch (type) {
-    case f32: return castSparseValues<float  >(in, type);
-    case f64: return castSparseValues<double >(in, type);
-    case c32: return castSparseValues<cfloat >(in, type);
-    case c64: return castSparseValues<cdouble>(in, type);
+    case f32: return getHandle(castSparse<float  >(in));
+    case f64: return getHandle(castSparse<double >(in));
+    case c32: return getHandle(castSparse<cfloat >(in));
+    case c64: return getHandle(castSparse<cdouble>(in));
     default: TYPE_ERROR(2, type);
     }
 }

--- a/src/api/c/cast.cpp
+++ b/src/api/c/cast.cpp
@@ -24,45 +24,36 @@ using namespace detail;
 
 static af_array cast(const af_array in, const af_dtype type)
 {
-    const ArrayInfo info = getInfo(in);
+    const ArrayInfo info = getInfo(in, false, true);
 
     if (info.getType() == type) {
         return retain(in);
     }
 
-    switch (type) {
-    case f32: return getHandle(castArray<float   >(in));
-    case f64: return getHandle(castArray<double  >(in));
-    case c32: return getHandle(castArray<cfloat  >(in));
-    case c64: return getHandle(castArray<cdouble >(in));
-    case s32: return getHandle(castArray<int     >(in));
-    case u32: return getHandle(castArray<uint    >(in));
-    case u8 : return getHandle(castArray<uchar   >(in));
-    case b8 : return getHandle(castArray<char    >(in));
-    case s64: return getHandle(castArray<intl    >(in));
-    case u64: return getHandle(castArray<uintl   >(in));
-    case s16: return getHandle(castArray<short   >(in));
-    case u16: return getHandle(castArray<ushort  >(in));
-    default: TYPE_ERROR(2, type);
-    }
-}
-
-static af_array castSparse(const af_array in, const af_dtype type)
-{
-    using namespace common;
-
-    const SparseArrayBase info = getSparseArrayBase(in);
-
-    if (info.getType() == type) {
-        return retain(in);
-    }
-
-    switch (type) {
-    case f32: return getHandle(castSparse<float  >(in));
-    case f64: return getHandle(castSparse<double >(in));
-    case c32: return getHandle(castSparse<cfloat >(in));
-    case c64: return getHandle(castSparse<cdouble>(in));
-    default: TYPE_ERROR(2, type);
+    if(info.isSparse()) {
+        switch (type) {
+        case f32: return getHandle(castSparse<float  >(in));
+        case f64: return getHandle(castSparse<double >(in));
+        case c32: return getHandle(castSparse<cfloat >(in));
+        case c64: return getHandle(castSparse<cdouble>(in));
+        default: TYPE_ERROR(2, type);
+        }
+    } else {
+        switch (type) {
+        case f32: return getHandle(castArray<float   >(in));
+        case f64: return getHandle(castArray<double  >(in));
+        case c32: return getHandle(castArray<cfloat  >(in));
+        case c64: return getHandle(castArray<cdouble >(in));
+        case s32: return getHandle(castArray<int     >(in));
+        case u32: return getHandle(castArray<uint    >(in));
+        case u8 : return getHandle(castArray<uchar   >(in));
+        case b8 : return getHandle(castArray<char    >(in));
+        case s64: return getHandle(castArray<intl    >(in));
+        case u64: return getHandle(castArray<uintl   >(in));
+        case s16: return getHandle(castArray<short   >(in));
+        case u16: return getHandle(castArray<ushort  >(in));
+        default: TYPE_ERROR(2, type);
+        }
     }
 }
 
@@ -85,12 +76,7 @@ af_err af_cast(af_array *out, const af_array in, const af_dtype type)
             return af_create_handle(out, AF_MAX_DIMS, my_dims, type);
         }
 
-        af_array res = 0;
-        if(info.isSparse()) {
-            res = castSparse(in, type);
-        } else {
-            res = cast(in, type);
-        }
+        af_array res = cast(in, type);
 
         std::swap(*out, res);
     }

--- a/src/api/c/cast.cpp
+++ b/src/api/c/cast.cpp
@@ -83,6 +83,15 @@ af_err af_cast(af_array *out, const af_array in, const af_dtype type)
 {
     try {
         const ArrayInfo info = getInfo(in, false, true);
+
+        af_dtype inType = info.getType();
+        if((inType == c32 || inType == c64)
+            && (type == f32 || type == f64)) {
+            AF_ERROR("Casting is not allowed from complex (c32/c64) to real (f32/f64) types.\n"
+                     "Use abs, real, imag etc to convert complex to floating type.",
+                     AF_ERR_TYPE);
+        }
+
         dim4 idims = info.dims();
         if(idims.elements() == 0) {
             dim_t my_dims[] = {0, 0, 0, 0};

--- a/src/api/c/sparse_handle.hpp
+++ b/src/api/c/sparse_handle.hpp
@@ -15,6 +15,7 @@
 #include <math.hpp>
 #include <copy.hpp>
 #include <cast.hpp>
+#include <handle.hpp>
 #include <af/dim4.hpp>
 
 #include <SparseArray.hpp>
@@ -60,4 +61,16 @@ af_array retainSparseHandle(const af_array in)
     common::SparseArray<T> *out = common::initSparseArray<T>();
     *out = *sparse;
     return reinterpret_cast<af_array>(out);
+}
+
+// based on castArray in handle.hpp
+template<typename To>
+common::SparseArray<To> castSparse(const af_array &in)
+{
+    using namespace common;
+    const SparseArray<To> sparse = getSparseArray<To>(in);
+    Array<To> values = castArray<To>(getHandle(sparse.getValues()));
+    return createArrayDataSparseArray(sparse.dims(), values,
+                                      sparse.getRowIdx(), sparse.getColIdx(),
+                                      sparse.getStorage());
 }

--- a/test/cast.cpp
+++ b/test/cast.cpp
@@ -13,7 +13,6 @@
 #include <af/data.h>
 #include <testHelpers.hpp>
 
-using namespace af;
 using af::cfloat;
 using af::cdouble;
 
@@ -25,8 +24,8 @@ void cast_test()
     if (noDoubleTests<Ti>()) return;
     if (noDoubleTests<To>()) return;
 
-    af_dtype ta = (af_dtype)dtype_traits<Ti>::af_type;
-    af_dtype tb = (af_dtype)dtype_traits<To>::af_type;
+    af_dtype ta = (af_dtype)af::dtype_traits<Ti>::af_type;
+    af_dtype tb = (af_dtype)af::dtype_traits<To>::af_type;
     af::dim4 dims(num, 1, 1, 1);
     af_array a, b;
     af_randu(&a, dims.ndims(), dims.get(), ta);
@@ -81,8 +80,8 @@ void cast_test_complex_real()
     if (noDoubleTests<Ti>()) return;
     if (noDoubleTests<To>()) return;
 
-    af_dtype ta = (af_dtype)dtype_traits<Ti>::af_type;
-    af_dtype tb = (af_dtype)dtype_traits<To>::af_type;
+    af_dtype ta = (af_dtype)af::dtype_traits<Ti>::af_type;
+    af_dtype tb = (af_dtype)af::dtype_traits<To>::af_type;
     af::dim4 dims(num, 1, 1, 1);
     af_array a, b;
     af_randu(&a, dims.ndims(), dims.get(), ta);

--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -230,16 +230,10 @@ CREATE_TESTS(AF_STORAGE_COO)
 template<typename Ti, typename To>
 void sparseCastTester(const int m, const int n, int factor)
 {
-    af::deviceGC();
-
     if (noDoubleTests<Ti>()) return;
     if (noDoubleTests<To>()) return;
 
-#if 1
     af::array A = cpu_randu<Ti>(af::dim4(m, n));
-#else
-    af::array A = af::randu(m, n, (af::dtype)af::dtype_traits<Ti>::af_type);
-#endif
 
     A = makeSparse<Ti>(A, factor);
 
@@ -273,12 +267,13 @@ void sparseCastTester(const int m, const int n, int factor)
     ASSERT_EQ(0, af::max<int>(af::abs(iRowIdx - oRowIdx)));
     ASSERT_EQ(0, af::max<int>(af::abs(iColIdx - oColIdx)));
 
+    static const double eps = 1e-6;
     if(iValues.iscomplex() && !oValues.iscomplex()) {
-        ASSERT_NEAR(0, af::max<double>(af::abs(af::abs(iValues) - oValues)), 1e-6);
+        ASSERT_NEAR(0, af::max<double>(af::abs(af::abs(iValues) - oValues)), eps);
     } else if(!iValues.iscomplex() && oValues.iscomplex()) {
-        ASSERT_NEAR(0, af::max<double>(af::abs(iValues - af::abs(oValues))), 1e-6);
+        ASSERT_NEAR(0, af::max<double>(af::abs(iValues - af::abs(oValues))), eps);
     } else {
-        ASSERT_NEAR(0, af::max<double>(af::abs(iValues - oValues)), 1e-6);
+        ASSERT_NEAR(0, af::max<double>(af::abs(iValues - oValues)), eps);
     }
 }
 

--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -226,3 +226,84 @@ CREATE_TESTS(AF_STORAGE_CSR)
 CREATE_TESTS(AF_STORAGE_COO)
 
 #undef CREATE_TESTS
+
+template<typename Ti, typename To>
+void sparseCastTester(const int m, const int n, int factor)
+{
+    af::deviceGC();
+
+    if (noDoubleTests<Ti>()) return;
+    if (noDoubleTests<To>()) return;
+
+#if 1
+    af::array A = cpu_randu<Ti>(af::dim4(m, n));
+#else
+    af::array A = af::randu(m, n, (af::dtype)af::dtype_traits<Ti>::af_type);
+#endif
+
+    A = makeSparse<Ti>(A, factor);
+
+    af::array sTi = af::sparse(A, AF_STORAGE_CSR);
+
+    // Cast
+    af::array sTo = sTi.as((af::dtype)af::dtype_traits<To>::af_type);
+
+    // Verify nnZ
+    dim_t iNNZ = sparseGetNNZ(sTi);
+    dim_t oNNZ = sparseGetNNZ(sTo);
+
+    ASSERT_EQ(iNNZ, oNNZ);
+
+    // Verify Types
+    dim_t iSType = sparseGetStorage(sTi);
+    dim_t oSType = sparseGetStorage(sTo);
+
+    ASSERT_EQ(iSType, oSType);
+
+    // Get the individual arrays and verify equality
+    af::array iValues = sparseGetValues(sTi);
+    af::array iRowIdx = sparseGetRowIdx(sTi);
+    af::array iColIdx = sparseGetColIdx(sTi);
+
+    af::array oValues = sparseGetValues(sTo);
+    af::array oRowIdx = sparseGetRowIdx(sTo);
+    af::array oColIdx = sparseGetColIdx(sTo);
+
+    // Verify values
+    ASSERT_EQ(0, af::max<int>(af::abs(iRowIdx - oRowIdx)));
+    ASSERT_EQ(0, af::max<int>(af::abs(iColIdx - oColIdx)));
+
+    if(iValues.iscomplex() && !oValues.iscomplex()) {
+        ASSERT_NEAR(0, af::max<double>(af::abs(af::abs(iValues) - oValues)), 1e-6);
+    } else if(!iValues.iscomplex() && oValues.iscomplex()) {
+        ASSERT_NEAR(0, af::max<double>(af::abs(iValues - af::abs(oValues))), 1e-6);
+    } else {
+        ASSERT_NEAR(0, af::max<double>(af::abs(iValues - oValues)), 1e-6);
+    }
+}
+
+#define CAST_TESTS_TYPES(Ti, To, SUFFIX, M, N, F)                               \
+    TEST(SPARSE_CAST, Ti##_##To##_##SUFFIX)                                     \
+    {                                                                           \
+        sparseCastTester<Ti, To>(M, N, F);                                      \
+    }                                                                           \
+
+#define CAST_TESTS(Ti, To)                                                      \
+    CAST_TESTS_TYPES(Ti, To, 1, 1000, 1000,  5)                                 \
+    CAST_TESTS_TYPES(Ti, To, 2,  512, 1024,  2)                                 \
+
+CAST_TESTS(float  , float   )
+CAST_TESTS(float  , double  )
+CAST_TESTS(float  , cfloat  )
+CAST_TESTS(float  , cdouble )
+
+CAST_TESTS(double , float   )
+CAST_TESTS(double , double  )
+CAST_TESTS(double , cfloat  )
+CAST_TESTS(double , cdouble )
+
+CAST_TESTS(cfloat , cfloat  )
+CAST_TESTS(cfloat , cdouble )
+
+CAST_TESTS(cdouble, cfloat  )
+CAST_TESTS(cdouble, cdouble )


### PR DESCRIPTION
`mysparsearray.as(type)` is now supported.
This cast only changes the `values` array and the type. The row and column index arrays are not changed.

Fixes #1648 