### PR TITLE
Remove support for sparse conversions for CUDA 6.5 and older

### DIFF
--- a/src/backend/cuda/sparse.cu
+++ b/src/backend/cuda/sparse.cu
@@ -363,6 +363,8 @@ Array<T> sparseConvertStorageToDense(const SparseArray<T> &in)
     return dense;
 }
 
+// Some of the API used here is available only in CUDA 7 or newer
+#if CUDA_VERSION >= 7000
 template<typename T, af_storage dest, af_storage src>
 SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in)
 {
@@ -475,6 +477,14 @@ SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in)
 
     return converted;
 }
+#else // CUDA 6.5 and older (older than 7)
+template<typename T, af_storage dest, af_storage src>
+SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in)
+{
+    AF_ERROR("Sparse storage format conversions are not supported for CUDA 6.5 or older",
+             AF_ERR_NOT_SUPPORTED);
+}
+#endif // CUDA_VERSION >= 7000
 
 #define INSTANTIATE_TO_STORAGE(T, S)                                                                        \
     template SparseArray<T> sparseConvertStorageToStorage<T, S, AF_STORAGE_CSR>(const SparseArray<T> &in);  \


### PR DESCRIPTION
This is inline with CUDA 6.5 support being dropped with ArrayFire v3.5.0.

The code in the PR is to support compilation for CUDA 6.5. However, the functionality will not be supported.
As of v3.5, this code will be removed and support for CUDA 6.5 completely dropped.

[skip arrayfire ci]