### PR TITLE
optimization: inline some dim4 functions

### DIFF
--- a/include/af/dim4.hpp
+++ b/include/af/dim4.hpp
@@ -38,19 +38,26 @@ public:
             dim_t fourth = 1);
     dim4(const dim4& other);
     dim4(const unsigned ndims, const dim_t * const dims);
-    dim_t elements();
-    dim_t elements() const;
-    dim_t ndims();
-    dim_t ndims() const;
+    inline dim_t elements() const { return dims[0] * dims[1] * dims[2] * dims[3]; }
+    inline dim_t ndims() const {
+        if (dims[0] == 0 || dims[1] == 0 || dims[2] == 0 || dims[3] == 0) {
+            return 0;
+        }
+        if (dims[3] != 1) return 4;
+        if (dims[2] != 1) return 3;
+        if (dims[1] != 1) return 2;
+
+        return 1;
+    }
     bool operator==(const dim4& other) const;
     bool operator!=(const dim4& other) const;
     dim4& operator*=(const dim4& other);
     dim4& operator+=(const dim4& other);
     dim4& operator-=(const dim4& other);
-    dim_t& operator[](const unsigned dim);
-    const dim_t& operator[](const unsigned dim) const;
-            dim_t* get()         { return dims; }
-    const   dim_t* get() const   { return dims; }
+    inline dim_t& operator[](const unsigned dim) { return dims[dim]; }
+    inline const dim_t& operator[](const unsigned dim) const { return dims[dim]; }
+    inline dim_t* get() { return dims; }
+    inline const dim_t* get() const { return dims; }
 };
 
 AFAPI dim4 operator+(const dim4& first, const dim4& second);

--- a/src/backend/dim4.cpp
+++ b/src/backend/dim4.cpp
@@ -59,51 +59,6 @@ dim4::dim4(const unsigned ndims_, const dim_t * const dims_)
     }
 }
 
-
-dim_t
-dim4::elements() const
-{
-    return dims[0] * dims[1] * dims[2] * dims[3];
-}
-
-dim_t
-dim4::elements()
-{
-    return static_cast<const dim4&>(*this).elements();
-}
-
-dim_t
-dim4::ndims() const
-{
-    int num = elements();
-    if (num == 0) return 0;
-    if (num == 1) return 1;
-
-    if (dims[3] != 1) return 4;
-    if (dims[2] != 1) return 3;
-    if (dims[1] != 1) return 2;
-
-    return 1;
-}
-
-dim_t
-dim4::ndims()
-{
-    return static_cast<const dim4&>(*this).ndims();
-}
-
-const dim_t&
-dim4::operator[](const unsigned dim) const
-{
-    return dims[dim];
-}
-
-dim_t &
-dim4::operator[](const unsigned dim)
-{
-    return const_cast<dim_t&>(static_cast<const dim4&>((*this))[dim]);
-}
-
 bool
 dim4::operator==(const dim4 &other) const
 {


### PR DESCRIPTION
In my profiles `dim4::operator[]` always registers as consuming some non-zero time. This patch inlines that operator and a few others in `dim4`. It also changes `ndims()` to avoid calling `elements()` which does multiplication.