### PR TITLE
optimization: avoid unnecessarily copying ArrayInfo objects

### DIFF
--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -38,8 +38,8 @@ af_err af_approx1(af_array *out, const af_array in, const af_array pos,
                   const af_interp_type method, const float offGrid)
 {
     try {
-        ArrayInfo i_info = getInfo(in);
-        ArrayInfo p_info = getInfo(pos);
+        const ArrayInfo& i_info = getInfo(in);
+        const ArrayInfo& p_info = getInfo(pos);
 
         dim4 idims = i_info.dims();
         dim4 pdims = p_info.dims();
@@ -85,9 +85,9 @@ af_err af_approx2(af_array *out, const af_array in, const af_array pos0, const a
                   const af_interp_type method, const float offGrid)
 {
     try {
-        ArrayInfo i_info = getInfo(in);
-        ArrayInfo p_info = getInfo(pos0);
-        ArrayInfo q_info = getInfo(pos1);
+        const ArrayInfo& i_info = getInfo(in);
+        const ArrayInfo& p_info = getInfo(pos0);
+        const ArrayInfo& q_info = getInfo(pos1);
 
         dim4 idims = i_info.dims();
         dim4 pdims = p_info.dims();

--- a/src/api/c/array.cpp
+++ b/src/api/c/array.cpp
@@ -127,7 +127,7 @@ af_err af_create_handle(af_array *result, const unsigned ndims, const dim_t * co
 af_err af_copy_array(af_array *out, const af_array in)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         const af_dtype type = info.getType();
 
         if(info.ndims() == 0) {
@@ -161,7 +161,7 @@ af_err af_copy_array(af_array *out, const af_array in)
 af_err af_get_data_ref_count(int *use_count, const af_array in)
 {
     try {
-        ArrayInfo info = getInfo(in, false, false);
+        const ArrayInfo& info = getInfo(in, false, false);
         const af_dtype type = info.getType();
 
         int res;
@@ -191,7 +191,7 @@ af_err af_release_array(af_array arr)
     try {
         int dev = getActiveDeviceId();
 
-        ArrayInfo info = getInfo(arr, false, false);
+        const ArrayInfo& info = getInfo(arr, false, false);
         af_dtype type = info.getType();
 
         if(info.isSparse()) {
@@ -242,7 +242,7 @@ static af_array retainHandle(const af_array in)
 
 af_array retain(const af_array in)
 {
-    ArrayInfo info = getInfo(in, false, false);
+    const ArrayInfo& info = getInfo(in, false, false);
     af_dtype ty = info.getType();
 
     if(info.isSparse()) {
@@ -341,7 +341,7 @@ af_err af_get_dims(dim_t *d0, dim_t *d1, dim_t *d2, dim_t *d3,
 {
     try {
         // Do not check for device mismatch
-        ArrayInfo info = getInfo(in, false, false);
+        const ArrayInfo& info = getInfo(in, false, false);
         *d0 = info.dims()[0];
         *d1 = info.dims()[1];
         *d2 = info.dims()[2];
@@ -355,7 +355,7 @@ af_err af_get_numdims(unsigned *nd, const af_array in)
 {
     try {
         // Do not check for device mismatch
-        ArrayInfo info = getInfo(in, false, false);
+        const ArrayInfo& info = getInfo(in, false, false);
         *nd = info.ndims();
     }
     CATCHALL
@@ -368,7 +368,7 @@ af_err af_get_numdims(unsigned *nd, const af_array in)
     af_err fn1(bool *result, const af_array in)                 \
     {                                                           \
         try {                                                   \
-            ArrayInfo info = getInfo(in, false, false);         \
+            const ArrayInfo& info = getInfo(in, false, false);         \
             *result = info.fn2();                               \
         }                                                       \
         CATCHALL                                                \

--- a/src/api/c/assign.cpp
+++ b/src/api/c/assign.cpp
@@ -80,7 +80,7 @@ template<typename T>
 static
 void assign_helper(Array<T> &out, const unsigned &ndims, const af_seq *index, const af_array &in_)
 {
-    ArrayInfo iInfo = getInfo(in_);
+    const ArrayInfo& iInfo = getInfo(in_);
     af_dtype iType  = iInfo.getType();
 
     if(out.getType() == c64 || out.getType() == c32)
@@ -119,7 +119,7 @@ af_err af_assign_seq(af_array *out,
         ARG_ASSERT(1, (ndims>0));
         ARG_ASSERT(3, (rhs!=0));
 
-        ArrayInfo lInfo = getInfo(lhs);
+        const ArrayInfo& lInfo = getInfo(lhs);
 
         if (ndims == 1 && ndims != lInfo.ndims()) {
             af_array tmp_in, tmp_out;
@@ -155,7 +155,7 @@ af_err af_assign_seq(af_array *out,
         try {
 
             if (lhs != rhs) {
-                ArrayInfo oInfo = getInfo(lhs);
+                const ArrayInfo& oInfo = getInfo(lhs);
                 af_dtype oType  = oInfo.getType();
                 switch(oType) {
                 case c64: assign_helper<cdouble>(getWritableArray<cdouble>(res), ndims, index, rhs);  break;
@@ -223,8 +223,8 @@ af_err af_assign_gen(af_array *out,
         ARG_ASSERT(1, (lhs!=0));
         ARG_ASSERT(4, (rhs!=0));
 
-        ArrayInfo lInfo = getInfo(lhs);
-        ArrayInfo rInfo = getInfo(rhs);
+        const ArrayInfo& lInfo = getInfo(lhs);
+        const ArrayInfo& rInfo = getInfo(rhs);
         dim4 lhsDims    = lInfo.dims();
         dim4 rhsDims    = rInfo.dims();
         af_dtype lhsType= lInfo.getType();
@@ -319,7 +319,7 @@ af_err af_assign_gen(af_array *out,
             if (!indexs[i].isSeq) {
                 // check if all af_arrays have atleast one value
                 // to enable indexing along that dimension
-                ArrayInfo idxInfo = getInfo(indexs[i].idx.arr);
+                const ArrayInfo& idxInfo = getInfo(indexs[i].idx.arr);
                 af_dtype idxType  = idxInfo.getType();
 
                 ARG_ASSERT(3, (idxType!=c32));

--- a/src/api/c/bilateral.cpp
+++ b/src/api/c/bilateral.cpp
@@ -28,7 +28,7 @@ template<bool isColor>
 static af_err bilateral(af_array *out, const af_array &in, const float &s_sigma, const float &c_sigma)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type  = info.getType();
         af::dim4 dims  = info.dims();
 

--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -36,8 +36,8 @@ template<af_op_t op>
 static af_err af_arith(af_array *out, const af_array lhs, const af_array rhs, const bool batchMode)
 {
     try {
-        ArrayInfo linfo = getInfo(lhs);
-        ArrayInfo rinfo = getInfo(rhs);
+        const ArrayInfo& linfo = getInfo(lhs);
+        const ArrayInfo& rinfo = getInfo(rhs);
 
         dim4 odims = getOutDims(linfo.dims(), rinfo.dims(), batchMode);
 
@@ -70,8 +70,8 @@ static af_err af_arith_real(af_array *out, const af_array lhs, const af_array rh
 {
     try {
 
-        ArrayInfo linfo = getInfo(lhs);
-        ArrayInfo rinfo = getInfo(rhs);
+        const ArrayInfo& linfo = getInfo(lhs);
+        const ArrayInfo& rinfo = getInfo(rhs);
 
         dim4 odims = getOutDims(linfo.dims(), rinfo.dims(), batchMode);
 
@@ -140,8 +140,8 @@ af_err af_mod(af_array *out, const af_array lhs, const af_array rhs, const bool 
 af_err af_pow(af_array *out, const af_array lhs, const af_array rhs, const bool batchMode)
 {
     try {
-        ArrayInfo linfo = getInfo(lhs);
-        ArrayInfo rinfo = getInfo(rhs);
+        const ArrayInfo& linfo = getInfo(lhs);
+        const ArrayInfo& rinfo = getInfo(rhs);
         if (linfo.isComplex() || rinfo.isComplex()) {
             af_array log_lhs, log_res;
             af_array res;
@@ -159,8 +159,8 @@ af_err af_pow(af_array *out, const af_array lhs, const af_array rhs, const bool 
 af_err af_root(af_array *out, const af_array lhs, const af_array rhs, const bool batchMode)
 {
     try {
-        ArrayInfo linfo = getInfo(lhs);
-        ArrayInfo rinfo = getInfo(rhs);
+        const ArrayInfo& linfo = getInfo(lhs);
+        const ArrayInfo& rinfo = getInfo(rhs);
         if (linfo.isComplex() || rinfo.isComplex()) {
             af_array log_lhs, log_res;
             af_array res;
@@ -198,8 +198,8 @@ af_err af_atan2(af_array *out, const af_array lhs, const af_array rhs, const boo
                      AF_ERR_NOT_SUPPORTED);
         }
 
-        ArrayInfo linfo = getInfo(lhs);
-        ArrayInfo rinfo = getInfo(rhs);
+        const ArrayInfo& linfo = getInfo(lhs);
+        const ArrayInfo& rinfo = getInfo(rhs);
 
         dim4 odims = getOutDims(linfo.dims(), rinfo.dims(), batchMode);
 
@@ -227,8 +227,8 @@ af_err af_hypot(af_array *out, const af_array lhs, const af_array rhs, const boo
                      AF_ERR_NOT_SUPPORTED);
         }
 
-        ArrayInfo linfo = getInfo(lhs);
-        ArrayInfo rinfo = getInfo(rhs);
+        const ArrayInfo& linfo = getInfo(lhs);
+        const ArrayInfo& rinfo = getInfo(rhs);
 
         dim4 odims = getOutDims(linfo.dims(), rinfo.dims(), batchMode);
 
@@ -258,8 +258,8 @@ static af_err af_logic(af_array *out, const af_array lhs, const af_array rhs, co
     try {
         const af_dtype type = implicit(lhs, rhs);
 
-        ArrayInfo linfo = getInfo(lhs);
-        ArrayInfo rinfo = getInfo(rhs);
+        const ArrayInfo& linfo = getInfo(lhs);
+        const ArrayInfo& rinfo = getInfo(rhs);
 
         dim4 odims = getOutDims(linfo.dims(), rinfo.dims(), batchMode);
 
@@ -339,8 +339,8 @@ static af_err af_bitwise(af_array *out, const af_array lhs, const af_array rhs, 
     try {
         const af_dtype type = implicit(lhs, rhs);
 
-        ArrayInfo linfo = getInfo(lhs);
-        ArrayInfo rinfo = getInfo(rhs);
+        const ArrayInfo& linfo = getInfo(lhs);
+        const ArrayInfo& rinfo = getInfo(rhs);
 
         dim4 odims = getOutDims(linfo.dims(), rinfo.dims(), batchMode);
 

--- a/src/api/c/blas.cpp
+++ b/src/api/c/blas.cpp
@@ -49,7 +49,7 @@ af_err af_sparse_matmul(af_array *out,
 
     try {
         common::SparseArrayBase lhsBase = getSparseArrayBase(lhs);
-        ArrayInfo rhsInfo = getInfo(rhs);
+        const ArrayInfo& rhsInfo = getInfo(rhs);
 
         ARG_ASSERT(2, lhsBase.isSparse() == true && rhsInfo.isSparse() == false);
 
@@ -103,8 +103,8 @@ af_err af_matmul(af_array *out,
     using namespace detail;
 
     try {
-        ArrayInfo lhsInfo = getInfo(lhs, false, true);
-        ArrayInfo rhsInfo = getInfo(rhs, true, true);
+        const ArrayInfo& lhsInfo = getInfo(lhs, false, true);
+        const ArrayInfo& rhsInfo = getInfo(rhs, true, true);
 
         if(lhsInfo.isSparse())
             return af_sparse_matmul(out, lhs, rhs, optLhs, optRhs);
@@ -158,8 +158,8 @@ af_err af_dot(af_array *out,
     using namespace detail;
 
     try {
-        ArrayInfo lhsInfo = getInfo(lhs);
-        ArrayInfo rhsInfo = getInfo(rhs);
+        const ArrayInfo& lhsInfo = getInfo(lhs);
+        const ArrayInfo& rhsInfo = getInfo(rhs);
 
         if (optLhs != AF_MAT_NONE && optLhs != AF_MAT_CONJ) {
             AF_ERROR("Using this property is not yet supported in dot", AF_ERR_NOT_SUPPORTED);
@@ -221,7 +221,7 @@ af_err af_dot_all(double *rval, double *ival,
         af_array out = 0;
         AF_CHECK(af_dot(&out, lhs, rhs, optLhs, optRhs));
 
-        ArrayInfo lhsInfo = getInfo(lhs);
+        const ArrayInfo& lhsInfo = getInfo(lhs);
         af_dtype lhs_type = lhsInfo.getType();
 
         switch(lhs_type) {

--- a/src/api/c/cast.cpp
+++ b/src/api/c/cast.cpp
@@ -22,7 +22,7 @@ using namespace detail;
 
 static af_array cast(const af_array in, const af_dtype type)
 {
-    const ArrayInfo info = getInfo(in);
+    const ArrayInfo& info = getInfo(in);
 
     if (info.getType() == type) {
         return retain(in);
@@ -48,7 +48,7 @@ static af_array cast(const af_array in, const af_dtype type)
 af_err af_cast(af_array *out, const af_array in, const af_dtype type)
 {
     try {
-        const ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         dim4 idims = info.dims();
         if(idims.elements() == 0) {
             dim_t my_dims[] = {0, 0, 0, 0};
@@ -67,7 +67,7 @@ af_err af_cplx(af_array *out, const af_array in, const af_dtype type)
 {
     try {
         af_array res;
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
 
         if (in_info.isDouble()) {
             res = cast(in, c64);

--- a/src/api/c/cholesky.cpp
+++ b/src/api/c/cholesky.cpp
@@ -34,7 +34,7 @@ static inline int cholesky_inplace(af_array in, const bool is_upper)
 af_err af_cholesky(af_array *out, int *info, const af_array in, const bool is_upper)
 {
     try {
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& i_info = getInfo(in);
 
         if (i_info.ndims() > 2) {
             AF_ERROR("cholesky can not be used in batch mode", AF_ERR_BATCH);
@@ -68,7 +68,7 @@ af_err af_cholesky(af_array *out, int *info, const af_array in, const bool is_up
 af_err af_cholesky_inplace(int *info, af_array in, const bool is_upper)
 {
     try {
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& i_info = getInfo(in);
 
         if (i_info.ndims() > 2) {
             AF_ERROR("cholesky can not be used in batch mode", AF_ERR_BATCH);

--- a/src/api/c/clamp.cpp
+++ b/src/api/c/clamp.cpp
@@ -40,9 +40,9 @@ af_err af_clamp(af_array *out, const af_array in,
                 const af_array lo, const af_array hi, const bool batch)
 {
     try {
-        ArrayInfo linfo = getInfo(lo);
-        ArrayInfo hinfo = getInfo(hi);
-        ArrayInfo iinfo = getInfo(in);
+        const ArrayInfo& linfo = getInfo(lo);
+        const ArrayInfo& hinfo = getInfo(hi);
+        const ArrayInfo& iinfo = getInfo(in);
 
         DIM_ASSERT(2, linfo.dims() == hinfo.dims());
         TYPE_ASSERT(linfo.getType() == hinfo.getType());

--- a/src/api/c/complex.cpp
+++ b/src/api/c/complex.cpp
@@ -62,7 +62,7 @@ af_err af_cplx(af_array *out, const af_array in)
 {
     try {
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         if (type == c32 || type == c64) {
@@ -96,7 +96,7 @@ af_err af_real(af_array *out, const af_array in)
 {
     try {
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         if (type != c32 && type != c64) {
@@ -122,7 +122,7 @@ af_err af_imag(af_array *out, const af_array in)
 {
     try {
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         if (type != c32 && type != c64) {
@@ -148,7 +148,7 @@ af_err af_conjg(af_array *out, const af_array in)
 {
     try {
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         if (type != c32 && type != c64) {
@@ -174,7 +174,7 @@ af_err af_abs(af_array *out, const af_array in)
 {
     try {
 
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
         af_dtype in_type = in_info.getType();
         af_array res;
 

--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -64,8 +64,8 @@ template<dim_t baseDim, bool expand>
 af_err convolve(af_array *out, const af_array signal, const af_array filter)
 {
     try {
-        ArrayInfo sInfo = getInfo(signal);
-        ArrayInfo fInfo = getInfo(filter);
+        const ArrayInfo& sInfo = getInfo(signal);
+        const ArrayInfo& fInfo = getInfo(filter);
 
         af_dtype stype  = sInfo.getType();
 
@@ -107,9 +107,9 @@ template<bool expand>
 af_err convolve2_sep(af_array *out, af_array col_filter, af_array row_filter, const af_array signal)
 {
     try {
-        ArrayInfo sInfo = getInfo(signal);
-        ArrayInfo cfInfo= getInfo(col_filter);
-        ArrayInfo rfInfo= getInfo(row_filter);
+        const ArrayInfo& sInfo = getInfo(signal);
+        const ArrayInfo& cfInfo= getInfo(col_filter);
+        const ArrayInfo& rfInfo= getInfo(row_filter);
 
         af_dtype signalType  = sInfo.getType();
 
@@ -149,8 +149,8 @@ bool isFreqDomain(const af_array &signal, const af_array filter, af_conv_domain 
     if (domain == AF_CONV_FREQ) return true;
     if (domain != AF_CONV_AUTO) return false;
 
-    ArrayInfo sInfo = getInfo(signal);
-    ArrayInfo fInfo = getInfo(filter);
+    const ArrayInfo& sInfo = getInfo(signal);
+    const ArrayInfo& fInfo = getInfo(filter);
 
     dim4 sdims = sInfo.dims();
     dim4 fdims = fInfo.dims();

--- a/src/api/c/corrcoef.cpp
+++ b/src/api/c/corrcoef.cpp
@@ -51,8 +51,8 @@ static To corrcoef(const af_array& X, const af_array& Y)
 af_err af_corrcoef(double *realVal, double *imagVal, const af_array X, const af_array Y)
 {
     try {
-        ArrayInfo xInfo = getInfo(X);
-        ArrayInfo yInfo = getInfo(Y);
+        const ArrayInfo& xInfo = getInfo(X);
+        const ArrayInfo& yInfo = getInfo(Y);
         dim4 xDims      = xInfo.dims();
         dim4 yDims      = yInfo.dims();
         af_dtype xType  = xInfo.getType();

--- a/src/api/c/covariance.cpp
+++ b/src/api/c/covariance.cpp
@@ -52,8 +52,8 @@ static af_array cov(const af_array& X, const af_array& Y, const bool isbiased)
 af_err af_cov(af_array* out, const af_array X, const af_array Y, const bool isbiased)
 {
     try {
-        ArrayInfo xInfo = getInfo(X);
-        ArrayInfo yInfo = getInfo(Y);
+        const ArrayInfo& xInfo = getInfo(X);
+        const ArrayInfo& yInfo = getInfo(Y);
         dim4 xDims      = xInfo.dims();
         dim4 yDims      = yInfo.dims();
         af_dtype xType  = xInfo.getType();

--- a/src/api/c/data.cpp
+++ b/src/api/c/data.cpp
@@ -301,7 +301,7 @@ static inline af_array diagExtract(const af_array in, const int num)
 af_err af_diag_create(af_array *out, const af_array in, const int num)
 {
     try {
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
         DIM_ASSERT(1, in_info.ndims() <= 2);
         af_dtype type = in_info.getType();
 
@@ -338,7 +338,7 @@ af_err af_diag_extract(af_array *out, const af_array in, const int num)
 {
 
     try {
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
         af_dtype type = in_info.getType();
 
         if(in_info.ndims() == 0) {
@@ -384,7 +384,7 @@ af_array triangle(const af_array in, bool is_unit_diag)
 af_err af_lower(af_array *out, const af_array in, bool is_unit_diag)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         if(info.ndims() == 0) {
@@ -416,7 +416,7 @@ af_err af_lower(af_array *out, const af_array in, bool is_unit_diag)
 af_err af_upper(af_array *out, const af_array in, bool is_unit_diag)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         if(info.ndims() == 0) {

--- a/src/api/c/det.cpp
+++ b/src/api/c/det.cpp
@@ -67,7 +67,7 @@ af_err af_det(double *real_val, double *imag_val, const af_array in)
 {
 
     try {
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& i_info = getInfo(in);
 
         if (i_info.ndims() > 2) {
             AF_ERROR("solve can not be used in batch mode", AF_ERR_BATCH);

--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -49,7 +49,7 @@ af_err af_get_backend_id(af_backend *result, const af_array in)
 {
     try {
         ARG_ASSERT(1, in != 0);
-        ArrayInfo info = getInfo(in, false, false);
+        const ArrayInfo& info = getInfo(in, false, false);
         *result = info.getBackendId();
     } CATCHALL;
     return AF_SUCCESS;
@@ -59,7 +59,7 @@ af_err af_get_device_id(int *device, const af_array in)
 {
     try {
         ARG_ASSERT(1, in != 0);
-        ArrayInfo info = getInfo(in, false, false);
+        const ArrayInfo& info = getInfo(in, false, false);
         *device = info.getDevId();
     } CATCHALL;
     return AF_SUCCESS;
@@ -176,7 +176,7 @@ static inline void sparseEval(af_array arr)
 af_err af_eval(af_array arr)
 {
     try {
-        ArrayInfo info = getInfo(arr, false);
+        const ArrayInfo& info = getInfo(arr, false);
         af_dtype type = info.getType();
 
         if(info.isSparse()) {
@@ -226,12 +226,12 @@ static inline void evalMultiple(int num, af_array *arrayPtrs)
 af_err af_eval_multiple(int num, af_array *arrays)
 {
     try {
-        ArrayInfo info = getInfo(arrays[0]);
+        const ArrayInfo& info = getInfo(arrays[0]);
         af_dtype type = info.getType();
         dim4 dims = info.dims();
 
         for (int i = 1; i < num; i++) {
-            ArrayInfo currInfo = getInfo(arrays[i]);
+            const ArrayInfo& currInfo = getInfo(arrays[i]);
 
             // FIXME: This needs to be removed when new functionality is added
             if (type != currInfo.getType()) {

--- a/src/api/c/diff.cpp
+++ b/src/api/c/diff.cpp
@@ -36,7 +36,7 @@ af_err af_diff1(af_array *out, const af_array in, const int dim)
 
         ARG_ASSERT(2, ((dim >= 0) && (dim < 4)));
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         af::dim4 in_dims = info.dims();
@@ -78,7 +78,7 @@ af_err af_diff2(af_array *out, const af_array in, const int dim)
 
         ARG_ASSERT(2, ((dim >= 0) && (dim < 4)));
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         af::dim4 in_dims = info.dims();

--- a/src/api/c/dog.cpp
+++ b/src/api/c/dog.cpp
@@ -46,7 +46,7 @@ static af_array dog(const af_array& in, const int radius1, const int radius2)
 af_err af_dog(af_array *out, const af_array in, const int radius1, const int radius2)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         dim4 inDims = info.dims();
         ARG_ASSERT(1, (inDims.ndims()>=2));
         ARG_ASSERT(1, (inDims.ndims()<=3));

--- a/src/api/c/exampleFunction.cpp
+++ b/src/api/c/exampleFunction.cpp
@@ -52,7 +52,7 @@ af_err af_example_function(af_array* out, const af_array a, const af_someenum_t 
 {
     try {
         af_array output = 0;
-        ArrayInfo info = getInfo(a);        // ArrayInfo is the base class which
+        const ArrayInfo& info = getInfo(a);        // ArrayInfo is the base class which
                                             // each backend specific Array inherits
                                             // This class stores the basic array meta-data
                                             // such as type of data, dimensions,

--- a/src/api/c/fast.cpp
+++ b/src/api/c/fast.cpp
@@ -52,7 +52,7 @@ af_err af_fast(af_features *out, const af_array in, const float thr,
                const float feature_ratio, const unsigned edge)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims  = info.dims();
 
         ARG_ASSERT(2, (dims[0] >= (dim_t)(2*edge+1) || dims[1] >= (dim_t)(2*edge+1)));

--- a/src/api/c/fft.cpp
+++ b/src/api/c/fft.cpp
@@ -29,7 +29,7 @@ template<int rank, bool direction>
 static af_err fft(af_array *out, const af_array in, const double norm_factor, const dim_t npad, const dim_t * const pad)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type  = info.getType();
         af::dim4 dims  = info.dims();
 
@@ -104,7 +104,7 @@ template<int rank, bool direction>
 static af_err fft_inplace(af_array in, const double norm_factor)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type  = info.getType();
         af::dim4 dims  = info.dims();
 
@@ -166,7 +166,7 @@ template<int rank>
 static af_err fft_r2c(af_array *out, const af_array in, const double norm_factor, const dim_t npad, const dim_t * const pad)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type  = info.getType();
         af::dim4 dims  = info.dims();
 
@@ -221,7 +221,7 @@ template<int rank>
 static af_err fft_c2r(af_array *out, const af_array in, const double norm_factor, const bool is_odd)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type  = info.getType();
         af::dim4 idims  = info.dims();
 

--- a/src/api/c/fftconvolve.cpp
+++ b/src/api/c/fftconvolve.cpp
@@ -124,8 +124,8 @@ template<dim_t baseDim>
 af_err fft_convolve(af_array *out, const af_array signal, const af_array filter, const bool expand)
 {
     try {
-        ArrayInfo sInfo = getInfo(signal);
-        ArrayInfo fInfo = getInfo(filter);
+        const ArrayInfo& sInfo = getInfo(signal);
+        const ArrayInfo& fInfo = getInfo(filter);
 
         af_dtype stype  = sInfo.getType();
 

--- a/src/api/c/filters.cpp
+++ b/src/api/c/filters.cpp
@@ -41,7 +41,7 @@ af_err af_medfilt1(af_array *out, const af_array in, const dim_t wind_width, con
         ARG_ASSERT(2, (wind_width>0));
         ARG_ASSERT(4, (edge_pad>=AF_PAD_ZERO && edge_pad<=AF_PAD_SYM));
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims  = info.dims();
 
         dim_t input_ndims = dims.ndims();
@@ -89,7 +89,7 @@ af_err af_medfilt2(af_array *out, const af_array in, const dim_t wind_length, co
         ARG_ASSERT(3, (wind_width>0));
         ARG_ASSERT(4, (edge_pad>=AF_PAD_ZERO && edge_pad<=AF_PAD_SYM));
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims  = info.dims();
 
         if(info.isColumn()) {
@@ -132,7 +132,7 @@ af_err af_minfilt(af_array *out, const af_array in, const dim_t wind_length,
         ARG_ASSERT(3, (wind_width>0));
         ARG_ASSERT(4, (edge_pad==AF_PAD_ZERO));
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims  = info.dims();
 
         dim_t input_ndims = dims.ndims();
@@ -160,7 +160,7 @@ af_err af_maxfilt(af_array *out, const af_array in, const dim_t wind_length,
         ARG_ASSERT(3, (wind_width>0));
         ARG_ASSERT(4, (edge_pad==AF_PAD_ZERO));
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims  = info.dims();
 
         dim_t input_ndims = dims.ndims();

--- a/src/api/c/flip.cpp
+++ b/src/api/c/flip.cpp
@@ -50,7 +50,7 @@ af_err af_flip(af_array *result, const af_array in, const unsigned dim)
 {
     af_array out;
     try {
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
 
         if (in_info.ndims() <= dim) {
             *result = retain(in);

--- a/src/api/c/gradient.cpp
+++ b/src/api/c/gradient.cpp
@@ -27,7 +27,7 @@ static inline void gradient(af_array *grad0, af_array *grad1, const af_array in)
 af_err af_gradient(af_array *grows, af_array *gcols, const af_array in)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
         af::dim4 idims = info.dims();
 

--- a/src/api/c/handle.hpp
+++ b/src/api/c/handle.hpp
@@ -41,7 +41,7 @@ detail::Array<To> castArray(const af_array &in)
     using detail::uchar;
     using detail::ushort;
 
-    const ArrayInfo info = getInfo(in);
+    const ArrayInfo& info = getInfo(in);
     switch (info.getType()) {
     case f32: return detail::cast<To, float  >(getArray<float  >(in));
     case f64: return detail::cast<To, double >(getArray<double >(in));

--- a/src/api/c/harris.cpp
+++ b/src/api/c/harris.cpp
@@ -52,7 +52,7 @@ af_err af_harris(af_features *out, const af_array in, const unsigned max_corners
                  const unsigned block_size, const float k_thr)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims  = info.dims();
         dim_t in_ndims = dims.ndims();
 

--- a/src/api/c/hist.cpp
+++ b/src/api/c/hist.cpp
@@ -63,7 +63,7 @@ af_err af_draw_hist(const af_window wind, const af_array X, const double minval,
     }
 
     try {
-        ArrayInfo Xinfo = getInfo(X);
+        const ArrayInfo& Xinfo = getInfo(X);
         af_dtype Xtype  = Xinfo.getType();
 
         ARG_ASSERT(0, Xinfo.isVector());

--- a/src/api/c/histeq.cpp
+++ b/src/api/c/histeq.cpp
@@ -63,8 +63,8 @@ static af_array hist_equal(const af_array& in, const af_array& hist)
 af_err af_hist_equal(af_array *out, const af_array in, const af_array hist)
 {
     try {
-        ArrayInfo dataInfo = getInfo(in);
-        ArrayInfo histInfo = getInfo(hist);
+        const ArrayInfo& dataInfo = getInfo(in);
+        const ArrayInfo& histInfo = getInfo(hist);
 
         af_dtype dataType  = dataInfo.getType();
         af::dim4 histDims  = histInfo.dims();

--- a/src/api/c/histogram.cpp
+++ b/src/api/c/histogram.cpp
@@ -32,7 +32,7 @@ af_err af_histogram(af_array *out, const af_array in,
                     const unsigned nbins, const double minval, const double maxval)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type  = info.getType();
 
         if(info.ndims() == 0) {

--- a/src/api/c/homography.cpp
+++ b/src/api/c/homography.cpp
@@ -48,10 +48,10 @@ af_err af_homography(af_array *H, int *inliers,
                      const unsigned iterations, const af_dtype otype)
 {
     try {
-        ArrayInfo xsinfo = getInfo(x_src);
-        ArrayInfo ysinfo = getInfo(y_src);
-        ArrayInfo xdinfo = getInfo(x_dst);
-        ArrayInfo ydinfo = getInfo(y_dst);
+        const ArrayInfo& xsinfo = getInfo(x_src);
+        const ArrayInfo& ysinfo = getInfo(y_src);
+        const ArrayInfo& xdinfo = getInfo(x_dst);
+        const ArrayInfo& ydinfo = getInfo(y_dst);
 
         af::dim4 xsdims  = xsinfo.dims();
         af::dim4 ysdims  = ysinfo.dims();

--- a/src/api/c/hsv_rgb.cpp
+++ b/src/api/c/hsv_rgb.cpp
@@ -34,7 +34,7 @@ template<bool isHSV2RGB>
 af_err convert(af_array* out, const af_array& in)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype iType = info.getType();
         af::dim4 inputDims = info.dims();
 

--- a/src/api/c/iir.cpp
+++ b/src/api/c/iir.cpp
@@ -51,9 +51,9 @@ inline static af_array iir(const af_array b, const af_array a, const af_array x)
 af_err af_iir(af_array *y, const af_array b, const af_array a, const af_array x)
 {
     try {
-        ArrayInfo ainfo = getInfo(a);
-        ArrayInfo binfo = getInfo(b);
-        ArrayInfo xinfo = getInfo(x);
+        const ArrayInfo& ainfo = getInfo(a);
+        const ArrayInfo& binfo = getInfo(b);
+        const ArrayInfo& xinfo = getInfo(x);
 
         af_dtype xtype = xinfo.getType();
 

--- a/src/api/c/image.cpp
+++ b/src/api/c/image.cpp
@@ -84,7 +84,7 @@ af_err af_draw_image(const af_window wind, const af_array in, const af_cell* con
     }
 
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
 
         af::dim4 in_dims = info.dims();
         af_dtype type    = info.getType();

--- a/src/api/c/imageio.cpp
+++ b/src/api/c/imageio.cpp
@@ -297,7 +297,7 @@ af_err af_save_image(const char* filename, const af_array in_)
             AF_ERROR("FreeImage Error: Unknown Filetype", AF_ERR_NOT_SUPPORTED);
         }
 
-        ArrayInfo info = getInfo(in_);
+        const ArrayInfo& info = getInfo(in_);
         // check image color type
         uint channels = info.dims()[2];
         DIM_ASSERT(1, channels <= 4);
@@ -359,7 +359,7 @@ af_err af_save_image(const char* filename, const af_array in_)
             AF_CHECK(af_transpose(&bbT, bb, false));
             AF_CHECK(af_transpose(&aaT, aa, false));
 
-            ArrayInfo cinfo = getInfo(rrT);
+            const ArrayInfo& cinfo = getInfo(rrT);
             float* pSrc0 = pinnedAlloc<float>(cinfo.elements());
             float* pSrc1 = pinnedAlloc<float>(cinfo.elements());
             float* pSrc2 = pinnedAlloc<float>(cinfo.elements());
@@ -390,7 +390,7 @@ af_err af_save_image(const char* filename, const af_array in_)
             AF_CHECK(af_transpose(&ggT, gg, false));
             AF_CHECK(af_transpose(&bbT, bb, false));
 
-            ArrayInfo cinfo = getInfo(rrT);
+            const ArrayInfo& cinfo = getInfo(rrT);
             float* pSrc0 = pinnedAlloc<float>(cinfo.elements());
             float* pSrc1 = pinnedAlloc<float>(cinfo.elements());
             float* pSrc2 = pinnedAlloc<float>(cinfo.elements());
@@ -414,7 +414,7 @@ af_err af_save_image(const char* filename, const af_array in_)
             pinnedFree(pSrc2);
         } else {
             AF_CHECK(af_transpose(&rrT, rr, false));
-            ArrayInfo cinfo = getInfo(rrT);
+            const ArrayInfo& cinfo = getInfo(rrT);
             float* pSrc0 = pinnedAlloc<float>(cinfo.elements());
             AF_CHECK(af_get_data_ptr((void*)pSrc0, rrT));
 
@@ -574,7 +574,7 @@ af_err af_save_image_memory(void **ptr, const af_array in_, const af_image_forma
             AF_ERROR("FreeImage Error: Unknown Filetype", AF_ERR_NOT_SUPPORTED);
         }
 
-        ArrayInfo info = getInfo(in_);
+        const ArrayInfo& info = getInfo(in_);
         // check image color type
         uint channels = info.dims()[2];
         DIM_ASSERT(1, channels <= 4);
@@ -628,7 +628,7 @@ af_err af_save_image_memory(void **ptr, const af_array in_, const af_image_forma
             AF_CHECK(af_transpose(&bbT, bb, false));
             AF_CHECK(af_transpose(&aaT, aa, false));
 
-            ArrayInfo cinfo = getInfo(rrT);
+            const ArrayInfo& cinfo = getInfo(rrT);
             float* pSrc0 = pinnedAlloc<float>(cinfo.elements());
             float* pSrc1 = pinnedAlloc<float>(cinfo.elements());
             float* pSrc2 = pinnedAlloc<float>(cinfo.elements());
@@ -659,7 +659,7 @@ af_err af_save_image_memory(void **ptr, const af_array in_, const af_image_forma
             AF_CHECK(af_transpose(&ggT, gg, false));
             AF_CHECK(af_transpose(&bbT, bb, false));
 
-            ArrayInfo cinfo = getInfo(rrT);
+            const ArrayInfo& cinfo = getInfo(rrT);
             float* pSrc0 = pinnedAlloc<float>(cinfo.elements());
             float* pSrc1 = pinnedAlloc<float>(cinfo.elements());
             float* pSrc2 = pinnedAlloc<float>(cinfo.elements());
@@ -683,7 +683,7 @@ af_err af_save_image_memory(void **ptr, const af_array in_, const af_image_forma
             pinnedFree(pSrc2);
         } else {
             AF_CHECK(af_transpose(&rrT, rr, false));
-            ArrayInfo cinfo = getInfo(rrT);
+            const ArrayInfo& cinfo = getInfo(rrT);
             float* pSrc0 = pinnedAlloc<float>(cinfo.elements());
             AF_CHECK(af_get_data_ptr((void*)pSrc0, rrT));
 

--- a/src/api/c/imageio2.cpp
+++ b/src/api/c/imageio2.cpp
@@ -238,7 +238,7 @@ static void save_t(T* pDstLine, const af_array in, const dim4 dims, uint nDstPit
     if(channels >= 3) AF_CHECK(af_transpose(&bbT, bb, false));
     if(channels >= 4) AF_CHECK(af_transpose(&aaT, aa, false));
 
-    ArrayInfo cinfo = getInfo(rrT);
+    const ArrayInfo& cinfo = getInfo(rrT);
                       pSrc0 = pinnedAlloc<T>(cinfo.elements());
     if(channels >= 3) pSrc1 = pinnedAlloc<T>(cinfo.elements());
     if(channels >= 3) pSrc2 = pinnedAlloc<T>(cinfo.elements());
@@ -313,7 +313,7 @@ af_err af_save_image_native(const char* filename, const af_array in)
             AF_ERROR("FreeImage Error: Unknown Filetype", AF_ERR_NOT_SUPPORTED);
         }
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         // check image color type
         FI_CHANNELS channels = (FI_CHANNELS)info.dims()[2];
         DIM_ASSERT(1, channels <= 4);

--- a/src/api/c/implicit.cpp
+++ b/src/api/c/implicit.cpp
@@ -64,8 +64,8 @@ af_dtype implicit(const af_dtype lty, const af_dtype rty)
 
 af_dtype implicit(const af_array lhs, const af_array rhs)
 {
-    ArrayInfo lInfo = getInfo(lhs);
-    ArrayInfo rInfo = getInfo(rhs);
+    const ArrayInfo& lInfo = getInfo(lhs);
+    const ArrayInfo& rInfo = getInfo(rhs);
 
     return implicit(lInfo.getType(), rInfo.getType());
 }

--- a/src/api/c/index.cpp
+++ b/src/api/c/index.cpp
@@ -41,7 +41,7 @@ af_err af_index(af_array *result, const af_array in, const unsigned ndims, const
     af_array out;
     try {
 
-        ArrayInfo iInfo = getInfo(in);
+        const ArrayInfo& iInfo = getInfo(in);
         if (ndims == 1 && ndims != iInfo.ndims()) {
             af_array tmp_in;
             AF_CHECK(af_flat(&tmp_in, in));
@@ -77,7 +77,7 @@ af_err af_index(af_array *result, const af_array in, const unsigned ndims, const
 template<typename idx_t>
 static af_array lookup(const af_array &in, const af_array &idx, const unsigned dim)
 {
-    ArrayInfo inInfo = getInfo(in);
+    const ArrayInfo& inInfo = getInfo(in);
 
     af_dtype inType  = inInfo.getType();
 
@@ -105,7 +105,7 @@ af_err af_lookup(af_array *out, const af_array in, const af_array indices, const
     try {
         ARG_ASSERT(3, (dim>=0 && dim<=3));
 
-        ArrayInfo idxInfo= getInfo(indices);
+        const ArrayInfo& idxInfo= getInfo(indices);
 
         if(idxInfo.ndims() == 0) {
             return af_retain_array(out, indices);
@@ -160,7 +160,7 @@ af_err af_index_gen(af_array *out, const af_array in, const dim_t ndims, const a
         ARG_ASSERT(2, (ndims>0));
         ARG_ASSERT(3, (indexs!=NULL));
 
-        ArrayInfo iInfo = getInfo(in);
+        const ArrayInfo& iInfo = getInfo(in);
 
         dim4 iDims = iInfo.dims();
         af_dtype inType = getInfo(in).getType();
@@ -200,7 +200,7 @@ af_err af_index_gen(af_array *out, const af_array in, const dim_t ndims, const a
             if (!indexs[i].isSeq) {
                 // check if all af_arrays have atleast one value
                 // to enable indexing along that dimension
-                ArrayInfo idxInfo = getInfo(indexs[i].idx.arr);
+                const ArrayInfo& idxInfo = getInfo(indexs[i].idx.arr);
                 af_dtype idxType  = idxInfo.getType();
 
                 ARG_ASSERT(3, (idxType!=c32));

--- a/src/api/c/internal.cpp
+++ b/src/api/c/internal.cpp
@@ -78,7 +78,7 @@ af_err af_create_strided_array(af_array *arr,
 af_err af_get_strides(dim_t *s0, dim_t *s1, dim_t *s2, dim_t *s3, const af_array in)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         *s0 = info.strides()[0];
         *s1 = info.strides()[1];
         *s2 = info.strides()[2];

--- a/src/api/c/inverse.cpp
+++ b/src/api/c/inverse.cpp
@@ -28,7 +28,7 @@ static inline af_array inverse(const af_array in)
 af_err af_inverse(af_array *out, const af_array in, const af_mat_prop options)
 {
     try {
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& i_info = getInfo(in);
 
         if (i_info.ndims() > 2) {
             AF_ERROR("solve can not be used in batch mode", AF_ERR_BATCH);

--- a/src/api/c/join.cpp
+++ b/src/api/c/join.cpp
@@ -39,8 +39,8 @@ static inline af_array join_many(const int dim, const unsigned n_arrays, const a
 af_err af_join(af_array *out, const int dim, const af_array first, const af_array second)
 {
     try {
-        ArrayInfo finfo = getInfo(first);
-        ArrayInfo sinfo = getInfo(second);
+        const ArrayInfo& finfo = getInfo(first);
+        const ArrayInfo& sinfo = getInfo(second);
         af::dim4  fdims = finfo.dims();
         af::dim4  sdims = sinfo.dims();
 

--- a/src/api/c/lu.cpp
+++ b/src/api/c/lu.cpp
@@ -43,7 +43,7 @@ static inline af_array lu_inplace(af_array in, bool is_lapack_piv)
 af_err af_lu(af_array *lower, af_array *upper, af_array *pivot, const af_array in)
 {
     try {
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& i_info = getInfo(in);
 
         if (i_info.ndims() > 2) {
             AF_ERROR("lu can not be used in batch mode", AF_ERR_BATCH);
@@ -78,7 +78,7 @@ af_err af_lu_inplace(af_array *pivot, af_array in, const bool is_lapack_piv)
 {
     try {
 
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& i_info = getInfo(in);
         af_dtype type = i_info.getType();
 
         if (i_info.ndims() > 2) {

--- a/src/api/c/match_template.cpp
+++ b/src/api/c/match_template.cpp
@@ -40,8 +40,8 @@ af_err af_match_template(af_array *out, const af_array search_img, const af_arra
     try {
         ARG_ASSERT(3, (m_type>=AF_SAD && m_type<=AF_LSSD));
 
-        ArrayInfo sInfo = getInfo(search_img);
-        ArrayInfo tInfo = getInfo(template_img);
+        const ArrayInfo& sInfo = getInfo(search_img);
+        const ArrayInfo& tInfo = getInfo(template_img);
 
         dim4 const sDims = sInfo.dims();
         dim4 const tDims = tInfo.dims();

--- a/src/api/c/mean.cpp
+++ b/src/api/c/mean.cpp
@@ -57,7 +57,7 @@ af_err af_mean(af_array *out, const af_array in, const dim_t dim)
         ARG_ASSERT(2, (dim>=0 && dim<=3));
 
         af_array output = 0;
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
         switch(type) {
             case f64: output = mean<double  ,  double>(in, dim); break;
@@ -86,8 +86,8 @@ af_err af_mean_weighted(af_array *out, const af_array in, const af_array weights
         ARG_ASSERT(2, (dim>=0 && dim<=3));
 
         af_array output = 0;
-        ArrayInfo iInfo = getInfo(in);
-        ArrayInfo wInfo = getInfo(weights);
+        const ArrayInfo& iInfo = getInfo(in);
+        const ArrayInfo& wInfo = getInfo(weights);
         af_dtype iType  = iInfo.getType();
         af_dtype wType  = wInfo.getType();
 
@@ -117,7 +117,7 @@ af_err af_mean_weighted(af_array *out, const af_array in, const af_array weights
 af_err af_mean_all(double *realVal, double *imagVal, const af_array in)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
         switch(type) {
             case f64: *realVal = mean<double  , double>(in); break;
@@ -150,8 +150,8 @@ af_err af_mean_all(double *realVal, double *imagVal, const af_array in)
 af_err af_mean_all_weighted(double *realVal, double *imagVal, const af_array in, const af_array weights)
 {
     try {
-        ArrayInfo iInfo = getInfo(in);
-        ArrayInfo wInfo = getInfo(weights);
+        const ArrayInfo& iInfo = getInfo(in);
+        const ArrayInfo& wInfo = getInfo(weights);
         af_dtype iType  = iInfo.getType();
         af_dtype wType  = wInfo.getType();
 

--- a/src/api/c/meanshift.cpp
+++ b/src/api/c/meanshift.cpp
@@ -32,7 +32,7 @@ af_err mean_shift(af_array *out, const af_array in, const float s_sigma, const f
         ARG_ASSERT(3, (c_sigma>=0));
         ARG_ASSERT(4, (iter>0));
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type  = info.getType();
         af::dim4 dims  = info.dims();
 

--- a/src/api/c/median.cpp
+++ b/src/api/c/median.cpp
@@ -153,7 +153,7 @@ static af_array median(const af_array& in, const dim_t dim)
 af_err af_median_all(double *realVal, double *imagVal, const af_array in)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         ARG_ASSERT(2, info.ndims() > 0);
@@ -178,7 +178,7 @@ af_err af_median(af_array* out, const af_array in, const dim_t dim)
         ARG_ASSERT(2, (dim >= 0 && dim <= 4));
 
         af_array output = 0;
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
 
         ARG_ASSERT(1, info.ndims() > 0);
         af_dtype type = info.getType();

--- a/src/api/c/moddims.cpp
+++ b/src/api/c/moddims.cpp
@@ -61,7 +61,7 @@ af_err af_moddims(af_array *out, const af_array in,
 
         af_array output = 0;
         dim4 newDims(ndims, dims);
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         dim_t in_elements = info.elements();
         dim_t new_elements = newDims.elements();
 
@@ -96,7 +96,7 @@ af_err af_flat(af_array *out, const af_array in)
     af_array res;
     try {
 
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
 
         if (in_info.ndims() == 1) {
             AF_CHECK(af_retain_array(&res, in));

--- a/src/api/c/moments.cpp
+++ b/src/api/c/moments.cpp
@@ -42,7 +42,7 @@ static inline void moments(af_array *out, const af_array in, af_moment_type mome
 af_err af_moments(af_array *out, const af_array in, const af_moment_type moment)
 {
     try {
-        const ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
         af_dtype type = in_info.getType();
 
         switch(type) {
@@ -77,14 +77,14 @@ static inline void moment_copy(double* out, const af_array moments)
 af_err af_moments_all(double* out, const af_array in, const af_moment_type moment)
 {
     try {
-        const ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
         dim4 idims = in_info.dims();
         DIM_ASSERT(1, idims[2] == 1 && idims[3] == 1);
 
         af_array moments_arr;
         af_moments(&moments_arr, in, moment);
 
-        const ArrayInfo m_info = getInfo(moments_arr);
+        const ArrayInfo& m_info = getInfo(moments_arr);
         af_dtype type = m_info.getType();
 
         switch(type) {

--- a/src/api/c/morph.cpp
+++ b/src/api/c/morph.cpp
@@ -40,8 +40,8 @@ template<bool isDilation>
 static af_err morph(af_array *out, const af_array &in, const af_array &mask)
 {
     try {
-        ArrayInfo info = getInfo(in);
-        ArrayInfo mInfo= getInfo(mask);
+        const ArrayInfo& info = getInfo(in);
+        const ArrayInfo& mInfo= getInfo(mask);
         af::dim4 dims  = info.dims();
         af::dim4 mdims = mInfo.dims();
         dim_t in_ndims = dims.ndims();
@@ -74,8 +74,8 @@ template<bool isDilation>
 static af_err morph3d(af_array *out, const af_array &in, const af_array &mask)
 {
     try {
-        ArrayInfo info = getInfo(in);
-        ArrayInfo mInfo= getInfo(mask);
+        const ArrayInfo& info = getInfo(in);
+        const ArrayInfo& mInfo= getInfo(mask);
         af::dim4 dims  = info.dims();
         af::dim4 mdims = mInfo.dims();
         dim_t in_ndims = dims.ndims();

--- a/src/api/c/nearest_neighbour.cpp
+++ b/src/api/c/nearest_neighbour.cpp
@@ -40,8 +40,8 @@ af_err af_nearest_neighbour(af_array* idx, af_array* dist,
         const af_match_type dist_type)
 {
     try {
-        ArrayInfo qInfo = getInfo(query);
-        ArrayInfo tInfo = getInfo(train);
+        const ArrayInfo& qInfo = getInfo(query);
+        const ArrayInfo& tInfo = getInfo(train);
         af_dtype qType  = qInfo.getType();
         af_dtype tType  = tInfo.getType();
         af::dim4 qDims  = qInfo.dims();

--- a/src/api/c/norm.cpp
+++ b/src/api/c/norm.cpp
@@ -126,7 +126,7 @@ af_err af_norm(double *out, const af_array in,
 {
 
     try {
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& i_info = getInfo(in);
 
         if (i_info.ndims() > 2) {
             AF_ERROR("solve can not be used in batch mode", AF_ERR_BATCH);

--- a/src/api/c/orb.cpp
+++ b/src/api/c/orb.cpp
@@ -55,7 +55,7 @@ af_err af_orb(af_features* feat, af_array* desc,
               const unsigned levels, const bool blur_img)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims  = info.dims();
 
         ARG_ASSERT(2, (dims[0] >= 7 && dims[1] >= 7 && dims[2] == 1 && dims[3] == 1));

--- a/src/api/c/plot.cpp
+++ b/src/api/c/plot.cpp
@@ -93,7 +93,7 @@ af_err plotWrapper(const af_window wind, const af_array in, const int order_dim,
     }
 
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4  dims = info.dims();
         af_dtype  type = info.getType();
 
@@ -136,15 +136,15 @@ af_err plotWrapper(const af_window wind, const af_array X, const af_array Y, con
     }
 
     try {
-        ArrayInfo xInfo = getInfo(X);
+        const ArrayInfo& xInfo = getInfo(X);
         af::dim4  xDims = xInfo.dims();
         af_dtype  xType = xInfo.getType();
 
-        ArrayInfo yInfo = getInfo(Y);
+        const ArrayInfo& yInfo = getInfo(Y);
         af::dim4  yDims = yInfo.dims();
         af_dtype  yType = yInfo.getType();
 
-        ArrayInfo zInfo = getInfo(Z);
+        const ArrayInfo& zInfo = getInfo(Z);
         af::dim4  zDims = zInfo.dims();
         af_dtype  zType = zInfo.getType();
 
@@ -197,11 +197,11 @@ af_err plotWrapper(const af_window wind, const af_array X, const af_array Y,
     }
 
     try {
-        ArrayInfo xInfo = getInfo(X);
+        const ArrayInfo& xInfo = getInfo(X);
         af::dim4  xDims = xInfo.dims();
         af_dtype  xType = xInfo.getType();
 
-        ArrayInfo yInfo = getInfo(Y);
+        const ArrayInfo& yInfo = getInfo(Y);
         af::dim4  yDims = yInfo.dims();
         af_dtype  yType = yInfo.getType();
 
@@ -344,7 +344,7 @@ af_err af_draw_plot3(const af_window wind, const af_array P, const af_cell* cons
 {
 #if defined(WITH_GRAPHICS)
     try {
-        ArrayInfo info = getInfo(P);
+        const ArrayInfo& info = getInfo(P);
         af::dim4  dims = info.dims();
 
         if(dims.ndims() == 2 && dims[1] == 3) {
@@ -426,7 +426,7 @@ af_err af_draw_scatter3(const af_window wind, const af_array P, const af_marker_
 #if defined(WITH_GRAPHICS)
     forge::MarkerType fg_marker = getFGMarker(af_marker);
     try {
-        ArrayInfo info = getInfo(P);
+        const ArrayInfo& info = getInfo(P);
         af::dim4  dims = info.dims();
 
         if(dims.ndims() == 2 && dims[1] == 3) {

--- a/src/api/c/print.cpp
+++ b/src/api/c/print.cpp
@@ -96,11 +96,11 @@ static void print(const char *exp, af_array arr, const int precision, std::ostre
     AF_CHECK(af_get_data_ptr(&data.front(), arrT));
     const ArrayInfo& infoT = getInfo(arrT);
 
+    printer(os, &data.front(), infoT, infoT.ndims() - 1, precision);
+
     if(transpose) {
         AF_CHECK(af_release_array(arrT));
     }
-
-    printer(os, &data.front(), infoT, infoT.ndims() - 1, precision);
 
     os.flags(backup);
 }

--- a/src/api/c/print.cpp
+++ b/src/api/c/print.cpp
@@ -66,7 +66,7 @@ static void print(const char *exp, af_array arr, const int precision, std::ostre
         os << exp << std::endl;
     }
 
-    const ArrayInfo info = getInfo(arr);
+    const ArrayInfo& info = getInfo(arr);
 
     std::ios_base::fmtflags backup = os.flags();
 
@@ -94,7 +94,7 @@ static void print(const char *exp, af_array arr, const int precision, std::ostre
 
     //FIXME: Use alternative function to avoid copies if possible
     AF_CHECK(af_get_data_ptr(&data.front(), arrT));
-    const ArrayInfo infoT = getInfo(arrT);
+    const ArrayInfo& infoT = getInfo(arrT);
 
     if(transpose) {
         AF_CHECK(af_release_array(arrT));
@@ -136,7 +136,7 @@ static void printSparse(const char *exp, af_array arr, const int precision,
 af_err af_print_array(af_array arr)
 {
     try {
-        ArrayInfo info = getInfo(arr, false);   // Don't assert sparse/dense
+        const ArrayInfo& info = getInfo(arr, false);   // Don't assert sparse/dense
         af_dtype type = info.getType();
 
         if(info.isSparse()) {
@@ -174,7 +174,7 @@ af_err af_print_array_gen(const char *exp, const af_array arr, const int precisi
 {
     try {
         ARG_ASSERT(0, exp != NULL);
-        ArrayInfo info = getInfo(arr, false);   // Don't assert sparse/dense
+        const ArrayInfo& info = getInfo(arr, false);   // Don't assert sparse/dense
         af_dtype type = info.getType();
 
         if(info.isSparse()) {
@@ -213,7 +213,7 @@ af_err af_array_to_string(char **output, const char *exp, const af_array arr,
 {
     try {
         ARG_ASSERT(0, exp != NULL);
-        ArrayInfo info = getInfo(arr, false);   // Don't assert sparse/dense
+        const ArrayInfo& info = getInfo(arr, false);   // Don't assert sparse/dense
         af_dtype type = info.getType();
         std::stringstream ss;
 

--- a/src/api/c/qr.cpp
+++ b/src/api/c/qr.cpp
@@ -42,7 +42,7 @@ static inline af_array qr_inplace(af_array in)
 af_err af_qr(af_array *q, af_array *r, af_array *tau, const af_array in)
 {
     try {
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& i_info = getInfo(in);
 
         if (i_info.ndims() > 2) {
             AF_ERROR("qr can not be used in batch mode", AF_ERR_BATCH);
@@ -76,7 +76,7 @@ af_err af_qr(af_array *q, af_array *r, af_array *tau, const af_array in)
 af_err af_qr_inplace(af_array *tau, af_array in)
 {
     try {
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& i_info = getInfo(in);
 
         if (i_info.ndims() > 2) {
             AF_ERROR("qr can not be used in batch mode", AF_ERR_BATCH);

--- a/src/api/c/rank.cpp
+++ b/src/api/c/rank.cpp
@@ -49,7 +49,7 @@ static inline uint rank(const af_array in, double tol)
 af_err af_rank(uint *out, const af_array in, const double tol)
 {
     try {
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& i_info = getInfo(in);
 
         if (i_info.ndims() > 2) {
             AF_ERROR("solve can not be used in batch mode", AF_ERR_BATCH);

--- a/src/api/c/reduce.cpp
+++ b/src/api/c/reduce.cpp
@@ -37,7 +37,7 @@ static af_err reduce_type(af_array *out, const af_array in, const int dim)
         ARG_ASSERT(2, dim >= 0);
         ARG_ASSERT(2, dim <  4);
 
-        const ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
 
         if (dim >= (int)in_info.ndims()) {
             *out = retain(in);
@@ -78,7 +78,7 @@ static af_err reduce_common(af_array *out, const af_array in, const int dim)
         ARG_ASSERT(2, dim >= 0);
         ARG_ASSERT(2, dim <  4);
 
-        const ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
 
         if (dim >= (int)in_info.ndims()) {
             return af_retain_array(out, in);
@@ -119,7 +119,7 @@ static af_err reduce_promote(af_array *out, const af_array in, const int dim,
         ARG_ASSERT(2, dim >= 0);
         ARG_ASSERT(2, dim <  4);
 
-        const ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
 
         if (dim >= (int)in_info.ndims()) {
             *out = retain(in);
@@ -208,7 +208,7 @@ static af_err reduce_all_type(double *real, double *imag, const af_array in)
 {
     try {
 
-        const ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
         af_dtype type = in_info.getType();
 
         ARG_ASSERT(0, real != NULL);
@@ -242,7 +242,7 @@ static af_err reduce_all_common(double *real_val, double *imag_val, const af_arr
 {
     try {
 
-        const ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
         af_dtype type = in_info.getType();
 
         ARG_ASSERT(2, in_info.ndims() > 0);
@@ -294,7 +294,7 @@ static af_err reduce_all_promote(double *real_val, double *imag_val, const af_ar
 {
     try {
 
-        const ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
         af_dtype type = in_info.getType();
 
         ARG_ASSERT(0, real_val != NULL);
@@ -398,7 +398,7 @@ static af_err ireduce_common(af_array *val, af_array *idx, const af_array in, co
         ARG_ASSERT(2, dim >= 0);
         ARG_ASSERT(2, dim <  4);
 
-        const ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
         ARG_ASSERT(2, in_info.ndims() > 0);
 
         if (dim >= (int)in_info.ndims()) {
@@ -455,7 +455,7 @@ static af_err ireduce_all_common(double *real_val, double *imag_val,
 {
     try {
 
-        const ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
         af_dtype type = in_info.getType();
 
         ARG_ASSERT(3, in_info.ndims() > 0);

--- a/src/api/c/regions.cpp
+++ b/src/api/c/regions.cpp
@@ -29,7 +29,7 @@ af_err af_regions(af_array *out, const af_array in, const af_connectivity connec
     try {
         ARG_ASSERT(2, (connectivity==AF_CONNECTIVITY_4 || connectivity==AF_CONNECTIVITY_8));
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims  = info.dims();
 
         dim_t in_ndims = dims.ndims();

--- a/src/api/c/reorder.cpp
+++ b/src/api/c/reorder.cpp
@@ -27,7 +27,7 @@ static inline af_array reorder(const af_array in, const af::dim4 &rdims)
 af_err af_reorder(af_array *out, const af_array in, const af::dim4 &rdims)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         if(info.elements() == 0) {

--- a/src/api/c/replace.cpp
+++ b/src/api/c/replace.cpp
@@ -31,9 +31,9 @@ void replace(af_array a, const af_array cond, const af_array b)
 af_err af_replace(af_array a, const af_array cond, const af_array b)
 {
     try {
-        ArrayInfo ainfo = getInfo(a);
-        ArrayInfo binfo = getInfo(b);
-        ArrayInfo cinfo = getInfo(cond);
+        const ArrayInfo& ainfo = getInfo(a);
+        const ArrayInfo& binfo = getInfo(b);
+        const ArrayInfo& cinfo = getInfo(cond);
 
         if(cinfo.ndims() == 0) {
             return AF_SUCCESS;
@@ -83,8 +83,8 @@ void replace_scalar(af_array a, const af_array cond, const double b)
 af_err af_replace_scalar(af_array a, const af_array cond, const double b)
 {
     try {
-        ArrayInfo ainfo = getInfo(a);
-        ArrayInfo cinfo = getInfo(cond);
+        const ArrayInfo& ainfo = getInfo(a);
+        const ArrayInfo& cinfo = getInfo(cond);
 
         ARG_ASSERT(1, cinfo.getType() == b8);
         DIM_ASSERT(1, cinfo.ndims() == ainfo.ndims());

--- a/src/api/c/resize.cpp
+++ b/src/api/c/resize.cpp
@@ -30,7 +30,7 @@ af_err af_resize(af_array *out, const af_array in, const dim_t odim0, const dim_
                  const af_interp_type method)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         ARG_ASSERT(4, method == AF_INTERP_NEAREST  ||

--- a/src/api/c/rgb_gray.cpp
+++ b/src/api/c/rgb_gray.cpp
@@ -105,7 +105,7 @@ template<bool isRGB2GRAY>
 af_err convert(af_array* out, const af_array in, const float r, const float g, const float b)
 {
     try {
-        ArrayInfo info     = getInfo(in);
+        const ArrayInfo& info     = getInfo(in);
         af_dtype iType     = info.getType();
         af::dim4 inputDims = info.dims();
 

--- a/src/api/c/rotate.cpp
+++ b/src/api/c/rotate.cpp
@@ -32,7 +32,7 @@ af_err af_rotate(af_array *out, const af_array in, const float theta,
     try {
         unsigned odims0 = 0, odims1 = 0;
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 idims = info.dims();
 
         if(!crop) {

--- a/src/api/c/sat.cpp
+++ b/src/api/c/sat.cpp
@@ -30,7 +30,7 @@ static af_array sat(const af_array& in)
 af_err af_sat(af_array* out, const af_array in)
 {
     try{
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         const dim4 dims = info.dims();
 
         ARG_ASSERT(1, (dims.ndims() >= 2));

--- a/src/api/c/select.cpp
+++ b/src/api/c/select.cpp
@@ -32,9 +32,9 @@ af_array select(const af_array cond, const af_array a, const af_array b, const d
 af_err af_select(af_array *out, const af_array cond, const af_array a, const af_array b)
 {
     try {
-        ArrayInfo ainfo = getInfo(a);
-        ArrayInfo binfo = getInfo(b);
-        ArrayInfo cinfo = getInfo(cond);
+        const ArrayInfo& ainfo = getInfo(a);
+        const ArrayInfo& binfo = getInfo(b);
+        const ArrayInfo& cinfo = getInfo(cond);
 
         if(cinfo.ndims() == 0) {
             return af_retain_array(out, cond);
@@ -90,8 +90,8 @@ af_array select_scalar(const af_array cond, const af_array a, const double b, co
 af_err af_select_scalar_r(af_array *out, const af_array cond, const af_array a, const double b)
 {
     try {
-        ArrayInfo ainfo = getInfo(a);
-        ArrayInfo cinfo = getInfo(cond);
+        const ArrayInfo& ainfo = getInfo(a);
+        const ArrayInfo& cinfo = getInfo(cond);
 
         ARG_ASSERT(1, cinfo.getType() == b8);
         DIM_ASSERT(1, cinfo.ndims() == ainfo.ndims());
@@ -129,8 +129,8 @@ af_err af_select_scalar_r(af_array *out, const af_array cond, const af_array a, 
 af_err af_select_scalar_l(af_array *out, const af_array cond, const double a, const af_array b)
 {
     try {
-        ArrayInfo binfo = getInfo(b);
-        ArrayInfo cinfo = getInfo(cond);
+        const ArrayInfo& binfo = getInfo(b);
+        const ArrayInfo& cinfo = getInfo(cond);
 
         ARG_ASSERT(1, cinfo.getType() == b8);
         DIM_ASSERT(1, cinfo.ndims() == binfo.ndims());

--- a/src/api/c/set.cpp
+++ b/src/api/c/set.cpp
@@ -28,7 +28,7 @@ af_err af_set_unique(af_array *out, const af_array in, const bool is_sorted)
 {
     try {
 
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
         if(in_info.isEmpty()) {
             return af_retain_array(out, in);
         }
@@ -67,8 +67,8 @@ af_err af_set_union(af_array *out, const af_array first, const af_array second, 
 {
     try {
 
-        ArrayInfo first_info = getInfo(first);
-        ArrayInfo second_info = getInfo(second);
+        const ArrayInfo& first_info = getInfo(first);
+        const ArrayInfo& second_info = getInfo(second);
 
         af_array res;
         if(first_info.isEmpty()) {
@@ -117,8 +117,8 @@ af_err af_set_intersect(af_array *out, const af_array first, const af_array seco
 {
     try {
 
-        ArrayInfo first_info = getInfo(first);
-        ArrayInfo second_info = getInfo(second);
+        const ArrayInfo& first_info = getInfo(first);
+        const ArrayInfo& second_info = getInfo(second);
 
         //TODO: fix for set intersect from union
         if(first_info.isEmpty()) {

--- a/src/api/c/shift.cpp
+++ b/src/api/c/shift.cpp
@@ -26,7 +26,7 @@ static inline af_array shift(const af_array in, const int sdims[4])
 af_err af_shift(af_array *out, const af_array in, const int sdims[4])
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         if(info.ndims() == 0) {

--- a/src/api/c/sift.cpp
+++ b/src/api/c/sift.cpp
@@ -55,7 +55,7 @@ af_err af_sift(af_features* feat, af_array* desc, const af_array in, const unsig
 {
     try {
 #ifdef AF_BUILD_NONFREE_SIFT
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims  = info.dims();
 
         ARG_ASSERT(2, (dims[0] >= 15 && dims[1] >= 15 && dims[2] == 1 && dims[3] == 1));
@@ -96,7 +96,7 @@ af_err af_gloh(af_features* feat, af_array* desc, const af_array in, const unsig
 {
     try {
 #ifdef AF_BUILD_NONFREE_SIFT
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims  = info.dims();
 
         ARG_ASSERT(2, (dims[0] >= 15 && dims[1] >= 15 && dims[2] == 1 && dims[3] == 1));

--- a/src/api/c/sobel.cpp
+++ b/src/api/c/sobel.cpp
@@ -36,7 +36,7 @@ af_err af_sobel_operator(af_array *dx, af_array *dy, const af_array img, const u
         //ARG_ASSERT(4, (ker_size==3 || ker_size==5 || ker_size==7));
         ARG_ASSERT(4, (ker_size==3));
 
-        ArrayInfo info = getInfo(img);
+        const ArrayInfo& info = getInfo(img);
         af::dim4 dims  = info.dims();
 
         DIM_ASSERT(3, (dims.ndims() >= 2));

--- a/src/api/c/solve.cpp
+++ b/src/api/c/solve.cpp
@@ -28,8 +28,8 @@ static inline af_array solve(const af_array a, const af_array b, const af_mat_pr
 af_err af_solve(af_array *out, const af_array a, const af_array b, const af_mat_prop options)
 {
     try {
-        ArrayInfo a_info = getInfo(a);
-        ArrayInfo b_info = getInfo(b);
+        const ArrayInfo& a_info = getInfo(a);
+        const ArrayInfo& b_info = getInfo(b);
 
         if (a_info.ndims() > 2 ||
             b_info.ndims() > 2) {
@@ -98,8 +98,8 @@ af_err af_solve_lu(af_array *out, const af_array a,
                    const af_mat_prop options)
 {
     try {
-        ArrayInfo a_info = getInfo(a);
-        ArrayInfo b_info = getInfo(b);
+        const ArrayInfo& a_info = getInfo(a);
+        const ArrayInfo& b_info = getInfo(b);
 
         if (a_info.ndims() > 2 ||
             b_info.ndims() > 2) {

--- a/src/api/c/sort.cpp
+++ b/src/api/c/sort.cpp
@@ -34,7 +34,7 @@ static inline af_array sort(const af_array in, const unsigned dim, const bool is
 af_err af_sort(af_array *out, const af_array in, const unsigned dim, const bool isAscending)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         if(info.elements() == 0) {
@@ -82,7 +82,7 @@ static inline void sort_index(af_array *val, af_array *idx, const af_array in,
 af_err af_sort_index(af_array *out, af_array *indices, const af_array in, const unsigned dim, const bool isAscending)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         if(info.elements() <= 0) {
@@ -136,7 +136,7 @@ template<typename Tk>
 void sort_by_key_tmplt(af_array *okey, af_array *oval, const af_array ikey, const af_array ival,
                        const unsigned dim, const bool isAscending)
 {
-    ArrayInfo info = getInfo(ival);
+    const ArrayInfo& info = getInfo(ival);
     af_dtype vtype = info.getType();
 
     switch(vtype) {
@@ -163,10 +163,10 @@ af_err af_sort_by_key(af_array *out_keys, af_array *out_values,
                       const unsigned dim, const bool isAscending)
 {
     try {
-        ArrayInfo kinfo = getInfo(keys);
+        const ArrayInfo& kinfo = getInfo(keys);
         af_dtype ktype = kinfo.getType();
 
-        ArrayInfo vinfo = getInfo(values);
+        const ArrayInfo& vinfo = getInfo(values);
 
         DIM_ASSERT(4, kinfo.dims() == vinfo.dims());
         if(kinfo.elements() == 0) {

--- a/src/api/c/sparse.cpp
+++ b/src/api/c/sparse.cpp
@@ -76,9 +76,9 @@ af_err af_create_sparse_array(
             AF_ERROR("Storage type is out of range/unsupported", AF_ERR_ARG);
         }
 
-        ArrayInfo vInfo = getInfo(values);
-        ArrayInfo rInfo = getInfo(rowIdx);
-        ArrayInfo cInfo = getInfo(colIdx);
+        const ArrayInfo& vInfo = getInfo(values);
+        const ArrayInfo& rInfo = getInfo(rowIdx);
+        const ArrayInfo& cInfo = getInfo(colIdx);
 
         TYPE_ASSERT(vInfo.isFloating());
         DIM_ASSERT(4, vInfo.isLinear());
@@ -199,7 +199,7 @@ af_err af_create_sparse_array_from_dense(af_array *out, const af_array in,
         // stype is within acceptable range
         // values is of floating point type
 
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
 
         if(!(stype == AF_STORAGE_CSR
           || stype == AF_STORAGE_CSC

--- a/src/api/c/stdev.cpp
+++ b/src/api/c/stdev.cpp
@@ -68,7 +68,7 @@ static af_array stdev(const af_array& in, int dim)
 af_err af_stdev_all(double *realVal, double *imagVal, const af_array in)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
         switch(type) {
             case f64: *realVal = stdev<double, double>(in); break;
@@ -105,7 +105,7 @@ af_err af_stdev(af_array *out, const af_array in, const dim_t dim)
         ARG_ASSERT(2, (dim>=0 && dim<=3));
 
         af_array output = 0;
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
         switch(type) {
             case f64: output = stdev<double,  double>(in, dim); break;

--- a/src/api/c/stream.cpp
+++ b/src/api/c/stream.cpp
@@ -43,7 +43,7 @@ static int save(const char *key, const af_array arr, const char *filename, const
     std::string k(key);
     int klen = k.size();
 
-    const ArrayInfo info = getInfo(arr);
+    const ArrayInfo& info = getInfo(arr);
     std::vector<T> data(info.elements());
 
     AF_CHECK(af_get_data_ptr(&data.front(), arr));
@@ -119,7 +119,7 @@ af_err af_save_array(int *index, const char *key, const af_array arr, const char
         ARG_ASSERT(0, key != NULL);
         ARG_ASSERT(2, filename != NULL);
 
-        ArrayInfo info = getInfo(arr);
+        const ArrayInfo& info = getInfo(arr);
         af_dtype type = info.getType();
         int id = -1;
         switch(type) {

--- a/src/api/c/surface.cpp
+++ b/src/api/c/surface.cpp
@@ -36,9 +36,9 @@ forge::Chart* setup_surface(const forge::Window* const window,
     Array<T> yIn = getArray<T>(yVals);
     Array<T> zIn = getArray<T>(zVals);
 
-    ArrayInfo Xinfo = getInfo(xVals);
-    ArrayInfo Yinfo = getInfo(yVals);
-    ArrayInfo Zinfo = getInfo(zVals);
+    const ArrayInfo& Xinfo = getInfo(xVals);
+    const ArrayInfo& Yinfo = getInfo(yVals);
+    const ArrayInfo& Zinfo = getInfo(zVals);
 
     af::dim4 X_dims = Xinfo.dims();
     af::dim4 Y_dims = Yinfo.dims();
@@ -96,15 +96,15 @@ af_err af_draw_surface(const af_window wind, const af_array xVals, const af_arra
     }
 
     try {
-        ArrayInfo Xinfo = getInfo(xVals);
+        const ArrayInfo& Xinfo = getInfo(xVals);
         af::dim4 X_dims = Xinfo.dims();
         af_dtype Xtype  = Xinfo.getType();
 
-        ArrayInfo Yinfo = getInfo(yVals);
+        const ArrayInfo& Yinfo = getInfo(yVals);
         af::dim4 Y_dims = Yinfo.dims();
         af_dtype Ytype  = Yinfo.getType();
 
-        ArrayInfo Sinfo = getInfo(S);
+        const ArrayInfo& Sinfo = getInfo(S);
         af::dim4 S_dims = Sinfo.dims();
         af_dtype Stype  = Sinfo.getType();
 

--- a/src/api/c/susan.cpp
+++ b/src/api/c/susan.cpp
@@ -48,7 +48,7 @@ af_err af_susan(af_features* out, const af_array in,
                 const float feature_ratio, const unsigned edge)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims  = info.dims();
 
         ARG_ASSERT(1, dims.ndims()==2);

--- a/src/api/c/svd.cpp
+++ b/src/api/c/svd.cpp
@@ -23,7 +23,7 @@ using namespace detail;
 template <typename T>
 static inline void svd(af_array *s, af_array *u, af_array *vt, const af_array in)
 {
-    ArrayInfo info = getInfo(in);  // ArrayInfo is the base class which
+    const ArrayInfo& info = getInfo(in);  // ArrayInfo is the base class which
     af::dim4 dims = info.dims();
     int M = dims[0];
     int N = dims[1];
@@ -45,7 +45,7 @@ static inline void svd(af_array *s, af_array *u, af_array *vt, const af_array in
 template <typename T>
 static inline void svdInPlace(af_array *s, af_array *u, af_array *vt, af_array in)
 {
-    ArrayInfo info = getInfo(in);  // ArrayInfo is the base class which
+    const ArrayInfo& info = getInfo(in);  // ArrayInfo is the base class which
     af::dim4 dims = info.dims();
     int M = dims[0];
     int N = dims[1];
@@ -67,7 +67,7 @@ static inline void svdInPlace(af_array *s, af_array *u, af_array *vt, af_array i
 af_err af_svd(af_array *u, af_array *s, af_array *vt, const af_array in)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims = info.dims();
 
         ARG_ASSERT(3, (dims.ndims() >= 0 && dims.ndims() <= 3));
@@ -105,7 +105,7 @@ af_err af_svd(af_array *u, af_array *s, af_array *vt, const af_array in)
 af_err af_svd_inplace(af_array *u, af_array *s, af_array *vt, af_array in)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af::dim4 dims = info.dims();
 
         DIM_ASSERT(3, dims[0] <= dims[1]);

--- a/src/api/c/tile.cpp
+++ b/src/api/c/tile.cpp
@@ -52,7 +52,7 @@ static inline af_array tile(const af_array in, const af::dim4 &tileDims)
 af_err af_tile(af_array *out, const af_array in, const af::dim4 &tileDims)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
 
         if(info.ndims() == 0) {

--- a/src/api/c/transform.cpp
+++ b/src/api/c/transform.cpp
@@ -57,8 +57,8 @@ af_err af_transform(af_array *out, const af_array in, const af_array tf,
                     const af_interp_type method, const bool inverse)
 {
     try {
-        ArrayInfo t_info = getInfo(tf);
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& t_info = getInfo(tf);
+        const ArrayInfo& i_info = getInfo(in);
 
         af::dim4 idims = i_info.dims();
         af::dim4 tdims = t_info.dims();
@@ -181,7 +181,7 @@ af_err af_scale(af_array *out, const af_array in, const float scale0, const floa
                 const dim_t odim0, const dim_t odim1, const af_interp_type method)
 {
     try {
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& i_info = getInfo(in);
         af::dim4 idims = i_info.dims();
 
         dim_t _odim0 = odim0, _odim1 = odim1;

--- a/src/api/c/transform_coordinates.cpp
+++ b/src/api/c/transform_coordinates.cpp
@@ -65,7 +65,7 @@ static af_array transform_coordinates(const af_array& tf, const float d0, const 
 af_err af_transform_coordinates(af_array *out, const af_array tf, const float d0, const float d1)
 {
     try {
-        ArrayInfo tfInfo = getInfo(tf);
+        const ArrayInfo& tfInfo = getInfo(tf);
         dim4 tfDims = tfInfo.dims();
         ARG_ASSERT(1, (tfDims[0]==3 && tfDims[1]==3 && tfDims.ndims()==2));
 

--- a/src/api/c/transpose.cpp
+++ b/src/api/c/transpose.cpp
@@ -29,7 +29,7 @@ static inline af_array trs(const af_array in, const bool conjugate)
 af_err af_transpose(af_array *out, af_array in, const bool conjugate)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
         af::dim4 dims = info.dims();
 
@@ -85,7 +85,7 @@ static inline void transpose_inplace(af_array in, const bool conjugate)
 af_err af_transpose_inplace(af_array in, const bool conjugate)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
         af::dim4 dims = info.dims();
 

--- a/src/api/c/unary.cpp
+++ b/src/api/c/unary.cpp
@@ -59,7 +59,7 @@ static af_err af_unary(af_array *out, const af_array in)
 {
     try {
 
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
         ARG_ASSERT(1, in_info.isReal());
 
         af_dtype in_type = in_info.getType();
@@ -85,7 +85,7 @@ template<af_op_t op>
 static af_err af_unary_complex(af_array *out, const af_array in)
 {
     try {
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
 
         af_dtype in_type = in_info.getType();
         af_array res;
@@ -562,7 +562,7 @@ af_err af_not(af_array *out, const af_array in)
     try {
 
         af_array tmp;
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
 
         AF_CHECK(af_constant(&tmp, 0,
                              in_info.ndims(),
@@ -580,7 +580,7 @@ af_err af_arg(af_array *out, const af_array in)
 {
     try {
 
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
 
         if (!in_info.isComplex()) {
             return af_constant(out, 0,
@@ -608,7 +608,7 @@ af_err af_pow2(af_array *out, const af_array in)
     try {
 
         af_array two;
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
 
         AF_CHECK(af_constant(&two, 2,
                              in_info.ndims(),
@@ -627,7 +627,7 @@ af_err af_factorial(af_array *out, const af_array in)
     try {
 
         af_array one;
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
 
         AF_CHECK(af_constant(&one, 1,
                              in_info.ndims(),
@@ -679,7 +679,7 @@ static inline af_array checkOpCplx(const af_array in)
     Array<char> resR = checkOp<BT, op>(R);
     Array<char> resI = checkOp<BT, op>(I);
 
-    ArrayInfo in_info = getInfo(in);
+    const ArrayInfo& in_info = getInfo(in);
     dim4 dims = in_info.dims();
     cplxLogicOp<op> cplxLogic;
     af_array res = cplxLogic(resR, resI, dims);
@@ -692,7 +692,7 @@ static af_err af_check(af_array *out, const af_array in)
 {
     try {
 
-        ArrayInfo in_info = getInfo(in);
+        const ArrayInfo& in_info = getInfo(in);
 
         af_dtype in_type = in_info.getType();
         af_array res;

--- a/src/api/c/unwrap.cpp
+++ b/src/api/c/unwrap.cpp
@@ -30,7 +30,7 @@ af_err af_unwrap(af_array *out, const af_array in, const dim_t wx, const dim_t w
                  const dim_t sx, const dim_t sy, const dim_t px, const dim_t py, const bool is_column)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
         af::dim4 idims = info.dims();
 

--- a/src/api/c/var.cpp
+++ b/src/api/c/var.cpp
@@ -122,7 +122,7 @@ af_err af_var(af_array *out, const af_array in, const bool isbiased, const dim_t
         ARG_ASSERT(2, (dim>=0 && dim<=3));
 
         af_array output = 0;
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
         switch(type) {
             case f64: output = var<double,  double>(in, isbiased, dim); break;
@@ -151,8 +151,8 @@ af_err af_var_weighted(af_array *out, const af_array in, const af_array weights,
         ARG_ASSERT(2, (dim>=0 && dim<=3));
 
         af_array output = 0;
-        ArrayInfo iInfo = getInfo(in);
-        ArrayInfo wInfo = getInfo(weights);
+        const ArrayInfo& iInfo = getInfo(in);
+        const ArrayInfo& wInfo = getInfo(weights);
         af_dtype iType  = iInfo.getType();
         af_dtype wType  = wInfo.getType();
 
@@ -182,7 +182,7 @@ af_err af_var_weighted(af_array *out, const af_array in, const af_array weights,
 af_err af_var_all(double *realVal, double *imagVal, const af_array in, const bool isbiased)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
         switch(type) {
             case f64: *realVal = varAll<double, double>(in, isbiased); break;
@@ -215,8 +215,8 @@ af_err af_var_all(double *realVal, double *imagVal, const af_array in, const boo
 af_err af_var_all_weighted(double *realVal, double *imagVal, const af_array in, const af_array weights)
 {
     try {
-        ArrayInfo iInfo = getInfo(in);
-        ArrayInfo wInfo = getInfo(weights);
+        const ArrayInfo& iInfo = getInfo(in);
+        const ArrayInfo& wInfo = getInfo(weights);
         af_dtype iType  = iInfo.getType();
         af_dtype wType  = wInfo.getType();
 

--- a/src/api/c/vector_field.cpp
+++ b/src/api/c/vector_field.cpp
@@ -74,11 +74,11 @@ af_err vectorFieldWrapper(const af_window wind, const af_array points, const af_
     }
 
     try {
-        ArrayInfo pInfo = getInfo(points);
+        const ArrayInfo& pInfo = getInfo(points);
         af::dim4 pDims  = pInfo.dims();
         af_dtype pType  = pInfo.getType();
 
-        ArrayInfo dInfo = getInfo(directions);
+        const ArrayInfo& dInfo = getInfo(directions);
         af::dim4 dDims  = dInfo.dims();
         af_dtype dType  = dInfo.getType();
 
@@ -123,9 +123,9 @@ af_err vectorFieldWrapper(const af_window wind,
     }
 
     try {
-        ArrayInfo xpInfo = getInfo(xPoints);
-        ArrayInfo ypInfo = getInfo(yPoints);
-        ArrayInfo zpInfo = getInfo(zPoints);
+        const ArrayInfo& xpInfo = getInfo(xPoints);
+        const ArrayInfo& ypInfo = getInfo(yPoints);
+        const ArrayInfo& zpInfo = getInfo(zPoints);
 
         af::dim4 xpDims  = xpInfo.dims();
         af::dim4 ypDims  = ypInfo.dims();
@@ -135,9 +135,9 @@ af_err vectorFieldWrapper(const af_window wind,
         af_dtype ypType  = ypInfo.getType();
         af_dtype zpType  = zpInfo.getType();
 
-        ArrayInfo xdInfo = getInfo(xDirs);
-        ArrayInfo ydInfo = getInfo(yDirs);
-        ArrayInfo zdInfo = getInfo(zDirs);
+        const ArrayInfo& xdInfo = getInfo(xDirs);
+        const ArrayInfo& ydInfo = getInfo(yDirs);
+        const ArrayInfo& zdInfo = getInfo(zDirs);
 
         af::dim4 xdDims  = xdInfo.dims();
         af::dim4 ydDims  = ydInfo.dims();
@@ -211,8 +211,8 @@ af_err vectorFieldWrapper(const af_window wind,
     }
 
     try {
-        ArrayInfo xpInfo = getInfo(xPoints);
-        ArrayInfo ypInfo = getInfo(yPoints);
+        const ArrayInfo& xpInfo = getInfo(xPoints);
+        const ArrayInfo& ypInfo = getInfo(yPoints);
 
         af::dim4 xpDims  = xpInfo.dims();
         af::dim4 ypDims  = ypInfo.dims();
@@ -220,8 +220,8 @@ af_err vectorFieldWrapper(const af_window wind,
         af_dtype xpType  = xpInfo.getType();
         af_dtype ypType  = ypInfo.getType();
 
-        ArrayInfo xdInfo = getInfo(xDirs);
-        ArrayInfo ydInfo = getInfo(yDirs);
+        const ArrayInfo& xdInfo = getInfo(xDirs);
+        const ArrayInfo& ydInfo = getInfo(yDirs);
 
         af::dim4 xdDims  = xdInfo.dims();
         af::dim4 ydDims  = ydInfo.dims();

--- a/src/api/c/where.cpp
+++ b/src/api/c/where.cpp
@@ -29,7 +29,7 @@ static inline af_array where(const af_array in)
 af_err af_where(af_array *idx, const af_array in)
 {
     try {
-        ArrayInfo i_info = getInfo(in);
+        const ArrayInfo& i_info = getInfo(in);
         af_dtype type = i_info.getType();
 
         if(i_info.ndims() == 0) {

--- a/src/api/c/wrap.cpp
+++ b/src/api/c/wrap.cpp
@@ -37,7 +37,7 @@ af_err af_wrap(af_array *out, const af_array in,
                const bool is_column)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype type = info.getType();
         af::dim4 idims = info.dims();
 

--- a/src/api/c/ycbcr_rgb.cpp
+++ b/src/api/c/ycbcr_rgb.cpp
@@ -131,7 +131,7 @@ template<bool isYCbCr2RGB>
 af_err convert(af_array* out, const af_array& in, const af_ycc_std standard)
 {
     try {
-        ArrayInfo info = getInfo(in);
+        const ArrayInfo& info = getInfo(in);
         af_dtype iType = info.getType();
         af::dim4 inputDims = info.dims();
 


### PR DESCRIPTION
The `getInfo` method returns a const reference to `ArrayInfo`, but almost all the calls to it do a copy of the object. Unless I'm completely missing the point for this, the copy should be avoided since the `ArrayInfo` object (on my system) takes `88` bytes vs the pointer which takes `8` bytes.