### PR TITLE
Remove CL_TO_AF_ERROR macro

### DIFF
--- a/src/api/c/err_common.cpp
+++ b/src/api/c/err_common.cpp
@@ -22,6 +22,11 @@
 #include <graphics_common.hpp>
 #endif
 
+#ifdef AF_OPENCL
+#include <platform.hpp>
+#include <errorcodes.hpp>
+#endif
+
 using std::string;
 using std::stringstream;
 
@@ -210,6 +215,19 @@ af_err processException()
         ss << ex << "\n";
         print_error(ss.str());
         err = AF_ERR_INTERNAL;
+#endif
+#ifdef AF_OPENCL
+    } catch(const cl::Error &ex) {
+      char opencl_err_msg[1024];
+      snprintf(opencl_err_msg, sizeof(opencl_err_msg),
+               "OpenCL Error (%d): %s when calling %s", ex.err(),
+               getErrorMessage(ex.err()).c_str(), ex.what());
+      print_error(opencl_err_msg);
+      if (ex.err() == CL_MEM_OBJECT_ALLOCATION_FAILURE) {
+        err = AF_ERR_NO_MEM;
+      } else {
+        err = AF_ERR_INTERNAL;
+      }
 #endif
     } catch (...) {
         print_error(ss.str());

--- a/src/api/c/err_common.hpp
+++ b/src/api/c/err_common.hpp
@@ -204,6 +204,5 @@ void print_error(const std::string &msg);
                       "\n", __err);                         \
     } while(0)
 
-
 static const int MAX_ERR_SIZE = 1024;
 std::string& get_global_error_string();

--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -19,7 +19,6 @@
 #include <JIT/Node.hpp>
 #include <memory.hpp>
 #include <memory>
-#include <err_common.hpp>
 #include <err_opencl.hpp>
 
 namespace opencl
@@ -242,27 +241,19 @@ namespace opencl
         std::shared_ptr<T> getMappedPtr() const
         {
             auto func = [=] (void* ptr) {
-                try {
-                    if(ptr != nullptr) {
-                        getQueue().enqueueUnmapMemObject(*data, ptr);
-                        ptr = nullptr;
-                    }
-                } catch(cl::Error err) {
-                    CL_TO_AF_ERROR(err);
+                if(ptr != nullptr) {
+                    getQueue().enqueueUnmapMemObject(*data, ptr);
+                    ptr = nullptr;
                 }
             };
 
             T *ptr = nullptr;
-            try {
-                if(ptr == nullptr) {
-                    ptr = (T*)getQueue().enqueueMapBuffer(*const_cast<cl::Buffer*>(get()),
-                                                          true, CL_MAP_READ|CL_MAP_WRITE,
-                                                          getOffset() * sizeof(T),
-                                                          (getDataDims().elements() - getOffset())
-                                                          * sizeof(T));
-                }
-            } catch(cl::Error err) {
-                CL_TO_AF_ERROR(err);
+            if(ptr == nullptr) {
+                ptr = (T*)getQueue().enqueueMapBuffer(*const_cast<cl::Buffer*>(get()),
+                                                      true, CL_MAP_READ|CL_MAP_WRITE,
+                                                      getOffset() * sizeof(T),
+                                                      (getDataDims().elements() - getOffset())
+                                                      * sizeof(T));
             }
 
             return std::shared_ptr<T>(ptr, func);

--- a/src/backend/opencl/blas.cpp
+++ b/src/backend/opencl/blas.cpp
@@ -14,7 +14,7 @@
 #include <functional>
 #include <stdexcept>
 #include <mutex>
-#include <err_common.hpp>
+#include <err_opencl.hpp>
 #include <err_clblas.hpp>
 #include <math.hpp>
 #include <transpose.hpp>

--- a/src/backend/opencl/cholesky.cpp
+++ b/src/backend/opencl/cholesky.cpp
@@ -8,7 +8,6 @@
  ********************************************************/
 
 #include <cholesky.hpp>
-#include <err_common.hpp>
 #include <err_opencl.hpp>
 #include <blas.hpp>
 #include <copy.hpp>
@@ -25,48 +24,39 @@ namespace opencl
 template<typename T>
 int cholesky_inplace(Array<T> &in, const bool is_upper)
 {
-    try {
-        if(OpenCLCPUOffload()) {
-            return cpu::cholesky_inplace(in, is_upper);
-        }
-
-        initBlas();
-
-        dim4 iDims = in.dims();
-        int N = iDims[0];
-
-        magma_uplo_t uplo = is_upper ? MagmaUpper : MagmaLower;
-
-        int info = 0;
-        cl::Buffer *in_buf = in.get();
-        magma_potrf_gpu<T>(uplo, N,
-                           (*in_buf)(), in.getOffset(),  in.strides()[1],
-                           getQueue()(), &info);
-        return info;
-    } catch (cl::Error &err) {
-        CL_TO_AF_ERROR(err);
+    if(OpenCLCPUOffload()) {
+        return cpu::cholesky_inplace(in, is_upper);
     }
+
+    initBlas();
+
+    dim4 iDims = in.dims();
+    int N = iDims[0];
+
+    magma_uplo_t uplo = is_upper ? MagmaUpper : MagmaLower;
+
+    int info = 0;
+    cl::Buffer *in_buf = in.get();
+    magma_potrf_gpu<T>(uplo, N,
+                        (*in_buf)(), in.getOffset(),  in.strides()[1],
+                        getQueue()(), &info);
+    return info;
 }
 
 template<typename T>
 Array<T> cholesky(int *info, const Array<T> &in, const bool is_upper)
 {
-    try {
-        if(OpenCLCPUOffload()) {
-            return cpu::cholesky(info, in, is_upper);
-        }
-
-        Array<T> out = copyArray<T>(in);
-        *info = cholesky_inplace(out, is_upper);
-
-        if (is_upper) triangle<T, true , false>(out, out);
-        else          triangle<T, false, false>(out, out);
-
-        return out;
-
-    } catch (cl::Error &err) {
-        CL_TO_AF_ERROR(err);
+    if(OpenCLCPUOffload()) {
+        return cpu::cholesky(info, in, is_upper);
     }
+
+    Array<T> out = copyArray<T>(in);
+    *info = cholesky_inplace(out, is_upper);
+
+    if (is_upper) triangle<T, true , false>(out, out);
+    else          triangle<T, false, false>(out, out);
+
+    return out;
 }
 
 #define INSTANTIATE_CH(T)                                                                   \

--- a/src/backend/opencl/cpu/cpu_helper.hpp
+++ b/src/backend/opencl/cpu/cpu_helper.hpp
@@ -13,7 +13,6 @@
 #include <Array.hpp>
 #include <memory.hpp>
 #include <types.hpp>
-#include <err_common.hpp>
 #include <platform.hpp>
 
 //********************************************************/

--- a/src/backend/opencl/cpu/cpu_sparse_blas.cpp
+++ b/src/backend/opencl/cpu/cpu_sparse_blas.cpp
@@ -16,7 +16,7 @@
 
 #include <af/dim4.hpp>
 #include <complex.hpp>
-#include <err_common.hpp>
+#include <err_opencl.hpp>
 #include <math.hpp>
 #include <platform.hpp>
 

--- a/src/backend/opencl/err_clblas.hpp
+++ b/src/backend/opencl/err_clblas.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 #include <stdio.h>
-#include <err_common.hpp>
+#include <err_opencl.hpp>
 #include <clBLAS.h>
 
 static const char * _clblasGetResultString(clblasStatus st)

--- a/src/backend/opencl/err_clfft.hpp
+++ b/src/backend/opencl/err_clfft.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 #include <stdio.h>
-#include <err_common.hpp>
+#include <err_opencl.hpp>
 #include <clFFT.h>
 
 static const char * _clfftGetResultString(clfftStatus st)

--- a/src/backend/opencl/err_opencl.hpp
+++ b/src/backend/opencl/err_opencl.hpp
@@ -19,21 +19,6 @@
                 __AF_FILENAME__, __LINE__, "OpenCL");   \
     } while(0)
 
-#define CL_TO_AF_ERROR(ERR) do {                                \
-        char opencl_err_msg[1024];                              \
-        snprintf(opencl_err_msg,                                \
-                 sizeof(opencl_err_msg),                        \
-                 "OpenCL Error (%d): %s when calling %s",       \
-                 ERR.err(), getErrorMessage(ERR.err()).c_str(), \
-                 ERR.what());                                   \
-        if (ERR.err() == CL_MEM_OBJECT_ALLOCATION_FAILURE) {    \
-            AF_ERROR(opencl_err_msg, AF_ERR_NO_MEM);            \
-        } else {                                                \
-            AF_ERROR(opencl_err_msg,                            \
-                     AF_ERR_INTERNAL);                          \
-        }                                                       \
-    } while(0)
-
 namespace opencl
 {
     template <typename T>

--- a/src/backend/opencl/iir.cpp
+++ b/src/backend/opencl/iir.cpp
@@ -23,36 +23,31 @@ namespace opencl
     template<typename T>
     Array<T> iir(const Array<T> &b, const Array<T> &a, const Array<T> &x)
     {
-        try {
-
-            AF_BATCH_KIND type = x.ndims() == 1 ? AF_BATCH_NONE : AF_BATCH_SAME;
-            if (x.ndims() != b.ndims()) {
-                type = (x.ndims() < b.ndims()) ?  AF_BATCH_RHS  : AF_BATCH_LHS;
-            }
-
-            // Extract the first N elements
-            Array<T> c = convolve<T, T, 1, true>(x, b, type);
-            dim4 cdims = c.dims();
-            cdims[0] = x.dims()[0];
-            c.resetDims(cdims);
-
-            int num_a = a.dims()[0];
-
-            if (num_a == 1) return c;
-
-            dim4 ydims = c.dims();
-            Array<T> y = createEmptyArray<T>(ydims);
-
-            if (a.ndims() > 1) {
-                kernel::iir<T,  true>(y, c, a);
-            } else {
-                kernel::iir<T, false>(y, c, a);
-            }
-
-            return y;
-        } catch (cl::Error &err) {
-            CL_TO_AF_ERROR(err);
+        AF_BATCH_KIND type = x.ndims() == 1 ? AF_BATCH_NONE : AF_BATCH_SAME;
+        if (x.ndims() != b.ndims()) {
+            type = (x.ndims() < b.ndims()) ?  AF_BATCH_RHS  : AF_BATCH_LHS;
         }
+
+        // Extract the first N elements
+        Array<T> c = convolve<T, T, 1, true>(x, b, type);
+        dim4 cdims = c.dims();
+        cdims[0] = x.dims()[0];
+        c.resetDims(cdims);
+
+        int num_a = a.dims()[0];
+
+        if (num_a == 1) return c;
+
+        dim4 ydims = c.dims();
+        Array<T> y = createEmptyArray<T>(ydims);
+
+        if (a.ndims() > 1) {
+            kernel::iir<T,  true>(y, c, a);
+        } else {
+            kernel::iir<T, false>(y, c, a);
+        }
+
+        return y;
     }
 
 #define INSTANTIATE(T)                          \

--- a/src/backend/opencl/inverse.cpp
+++ b/src/backend/opencl/inverse.cpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include <err_common.hpp>
+#include <err_opencl.hpp>
 #include <solve.hpp>
 #include <identity.hpp>
 

--- a/src/backend/opencl/kernel/approx.hpp
+++ b/src/backend/opencl/kernel/approx.hpp
@@ -48,144 +48,134 @@ namespace opencl
         void approx1(Param out, const Param in, const Param xpos, const float offGrid,
                      af_interp_type method)
         {
-            try {
-                static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-                static std::map<int, Program*>  approxProgs;
-                static std::map<int, Kernel*> approxKernels;
+            static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+            static std::map<int, Program*>  approxProgs;
+            static std::map<int, Kernel*> approxKernels;
 
-                int device = getActiveDeviceId();
+            int device = getActiveDeviceId();
 
-                std::call_once( compileFlags[device], [device] () {
-                    ToNumStr<Ty> toNumStr;
-                    std::ostringstream options;
-                    options << " -D Ty="          << dtype_traits<Ty>::getName()
-                            << " -D Tp="          << dtype_traits<Tp>::getName()
-                            << " -D InterpInTy="  << dtype_traits<Ty>::getName()
-                            << " -D InterpValTy=" << dtype_traits<Ty>::getName()
-                            << " -D InterpPosTy=" << dtype_traits<Tp>::getName()
-                            << " -D ZERO="        << toNumStr(scalar<Ty>(0));
+            std::call_once( compileFlags[device], [device] () {
+                ToNumStr<Ty> toNumStr;
+                std::ostringstream options;
+                options << " -D Ty="          << dtype_traits<Ty>::getName()
+                        << " -D Tp="          << dtype_traits<Tp>::getName()
+                        << " -D InterpInTy="  << dtype_traits<Ty>::getName()
+                        << " -D InterpValTy=" << dtype_traits<Ty>::getName()
+                        << " -D InterpPosTy=" << dtype_traits<Tp>::getName()
+                        << " -D ZERO="        << toNumStr(scalar<Ty>(0));
 
-                    if((af_dtype) dtype_traits<Ty>::af_type == c32 ||
-                       (af_dtype) dtype_traits<Ty>::af_type == c64) {
-                        options << " -D IS_CPLX=1";
-                    } else {
-                        options << " -D IS_CPLX=0";
-                    }
-                    if (std::is_same<Ty, double>::value ||
-                        std::is_same<Ty, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
+                if((af_dtype) dtype_traits<Ty>::af_type == c32 ||
+                    (af_dtype) dtype_traits<Ty>::af_type == c64) {
+                    options << " -D IS_CPLX=1";
+                } else {
+                    options << " -D IS_CPLX=0";
+                }
+                if (std::is_same<Ty, double>::value ||
+                    std::is_same<Ty, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
 
-                    options << " -D INTERP_ORDER=" << order;
-                    addInterpEnumOptions(options);
+                options << " -D INTERP_ORDER=" << order;
+                addInterpEnumOptions(options);
 
-                    Program prog;
-                    const char *ker_strs[] = {interp_cl, approx1_cl};
-                    const int   ker_lens[] = {interp_cl_len, approx1_cl_len};
-                    buildProgram(prog, 2, ker_strs, ker_lens, options.str());
-                    approxProgs[device] = new Program(prog);
+                Program prog;
+                const char *ker_strs[] = {interp_cl, approx1_cl};
+                const int   ker_lens[] = {interp_cl_len, approx1_cl_len};
+                buildProgram(prog, 2, ker_strs, ker_lens, options.str());
+                approxProgs[device] = new Program(prog);
 
-                    approxKernels[device] = new Kernel(*approxProgs[device], "approx1_kernel");
-                });
+                approxKernels[device] = new Kernel(*approxProgs[device], "approx1_kernel");
+            });
 
 
-                auto approx1Op = KernelFunctor<Buffer, const KParam, const Buffer, const KParam,
-                                               const Buffer, const KParam, const Ty,
-                                               const int, const int, const int>
-                                      (*approxKernels[device]);
+            auto approx1Op = KernelFunctor<Buffer, const KParam, const Buffer, const KParam,
+                                            const Buffer, const KParam, const Ty,
+                                            const int, const int, const int>
+                                  (*approxKernels[device]);
 
-                NDRange local(THREADS, 1, 1);
-                dim_t blocksPerMat = divup(out.info.dims[0], local[0]);
-                NDRange global(blocksPerMat * local[0] * out.info.dims[1],
-                               out.info.dims[2] * out.info.dims[3] * local[0],
-                               1);
+            NDRange local(THREADS, 1, 1);
+            dim_t blocksPerMat = divup(out.info.dims[0], local[0]);
+            NDRange global(blocksPerMat * local[0] * out.info.dims[1],
+                            out.info.dims[2] * out.info.dims[3] * local[0],
+                            1);
 
-                // Passing bools to opencl kernels is not allowed
-                bool batch = !(xpos.info.dims[1] == 1 && xpos.info.dims[2] == 1 &&
-                                xpos.info.dims[3] == 1);
+            // Passing bools to opencl kernels is not allowed
+            bool batch = !(xpos.info.dims[1] == 1 && xpos.info.dims[2] == 1 &&
+                            xpos.info.dims[3] == 1);
 
-                approx1Op(EnqueueArgs(getQueue(), global, local),
-                          *out.data, out.info, *in.data, in.info,
-                          *xpos.data, xpos.info, scalar<Ty>(offGrid),
-                          blocksPerMat, (int)batch, (int)method);
+            approx1Op(EnqueueArgs(getQueue(), global, local),
+                      *out.data, out.info, *in.data, in.info,
+                      *xpos.data, xpos.info, scalar<Ty>(offGrid),
+                      blocksPerMat, (int)batch, (int)method);
 
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
-            }
+            CL_DEBUG_FINISH(getQueue());
         }
 
         template <typename Ty, typename Tp, int order>
         void approx2(Param out, const Param in, const Param xpos, const Param ypos,
                      const float offGrid, af_interp_type method)
         {
-            try {
-                static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-                static std::map<int, Program*>       approxProgs;
-                static std::map<int, Kernel*>      approxKernels;
+            static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+            static std::map<int, Program*>       approxProgs;
+            static std::map<int, Kernel*>      approxKernels;
 
-                int device = getActiveDeviceId();
+            int device = getActiveDeviceId();
 
-                std::call_once( compileFlags[device], [device] () {
-                    ToNumStr<Ty> toNumStr;
-                    std::ostringstream options;
-                    options << " -D Ty="          << dtype_traits<Ty>::getName()
-                            << " -D Tp="          << dtype_traits<Tp>::getName()
-                            << " -D InterpInTy="  << dtype_traits<Ty>::getName()
-                            << " -D InterpValTy=" << dtype_traits<Ty>::getName()
-                            << " -D InterpPosTy=" << dtype_traits<Tp>::getName()
-                            << " -D ZERO="        << toNumStr(scalar<Ty>(0));
+            std::call_once( compileFlags[device], [device] () {
+                ToNumStr<Ty> toNumStr;
+                std::ostringstream options;
+                options << " -D Ty="          << dtype_traits<Ty>::getName()
+                        << " -D Tp="          << dtype_traits<Tp>::getName()
+                        << " -D InterpInTy="  << dtype_traits<Ty>::getName()
+                        << " -D InterpValTy=" << dtype_traits<Ty>::getName()
+                        << " -D InterpPosTy=" << dtype_traits<Tp>::getName()
+                        << " -D ZERO="        << toNumStr(scalar<Ty>(0));
 
-                    if((af_dtype) dtype_traits<Ty>::af_type == c32 ||
-                       (af_dtype) dtype_traits<Ty>::af_type == c64) {
-                        options << " -D IS_CPLX=1";
-                    } else {
-                        options << " -D IS_CPLX=0";
-                    }
-                    if (std::is_same<Ty, double>::value ||
-                        std::is_same<Ty, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
+                if((af_dtype) dtype_traits<Ty>::af_type == c32 ||
+                    (af_dtype) dtype_traits<Ty>::af_type == c64) {
+                    options << " -D IS_CPLX=1";
+                } else {
+                    options << " -D IS_CPLX=0";
+                }
+                if (std::is_same<Ty, double>::value ||
+                    std::is_same<Ty, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
 
-                    options << " -D INTERP_ORDER=" << order;
-                    addInterpEnumOptions(options);
+                options << " -D INTERP_ORDER=" << order;
+                addInterpEnumOptions(options);
 
-                    Program prog;
-                    const char *ker_strs[] = {interp_cl, approx2_cl};
-                    const int   ker_lens[] = {interp_cl_len, approx2_cl_len};
-                    buildProgram(prog, 2, ker_strs, ker_lens, options.str());
-                    approxProgs[device] = new Program(prog);
+                Program prog;
+                const char *ker_strs[] = {interp_cl, approx2_cl};
+                const int   ker_lens[] = {interp_cl_len, approx2_cl_len};
+                buildProgram(prog, 2, ker_strs, ker_lens, options.str());
+                approxProgs[device] = new Program(prog);
 
-                    approxKernels[device] = new Kernel(*approxProgs[device], "approx2_kernel");
-                });
+                approxKernels[device] = new Kernel(*approxProgs[device], "approx2_kernel");
+            });
 
-                auto approx2Op = KernelFunctor<Buffer, const KParam, const Buffer, const KParam,
-                                       const Buffer, const KParam, const Buffer, const KParam,
-                                               const Ty, const int, const int, const int, const int>
-                                       (*approxKernels[device]);
+            auto approx2Op = KernelFunctor<Buffer, const KParam, const Buffer, const KParam,
+                                    const Buffer, const KParam, const Buffer, const KParam,
+                                            const Ty, const int, const int, const int, const int>
+                                    (*approxKernels[device]);
 
-                NDRange local(TX, TY, 1);
-                dim_t blocksPerMatX = divup(out.info.dims[0], local[0]);
-                dim_t blocksPerMatY = divup(out.info.dims[1], local[1]);
-                NDRange global(blocksPerMatX * local[0] * out.info.dims[2],
-                               blocksPerMatY * local[1] * out.info.dims[3],
-                               1);
+            NDRange local(TX, TY, 1);
+            dim_t blocksPerMatX = divup(out.info.dims[0], local[0]);
+            dim_t blocksPerMatY = divup(out.info.dims[1], local[1]);
+            NDRange global(blocksPerMatX * local[0] * out.info.dims[2],
+                            blocksPerMatY * local[1] * out.info.dims[3],
+                            1);
 
-                // Passing bools to opencl kernels is not allowed
-                bool batch = !(xpos.info.dims[2] == 1 && xpos.info.dims[3] == 1);
+            // Passing bools to opencl kernels is not allowed
+            bool batch = !(xpos.info.dims[2] == 1 && xpos.info.dims[3] == 1);
 
-                approx2Op(EnqueueArgs(getQueue(), global, local),
-                          *out.data, out.info,
-                          *in.data, in.info,
-                          *xpos.data, xpos.info,
-                          *ypos.data, ypos.info,
-                          scalar<Ty>(offGrid), blocksPerMatX, blocksPerMatY, (int)batch, (int)method);
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
-            }
+            approx2Op(EnqueueArgs(getQueue(), global, local),
+                      *out.data, out.info,
+                      *in.data, in.info,
+                      *xpos.data, xpos.info,
+                      *ypos.data, ypos.info,
+                      scalar<Ty>(offGrid), blocksPerMatX, blocksPerMatY, (int)batch, (int)method);
+            CL_DEBUG_FINISH(getQueue());
         }
     }
 }

--- a/src/backend/opencl/kernel/bilateral.hpp
+++ b/src/backend/opencl/kernel/bilateral.hpp
@@ -41,69 +41,64 @@ static const int THREADS_Y = 16;
 template<typename inType, typename outType, bool isColor>
 void bilateral(Param out, const Param in, float s_sigma, float c_sigma)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*>  bilProgs;
-        static std::map<int, Kernel*> bilKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*>  bilProgs;
+    static std::map<int, Kernel*> bilKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
-                bool use_native_exp = (getActivePlatform() != AFCL_PLATFORM_POCL
-                                    && getActivePlatform() != AFCL_PLATFORM_APPLE);
-                std::ostringstream options;
-                options << " -D inType=" << dtype_traits<inType>::getName()
-                        << " -D outType=" << dtype_traits<outType>::getName();
-                if (std::is_same<inType, double>::value ||
-                    std::is_same<inType, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                }
-                options << " -D USE_NATIVE_EXP=" << (int)use_native_exp;
+    std::call_once( compileFlags[device], [device] () {
+            bool use_native_exp = (getActivePlatform() != AFCL_PLATFORM_POCL
+                                && getActivePlatform() != AFCL_PLATFORM_APPLE);
+            std::ostringstream options;
+            options << " -D inType=" << dtype_traits<inType>::getName()
+                    << " -D outType=" << dtype_traits<outType>::getName();
+            if (std::is_same<inType, double>::value ||
+                std::is_same<inType, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+            }
+            options << " -D USE_NATIVE_EXP=" << (int)use_native_exp;
 
-                Program prog;
-                buildProgram(prog, bilateral_cl, bilateral_cl_len, options.str());
-                bilProgs[device] = new Program(prog);
+            Program prog;
+            buildProgram(prog, bilateral_cl, bilateral_cl_len, options.str());
+            bilProgs[device] = new Program(prog);
 
-                    bilKernels[device] = new Kernel(*bilProgs[device], "bilateral");
-            });
+                bilKernels[device] = new Kernel(*bilProgs[device], "bilateral");
+        });
 
-        auto bilateralOp = KernelFunctor<Buffer, KParam,
-                                       Buffer, KParam,
-                                       LocalSpaceArg,
-                                       LocalSpaceArg,
-                                       float, float,
-                                       int, int, int
-                                      >(*bilKernels[device]);
+    auto bilateralOp = KernelFunctor<Buffer, KParam,
+                                    Buffer, KParam,
+                                    LocalSpaceArg,
+                                    LocalSpaceArg,
+                                    float, float,
+                                    int, int, int
+                                  >(*bilKernels[device]);
 
-        NDRange local(THREADS_X, THREADS_Y);
+    NDRange local(THREADS_X, THREADS_Y);
 
-        int blk_x = divup(in.info.dims[0], THREADS_X);
-        int blk_y = divup(in.info.dims[1], THREADS_Y);
+    int blk_x = divup(in.info.dims[0], THREADS_X);
+    int blk_y = divup(in.info.dims[1], THREADS_Y);
 
-        NDRange global(blk_x*in.info.dims[2]*THREADS_X,
-                       blk_y*in.info.dims[3]*THREADS_Y);
+    NDRange global(blk_x*in.info.dims[2]*THREADS_X,
+                    blk_y*in.info.dims[3]*THREADS_Y);
 
-        // calculate local memory size
-        int radius = (int)std::max(s_sigma * 1.5f, 1.f);
-        int num_shrd_elems    = (THREADS_X + 2 * radius) * (THREADS_Y + 2 * radius);
-        int num_gauss_elems   = (2*radius+1)*(2*radius+1);
-        size_t localMemSize   = (num_shrd_elems + num_gauss_elems)*sizeof(outType);
-        size_t MaxLocalSize   = getDevice(getActiveDeviceId()).getInfo<CL_DEVICE_LOCAL_MEM_SIZE>();
-        if (localMemSize>MaxLocalSize) {
-            OPENCL_NOT_SUPPORTED();
-        }
-
-        bilateralOp(EnqueueArgs(getQueue(), global, local),
-                    *out.data, out.info, *in.data, in.info,
-                    cl::Local(num_shrd_elems*sizeof(outType)),
-                    cl::Local(num_gauss_elems*sizeof(outType)),
-                    s_sigma, c_sigma, num_shrd_elems, blk_x, blk_y);
-
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
+    // calculate local memory size
+    int radius = (int)std::max(s_sigma * 1.5f, 1.f);
+    int num_shrd_elems    = (THREADS_X + 2 * radius) * (THREADS_Y + 2 * radius);
+    int num_gauss_elems   = (2*radius+1)*(2*radius+1);
+    size_t localMemSize   = (num_shrd_elems + num_gauss_elems)*sizeof(outType);
+    size_t MaxLocalSize   = getDevice(getActiveDeviceId()).getInfo<CL_DEVICE_LOCAL_MEM_SIZE>();
+    if (localMemSize>MaxLocalSize) {
+        OPENCL_NOT_SUPPORTED();
     }
+
+    bilateralOp(EnqueueArgs(getQueue(), global, local),
+                *out.data, out.info, *in.data, in.info,
+                cl::Local(num_shrd_elems*sizeof(outType)),
+                cl::Local(num_gauss_elems*sizeof(outType)),
+                s_sigma, c_sigma, num_shrd_elems, blk_x, blk_y);
+
+    CL_DEBUG_FINISH(getQueue());
 }
 
 }

--- a/src/backend/opencl/kernel/convolve/conv2_impl.hpp
+++ b/src/backend/opencl/kernel/convolve/conv2_impl.hpp
@@ -19,66 +19,60 @@ namespace kernel
 template<typename T, typename aT, bool expand>
 void conv2Helper(const conv_kparam_t& param, Param out, const Param signal, const Param filter)
 {
-    try {
-        int f0 = filter.info.dims[0];
-        int f1 = filter.info.dims[1];
+    int f0 = filter.info.dims[0];
+    int f1 = filter.info.dims[1];
 
-        std::string ref_name =
-            std::string("conv2_") +
-            std::string(dtype_traits<T>::getName()) +
-            std::string("_") +
-            std::string(dtype_traits<aT>::getName()) +
-            std::string("_") +
-            std::to_string(expand) +
-            std::string("_") +
-            std::to_string(f0) +
-            std::string("_") +
-            std::to_string(f1);
+    std::string ref_name =
+        std::string("conv2_") +
+        std::string(dtype_traits<T>::getName()) +
+        std::string("_") +
+        std::string(dtype_traits<aT>::getName()) +
+        std::string("_") +
+        std::to_string(expand) +
+        std::string("_") +
+        std::to_string(f0) +
+        std::string("_") +
+        std::to_string(f1);
 
-        int device = getActiveDeviceId();
-        kc_t::iterator idx = kernelCaches[device].find(ref_name);
+    int device = getActiveDeviceId();
+    kc_t::iterator idx = kernelCaches[device].find(ref_name);
 
-        kc_entry_t entry;
-        if (idx == kernelCaches[device].end()) {
-            size_t LOC_SIZE = (THREADS_X+2*(f0-1))*(THREADS_Y+2*(f1-1));
+    kc_entry_t entry;
+    if (idx == kernelCaches[device].end()) {
+        size_t LOC_SIZE = (THREADS_X+2*(f0-1))*(THREADS_Y+2*(f1-1));
 
-            std::ostringstream options;
-            options << " -D T=" << dtype_traits<T>::getName()
-                    << " -D accType="<< dtype_traits<aT>::getName()
-                    << " -D BASE_DIM="<< 2 /* hard constant specific to this convolution type */
-                    << " -D FLEN0=" << f0
-                    << " -D FLEN1=" << f1
-                    << " -D EXPAND="<< expand
-                    << " -D C_SIZE="<< LOC_SIZE;
-            if (std::is_same<T, double>::value ||
-                std::is_same<T, cdouble>::value) {
-                options << " -D USE_DOUBLE";
-            }
-            Program prog;
-            buildProgram(prog, convolve_cl, convolve_cl_len, options.str());
-            entry.prog   = new Program(prog);
-            entry.ker = new Kernel(*entry.prog, "convolve");
-
-            kernelCaches[device][ref_name] = entry;
-        } else {
-            entry = idx->second;
+        std::ostringstream options;
+        options << " -D T=" << dtype_traits<T>::getName()
+                << " -D accType="<< dtype_traits<aT>::getName()
+                << " -D BASE_DIM="<< 2 /* hard constant specific to this convolution type */
+                << " -D FLEN0=" << f0
+                << " -D FLEN1=" << f1
+                << " -D EXPAND="<< expand
+                << " -D C_SIZE="<< LOC_SIZE;
+        if (std::is_same<T, double>::value ||
+            std::is_same<T, cdouble>::value) {
+            options << " -D USE_DOUBLE";
         }
+        Program prog;
+        buildProgram(prog, convolve_cl, convolve_cl_len, options.str());
+        entry.prog   = new Program(prog);
+        entry.ker = new Kernel(*entry.prog, "convolve");
 
-        auto convOp = cl::KernelFunctor<Buffer, KParam, Buffer, KParam,
-                                  Buffer, KParam, int, int,
-                                  int, int,
-                                  int, int
-                                 >(*entry.ker);
-
-        convOp(EnqueueArgs(getQueue(), param.global, param.local),
-                *out.data, out.info, *signal.data, signal.info,
-                *param.impulse, filter.info, param.nBBS0, param.nBBS1,
-                param.o[1], param.o[2], param.s[1], param.s[2]);
-
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
+        kernelCaches[device][ref_name] = entry;
+    } else {
+        entry = idx->second;
     }
+
+    auto convOp = cl::KernelFunctor<Buffer, KParam, Buffer, KParam,
+                              Buffer, KParam, int, int,
+                              int, int,
+                              int, int
+                              >(*entry.ker);
+
+    convOp(EnqueueArgs(getQueue(), param.global, param.local),
+            *out.data, out.info, *signal.data, signal.info,
+            *param.impulse, filter.info, param.nBBS0, param.nBBS1,
+            param.o[1], param.o[2], param.s[1], param.s[2]);
 }
 
 template<typename T, typename aT, bool expand>

--- a/src/backend/opencl/kernel/convolve_separable.cpp
+++ b/src/backend/opencl/kernel/convolve_separable.cpp
@@ -39,76 +39,70 @@ static const int THREADS_Y = 16;
 template<typename T, typename accType, int conv_dim, bool expand>
 void convSep(Param out, const Param signal, const Param filter)
 {
-    try {
+    const int fLen = filter.info.dims[0] * filter.info.dims[1];
 
-        const int fLen = filter.info.dims[0] * filter.info.dims[1];
+    std::string ref_name =
+        std::string("convsep_") +
+        std::to_string(conv_dim) +
+        std::string("_") +
+        std::string(dtype_traits<T>::getName()) +
+        std::string("_") +
+        std::string(dtype_traits<accType>::getName()) +
+        std::string("_") +
+        std::to_string(expand) +
+        std::string("_") +
+        std::to_string(fLen);
 
-        std::string ref_name =
-            std::string("convsep_") +
-            std::to_string(conv_dim) +
-            std::string("_") +
-            std::string(dtype_traits<T>::getName()) +
-            std::string("_") +
-            std::string(dtype_traits<accType>::getName()) +
-            std::string("_") +
-            std::to_string(expand) +
-            std::string("_") +
-            std::to_string(fLen);
+    int device = getActiveDeviceId();
+    kc_t::iterator idx = kernelCaches[device].find(ref_name);
 
-        int device = getActiveDeviceId();
-        kc_t::iterator idx = kernelCaches[device].find(ref_name);
+    kc_entry_t entry;
+    if (idx == kernelCaches[device].end()) {
+        const size_t C0_SIZE  = (THREADS_X+2*(fLen-1))* THREADS_Y;
+        const size_t C1_SIZE  = (THREADS_Y+2*(fLen-1))* THREADS_X;
 
-        kc_entry_t entry;
-        if (idx == kernelCaches[device].end()) {
-            const size_t C0_SIZE  = (THREADS_X+2*(fLen-1))* THREADS_Y;
-            const size_t C1_SIZE  = (THREADS_Y+2*(fLen-1))* THREADS_X;
+        size_t locSize = (conv_dim==0 ? C0_SIZE : C1_SIZE);
 
-            size_t locSize = (conv_dim==0 ? C0_SIZE : C1_SIZE);
-
-            std::ostringstream options;
-            options << " -D T=" << dtype_traits<T>::getName()
-                    << " -D accType="<< dtype_traits<accType>::getName()
-                    << " -D CONV_DIM="<< conv_dim
-                    << " -D EXPAND="<< expand
-                    << " -D FLEN="<< fLen
-                    << " -D LOCAL_MEM_SIZE="<<locSize;
-            if (std::is_same<T, double>::value ||
-                std::is_same<T, cdouble>::value) {
-                options << " -D USE_DOUBLE";
-            }
-            Program prog;
-            buildProgram(prog, convolve_separable_cl, convolve_separable_cl_len, options.str());
-
-            entry.prog   = new Program(prog);
-            entry.ker  = new Kernel(*entry.prog, "convolve");
-            kernelCaches[device][ref_name] = entry;
-        } else {
-            entry = idx->second;
+        std::ostringstream options;
+        options << " -D T=" << dtype_traits<T>::getName()
+                << " -D accType="<< dtype_traits<accType>::getName()
+                << " -D CONV_DIM="<< conv_dim
+                << " -D EXPAND="<< expand
+                << " -D FLEN="<< fLen
+                << " -D LOCAL_MEM_SIZE="<<locSize;
+        if (std::is_same<T, double>::value ||
+            std::is_same<T, cdouble>::value) {
+            options << " -D USE_DOUBLE";
         }
+        Program prog;
+        buildProgram(prog, convolve_separable_cl, convolve_separable_cl_len, options.str());
 
-        auto convOp = KernelFunctor<Buffer, KParam, Buffer, KParam, Buffer,
-                                  int, int>(*entry.ker);
-
-        NDRange local(THREADS_X, THREADS_Y);
-
-        int blk_x = divup(out.info.dims[0], THREADS_X);
-        int blk_y = divup(out.info.dims[1], THREADS_Y);
-
-        NDRange global(blk_x*signal.info.dims[2]*THREADS_X,
-                       blk_y*signal.info.dims[3]*THREADS_Y);
-
-        cl::Buffer *mBuff = bufferAlloc(fLen*sizeof(accType));
-        // FIX ME: if the filter array is strided, direct might cause issues
-        getQueue().enqueueCopyBuffer(*filter.data, *mBuff, 0, 0, fLen*sizeof(accType));
-
-        convOp(EnqueueArgs(getQueue(), global, local),
-               *out.data, out.info, *signal.data, signal.info, *mBuff, blk_x, blk_y);
-
-        bufferFree(mBuff);
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
+        entry.prog   = new Program(prog);
+        entry.ker  = new Kernel(*entry.prog, "convolve");
+        kernelCaches[device][ref_name] = entry;
+    } else {
+        entry = idx->second;
     }
+
+    auto convOp = KernelFunctor<Buffer, KParam, Buffer, KParam, Buffer,
+                              int, int>(*entry.ker);
+
+    NDRange local(THREADS_X, THREADS_Y);
+
+    int blk_x = divup(out.info.dims[0], THREADS_X);
+    int blk_y = divup(out.info.dims[1], THREADS_Y);
+
+    NDRange global(blk_x*signal.info.dims[2]*THREADS_X,
+                    blk_y*signal.info.dims[3]*THREADS_Y);
+
+    cl::Buffer *mBuff = bufferAlloc(fLen*sizeof(accType));
+    // FIX ME: if the filter array is strided, direct might cause issues
+    getQueue().enqueueCopyBuffer(*filter.data, *mBuff, 0, 0, fLen*sizeof(accType));
+
+    convOp(EnqueueArgs(getQueue(), global, local),
+            *out.data, out.info, *signal.data, signal.info, *mBuff, blk_x, blk_y);
+
+    bufferFree(mBuff);
 }
 
 #define INSTANTIATE(T, accT)  \

--- a/src/backend/opencl/kernel/cscmm.hpp
+++ b/src/backend/opencl/kernel/cscmm.hpp
@@ -43,91 +43,87 @@ namespace opencl
                       const Param &values, const Param &colIdx, const Param &rowIdx,
                       const Param &rhs, const T alpha, const T beta, bool is_conj)
         {
-            try {
-                bool use_alpha = (alpha != scalar<T>(1.0));
-                bool use_beta = (beta != scalar<T>(0.0));
+            bool use_alpha = (alpha != scalar<T>(1.0));
+            bool use_beta = (beta != scalar<T>(0.0));
 
-                int threads = 256;
-                // TODO: Find a better way to tune these parameters
-                int rows_per_group = 8;
-                int cols_per_group = 8;
+            int threads = 256;
+            // TODO: Find a better way to tune these parameters
+            int rows_per_group = 8;
+            int cols_per_group = 8;
 
-                std::string ref_name =
-                    std::string("cscmm_nn_") +
-                    std::string(dtype_traits<T>::getName()) +
-                    std::string("_") +
-                    std::to_string(use_alpha) +
-                    std::string("_") +
-                    std::to_string(use_beta) +
-                    std::string("_") +
-                    std::to_string(is_conj) +
-                    std::string("_") +
-                    std::to_string(rows_per_group) +
-                    std::string("_") +
-                    std::to_string(cols_per_group) +
-                    std::string("_") +
-                    std::to_string(threads);
+            std::string ref_name =
+                std::string("cscmm_nn_") +
+                std::string(dtype_traits<T>::getName()) +
+                std::string("_") +
+                std::to_string(use_alpha) +
+                std::string("_") +
+                std::to_string(use_beta) +
+                std::string("_") +
+                std::to_string(is_conj) +
+                std::string("_") +
+                std::to_string(rows_per_group) +
+                std::string("_") +
+                std::to_string(cols_per_group) +
+                std::string("_") +
+                std::to_string(threads);
 
-                int device = getActiveDeviceId();
-                auto idx = kernelCaches[device].find(ref_name);
-                kc_entry_t entry;
+            int device = getActiveDeviceId();
+            auto idx = kernelCaches[device].find(ref_name);
+            kc_entry_t entry;
 
-                if (idx == kernelCaches[device].end()) {
+            if (idx == kernelCaches[device].end()) {
 
-                    std::ostringstream options;
-                    options << " -D T=" << dtype_traits<T>::getName();
-                    options << " -D USE_ALPHA=" << use_alpha;
-                    options << " -D USE_BETA=" << use_beta;
-                    options << " -D IS_CONJ=" << is_conj;
-                    options << " -D THREADS=" << threads;
-                    options << " -D ROWS_PER_GROUP=" << rows_per_group;
-                    options << " -D COLS_PER_GROUP=" << cols_per_group;
+                std::ostringstream options;
+                options << " -D T=" << dtype_traits<T>::getName();
+                options << " -D USE_ALPHA=" << use_alpha;
+                options << " -D USE_BETA=" << use_beta;
+                options << " -D IS_CONJ=" << is_conj;
+                options << " -D THREADS=" << threads;
+                options << " -D ROWS_PER_GROUP=" << rows_per_group;
+                options << " -D COLS_PER_GROUP=" << cols_per_group;
 
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-                    if (std::is_same<T, cfloat>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D IS_CPLX=1";
-                    } else {
-                        options << " -D IS_CPLX=0";
-                    }
-
-                    const char *ker_strs[] = {cscmm_cl};
-                    const int   ker_lens[] = {cscmm_cl_len};
-
-                    Program prog;
-                    buildProgram(prog, 1, ker_strs, ker_lens, options.str());
-                    entry.prog = new Program(prog);
-                    entry.ker  = new Kernel(*entry.prog, "cscmm_nn");
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
+                if (std::is_same<T, cfloat>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D IS_CPLX=1";
                 } else {
-                    entry = idx->second;
+                    options << " -D IS_CPLX=0";
                 }
 
-                auto cscmm_kernel = *entry.ker;
-                auto cscmm_func = KernelFunctor<Buffer,
-                                                Buffer, Buffer, Buffer,
-                                                int, int, int,
-                                                Buffer, KParam, T, T>(cscmm_kernel);
+                const char *ker_strs[] = {cscmm_cl};
+                const int   ker_lens[] = {cscmm_cl_len};
 
-                NDRange local(threads, 1);
-                int M = out.info.dims[0];
-                int N = out.info.dims[1];
-                int K = colIdx.info.dims[0] - 1;
-
-                int groups_x = divup(M, rows_per_group);
-                int groups_y = divup(N, cols_per_group);
-                NDRange global(local[0] * groups_x, local[1] * groups_y);
-
-                cscmm_func(EnqueueArgs(getQueue(), global, local),
-                           *out.data, *values.data, *colIdx.data, *rowIdx.data,
-                           M, K, N, *rhs.data, rhs.info, alpha, beta);
-
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error &ex) {
-                CL_TO_AF_ERROR(ex);
+                Program prog;
+                buildProgram(prog, 1, ker_strs, ker_lens, options.str());
+                entry.prog = new Program(prog);
+                entry.ker  = new Kernel(*entry.prog, "cscmm_nn");
+            } else {
+                entry = idx->second;
             }
+
+            auto cscmm_kernel = *entry.ker;
+            auto cscmm_func = KernelFunctor<Buffer,
+                                            Buffer, Buffer, Buffer,
+                                            int, int, int,
+                                            Buffer, KParam, T, T>(cscmm_kernel);
+
+            NDRange local(threads, 1);
+            int M = out.info.dims[0];
+            int N = out.info.dims[1];
+            int K = colIdx.info.dims[0] - 1;
+
+            int groups_x = divup(M, rows_per_group);
+            int groups_y = divup(N, cols_per_group);
+            NDRange global(local[0] * groups_x, local[1] * groups_y);
+
+            cscmm_func(EnqueueArgs(getQueue(), global, local),
+                        *out.data, *values.data, *colIdx.data, *rowIdx.data,
+                        M, K, N, *rhs.data, rhs.info, alpha, beta);
+
+            CL_DEBUG_FINISH(getQueue());
         }
     }
 }

--- a/src/backend/opencl/kernel/csrmm.hpp
+++ b/src/backend/opencl/kernel/csrmm.hpp
@@ -43,91 +43,87 @@ namespace opencl
                       const Param &values, const Param &rowIdx, const Param &colIdx,
                       const Param &rhs, const T alpha, const T beta)
         {
-            try {
-                bool use_alpha = (alpha != scalar<T>(1.0));
-                bool use_beta = (beta != scalar<T>(0.0));
+            bool use_alpha = (alpha != scalar<T>(1.0));
+            bool use_beta = (beta != scalar<T>(0.0));
 
-                // Using greedy indexing is causing performance issues on many platforms
-                // FIXME: Figure out why
-                bool use_greedy = false;
+            // Using greedy indexing is causing performance issues on many platforms
+            // FIXME: Figure out why
+            bool use_greedy = false;
 
-                std::string ref_name =
-                    std::string("csrmm_nt_") +
-                    std::string(dtype_traits<T>::getName()) +
-                    std::string("_") +
-                    std::to_string(use_alpha) +
-                    std::string("_") +
-                    std::to_string(use_beta) +
-                    std::string("_") +
-                    std::to_string(use_greedy);
+            std::string ref_name =
+                std::string("csrmm_nt_") +
+                std::string(dtype_traits<T>::getName()) +
+                std::string("_") +
+                std::to_string(use_alpha) +
+                std::string("_") +
+                std::to_string(use_beta) +
+                std::string("_") +
+                std::to_string(use_greedy);
 
-                int device = getActiveDeviceId();
-                auto idx = kernelCaches[device].find(ref_name);
-                kc_entry_t entry;
+            int device = getActiveDeviceId();
+            auto idx = kernelCaches[device].find(ref_name);
+            kc_entry_t entry;
 
-                if (idx == kernelCaches[device].end()) {
+            if (idx == kernelCaches[device].end()) {
 
-                    std::ostringstream options;
-                    options << " -D T=" << dtype_traits<T>::getName();
-                    options << " -D USE_ALPHA=" << use_alpha;
-                    options << " -D USE_BETA=" << use_beta;
-                    options << " -D USE_GREEDY=" << use_greedy;
-                    options << " -D THREADS_PER_GROUP=" << THREADS_PER_GROUP;
+                std::ostringstream options;
+                options << " -D T=" << dtype_traits<T>::getName();
+                options << " -D USE_ALPHA=" << use_alpha;
+                options << " -D USE_BETA=" << use_beta;
+                options << " -D USE_GREEDY=" << use_greedy;
+                options << " -D THREADS_PER_GROUP=" << THREADS_PER_GROUP;
 
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-                    if (std::is_same<T, cfloat>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D IS_CPLX=1";
-                    } else {
-                        options << " -D IS_CPLX=0";
-                    }
-
-                    const char *ker_strs[] = {csrmm_cl};
-                    const int   ker_lens[] = {csrmm_cl_len};
-
-                    Program prog;
-                    buildProgram(prog, 1, ker_strs, ker_lens, options.str());
-                    entry.prog = new Program(prog);
-                    entry.ker  = new Kernel[2];
-                    entry.ker[0] = Kernel(*entry.prog, "csrmm_nt");
-                    // FIXME: Change this after adding another kernel
-                    entry.ker[1] = Kernel(*entry.prog, "csrmm_nt");
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
+                if (std::is_same<T, cfloat>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D IS_CPLX=1";
                 } else {
-                    entry = idx->second;
+                    options << " -D IS_CPLX=0";
                 }
 
-                auto csrmm_nt_kernel = entry.ker[0];
-                auto csrmm_nt_func = KernelFunctor<Buffer,
-                                                   Buffer, Buffer, Buffer,
-                                                   int, int,
-                                                   Buffer, KParam, T, T, Buffer>(csrmm_nt_kernel);
-                NDRange local(THREADS_PER_GROUP, 1);
-                int M = rowIdx.info.dims[0] - 1;
-                int N = rhs.info.dims[0];
+                const char *ker_strs[] = {csrmm_cl};
+                const int   ker_lens[] = {csrmm_cl_len};
 
-                int groups_x = divup(N, local[0]);
-                int groups_y = divup(M, REPEAT);
-                groups_y = std::min(groups_y, MAX_CSRMM_GROUPS);
-                NDRange global(local[0] * groups_x, local[1] * groups_y);
-
-                std::vector<int> count(groups_x);
-                cl::Buffer *counter = bufferAlloc(count.size() * sizeof(int));
-                getQueue().enqueueWriteBuffer(*counter, CL_TRUE,
-                                              0,
-                                              count.size() * sizeof(int),
-                                              (void *)count.data());
-
-                csrmm_nt_func(EnqueueArgs(getQueue(), global, local),
-                              *out.data, *values.data, *rowIdx.data, *colIdx.data,
-                              M, N, *rhs.data, rhs.info, alpha, beta, *counter);
-
-                bufferFree(counter);
-            } catch (cl::Error &ex) {
-                CL_TO_AF_ERROR(ex);
+                Program prog;
+                buildProgram(prog, 1, ker_strs, ker_lens, options.str());
+                entry.prog = new Program(prog);
+                entry.ker  = new Kernel[2];
+                entry.ker[0] = Kernel(*entry.prog, "csrmm_nt");
+                // FIXME: Change this after adding another kernel
+                entry.ker[1] = Kernel(*entry.prog, "csrmm_nt");
+            } else {
+                entry = idx->second;
             }
+
+            auto csrmm_nt_kernel = entry.ker[0];
+            auto csrmm_nt_func = KernelFunctor<Buffer,
+                                                Buffer, Buffer, Buffer,
+                                                int, int,
+                                                Buffer, KParam, T, T, Buffer>(csrmm_nt_kernel);
+            NDRange local(THREADS_PER_GROUP, 1);
+            int M = rowIdx.info.dims[0] - 1;
+            int N = rhs.info.dims[0];
+
+            int groups_x = divup(N, local[0]);
+            int groups_y = divup(M, REPEAT);
+            groups_y = std::min(groups_y, MAX_CSRMM_GROUPS);
+            NDRange global(local[0] * groups_x, local[1] * groups_y);
+
+            std::vector<int> count(groups_x);
+            cl::Buffer *counter = bufferAlloc(count.size() * sizeof(int));
+            getQueue().enqueueWriteBuffer(*counter, CL_TRUE,
+                                          0,
+                                          count.size() * sizeof(int),
+                                          (void *)count.data());
+
+            csrmm_nt_func(EnqueueArgs(getQueue(), global, local),
+                          *out.data, *values.data, *rowIdx.data, *colIdx.data,
+                          M, N, *rhs.data, rhs.info, alpha, beta, *counter);
+
+            bufferFree(counter);
         }
     }
 }

--- a/src/backend/opencl/kernel/csrmv.hpp
+++ b/src/backend/opencl/kernel/csrmv.hpp
@@ -44,97 +44,93 @@ namespace opencl
                    const Param &values, const Param &rowIdx, const Param &colIdx,
                    const Param &rhs, const T alpha, const T beta)
         {
-            try {
-                bool use_alpha = (alpha != scalar<T>(1.0));
-                bool use_beta = (beta != scalar<T>(0.0));
+            bool use_alpha = (alpha != scalar<T>(1.0));
+            bool use_beta = (beta != scalar<T>(0.0));
 
-                // Using greedy indexing is causing performance issues on many platforms
-                // FIXME: Figure out why
-                bool use_greedy = false;
+            // Using greedy indexing is causing performance issues on many platforms
+            // FIXME: Figure out why
+            bool use_greedy = false;
 
-                // FIXME: Find a better number based on average non zeros per row
-                int threads = 64;
+            // FIXME: Find a better number based on average non zeros per row
+            int threads = 64;
 
-                std::string ref_name =
-                    std::string("csrmv_") +
-                    std::string(dtype_traits<T>::getName()) +
-                    std::string("_") +
-                    std::to_string(use_alpha) +
-                    std::string("_") +
-                    std::to_string(use_beta) +
-                    std::string("_") +
-                    std::to_string(use_greedy) +
-                    std::string("_") +
-                    std::to_string(threads);
+            std::string ref_name =
+                std::string("csrmv_") +
+                std::string(dtype_traits<T>::getName()) +
+                std::string("_") +
+                std::to_string(use_alpha) +
+                std::string("_") +
+                std::to_string(use_beta) +
+                std::string("_") +
+                std::to_string(use_greedy) +
+                std::string("_") +
+                std::to_string(threads);
 
-                int device = getActiveDeviceId();
-                auto idx = kernelCaches[device].find(ref_name);
-                kc_entry_t entry;
+            int device = getActiveDeviceId();
+            auto idx = kernelCaches[device].find(ref_name);
+            kc_entry_t entry;
 
-                if (idx == kernelCaches[device].end()) {
+            if (idx == kernelCaches[device].end()) {
 
-                    std::ostringstream options;
-                    options << " -D T=" << dtype_traits<T>::getName();
-                    options << " -D USE_ALPHA=" << use_alpha;
-                    options << " -D USE_BETA=" << use_beta;
-                    options << " -D USE_GREEDY=" << use_greedy;
-                    options << " -D THREADS=" << threads;
+                std::ostringstream options;
+                options << " -D T=" << dtype_traits<T>::getName();
+                options << " -D USE_ALPHA=" << use_alpha;
+                options << " -D USE_BETA=" << use_beta;
+                options << " -D USE_GREEDY=" << use_greedy;
+                options << " -D THREADS=" << threads;
 
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-                    if (std::is_same<T, cfloat>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D IS_CPLX=1";
-                    } else {
-                        options << " -D IS_CPLX=0";
-                    }
-
-                    const char *ker_strs[] = {csrmv_cl};
-                    const int   ker_lens[] = {csrmv_cl_len};
-
-                    Program prog;
-                    buildProgram(prog, 1, ker_strs, ker_lens, options.str());
-                    entry.prog = new Program(prog);
-                    entry.ker  = new Kernel[2];
-                    entry.ker[0] = Kernel(*entry.prog, "csrmv_thread");
-                    entry.ker[1] = Kernel(*entry.prog, "csrmv_block");
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
+                if (std::is_same<T, cfloat>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D IS_CPLX=1";
                 } else {
-                    entry = idx->second;
+                    options << " -D IS_CPLX=0";
                 }
 
-                int count = 0;
-                cl::Buffer *counter = bufferAlloc(sizeof(int));
-                getQueue().enqueueWriteBuffer(*counter, CL_TRUE,
-                                              0,
-                                              sizeof(int),
-                                              (void *)&count);
+                const char *ker_strs[] = {csrmv_cl};
+                const int   ker_lens[] = {csrmv_cl_len};
 
-                // TODO: Figure out the proper way to choose either csrmv_thread or csrmv_block
-                bool is_csrmv_block = true;
-                auto csrmv_kernel = is_csrmv_block ? entry.ker[1] : entry.ker[0];
-                auto csrmv_func = KernelFunctor<Buffer,
-                                                Buffer, Buffer, Buffer,
-                                                int,
-                                                Buffer, KParam, T, T, Buffer>(csrmv_kernel);
-
-                NDRange local(is_csrmv_block ? threads : THREADS_PER_GROUP, 1);
-                int M = rowIdx.info.dims[0] - 1;
-
-                int groups_x = is_csrmv_block ? divup(M, REPEAT) : divup(M, REPEAT * local[0]);
-                groups_x = std::min(groups_x, MAX_CSRMV_GROUPS);
-                NDRange global(local[0] * groups_x, 1);
-
-                csrmv_func(EnqueueArgs(getQueue(), global, local),
-                           *out.data, *values.data, *rowIdx.data, *colIdx.data,
-                           M, *rhs.data, rhs.info, alpha, beta, *counter);
-
-                CL_DEBUG_FINISH(getQueue());
-                bufferFree(counter);
-            } catch (cl::Error &ex) {
-                CL_TO_AF_ERROR(ex);
+                Program prog;
+                buildProgram(prog, 1, ker_strs, ker_lens, options.str());
+                entry.prog = new Program(prog);
+                entry.ker  = new Kernel[2];
+                entry.ker[0] = Kernel(*entry.prog, "csrmv_thread");
+                entry.ker[1] = Kernel(*entry.prog, "csrmv_block");
+            } else {
+                entry = idx->second;
             }
+
+            int count = 0;
+            cl::Buffer *counter = bufferAlloc(sizeof(int));
+            getQueue().enqueueWriteBuffer(*counter, CL_TRUE,
+                                          0,
+                                          sizeof(int),
+                                          (void *)&count);
+
+            // TODO: Figure out the proper way to choose either csrmv_thread or csrmv_block
+            bool is_csrmv_block = true;
+            auto csrmv_kernel = is_csrmv_block ? entry.ker[1] : entry.ker[0];
+            auto csrmv_func = KernelFunctor<Buffer,
+                                            Buffer, Buffer, Buffer,
+                                            int,
+                                            Buffer, KParam, T, T, Buffer>(csrmv_kernel);
+
+            NDRange local(is_csrmv_block ? threads : THREADS_PER_GROUP, 1);
+            int M = rowIdx.info.dims[0] - 1;
+
+            int groups_x = is_csrmv_block ? divup(M, REPEAT) : divup(M, REPEAT * local[0]);
+            groups_x = std::min(groups_x, MAX_CSRMV_GROUPS);
+            NDRange global(local[0] * groups_x, 1);
+
+            csrmv_func(EnqueueArgs(getQueue(), global, local),
+                        *out.data, *values.data, *rowIdx.data, *colIdx.data,
+                        M, *rhs.data, rhs.info, alpha, beta, *counter);
+
+            CL_DEBUG_FINISH(getQueue());
+            bufferFree(counter);
         }
     }
 }

--- a/src/backend/opencl/kernel/diagonal.hpp
+++ b/src/backend/opencl/kernel/diagonal.hpp
@@ -37,89 +37,80 @@ namespace kernel
     template<typename T>
     static void diagCreate(Param out, Param in, int num)
     {
-        try {
-            static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-            static std::map<int, Program*>   diagCreateProgs;
-            static std::map<int, Kernel*>  diagCreateKernels;
+        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+        static std::map<int, Program*>   diagCreateProgs;
+        static std::map<int, Kernel*>  diagCreateKernels;
 
-            int device = getActiveDeviceId();
+        int device = getActiveDeviceId();
 
-            std::call_once( compileFlags[device], [device] () {
-                    std::ostringstream options;
-                    options << " -D T="    << dtype_traits<T>::getName()
-                            << " -D ZERO=(T)(" << scalar_to_option(scalar<T>(0)) << ")";
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-                    Program prog;
-                    buildProgram(prog, diag_create_cl, diag_create_cl_len, options.str());
-                    diagCreateProgs[device]   = new Program(prog);
-                    diagCreateKernels[device] = new Kernel(*diagCreateProgs[device],
-                                                           "diagCreateKernel");
-                });
+        std::call_once( compileFlags[device], [device] () {
+                std::ostringstream options;
+                options << " -D T="    << dtype_traits<T>::getName()
+                        << " -D ZERO=(T)(" << scalar_to_option(scalar<T>(0)) << ")";
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
+                Program prog;
+                buildProgram(prog, diag_create_cl, diag_create_cl_len, options.str());
+                diagCreateProgs[device]   = new Program(prog);
+                diagCreateKernels[device] = new Kernel(*diagCreateProgs[device],
+                                                        "diagCreateKernel");
+            });
 
-            NDRange local(32, 8);
-            int groups_x = divup(out.info.dims[0], local[0]);
-            int groups_y = divup(out.info.dims[1], local[1]);
-            NDRange global(groups_x * local[0] * out.info.dims[2],
-                           groups_y * local[1]);
+        NDRange local(32, 8);
+        int groups_x = divup(out.info.dims[0], local[0]);
+        int groups_y = divup(out.info.dims[1], local[1]);
+        NDRange global(groups_x * local[0] * out.info.dims[2],
+                        groups_y * local[1]);
 
-            auto diagCreateOp = KernelFunctor<Buffer, const KParam,
-                                            Buffer, const KParam,
-                                            int, int> (*diagCreateKernels[device]);
+        auto diagCreateOp = KernelFunctor<Buffer, const KParam,
+                                        Buffer, const KParam,
+                                        int, int> (*diagCreateKernels[device]);
 
-            diagCreateOp(EnqueueArgs(getQueue(), global, local),
-                         *(out.data), out.info, *(in.data), in.info, num, groups_x);
-            CL_DEBUG_FINISH(getQueue());
-
-        } catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
-        }
+        diagCreateOp(EnqueueArgs(getQueue(), global, local),
+                      *(out.data), out.info, *(in.data), in.info, num, groups_x);
+        CL_DEBUG_FINISH(getQueue());
     }
 
     template<typename T>
     static void diagExtract(Param out, Param in, int num)
     {
-        try {
-            static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-            static std::map<int, Program*>   diagExtractProgs;
-            static std::map<int, Kernel*>  diagExtractKernels;
+        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+        static std::map<int, Program*>   diagExtractProgs;
+        static std::map<int, Kernel*>  diagExtractKernels;
 
-            int device = getActiveDeviceId();
+        int device = getActiveDeviceId();
 
-            std::call_once( compileFlags[device], [device] () {
-                    std::ostringstream options;
-                    options << " -D T="    << dtype_traits<T>::getName()
-                            << " -D ZERO=(T)(" << scalar_to_option(scalar<T>(0)) << ")";
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-                    Program prog;
-                    buildProgram(prog, diag_extract_cl, diag_extract_cl_len, options.str());
-                    diagExtractProgs[device]   = new Program(prog);
-                    diagExtractKernels[device] = new Kernel(*diagExtractProgs[device],
-                                                           "diagExtractKernel");
-                });
+        std::call_once( compileFlags[device], [device] () {
+                std::ostringstream options;
+                options << " -D T="    << dtype_traits<T>::getName()
+                        << " -D ZERO=(T)(" << scalar_to_option(scalar<T>(0)) << ")";
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
+                Program prog;
+                buildProgram(prog, diag_extract_cl, diag_extract_cl_len, options.str());
+                diagExtractProgs[device]   = new Program(prog);
+                diagExtractKernels[device] = new Kernel(*diagExtractProgs[device],
+                                                        "diagExtractKernel");
+            });
 
-            NDRange local(256, 1);
-            int groups_x = divup(out.info.dims[0], local[0]);
-            int groups_z = out.info.dims[2];
-            NDRange global(groups_x * local[0],
-                           groups_z * local[1] * out.info.dims[3]);
+        NDRange local(256, 1);
+        int groups_x = divup(out.info.dims[0], local[0]);
+        int groups_z = out.info.dims[2];
+        NDRange global(groups_x * local[0],
+                        groups_z * local[1] * out.info.dims[3]);
 
-            auto diagExtractOp = KernelFunctor<Buffer, const KParam,
-                                             Buffer, const KParam,
-                                             int, int> (*diagExtractKernels[device]);
+        auto diagExtractOp = KernelFunctor<Buffer, const KParam,
+                                          Buffer, const KParam,
+                                          int, int> (*diagExtractKernels[device]);
 
-            diagExtractOp(EnqueueArgs(getQueue(), global, local),
-                          *(out.data), out.info, *(in.data), in.info, num, groups_z);
-            CL_DEBUG_FINISH(getQueue());
+        diagExtractOp(EnqueueArgs(getQueue(), global, local),
+                      *(out.data), out.info, *(in.data), in.info, num, groups_z);
+        CL_DEBUG_FINISH(getQueue());
 
-        } catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
-        }
     }
 
 }

--- a/src/backend/opencl/kernel/diff.hpp
+++ b/src/backend/opencl/kernel/diff.hpp
@@ -36,55 +36,50 @@ namespace opencl
         template<typename T, unsigned dim, bool isDiff2>
         void diff(Param out, const Param in, const unsigned indims)
         {
-            try {
-                static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-                static std::map<int, Program*>   diffProgs;
-                static std::map<int, Kernel*>  diffKernels;
+            static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+            static std::map<int, Program*>   diffProgs;
+            static std::map<int, Kernel*>  diffKernels;
 
-                int device = getActiveDeviceId();
+            int device = getActiveDeviceId();
 
-                std::call_once( compileFlags[device], [device] () {
-                    std::ostringstream options;
-                    options << " -D T="        << dtype_traits<T>::getName()
-                            << " -D DIM="      << dim
-                            << " -D isDiff2=" << isDiff2;
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-                    Program prog;
-                    buildProgram(prog, diff_cl, diff_cl_len, options.str());
-                    diffProgs[device]   = new Program(prog);
-                    diffKernels[device] = new Kernel(*diffProgs[device], "diff_kernel");
-                });
-
-                auto diffOp = KernelFunctor<Buffer, const Buffer, const KParam, const KParam,
-                                          const int, const int, const int>
-                                          (*diffKernels[device]);
-
-                NDRange local(TX, TY, 1);
-                if(dim == 0 && indims == 1) {
-                    local = NDRange(TX * TY, 1, 1);
+            std::call_once( compileFlags[device], [device] () {
+                std::ostringstream options;
+                options << " -D T="        << dtype_traits<T>::getName()
+                        << " -D DIM="      << dim
+                        << " -D isDiff2=" << isDiff2;
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
                 }
+                Program prog;
+                buildProgram(prog, diff_cl, diff_cl_len, options.str());
+                diffProgs[device]   = new Program(prog);
+                diffKernels[device] = new Kernel(*diffProgs[device], "diff_kernel");
+            });
 
-                int blocksPerMatX = divup(out.info.dims[0], local[0]);
-                int blocksPerMatY = divup(out.info.dims[1], local[1]);
-                NDRange global(local[0] * blocksPerMatX * out.info.dims[2],
-                               local[1] * blocksPerMatY * out.info.dims[3],
-                               1);
+            auto diffOp = KernelFunctor<Buffer, const Buffer, const KParam, const KParam,
+                                      const int, const int, const int>
+                                      (*diffKernels[device]);
 
-                const int oElem = out.info.dims[0] * out.info.dims[1]
-                                     * out.info.dims[2] * out.info.dims[3];
-
-                diffOp(EnqueueArgs(getQueue(), global, local),
-                       *out.data, *in.data, out.info, in.info,
-                       oElem, blocksPerMatX, blocksPerMatY);
-
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
+            NDRange local(TX, TY, 1);
+            if(dim == 0 && indims == 1) {
+                local = NDRange(TX * TY, 1, 1);
             }
+
+            int blocksPerMatX = divup(out.info.dims[0], local[0]);
+            int blocksPerMatY = divup(out.info.dims[1], local[1]);
+            NDRange global(local[0] * blocksPerMatX * out.info.dims[2],
+                            local[1] * blocksPerMatY * out.info.dims[3],
+                            1);
+
+            const int oElem = out.info.dims[0] * out.info.dims[1]
+                                  * out.info.dims[2] * out.info.dims[3];
+
+            diffOp(EnqueueArgs(getQueue(), global, local),
+                    *out.data, *in.data, out.info, in.info,
+                    oElem, blocksPerMatX, blocksPerMatY);
+
+            CL_DEBUG_FINISH(getQueue());
         }
     }
 }

--- a/src/backend/opencl/kernel/exampleFunction.hpp
+++ b/src/backend/opencl/kernel/exampleFunction.hpp
@@ -53,72 +53,67 @@ static const int THREADS_Y = 16;
 template<typename T>
 void exampleFunc(Param c, const Param a, const Param b, const af_someenum_t p)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*>  egProgs;
-        static std::map<int, Kernel*> egKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*>  egProgs;
+    static std::map<int, Kernel*> egKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        // std::call_once is used to ensure OpenCL kernels
-        // are compiled only once for any given device and combination
-        // of template parameters to this kernel wrapper function 'exampleFunc<T>'
-        std::call_once( compileFlags[device], [device] () {
+    // std::call_once is used to ensure OpenCL kernels
+    // are compiled only once for any given device and combination
+    // of template parameters to this kernel wrapper function 'exampleFunc<T>'
+    std::call_once( compileFlags[device], [device] () {
 
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName();
-                // You can pass any template parameters as compile options
-                // to kernel the compilation step. This is equivalent of
-                // having templated kernels in CUDA
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName();
+            // You can pass any template parameters as compile options
+            // to kernel the compilation step. This is equivalent of
+            // having templated kernels in CUDA
 
-                // The following option is passed to kernel compilation
-                // if template parameter T is double or complex double
-                // to enable FP64 extension
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
+            // The following option is passed to kernel compilation
+            // if template parameter T is double or complex double
+            // to enable FP64 extension
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
+            }
 
-                Program prog;
-                // below helper function 'buildProgram' uses the option string
-                // we just created and compiles the kernel string
-                // 'example_cl' which was created by our opencl kernel code obfuscation
-                // stage
-                buildProgram(prog, example_cl, example_cl_len, options.str());
+            Program prog;
+            // below helper function 'buildProgram' uses the option string
+            // we just created and compiles the kernel string
+            // 'example_cl' which was created by our opencl kernel code obfuscation
+            // stage
+            buildProgram(prog, example_cl, example_cl_len, options.str());
 
-                // create a cl::Program object on heap
-                egProgs[device]   = new Program(prog);
+            // create a cl::Program object on heap
+            egProgs[device]   = new Program(prog);
 
-                // create a cl::Kernel object on heap
-                egKernels[device] = new Kernel(*egProgs[device], "example");
-            });
+            // create a cl::Kernel object on heap
+            egKernels[device] = new Kernel(*egProgs[device], "example");
+        });
 
-        // configure work group parameters
-        NDRange local(THREADS_X, THREADS_Y);
+    // configure work group parameters
+    NDRange local(THREADS_X, THREADS_Y);
 
-        int blk_x = divup(c.info.dims[0], THREADS_X);
-        int blk_y = divup(c.info.dims[1], THREADS_Y);
+    int blk_x = divup(c.info.dims[0], THREADS_X);
+    int blk_y = divup(c.info.dims[1], THREADS_Y);
 
-        // configure global launch parameters
-        NDRange global(blk_x * THREADS_X, blk_y * THREADS_Y);
+    // configure global launch parameters
+    NDRange global(blk_x * THREADS_X, blk_y * THREADS_Y);
 
-        // create a kernel functor from the cl::Kernel object
-        // corresponding to the device on which current execution
-        // is happending.
-        auto exampleFuncOp = KernelFunctor<Buffer, KParam, Buffer, KParam,
-                                           Buffer, KParam, int>(*egKernels[device]);
+    // create a kernel functor from the cl::Kernel object
+    // corresponding to the device on which current execution
+    // is happending.
+    auto exampleFuncOp = KernelFunctor<Buffer, KParam, Buffer, KParam,
+                                        Buffer, KParam, int>(*egKernels[device]);
 
-        // launch the kernel
-        exampleFuncOp(EnqueueArgs(getQueue(), global, local),
-                    *c.data, c.info, *a.data, a.info, *b.data, b.info, (int)p);
+    // launch the kernel
+    exampleFuncOp(EnqueueArgs(getQueue(), global, local),
+                *c.data, c.info, *a.data, a.info, *b.data, b.info, (int)p);
 
-        // Below Macro activates validations ONLY in DEBUG
-        // mode as its name indicates
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) { // Catch all cl::Errors and convert them
-                              // to appropriate ArrayFire error codes
-        CL_TO_AF_ERROR(err);
-    }
+    // Below Macro activates validations ONLY in DEBUG
+    // mode as its name indicates
+    CL_DEBUG_FINISH(getQueue());
 }
 
 }

--- a/src/backend/opencl/kernel/fast.hpp
+++ b/src/backend/opencl/kernel/fast.hpp
@@ -47,145 +47,140 @@ void fast(const unsigned arc_length,
           const float feature_ratio,
           const unsigned edge)
 {
-    try {
-        std::string ref_name =
-            std::string("fast_") +
-            std::to_string(arc_length) +
-            std::string("_") +
-            std::to_string(nonmax) +
-            std::string("_") +
-            std::string(dtype_traits<T>::getName());
+    std::string ref_name =
+        std::string("fast_") +
+        std::to_string(arc_length) +
+        std::string("_") +
+        std::to_string(nonmax) +
+        std::string("_") +
+        std::string(dtype_traits<T>::getName());
 
-        int device = getActiveDeviceId();
-        kc_t::iterator cache_idx = kernelCaches[device].find(ref_name);
+    int device = getActiveDeviceId();
+    kc_t::iterator cache_idx = kernelCaches[device].find(ref_name);
 
-        kc_entry_t entry;
-        if (cache_idx == kernelCaches[device].end()) {
+    kc_entry_t entry;
+    if (cache_idx == kernelCaches[device].end()) {
 
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName()
-                        << " -D ARC_LENGTH=" << arc_length
-                        << " -D NONMAX=" << static_cast<unsigned>(nonmax);
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName()
+                    << " -D ARC_LENGTH=" << arc_length
+                    << " -D NONMAX=" << static_cast<unsigned>(nonmax);
 
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
+            }
 
-                cl::Program prog;
-                buildProgram(prog, fast_cl, fast_cl_len, options.str());
-                entry.prog = new Program(prog);
-                entry.ker = new Kernel[3];
+            cl::Program prog;
+            buildProgram(prog, fast_cl, fast_cl_len, options.str());
+            entry.prog = new Program(prog);
+            entry.ker = new Kernel[3];
 
-                entry.ker[0] = Kernel(*entry.prog, "locate_features");
-                entry.ker[1] = Kernel(*entry.prog, "non_max_counts");
-                entry.ker[2] = Kernel(*entry.prog, "get_features");
+            entry.ker[0] = Kernel(*entry.prog, "locate_features");
+            entry.ker[1] = Kernel(*entry.prog, "non_max_counts");
+            entry.ker[2] = Kernel(*entry.prog, "get_features");
 
-                kernelCaches[device][ref_name] = entry;
-        } else {
-            entry = cache_idx -> second;
-        }
-
-        const unsigned max_feat = ceil(in.info.dims[0] * in.info.dims[1] * feature_ratio);
-
-        // Matrix containing scores for detected features, scores are stored in the
-        // same coordinates as features, dimensions should be equal to in.
-        cl::Buffer *d_score = bufferAlloc(in.info.dims[0] * in.info.dims[1] * sizeof(float));
-        std::vector<float> score_init(in.info.dims[0] * in.info.dims[1], (float)0);
-        getQueue().enqueueWriteBuffer(*d_score, CL_TRUE, 0, in.info.dims[0] * in.info.dims[1] * sizeof(float), &score_init[0]);
-
-        cl::Buffer *d_flags = d_score;
-        if (nonmax) {
-            d_flags = bufferAlloc(in.info.dims[0] * in.info.dims[1] * sizeof(float));
-        }
-
-        const int blk_x = divup(in.info.dims[0]-edge*2, FAST_THREADS_X);
-        const int blk_y = divup(in.info.dims[1]-edge*2, FAST_THREADS_Y);
-
-        // Locate features kernel sizes
-        const NDRange local(FAST_THREADS_X, FAST_THREADS_Y);
-        const NDRange global(blk_x * FAST_THREADS_X, blk_y * FAST_THREADS_Y);
-
-        auto lfOp = KernelFunctor<Buffer, KParam,
-                                Buffer, const float, const unsigned,
-                                LocalSpaceArg> (entry.ker[0]);
-
-        lfOp(EnqueueArgs(getQueue(), global, local),
-             *in.data, in.info, *d_score, thr, edge,
-             cl::Local((FAST_THREADS_X + 6) * (FAST_THREADS_Y + 6) * sizeof(T)));
-        CL_DEBUG_FINISH(getQueue());
-
-        const int blk_nonmax_x = divup(in.info.dims[0], 64);
-        const int blk_nonmax_y = divup(in.info.dims[1], 64);
-
-        // Nonmax kernel sizes
-        const NDRange local_nonmax(FAST_THREADS_NONMAX_X, FAST_THREADS_NONMAX_Y);
-        const NDRange global_nonmax(blk_nonmax_x * FAST_THREADS_NONMAX_X, blk_nonmax_y * FAST_THREADS_NONMAX_Y);
-
-        unsigned count_init = 0;
-        cl::Buffer *d_total = bufferAlloc(sizeof(unsigned));
-        getQueue().enqueueWriteBuffer(*d_total, CL_TRUE, 0, sizeof(unsigned), &count_init);
-
-        //size_t *global_nonmax_dims = global_nonmax();
-        size_t blocks_sz = blk_nonmax_x * FAST_THREADS_NONMAX_X * blk_nonmax_y * FAST_THREADS_NONMAX_Y * sizeof(unsigned);
-        cl::Buffer *d_counts  = bufferAlloc(blocks_sz);
-        cl::Buffer *d_offsets = bufferAlloc(blocks_sz);
-
-        auto nmOp = KernelFunctor<Buffer, Buffer, Buffer,
-                                Buffer, Buffer,
-                                KParam, const unsigned> (entry.ker[1]);
-        nmOp(EnqueueArgs(getQueue(), global_nonmax, local_nonmax),
-                         *d_counts, *d_offsets, *d_total, *d_flags, *d_score, in.info, edge);
-        CL_DEBUG_FINISH(getQueue());
-
-        unsigned total;
-        getQueue().enqueueReadBuffer(*d_total, CL_TRUE, 0, sizeof(unsigned), &total);
-        total = total < max_feat ? total : max_feat;
-
-        if (total > 0) {
-            size_t out_sz = total * sizeof(float);
-            x_out.data = bufferAlloc(out_sz);
-            y_out.data = bufferAlloc(out_sz);
-            score_out.data = bufferAlloc(out_sz);
-
-            auto gfOp = KernelFunctor<Buffer, Buffer, Buffer,
-                                    Buffer, Buffer, Buffer,
-                                    KParam, const unsigned,
-                                    const unsigned> (entry.ker[2]);
-            gfOp(EnqueueArgs(getQueue(), global_nonmax, local_nonmax),
-                             *x_out.data, *y_out.data, *score_out.data,
-                             *d_flags, *d_counts, *d_offsets,
-                             in.info, total, edge);
-            CL_DEBUG_FINISH(getQueue());
-        }
-
-        *out_feat = total;
-
-        x_out.info.dims[0] = total;
-        x_out.info.strides[0] = 1;
-        y_out.info.dims[0] = total;
-        y_out.info.strides[0] = 1;
-        score_out.info.dims[0] = total;
-        score_out.info.strides[0] = 1;
-
-        for (int k = 1; k < 4; k++) {
-            x_out.info.dims[k] = 1;
-            x_out.info.strides[k] = total;
-            y_out.info.dims[k] = 1;
-            y_out.info.strides[k] = total;
-            score_out.info.dims[k] = 1;
-            score_out.info.strides[k] = total;
-        }
-
-        bufferFree(d_score);
-        if (nonmax) bufferFree(d_flags);
-        bufferFree(d_total);
-        bufferFree(d_counts);
-        bufferFree(d_offsets);
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
+            kernelCaches[device][ref_name] = entry;
+    } else {
+        entry = cache_idx -> second;
     }
+
+    const unsigned max_feat = ceil(in.info.dims[0] * in.info.dims[1] * feature_ratio);
+
+    // Matrix containing scores for detected features, scores are stored in the
+    // same coordinates as features, dimensions should be equal to in.
+    cl::Buffer *d_score = bufferAlloc(in.info.dims[0] * in.info.dims[1] * sizeof(float));
+    std::vector<float> score_init(in.info.dims[0] * in.info.dims[1], (float)0);
+    getQueue().enqueueWriteBuffer(*d_score, CL_TRUE, 0, in.info.dims[0] * in.info.dims[1] * sizeof(float), &score_init[0]);
+
+    cl::Buffer *d_flags = d_score;
+    if (nonmax) {
+        d_flags = bufferAlloc(in.info.dims[0] * in.info.dims[1] * sizeof(float));
+    }
+
+    const int blk_x = divup(in.info.dims[0]-edge*2, FAST_THREADS_X);
+    const int blk_y = divup(in.info.dims[1]-edge*2, FAST_THREADS_Y);
+
+    // Locate features kernel sizes
+    const NDRange local(FAST_THREADS_X, FAST_THREADS_Y);
+    const NDRange global(blk_x * FAST_THREADS_X, blk_y * FAST_THREADS_Y);
+
+    auto lfOp = KernelFunctor<Buffer, KParam,
+                            Buffer, const float, const unsigned,
+                            LocalSpaceArg> (entry.ker[0]);
+
+    lfOp(EnqueueArgs(getQueue(), global, local),
+          *in.data, in.info, *d_score, thr, edge,
+          cl::Local((FAST_THREADS_X + 6) * (FAST_THREADS_Y + 6) * sizeof(T)));
+    CL_DEBUG_FINISH(getQueue());
+
+    const int blk_nonmax_x = divup(in.info.dims[0], 64);
+    const int blk_nonmax_y = divup(in.info.dims[1], 64);
+
+    // Nonmax kernel sizes
+    const NDRange local_nonmax(FAST_THREADS_NONMAX_X, FAST_THREADS_NONMAX_Y);
+    const NDRange global_nonmax(blk_nonmax_x * FAST_THREADS_NONMAX_X, blk_nonmax_y * FAST_THREADS_NONMAX_Y);
+
+    unsigned count_init = 0;
+    cl::Buffer *d_total = bufferAlloc(sizeof(unsigned));
+    getQueue().enqueueWriteBuffer(*d_total, CL_TRUE, 0, sizeof(unsigned), &count_init);
+
+    //size_t *global_nonmax_dims = global_nonmax();
+    size_t blocks_sz = blk_nonmax_x * FAST_THREADS_NONMAX_X * blk_nonmax_y * FAST_THREADS_NONMAX_Y * sizeof(unsigned);
+    cl::Buffer *d_counts  = bufferAlloc(blocks_sz);
+    cl::Buffer *d_offsets = bufferAlloc(blocks_sz);
+
+    auto nmOp = KernelFunctor<Buffer, Buffer, Buffer,
+                            Buffer, Buffer,
+                            KParam, const unsigned> (entry.ker[1]);
+    nmOp(EnqueueArgs(getQueue(), global_nonmax, local_nonmax),
+                      *d_counts, *d_offsets, *d_total, *d_flags, *d_score, in.info, edge);
+    CL_DEBUG_FINISH(getQueue());
+
+    unsigned total;
+    getQueue().enqueueReadBuffer(*d_total, CL_TRUE, 0, sizeof(unsigned), &total);
+    total = total < max_feat ? total : max_feat;
+
+    if (total > 0) {
+        size_t out_sz = total * sizeof(float);
+        x_out.data = bufferAlloc(out_sz);
+        y_out.data = bufferAlloc(out_sz);
+        score_out.data = bufferAlloc(out_sz);
+
+        auto gfOp = KernelFunctor<Buffer, Buffer, Buffer,
+                                Buffer, Buffer, Buffer,
+                                KParam, const unsigned,
+                                const unsigned> (entry.ker[2]);
+        gfOp(EnqueueArgs(getQueue(), global_nonmax, local_nonmax),
+                          *x_out.data, *y_out.data, *score_out.data,
+                          *d_flags, *d_counts, *d_offsets,
+                          in.info, total, edge);
+        CL_DEBUG_FINISH(getQueue());
+    }
+
+    *out_feat = total;
+
+    x_out.info.dims[0] = total;
+    x_out.info.strides[0] = 1;
+    y_out.info.dims[0] = total;
+    y_out.info.strides[0] = 1;
+    score_out.info.dims[0] = total;
+    score_out.info.strides[0] = 1;
+
+    for (int k = 1; k < 4; k++) {
+        x_out.info.dims[k] = 1;
+        x_out.info.strides[k] = total;
+        y_out.info.dims[k] = 1;
+        y_out.info.strides[k] = total;
+        score_out.info.dims[k] = 1;
+        score_out.info.strides[k] = total;
+    }
+
+    bufferFree(d_score);
+    if (nonmax) bufferFree(d_flags);
+    bufferFree(d_total);
+    bufferFree(d_counts);
+    bufferFree(d_offsets);
 }
 
 template<typename T>

--- a/src/backend/opencl/kernel/gradient.hpp
+++ b/src/backend/opencl/kernel/gradient.hpp
@@ -40,58 +40,53 @@ namespace opencl
         template<typename T>
         void gradient(Param grad0, Param grad1, const Param in)
         {
-            try {
-                static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-                static std::map<int, Program*>  gradProgs;
-                static std::map<int, Kernel*> gradKernels;
+            static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+            static std::map<int, Program*>  gradProgs;
+            static std::map<int, Kernel*> gradKernels;
 
-                int device = getActiveDeviceId();
+            int device = getActiveDeviceId();
 
-                std::call_once( compileFlags[device], [device] () {
-                    ToNumStr<T> toNumStr;
-                    std::ostringstream options;
-                    options << " -D T=" << dtype_traits<T>::getName()
-                            << " -D TX=" << TX
-                            << " -D TY=" << TY
-                            << " -D ZERO=" << toNumStr(scalar<T>(0));
+            std::call_once( compileFlags[device], [device] () {
+                ToNumStr<T> toNumStr;
+                std::ostringstream options;
+                options << " -D T=" << dtype_traits<T>::getName()
+                        << " -D TX=" << TX
+                        << " -D TY=" << TY
+                        << " -D ZERO=" << toNumStr(scalar<T>(0));
 
-                    if((af_dtype) dtype_traits<T>::af_type == c32 ||
-                       (af_dtype) dtype_traits<T>::af_type == c64) {
-                        options << " -D CPLX=1";
-                    } else {
-                        options << " -D CPLX=0";
-                    }
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-                    Program prog;
-                    buildProgram(prog, gradient_cl, gradient_cl_len, options.str());
-                    gradProgs[device]   = new Program(prog);
-                    gradKernels[device] = new Kernel(*gradProgs[device], "gradient_kernel");
-                });
+                if((af_dtype) dtype_traits<T>::af_type == c32 ||
+                    (af_dtype) dtype_traits<T>::af_type == c64) {
+                    options << " -D CPLX=1";
+                } else {
+                    options << " -D CPLX=0";
+                }
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
+                Program prog;
+                buildProgram(prog, gradient_cl, gradient_cl_len, options.str());
+                gradProgs[device]   = new Program(prog);
+                gradKernels[device] = new Kernel(*gradProgs[device], "gradient_kernel");
+            });
 
-                auto gradOp = KernelFunctor<Buffer, const KParam, Buffer, const KParam,
-                                    const Buffer, const KParam, const int, const int>
-                                        (*gradKernels[device]);
+            auto gradOp = KernelFunctor<Buffer, const KParam, Buffer, const KParam,
+                                const Buffer, const KParam, const int, const int>
+                                    (*gradKernels[device]);
 
-                NDRange local(TX, TY, 1);
+            NDRange local(TX, TY, 1);
 
-                int blocksPerMatX = divup(in.info.dims[0], TX);
-                int blocksPerMatY = divup(in.info.dims[1], TY);
-                NDRange global(local[0] * blocksPerMatX * in.info.dims[2],
-                               local[1] * blocksPerMatY * in.info.dims[3],
-                               1);
+            int blocksPerMatX = divup(in.info.dims[0], TX);
+            int blocksPerMatY = divup(in.info.dims[1], TY);
+            NDRange global(local[0] * blocksPerMatX * in.info.dims[2],
+                            local[1] * blocksPerMatY * in.info.dims[3],
+                            1);
 
-                gradOp(EnqueueArgs(getQueue(), global, local),
-                        *grad0.data, grad0.info, *grad1.data, grad1.info,
-                        *in.data, in.info, blocksPerMatX, blocksPerMatY);
+            gradOp(EnqueueArgs(getQueue(), global, local),
+                    *grad0.data, grad0.info, *grad1.data, grad1.info,
+                    *in.data, in.info, blocksPerMatX, blocksPerMatY);
 
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
-            }
+            CL_DEBUG_FINISH(getQueue());
         }
     }
 }

--- a/src/backend/opencl/kernel/harris.hpp
+++ b/src/backend/opencl/kernel/harris.hpp
@@ -97,246 +97,241 @@ void harris(unsigned* corners_out,
             const unsigned filter_len,
             const float k_thr)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*> harrisProgs;
-        static std::map<int, Kernel*>  soKernel;
-        static std::map<int, Kernel*>  kcKernel;
-        static std::map<int, Kernel*>  hrKernel;
-        static std::map<int, Kernel*>  nmKernel;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*> harrisProgs;
+    static std::map<int, Kernel*>  soKernel;
+    static std::map<int, Kernel*>  kcKernel;
+    static std::map<int, Kernel*>  hrKernel;
+    static std::map<int, Kernel*>  nmKernel;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
+    std::call_once( compileFlags[device], [device] () {
 
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName();
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName();
 
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
-
-                cl::Program prog;
-                buildProgram(prog, harris_cl, harris_cl_len, options.str());
-                harrisProgs[device] = new Program(prog);
-
-                soKernel[device] = new Kernel(*harrisProgs[device], "second_order_deriv");
-                kcKernel[device] = new Kernel(*harrisProgs[device], "keep_corners");
-                hrKernel[device] = new Kernel(*harrisProgs[device], "harris_responses");
-                nmKernel[device] = new Kernel(*harrisProgs[device], "non_maximal");
-            });
-
-        // Window filter
-        convAccT* h_filter = new convAccT[filter_len];
-        // Decide between rectangular or circular filter
-        if (sigma < 0.5f) {
-            for (unsigned i = 0; i < filter_len; i++)
-                h_filter[i] = (T)1.f / (filter_len);
-        }
-        else {
-            gaussian1D<convAccT>(h_filter, (int)filter_len, sigma);
-        }
-
-        const unsigned border_len = filter_len / 2 + 1;
-
-        // Copy filter to device object
-        Param filter;
-        filter.info.dims[0] = filter_len;
-        filter.info.strides[0] = 1;
-        filter.info.offset = 0;
-
-        for (int k = 1; k < 4; k++) {
-            filter.info.dims[k] = 1;
-            filter.info.strides[k] = filter.info.dims[k - 1] * filter.info.strides[k - 1];
-        }
-
-        int filter_elem = filter.info.strides[3] * filter.info.dims[3];
-        filter.data = bufferAlloc(filter_elem * sizeof(convAccT));
-        getQueue().enqueueWriteBuffer(*filter.data, CL_TRUE, 0, filter_elem * sizeof(convAccT), h_filter);
-
-        Param ix, iy;
-        ix.info.offset = iy.info.offset = 0;
-        for (dim_t i = 0; i < 4; i++) {
-            ix.info.dims[i] = iy.info.dims[i] = in.info.dims[i];
-            ix.info.strides[i] = iy.info.strides[i] = in.info.strides[i];
-        }
-        ix.data = bufferAlloc(ix.info.dims[3] * ix.info.strides[3] * sizeof(T));
-        iy.data = bufferAlloc(iy.info.dims[3] * iy.info.strides[3] * sizeof(T));
-
-        // Compute first-order derivatives as gradients
-        gradient<T>(iy, ix, in);
-
-        Param ixx, ixy, iyy;
-        ixx.info.offset = ixy.info.offset = iyy.info.offset = 0;
-        for (dim_t i = 0; i < 4; i++) {
-            ixx.info.dims[i] = ixy.info.dims[i] = iyy.info.dims[i] = in.info.dims[i];
-            ixx.info.strides[i] = ixy.info.strides[i] = iyy.info.strides[i] = in.info.strides[i];
-        }
-        ixx.data = bufferAlloc(ixx.info.dims[3] * ixx.info.strides[3] * sizeof(T));
-        ixy.data = bufferAlloc(ixy.info.dims[3] * ixy.info.strides[3] * sizeof(T));
-        iyy.data = bufferAlloc(iyy.info.dims[3] * iyy.info.strides[3] * sizeof(T));
-
-        // Second order-derivatives kernel sizes
-        const unsigned blk_x_so = divup(in.info.dims[3] * in.info.strides[3], HARRIS_THREADS_PER_GROUP);
-        const NDRange local_so(HARRIS_THREADS_PER_GROUP, 1);
-        const NDRange global_so(blk_x_so * HARRIS_THREADS_PER_GROUP, 1);
-
-        auto soOp = KernelFunctor<Buffer, Buffer, Buffer,
-                                unsigned, Buffer, Buffer> (*soKernel[device]);
-
-        // Compute second-order derivatives
-        soOp(EnqueueArgs(getQueue(), global_so, local_so),
-             *ixx.data, *ixy.data, *iyy.data,
-             in.info.dims[3] * in.info.strides[3], *ix.data, *iy.data);
-        CL_DEBUG_FINISH(getQueue());
-
-        bufferFree(ix.data);
-        bufferFree(iy.data);
-
-        // Convolve second order derivatives with proper window filter
-        conv_helper<T, convAccT>(ixx, ixy, iyy, filter);
-        bufferFree(filter.data);
-
-        cl::Buffer *d_responses = bufferAlloc(in.info.dims[3] * in.info.strides[3] * sizeof(T));
-
-        // Harris responses kernel sizes
-        unsigned blk_x_hr = divup(in.info.dims[0] - border_len*2, HARRIS_THREADS_X);
-        unsigned blk_y_hr = divup(in.info.dims[1] - border_len*2, HARRIS_THREADS_Y);
-        const NDRange local_hr(HARRIS_THREADS_X, HARRIS_THREADS_Y);
-        const NDRange global_hr(blk_x_hr * HARRIS_THREADS_X, blk_y_hr * HARRIS_THREADS_Y);
-
-        auto hrOp = KernelFunctor<Buffer, unsigned, unsigned,
-                                Buffer, Buffer, Buffer,
-                                float, unsigned> (*hrKernel[device]);
-
-        // Calculate Harris responses for all pixels
-        hrOp(EnqueueArgs(getQueue(), global_hr, local_hr),
-             *d_responses, in.info.dims[0], in.info.dims[1],
-             *ixx.data, *ixy.data, *iyy.data, k_thr, border_len);
-        CL_DEBUG_FINISH(getQueue());
-
-        bufferFree(ixx.data);
-        bufferFree(ixy.data);
-        bufferFree(iyy.data);
-
-        // Number of corners is not known a priori, limit maximum number of corners
-        // according to image dimensions
-        unsigned corner_lim = in.info.dims[3] * in.info.strides[3] * 0.2f;
-
-        unsigned corners_found = 0;
-        cl::Buffer *d_corners_found = bufferAlloc(sizeof(unsigned));
-        getQueue().enqueueWriteBuffer(*d_corners_found, CL_TRUE, 0, sizeof(unsigned), &corners_found);
-
-        cl::Buffer *d_x_corners = bufferAlloc(corner_lim * sizeof(float));
-        cl::Buffer *d_y_corners = bufferAlloc(corner_lim * sizeof(float));
-        cl::Buffer *d_resp_corners = bufferAlloc(corner_lim * sizeof(float));
-
-        const float min_r = (max_corners > 0) ? 0.f : min_response;
-
-        auto nmOp = KernelFunctor<Buffer, Buffer, Buffer, Buffer,
-                                Buffer, unsigned, unsigned,
-                                float, unsigned, unsigned> (*nmKernel[device]);
-
-        // Perform non-maximal suppression
-        nmOp(EnqueueArgs(getQueue(), global_hr, local_hr),
-             *d_x_corners, *d_y_corners, *d_resp_corners, *d_corners_found,
-             *d_responses, in.info.dims[0], in.info.dims[1],
-             min_r, border_len, corner_lim);
-        CL_DEBUG_FINISH(getQueue());
-
-        getQueue().enqueueReadBuffer(*d_corners_found, CL_TRUE, 0, sizeof(unsigned), &corners_found);
-
-        bufferFree(d_responses);
-        bufferFree(d_corners_found);
-
-        *corners_out = (max_corners > 0) ?
-                       min(corners_found, max_corners) :
-                       min(corners_found, corner_lim);
-
-        if (*corners_out == 0)
-            return;
-
-        // Set output Param info
-        x_out.info.dims[0] = y_out.info.dims[0] = resp_out.info.dims[0] = *corners_out;
-        x_out.info.strides[0] = y_out.info.strides[0] = resp_out.info.strides[0] = 1;
-        x_out.info.offset = y_out.info.offset = resp_out.info.offset = 0;
-        for (int k = 1; k < 4; k++) {
-            x_out.info.dims[k] = y_out.info.dims[k] = resp_out.info.dims[k] =  1;
-            x_out.info.strides[k] = x_out.info.dims[k - 1] * x_out.info.strides[k - 1];
-            y_out.info.strides[k] = y_out.info.dims[k - 1] * y_out.info.strides[k - 1];
-            resp_out.info.strides[k] = resp_out.info.dims[k - 1] * resp_out.info.strides[k - 1];
-        }
-
-        if (max_corners > 0 && corners_found > *corners_out) {
-            Param harris_resp;
-            Param harris_idx;
-
-            harris_resp.info.dims[0] = harris_idx.info.dims[0] = corners_found;
-            harris_resp.info.strides[0] = harris_idx.info.strides[0] = 1;
-
-            for (int k = 1; k < 4; k++) {
-                harris_resp.info.dims[k] = 1;
-                harris_resp.info.strides[k] = harris_resp.info.dims[k - 1] * harris_resp.info.strides[k - 1];
-                harris_idx.info.dims[k] = 1;
-                harris_idx.info.strides[k] = harris_idx.info.dims[k - 1] * harris_idx.info.strides[k - 1];
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
             }
 
-            int sort_elem = harris_resp.info.strides[3] * harris_resp.info.dims[3];
-            harris_resp.data = d_resp_corners;
-            // Create indices using range
-            harris_idx.data = bufferAlloc(sort_elem * sizeof(unsigned));
-            kernel::range<uint>(harris_idx, 0);
+            cl::Program prog;
+            buildProgram(prog, harris_cl, harris_cl_len, options.str());
+            harrisProgs[device] = new Program(prog);
 
-            // Sort Harris responses
-            kernel::sort0ByKey<float, uint>(harris_resp, harris_idx, false);
+            soKernel[device] = new Kernel(*harrisProgs[device], "second_order_deriv");
+            kcKernel[device] = new Kernel(*harrisProgs[device], "keep_corners");
+            hrKernel[device] = new Kernel(*harrisProgs[device], "harris_responses");
+            nmKernel[device] = new Kernel(*harrisProgs[device], "non_maximal");
+        });
 
-            x_out.data = bufferAlloc(*corners_out * sizeof(float));
-            y_out.data = bufferAlloc(*corners_out * sizeof(float));
-            resp_out.data = bufferAlloc(*corners_out * sizeof(float));
+    // Window filter
+    convAccT* h_filter = new convAccT[filter_len];
+    // Decide between rectangular or circular filter
+    if (sigma < 0.5f) {
+        for (unsigned i = 0; i < filter_len; i++)
+            h_filter[i] = (T)1.f / (filter_len);
+    }
+    else {
+        gaussian1D<convAccT>(h_filter, (int)filter_len, sigma);
+    }
 
-            // Keep corners kernel sizes
-            const unsigned blk_x_kc = divup(*corners_out, HARRIS_THREADS_PER_GROUP);
-            const NDRange local_kc(HARRIS_THREADS_PER_GROUP, 1);
-            const NDRange global_kc(blk_x_kc * HARRIS_THREADS_PER_GROUP, 1);
+    const unsigned border_len = filter_len / 2 + 1;
 
-            auto kcOp = KernelFunctor<Buffer, Buffer, Buffer,
-                                    Buffer, Buffer, Buffer, Buffer,
-                                    unsigned> (*kcKernel[device]);
+    // Copy filter to device object
+    Param filter;
+    filter.info.dims[0] = filter_len;
+    filter.info.strides[0] = 1;
+    filter.info.offset = 0;
 
-            // Keep only the first corners_to_keep corners with higher Harris
-            // responses
-            kcOp(EnqueueArgs(getQueue(), global_kc, local_kc),
-                 *x_out.data, *y_out.data, *resp_out.data,
-                 *d_x_corners, *d_y_corners, *harris_resp.data, *harris_idx.data,
-                 *corners_out);
-            CL_DEBUG_FINISH(getQueue());
+    for (int k = 1; k < 4; k++) {
+        filter.info.dims[k] = 1;
+        filter.info.strides[k] = filter.info.dims[k - 1] * filter.info.strides[k - 1];
+    }
 
-            bufferFree(d_x_corners);
-            bufferFree(d_y_corners);
-            bufferFree(harris_resp.data);
-            bufferFree(harris_idx.data);
+    int filter_elem = filter.info.strides[3] * filter.info.dims[3];
+    filter.data = bufferAlloc(filter_elem * sizeof(convAccT));
+    getQueue().enqueueWriteBuffer(*filter.data, CL_TRUE, 0, filter_elem * sizeof(convAccT), h_filter);
+
+    Param ix, iy;
+    ix.info.offset = iy.info.offset = 0;
+    for (dim_t i = 0; i < 4; i++) {
+        ix.info.dims[i] = iy.info.dims[i] = in.info.dims[i];
+        ix.info.strides[i] = iy.info.strides[i] = in.info.strides[i];
+    }
+    ix.data = bufferAlloc(ix.info.dims[3] * ix.info.strides[3] * sizeof(T));
+    iy.data = bufferAlloc(iy.info.dims[3] * iy.info.strides[3] * sizeof(T));
+
+    // Compute first-order derivatives as gradients
+    gradient<T>(iy, ix, in);
+
+    Param ixx, ixy, iyy;
+    ixx.info.offset = ixy.info.offset = iyy.info.offset = 0;
+    for (dim_t i = 0; i < 4; i++) {
+        ixx.info.dims[i] = ixy.info.dims[i] = iyy.info.dims[i] = in.info.dims[i];
+        ixx.info.strides[i] = ixy.info.strides[i] = iyy.info.strides[i] = in.info.strides[i];
+    }
+    ixx.data = bufferAlloc(ixx.info.dims[3] * ixx.info.strides[3] * sizeof(T));
+    ixy.data = bufferAlloc(ixy.info.dims[3] * ixy.info.strides[3] * sizeof(T));
+    iyy.data = bufferAlloc(iyy.info.dims[3] * iyy.info.strides[3] * sizeof(T));
+
+    // Second order-derivatives kernel sizes
+    const unsigned blk_x_so = divup(in.info.dims[3] * in.info.strides[3], HARRIS_THREADS_PER_GROUP);
+    const NDRange local_so(HARRIS_THREADS_PER_GROUP, 1);
+    const NDRange global_so(blk_x_so * HARRIS_THREADS_PER_GROUP, 1);
+
+    auto soOp = KernelFunctor<Buffer, Buffer, Buffer,
+                            unsigned, Buffer, Buffer> (*soKernel[device]);
+
+    // Compute second-order derivatives
+    soOp(EnqueueArgs(getQueue(), global_so, local_so),
+          *ixx.data, *ixy.data, *iyy.data,
+          in.info.dims[3] * in.info.strides[3], *ix.data, *iy.data);
+    CL_DEBUG_FINISH(getQueue());
+
+    bufferFree(ix.data);
+    bufferFree(iy.data);
+
+    // Convolve second order derivatives with proper window filter
+    conv_helper<T, convAccT>(ixx, ixy, iyy, filter);
+    bufferFree(filter.data);
+
+    cl::Buffer *d_responses = bufferAlloc(in.info.dims[3] * in.info.strides[3] * sizeof(T));
+
+    // Harris responses kernel sizes
+    unsigned blk_x_hr = divup(in.info.dims[0] - border_len*2, HARRIS_THREADS_X);
+    unsigned blk_y_hr = divup(in.info.dims[1] - border_len*2, HARRIS_THREADS_Y);
+    const NDRange local_hr(HARRIS_THREADS_X, HARRIS_THREADS_Y);
+    const NDRange global_hr(blk_x_hr * HARRIS_THREADS_X, blk_y_hr * HARRIS_THREADS_Y);
+
+    auto hrOp = KernelFunctor<Buffer, unsigned, unsigned,
+                            Buffer, Buffer, Buffer,
+                            float, unsigned> (*hrKernel[device]);
+
+    // Calculate Harris responses for all pixels
+    hrOp(EnqueueArgs(getQueue(), global_hr, local_hr),
+          *d_responses, in.info.dims[0], in.info.dims[1],
+          *ixx.data, *ixy.data, *iyy.data, k_thr, border_len);
+    CL_DEBUG_FINISH(getQueue());
+
+    bufferFree(ixx.data);
+    bufferFree(ixy.data);
+    bufferFree(iyy.data);
+
+    // Number of corners is not known a priori, limit maximum number of corners
+    // according to image dimensions
+    unsigned corner_lim = in.info.dims[3] * in.info.strides[3] * 0.2f;
+
+    unsigned corners_found = 0;
+    cl::Buffer *d_corners_found = bufferAlloc(sizeof(unsigned));
+    getQueue().enqueueWriteBuffer(*d_corners_found, CL_TRUE, 0, sizeof(unsigned), &corners_found);
+
+    cl::Buffer *d_x_corners = bufferAlloc(corner_lim * sizeof(float));
+    cl::Buffer *d_y_corners = bufferAlloc(corner_lim * sizeof(float));
+    cl::Buffer *d_resp_corners = bufferAlloc(corner_lim * sizeof(float));
+
+    const float min_r = (max_corners > 0) ? 0.f : min_response;
+
+    auto nmOp = KernelFunctor<Buffer, Buffer, Buffer, Buffer,
+                            Buffer, unsigned, unsigned,
+                            float, unsigned, unsigned> (*nmKernel[device]);
+
+    // Perform non-maximal suppression
+    nmOp(EnqueueArgs(getQueue(), global_hr, local_hr),
+          *d_x_corners, *d_y_corners, *d_resp_corners, *d_corners_found,
+          *d_responses, in.info.dims[0], in.info.dims[1],
+          min_r, border_len, corner_lim);
+    CL_DEBUG_FINISH(getQueue());
+
+    getQueue().enqueueReadBuffer(*d_corners_found, CL_TRUE, 0, sizeof(unsigned), &corners_found);
+
+    bufferFree(d_responses);
+    bufferFree(d_corners_found);
+
+    *corners_out = (max_corners > 0) ?
+                    min(corners_found, max_corners) :
+                    min(corners_found, corner_lim);
+
+    if (*corners_out == 0)
+        return;
+
+    // Set output Param info
+    x_out.info.dims[0] = y_out.info.dims[0] = resp_out.info.dims[0] = *corners_out;
+    x_out.info.strides[0] = y_out.info.strides[0] = resp_out.info.strides[0] = 1;
+    x_out.info.offset = y_out.info.offset = resp_out.info.offset = 0;
+    for (int k = 1; k < 4; k++) {
+        x_out.info.dims[k] = y_out.info.dims[k] = resp_out.info.dims[k] =  1;
+        x_out.info.strides[k] = x_out.info.dims[k - 1] * x_out.info.strides[k - 1];
+        y_out.info.strides[k] = y_out.info.dims[k - 1] * y_out.info.strides[k - 1];
+        resp_out.info.strides[k] = resp_out.info.dims[k - 1] * resp_out.info.strides[k - 1];
+    }
+
+    if (max_corners > 0 && corners_found > *corners_out) {
+        Param harris_resp;
+        Param harris_idx;
+
+        harris_resp.info.dims[0] = harris_idx.info.dims[0] = corners_found;
+        harris_resp.info.strides[0] = harris_idx.info.strides[0] = 1;
+
+        for (int k = 1; k < 4; k++) {
+            harris_resp.info.dims[k] = 1;
+            harris_resp.info.strides[k] = harris_resp.info.dims[k - 1] * harris_resp.info.strides[k - 1];
+            harris_idx.info.dims[k] = 1;
+            harris_idx.info.strides[k] = harris_idx.info.dims[k - 1] * harris_idx.info.strides[k - 1];
         }
-        else if (max_corners == 0 && corners_found < corner_lim) {
-            x_out.data = bufferAlloc(*corners_out * sizeof(float));
-            y_out.data = bufferAlloc(*corners_out * sizeof(float));
-            resp_out.data = bufferAlloc(*corners_out * sizeof(float));
-            getQueue().enqueueCopyBuffer(*d_x_corners, *x_out.data, 0, 0, *corners_out * sizeof(float));
-            getQueue().enqueueCopyBuffer(*d_y_corners, *y_out.data, 0, 0, *corners_out * sizeof(float));
-            getQueue().enqueueCopyBuffer(*d_resp_corners, *resp_out.data, 0, 0, *corners_out * sizeof(float));
 
-            bufferFree(d_x_corners);
-            bufferFree(d_y_corners);
-            bufferFree(d_resp_corners);
-        }
-        else {
-            x_out.data = d_x_corners;
-            y_out.data = d_y_corners;
-            resp_out.data = d_resp_corners;
-        }
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
+        int sort_elem = harris_resp.info.strides[3] * harris_resp.info.dims[3];
+        harris_resp.data = d_resp_corners;
+        // Create indices using range
+        harris_idx.data = bufferAlloc(sort_elem * sizeof(unsigned));
+        kernel::range<uint>(harris_idx, 0);
+
+        // Sort Harris responses
+        kernel::sort0ByKey<float, uint>(harris_resp, harris_idx, false);
+
+        x_out.data = bufferAlloc(*corners_out * sizeof(float));
+        y_out.data = bufferAlloc(*corners_out * sizeof(float));
+        resp_out.data = bufferAlloc(*corners_out * sizeof(float));
+
+        // Keep corners kernel sizes
+        const unsigned blk_x_kc = divup(*corners_out, HARRIS_THREADS_PER_GROUP);
+        const NDRange local_kc(HARRIS_THREADS_PER_GROUP, 1);
+        const NDRange global_kc(blk_x_kc * HARRIS_THREADS_PER_GROUP, 1);
+
+        auto kcOp = KernelFunctor<Buffer, Buffer, Buffer,
+                                Buffer, Buffer, Buffer, Buffer,
+                                unsigned> (*kcKernel[device]);
+
+        // Keep only the first corners_to_keep corners with higher Harris
+        // responses
+        kcOp(EnqueueArgs(getQueue(), global_kc, local_kc),
+              *x_out.data, *y_out.data, *resp_out.data,
+              *d_x_corners, *d_y_corners, *harris_resp.data, *harris_idx.data,
+              *corners_out);
+        CL_DEBUG_FINISH(getQueue());
+
+        bufferFree(d_x_corners);
+        bufferFree(d_y_corners);
+        bufferFree(harris_resp.data);
+        bufferFree(harris_idx.data);
+    }
+    else if (max_corners == 0 && corners_found < corner_lim) {
+        x_out.data = bufferAlloc(*corners_out * sizeof(float));
+        y_out.data = bufferAlloc(*corners_out * sizeof(float));
+        resp_out.data = bufferAlloc(*corners_out * sizeof(float));
+        getQueue().enqueueCopyBuffer(*d_x_corners, *x_out.data, 0, 0, *corners_out * sizeof(float));
+        getQueue().enqueueCopyBuffer(*d_y_corners, *y_out.data, 0, 0, *corners_out * sizeof(float));
+        getQueue().enqueueCopyBuffer(*d_resp_corners, *resp_out.data, 0, 0, *corners_out * sizeof(float));
+
+        bufferFree(d_x_corners);
+        bufferFree(d_y_corners);
+        bufferFree(d_resp_corners);
+    }
+    else {
+        x_out.data = d_x_corners;
+        y_out.data = d_y_corners;
+        resp_out.data = d_resp_corners;
     }
 }
 

--- a/src/backend/opencl/kernel/histogram.hpp
+++ b/src/backend/opencl/kernel/histogram.hpp
@@ -34,54 +34,48 @@ static const int THRD_LOAD =   16;
 template<typename inType, typename outType, bool isLinear>
 void histogram(Param out, const Param in, int nbins, float minval, float maxval)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*> histProgs;
-        static std::map<int, Kernel *> histKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*> histProgs;
+    static std::map<int, Kernel *> histKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
-                    std::ostringstream options;
-                    options << " -D inType=" << dtype_traits<inType>::getName()
-                            << " -D outType=" << dtype_traits<outType>::getName()
-                            << " -D THRD_LOAD=" << THRD_LOAD;
-                    if (isLinear)
-                        options << " -D IS_LINEAR";
-                    if (std::is_same<inType, double>::value ||
-                        std::is_same<inType, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
+    std::call_once( compileFlags[device], [device] () {
+                std::ostringstream options;
+                options << " -D inType=" << dtype_traits<inType>::getName()
+                        << " -D outType=" << dtype_traits<outType>::getName()
+                        << " -D THRD_LOAD=" << THRD_LOAD;
+                if (isLinear)
+                    options << " -D IS_LINEAR";
+                if (std::is_same<inType, double>::value ||
+                    std::is_same<inType, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
 
-                    Program prog;
-                    buildProgram(prog, histogram_cl, histogram_cl_len, options.str());
-                    histProgs[device]   = new Program(prog);
-                    histKernels[device] = new Kernel(*histProgs[device], "histogram");
-                });
+                Program prog;
+                buildProgram(prog, histogram_cl, histogram_cl_len, options.str());
+                histProgs[device]   = new Program(prog);
+                histKernels[device] = new Kernel(*histProgs[device], "histogram");
+            });
 
-        auto histogramOp = KernelFunctor<Buffer, KParam, Buffer, KParam,
-                                       cl::LocalSpaceArg,
-                                       int, int, float, float, int
-                                      >(*histKernels[device]);
+    auto histogramOp = KernelFunctor<Buffer, KParam, Buffer, KParam,
+                                    cl::LocalSpaceArg,
+                                    int, int, float, float, int
+                                  >(*histKernels[device]);
 
-        int nElems = in.info.dims[0]*in.info.dims[1];
-        int blk_x  = divup(nElems, THRD_LOAD*THREADS_X);
-        int locSize = nbins * sizeof(outType);
+    int nElems = in.info.dims[0]*in.info.dims[1];
+    int blk_x  = divup(nElems, THRD_LOAD*THREADS_X);
+    int locSize = nbins * sizeof(outType);
 
-        NDRange local(THREADS_X, 1);
-        NDRange global(blk_x*in.info.dims[2]*THREADS_X, in.info.dims[3]);
+    NDRange local(THREADS_X, 1);
+    NDRange global(blk_x*in.info.dims[2]*THREADS_X, in.info.dims[3]);
 
-        histogramOp(EnqueueArgs(getQueue(), global, local),
-                *out.data, out.info, *in.data, in.info,
-                cl::Local(locSize), nElems, nbins, minval, maxval, blk_x);
+    histogramOp(EnqueueArgs(getQueue(), global, local),
+            *out.data, out.info, *in.data, in.info,
+            cl::Local(locSize), nElems, nbins, minval, maxval, blk_x);
 
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
+    CL_DEBUG_FINISH(getQueue());
 }
 
 }
-
 }

--- a/src/backend/opencl/kernel/homography.hpp
+++ b/src/backend/opencl/kernel/homography.hpp
@@ -50,194 +50,189 @@ int computeH(
     const unsigned nsamples,
     const float inlier_thr)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*> hgProgs;
-        static std::map<int, Kernel*>  chKernel;
-        static std::map<int, Kernel*>  ehKernel;
-        static std::map<int, Kernel*>  cmKernel;
-        static std::map<int, Kernel*>  fmKernel;
-        static std::map<int, Kernel*>  clKernel;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*> hgProgs;
+    static std::map<int, Kernel*>  chKernel;
+    static std::map<int, Kernel*>  ehKernel;
+    static std::map<int, Kernel*>  cmKernel;
+    static std::map<int, Kernel*>  fmKernel;
+    static std::map<int, Kernel*>  clKernel;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
+    std::call_once( compileFlags[device], [device] () {
 
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName();
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName();
 
-                if (std::is_same<T, double>::value) {
-                    options << " -D USE_DOUBLE";
-                    options << " -D EPS=" << DBL_EPSILON;
-                } else
-                    options << " -D EPS=" << FLT_EPSILON;
+            if (std::is_same<T, double>::value) {
+                options << " -D USE_DOUBLE";
+                options << " -D EPS=" << DBL_EPSILON;
+            } else
+                options << " -D EPS=" << FLT_EPSILON;
 
-                if (htype == AF_HOMOGRAPHY_RANSAC)
-                    options << " -D RANSAC";
-                else if (htype == AF_HOMOGRAPHY_LMEDS)
-                    options << " -D LMEDS";
+            if (htype == AF_HOMOGRAPHY_RANSAC)
+                options << " -D RANSAC";
+            else if (htype == AF_HOMOGRAPHY_LMEDS)
+                options << " -D LMEDS";
 
-                if (getActiveDeviceType() == CL_DEVICE_TYPE_CPU) {
-                    options << " -D IS_CPU";
-                }
-
-                cl::Program prog;
-                buildProgram(prog, homography_cl, homography_cl_len, options.str());
-                hgProgs[device] = new Program(prog);
-
-                chKernel[device] = new Kernel(*hgProgs[device], "compute_homography");
-                ehKernel[device] = new Kernel(*hgProgs[device], "eval_homography");
-                cmKernel[device] = new Kernel(*hgProgs[device], "compute_median");
-                fmKernel[device] = new Kernel(*hgProgs[device], "find_min_median");
-                clKernel[device] = new Kernel(*hgProgs[device], "compute_lmeds_inliers");
-            });
-
-        const int blk_x_ch = 1;
-        const int blk_y_ch = divup(iterations, HG_THREADS_Y);
-        const NDRange local_ch(HG_THREADS_X, HG_THREADS_Y);
-        const NDRange global_ch(blk_x_ch * HG_THREADS_X, blk_y_ch * HG_THREADS_Y);
-
-        // Build linear system and solve SVD
-        auto chOp = KernelFunctor<Buffer, KParam,
-                                Buffer, Buffer, Buffer, Buffer,
-                                Buffer, KParam, unsigned>(*chKernel[device]);
-
-        chOp(EnqueueArgs(getQueue(), global_ch, local_ch),
-             *H.data, H.info,
-             *x_src.data, *y_src.data, *x_dst.data, *y_dst.data,
-             *rnd.data, rnd.info, iterations);
-        CL_DEBUG_FINISH(getQueue());
-
-        const int blk_x_eh = divup(iterations, HG_THREADS);
-        const NDRange local_eh(HG_THREADS);
-        const NDRange global_eh(blk_x_eh * HG_THREADS);
-
-        // Allocate some temporary buffers
-        Param inliers, idx, median;
-        inliers.info.offset = idx.info.offset = median.info.offset = 0;
-        inliers.info.dims[0] = (htype == AF_HOMOGRAPHY_RANSAC) ? blk_x_eh : divup(nsamples, HG_THREADS);
-        inliers.info.strides[0] = 1;
-        idx.info.dims[0] = median.info.dims[0] = blk_x_eh;
-        idx.info.strides[0] = median.info.strides[0] = 1;
-        for (int k = 1; k < 4; k++) {
-            inliers.info.dims[k] = 1;
-            inliers.info.strides[k] = inliers.info.dims[k-1] * inliers.info.strides[k-1];
-            idx.info.dims[k] = median.info.dims[k] = 1;
-            idx.info.strides[k] = median.info.strides[k] = idx.info.dims[k-1] * idx.info.strides[k-1];
-        }
-        idx.data = bufferAlloc(idx.info.dims[3] * idx.info.strides[3] * sizeof(unsigned));
-        inliers.data = bufferAlloc(inliers.info.dims[3] * inliers.info.strides[3] * sizeof(unsigned));
-        if (htype == AF_HOMOGRAPHY_LMEDS)
-            median.data = bufferAlloc(median.info.dims[3] * median.info.strides[3] * sizeof(float));
-        else
-            median.data = bufferAlloc(sizeof(float));
-
-        // Compute (and for RANSAC, evaluate) homographies
-        auto ehOp = KernelFunctor<Buffer, Buffer, Buffer, KParam,
-                                Buffer, KParam,
-                                Buffer, Buffer, Buffer, Buffer,
-                                Buffer, unsigned, unsigned, float>(*ehKernel[device]);
-
-        ehOp(EnqueueArgs(getQueue(), global_eh, local_eh),
-             *inliers.data, *idx.data, *H.data, H.info,
-             *err.data, err.info,
-             *x_src.data, *y_src.data, *x_dst.data, *y_dst.data,
-             *rnd.data, iterations, nsamples, inlier_thr);
-        CL_DEBUG_FINISH(getQueue());
-
-        unsigned inliersH, idxH;
-        if (htype == AF_HOMOGRAPHY_LMEDS) {
-            // TODO: Improve this sorting, if the number of iterations is
-            // sufficiently large, this can be *very* slow
-            kernel::sort0<float>(err, true);
-
-            unsigned minIdx;
-            float minMedian;
-
-            // Compute median of every iteration
-            auto cmOp = KernelFunctor<Buffer, Buffer, Buffer, KParam,
-                                    unsigned>(*cmKernel[device]);
-
-            cmOp(EnqueueArgs(getQueue(), global_eh, local_eh),
-                 *median.data, *idx.data, *err.data, err.info,
-                 iterations);
-            CL_DEBUG_FINISH(getQueue());
-
-            // Reduce medians, only in case iterations > 256
-            if (blk_x_eh > 1) {
-                const NDRange local_fm(HG_THREADS);
-                const NDRange global_fm(HG_THREADS);
-
-                cl::Buffer* finalMedian = bufferAlloc(sizeof(float));
-                cl::Buffer* finalIdx = bufferAlloc(sizeof(unsigned));
-
-                auto fmOp = KernelFunctor<Buffer, Buffer, Buffer, KParam,
-                                        Buffer>(*fmKernel[device]);
-
-                fmOp(EnqueueArgs(getQueue(), global_fm, local_fm),
-                     *finalMedian, *finalIdx, *median.data, median.info,
-                     *idx.data);
-                CL_DEBUG_FINISH(getQueue());
-
-                getQueue().enqueueReadBuffer(*finalMedian, CL_TRUE, 0, sizeof(float), &minMedian);
-                getQueue().enqueueReadBuffer(*finalIdx, CL_TRUE, 0, sizeof(unsigned), &minIdx);
-
-                bufferFree(finalMedian);
-                bufferFree(finalIdx);
-            }
-            else {
-                getQueue().enqueueReadBuffer(*median.data, CL_TRUE, 0, sizeof(float), &minMedian);
-                getQueue().enqueueReadBuffer(*idx.data, CL_TRUE, 0, sizeof(unsigned), &minIdx);
+            if (getActiveDeviceType() == CL_DEVICE_TYPE_CPU) {
+                options << " -D IS_CPU";
             }
 
-            // Copy best homography to output
-            getQueue().enqueueCopyBuffer(*H.data, *bestH.data, minIdx*9*sizeof(T), 0, 9*sizeof(T));
+            cl::Program prog;
+            buildProgram(prog, homography_cl, homography_cl_len, options.str());
+            hgProgs[device] = new Program(prog);
 
-            const int blk_x_cl = divup(nsamples, HG_THREADS);
-            const NDRange local_cl(HG_THREADS);
-            const NDRange global_cl(blk_x_cl * HG_THREADS);
+            chKernel[device] = new Kernel(*hgProgs[device], "compute_homography");
+            ehKernel[device] = new Kernel(*hgProgs[device], "eval_homography");
+            cmKernel[device] = new Kernel(*hgProgs[device], "compute_median");
+            fmKernel[device] = new Kernel(*hgProgs[device], "find_min_median");
+            clKernel[device] = new Kernel(*hgProgs[device], "compute_lmeds_inliers");
+        });
 
-            auto clOp = KernelFunctor<Buffer, Buffer,
-                                    Buffer, Buffer, Buffer, Buffer,
-                                    float, unsigned>(*clKernel[device]);
+    const int blk_x_ch = 1;
+    const int blk_y_ch = divup(iterations, HG_THREADS_Y);
+    const NDRange local_ch(HG_THREADS_X, HG_THREADS_Y);
+    const NDRange global_ch(blk_x_ch * HG_THREADS_X, blk_y_ch * HG_THREADS_Y);
 
-            clOp(EnqueueArgs(getQueue(), global_cl, local_cl),
-                 *inliers.data, *bestH.data,
-                 *x_src.data, *y_src.data, *x_dst.data, *y_dst.data,
-                 minMedian, nsamples);
-            CL_DEBUG_FINISH(getQueue());
+    // Build linear system and solve SVD
+    auto chOp = KernelFunctor<Buffer, KParam,
+                            Buffer, Buffer, Buffer, Buffer,
+                            Buffer, KParam, unsigned>(*chKernel[device]);
 
-            // Adds up the total number of inliers
-            Param totalInliers;
-            totalInliers.info.offset = 0;
-            for (int k = 0; k < 4; k++)
-                totalInliers.info.dims[k] = totalInliers.info.strides[k] = 1;
-            totalInliers.data = bufferAlloc(sizeof(unsigned));
+    chOp(EnqueueArgs(getQueue(), global_ch, local_ch),
+          *H.data, H.info,
+          *x_src.data, *y_src.data, *x_dst.data, *y_dst.data,
+          *rnd.data, rnd.info, iterations);
+    CL_DEBUG_FINISH(getQueue());
 
-            kernel::reduce<unsigned, unsigned, af_add_t>(totalInliers, inliers, 0, false, 0.0);
+    const int blk_x_eh = divup(iterations, HG_THREADS);
+    const NDRange local_eh(HG_THREADS);
+    const NDRange global_eh(blk_x_eh * HG_THREADS);
 
-            getQueue().enqueueReadBuffer(*totalInliers.data, CL_TRUE, 0, sizeof(unsigned), &inliersH);
-
-            bufferFree(totalInliers.data);
-        } else if (htype == AF_HOMOGRAPHY_RANSAC) {
-            unsigned blockIdx;
-            inliersH = kernel::ireduce_all<unsigned, af_max_t>(&blockIdx, inliers);
-
-            // Copies back index and number of inliers of best homography estimation
-            getQueue().enqueueReadBuffer(*idx.data, CL_TRUE, blockIdx*sizeof(unsigned),
-                                         sizeof(unsigned), &idxH);
-            getQueue().enqueueCopyBuffer(*H.data, *bestH.data, idxH*9*sizeof(T), 0, 9*sizeof(T));
-        }
-
-        bufferFree(inliers.data);
-        bufferFree(idx.data);
-        bufferFree(median.data);
-
-        return (int)inliersH;
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
+    // Allocate some temporary buffers
+    Param inliers, idx, median;
+    inliers.info.offset = idx.info.offset = median.info.offset = 0;
+    inliers.info.dims[0] = (htype == AF_HOMOGRAPHY_RANSAC) ? blk_x_eh : divup(nsamples, HG_THREADS);
+    inliers.info.strides[0] = 1;
+    idx.info.dims[0] = median.info.dims[0] = blk_x_eh;
+    idx.info.strides[0] = median.info.strides[0] = 1;
+    for (int k = 1; k < 4; k++) {
+        inliers.info.dims[k] = 1;
+        inliers.info.strides[k] = inliers.info.dims[k-1] * inliers.info.strides[k-1];
+        idx.info.dims[k] = median.info.dims[k] = 1;
+        idx.info.strides[k] = median.info.strides[k] = idx.info.dims[k-1] * idx.info.strides[k-1];
     }
+    idx.data = bufferAlloc(idx.info.dims[3] * idx.info.strides[3] * sizeof(unsigned));
+    inliers.data = bufferAlloc(inliers.info.dims[3] * inliers.info.strides[3] * sizeof(unsigned));
+    if (htype == AF_HOMOGRAPHY_LMEDS)
+        median.data = bufferAlloc(median.info.dims[3] * median.info.strides[3] * sizeof(float));
+    else
+        median.data = bufferAlloc(sizeof(float));
+
+    // Compute (and for RANSAC, evaluate) homographies
+    auto ehOp = KernelFunctor<Buffer, Buffer, Buffer, KParam,
+                            Buffer, KParam,
+                            Buffer, Buffer, Buffer, Buffer,
+                            Buffer, unsigned, unsigned, float>(*ehKernel[device]);
+
+    ehOp(EnqueueArgs(getQueue(), global_eh, local_eh),
+          *inliers.data, *idx.data, *H.data, H.info,
+          *err.data, err.info,
+          *x_src.data, *y_src.data, *x_dst.data, *y_dst.data,
+          *rnd.data, iterations, nsamples, inlier_thr);
+    CL_DEBUG_FINISH(getQueue());
+
+    unsigned inliersH, idxH;
+    if (htype == AF_HOMOGRAPHY_LMEDS) {
+        // TODO: Improve this sorting, if the number of iterations is
+        // sufficiently large, this can be *very* slow
+        kernel::sort0<float>(err, true);
+
+        unsigned minIdx;
+        float minMedian;
+
+        // Compute median of every iteration
+        auto cmOp = KernelFunctor<Buffer, Buffer, Buffer, KParam,
+                                unsigned>(*cmKernel[device]);
+
+        cmOp(EnqueueArgs(getQueue(), global_eh, local_eh),
+              *median.data, *idx.data, *err.data, err.info,
+              iterations);
+        CL_DEBUG_FINISH(getQueue());
+
+        // Reduce medians, only in case iterations > 256
+        if (blk_x_eh > 1) {
+            const NDRange local_fm(HG_THREADS);
+            const NDRange global_fm(HG_THREADS);
+
+            cl::Buffer* finalMedian = bufferAlloc(sizeof(float));
+            cl::Buffer* finalIdx = bufferAlloc(sizeof(unsigned));
+
+            auto fmOp = KernelFunctor<Buffer, Buffer, Buffer, KParam,
+                                    Buffer>(*fmKernel[device]);
+
+            fmOp(EnqueueArgs(getQueue(), global_fm, local_fm),
+                  *finalMedian, *finalIdx, *median.data, median.info,
+                  *idx.data);
+            CL_DEBUG_FINISH(getQueue());
+
+            getQueue().enqueueReadBuffer(*finalMedian, CL_TRUE, 0, sizeof(float), &minMedian);
+            getQueue().enqueueReadBuffer(*finalIdx, CL_TRUE, 0, sizeof(unsigned), &minIdx);
+
+            bufferFree(finalMedian);
+            bufferFree(finalIdx);
+        }
+        else {
+            getQueue().enqueueReadBuffer(*median.data, CL_TRUE, 0, sizeof(float), &minMedian);
+            getQueue().enqueueReadBuffer(*idx.data, CL_TRUE, 0, sizeof(unsigned), &minIdx);
+        }
+
+        // Copy best homography to output
+        getQueue().enqueueCopyBuffer(*H.data, *bestH.data, minIdx*9*sizeof(T), 0, 9*sizeof(T));
+
+        const int blk_x_cl = divup(nsamples, HG_THREADS);
+        const NDRange local_cl(HG_THREADS);
+        const NDRange global_cl(blk_x_cl * HG_THREADS);
+
+        auto clOp = KernelFunctor<Buffer, Buffer,
+                                Buffer, Buffer, Buffer, Buffer,
+                                float, unsigned>(*clKernel[device]);
+
+        clOp(EnqueueArgs(getQueue(), global_cl, local_cl),
+              *inliers.data, *bestH.data,
+              *x_src.data, *y_src.data, *x_dst.data, *y_dst.data,
+              minMedian, nsamples);
+        CL_DEBUG_FINISH(getQueue());
+
+        // Adds up the total number of inliers
+        Param totalInliers;
+        totalInliers.info.offset = 0;
+        for (int k = 0; k < 4; k++)
+            totalInliers.info.dims[k] = totalInliers.info.strides[k] = 1;
+        totalInliers.data = bufferAlloc(sizeof(unsigned));
+
+        kernel::reduce<unsigned, unsigned, af_add_t>(totalInliers, inliers, 0, false, 0.0);
+
+        getQueue().enqueueReadBuffer(*totalInliers.data, CL_TRUE, 0, sizeof(unsigned), &inliersH);
+
+        bufferFree(totalInliers.data);
+    } else if (htype == AF_HOMOGRAPHY_RANSAC) {
+        unsigned blockIdx;
+        inliersH = kernel::ireduce_all<unsigned, af_max_t>(&blockIdx, inliers);
+
+        // Copies back index and number of inliers of best homography estimation
+        getQueue().enqueueReadBuffer(*idx.data, CL_TRUE, blockIdx*sizeof(unsigned),
+                                      sizeof(unsigned), &idxH);
+        getQueue().enqueueCopyBuffer(*H.data, *bestH.data, idxH*9*sizeof(T), 0, 9*sizeof(T));
+    }
+
+    bufferFree(inliers.data);
+    bufferFree(idx.data);
+    bufferFree(median.data);
+
+    return (int)inliersH;
 }
 
 } // namespace kernel

--- a/src/backend/opencl/kernel/hsv_rgb.hpp
+++ b/src/backend/opencl/kernel/hsv_rgb.hpp
@@ -38,48 +38,43 @@ static const int THREADS_Y = 16;
 template<typename T, bool isHSV2RGB>
 void hsv2rgb_convert(Param out, const Param in)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*>  hrProgs;
-        static std::map<int, Kernel*> hrKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*>  hrProgs;
+    static std::map<int, Kernel*> hrKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
+    std::call_once( compileFlags[device], [device] () {
 
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName();
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName();
 
-                if(isHSV2RGB) options << " -D isHSV2RGB";
+            if(isHSV2RGB) options << " -D isHSV2RGB";
 
-                if (std::is_same<T, double>::value) {
-                    options << " -D USE_DOUBLE";
-                }
-                Program prog;
-                buildProgram(prog, hsv_rgb_cl, hsv_rgb_cl_len, options.str());
-                hrProgs[device]   = new Program(prog);
-                hrKernels[device] = new Kernel(*hrProgs[device], "convert");
-            });
+            if (std::is_same<T, double>::value) {
+                options << " -D USE_DOUBLE";
+            }
+            Program prog;
+            buildProgram(prog, hsv_rgb_cl, hsv_rgb_cl_len, options.str());
+            hrProgs[device]   = new Program(prog);
+            hrKernels[device] = new Kernel(*hrProgs[device], "convert");
+        });
 
-        NDRange local(THREADS_X, THREADS_Y);
+    NDRange local(THREADS_X, THREADS_Y);
 
-        int blk_x = divup(in.info.dims[0], THREADS_X);
-        int blk_y = divup(in.info.dims[1], THREADS_Y);
+    int blk_x = divup(in.info.dims[0], THREADS_X);
+    int blk_y = divup(in.info.dims[1], THREADS_Y);
 
-        // all images are three channels, so batch
-        // parameter would be along 4th dimension
-        NDRange global(blk_x * in.info.dims[3] * THREADS_X, blk_y * THREADS_Y);
+    // all images are three channels, so batch
+    // parameter would be along 4th dimension
+    NDRange global(blk_x * in.info.dims[3] * THREADS_X, blk_y * THREADS_Y);
 
-        auto hsvrgbOp = KernelFunctor<Buffer, KParam, Buffer, KParam, int> (*hrKernels[device]);
+    auto hsvrgbOp = KernelFunctor<Buffer, KParam, Buffer, KParam, int> (*hrKernels[device]);
 
-        hsvrgbOp(EnqueueArgs(getQueue(), global, local),
-                    *out.data, out.info, *in.data, in.info, blk_x);
+    hsvrgbOp(EnqueueArgs(getQueue(), global, local),
+                *out.data, out.info, *in.data, in.info, blk_x);
 
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
+    CL_DEBUG_FINISH(getQueue());
 }
 
 }

--- a/src/backend/opencl/kernel/identity.hpp
+++ b/src/backend/opencl/kernel/identity.hpp
@@ -37,44 +37,40 @@ namespace kernel
     template<typename T>
     static void identity(Param out)
     {
-        try {
-            static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-            static std::map<int, Program*>   identityProgs;
-            static std::map<int, Kernel*>  identityKernels;
+        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+        static std::map<int, Program*>   identityProgs;
+        static std::map<int, Kernel*>  identityKernels;
 
-            int device = getActiveDeviceId();
+        int device = getActiveDeviceId();
 
-            std::call_once( compileFlags[device], [device] () {
-                    ostringstream options;
-                    options << " -D T="    << dtype_traits<T>::getName()
-                            << " -D ONE=(T)("  << scalar_to_option(scalar<T>(1)) << ")"
-                            << " -D ZERO=(T)(" << scalar_to_option(scalar<T>(0)) << ")";
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-                    Program prog;
-                    buildProgram(prog, identity_cl, identity_cl_len, options.str());
-                    identityProgs[device]   = new Program(prog);
-                    identityKernels[device] = new Kernel(*identityProgs[device], "identity_kernel");
-                });
+        std::call_once( compileFlags[device], [device] () {
+                ostringstream options;
+                options << " -D T="    << dtype_traits<T>::getName()
+                        << " -D ONE=(T)("  << scalar_to_option(scalar<T>(1)) << ")"
+                        << " -D ZERO=(T)(" << scalar_to_option(scalar<T>(0)) << ")";
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
+                Program prog;
+                buildProgram(prog, identity_cl, identity_cl_len, options.str());
+                identityProgs[device]   = new Program(prog);
+                identityKernels[device] = new Kernel(*identityProgs[device], "identity_kernel");
+            });
 
-            NDRange local(32, 8);
-            int groups_x = divup(out.info.dims[0], local[0]);
-            int groups_y = divup(out.info.dims[1], local[1]);
-            NDRange global(groups_x * out.info.dims[2] * local[0],
-                           groups_y * out.info.dims[3] * local[1]);
+        NDRange local(32, 8);
+        int groups_x = divup(out.info.dims[0], local[0]);
+        int groups_y = divup(out.info.dims[1], local[1]);
+        NDRange global(groups_x * out.info.dims[2] * local[0],
+                        groups_y * out.info.dims[3] * local[1]);
 
-            auto identityOp = KernelFunctor<Buffer, const KParam,
-                                          int, int> (*identityKernels[device]);
+        auto identityOp = KernelFunctor<Buffer, const KParam,
+                                      int, int> (*identityKernels[device]);
 
-            identityOp(EnqueueArgs(getQueue(), global, local),
-                       *(out.data), out.info, groups_x, groups_y);
-            CL_DEBUG_FINISH(getQueue());
+        identityOp(EnqueueArgs(getQueue(), global, local),
+                    *(out.data), out.info, groups_x, groups_y);
+        CL_DEBUG_FINISH(getQueue());
 
-        } catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
-        }
     }
 
 }

--- a/src/backend/opencl/kernel/iota.hpp
+++ b/src/backend/opencl/kernel/iota.hpp
@@ -40,48 +40,43 @@ namespace opencl
         template<typename T>
         void iota(Param out, const af::dim4 &sdims, const af::dim4 &tdims)
         {
-            try {
-                static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-                static std::map<int, Program*>  iotaProgs;
-                static std::map<int, Kernel*> iotaKernels;
+            static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+            static std::map<int, Program*>  iotaProgs;
+            static std::map<int, Kernel*> iotaKernels;
 
-                int device = getActiveDeviceId();
+            int device = getActiveDeviceId();
 
-                std::call_once( compileFlags[device], [device] () {
-                    std::ostringstream options;
-                    options << " -D T=" << dtype_traits<T>::getName();
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-                    Program prog;
-                    buildProgram(prog, iota_cl, iota_cl_len, options.str());
-                    iotaProgs[device]   = new Program(prog);
-                    iotaKernels[device] = new Kernel(*iotaProgs[device], "iota_kernel");
-                });
+            std::call_once( compileFlags[device], [device] () {
+                std::ostringstream options;
+                options << " -D T=" << dtype_traits<T>::getName();
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
+                Program prog;
+                buildProgram(prog, iota_cl, iota_cl_len, options.str());
+                iotaProgs[device]   = new Program(prog);
+                iotaKernels[device] = new Kernel(*iotaProgs[device], "iota_kernel");
+            });
 
-                auto iotaOp = KernelFunctor<Buffer, const KParam,
-                                          const int, const int, const int, const int,
-                                          const int, const int, const int, const int,
-                                          const int, const int> (*iotaKernels[device]);
+            auto iotaOp = KernelFunctor<Buffer, const KParam,
+                                      const int, const int, const int, const int,
+                                      const int, const int, const int, const int,
+                                      const int, const int> (*iotaKernels[device]);
 
-                NDRange local(IOTA_TX, IOTA_TY, 1);
+            NDRange local(IOTA_TX, IOTA_TY, 1);
 
-                int blocksPerMatX = divup(out.info.dims[0], TILEX);
-                int blocksPerMatY = divup(out.info.dims[1], TILEY);
-                NDRange global(local[0] * blocksPerMatX * out.info.dims[2],
-                               local[1] * blocksPerMatY * out.info.dims[3],
-                               1);
+            int blocksPerMatX = divup(out.info.dims[0], TILEX);
+            int blocksPerMatY = divup(out.info.dims[1], TILEY);
+            NDRange global(local[0] * blocksPerMatX * out.info.dims[2],
+                            local[1] * blocksPerMatY * out.info.dims[3],
+                            1);
 
-                iotaOp(EnqueueArgs(getQueue(), global, local),
-                       *out.data, out.info, sdims[0], sdims[1], sdims[2], sdims[3],
-                       tdims[0], tdims[1], tdims[2], tdims[3], blocksPerMatX, blocksPerMatY);
+            iotaOp(EnqueueArgs(getQueue(), global, local),
+                    *out.data, out.info, sdims[0], sdims[1], sdims[2], sdims[3],
+                    tdims[0], tdims[1], tdims[2], tdims[3], blocksPerMatX, blocksPerMatY);
 
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
-            }
+            CL_DEBUG_FINISH(getQueue());
         }
     }
 }

--- a/src/backend/opencl/kernel/lookup.hpp
+++ b/src/backend/opencl/kernel/lookup.hpp
@@ -38,52 +38,47 @@ static const int THREADS_Y = 8;
 template<typename in_t, typename idx_t, unsigned dim>
 void lookup(Param out, const Param in, const Param indices, int nDims)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*>  aiProgs;
-        static std::map<int, Kernel*> aiKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*>  aiProgs;
+    static std::map<int, Kernel*> aiKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
-                    std::ostringstream options;
-                    options << " -D in_t=" << dtype_traits<in_t>::getName()
-                            << " -D idx_t=" << dtype_traits<idx_t>::getName()
-                            << " -D DIM=" <<dim;
+    std::call_once( compileFlags[device], [device] () {
+                std::ostringstream options;
+                options << " -D in_t=" << dtype_traits<in_t>::getName()
+                        << " -D idx_t=" << dtype_traits<idx_t>::getName()
+                        << " -D DIM=" <<dim;
 
-                    if (std::is_same<in_t, double>::value ||
-                        std::is_same<in_t, cdouble>::value ||
-                        std::is_same<idx_t, double>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
+                if (std::is_same<in_t, double>::value ||
+                    std::is_same<in_t, cdouble>::value ||
+                    std::is_same<idx_t, double>::value) {
+                    options << " -D USE_DOUBLE";
+                }
 
-                    Program prog;
-                    buildProgram(prog, lookup_cl, lookup_cl_len, options.str());
-                    aiProgs[device]   = new Program(prog);
-                    aiKernels[device] = new Kernel(*aiProgs[device], "lookupND");
-                });
+                Program prog;
+                buildProgram(prog, lookup_cl, lookup_cl_len, options.str());
+                aiProgs[device]   = new Program(prog);
+                aiKernels[device] = new Kernel(*aiProgs[device], "lookupND");
+            });
 
-        NDRange local(THREADS_X, THREADS_Y);
+    NDRange local(THREADS_X, THREADS_Y);
 
-        int blk_x = divup(out.info.dims[0], THREADS_X);
-        int blk_y = divup(out.info.dims[1], THREADS_Y);
+    int blk_x = divup(out.info.dims[0], THREADS_X);
+    int blk_y = divup(out.info.dims[1], THREADS_Y);
 
-        NDRange global(blk_x * out.info.dims[2] * THREADS_X,
-                       blk_y * out.info.dims[3] * THREADS_Y);
+    NDRange global(blk_x * out.info.dims[2] * THREADS_X,
+                    blk_y * out.info.dims[3] * THREADS_Y);
 
-        auto arrIdxOp = KernelFunctor<Buffer, KParam,
-                                    Buffer, KParam,
-                                    Buffer, KParam,
-                                    int, int>(*aiKernels[device]);
+    auto arrIdxOp = KernelFunctor<Buffer, KParam,
+                                Buffer, KParam,
+                                Buffer, KParam,
+                                int, int>(*aiKernels[device]);
 
-        arrIdxOp(EnqueueArgs(getQueue(), global, local),
-                *out.data, out.info, *in.data, in.info, *indices.data, indices.info, blk_x, blk_y);
+    arrIdxOp(EnqueueArgs(getQueue(), global, local),
+            *out.data, out.info, *in.data, in.info, *indices.data, indices.info, blk_x, blk_y);
 
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
+    CL_DEBUG_FINISH(getQueue());
 }
 
 }

--- a/src/backend/opencl/kernel/match_template.hpp
+++ b/src/backend/opencl/kernel/match_template.hpp
@@ -38,58 +38,53 @@ static const int THREADS_Y = 16;
 template<typename inType, typename outType, af_match_type mType, bool needMean>
 void matchTemplate(Param out, const Param srch, const Param tmplt)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*>  mtProgs;
-        static std::map<int, Kernel*> mtKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*>  mtProgs;
+    static std::map<int, Kernel*> mtKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
+    std::call_once( compileFlags[device], [device] () {
 
-                std::ostringstream options;
-                options << " -D inType="  << dtype_traits<inType>::getName()
-                        << " -D outType=" << dtype_traits<outType>::getName()
-                        << " -D MATCH_T=" << mType
-                        << " -D NEEDMEAN="<< needMean
-                        << " -D AF_SAD="  << AF_SAD
-                        << " -D AF_ZSAD=" << AF_ZSAD
-                        << " -D AF_LSAD=" << AF_LSAD
-                        << " -D AF_SSD="  << AF_SSD
-                        << " -D AF_ZSSD=" << AF_ZSSD
-                        << " -D AF_LSSD=" << AF_LSSD
-                        << " -D AF_NCC="  << AF_NCC
-                        << " -D AF_ZNCC=" << AF_ZNCC
-                        << " -D AF_SHD="  << AF_SHD;
-                if (std::is_same<outType, double>::value) {
-                    options << " -D USE_DOUBLE";
-                }
-                Program prog;
-                buildProgram(prog, matchTemplate_cl, matchTemplate_cl_len, options.str());
-                mtProgs[device]   = new Program(prog);
-                mtKernels[device] = new Kernel(*mtProgs[device], "matchTemplate");
-            });
+            std::ostringstream options;
+            options << " -D inType="  << dtype_traits<inType>::getName()
+                    << " -D outType=" << dtype_traits<outType>::getName()
+                    << " -D MATCH_T=" << mType
+                    << " -D NEEDMEAN="<< needMean
+                    << " -D AF_SAD="  << AF_SAD
+                    << " -D AF_ZSAD=" << AF_ZSAD
+                    << " -D AF_LSAD=" << AF_LSAD
+                    << " -D AF_SSD="  << AF_SSD
+                    << " -D AF_ZSSD=" << AF_ZSSD
+                    << " -D AF_LSSD=" << AF_LSSD
+                    << " -D AF_NCC="  << AF_NCC
+                    << " -D AF_ZNCC=" << AF_ZNCC
+                    << " -D AF_SHD="  << AF_SHD;
+            if (std::is_same<outType, double>::value) {
+                options << " -D USE_DOUBLE";
+            }
+            Program prog;
+            buildProgram(prog, matchTemplate_cl, matchTemplate_cl_len, options.str());
+            mtProgs[device]   = new Program(prog);
+            mtKernels[device] = new Kernel(*mtProgs[device], "matchTemplate");
+        });
 
-        NDRange local(THREADS_X, THREADS_Y);
+    NDRange local(THREADS_X, THREADS_Y);
 
-        int blk_x = divup(srch.info.dims[0], THREADS_X);
-        int blk_y = divup(srch.info.dims[1], THREADS_Y);
+    int blk_x = divup(srch.info.dims[0], THREADS_X);
+    int blk_y = divup(srch.info.dims[1], THREADS_Y);
 
-        NDRange global(blk_x * srch.info.dims[2] * THREADS_X, blk_y * srch.info.dims[3] * THREADS_Y);
+    NDRange global(blk_x * srch.info.dims[2] * THREADS_X, blk_y * srch.info.dims[3] * THREADS_Y);
 
-        auto matchImgOp = KernelFunctor<Buffer, KParam,
-                                       Buffer, KParam,
-                                       Buffer, KParam,
-                                       int, int> (*mtKernels[device]);
+    auto matchImgOp = KernelFunctor<Buffer, KParam,
+                                    Buffer, KParam,
+                                    Buffer, KParam,
+                                    int, int> (*mtKernels[device]);
 
-        matchImgOp(EnqueueArgs(getQueue(), global, local),
-                    *out.data, out.info, *srch.data, srch.info, *tmplt.data, tmplt.info, blk_x, blk_y);
+    matchImgOp(EnqueueArgs(getQueue(), global, local),
+                *out.data, out.info, *srch.data, srch.info, *tmplt.data, tmplt.info, blk_x, blk_y);
 
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
+    CL_DEBUG_FINISH(getQueue());
 }
 
 }

--- a/src/backend/opencl/kernel/medfilt.hpp
+++ b/src/backend/opencl/kernel/medfilt.hpp
@@ -42,114 +42,104 @@ static const int THREADS_Y = 16;
 template<typename T, af_border_type pad>
 void medfilt1(Param out, const Param in, unsigned w_wid)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*>  mfProgs;
-        static std::map<int, Kernel*> mfKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*>  mfProgs;
+    static std::map<int, Kernel*> mfKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device, w_wid] () {
+    std::call_once( compileFlags[device], [device, w_wid] () {
 
-                const int ARR_SIZE = (w_wid-w_wid/2) + 1;
+            const int ARR_SIZE = (w_wid-w_wid/2) + 1;
 
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName()
-                        << " -D pad="<< pad
-                        << " -D AF_PAD_ZERO="<< AF_PAD_ZERO
-                        << " -D AF_PAD_SYM="<< AF_PAD_SYM
-                        << " -D ARR_SIZE="<< ARR_SIZE
-                        << " -D w_wid=" << w_wid;
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
-                Program prog;
-                buildProgram(prog, medfilt1_cl, medfilt1_cl_len, options.str());
-                mfProgs[device]   = new Program(prog);
-                mfKernels[device] = new Kernel(*mfProgs[device], "medfilt1");
-            });
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName()
+                    << " -D pad="<< pad
+                    << " -D AF_PAD_ZERO="<< AF_PAD_ZERO
+                    << " -D AF_PAD_SYM="<< AF_PAD_SYM
+                    << " -D ARR_SIZE="<< ARR_SIZE
+                    << " -D w_wid=" << w_wid;
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
+            }
+            Program prog;
+            buildProgram(prog, medfilt1_cl, medfilt1_cl_len, options.str());
+            mfProgs[device]   = new Program(prog);
+            mfKernels[device] = new Kernel(*mfProgs[device], "medfilt1");
+        });
 
-        NDRange local(THREADS_X, 1, 1);
+    NDRange local(THREADS_X, 1, 1);
 
-        int blk_x = divup(in.info.dims[0], THREADS_X);
+    int blk_x = divup(in.info.dims[0], THREADS_X);
 
-        NDRange global(blk_x * in.info.dims[1] * THREADS_X,
-                                           in.info.dims[2],
-                                           in.info.dims[3]);
+    NDRange global(blk_x * in.info.dims[1] * THREADS_X,
+                                        in.info.dims[2],
+                                        in.info.dims[3]);
 
-        auto medfiltOp = KernelFunctor<Buffer, KParam,
-                                       Buffer, KParam,
-                                       cl::LocalSpaceArg,
-                                       int> (*mfKernels[device]);
+    auto medfiltOp = KernelFunctor<Buffer, KParam,
+                                    Buffer, KParam,
+                                    cl::LocalSpaceArg,
+                                    int> (*mfKernels[device]);
 
-        size_t loc_size = (THREADS_X+w_wid-1)*sizeof(T);
+    size_t loc_size = (THREADS_X+w_wid-1)*sizeof(T);
 
-        medfiltOp(EnqueueArgs(getQueue(), global, local),
-                    *out.data, out.info, *in.data, in.info, cl::Local(loc_size), blk_x);
+    medfiltOp(EnqueueArgs(getQueue(), global, local),
+                *out.data, out.info, *in.data, in.info, cl::Local(loc_size), blk_x);
 
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
+    CL_DEBUG_FINISH(getQueue());
 }
 
 template<typename T, af_border_type pad, unsigned w_len, unsigned w_wid>
 void medfilt2(Param out, const Param in)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*>  mfProgs;
-        static std::map<int, Kernel*> mfKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*>  mfProgs;
+    static std::map<int, Kernel*> mfKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
+    std::call_once( compileFlags[device], [device] () {
 
-                const int ARR_SIZE = w_len * (w_wid-w_wid/2);
+            const int ARR_SIZE = w_len * (w_wid-w_wid/2);
 
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName()
-                        << " -D pad="<< pad
-                        << " -D AF_PAD_ZERO="<< AF_PAD_ZERO
-                        << " -D AF_PAD_SYM="<< AF_PAD_SYM
-                        << " -D ARR_SIZE="<< ARR_SIZE
-                        << " -D w_len="<< w_len
-                        << " -D w_wid=" << w_wid;
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
-                Program prog;
-                buildProgram(prog, medfilt2_cl, medfilt2_cl_len, options.str());
-                mfProgs[device]   = new Program(prog);
-                mfKernels[device] = new Kernel(*mfProgs[device], "medfilt2");
-            });
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName()
+                    << " -D pad="<< pad
+                    << " -D AF_PAD_ZERO="<< AF_PAD_ZERO
+                    << " -D AF_PAD_SYM="<< AF_PAD_SYM
+                    << " -D ARR_SIZE="<< ARR_SIZE
+                    << " -D w_len="<< w_len
+                    << " -D w_wid=" << w_wid;
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
+            }
+            Program prog;
+            buildProgram(prog, medfilt2_cl, medfilt2_cl_len, options.str());
+            mfProgs[device]   = new Program(prog);
+            mfKernels[device] = new Kernel(*mfProgs[device], "medfilt2");
+        });
 
-        NDRange local(THREADS_X, THREADS_Y);
+    NDRange local(THREADS_X, THREADS_Y);
 
-        int blk_x = divup(in.info.dims[0], THREADS_X);
-        int blk_y = divup(in.info.dims[1], THREADS_Y);
+    int blk_x = divup(in.info.dims[0], THREADS_X);
+    int blk_y = divup(in.info.dims[1], THREADS_Y);
 
-        NDRange global(blk_x * in.info.dims[2] * THREADS_X,
-                       blk_y * in.info.dims[3] * THREADS_Y);
+    NDRange global(blk_x * in.info.dims[2] * THREADS_X,
+                    blk_y * in.info.dims[3] * THREADS_Y);
 
-        auto medfiltOp = KernelFunctor<Buffer, KParam,
-                                     Buffer, KParam,
-                                     cl::LocalSpaceArg,
-                                     int, int> (*mfKernels[device]);
+    auto medfiltOp = KernelFunctor<Buffer, KParam,
+                                  Buffer, KParam,
+                                  cl::LocalSpaceArg,
+                                  int, int> (*mfKernels[device]);
 
-        size_t loc_size = (THREADS_X+w_len-1)*(THREADS_Y+w_wid-1)*sizeof(T);
+    size_t loc_size = (THREADS_X+w_len-1)*(THREADS_Y+w_wid-1)*sizeof(T);
 
-        medfiltOp(EnqueueArgs(getQueue(), global, local),
-                    *out.data, out.info, *in.data, in.info, cl::Local(loc_size), blk_x, blk_y);
+    medfiltOp(EnqueueArgs(getQueue(), global, local),
+                *out.data, out.info, *in.data, in.info, cl::Local(loc_size), blk_x, blk_y);
 
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
+    CL_DEBUG_FINISH(getQueue());
 }
 
 }

--- a/src/backend/opencl/kernel/memcopy.hpp
+++ b/src/backend/opencl/kernel/memcopy.hpp
@@ -46,127 +46,116 @@ namespace kernel
                  const cl::Buffer in, const dim_t *idims,
                  const dim_t *istrides, int offset, uint ndims)
     {
-        try {
-            static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-            static std::map<int, Program*>    cpyProgs;
-            static std::map<int, Kernel*>   cpyKernels;
+        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+        static std::map<int, Program*>    cpyProgs;
+        static std::map<int, Kernel*>   cpyKernels;
 
-            int device = getActiveDeviceId();
+        int device = getActiveDeviceId();
 
-            std::call_once(compileFlags[device], [&]() {
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName();
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
-                Program prog;
-                buildProgram(prog, memcopy_cl, memcopy_cl_len, options.str());
-                cpyProgs[device]   = new Program(prog);
-                cpyKernels[device] = new Kernel(*cpyProgs[device], "memcopy_kernel");
-            });
-
-            dims_t _ostrides = {{ostrides[0], ostrides[1], ostrides[2], ostrides[3]}};
-            dims_t _istrides = {{istrides[0], istrides[1], istrides[2], istrides[3]}};
-            dims_t _idims = {{idims[0], idims[1], idims[2], idims[3]}};
-
-            size_t local_size[2] = {DIM0, DIM1};
-            if (ndims == 1) {
-                local_size[0] *= local_size[1];
-                local_size[1]  = 1;
+        std::call_once(compileFlags[device], [&]() {
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName();
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
             }
+            Program prog;
+            buildProgram(prog, memcopy_cl, memcopy_cl_len, options.str());
+            cpyProgs[device]   = new Program(prog);
+            cpyKernels[device] = new Kernel(*cpyProgs[device], "memcopy_kernel");
+        });
 
-            int groups_0 = divup(idims[0], local_size[0]);
-            int groups_1 = divup(idims[1], local_size[1]);
+        dims_t _ostrides = {{ostrides[0], ostrides[1], ostrides[2], ostrides[3]}};
+        dims_t _istrides = {{istrides[0], istrides[1], istrides[2], istrides[3]}};
+        dims_t _idims = {{idims[0], idims[1], idims[2], idims[3]}};
 
-            NDRange local(local_size[0], local_size[1]);
-            NDRange global(groups_0 * idims[2] * local_size[0],
-                           groups_1 * idims[3] * local_size[1]);
-
-            auto memcopy_kernel = KernelFunctor< Buffer, dims_t,
-                                               Buffer, dims_t,
-                                               dims_t, int,
-                                               int, int >(*cpyKernels[device]);
-
-            memcopy_kernel(EnqueueArgs(getQueue(), global, local),
-                out, _ostrides, in, _idims, _istrides, offset, groups_0, groups_1);
-            CL_DEBUG_FINISH(getQueue());
+        size_t local_size[2] = {DIM0, DIM1};
+        if (ndims == 1) {
+            local_size[0] *= local_size[1];
+            local_size[1]  = 1;
         }
-        catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
-            throw;
-        }
+
+        int groups_0 = divup(idims[0], local_size[0]);
+        int groups_1 = divup(idims[1], local_size[1]);
+
+        NDRange local(local_size[0], local_size[1]);
+        NDRange global(groups_0 * idims[2] * local_size[0],
+                        groups_1 * idims[3] * local_size[1]);
+
+        auto memcopy_kernel = KernelFunctor< Buffer, dims_t,
+                                            Buffer, dims_t,
+                                            dims_t, int,
+                                            int, int >(*cpyKernels[device]);
+
+        memcopy_kernel(EnqueueArgs(getQueue(), global, local),
+            out, _ostrides, in, _idims, _istrides, offset, groups_0, groups_1);
+        CL_DEBUG_FINISH(getQueue());
     }
 
     template<typename inType, typename outType, bool same_dims>
     void copy(Param dst, const Param src, int ndims, outType default_value, double factor)
     {
-        try {
-            static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-            static std::map<int, Program*>    cpyProgs;
-            static std::map<int, Kernel*>   cpyKernels;
+        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+        static std::map<int, Program*>    cpyProgs;
+        static std::map<int, Kernel*>   cpyKernels;
 
-            int device = getActiveDeviceId();
+        int device = getActiveDeviceId();
 
-            std::call_once(compileFlags[device], [&]() {
+        std::call_once(compileFlags[device], [&]() {
 
-                        std::ostringstream options;
-                        options << " -D inType=" << dtype_traits<inType>::getName()
-                            << " -D outType=" << dtype_traits<outType>::getName()
-                            << " -D inType_" << dtype_traits<inType>::getName()
-                            << " -D outType_" << dtype_traits<outType>::getName()
-                            << " -D SAME_DIMS=" << same_dims;
-                        if (std::is_same<inType, double>::value  ||
-                            std::is_same<inType, cdouble>::value ||
-                            std::is_same<outType, double>::value ||
-                            std::is_same<outType, cdouble>::value) {
-                            options << " -D USE_DOUBLE";
-                        }
+                    std::ostringstream options;
+                    options << " -D inType=" << dtype_traits<inType>::getName()
+                        << " -D outType=" << dtype_traits<outType>::getName()
+                        << " -D inType_" << dtype_traits<inType>::getName()
+                        << " -D outType_" << dtype_traits<outType>::getName()
+                        << " -D SAME_DIMS=" << same_dims;
+                    if (std::is_same<inType, double>::value  ||
+                        std::is_same<inType, cdouble>::value ||
+                        std::is_same<outType, double>::value ||
+                        std::is_same<outType, cdouble>::value) {
+                        options << " -D USE_DOUBLE";
+                    }
 
-                        Program prog;
-                        buildProgram(prog, copy_cl, copy_cl_len, options.str());
-                        cpyProgs[device]   = new Program(prog);
-                        cpyKernels[device] = new Kernel(*cpyProgs[device], "copy");
-                    });
+                    Program prog;
+                    buildProgram(prog, copy_cl, copy_cl_len, options.str());
+                    cpyProgs[device]   = new Program(prog);
+                    cpyKernels[device] = new Kernel(*cpyProgs[device], "copy");
+                });
 
-            NDRange local(DIM0, DIM1);
-            size_t local_size[] = {DIM0, DIM1};
+        NDRange local(DIM0, DIM1);
+        size_t local_size[] = {DIM0, DIM1};
 
-            local_size[0] *= local_size[1];
-            if (ndims == 1) {
-                local_size[1] = 1;
-            }
-
-            int blk_x = divup(dst.info.dims[0], local_size[0]);
-            int blk_y = divup(dst.info.dims[1], local_size[1]);
-
-            NDRange global(blk_x * dst.info.dims[2] * DIM0,
-                    blk_y * dst.info.dims[3] * DIM1);
-
-            dims_t trgt_dims;
-            if (same_dims) {
-                trgt_dims= {{dst.info.dims[0], dst.info.dims[1], dst.info.dims[2], dst.info.dims[3]}};
-            } else {
-                dim_t trgt_l = std::min(dst.info.dims[3], src.info.dims[3]);
-                dim_t trgt_k = std::min(dst.info.dims[2], src.info.dims[2]);
-                dim_t trgt_j = std::min(dst.info.dims[1], src.info.dims[1]);
-                dim_t trgt_i = std::min(dst.info.dims[0], src.info.dims[0]);
-                trgt_dims= {{trgt_i, trgt_j, trgt_k, trgt_l}};
-            }
-
-            auto copyOp = KernelFunctor<Buffer, KParam, Buffer, KParam,
-                                      outType, float, dims_t,
-                                      int, int
-                                     >(*cpyKernels[device]);
-
-            copyOp(EnqueueArgs(getQueue(), global, local),
-                   *dst.data, dst.info, *src.data, src.info,
-                   default_value, (float)factor, trgt_dims, blk_x, blk_y);
-            CL_DEBUG_FINISH(getQueue());
-        } catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
-            throw;
+        local_size[0] *= local_size[1];
+        if (ndims == 1) {
+            local_size[1] = 1;
         }
+
+        int blk_x = divup(dst.info.dims[0], local_size[0]);
+        int blk_y = divup(dst.info.dims[1], local_size[1]);
+
+        NDRange global(blk_x * dst.info.dims[2] * DIM0,
+                blk_y * dst.info.dims[3] * DIM1);
+
+        dims_t trgt_dims;
+        if (same_dims) {
+            trgt_dims= {{dst.info.dims[0], dst.info.dims[1], dst.info.dims[2], dst.info.dims[3]}};
+        } else {
+            dim_t trgt_l = std::min(dst.info.dims[3], src.info.dims[3]);
+            dim_t trgt_k = std::min(dst.info.dims[2], src.info.dims[2]);
+            dim_t trgt_j = std::min(dst.info.dims[1], src.info.dims[1]);
+            dim_t trgt_i = std::min(dst.info.dims[0], src.info.dims[0]);
+            trgt_dims= {{trgt_i, trgt_j, trgt_k, trgt_l}};
+        }
+
+        auto copyOp = KernelFunctor<Buffer, KParam, Buffer, KParam,
+                                  outType, float, dims_t,
+                                  int, int
+                                  >(*cpyKernels[device]);
+
+        copyOp(EnqueueArgs(getQueue(), global, local),
+                *dst.data, dst.info, *src.data, src.info,
+                default_value, (float)factor, trgt_dims, blk_x, blk_y);
+        CL_DEBUG_FINISH(getQueue());
     }
 
 }

--- a/src/backend/opencl/kernel/moments.hpp
+++ b/src/backend/opencl/kernel/moments.hpp
@@ -42,59 +42,54 @@ namespace opencl
         template <typename T>
         void moments(Param out, const Param in, af_moment_type moment)
         {
-            try {
-                std::string ref_name =
-                std::string("moments_") +
-                std::string(dtype_traits<T>::getName()) +
-                std::string("_") +
-                std::to_string(out.info.dims[0]);
+            std::string ref_name =
+            std::string("moments_") +
+            std::string(dtype_traits<T>::getName()) +
+            std::string("_") +
+            std::to_string(out.info.dims[0]);
 
-                int device = getActiveDeviceId();
-                kc_t::iterator idx = kernelCaches[device].find(ref_name);
+            int device = getActiveDeviceId();
+            kc_t::iterator idx = kernelCaches[device].find(ref_name);
 
-                kc_entry_t entry;
-                if (idx == kernelCaches[device].end()) {
-                    std::ostringstream options;
-                    options << " -D T="        << dtype_traits<T>::getName();
-                    options << " -D MOMENTS_SZ=" << out.info.dims[0];
+            kc_entry_t entry;
+            if (idx == kernelCaches[device].end()) {
+                std::ostringstream options;
+                options << " -D T="        << dtype_traits<T>::getName();
+                options << " -D MOMENTS_SZ=" << out.info.dims[0];
 
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-
-
-                    Program prog;
-                    buildProgram(prog, moments_cl, moments_cl_len, options.str());
-
-                    entry.prog = new Program(prog);
-                    entry.ker = new Kernel(*entry.prog, "moments_kernel");
-
-                    kernelCaches[device][ref_name] = entry;
-                } else {
-                    entry = idx->second;
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
                 }
 
 
-                auto momentsp = KernelFunctor<Buffer, const KParam,
-                                              const Buffer, const KParam,
-                                              const int, const int>(*entry.ker);
+                Program prog;
+                buildProgram(prog, moments_cl, moments_cl_len, options.str());
 
-                NDRange local(THREADS, 1, 1);
-                NDRange global(in.info.dims[1] * local[0] ,
-                               in.info.dims[2] * in.info.dims[3] * local[1] );
+                entry.prog = new Program(prog);
+                entry.ker = new Kernel(*entry.prog, "moments_kernel");
 
-                bool pBatch = !(in.info.dims[2] == 1 && in.info.dims[3] == 1);
-
-                momentsp(EnqueueArgs(getQueue(), global, local),
-                          *out.data, out.info, *in.data, in.info,
-                          (int)moment, (int)pBatch);
-
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
+                kernelCaches[device][ref_name] = entry;
+            } else {
+                entry = idx->second;
             }
+
+
+            auto momentsp = KernelFunctor<Buffer, const KParam,
+                                          const Buffer, const KParam,
+                                          const int, const int>(*entry.ker);
+
+            NDRange local(THREADS, 1, 1);
+            NDRange global(in.info.dims[1] * local[0] ,
+                            in.info.dims[2] * in.info.dims[3] * local[1] );
+
+            bool pBatch = !(in.info.dims[2] == 1 && in.info.dims[3] == 1);
+
+            momentsp(EnqueueArgs(getQueue(), global, local),
+                      *out.data, out.info, *in.data, in.info,
+                      (int)moment, (int)pBatch);
+
+            CL_DEBUG_FINISH(getQueue());
         }
     }
 }

--- a/src/backend/opencl/kernel/morph.hpp
+++ b/src/backend/opencl/kernel/morph.hpp
@@ -48,67 +48,62 @@ void morph(Param         out,
         const Param      in,
         const Param      mask)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*> morProgs;
-        static std::map<int, Kernel*> morKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*> morProgs;
+    static std::map<int, Kernel*> morKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
-                ToNumStr<T> toNumStr;
-                T init = isDilation ? Binary<T, af_max_t>().init() : Binary<T, af_min_t>().init();
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName()
-                        << " -D isDilation="<< isDilation
-                        << " -D init=" << toNumStr(init)
-                        << " -D windLen=" << windLen;
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
-                Program prog;
-                buildProgram(prog, morph_cl, morph_cl_len, options.str());
-                morProgs[device]   = new Program(prog);
-                morKernels[device] = new Kernel(*morProgs[device], "morph");
-            });
+    std::call_once( compileFlags[device], [device] () {
+            ToNumStr<T> toNumStr;
+            T init = isDilation ? Binary<T, af_max_t>().init() : Binary<T, af_min_t>().init();
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName()
+                    << " -D isDilation="<< isDilation
+                    << " -D init=" << toNumStr(init)
+                    << " -D windLen=" << windLen;
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
+            }
+            Program prog;
+            buildProgram(prog, morph_cl, morph_cl_len, options.str());
+            morProgs[device]   = new Program(prog);
+            morKernels[device] = new Kernel(*morProgs[device], "morph");
+        });
 
-        auto morphOp = KernelFunctor<Buffer, KParam,
-                                   Buffer, KParam,
-                                   Buffer, cl::LocalSpaceArg,
-                                   int, int
-                                  >(*morKernels[device]);
+    auto morphOp = KernelFunctor<Buffer, KParam,
+                                Buffer, KParam,
+                                Buffer, cl::LocalSpaceArg,
+                                int, int
+                              >(*morKernels[device]);
 
-        NDRange local(THREADS_X, THREADS_Y);
+    NDRange local(THREADS_X, THREADS_Y);
 
-        int blk_x = divup(in.info.dims[0], THREADS_X);
-        int blk_y = divup(in.info.dims[1], THREADS_Y);
-        // launch batch * blk_x blocks along x dimension
-        NDRange global(blk_x * THREADS_X * in.info.dims[2],
-                       blk_y * THREADS_Y * in.info.dims[3]);
+    int blk_x = divup(in.info.dims[0], THREADS_X);
+    int blk_y = divup(in.info.dims[1], THREADS_Y);
+    // launch batch * blk_x blocks along x dimension
+    NDRange global(blk_x * THREADS_X * in.info.dims[2],
+                    blk_y * THREADS_Y * in.info.dims[3]);
 
-        // copy mask/filter to constant memory
-        cl_int se_size   = sizeof(T)*windLen*windLen;
-        cl::Buffer *mBuff = bufferAlloc(se_size);
-        getQueue().enqueueCopyBuffer(*mask.data, *mBuff, 0, 0, se_size);
+    // copy mask/filter to constant memory
+    cl_int se_size   = sizeof(T)*windLen*windLen;
+    cl::Buffer *mBuff = bufferAlloc(se_size);
+    getQueue().enqueueCopyBuffer(*mask.data, *mBuff, 0, 0, se_size);
 
-        // calculate shared memory size
-        const int halo    = windLen/2;
-        const int padding = 2*halo;
-        const int locLen  = THREADS_X + padding + 1;
-        const int locSize = locLen * (THREADS_Y+padding);
+    // calculate shared memory size
+    const int halo    = windLen/2;
+    const int padding = 2*halo;
+    const int locLen  = THREADS_X + padding + 1;
+    const int locSize = locLen * (THREADS_Y+padding);
 
-        morphOp(EnqueueArgs(getQueue(), global, local),
-                *out.data, out.info, *in.data, in.info, *mBuff,
-                cl::Local(locSize*sizeof(T)), blk_x, blk_y);
+    morphOp(EnqueueArgs(getQueue(), global, local),
+            *out.data, out.info, *in.data, in.info, *mBuff,
+            cl::Local(locSize*sizeof(T)), blk_x, blk_y);
 
-        bufferFree(mBuff);
+    bufferFree(mBuff);
 
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
+    CL_DEBUG_FINISH(getQueue());
 }
 
 template<typename T, bool isDilation, int windLen>
@@ -116,68 +111,63 @@ void morph3d(Param       out,
         const Param      in,
         const Param      mask)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*>  morProgs;
-        static std::map<int, Kernel*> morKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*>  morProgs;
+    static std::map<int, Kernel*> morKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
-                ToNumStr<T> toNumStr;
-                T init = isDilation ? Binary<T, af_max_t>().init() : Binary<T, af_min_t>().init();
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName()
-                        << " -D isDilation="<< isDilation
-                        << " -D init=" << toNumStr(init)
-                        << " -D windLen=" << windLen;
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
-                Program prog;
-                buildProgram(prog, morph_cl, morph_cl_len, options.str());
-                morProgs[device]   = new Program(prog);
-                morKernels[device] = new Kernel(*morProgs[device], "morph3d");
-            });
+    std::call_once( compileFlags[device], [device] () {
+            ToNumStr<T> toNumStr;
+            T init = isDilation ? Binary<T, af_max_t>().init() : Binary<T, af_min_t>().init();
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName()
+                    << " -D isDilation="<< isDilation
+                    << " -D init=" << toNumStr(init)
+                    << " -D windLen=" << windLen;
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
+            }
+            Program prog;
+            buildProgram(prog, morph_cl, morph_cl_len, options.str());
+            morProgs[device]   = new Program(prog);
+            morKernels[device] = new Kernel(*morProgs[device], "morph3d");
+        });
 
-        auto morphOp = KernelFunctor<Buffer, KParam,
-                                   Buffer, KParam,
-                                   Buffer, cl::LocalSpaceArg, int
-                                  >(*morKernels[device]);
+    auto morphOp = KernelFunctor<Buffer, KParam,
+                                Buffer, KParam,
+                                Buffer, cl::LocalSpaceArg, int
+                              >(*morKernels[device]);
 
-        NDRange local(CUBE_X, CUBE_Y, CUBE_Z);
+    NDRange local(CUBE_X, CUBE_Y, CUBE_Z);
 
-        int blk_x = divup(in.info.dims[0], CUBE_X);
-        int blk_y = divup(in.info.dims[1], CUBE_Y);
-        int blk_z = divup(in.info.dims[2], CUBE_Z);
-        // launch batch * blk_x blocks along x dimension
-        NDRange global(blk_x * CUBE_X * in.info.dims[3],
-                       blk_y * CUBE_Y,
-                       blk_z * CUBE_Z);
+    int blk_x = divup(in.info.dims[0], CUBE_X);
+    int blk_y = divup(in.info.dims[1], CUBE_Y);
+    int blk_z = divup(in.info.dims[2], CUBE_Z);
+    // launch batch * blk_x blocks along x dimension
+    NDRange global(blk_x * CUBE_X * in.info.dims[3],
+                    blk_y * CUBE_Y,
+                    blk_z * CUBE_Z);
 
-        // copy mask/filter to constant memory
-        cl_int se_size   = sizeof(T)*windLen*windLen*windLen;
-        cl::Buffer *mBuff = bufferAlloc(se_size);
-        getQueue().enqueueCopyBuffer(*mask.data, *mBuff, 0, 0, se_size);
+    // copy mask/filter to constant memory
+    cl_int se_size   = sizeof(T)*windLen*windLen*windLen;
+    cl::Buffer *mBuff = bufferAlloc(se_size);
+    getQueue().enqueueCopyBuffer(*mask.data, *mBuff, 0, 0, se_size);
 
-        // calculate shared memory size
-        const int halo    = windLen/2;
-        const int padding = 2*halo;
-        const int locLen  = CUBE_X+padding+1;
-        const int locArea = locLen *(CUBE_Y+padding);
-        const int locSize = locArea*(CUBE_Z+padding);
+    // calculate shared memory size
+    const int halo    = windLen/2;
+    const int padding = 2*halo;
+    const int locLen  = CUBE_X+padding+1;
+    const int locArea = locLen *(CUBE_Y+padding);
+    const int locSize = locArea*(CUBE_Z+padding);
 
-        morphOp(EnqueueArgs(getQueue(), global, local),
-                *out.data, out.info, *in.data, in.info,
-                *mBuff, cl::Local(locSize*sizeof(T)), blk_x);
+    morphOp(EnqueueArgs(getQueue(), global, local),
+            *out.data, out.info, *in.data, in.info,
+            *mBuff, cl::Local(locSize*sizeof(T)), blk_x);
 
-        bufferFree(mBuff);
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
+    bufferFree(mBuff);
+    CL_DEBUG_FINISH(getQueue());
 }
 
 }

--- a/src/backend/opencl/kernel/nearest_neighbour.hpp
+++ b/src/backend/opencl/kernel/nearest_neighbour.hpp
@@ -37,137 +37,132 @@ void nearest_neighbour(Param idx,
                        const dim_t dist_dim,
                        const unsigned n_dist)
 {
-    try {
-        const unsigned feat_len = query.info.dims[dist_dim];
-        const To max_dist = maxval<To>();
+    const unsigned feat_len = query.info.dims[dist_dim];
+    const To max_dist = maxval<To>();
 
-        // Determine maximum feat_len capable of using shared memory (faster)
-        cl_ulong avail_lmem = getDevice().getInfo<CL_DEVICE_LOCAL_MEM_SIZE>();
-        size_t lmem_predef = 2 * THREADS * sizeof(unsigned) + feat_len * sizeof(T);
-        size_t ltrain_sz = THREADS * feat_len * sizeof(T);
-        bool use_lmem = (avail_lmem >= (lmem_predef + ltrain_sz)) ? true : false;
-        size_t lmem_sz = (use_lmem) ? lmem_predef + ltrain_sz : lmem_predef;
+    // Determine maximum feat_len capable of using shared memory (faster)
+    cl_ulong avail_lmem = getDevice().getInfo<CL_DEVICE_LOCAL_MEM_SIZE>();
+    size_t lmem_predef = 2 * THREADS * sizeof(unsigned) + feat_len * sizeof(T);
+    size_t ltrain_sz = THREADS * feat_len * sizeof(T);
+    bool use_lmem = (avail_lmem >= (lmem_predef + ltrain_sz)) ? true : false;
+    size_t lmem_sz = (use_lmem) ? lmem_predef + ltrain_sz : lmem_predef;
 
-        unsigned unroll_len = nextpow2(feat_len);
-        if (unroll_len != feat_len) unroll_len = 0;
+    unsigned unroll_len = nextpow2(feat_len);
+    if (unroll_len != feat_len) unroll_len = 0;
 
-        std::string ref_name =
-            std::string("knn_") +
-            std::to_string(dist_type) +
-            std::string("_") +
-            std::to_string(use_lmem) +
-            std::string("_") +
-            std::string(dtype_traits<T>::getName()) +
-            std::string("_") +
-            std::to_string(unroll_len);
+    std::string ref_name =
+        std::string("knn_") +
+        std::to_string(dist_type) +
+        std::string("_") +
+        std::to_string(use_lmem) +
+        std::string("_") +
+        std::string(dtype_traits<T>::getName()) +
+        std::string("_") +
+        std::to_string(unroll_len);
 
-        int device = getActiveDeviceId();
-        kc_t::iterator cache_idx = kernelCaches[device].find(ref_name);
+    int device = getActiveDeviceId();
+    kc_t::iterator cache_idx = kernelCaches[device].find(ref_name);
 
-        kc_entry_t entry;
-        if (cache_idx == kernelCaches[device].end()) {
+    kc_entry_t entry;
+    if (cache_idx == kernelCaches[device].end()) {
 
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName()
-                        << " -D To=" << dtype_traits<To>::getName()
-                        << " -D THREADS=" << THREADS
-                        << " -D FEAT_LEN=" << unroll_len;
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName()
+                    << " -D To=" << dtype_traits<To>::getName()
+                    << " -D THREADS=" << THREADS
+                    << " -D FEAT_LEN=" << unroll_len;
 
-                switch(dist_type) {
-                    case AF_SAD: options <<" -D DISTOP=_sad_"; break;
-                    case AF_SSD: options <<" -D DISTOP=_ssd_"; break;
-                    case AF_SHD: options <<" -D DISTOP=_shd_ -D __SHD__";
-                                 break;
-                    default: break;
-                }
+            switch(dist_type) {
+                case AF_SAD: options <<" -D DISTOP=_sad_"; break;
+                case AF_SSD: options <<" -D DISTOP=_ssd_"; break;
+                case AF_SHD: options <<" -D DISTOP=_shd_ -D __SHD__";
+                              break;
+                default: break;
+            }
 
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
+            }
 
-                if (use_lmem)
-                    options << " -D USE_LOCAL_MEM";
+            if (use_lmem)
+                options << " -D USE_LOCAL_MEM";
 
-                cl::Program prog;
-                buildProgram(prog,
-                             nearest_neighbour_cl,
-                             nearest_neighbour_cl_len,
-                             options.str());
+            cl::Program prog;
+            buildProgram(prog,
+                          nearest_neighbour_cl,
+                          nearest_neighbour_cl_len,
+                          options.str());
 
-                entry.prog = new Program(prog);
-                entry.ker = new Kernel[3];
+            entry.prog = new Program(prog);
+            entry.ker = new Kernel[3];
 
-                entry.ker[0] = Kernel(*entry.prog, "nearest_neighbour_unroll");
-                entry.ker[1] = Kernel(*entry.prog, "nearest_neighbour");
-                entry.ker[2] = Kernel(*entry.prog, "select_matches");
+            entry.ker[0] = Kernel(*entry.prog, "nearest_neighbour_unroll");
+            entry.ker[1] = Kernel(*entry.prog, "nearest_neighbour");
+            entry.ker[2] = Kernel(*entry.prog, "select_matches");
 
-                kernelCaches[device][ref_name] = entry;
-        } else {
-            entry = cache_idx->second;
-        }
-
-        const dim_t sample_dim = (dist_dim == 0) ? 1 : 0;
-
-        const unsigned nquery = query.info.dims[sample_dim];
-        const unsigned ntrain = train.info.dims[sample_dim];
-
-        unsigned nblk = divup(ntrain, THREADS);
-        const NDRange local(THREADS, 1);
-        const NDRange global(nblk * THREADS, 1);
-
-        cl::Buffer *d_blk_idx  = bufferAlloc(nblk * nquery * sizeof(unsigned));
-        cl::Buffer *d_blk_dist = bufferAlloc(nblk * nquery * sizeof(To));
-
-        // For each query vector, find training vector with smallest Hamming
-        // distance per CUDA block
-        if (unroll_len > 0) {
-            auto huOp = KernelFunctor<Buffer, Buffer,
-                                    Buffer, KParam,
-                                    Buffer, KParam,
-                                    const To,
-                                    LocalSpaceArg> (entry.ker[0]);
-
-            huOp(EnqueueArgs(getQueue(), global, local),
-                 *d_blk_idx, *d_blk_dist,
-                 *query.data, query.info, *train.data, train.info,
-                 max_dist, cl::Local(lmem_sz));
-        }
-        else {
-            auto hmOp = KernelFunctor<Buffer, Buffer,
-                                    Buffer, KParam,
-                                    Buffer, KParam,
-                                    const To, const unsigned,
-                                    LocalSpaceArg> (entry.ker[1]);
-
-            hmOp(EnqueueArgs(getQueue(), global, local),
-                 *d_blk_idx, *d_blk_dist,
-                 *query.data, query.info, *train.data, train.info,
-                 max_dist, feat_len, cl::Local(lmem_sz));
-        }
-        CL_DEBUG_FINISH(getQueue());
-
-        const NDRange local_sm(32, 8);
-        const NDRange global_sm(divup(nquery, 32) * 32, 8);
-
-        // Reduce all smallest Hamming distances from each block and store final
-        // best match
-        auto smOp = KernelFunctor<Buffer, Buffer, Buffer, Buffer,
-                                const unsigned, const unsigned,
-                                const To> (entry.ker[2]);
-
-        smOp(EnqueueArgs(getQueue(), global_sm, local_sm),
-             *idx.data, *dist.data,
-             *d_blk_idx, *d_blk_dist,
-             nquery, nblk, max_dist);
-        CL_DEBUG_FINISH(getQueue());
-
-        bufferFree(d_blk_idx);
-        bufferFree(d_blk_dist);
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
+            kernelCaches[device][ref_name] = entry;
+    } else {
+        entry = cache_idx->second;
     }
+
+    const dim_t sample_dim = (dist_dim == 0) ? 1 : 0;
+
+    const unsigned nquery = query.info.dims[sample_dim];
+    const unsigned ntrain = train.info.dims[sample_dim];
+
+    unsigned nblk = divup(ntrain, THREADS);
+    const NDRange local(THREADS, 1);
+    const NDRange global(nblk * THREADS, 1);
+
+    cl::Buffer *d_blk_idx  = bufferAlloc(nblk * nquery * sizeof(unsigned));
+    cl::Buffer *d_blk_dist = bufferAlloc(nblk * nquery * sizeof(To));
+
+    // For each query vector, find training vector with smallest Hamming
+    // distance per CUDA block
+    if (unroll_len > 0) {
+        auto huOp = KernelFunctor<Buffer, Buffer,
+                                Buffer, KParam,
+                                Buffer, KParam,
+                                const To,
+                                LocalSpaceArg> (entry.ker[0]);
+
+        huOp(EnqueueArgs(getQueue(), global, local),
+              *d_blk_idx, *d_blk_dist,
+              *query.data, query.info, *train.data, train.info,
+              max_dist, cl::Local(lmem_sz));
+    }
+    else {
+        auto hmOp = KernelFunctor<Buffer, Buffer,
+                                Buffer, KParam,
+                                Buffer, KParam,
+                                const To, const unsigned,
+                                LocalSpaceArg> (entry.ker[1]);
+
+        hmOp(EnqueueArgs(getQueue(), global, local),
+              *d_blk_idx, *d_blk_dist,
+              *query.data, query.info, *train.data, train.info,
+              max_dist, feat_len, cl::Local(lmem_sz));
+    }
+    CL_DEBUG_FINISH(getQueue());
+
+    const NDRange local_sm(32, 8);
+    const NDRange global_sm(divup(nquery, 32) * 32, 8);
+
+    // Reduce all smallest Hamming distances from each block and store final
+    // best match
+    auto smOp = KernelFunctor<Buffer, Buffer, Buffer, Buffer,
+                            const unsigned, const unsigned,
+                            const To> (entry.ker[2]);
+
+    smOp(EnqueueArgs(getQueue(), global_sm, local_sm),
+          *idx.data, *dist.data,
+          *d_blk_idx, *d_blk_dist,
+          nquery, nblk, max_dist);
+    CL_DEBUG_FINISH(getQueue());
+
+    bufferFree(d_blk_idx);
+    bufferFree(d_blk_dist);
 }
 
 } // namespace kernel

--- a/src/backend/opencl/kernel/orb.hpp
+++ b/src/backend/opencl/kernel/orb.hpp
@@ -101,423 +101,418 @@ void orb(unsigned* out_feat,
          const unsigned levels,
          const bool blur_img)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*> orbProgs;
-        static std::map<int, Kernel*>  hrKernel;
-        static std::map<int, Kernel*>  kfKernel;
-        static std::map<int, Kernel*>  caKernel;
-        static std::map<int, Kernel*>  eoKernel;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*> orbProgs;
+    static std::map<int, Kernel*>  hrKernel;
+    static std::map<int, Kernel*>  kfKernel;
+    static std::map<int, Kernel*>  caKernel;
+    static std::map<int, Kernel*>  eoKernel;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
+    std::call_once( compileFlags[device], [device] () {
 
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName()
-                        << " -D BLOCK_SIZE=" << ORB_THREADS_X;
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName()
+                    << " -D BLOCK_SIZE=" << ORB_THREADS_X;
 
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
+            }
 
-                cl::Program prog;
-                buildProgram(prog, orb_cl, orb_cl_len, options.str());
-                orbProgs[device] = new Program(prog);
+            cl::Program prog;
+            buildProgram(prog, orb_cl, orb_cl_len, options.str());
+            orbProgs[device] = new Program(prog);
 
-                hrKernel[device] = new Kernel(*orbProgs[device], "harris_response");
-                kfKernel[device] = new Kernel(*orbProgs[device], "keep_features");
-                caKernel[device] = new Kernel(*orbProgs[device], "centroid_angle");
-                eoKernel[device] = new Kernel(*orbProgs[device], "extract_orb");
-            });
+            hrKernel[device] = new Kernel(*orbProgs[device], "harris_response");
+            kfKernel[device] = new Kernel(*orbProgs[device], "keep_features");
+            caKernel[device] = new Kernel(*orbProgs[device], "centroid_angle");
+            eoKernel[device] = new Kernel(*orbProgs[device], "extract_orb");
+        });
 
-        unsigned patch_size = REF_PAT_SIZE;
+    unsigned patch_size = REF_PAT_SIZE;
 
-        unsigned min_side = std::min(image.info.dims[0], image.info.dims[1]);
-        unsigned max_levels = 0;
-        float scl_sum = 0.f;
-        for (unsigned i = 0; i < levels; i++) {
-            min_side /= scl_fctr;
+    unsigned min_side = std::min(image.info.dims[0], image.info.dims[1]);
+    unsigned max_levels = 0;
+    float scl_sum = 0.f;
+    for (unsigned i = 0; i < levels; i++) {
+        min_side /= scl_fctr;
 
-            // Minimum image side for a descriptor to be computed
-            if (min_side < patch_size || max_levels == levels) break;
+        // Minimum image side for a descriptor to be computed
+        if (min_side < patch_size || max_levels == levels) break;
 
-            max_levels++;
-            scl_sum += 1.f / (float)pow(scl_fctr,(float)i);
+        max_levels++;
+        scl_sum += 1.f / (float)pow(scl_fctr,(float)i);
+    }
+
+    vector<cl::Buffer*> d_x_pyr(max_levels);
+    vector<cl::Buffer*> d_y_pyr(max_levels);
+    vector<cl::Buffer*> d_score_pyr(max_levels);
+    vector<cl::Buffer*> d_ori_pyr(max_levels);
+    vector<cl::Buffer*> d_size_pyr(max_levels);
+    vector<cl::Buffer*> d_desc_pyr(max_levels);
+
+    vector<unsigned> feat_pyr(max_levels);
+    unsigned total_feat = 0;
+
+    // Compute number of features to keep for each level
+    vector<unsigned> lvl_best(max_levels);
+    unsigned feat_sum = 0;
+    for (unsigned i = 0; i < max_levels-1; i++) {
+        float lvl_scl = (float)pow(scl_fctr,(float)i);
+        lvl_best[i] = ceil((max_feat / scl_sum) / lvl_scl);
+        feat_sum += lvl_best[i];
+    }
+    lvl_best[max_levels-1] = max_feat - feat_sum;
+
+    // Maintain a reference to previous level image
+    Param prev_img;
+    Param lvl_img;
+
+    const unsigned gauss_len = 9;
+    T* h_gauss = nullptr;
+    Param gauss_filter;
+    gauss_filter.data = nullptr;
+
+    for (unsigned i = 0; i < max_levels; i++) {
+        const float lvl_scl = (float)pow(scl_fctr,(float)i);
+
+        if (i == 0) {
+            // First level is used in its original size
+            lvl_img = image;
+
+            prev_img = image;
+        }
+        else if (i > 0) {
+            // Resize previous level image to current level dimensions
+            lvl_img.info.dims[0] = round(image.info.dims[0] / lvl_scl);
+            lvl_img.info.dims[1] = round(image.info.dims[1] / lvl_scl);
+
+            lvl_img.info.strides[0] = 1;
+            lvl_img.info.strides[1] = lvl_img.info.dims[0];
+
+            for (int k = 2; k < 4; k++) {
+                lvl_img.info.dims[k] = 1;
+                lvl_img.info.strides[k] = lvl_img.info.dims[k - 1] * lvl_img.info.strides[k - 1];
+            }
+
+            lvl_img.info.offset = 0;
+            lvl_img.data = bufferAlloc(lvl_img.info.dims[3] * lvl_img.info.strides[3] * sizeof(T));
+
+            resize<T, AF_INTERP_BILINEAR>(lvl_img, prev_img);
+
+            if (i > 1)
+                bufferFree(prev_img.data);
+            prev_img = lvl_img;
         }
 
-        vector<cl::Buffer*> d_x_pyr(max_levels);
-        vector<cl::Buffer*> d_y_pyr(max_levels);
-        vector<cl::Buffer*> d_score_pyr(max_levels);
-        vector<cl::Buffer*> d_ori_pyr(max_levels);
-        vector<cl::Buffer*> d_size_pyr(max_levels);
-        vector<cl::Buffer*> d_desc_pyr(max_levels);
+        unsigned lvl_feat = 0;
+        Param d_x_feat, d_y_feat, d_score_feat;
 
-        vector<unsigned> feat_pyr(max_levels);
-        unsigned total_feat = 0;
+        // Round feature size to nearest odd integer
+        float size = 2.f * floor(patch_size / 2.f) + 1.f;
 
-        // Compute number of features to keep for each level
-        vector<unsigned> lvl_best(max_levels);
-        unsigned feat_sum = 0;
-        for (unsigned i = 0; i < max_levels-1; i++) {
-            float lvl_scl = (float)pow(scl_fctr,(float)i);
-            lvl_best[i] = ceil((max_feat / scl_sum) / lvl_scl);
-            feat_sum += lvl_best[i];
-        }
-        lvl_best[max_levels-1] = max_feat - feat_sum;
+        // Avoid keeping features that might be too wide and might not fit on
+        // the image, sqrt(2.f) is the radius when angle is 45 degrees and
+        // represents widest case possible
+        unsigned edge = ceil(size * sqrt(2.f) / 2.f);
 
-        // Maintain a reference to previous level image
-        Param prev_img;
-        Param lvl_img;
+        // Detect FAST features
+        fast<T, true>(9, &lvl_feat, d_x_feat, d_y_feat, d_score_feat,
+                      lvl_img, fast_thr, 0.15f, edge);
 
-        const unsigned gauss_len = 9;
-        T* h_gauss = nullptr;
-        Param gauss_filter;
-        gauss_filter.data = nullptr;
-
-        for (unsigned i = 0; i < max_levels; i++) {
-            const float lvl_scl = (float)pow(scl_fctr,(float)i);
-
-            if (i == 0) {
-                // First level is used in its original size
-                lvl_img = image;
-
-                prev_img = image;
-            }
-            else if (i > 0) {
-                // Resize previous level image to current level dimensions
-                lvl_img.info.dims[0] = round(image.info.dims[0] / lvl_scl);
-                lvl_img.info.dims[1] = round(image.info.dims[1] / lvl_scl);
-
-                lvl_img.info.strides[0] = 1;
-                lvl_img.info.strides[1] = lvl_img.info.dims[0];
-
-                for (int k = 2; k < 4; k++) {
-                    lvl_img.info.dims[k] = 1;
-                    lvl_img.info.strides[k] = lvl_img.info.dims[k - 1] * lvl_img.info.strides[k - 1];
-                }
-
-                lvl_img.info.offset = 0;
-                lvl_img.data = bufferAlloc(lvl_img.info.dims[3] * lvl_img.info.strides[3] * sizeof(T));
-
-                resize<T, AF_INTERP_BILINEAR>(lvl_img, prev_img);
-
-                if (i > 1)
-                   bufferFree(prev_img.data);
-                prev_img = lvl_img;
-            }
-
-            unsigned lvl_feat = 0;
-            Param d_x_feat, d_y_feat, d_score_feat;
-
-            // Round feature size to nearest odd integer
-            float size = 2.f * floor(patch_size / 2.f) + 1.f;
-
-            // Avoid keeping features that might be too wide and might not fit on
-            // the image, sqrt(2.f) is the radius when angle is 45 degrees and
-            // represents widest case possible
-            unsigned edge = ceil(size * sqrt(2.f) / 2.f);
-
-            // Detect FAST features
-            fast<T, true>(9, &lvl_feat, d_x_feat, d_y_feat, d_score_feat,
-                          lvl_img, fast_thr, 0.15f, edge);
-
-            if (lvl_feat == 0) {
-                feat_pyr[i] = 0;
-
-                if (i > 0 && i == max_levels-1)
-                    bufferFree(lvl_img.data);
-
-                continue;
-            }
-
-            bufferFree(d_score_feat.data);
-
-            unsigned usable_feat = 0;
-            cl::Buffer* d_usable_feat = bufferAlloc(sizeof(unsigned));
-            getQueue().enqueueWriteBuffer(*d_usable_feat, CL_TRUE, 0, sizeof(unsigned), &usable_feat);
-
-            cl::Buffer* d_x_harris = bufferAlloc(lvl_feat * sizeof(float));
-            cl::Buffer* d_y_harris = bufferAlloc(lvl_feat * sizeof(float));
-            cl::Buffer* d_score_harris = bufferAlloc(lvl_feat * sizeof(float));
-
-            // Calculate Harris responses
-            // Good block_size >= 7 (must be an odd number)
-            const int blk_x = divup(lvl_feat, ORB_THREADS_X);
-            const NDRange local(ORB_THREADS_X, ORB_THREADS_Y);
-            const NDRange global(blk_x * ORB_THREADS_X, ORB_THREADS_Y);
-
-            unsigned block_size = 7;
-            float k_thr = 0.04f;
-
-            auto hrOp = KernelFunctor<Buffer, Buffer, Buffer,
-                                    Buffer, Buffer, const unsigned,
-                                    Buffer, Buffer, KParam,
-                                    const unsigned, const float, const unsigned> (*hrKernel[device]);
-
-            hrOp(EnqueueArgs(getQueue(), global, local),
-                 *d_x_harris, *d_y_harris, *d_score_harris,
-                 *d_x_feat.data, *d_y_feat.data, lvl_feat,
-                 *d_usable_feat, *lvl_img.data, lvl_img.info,
-                 block_size, k_thr, patch_size);
-            CL_DEBUG_FINISH(getQueue());
-
-            getQueue().enqueueReadBuffer(*d_usable_feat, CL_TRUE, 0, sizeof(unsigned), &usable_feat);
-
-            if (lvl_feat > 0) { //This is just to supress warnings
-                bufferFree(d_x_feat.data);
-                bufferFree(d_y_feat.data);
-                bufferFree(d_usable_feat);
-            }
-
-            if (usable_feat == 0) {
-                feat_pyr[i] = 0;
-
-                bufferFree(d_x_harris);
-                bufferFree(d_y_harris);
-                bufferFree(d_score_harris);
-
-                if (i > 0 && i == max_levels-1)
-                    bufferFree(lvl_img.data);
-
-                continue;
-            }
-
-            // Sort features according to Harris responses
-            Param d_harris_sorted;
-            Param d_harris_idx;
-
-            d_harris_sorted.info.dims[0] = usable_feat;
-            d_harris_idx.info.dims[0] = usable_feat;
-            d_harris_sorted.info.strides[0] = 1;
-            d_harris_idx.info.strides[0] = 1;
-
-            for (int k = 1; k < 4; k++) {
-                d_harris_sorted.info.dims[k] = 1;
-                d_harris_idx.info.dims[k] = 1;
-                d_harris_sorted.info.strides[k] = d_harris_sorted.info.dims[k - 1] * d_harris_sorted.info.strides[k - 1];
-                d_harris_idx.info.strides[k] = d_harris_idx.info.dims[k - 1] * d_harris_idx.info.strides[k - 1];
-            }
-
-            d_harris_sorted.info.offset = 0;
-            d_harris_idx.info.offset = 0;
-            d_harris_sorted.data = d_score_harris;
-            // Create indices using range
-            d_harris_idx.data = bufferAlloc((d_harris_idx.info.dims[0]) * sizeof(unsigned));
-            kernel::range<uint>(d_harris_idx, 0);
-
-            kernel::sort0ByKey<float, uint>(d_harris_sorted, d_harris_idx, false);
-
-            cl::Buffer* d_x_lvl = bufferAlloc(usable_feat * sizeof(float));
-            cl::Buffer* d_y_lvl = bufferAlloc(usable_feat * sizeof(float));
-            cl::Buffer* d_score_lvl = bufferAlloc(usable_feat * sizeof(float));
-
-            usable_feat = min(usable_feat, lvl_best[i]);
-
-            // Keep only features with higher Harris responses
-            const int keep_blk = divup(usable_feat, ORB_THREADS);
-            const NDRange local_keep(ORB_THREADS, 1);
-            const NDRange global_keep(keep_blk * ORB_THREADS, 1);
-
-            auto kfOp = KernelFunctor<Buffer, Buffer, Buffer,
-                                    Buffer, Buffer, Buffer, Buffer,
-                                    const unsigned> (*kfKernel[device]);
-
-            kfOp(EnqueueArgs(getQueue(), global_keep, local_keep),
-                 *d_x_lvl, *d_y_lvl, *d_score_lvl,
-                 *d_x_harris, *d_y_harris, *d_harris_sorted.data, *d_harris_idx.data,
-                 usable_feat);
-            CL_DEBUG_FINISH(getQueue());
-
-            bufferFree(d_x_harris);
-            bufferFree(d_y_harris);
-            bufferFree(d_harris_sorted.data);
-            bufferFree(d_harris_idx.data);
-
-            cl::Buffer* d_ori_lvl = bufferAlloc(usable_feat * sizeof(float));
-            cl::Buffer* d_size_lvl = bufferAlloc(usable_feat * sizeof(float));
-
-            // Compute orientation of features
-            const int centroid_blk_x = divup(usable_feat, ORB_THREADS_X);
-            const NDRange local_centroid(ORB_THREADS_X, ORB_THREADS_Y);
-            const NDRange global_centroid(centroid_blk_x * ORB_THREADS_X, ORB_THREADS_Y);
-
-            auto caOp = KernelFunctor<Buffer, Buffer, Buffer,
-                                    const unsigned, Buffer, KParam,
-                                    const unsigned> (*caKernel[device]);
-
-            caOp(EnqueueArgs(getQueue(), global_centroid, local_centroid),
-                 *d_x_lvl, *d_y_lvl, *d_ori_lvl,
-                 usable_feat, *lvl_img.data, lvl_img.info,
-                 patch_size);
-            CL_DEBUG_FINISH(getQueue());
-
-            Param lvl_filt;
-            Param lvl_tmp;
-
-            if (blur_img) {
-                lvl_filt = lvl_img;
-                lvl_tmp = lvl_img;
-
-                lvl_filt.data = bufferAlloc(lvl_filt.info.dims[0] * lvl_filt.info.dims[1] * sizeof(T));
-                lvl_tmp.data = bufferAlloc(lvl_tmp.info.dims[0] * lvl_tmp.info.dims[1] * sizeof(T));
-
-                // Calculate a separable Gaussian kernel
-                if (h_gauss == nullptr) {
-                    h_gauss = new T[gauss_len];
-                    gaussian1D(h_gauss, gauss_len, 2.f);
-                    gauss_filter.info.dims[0] = gauss_len;
-                    gauss_filter.info.strides[0] = 1;
-
-                    for (int k = 1; k < 4; k++) {
-                        gauss_filter.info.dims[k] = 1;
-                        gauss_filter.info.strides[k] = gauss_filter.info.dims[k - 1] * gauss_filter.info.strides[k - 1];
-                    }
-
-                    int gauss_elem = gauss_filter.info.strides[3] * gauss_filter.info.dims[3];
-                    gauss_filter.data = bufferAlloc(gauss_elem * sizeof(T));
-                    getQueue().enqueueWriteBuffer(*gauss_filter.data, CL_TRUE, 0, gauss_elem * sizeof(T), h_gauss);
-                }
-
-                // Filter level image with Gaussian kernel to reduce noise sensitivity
-                convSep<T, convAccT, 0, false>(lvl_tmp, lvl_img, gauss_filter);
-                convSep<T, convAccT, 1, false>(lvl_filt, lvl_tmp, gauss_filter);
-
-                bufferFree(lvl_tmp.data);
-            }
-
-            // Compute ORB descriptors
-            cl::Buffer* d_desc_lvl = bufferAlloc(usable_feat * 8 * sizeof(unsigned));
-            {
-                vector<unsigned> h_desc_lvl(usable_feat * 8);
-                getQueue().enqueueWriteBuffer(*d_desc_lvl, CL_TRUE, 0, usable_feat * 8 * sizeof(unsigned), h_desc_lvl.data());
-            }
-
-            auto eoOp = KernelFunctor<Buffer, const unsigned,
-                                    Buffer, Buffer, Buffer, Buffer,
-                                    Buffer, KParam,
-                                    const float, const unsigned> (*eoKernel[device]);
-
-            if (blur_img) {
-                eoOp(EnqueueArgs(getQueue(), global_centroid, local_centroid),
-                     *d_desc_lvl, usable_feat,
-                     *d_x_lvl, *d_y_lvl, *d_ori_lvl, *d_size_lvl,
-                     *lvl_filt.data, lvl_filt.info,
-                     lvl_scl, patch_size);
-                CL_DEBUG_FINISH(getQueue());
-
-                bufferFree(lvl_filt.data);
-            }
-            else {
-                eoOp(EnqueueArgs(getQueue(), global_centroid, local_centroid),
-                     *d_desc_lvl, usable_feat,
-                     *d_x_lvl, *d_y_lvl, *d_ori_lvl, *d_size_lvl,
-                     *lvl_img.data, lvl_img.info,
-                     lvl_scl, patch_size);
-                CL_DEBUG_FINISH(getQueue());
-            }
-
-            // Store results to pyramids
-            total_feat += usable_feat;
-            feat_pyr[i] = usable_feat;
-            d_x_pyr[i] = d_x_lvl;
-            d_y_pyr[i] = d_y_lvl;
-            d_score_pyr[i] = d_score_lvl;
-            d_ori_pyr[i] = d_ori_lvl;
-            d_size_pyr[i] = d_size_lvl;
-            d_desc_pyr[i] = d_desc_lvl;
+        if (lvl_feat == 0) {
+            feat_pyr[i] = 0;
 
             if (i > 0 && i == max_levels-1)
                 bufferFree(lvl_img.data);
+
+            continue;
         }
 
-        if (gauss_filter.data != nullptr)
-            bufferFree(gauss_filter.data);
-        if (h_gauss != nullptr)
-            delete[] h_gauss;
+        bufferFree(d_score_feat.data);
 
-        // If no features are found, set found features to 0 and return
-        if (total_feat == 0) {
-            *out_feat = 0;
-            return;
+        unsigned usable_feat = 0;
+        cl::Buffer* d_usable_feat = bufferAlloc(sizeof(unsigned));
+        getQueue().enqueueWriteBuffer(*d_usable_feat, CL_TRUE, 0, sizeof(unsigned), &usable_feat);
+
+        cl::Buffer* d_x_harris = bufferAlloc(lvl_feat * sizeof(float));
+        cl::Buffer* d_y_harris = bufferAlloc(lvl_feat * sizeof(float));
+        cl::Buffer* d_score_harris = bufferAlloc(lvl_feat * sizeof(float));
+
+        // Calculate Harris responses
+        // Good block_size >= 7 (must be an odd number)
+        const int blk_x = divup(lvl_feat, ORB_THREADS_X);
+        const NDRange local(ORB_THREADS_X, ORB_THREADS_Y);
+        const NDRange global(blk_x * ORB_THREADS_X, ORB_THREADS_Y);
+
+        unsigned block_size = 7;
+        float k_thr = 0.04f;
+
+        auto hrOp = KernelFunctor<Buffer, Buffer, Buffer,
+                                Buffer, Buffer, const unsigned,
+                                Buffer, Buffer, KParam,
+                                const unsigned, const float, const unsigned> (*hrKernel[device]);
+
+        hrOp(EnqueueArgs(getQueue(), global, local),
+              *d_x_harris, *d_y_harris, *d_score_harris,
+              *d_x_feat.data, *d_y_feat.data, lvl_feat,
+              *d_usable_feat, *lvl_img.data, lvl_img.info,
+              block_size, k_thr, patch_size);
+        CL_DEBUG_FINISH(getQueue());
+
+        getQueue().enqueueReadBuffer(*d_usable_feat, CL_TRUE, 0, sizeof(unsigned), &usable_feat);
+
+        if (lvl_feat > 0) { //This is just to supress warnings
+            bufferFree(d_x_feat.data);
+            bufferFree(d_y_feat.data);
+            bufferFree(d_usable_feat);
         }
 
-        // Allocate output memory
-        x_out.info.dims[0] = total_feat;
-        x_out.info.strides[0] = 1;
-        y_out.info.dims[0] = total_feat;
-        y_out.info.strides[0] = 1;
-        score_out.info.dims[0] = total_feat;
-        score_out.info.strides[0] = 1;
-        ori_out.info.dims[0] = total_feat;
-        ori_out.info.strides[0] = 1;
-        size_out.info.dims[0] = total_feat;
-        size_out.info.strides[0] = 1;
+        if (usable_feat == 0) {
+            feat_pyr[i] = 0;
 
-        desc_out.info.dims[0] = 8;
-        desc_out.info.strides[0] = 1;
-        desc_out.info.dims[1] = total_feat;
-        desc_out.info.strides[1] = desc_out.info.dims[0];
+            bufferFree(d_x_harris);
+            bufferFree(d_y_harris);
+            bufferFree(d_score_harris);
+
+            if (i > 0 && i == max_levels-1)
+                bufferFree(lvl_img.data);
+
+            continue;
+        }
+
+        // Sort features according to Harris responses
+        Param d_harris_sorted;
+        Param d_harris_idx;
+
+        d_harris_sorted.info.dims[0] = usable_feat;
+        d_harris_idx.info.dims[0] = usable_feat;
+        d_harris_sorted.info.strides[0] = 1;
+        d_harris_idx.info.strides[0] = 1;
 
         for (int k = 1; k < 4; k++) {
-            x_out.info.dims[k] = 1;
-            x_out.info.strides[k] = x_out.info.dims[k - 1] * x_out.info.strides[k - 1];
-            y_out.info.dims[k] = 1;
-            y_out.info.strides[k] = y_out.info.dims[k - 1] * y_out.info.strides[k - 1];
-            score_out.info.dims[k] = 1;
-            score_out.info.strides[k] = score_out.info.dims[k - 1] * score_out.info.strides[k - 1];
-            ori_out.info.dims[k] = 1;
-            ori_out.info.strides[k] = ori_out.info.dims[k - 1] * ori_out.info.strides[k - 1];
-            size_out.info.dims[k] = 1;
-            size_out.info.strides[k] = size_out.info.dims[k - 1] * size_out.info.strides[k - 1];
-            if (k > 1) {
-                desc_out.info.dims[k] = 1;
-                desc_out.info.strides[k] = desc_out.info.dims[k - 1] * desc_out.info.strides[k - 1];
+            d_harris_sorted.info.dims[k] = 1;
+            d_harris_idx.info.dims[k] = 1;
+            d_harris_sorted.info.strides[k] = d_harris_sorted.info.dims[k - 1] * d_harris_sorted.info.strides[k - 1];
+            d_harris_idx.info.strides[k] = d_harris_idx.info.dims[k - 1] * d_harris_idx.info.strides[k - 1];
+        }
+
+        d_harris_sorted.info.offset = 0;
+        d_harris_idx.info.offset = 0;
+        d_harris_sorted.data = d_score_harris;
+        // Create indices using range
+        d_harris_idx.data = bufferAlloc((d_harris_idx.info.dims[0]) * sizeof(unsigned));
+        kernel::range<uint>(d_harris_idx, 0);
+
+        kernel::sort0ByKey<float, uint>(d_harris_sorted, d_harris_idx, false);
+
+        cl::Buffer* d_x_lvl = bufferAlloc(usable_feat * sizeof(float));
+        cl::Buffer* d_y_lvl = bufferAlloc(usable_feat * sizeof(float));
+        cl::Buffer* d_score_lvl = bufferAlloc(usable_feat * sizeof(float));
+
+        usable_feat = min(usable_feat, lvl_best[i]);
+
+        // Keep only features with higher Harris responses
+        const int keep_blk = divup(usable_feat, ORB_THREADS);
+        const NDRange local_keep(ORB_THREADS, 1);
+        const NDRange global_keep(keep_blk * ORB_THREADS, 1);
+
+        auto kfOp = KernelFunctor<Buffer, Buffer, Buffer,
+                                Buffer, Buffer, Buffer, Buffer,
+                                const unsigned> (*kfKernel[device]);
+
+        kfOp(EnqueueArgs(getQueue(), global_keep, local_keep),
+              *d_x_lvl, *d_y_lvl, *d_score_lvl,
+              *d_x_harris, *d_y_harris, *d_harris_sorted.data, *d_harris_idx.data,
+              usable_feat);
+        CL_DEBUG_FINISH(getQueue());
+
+        bufferFree(d_x_harris);
+        bufferFree(d_y_harris);
+        bufferFree(d_harris_sorted.data);
+        bufferFree(d_harris_idx.data);
+
+        cl::Buffer* d_ori_lvl = bufferAlloc(usable_feat * sizeof(float));
+        cl::Buffer* d_size_lvl = bufferAlloc(usable_feat * sizeof(float));
+
+        // Compute orientation of features
+        const int centroid_blk_x = divup(usable_feat, ORB_THREADS_X);
+        const NDRange local_centroid(ORB_THREADS_X, ORB_THREADS_Y);
+        const NDRange global_centroid(centroid_blk_x * ORB_THREADS_X, ORB_THREADS_Y);
+
+        auto caOp = KernelFunctor<Buffer, Buffer, Buffer,
+                                const unsigned, Buffer, KParam,
+                                const unsigned> (*caKernel[device]);
+
+        caOp(EnqueueArgs(getQueue(), global_centroid, local_centroid),
+              *d_x_lvl, *d_y_lvl, *d_ori_lvl,
+              usable_feat, *lvl_img.data, lvl_img.info,
+              patch_size);
+        CL_DEBUG_FINISH(getQueue());
+
+        Param lvl_filt;
+        Param lvl_tmp;
+
+        if (blur_img) {
+            lvl_filt = lvl_img;
+            lvl_tmp = lvl_img;
+
+            lvl_filt.data = bufferAlloc(lvl_filt.info.dims[0] * lvl_filt.info.dims[1] * sizeof(T));
+            lvl_tmp.data = bufferAlloc(lvl_tmp.info.dims[0] * lvl_tmp.info.dims[1] * sizeof(T));
+
+            // Calculate a separable Gaussian kernel
+            if (h_gauss == nullptr) {
+                h_gauss = new T[gauss_len];
+                gaussian1D(h_gauss, gauss_len, 2.f);
+                gauss_filter.info.dims[0] = gauss_len;
+                gauss_filter.info.strides[0] = 1;
+
+                for (int k = 1; k < 4; k++) {
+                    gauss_filter.info.dims[k] = 1;
+                    gauss_filter.info.strides[k] = gauss_filter.info.dims[k - 1] * gauss_filter.info.strides[k - 1];
+                }
+
+                int gauss_elem = gauss_filter.info.strides[3] * gauss_filter.info.dims[3];
+                gauss_filter.data = bufferAlloc(gauss_elem * sizeof(T));
+                getQueue().enqueueWriteBuffer(*gauss_filter.data, CL_TRUE, 0, gauss_elem * sizeof(T), h_gauss);
             }
+
+            // Filter level image with Gaussian kernel to reduce noise sensitivity
+            convSep<T, convAccT, 0, false>(lvl_tmp, lvl_img, gauss_filter);
+            convSep<T, convAccT, 1, false>(lvl_filt, lvl_tmp, gauss_filter);
+
+            bufferFree(lvl_tmp.data);
         }
 
-        if (total_feat > 0) {
-            size_t out_sz  = total_feat * sizeof(float);
-            x_out.data     = bufferAlloc(out_sz);
-            y_out.data     = bufferAlloc(out_sz);
-            score_out.data = bufferAlloc(out_sz);
-            ori_out.data   = bufferAlloc(out_sz);
-            size_out.data  = bufferAlloc(out_sz);
-
-            size_t desc_sz = total_feat * 8 * sizeof(unsigned);
-            desc_out.data  = bufferAlloc(desc_sz);
+        // Compute ORB descriptors
+        cl::Buffer* d_desc_lvl = bufferAlloc(usable_feat * 8 * sizeof(unsigned));
+        {
+            vector<unsigned> h_desc_lvl(usable_feat * 8);
+            getQueue().enqueueWriteBuffer(*d_desc_lvl, CL_TRUE, 0, usable_feat * 8 * sizeof(unsigned), h_desc_lvl.data());
         }
 
-        unsigned offset = 0;
-        for (unsigned i = 0; i < max_levels; i++) {
-            if (feat_pyr[i] == 0)
-                continue;
+        auto eoOp = KernelFunctor<Buffer, const unsigned,
+                                Buffer, Buffer, Buffer, Buffer,
+                                Buffer, KParam,
+                                const float, const unsigned> (*eoKernel[device]);
 
-            if (i > 0)
-                offset += feat_pyr[i-1];
+        if (blur_img) {
+            eoOp(EnqueueArgs(getQueue(), global_centroid, local_centroid),
+                  *d_desc_lvl, usable_feat,
+                  *d_x_lvl, *d_y_lvl, *d_ori_lvl, *d_size_lvl,
+                  *lvl_filt.data, lvl_filt.info,
+                  lvl_scl, patch_size);
+            CL_DEBUG_FINISH(getQueue());
 
-            getQueue().enqueueCopyBuffer(*d_x_pyr[i], *x_out.data, 0, offset*sizeof(float), feat_pyr[i] * sizeof(float));
-            getQueue().enqueueCopyBuffer(*d_y_pyr[i], *y_out.data, 0, offset*sizeof(float), feat_pyr[i] * sizeof(float));
-            getQueue().enqueueCopyBuffer(*d_score_pyr[i], *score_out.data, 0, offset*sizeof(float), feat_pyr[i] * sizeof(float));
-            getQueue().enqueueCopyBuffer(*d_ori_pyr[i], *ori_out.data, 0, offset*sizeof(float), feat_pyr[i] * sizeof(float));
-            getQueue().enqueueCopyBuffer(*d_size_pyr[i], *size_out.data, 0, offset*sizeof(float), feat_pyr[i] * sizeof(float));
-            getQueue().enqueueCopyBuffer(*d_desc_pyr[i], *desc_out.data, 0, offset*8*sizeof(unsigned), feat_pyr[i] * 8 * sizeof(unsigned));
-
-            bufferFree(d_x_pyr[i]);
-            bufferFree(d_y_pyr[i]);
-            bufferFree(d_score_pyr[i]);
-            bufferFree(d_ori_pyr[i]);
-            bufferFree(d_size_pyr[i]);
-            bufferFree(d_desc_pyr[i]);
+            bufferFree(lvl_filt.data);
+        }
+        else {
+            eoOp(EnqueueArgs(getQueue(), global_centroid, local_centroid),
+                  *d_desc_lvl, usable_feat,
+                  *d_x_lvl, *d_y_lvl, *d_ori_lvl, *d_size_lvl,
+                  *lvl_img.data, lvl_img.info,
+                  lvl_scl, patch_size);
+            CL_DEBUG_FINISH(getQueue());
         }
 
-        // Sets number of output features
-        *out_feat = total_feat;
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
+        // Store results to pyramids
+        total_feat += usable_feat;
+        feat_pyr[i] = usable_feat;
+        d_x_pyr[i] = d_x_lvl;
+        d_y_pyr[i] = d_y_lvl;
+        d_score_pyr[i] = d_score_lvl;
+        d_ori_pyr[i] = d_ori_lvl;
+        d_size_pyr[i] = d_size_lvl;
+        d_desc_pyr[i] = d_desc_lvl;
+
+        if (i > 0 && i == max_levels-1)
+            bufferFree(lvl_img.data);
     }
+
+    if (gauss_filter.data != nullptr)
+        bufferFree(gauss_filter.data);
+    if (h_gauss != nullptr)
+        delete[] h_gauss;
+
+    // If no features are found, set found features to 0 and return
+    if (total_feat == 0) {
+        *out_feat = 0;
+        return;
+    }
+
+    // Allocate output memory
+    x_out.info.dims[0] = total_feat;
+    x_out.info.strides[0] = 1;
+    y_out.info.dims[0] = total_feat;
+    y_out.info.strides[0] = 1;
+    score_out.info.dims[0] = total_feat;
+    score_out.info.strides[0] = 1;
+    ori_out.info.dims[0] = total_feat;
+    ori_out.info.strides[0] = 1;
+    size_out.info.dims[0] = total_feat;
+    size_out.info.strides[0] = 1;
+
+    desc_out.info.dims[0] = 8;
+    desc_out.info.strides[0] = 1;
+    desc_out.info.dims[1] = total_feat;
+    desc_out.info.strides[1] = desc_out.info.dims[0];
+
+    for (int k = 1; k < 4; k++) {
+        x_out.info.dims[k] = 1;
+        x_out.info.strides[k] = x_out.info.dims[k - 1] * x_out.info.strides[k - 1];
+        y_out.info.dims[k] = 1;
+        y_out.info.strides[k] = y_out.info.dims[k - 1] * y_out.info.strides[k - 1];
+        score_out.info.dims[k] = 1;
+        score_out.info.strides[k] = score_out.info.dims[k - 1] * score_out.info.strides[k - 1];
+        ori_out.info.dims[k] = 1;
+        ori_out.info.strides[k] = ori_out.info.dims[k - 1] * ori_out.info.strides[k - 1];
+        size_out.info.dims[k] = 1;
+        size_out.info.strides[k] = size_out.info.dims[k - 1] * size_out.info.strides[k - 1];
+        if (k > 1) {
+            desc_out.info.dims[k] = 1;
+            desc_out.info.strides[k] = desc_out.info.dims[k - 1] * desc_out.info.strides[k - 1];
+        }
+    }
+
+    if (total_feat > 0) {
+        size_t out_sz  = total_feat * sizeof(float);
+        x_out.data     = bufferAlloc(out_sz);
+        y_out.data     = bufferAlloc(out_sz);
+        score_out.data = bufferAlloc(out_sz);
+        ori_out.data   = bufferAlloc(out_sz);
+        size_out.data  = bufferAlloc(out_sz);
+
+        size_t desc_sz = total_feat * 8 * sizeof(unsigned);
+        desc_out.data  = bufferAlloc(desc_sz);
+    }
+
+    unsigned offset = 0;
+    for (unsigned i = 0; i < max_levels; i++) {
+        if (feat_pyr[i] == 0)
+            continue;
+
+        if (i > 0)
+            offset += feat_pyr[i-1];
+
+        getQueue().enqueueCopyBuffer(*d_x_pyr[i], *x_out.data, 0, offset*sizeof(float), feat_pyr[i] * sizeof(float));
+        getQueue().enqueueCopyBuffer(*d_y_pyr[i], *y_out.data, 0, offset*sizeof(float), feat_pyr[i] * sizeof(float));
+        getQueue().enqueueCopyBuffer(*d_score_pyr[i], *score_out.data, 0, offset*sizeof(float), feat_pyr[i] * sizeof(float));
+        getQueue().enqueueCopyBuffer(*d_ori_pyr[i], *ori_out.data, 0, offset*sizeof(float), feat_pyr[i] * sizeof(float));
+        getQueue().enqueueCopyBuffer(*d_size_pyr[i], *size_out.data, 0, offset*sizeof(float), feat_pyr[i] * sizeof(float));
+        getQueue().enqueueCopyBuffer(*d_desc_pyr[i], *desc_out.data, 0, offset*8*sizeof(unsigned), feat_pyr[i] * 8 * sizeof(unsigned));
+
+        bufferFree(d_x_pyr[i]);
+        bufferFree(d_y_pyr[i]);
+        bufferFree(d_score_pyr[i]);
+        bufferFree(d_ori_pyr[i]);
+        bufferFree(d_size_pyr[i]);
+        bufferFree(d_desc_pyr[i]);
+    }
+
+    // Sets number of output features
+    *out_feat = total_feat;
 }
 
 } //namespace kernel

--- a/src/backend/opencl/kernel/reduce.hpp
+++ b/src/backend/opencl/kernel/reduce.hpp
@@ -273,93 +273,85 @@ namespace kernel
     template<typename Ti, typename To, af_op_t op>
     void reduce(Param out, Param in, int dim, int change_nan, double nanval)
     {
-        try {
-            if (dim == 0)
-                return reduce_first<Ti, To, op>(out, in, change_nan, nanval);
-            else
-                return reduce_dim  <Ti, To, op>(out, in, change_nan, nanval, dim);
-        } catch(cl::Error ex) {
-            CL_TO_AF_ERROR(ex);
-        }
+        if (dim == 0)
+            return reduce_first<Ti, To, op>(out, in, change_nan, nanval);
+        else
+            return reduce_dim  <Ti, To, op>(out, in, change_nan, nanval, dim);
     }
 
     template<typename Ti, typename To, af_op_t op>
     To reduce_all(Param in, int change_nan, double nanval)
     {
-        try {
-            int in_elements = in.info.dims[0] * in.info.dims[1] * in.info.dims[2] * in.info.dims[3];
+        int in_elements = in.info.dims[0] * in.info.dims[1] * in.info.dims[2] * in.info.dims[3];
 
-            bool is_linear = (in.info.strides[0] == 1);
-            for (int k = 1; k < 4; k++) {
-                is_linear &= (in.info.strides[k] == (in.info.strides[k - 1] * in.info.dims[k - 1]));
-            }
+        bool is_linear = (in.info.strides[0] == 1);
+        for (int k = 1; k < 4; k++) {
+            is_linear &= (in.info.strides[k] == (in.info.strides[k - 1] * in.info.dims[k - 1]));
+        }
 
-            // FIXME: Use better heuristics to get to the optimum number
-            if (in_elements > 4096 || !is_linear) {
+        // FIXME: Use better heuristics to get to the optimum number
+        if (in_elements > 4096 || !is_linear) {
 
-                if (is_linear) {
-                    in.info.dims[0] = in_elements;
-                    for (int k = 1; k < 4; k++) {
-                        in.info.dims[k] = 1;
-                        in.info.strides[k] = in_elements;
-                    }
-                }
-
-                uint threads_x = nextpow2(std::max(32u, (uint)in.info.dims[0]));
-                threads_x = std::min(threads_x, THREADS_PER_GROUP);
-                uint threads_y = THREADS_PER_GROUP / threads_x;
-
-                Param tmp;
-                uint groups_x = divup(in.info.dims[0], threads_x * REPEAT);
-                uint groups_y = divup(in.info.dims[1], threads_y);
-
-                tmp.info.offset = 0;
-                tmp.info.dims[0] = groups_x;
-                tmp.info.strides[0] = 1;
-
+            if (is_linear) {
+                in.info.dims[0] = in_elements;
                 for (int k = 1; k < 4; k++) {
-                    tmp.info.dims[k] = in.info.dims[k];
-                    tmp.info.strides[k] = tmp.info.dims[k - 1] * tmp.info.strides[k - 1];
+                    in.info.dims[k] = 1;
+                    in.info.strides[k] = in_elements;
                 }
-
-                int tmp_elements = tmp.info.strides[3] * tmp.info.dims[3];
-                tmp.data = bufferAlloc(tmp_elements * sizeof(To));
-
-                reduce_first_launcher<Ti, To, op>(tmp, in, groups_x, groups_y, threads_x, change_nan, nanval);
-
-                unique_ptr<To> h_ptr(new To[tmp_elements]);
-                getQueue().enqueueReadBuffer(*tmp.data, CL_TRUE, 0, sizeof(To) * tmp_elements, h_ptr.get());
-
-                Binary<To, op> reduce;
-                To out = reduce.init();
-                for (int i = 0; i < (int)tmp_elements; i++) {
-                    out = reduce(out, h_ptr.get()[i]);
-                }
-
-                bufferFree(tmp.data);
-                return out;
-
-            } else {
-
-                unique_ptr<Ti> h_ptr(new Ti[in_elements]);
-                getQueue().enqueueReadBuffer(*in.data, CL_TRUE, sizeof(Ti) * in.info.offset,
-                                             sizeof(Ti) * in_elements, h_ptr.get());
-
-                Transform<Ti, To, op> transform;
-                Binary<To, op> reduce;
-                To out = reduce.init();
-                To nanval_to = scalar<To>(nanval);
-
-                for (int i = 0; i < (int)in_elements; i++) {
-                    To in_val = transform(h_ptr.get()[i]);
-                    if (change_nan) in_val = IS_NAN(in_val) ? nanval_to : in_val;
-                    out = reduce(out, in_val);
-                }
-
-                return out;
             }
-        } catch(cl::Error ex) {
-            CL_TO_AF_ERROR(ex);
+
+            uint threads_x = nextpow2(std::max(32u, (uint)in.info.dims[0]));
+            threads_x = std::min(threads_x, THREADS_PER_GROUP);
+            uint threads_y = THREADS_PER_GROUP / threads_x;
+
+            Param tmp;
+            uint groups_x = divup(in.info.dims[0], threads_x * REPEAT);
+            uint groups_y = divup(in.info.dims[1], threads_y);
+
+            tmp.info.offset = 0;
+            tmp.info.dims[0] = groups_x;
+            tmp.info.strides[0] = 1;
+
+            for (int k = 1; k < 4; k++) {
+                tmp.info.dims[k] = in.info.dims[k];
+                tmp.info.strides[k] = tmp.info.dims[k - 1] * tmp.info.strides[k - 1];
+            }
+
+            int tmp_elements = tmp.info.strides[3] * tmp.info.dims[3];
+            tmp.data = bufferAlloc(tmp_elements * sizeof(To));
+
+            reduce_first_launcher<Ti, To, op>(tmp, in, groups_x, groups_y, threads_x, change_nan, nanval);
+
+            unique_ptr<To> h_ptr(new To[tmp_elements]);
+            getQueue().enqueueReadBuffer(*tmp.data, CL_TRUE, 0, sizeof(To) * tmp_elements, h_ptr.get());
+
+            Binary<To, op> reduce;
+            To out = reduce.init();
+            for (int i = 0; i < (int)tmp_elements; i++) {
+                out = reduce(out, h_ptr.get()[i]);
+            }
+
+            bufferFree(tmp.data);
+            return out;
+
+        } else {
+
+            unique_ptr<Ti> h_ptr(new Ti[in_elements]);
+            getQueue().enqueueReadBuffer(*in.data, CL_TRUE, sizeof(Ti) * in.info.offset,
+                                          sizeof(Ti) * in_elements, h_ptr.get());
+
+            Transform<Ti, To, op> transform;
+            Binary<To, op> reduce;
+            To out = reduce.init();
+            To nanval_to = scalar<To>(nanval);
+
+            for (int i = 0; i < (int)in_elements; i++) {
+                To in_val = transform(h_ptr.get()[i]);
+                if (change_nan) in_val = IS_NAN(in_val) ? nanval_to : in_val;
+                out = reduce(out, in_val);
+            }
+
+            return out;
         }
     }
 

--- a/src/backend/opencl/kernel/regions.hpp
+++ b/src/backend/opencl/kernel/regions.hpp
@@ -53,169 +53,164 @@ static const int THREADS_Y = 16;
 template<typename T, bool full_conn, int n_per_thread>
 void regions(Param out, Param in)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*> regionsProgs;
-        static std::map<int, Kernel *>     ilKernel;
-        static std::map<int, Kernel *>     frKernel;
-        static std::map<int, Kernel *>     ueKernel;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*> regionsProgs;
+    static std::map<int, Kernel *>     ilKernel;
+    static std::map<int, Kernel *>     frKernel;
+    static std::map<int, Kernel *>     ueKernel;
 
-        int device = getActiveDeviceId();
-        static const int block_dim = 16;
-        static const int num_warps = 8;
+    int device = getActiveDeviceId();
+    static const int block_dim = 16;
+    static const int num_warps = 8;
 
-        std::call_once( compileFlags[device], [device] () {
-                ToNumStr<T> toNumStr;
-                std::ostringstream options;
-                if (full_conn) {
-                    options << " -D T=" << dtype_traits<T>::getName()
-                            << " -D BLOCK_DIM=" << block_dim
-                            << " -D NUM_WARPS=" << num_warps
-                            << " -D N_PER_THREAD=" << n_per_thread
-                            << " -D LIMIT_MAX=" << toNumStr(maxval<T>())
-                            << " -D FULL_CONN";
-                }
-                else {
-                    options << " -D T=" << dtype_traits<T>::getName()
-                            << " -D BLOCK_DIM=" << block_dim
-                            << " -D NUM_WARPS=" << num_warps
-                            << " -D N_PER_THREAD=" << n_per_thread
-                            << " -D LIMIT_MAX=" << toNumStr(maxval<T>());
-                }
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
-
-                Program prog;
-                buildProgram(prog, regions_cl, regions_cl_len, options.str());
-                regionsProgs[device] = new Program(prog);
-
-                ilKernel[device] = new Kernel(*regionsProgs[device], "initial_label");
-                frKernel[device] = new Kernel(*regionsProgs[device], "final_relabel");
-                ueKernel[device] = new Kernel(*regionsProgs[device], "update_equiv");
-            });
-
-        const NDRange local(THREADS_X, THREADS_Y);
-
-        const int blk_x = divup(in.info.dims[0], THREADS_X*2);
-        const int blk_y = divup(in.info.dims[1], THREADS_Y*2);
-
-        const NDRange global(blk_x * THREADS_X, blk_y * THREADS_Y);
-
-        auto ilOp = KernelFunctor<Buffer, KParam,
-                                Buffer, KParam> (*ilKernel[device]);
-
-        ilOp(EnqueueArgs(getQueue(), global, local),
-             *out.data, out.info, *in.data, in.info);
-
-        CL_DEBUG_FINISH(getQueue());
-
-        int h_continue = 1;
-        cl::Buffer *d_continue = bufferAlloc(sizeof(int));
-
-        while (h_continue) {
-            h_continue = 0;
-            getQueue().enqueueWriteBuffer(*d_continue, CL_TRUE, 0, sizeof(int), &h_continue);
-
-            auto ueOp = KernelFunctor<Buffer, KParam,
-                                    Buffer> (*ueKernel[device]);
-
-            ueOp(EnqueueArgs(getQueue(), global, local),
-                 *out.data, out.info, *d_continue);
-            CL_DEBUG_FINISH(getQueue());
-
-            getQueue().enqueueReadBuffer(*d_continue, CL_TRUE, 0, sizeof(int), &h_continue);
-        }
-
-        bufferFree(d_continue);
-
-        // Now, perform the final relabeling.  This converts the equivalency
-        // map from having unique labels based on the lowest pixel in the
-        // component to being sequentially numbered components starting at
-        // 1.
-        int size = in.info.dims[0] * in.info.dims[1];
-
-        compute::command_queue c_queue(getQueue()());
-
-        // Wrap raw device ptr
-        compute::context context(getContext()());
-        compute::vector<T> tmp(size, context);
-        clEnqueueCopyBuffer(getQueue()(), (*out.data)(), tmp.get_buffer().get(), 0, 0, size * sizeof(T), 0, NULL, NULL);
-
-        // Sort the copy
-        compute::sort(tmp.begin(), tmp.end(), c_queue);
-
-        // Take the max element, this is the number of label assignments to
-        // compute.
-        //int num_bins = tmp[size - 1] + 1;
-        T last_label;
-        clEnqueueReadBuffer(getQueue()(), tmp.get_buffer().get(), CL_TRUE, (size - 1) * sizeof(T), sizeof(T), &last_label, 0, NULL, NULL);
-        int num_bins = (int)last_label + 1;
-
-        Buffer labels(getContext(), CL_MEM_READ_WRITE, num_bins * sizeof(T));
-        compute::buffer c_labels(labels());
-        compute::buffer_iterator<T> labels_begin = compute::make_buffer_iterator<T>(c_labels, 0);
-        compute::buffer_iterator<T> labels_end   = compute::make_buffer_iterator<T>(c_labels, num_bins);
-
-        // Find the end of each section of values
-        compute::counting_iterator<T> search_begin(0);
-
-        int tmp_size = size;
-        BOOST_COMPUTE_CLOSURE(int, upper_bound_closure, (int v), (tmp, tmp_size),
-        {
-            int start = 0, n = tmp_size, i;
-            while(start < n)
-            {
-                i = (start + n) / 2;
-                if(v < tmp[i])
-                {
-                    n = i;
-                }
-                else
-                {
-                    start = i + 1;
-                }
+    std::call_once( compileFlags[device], [device] () {
+            ToNumStr<T> toNumStr;
+            std::ostringstream options;
+            if (full_conn) {
+                options << " -D T=" << dtype_traits<T>::getName()
+                        << " -D BLOCK_DIM=" << block_dim
+                        << " -D NUM_WARPS=" << num_warps
+                        << " -D N_PER_THREAD=" << n_per_thread
+                        << " -D LIMIT_MAX=" << toNumStr(maxval<T>())
+                        << " -D FULL_CONN";
+            }
+            else {
+                options << " -D T=" << dtype_traits<T>::getName()
+                        << " -D BLOCK_DIM=" << block_dim
+                        << " -D NUM_WARPS=" << num_warps
+                        << " -D N_PER_THREAD=" << n_per_thread
+                        << " -D LIMIT_MAX=" << toNumStr(maxval<T>());
+            }
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
             }
 
-            return start;
+            Program prog;
+            buildProgram(prog, regions_cl, regions_cl_len, options.str());
+            regionsProgs[device] = new Program(prog);
+
+            ilKernel[device] = new Kernel(*regionsProgs[device], "initial_label");
+            frKernel[device] = new Kernel(*regionsProgs[device], "final_relabel");
+            ueKernel[device] = new Kernel(*regionsProgs[device], "update_equiv");
         });
 
-        BOOST_COMPUTE_FUNCTION(int, clamp_to_one, (int i),
-        {
-            return (i >= 1) ? 1 : i;
-        });
+    const NDRange local(THREADS_X, THREADS_Y);
 
-        compute::transform(search_begin, search_begin + num_bins,
-                           labels_begin,
-                           upper_bound_closure,
-                           c_queue);
-        compute::adjacent_difference(labels_begin, labels_end, labels_begin, c_queue);
+    const int blk_x = divup(in.info.dims[0], THREADS_X*2);
+    const int blk_y = divup(in.info.dims[1], THREADS_Y*2);
 
-        // Perform the scan -- this can computes the correct labels for each
-        // component
-        compute::transform(labels_begin, labels_end,
-                           labels_begin,
-                           clamp_to_one,
-                           c_queue);
-        compute::exclusive_scan(labels_begin,
-                                labels_end,
-                                labels_begin,
-                                c_queue);
+    const NDRange global(blk_x * THREADS_X, blk_y * THREADS_Y);
 
-        // Apply the correct labels to the equivalency map
-        auto frOp = KernelFunctor<Buffer, KParam,
-                                Buffer, KParam,
-                                Buffer> (*frKernel[device]);
+    auto ilOp = KernelFunctor<Buffer, KParam,
+                            Buffer, KParam> (*ilKernel[device]);
 
-        //Buffer labels_buf(tmp.get_buffer().get());
-        frOp(EnqueueArgs(getQueue(), global, local),
-             *out.data, out.info, *in.data, in.info, labels);
+    ilOp(EnqueueArgs(getQueue(), global, local),
+          *out.data, out.info, *in.data, in.info);
+
+    CL_DEBUG_FINISH(getQueue());
+
+    int h_continue = 1;
+    cl::Buffer *d_continue = bufferAlloc(sizeof(int));
+
+    while (h_continue) {
+        h_continue = 0;
+        getQueue().enqueueWriteBuffer(*d_continue, CL_TRUE, 0, sizeof(int), &h_continue);
+
+        auto ueOp = KernelFunctor<Buffer, KParam,
+                                Buffer> (*ueKernel[device]);
+
+        ueOp(EnqueueArgs(getQueue(), global, local),
+              *out.data, out.info, *d_continue);
         CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
+
+        getQueue().enqueueReadBuffer(*d_continue, CL_TRUE, 0, sizeof(int), &h_continue);
     }
+
+    bufferFree(d_continue);
+
+    // Now, perform the final relabeling.  This converts the equivalency
+    // map from having unique labels based on the lowest pixel in the
+    // component to being sequentially numbered components starting at
+    // 1.
+    int size = in.info.dims[0] * in.info.dims[1];
+
+    compute::command_queue c_queue(getQueue()());
+
+    // Wrap raw device ptr
+    compute::context context(getContext()());
+    compute::vector<T> tmp(size, context);
+    clEnqueueCopyBuffer(getQueue()(), (*out.data)(), tmp.get_buffer().get(), 0, 0, size * sizeof(T), 0, NULL, NULL);
+
+    // Sort the copy
+    compute::sort(tmp.begin(), tmp.end(), c_queue);
+
+    // Take the max element, this is the number of label assignments to
+    // compute.
+    //int num_bins = tmp[size - 1] + 1;
+    T last_label;
+    clEnqueueReadBuffer(getQueue()(), tmp.get_buffer().get(), CL_TRUE, (size - 1) * sizeof(T), sizeof(T), &last_label, 0, NULL, NULL);
+    int num_bins = (int)last_label + 1;
+
+    Buffer labels(getContext(), CL_MEM_READ_WRITE, num_bins * sizeof(T));
+    compute::buffer c_labels(labels());
+    compute::buffer_iterator<T> labels_begin = compute::make_buffer_iterator<T>(c_labels, 0);
+    compute::buffer_iterator<T> labels_end   = compute::make_buffer_iterator<T>(c_labels, num_bins);
+
+    // Find the end of each section of values
+    compute::counting_iterator<T> search_begin(0);
+
+    int tmp_size = size;
+    BOOST_COMPUTE_CLOSURE(int, upper_bound_closure, (int v), (tmp, tmp_size),
+    {
+        int start = 0, n = tmp_size, i;
+        while(start < n)
+        {
+            i = (start + n) / 2;
+            if(v < tmp[i])
+            {
+                n = i;
+            }
+            else
+            {
+                start = i + 1;
+            }
+        }
+
+        return start;
+    });
+
+    BOOST_COMPUTE_FUNCTION(int, clamp_to_one, (int i),
+    {
+        return (i >= 1) ? 1 : i;
+    });
+
+    compute::transform(search_begin, search_begin + num_bins,
+                        labels_begin,
+                        upper_bound_closure,
+                        c_queue);
+    compute::adjacent_difference(labels_begin, labels_end, labels_begin, c_queue);
+
+    // Perform the scan -- this can computes the correct labels for each
+    // component
+    compute::transform(labels_begin, labels_end,
+                        labels_begin,
+                        clamp_to_one,
+                        c_queue);
+    compute::exclusive_scan(labels_begin,
+                            labels_end,
+                            labels_begin,
+                            c_queue);
+
+    // Apply the correct labels to the equivalency map
+    auto frOp = KernelFunctor<Buffer, KParam,
+                            Buffer, KParam,
+                            Buffer> (*frKernel[device]);
+
+    //Buffer labels_buf(tmp.get_buffer().get());
+    frOp(EnqueueArgs(getQueue(), global, local),
+          *out.data, out.info, *in.data, in.info, labels);
+    CL_DEBUG_FINISH(getQueue());
 }
 
 } //namespace kernel

--- a/src/backend/opencl/kernel/rotate.hpp
+++ b/src/backend/opencl/kernel/rotate.hpp
@@ -57,103 +57,98 @@ namespace opencl
         template<typename T, int order>
         void rotate(Param out, const Param in, const float theta, af_interp_type method)
         {
-            try {
-                static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-                static std::map<int, Program*>   rotateProgs;
-                static std::map<int, Kernel *> rotateKernels;
+            static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+            static std::map<int, Program*>   rotateProgs;
+            static std::map<int, Kernel *> rotateKernels;
 
-                int device = getActiveDeviceId();
-                typedef typename dtype_traits<T>::base_type BT;
+            int device = getActiveDeviceId();
+            typedef typename dtype_traits<T>::base_type BT;
 
-                std::call_once( compileFlags[device], [device] () {
-                    ToNumStr<T> toNumStr;
-                    std::ostringstream options;
-                    options << " -D T="        << dtype_traits<T>::getName();
-                    options << " -D ZERO="      << toNumStr(scalar<T>(0));
-                    options << " -D InterpInTy=" << dtype_traits<T>::getName();
-                    options << " -D InterpValTy="  << dtype_traits<vtype_t<T>>::getName();
-                    options << " -D InterpPosTy=" << dtype_traits<wtype_t<BT>>::getName();
+            std::call_once( compileFlags[device], [device] () {
+                ToNumStr<T> toNumStr;
+                std::ostringstream options;
+                options << " -D T="        << dtype_traits<T>::getName();
+                options << " -D ZERO="      << toNumStr(scalar<T>(0));
+                options << " -D InterpInTy=" << dtype_traits<T>::getName();
+                options << " -D InterpValTy="  << dtype_traits<vtype_t<T>>::getName();
+                options << " -D InterpPosTy=" << dtype_traits<wtype_t<BT>>::getName();
 
-                    if((af_dtype) dtype_traits<T>::af_type == c32 ||
-                       (af_dtype) dtype_traits<T>::af_type == c64) {
-                        options << " -D IS_CPLX=1";
-                        options << " -D TB=" << dtype_traits<BT>::getName();
-                    } else {
-                        options << " -D IS_CPLX=0";
-                    }
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-
-                    options << " -D INTERP_ORDER=" << order;
-                    addInterpEnumOptions(options);
-
-                    const char *ker_strs[] = {interp_cl, rotate_cl};
-                    const int   ker_lens[] = {interp_cl_len, rotate_cl_len};
-                    Program prog;
-                    buildProgram(prog, 2, ker_strs, ker_lens, options.str());
-                    rotateProgs[device] = new Program(prog);
-                    rotateKernels[device] = new Kernel(*rotateProgs[device], "rotate_kernel");
-                });
-
-                auto rotateOp = KernelFunctor<Buffer, const KParam,
-                                              const Buffer, const KParam,
-                                              const tmat_t,
-                                              const int, const int,
-                                              const int, const int,
-                                              const int>(*rotateKernels[device]);
-
-                const float c = cos(-theta), s = sin(-theta);
-                float tx, ty;
-                {
-                    const float nx = 0.5 * (in.info.dims[0] - 1);
-                    const float ny = 0.5 * (in.info.dims[1] - 1);
-                    const float mx = 0.5 * (out.info.dims[0] - 1);
-                    const float my = 0.5 * (out.info.dims[1] - 1);
-                    const float sx = (mx * c + my *-s);
-                    const float sy = (mx * s + my * c);
-                    tx = -(sx - nx);
-                    ty = -(sy - ny);
+                if((af_dtype) dtype_traits<T>::af_type == c32 ||
+                    (af_dtype) dtype_traits<T>::af_type == c64) {
+                    options << " -D IS_CPLX=1";
+                    options << " -D TB=" << dtype_traits<BT>::getName();
+                } else {
+                    options << " -D IS_CPLX=0";
+                }
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
                 }
 
-                // Rounding error. Anything more than 3 decimal points wont make a diff
-                tmat_t t;
-                t.tmat[0] = round( c * 1000) / 1000.0f;
-                t.tmat[1] = round(-s * 1000) / 1000.0f;
-                t.tmat[2] = round(tx * 1000) / 1000.0f;
-                t.tmat[3] = round( s * 1000) / 1000.0f;
-                t.tmat[4] = round( c * 1000) / 1000.0f;
-                t.tmat[5] = round(ty * 1000) / 1000.0f;
+                options << " -D INTERP_ORDER=" << order;
+                addInterpEnumOptions(options);
 
+                const char *ker_strs[] = {interp_cl, rotate_cl};
+                const int   ker_lens[] = {interp_cl_len, rotate_cl_len};
+                Program prog;
+                buildProgram(prog, 2, ker_strs, ker_lens, options.str());
+                rotateProgs[device] = new Program(prog);
+                rotateKernels[device] = new Kernel(*rotateProgs[device], "rotate_kernel");
+            });
 
-                NDRange local(TX, TY, 1);
+            auto rotateOp = KernelFunctor<Buffer, const KParam,
+                                          const Buffer, const KParam,
+                                          const tmat_t,
+                                          const int, const int,
+                                          const int, const int,
+                                          const int>(*rotateKernels[device]);
 
-                int nimages  = in.info.dims[2];
-                int nbatches = in.info.dims[3];
-                int global_x = local[0] * divup(out.info.dims[0], local[0]);
-                int global_y = local[1] * divup(out.info.dims[1], local[1]);
-                const int blocksXPerImage = global_x / local[0];
-                const int blocksYPerImage = global_y / local[1];
-
-                if(nimages > TI) {
-                    int tile_images = divup(nimages, TI);
-                    nimages = TI;
-                    global_x = global_x * tile_images;
-                }
-                global_y *= nbatches;
-
-                NDRange global(global_x, global_y, 1);
-
-                rotateOp(EnqueueArgs(getQueue(), global, local),
-                         *out.data, out.info, *in.data, in.info, t, nimages, nbatches,
-                         blocksXPerImage, blocksYPerImage, (int)method);
-
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
+            const float c = cos(-theta), s = sin(-theta);
+            float tx, ty;
+            {
+                const float nx = 0.5 * (in.info.dims[0] - 1);
+                const float ny = 0.5 * (in.info.dims[1] - 1);
+                const float mx = 0.5 * (out.info.dims[0] - 1);
+                const float my = 0.5 * (out.info.dims[1] - 1);
+                const float sx = (mx * c + my *-s);
+                const float sy = (mx * s + my * c);
+                tx = -(sx - nx);
+                ty = -(sy - ny);
             }
+
+            // Rounding error. Anything more than 3 decimal points wont make a diff
+            tmat_t t;
+            t.tmat[0] = round( c * 1000) / 1000.0f;
+            t.tmat[1] = round(-s * 1000) / 1000.0f;
+            t.tmat[2] = round(tx * 1000) / 1000.0f;
+            t.tmat[3] = round( s * 1000) / 1000.0f;
+            t.tmat[4] = round( c * 1000) / 1000.0f;
+            t.tmat[5] = round(ty * 1000) / 1000.0f;
+
+
+            NDRange local(TX, TY, 1);
+
+            int nimages  = in.info.dims[2];
+            int nbatches = in.info.dims[3];
+            int global_x = local[0] * divup(out.info.dims[0], local[0]);
+            int global_y = local[1] * divup(out.info.dims[1], local[1]);
+            const int blocksXPerImage = global_x / local[0];
+            const int blocksYPerImage = global_y / local[1];
+
+            if(nimages > TI) {
+                int tile_images = divup(nimages, TI);
+                nimages = TI;
+                global_x = global_x * tile_images;
+            }
+            global_y *= nbatches;
+
+            NDRange global(global_x, global_y, 1);
+
+            rotateOp(EnqueueArgs(getQueue(), global, local),
+                      *out.data, out.info, *in.data, in.info, t, nimages, nbatches,
+                      blocksXPerImage, blocksYPerImage, (int)method);
+
+            CL_DEBUG_FINISH(getQueue());
         }
     }
 }

--- a/src/backend/opencl/kernel/scan_dim.hpp
+++ b/src/backend/opencl/kernel/scan_dim.hpp
@@ -107,31 +107,26 @@ namespace kernel
                                   int dim, bool isFinalPass, uint threads_y,
                                   const uint groups_all[4])
     {
-        try {
-            Kernel ker = get_scan_dim_kernels<Ti, To, op, inclusive_scan>(0, dim, isFinalPass, threads_y);
+        Kernel ker = get_scan_dim_kernels<Ti, To, op, inclusive_scan>(0, dim, isFinalPass, threads_y);
 
-            NDRange local(THREADS_X, threads_y);
-            NDRange global(groups_all[0] * groups_all[2] * local[0],
-                           groups_all[1] * groups_all[3] * local[1]);
+        NDRange local(THREADS_X, threads_y);
+        NDRange global(groups_all[0] * groups_all[2] * local[0],
+                        groups_all[1] * groups_all[3] * local[1]);
 
-            uint lim = divup(out.info.dims[dim], (threads_y * groups_all[dim]));
+        uint lim = divup(out.info.dims[dim], (threads_y * groups_all[dim]));
 
-            auto scanOp = KernelFunctor<Buffer, KParam,
-                                      Buffer, KParam,
-                                      Buffer, KParam,
-                                      uint, uint,
-                                      uint, uint>(ker);
+        auto scanOp = KernelFunctor<Buffer, KParam,
+                                  Buffer, KParam,
+                                  Buffer, KParam,
+                                  uint, uint,
+                                  uint, uint>(ker);
 
 
-            scanOp(EnqueueArgs(getQueue(), global, local),
-                   *out.data, out.info, *tmp.data, tmp.info, *in.data, in.info,
-                   groups_all[0], groups_all[1], groups_all[dim], lim);
+        scanOp(EnqueueArgs(getQueue(), global, local),
+                *out.data, out.info, *tmp.data, tmp.info, *in.data, in.info,
+                groups_all[0], groups_all[1], groups_all[dim], lim);
 
-            CL_DEBUG_FINISH(getQueue());
-        } catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
-            throw;
-        }
+        CL_DEBUG_FINISH(getQueue());
     }
 
     template<typename Ti, typename To, af_op_t op, bool inclusive_scan>
@@ -140,95 +135,85 @@ namespace kernel
                                    int dim, bool isFinalPass, uint threads_y,
                                    const uint groups_all[4])
     {
-        try {
-            Kernel ker = get_scan_dim_kernels<Ti, To, op, inclusive_scan>(1, dim, isFinalPass, threads_y);
+        Kernel ker = get_scan_dim_kernels<Ti, To, op, inclusive_scan>(1, dim, isFinalPass, threads_y);
 
-            NDRange local(THREADS_X, threads_y);
-            NDRange global(groups_all[0] * groups_all[2] * local[0],
-                           groups_all[1] * groups_all[3] * local[1]);
+        NDRange local(THREADS_X, threads_y);
+        NDRange global(groups_all[0] * groups_all[2] * local[0],
+                        groups_all[1] * groups_all[3] * local[1]);
 
-            uint lim = divup(out.info.dims[dim], (threads_y * groups_all[dim]));
+        uint lim = divup(out.info.dims[dim], (threads_y * groups_all[dim]));
 
-            auto bcastOp = KernelFunctor<Buffer, KParam,
-                                       Buffer, KParam,
-                                       uint, uint,
-                                       uint, uint>(ker);
+        auto bcastOp = KernelFunctor<Buffer, KParam,
+                                    Buffer, KParam,
+                                    uint, uint,
+                                    uint, uint>(ker);
 
-            bcastOp(EnqueueArgs(getQueue(), global, local),
-                    *out.data, out.info, *tmp.data, tmp.info,
-                    groups_all[0], groups_all[1], groups_all[dim], lim);
+        bcastOp(EnqueueArgs(getQueue(), global, local),
+                *out.data, out.info, *tmp.data, tmp.info,
+                groups_all[0], groups_all[1], groups_all[dim], lim);
 
-            CL_DEBUG_FINISH(getQueue());
-        } catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
-            throw;
-        }
+        CL_DEBUG_FINISH(getQueue());
     }
 
     template<typename Ti, typename To, af_op_t op, bool inclusive_scan = true>
     static void scan_dim(Param &out, const Param &in, int dim)
     {
-        try {
-            uint threads_y = std::min(THREADS_Y, nextpow2(out.info.dims[dim]));
-            uint threads_x = THREADS_X;
+        uint threads_y = std::min(THREADS_Y, nextpow2(out.info.dims[dim]));
+        uint threads_x = THREADS_X;
 
-            uint groups_all[] = {divup((uint)out.info.dims[0], threads_x),
-                                 (uint)out.info.dims[1],
-                                 (uint)out.info.dims[2],
-                                 (uint)out.info.dims[3]};
+        uint groups_all[] = {divup((uint)out.info.dims[0], threads_x),
+                              (uint)out.info.dims[1],
+                              (uint)out.info.dims[2],
+                              (uint)out.info.dims[3]};
 
-            groups_all[dim] = divup(out.info.dims[dim], threads_y * REPEAT);
+        groups_all[dim] = divup(out.info.dims[dim], threads_y * REPEAT);
 
-            if (groups_all[dim] == 1) {
+        if (groups_all[dim] == 1) {
 
-                scan_dim_launcher<Ti, To, op, inclusive_scan>(out, out, in,
-                                              dim, true,
-                                              threads_y,
-                                              groups_all);
-            } else {
+            scan_dim_launcher<Ti, To, op, inclusive_scan>(out, out, in,
+                                          dim, true,
+                                          threads_y,
+                                          groups_all);
+        } else {
 
-                Param tmp = out;
+            Param tmp = out;
 
-                tmp.info.dims[dim] = groups_all[dim];
-                tmp.info.strides[0] = 1;
-                for (int k = 1; k < 4; k++) {
-                    tmp.info.strides[k] = tmp.info.strides[k - 1] * tmp.info.dims[k - 1];
-                }
-
-                int tmp_elements = tmp.info.strides[3] * tmp.info.dims[3];
-                // FIXME: Do I need to free this ?
-                tmp.data = bufferAlloc(tmp_elements * sizeof(To));
-
-                scan_dim_launcher<Ti, To, op, inclusive_scan>(out, tmp, in,
-                                              dim, false,
-                                              threads_y,
-                                              groups_all);
-
-                int gdim = groups_all[dim];
-                groups_all[dim] = 1;
-
-                if (op == af_notzero_t) {
-                    scan_dim_launcher<To, To, af_add_t, true>(tmp, tmp, tmp,
-                                                        dim, true,
-                                                        threads_y,
-                                                        groups_all);
-                } else {
-                    scan_dim_launcher<To, To,       op, true>(tmp, tmp, tmp,
-                                                        dim, true,
-                                                        threads_y,
-                                                        groups_all);
-                }
-
-                groups_all[dim] = gdim;
-                bcast_dim_launcher<To, To, op, inclusive_scan>(out, tmp,
-                                               dim, true,
-                                               threads_y,
-                                               groups_all);
-                bufferFree(tmp.data);
+            tmp.info.dims[dim] = groups_all[dim];
+            tmp.info.strides[0] = 1;
+            for (int k = 1; k < 4; k++) {
+                tmp.info.strides[k] = tmp.info.strides[k - 1] * tmp.info.dims[k - 1];
             }
-        } catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
-            throw;
+
+            int tmp_elements = tmp.info.strides[3] * tmp.info.dims[3];
+            // FIXME: Do I need to free this ?
+            tmp.data = bufferAlloc(tmp_elements * sizeof(To));
+
+            scan_dim_launcher<Ti, To, op, inclusive_scan>(out, tmp, in,
+                                          dim, false,
+                                          threads_y,
+                                          groups_all);
+
+            int gdim = groups_all[dim];
+            groups_all[dim] = 1;
+
+            if (op == af_notzero_t) {
+                scan_dim_launcher<To, To, af_add_t, true>(tmp, tmp, tmp,
+                                                    dim, true,
+                                                    threads_y,
+                                                    groups_all);
+            } else {
+                scan_dim_launcher<To, To,       op, true>(tmp, tmp, tmp,
+                                                    dim, true,
+                                                    threads_y,
+                                                    groups_all);
+            }
+
+            groups_all[dim] = gdim;
+            bcast_dim_launcher<To, To, op, inclusive_scan>(out, tmp,
+                                            dim, true,
+                                            threads_y,
+                                            groups_all);
+            bufferFree(tmp.data);
         }
     }
 }

--- a/src/backend/opencl/kernel/scan_dim_by_key_impl.hpp
+++ b/src/backend/opencl/kernel/scan_dim_by_key_impl.hpp
@@ -114,37 +114,32 @@ namespace kernel
                                   int dim, uint threads_y,
                                   const uint groups_all[4])
     {
-        try {
-            Kernel ker = get_scan_dim_kernels<Ti, Tk, To, op, inclusive_scan>(1, dim, false, threads_y);
+        Kernel ker = get_scan_dim_kernels<Ti, Tk, To, op, inclusive_scan>(1, dim, false, threads_y);
 
-            NDRange local(THREADS_X, threads_y);
-            NDRange global(groups_all[0] * groups_all[2] * local[0],
-                           groups_all[1] * groups_all[3] * local[1]);
+        NDRange local(THREADS_X, threads_y);
+        NDRange global(groups_all[0] * groups_all[2] * local[0],
+                        groups_all[1] * groups_all[3] * local[1]);
 
-            uint lim = divup(out.info.dims[dim], (threads_y * groups_all[dim]));
+        uint lim = divup(out.info.dims[dim], (threads_y * groups_all[dim]));
 
-            auto scanOp = KernelFunctor<Buffer, KParam,
-                                        Buffer, KParam,
-                                        Buffer, KParam,
-                                        Buffer, KParam,
-                                        Buffer, KParam,
-                                        Buffer, KParam,
-                                        uint, uint,
-                                        uint, uint>(ker);
+        auto scanOp = KernelFunctor<Buffer, KParam,
+                                    Buffer, KParam,
+                                    Buffer, KParam,
+                                    Buffer, KParam,
+                                    Buffer, KParam,
+                                    Buffer, KParam,
+                                    uint, uint,
+                                    uint, uint>(ker);
 
-            scanOp(EnqueueArgs(getQueue(), global, local),
-                   *out.data, out.info,
-                   *tmp.data, tmp.info,
-                   *tmpflg.data, tmpflg.info,
-                   *tmpid.data, tmpid.info,
-                   *in.data, in.info, *key.data, key.info,
-                   groups_all[0], groups_all[1], groups_all[dim], lim);
+        scanOp(EnqueueArgs(getQueue(), global, local),
+                *out.data, out.info,
+                *tmp.data, tmp.info,
+                *tmpflg.data, tmpflg.info,
+                *tmpid.data, tmpid.info,
+                *in.data, in.info, *key.data, key.info,
+                groups_all[0], groups_all[1], groups_all[dim], lim);
 
-            CL_DEBUG_FINISH(getQueue());
-        } catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
-            throw;
-        }
+        CL_DEBUG_FINISH(getQueue());
     }
 
     template<typename Ti, typename Tk, typename To, af_op_t op, bool inclusive_scan>
@@ -154,30 +149,25 @@ namespace kernel
                                   int dim, const bool calculateFlags, uint threads_y,
                                   const uint groups_all[4])
     {
-        try {
-            Kernel ker = get_scan_dim_kernels<Ti, Tk, To, op, inclusive_scan>(0, dim, calculateFlags, threads_y);
+        Kernel ker = get_scan_dim_kernels<Ti, Tk, To, op, inclusive_scan>(0, dim, calculateFlags, threads_y);
 
-            NDRange local(THREADS_X, threads_y);
-            NDRange global(groups_all[0] * groups_all[2] * local[0],
-                           groups_all[1] * groups_all[3] * local[1]);
+        NDRange local(THREADS_X, threads_y);
+        NDRange global(groups_all[0] * groups_all[2] * local[0],
+                        groups_all[1] * groups_all[3] * local[1]);
 
-            uint lim = divup(out.info.dims[dim], (threads_y * groups_all[dim]));
+        uint lim = divup(out.info.dims[dim], (threads_y * groups_all[dim]));
 
-            auto scanOp = KernelFunctor<Buffer, KParam,
-                                        Buffer, KParam,
-                                        Buffer, KParam,
-                                        uint, uint,
-                                        uint, uint>(ker);
+        auto scanOp = KernelFunctor<Buffer, KParam,
+                                    Buffer, KParam,
+                                    Buffer, KParam,
+                                    uint, uint,
+                                    uint, uint>(ker);
 
-            scanOp(EnqueueArgs(getQueue(), global, local),
-                   *out.data, out.info, *in.data, in.info, *key.data, key.info,
-                   groups_all[0], groups_all[1], groups_all[dim], lim);
+        scanOp(EnqueueArgs(getQueue(), global, local),
+                *out.data, out.info, *in.data, in.info, *key.data, key.info,
+                groups_all[0], groups_all[1], groups_all[dim], lim);
 
-            CL_DEBUG_FINISH(getQueue());
-        } catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
-            throw;
-        }
+        CL_DEBUG_FINISH(getQueue());
     }
 
     template<typename Ti, typename Tk, typename To, af_op_t op, bool inclusive_scan>
@@ -187,102 +177,92 @@ namespace kernel
                                    int dim, uint threads_y,
                                    const uint groups_all[4])
     {
-        try {
-            Kernel ker = get_scan_dim_kernels<Ti, Tk, To, op, inclusive_scan>(2, dim, false, threads_y);
+        Kernel ker = get_scan_dim_kernels<Ti, Tk, To, op, inclusive_scan>(2, dim, false, threads_y);
 
-            NDRange local(THREADS_X, threads_y);
-            NDRange global(groups_all[0] * groups_all[2] * local[0],
-                           groups_all[1] * groups_all[3] * local[1]);
+        NDRange local(THREADS_X, threads_y);
+        NDRange global(groups_all[0] * groups_all[2] * local[0],
+                        groups_all[1] * groups_all[3] * local[1]);
 
-            uint lim = divup(out.info.dims[dim], (threads_y * groups_all[dim]));
+        uint lim = divup(out.info.dims[dim], (threads_y * groups_all[dim]));
 
-            auto bcastOp = KernelFunctor<Buffer, KParam,
-                                         Buffer, KParam,
-                                         Buffer, KParam,
-                                         uint, uint,
-                                         uint, uint>(ker);
+        auto bcastOp = KernelFunctor<Buffer, KParam,
+                                      Buffer, KParam,
+                                      Buffer, KParam,
+                                      uint, uint,
+                                      uint, uint>(ker);
 
-            bcastOp(EnqueueArgs(getQueue(), global, local),
-                    *out.data, out.info, *tmp.data, tmp.info, *tmpid.data, tmpid.info,
-                    groups_all[0], groups_all[1], groups_all[dim], lim);
+        bcastOp(EnqueueArgs(getQueue(), global, local),
+                *out.data, out.info, *tmp.data, tmp.info, *tmpid.data, tmpid.info,
+                groups_all[0], groups_all[1], groups_all[dim], lim);
 
-            CL_DEBUG_FINISH(getQueue());
-        } catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
-            throw;
-        }
+        CL_DEBUG_FINISH(getQueue());
     }
 
     template<typename Ti, typename Tk, typename To, af_op_t op, bool inclusive_scan>
     void scan_dim(Param &out, const Param &in, const Param &key, int dim)
     {
-        try {
-            uint threads_y = std::min(THREADS_Y, nextpow2(out.info.dims[dim]));
-            uint threads_x = THREADS_X;
+        uint threads_y = std::min(THREADS_Y, nextpow2(out.info.dims[dim]));
+        uint threads_x = THREADS_X;
 
-            uint groups_all[] = {divup((uint)out.info.dims[0], threads_x),
-                                 (uint)out.info.dims[1],
-                                 (uint)out.info.dims[2],
-                                 (uint)out.info.dims[3]};
+        uint groups_all[] = {divup((uint)out.info.dims[0], threads_x),
+                              (uint)out.info.dims[1],
+                              (uint)out.info.dims[2],
+                              (uint)out.info.dims[3]};
 
-            groups_all[dim] = divup(out.info.dims[dim], threads_y * REPEAT);
+        groups_all[dim] = divup(out.info.dims[dim], threads_y * REPEAT);
 
-            if (groups_all[dim] == 1) {
+        if (groups_all[dim] == 1) {
 
-                scan_dim_final_launcher<Ti, Tk, To, op, inclusive_scan>(out, in, key,
-                                              dim, true,
-                                              threads_y,
-                                              groups_all);
-            } else {
+            scan_dim_final_launcher<Ti, Tk, To, op, inclusive_scan>(out, in, key,
+                                          dim, true,
+                                          threads_y,
+                                          groups_all);
+        } else {
 
-                Param tmp = out;
+            Param tmp = out;
 
-                tmp.info.dims[dim] = groups_all[dim];
-                tmp.info.strides[0] = 1;
-                for (int k = 1; k < 4; k++) {
-                    tmp.info.strides[k] = tmp.info.strides[k - 1] * tmp.info.dims[k - 1];
-                }
-                Param tmpflg = tmp;
-                Param tmpid = tmp;
-
-                int tmp_elements = tmp.info.strides[3] * tmp.info.dims[3];
-                // FIXME: Do I need to free this ?
-                tmp.data = bufferAlloc(tmp_elements * sizeof(To));
-                tmpflg.data = bufferAlloc(tmp_elements * sizeof(char));
-                tmpid.data = bufferAlloc(tmp_elements * sizeof(int));
-
-                scan_dim_nonfinal_launcher<Ti, Tk, To, op, inclusive_scan>(out, tmp, tmpflg, tmpid, in, key,
-                                              dim,
-                                              threads_y,
-                                              groups_all);
-
-                int gdim = groups_all[dim];
-                groups_all[dim] = 1;
-
-                if (op == af_notzero_t) {
-                    scan_dim_final_launcher<To, char, To, af_add_t, true>(tmp, tmp, tmpflg,
-                                                        dim, false,
-                                                        threads_y,
-                                                        groups_all);
-                } else {
-                    scan_dim_final_launcher<To, char, To,       op, true>(tmp, tmp, tmpflg,
-                                                        dim, false,
-                                                        threads_y,
-                                                        groups_all);
-                }
-
-                groups_all[dim] = gdim;
-                bcast_dim_launcher<To, Tk, To, op, inclusive_scan>(out, tmp, tmpid,
-                                               dim,
-                                               threads_y,
-                                               groups_all);
-                bufferFree(tmp.data);
-                bufferFree(tmpflg.data);
-                bufferFree(tmpid.data);
+            tmp.info.dims[dim] = groups_all[dim];
+            tmp.info.strides[0] = 1;
+            for (int k = 1; k < 4; k++) {
+                tmp.info.strides[k] = tmp.info.strides[k - 1] * tmp.info.dims[k - 1];
             }
-        } catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
-            throw;
+            Param tmpflg = tmp;
+            Param tmpid = tmp;
+
+            int tmp_elements = tmp.info.strides[3] * tmp.info.dims[3];
+            // FIXME: Do I need to free this ?
+            tmp.data = bufferAlloc(tmp_elements * sizeof(To));
+            tmpflg.data = bufferAlloc(tmp_elements * sizeof(char));
+            tmpid.data = bufferAlloc(tmp_elements * sizeof(int));
+
+            scan_dim_nonfinal_launcher<Ti, Tk, To, op, inclusive_scan>(out, tmp, tmpflg, tmpid, in, key,
+                                          dim,
+                                          threads_y,
+                                          groups_all);
+
+            int gdim = groups_all[dim];
+            groups_all[dim] = 1;
+
+            if (op == af_notzero_t) {
+                scan_dim_final_launcher<To, char, To, af_add_t, true>(tmp, tmp, tmpflg,
+                                                    dim, false,
+                                                    threads_y,
+                                                    groups_all);
+            } else {
+                scan_dim_final_launcher<To, char, To,       op, true>(tmp, tmp, tmpflg,
+                                                    dim, false,
+                                                    threads_y,
+                                                    groups_all);
+            }
+
+            groups_all[dim] = gdim;
+            bcast_dim_launcher<To, Tk, To, op, inclusive_scan>(out, tmp, tmpid,
+                                            dim,
+                                            threads_y,
+                                            groups_all);
+            bufferFree(tmp.data);
+            bufferFree(tmpflg.data);
+            bufferFree(tmpid.data);
         }
     }
 }

--- a/src/backend/opencl/kernel/select.hpp
+++ b/src/backend/opencl/kernel/select.hpp
@@ -99,19 +99,15 @@ namespace opencl
         template<typename T>
         void select(Param out, Param cond, Param a, Param b, int ndims)
         {
-            try {
-                bool is_same = true;
-                for (int i = 0; i < 4; i++) {
-                    is_same &= (a.info.dims[i] == b.info.dims[i]);
-                }
+            bool is_same = true;
+            for (int i = 0; i < 4; i++) {
+                is_same &= (a.info.dims[i] == b.info.dims[i]);
+            }
 
-                if (is_same) {
-                    select_launcher<T, true >(out, cond, a, b, ndims);
-                } else {
-                    select_launcher<T, false>(out, cond, a, b, ndims);
-                }
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
+            if (is_same) {
+                select_launcher<T, true >(out, cond, a, b, ndims);
+            } else {
+                select_launcher<T, false>(out, cond, a, b, ndims);
             }
         }
 

--- a/src/backend/opencl/kernel/shift.hpp
+++ b/src/backend/opencl/kernel/shift.hpp
@@ -40,57 +40,52 @@ namespace opencl
         template<typename T>
         void shift(Param out, const Param in, const int *sdims)
         {
-            try {
-                static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-                static std::map<int, Program*>   shiftProgs;
-                static std::map<int, Kernel *> shiftKernels;
+            static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+            static std::map<int, Program*>   shiftProgs;
+            static std::map<int, Kernel *> shiftKernels;
 
-                int device = getActiveDeviceId();
+            int device = getActiveDeviceId();
 
-                std::call_once( compileFlags[device], [device] () {
-                    std::ostringstream options;
-                    options << " -D T=" << dtype_traits<T>::getName();
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-                    Program prog;
-                    buildProgram(prog, shift_cl, shift_cl_len, options.str());
-                    shiftProgs[device] = new Program(prog);
-                    shiftKernels[device] = new Kernel(*shiftProgs[device], "shift_kernel");
-                });
-
-                auto shiftOp = KernelFunctor<Buffer, const Buffer, const KParam, const KParam,
-                                          const int, const int, const int, const int,
-                                          const int, const int> (*shiftKernels[device]);
-
-                NDRange local(TX, TY, 1);
-
-                int blocksPerMatX = divup(out.info.dims[0], TILEX);
-                int blocksPerMatY = divup(out.info.dims[1], TILEY);
-                NDRange global(local[0] * blocksPerMatX * out.info.dims[2],
-                               local[1] * blocksPerMatY * out.info.dims[3],
-                               1);
-
-                int sdims_[4];
-                // Need to do this because we are mapping output to input in the kernel
-                for(int i = 0; i < 4; i++) {
-                    // sdims_[i] will always be positive and always [0, oDims[i]].
-                    // Negative shifts are converted to position by going the other way round
-                    sdims_[i] = -(sdims[i] % (int)out.info.dims[i]) + out.info.dims[i] * (sdims[i] > 0);
-                    assert(sdims_[i] >= 0 && sdims_[i] <= out.info.dims[i]);
+            std::call_once( compileFlags[device], [device] () {
+                std::ostringstream options;
+                options << " -D T=" << dtype_traits<T>::getName();
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
                 }
+                Program prog;
+                buildProgram(prog, shift_cl, shift_cl_len, options.str());
+                shiftProgs[device] = new Program(prog);
+                shiftKernels[device] = new Kernel(*shiftProgs[device], "shift_kernel");
+            });
 
-                shiftOp(EnqueueArgs(getQueue(), global, local),
-                        *out.data, *in.data, out.info, in.info,
-                        sdims_[0], sdims_[1], sdims_[2], sdims_[3],
-                        blocksPerMatX, blocksPerMatY);
+            auto shiftOp = KernelFunctor<Buffer, const Buffer, const KParam, const KParam,
+                                      const int, const int, const int, const int,
+                                      const int, const int> (*shiftKernels[device]);
 
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
+            NDRange local(TX, TY, 1);
+
+            int blocksPerMatX = divup(out.info.dims[0], TILEX);
+            int blocksPerMatY = divup(out.info.dims[1], TILEY);
+            NDRange global(local[0] * blocksPerMatX * out.info.dims[2],
+                            local[1] * blocksPerMatY * out.info.dims[3],
+                            1);
+
+            int sdims_[4];
+            // Need to do this because we are mapping output to input in the kernel
+            for(int i = 0; i < 4; i++) {
+                // sdims_[i] will always be positive and always [0, oDims[i]].
+                // Negative shifts are converted to position by going the other way round
+                sdims_[i] = -(sdims[i] % (int)out.info.dims[i]) + out.info.dims[i] * (sdims[i] > 0);
+                assert(sdims_[i] >= 0 && sdims_[i] <= out.info.dims[i]);
             }
+
+            shiftOp(EnqueueArgs(getQueue(), global, local),
+                    *out.data, *in.data, out.info, in.info,
+                    sdims_[0], sdims_[1], sdims_[2], sdims_[3],
+                    blocksPerMatX, blocksPerMatY);
+
+            CL_DEBUG_FINISH(getQueue());
         }
     }
 }

--- a/src/backend/opencl/kernel/sobel.hpp
+++ b/src/backend/opencl/kernel/sobel.hpp
@@ -38,53 +38,48 @@ static const int THREADS_Y = 16;
 template<typename Ti, typename To, unsigned ker_size>
 void sobel(Param dx, Param dy, const Param in)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*>  sobProgs;
-        static std::map<int, Kernel*> sobKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*>  sobProgs;
+    static std::map<int, Kernel*> sobKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
+    std::call_once( compileFlags[device], [device] () {
 
-                std::ostringstream options;
-                options << " -D Ti=" << dtype_traits<Ti>::getName()
-                        << " -D To=" << dtype_traits<To>::getName()
-                        << " -D KER_SIZE="<< ker_size;
-                if (std::is_same<Ti, double>::value) {
-                    options << " -D USE_DOUBLE";
-                }
-                Program prog;
-                buildProgram(prog, sobel_cl, sobel_cl_len, options.str());
-                sobProgs[device]   = new Program(prog);
-                sobKernels[device] = new Kernel(*sobProgs[device], "sobel3x3");
-            });
+            std::ostringstream options;
+            options << " -D Ti=" << dtype_traits<Ti>::getName()
+                    << " -D To=" << dtype_traits<To>::getName()
+                    << " -D KER_SIZE="<< ker_size;
+            if (std::is_same<Ti, double>::value) {
+                options << " -D USE_DOUBLE";
+            }
+            Program prog;
+            buildProgram(prog, sobel_cl, sobel_cl_len, options.str());
+            sobProgs[device]   = new Program(prog);
+            sobKernels[device] = new Kernel(*sobProgs[device], "sobel3x3");
+        });
 
-        NDRange local(THREADS_X, THREADS_Y);
+    NDRange local(THREADS_X, THREADS_Y);
 
-        int blk_x = divup(in.info.dims[0], THREADS_X);
-        int blk_y = divup(in.info.dims[1], THREADS_Y);
+    int blk_x = divup(in.info.dims[0], THREADS_X);
+    int blk_y = divup(in.info.dims[1], THREADS_Y);
 
-        NDRange global(blk_x * in.info.dims[2] * THREADS_X,
-                       blk_y * in.info.dims[3] * THREADS_Y);
+    NDRange global(blk_x * in.info.dims[2] * THREADS_X,
+                    blk_y * in.info.dims[3] * THREADS_Y);
 
-        auto sobelOp = KernelFunctor<Buffer, KParam,
-                                   Buffer, KParam,
-                                   Buffer, KParam,
-                                   cl::LocalSpaceArg,
-                                   int, int> (*sobKernels[device]);
+    auto sobelOp = KernelFunctor<Buffer, KParam,
+                                Buffer, KParam,
+                                Buffer, KParam,
+                                cl::LocalSpaceArg,
+                                int, int> (*sobKernels[device]);
 
-        size_t loc_size = (THREADS_X+ker_size-1)*(THREADS_Y+ker_size-1)*sizeof(Ti);
+    size_t loc_size = (THREADS_X+ker_size-1)*(THREADS_Y+ker_size-1)*sizeof(Ti);
 
-        sobelOp(EnqueueArgs(getQueue(), global, local),
-                    *dx.data, dx.info, *dy.data, dy.info,
-                    *in.data, in.info, cl::Local(loc_size), blk_x, blk_y);
+    sobelOp(EnqueueArgs(getQueue(), global, local),
+                *dx.data, dx.info, *dy.data, dy.info,
+                *in.data, in.info, cl::Local(loc_size), blk_x, blk_y);
 
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
+    CL_DEBUG_FINISH(getQueue());
 }
 
 }

--- a/src/backend/opencl/kernel/sort.hpp
+++ b/src/backend/opencl/kernel/sort.hpp
@@ -44,117 +44,107 @@ namespace opencl
         template<typename T>
         void sort0Iterative(Param val, bool isAscending)
         {
-            try {
-                compute::command_queue c_queue(getQueue()());
+            compute::command_queue c_queue(getQueue()());
 
-                compute::buffer val_buf((*val.data)());
+            compute::buffer val_buf((*val.data)());
 
-                for(int w = 0; w < val.info.dims[3]; w++) {
-                    int valW = w * val.info.strides[3];
-                    for(int z = 0; z < val.info.dims[2]; z++) {
-                        int valWZ = valW + z * val.info.strides[2];
-                        for(int y = 0; y < val.info.dims[1]; y++) {
+            for(int w = 0; w < val.info.dims[3]; w++) {
+                int valW = w * val.info.strides[3];
+                for(int z = 0; z < val.info.dims[2]; z++) {
+                    int valWZ = valW + z * val.info.strides[2];
+                    for(int y = 0; y < val.info.dims[1]; y++) {
 
-                            int valOffset = valWZ + y * val.info.strides[1];
+                        int valOffset = valWZ + y * val.info.strides[1];
 
-                            if(isAscending) {
-                                compute::sort(
-                                        compute::make_buffer_iterator< type_t<T> >(val_buf, valOffset),
-                                        compute::make_buffer_iterator< type_t<T> >(val_buf, valOffset + val.info.dims[0]),
-                                        compute::less< type_t<T> >(), c_queue);
-                            } else {
-                                compute::sort(
-                                        compute::make_buffer_iterator< type_t<T> >(val_buf, valOffset),
-                                        compute::make_buffer_iterator< type_t<T> >(val_buf, valOffset + val.info.dims[0]),
-                                        compute::greater< type_t<T> >(), c_queue);
-                            }
+                        if(isAscending) {
+                            compute::sort(
+                                    compute::make_buffer_iterator< type_t<T> >(val_buf, valOffset),
+                                    compute::make_buffer_iterator< type_t<T> >(val_buf, valOffset + val.info.dims[0]),
+                                    compute::less< type_t<T> >(), c_queue);
+                        } else {
+                            compute::sort(
+                                    compute::make_buffer_iterator< type_t<T> >(val_buf, valOffset),
+                                    compute::make_buffer_iterator< type_t<T> >(val_buf, valOffset + val.info.dims[0]),
+                                    compute::greater< type_t<T> >(), c_queue);
                         }
                     }
                 }
-
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
             }
+
+            CL_DEBUG_FINISH(getQueue());
         }
 
         template<typename T, int dim>
         void sortBatched(Param pVal, bool isAscending)
         {
-            try{
-                af::dim4 inDims;
-                for(int i = 0; i < 4; i++)
-                    inDims[i] = pVal.info.dims[i];
+            af::dim4 inDims;
+            for(int i = 0; i < 4; i++)
+                inDims[i] = pVal.info.dims[i];
 
-                // Sort dimension
-                // tileDims * seqDims = inDims
-                af::dim4 tileDims(1);
-                af::dim4 seqDims = inDims;
-                tileDims[dim] = inDims[dim];
-                seqDims[dim] = 1;
+            // Sort dimension
+            // tileDims * seqDims = inDims
+            af::dim4 tileDims(1);
+            af::dim4 seqDims = inDims;
+            tileDims[dim] = inDims[dim];
+            seqDims[dim] = 1;
 
-                // Create/call iota
-                // Array<uint> key = iota<uint>(seqDims, tileDims);
-                dim4 keydims = inDims;
-                cl::Buffer* key = bufferAlloc(keydims.elements() * sizeof(uint));
-                Param pKey;
-                pKey.data = key;
-                pKey.info.offset = 0;
-                pKey.info.dims[0] = keydims[0];
-                pKey.info.strides[0] = 1;
-                for(int i = 1; i < 4; i++) {
-                    pKey.info.dims[i] = keydims[i];
-                    pKey.info.strides[i] = pKey.info.strides[i - 1] * pKey.info.dims[i - 1];
-                }
-                kernel::iota<uint>(pKey, seqDims, tileDims);
-
-                // Flat
-                //val.modDims(inDims.elements());
-                //key.modDims(inDims.elements());
-                pKey.info.dims[0] = inDims.elements();
-                pKey.info.strides[0] = 1;
-                pVal.info.dims[0] = inDims.elements();
-                pVal.info.strides[0] = 1;
-                for(int i = 1; i < 4; i++) {
-                    pKey.info.dims[i] = 1;
-                    pKey.info.strides[i] = pKey.info.strides[i - 1] * pKey.info.dims[i - 1];
-                    pVal.info.dims[i] = 1;
-                    pVal.info.strides[i] = pVal.info.strides[i - 1] * pVal.info.dims[i - 1];
-                }
-
-                // Sort indices
-                // sort_by_key<T, uint, isAscending>(*resVal, *resKey, val, key, 0);
-                //kernel::sort0_by_key<T, uint, isAscending>(pVal, pKey);
-                compute::command_queue c_queue(getQueue()());
-
-                compute::buffer pKey_buf((*pKey.data)());
-                compute::buffer pVal_buf((*pVal.data)());
-
-                compute::buffer_iterator<type_t<T> > val0 = compute::make_buffer_iterator<type_t<T> >(pVal_buf, 0);
-                compute::buffer_iterator<type_t<T> > valN = compute::make_buffer_iterator<type_t<T> >(pVal_buf,+ pVal.info.dims[0]);
-                compute::buffer_iterator<uint      > key0 = compute::make_buffer_iterator<uint>(pKey_buf, 0);
-                compute::buffer_iterator<uint      > keyN = compute::make_buffer_iterator<uint>(pKey_buf, pKey.info.dims[0]);
-                if(isAscending) {
-                    compute::sort_by_key(val0, valN, key0, c_queue);
-                } else {
-                    compute::sort_by_key(val0, valN, key0, compute::greater< type_t<T> >(), c_queue);
-                }
-
-                // Needs to be ascending (true) in order to maintain the indices properly
-                //kernel::sort0_by_key<uint, T, true>(pKey, pVal);
-                compute::sort_by_key(key0, keyN, val0, c_queue);
-
-                // No need of doing moddims here because the original Array<T>
-                // dimensions have not been changed
-                //val.modDims(inDims);
-
-                CL_DEBUG_FINISH(getQueue());
-                bufferFree(key);
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
+            // Create/call iota
+            // Array<uint> key = iota<uint>(seqDims, tileDims);
+            dim4 keydims = inDims;
+            cl::Buffer* key = bufferAlloc(keydims.elements() * sizeof(uint));
+            Param pKey;
+            pKey.data = key;
+            pKey.info.offset = 0;
+            pKey.info.dims[0] = keydims[0];
+            pKey.info.strides[0] = 1;
+            for(int i = 1; i < 4; i++) {
+                pKey.info.dims[i] = keydims[i];
+                pKey.info.strides[i] = pKey.info.strides[i - 1] * pKey.info.dims[i - 1];
             }
+            kernel::iota<uint>(pKey, seqDims, tileDims);
+
+            // Flat
+            //val.modDims(inDims.elements());
+            //key.modDims(inDims.elements());
+            pKey.info.dims[0] = inDims.elements();
+            pKey.info.strides[0] = 1;
+            pVal.info.dims[0] = inDims.elements();
+            pVal.info.strides[0] = 1;
+            for(int i = 1; i < 4; i++) {
+                pKey.info.dims[i] = 1;
+                pKey.info.strides[i] = pKey.info.strides[i - 1] * pKey.info.dims[i - 1];
+                pVal.info.dims[i] = 1;
+                pVal.info.strides[i] = pVal.info.strides[i - 1] * pVal.info.dims[i - 1];
+            }
+
+            // Sort indices
+            // sort_by_key<T, uint, isAscending>(*resVal, *resKey, val, key, 0);
+            //kernel::sort0_by_key<T, uint, isAscending>(pVal, pKey);
+            compute::command_queue c_queue(getQueue()());
+
+            compute::buffer pKey_buf((*pKey.data)());
+            compute::buffer pVal_buf((*pVal.data)());
+
+            compute::buffer_iterator<type_t<T> > val0 = compute::make_buffer_iterator<type_t<T> >(pVal_buf, 0);
+            compute::buffer_iterator<type_t<T> > valN = compute::make_buffer_iterator<type_t<T> >(pVal_buf,+ pVal.info.dims[0]);
+            compute::buffer_iterator<uint      > key0 = compute::make_buffer_iterator<uint>(pKey_buf, 0);
+            compute::buffer_iterator<uint      > keyN = compute::make_buffer_iterator<uint>(pKey_buf, pKey.info.dims[0]);
+            if(isAscending) {
+                compute::sort_by_key(val0, valN, key0, c_queue);
+            } else {
+                compute::sort_by_key(val0, valN, key0, compute::greater< type_t<T> >(), c_queue);
+            }
+
+            // Needs to be ascending (true) in order to maintain the indices properly
+            //kernel::sort0_by_key<uint, T, true>(pKey, pVal);
+            compute::sort_by_key(key0, keyN, val0, c_queue);
+
+            // No need of doing moddims here because the original Array<T>
+            // dimensions have not been changed
+            //val.modDims(inDims);
+
+            CL_DEBUG_FINISH(getQueue());
+            bufferFree(key);
         }
 
         template<typename T>

--- a/src/backend/opencl/kernel/sort_by_key_impl.hpp
+++ b/src/backend/opencl/kernel/sort_by_key_impl.hpp
@@ -110,41 +110,36 @@ namespace opencl
         template<typename Tk, typename Tv>
         void sort0ByKeyIterative(Param pKey, Param pVal, bool isAscending)
         {
-            try {
-                compute::command_queue c_queue(getQueue()());
+            compute::command_queue c_queue(getQueue()());
 
-                compute::buffer pKey_buf((*pKey.data)());
-                compute::buffer pVal_buf((*pVal.data)());
+            compute::buffer pKey_buf((*pKey.data)());
+            compute::buffer pVal_buf((*pVal.data)());
 
-                for(int w = 0; w < pKey.info.dims[3]; w++) {
-                    int pKeyW = w * pKey.info.strides[3];
-                    int pValW = w * pVal.info.strides[3];
-                    for(int z = 0; z < pKey.info.dims[2]; z++) {
-                        int pKeyWZ = pKeyW + z * pKey.info.strides[2];
-                        int pValWZ = pValW + z * pVal.info.strides[2];
-                        for(int y = 0; y < pKey.info.dims[1]; y++) {
+            for(int w = 0; w < pKey.info.dims[3]; w++) {
+                int pKeyW = w * pKey.info.strides[3];
+                int pValW = w * pVal.info.strides[3];
+                for(int z = 0; z < pKey.info.dims[2]; z++) {
+                    int pKeyWZ = pKeyW + z * pKey.info.strides[2];
+                    int pValWZ = pValW + z * pVal.info.strides[2];
+                    for(int y = 0; y < pKey.info.dims[1]; y++) {
 
-                            int pKeyOffset = pKeyWZ + y * pKey.info.strides[1];
-                            int pValOffset = pValWZ + y * pVal.info.strides[1];
+                        int pKeyOffset = pKeyWZ + y * pKey.info.strides[1];
+                        int pValOffset = pValWZ + y * pVal.info.strides[1];
 
-                            compute::buffer_iterator< type_t<Tk> > start= compute::make_buffer_iterator< type_t<Tk> >(pKey_buf, pKeyOffset);
-                            compute::buffer_iterator< type_t<Tk> > end  = compute::make_buffer_iterator< type_t<Tk> >(pKey_buf, pKeyOffset + pKey.info.dims[0]);
-                            compute::buffer_iterator< type_t<Tv> > vals = compute::make_buffer_iterator< type_t<Tv> >(pVal_buf, pValOffset);
-                            if(isAscending) {
-                                compute::sort_by_key(start, end, vals, c_queue);
-                            } else {
-                                compute::sort_by_key(start, end, vals,
-                                                     compute::greater< type_t<Tk> >(), c_queue);
-                            }
+                        compute::buffer_iterator< type_t<Tk> > start= compute::make_buffer_iterator< type_t<Tk> >(pKey_buf, pKeyOffset);
+                        compute::buffer_iterator< type_t<Tk> > end  = compute::make_buffer_iterator< type_t<Tk> >(pKey_buf, pKeyOffset + pKey.info.dims[0]);
+                        compute::buffer_iterator< type_t<Tv> > vals = compute::make_buffer_iterator< type_t<Tv> >(pVal_buf, pValOffset);
+                        if(isAscending) {
+                            compute::sort_by_key(start, end, vals, c_queue);
+                        } else {
+                            compute::sort_by_key(start, end, vals,
+                                                  compute::greater< type_t<Tk> >(), c_queue);
                         }
                     }
                 }
-
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
             }
+
+            CL_DEBUG_FINISH(getQueue());
         }
 
         template<typename Tk_, typename Tv_>
@@ -153,101 +148,96 @@ namespace opencl
             typedef type_t<Tk_> Tk;
             typedef type_t<Tv_> Tv;
 
-            try {
-                af::dim4 inDims;
-                for(int i = 0; i < 4; i++)
-                    inDims[i] = pKey.info.dims[i];
+            af::dim4 inDims;
+            for(int i = 0; i < 4; i++)
+                inDims[i] = pKey.info.dims[i];
 
-                // Sort dimension
-                // tileDims * seqDims = inDims
-                af::dim4 tileDims(1);
-                af::dim4 seqDims = inDims;
-                tileDims[dim] = inDims[dim];
-                seqDims[dim] = 1;
+            // Sort dimension
+            // tileDims * seqDims = inDims
+            af::dim4 tileDims(1);
+            af::dim4 seqDims = inDims;
+            tileDims[dim] = inDims[dim];
+            seqDims[dim] = 1;
 
-                // Create/call iota
-                // Array<Tv> key = iota<Tv>(seqDims, tileDims);
-                cl::Buffer* Seq = bufferAlloc(inDims.elements() * sizeof(unsigned));
-                Param pSeq;
-                pSeq.data = Seq;
-                pSeq.info.offset = 0;
-                pSeq.info.dims[0] = inDims[0];
-                pSeq.info.strides[0] = 1;
-                for(int i = 1; i < 4; i++) {
-                    pSeq.info.dims[i] = inDims[i];
-                    pSeq.info.strides[i] = pSeq.info.strides[i - 1] * pSeq.info.dims[i - 1];
-                }
-                kernel::iota<unsigned>(pSeq, seqDims, tileDims);
-
-                int elements = inDims.elements();
-
-                // Flat - Not required since inplace and both are continuous
-                //val.modDims(inDims.elements());
-                //key.modDims(inDims.elements());
-
-                // Sort indices
-                // sort_by_key<T, Tv, isAscending>(*resVal, *resKey, val, key, 0);
-                //kernel::sort0_by_key<T, Tv, isAscending>(pVal, pKey);
-                compute::command_queue c_queue(getQueue()());
-                compute::context c_context(getContext()());
-
-                // Create buffer iterators for seq
-                compute::buffer pSeq_buf((*pSeq.data)());
-                compute::buffer_iterator<unsigned> seq0 = compute::make_buffer_iterator<unsigned>(pSeq_buf, 0);
-                compute::buffer_iterator<unsigned> seqN = compute::make_buffer_iterator<unsigned>(pSeq_buf, elements);
-                // Create buffer iterators for key and val
-                compute::buffer pKey_buf((*pKey.data)());
-                compute::buffer pVal_buf((*pVal.data)());
-                compute::buffer_iterator<Tk> key0 = compute::make_buffer_iterator<Tk>(pKey_buf, 0);
-                compute::buffer_iterator<Tk> keyN = compute::make_buffer_iterator<Tk>(pKey_buf, elements);
-                compute::buffer_iterator<Tv> val0 = compute::make_buffer_iterator<Tv>(pVal_buf, 0);
-                compute::buffer_iterator<Tv> valN = compute::make_buffer_iterator<Tv>(pVal_buf, elements);
-
-                // Sort By Key for descending is stable in the reverse
-                // (greater) order. Sorting in ascending with negated values
-                // will give the right result
-                if(!isAscending) compute::transform(key0, keyN, key0, flipFunction<Tk>(), c_queue);
-
-                // Create a copy of the pKey buffer
-                cl::Buffer* cKey = bufferAlloc(elements * sizeof(Tk));
-                compute::buffer cKey_buf((*cKey)());
-                compute::buffer_iterator<Tk> cKey0 = compute::make_buffer_iterator<Tk>(cKey_buf, 0);
-                compute::buffer_iterator<Tk> cKeyN = compute::make_buffer_iterator<Tk>(cKey_buf, elements);
-                compute::copy(key0, keyN, cKey0, c_queue);
-
-                // FIRST SORT
-                compute::sort_by_key(key0, keyN, seq0, c_queue);
-                compute::sort_by_key(cKey0, cKeyN, val0, c_queue);
-
-                // Create a copy of the seq buffer after first sort
-                cl::Buffer* cSeq = bufferAlloc(elements * sizeof(unsigned));
-                compute::buffer cSeq_buf((*cSeq)());
-                compute::buffer_iterator<unsigned> cSeq0 = compute::make_buffer_iterator<unsigned>(cSeq_buf, 0);
-                compute::buffer_iterator<unsigned> cSeqN = compute::make_buffer_iterator<unsigned>(cSeq_buf, elements);
-                compute::copy(seq0, seqN, cSeq0, c_queue);
-
-                // SECOND SORT
-                // First call will sort key, second sort will sort val
-                // Needs to be ascending (true) in order to maintain the indices properly
-                //kernel::sort0_by_key<Tv, T, true>(pKey, pVal);
-                compute::sort_by_key(seq0, seqN, key0, c_queue);
-                compute::sort_by_key(cSeq0, cSeqN, val0, c_queue);
-
-                // If descending, flip it back
-                if(!isAscending) compute::transform(key0, keyN, key0, flipFunction<Tk>(), c_queue);
-
-                //// No need of doing moddims here because the original Array<T>
-                //// dimensions have not been changed
-                ////val.modDims(inDims);
-
-                CL_DEBUG_FINISH(getQueue());
-                bufferFree(Seq);
-                bufferFree(cSeq);
-                bufferFree(cKey);
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
+            // Create/call iota
+            // Array<Tv> key = iota<Tv>(seqDims, tileDims);
+            cl::Buffer* Seq = bufferAlloc(inDims.elements() * sizeof(unsigned));
+            Param pSeq;
+            pSeq.data = Seq;
+            pSeq.info.offset = 0;
+            pSeq.info.dims[0] = inDims[0];
+            pSeq.info.strides[0] = 1;
+            for(int i = 1; i < 4; i++) {
+                pSeq.info.dims[i] = inDims[i];
+                pSeq.info.strides[i] = pSeq.info.strides[i - 1] * pSeq.info.dims[i - 1];
             }
+            kernel::iota<unsigned>(pSeq, seqDims, tileDims);
+
+            int elements = inDims.elements();
+
+            // Flat - Not required since inplace and both are continuous
+            //val.modDims(inDims.elements());
+            //key.modDims(inDims.elements());
+
+            // Sort indices
+            // sort_by_key<T, Tv, isAscending>(*resVal, *resKey, val, key, 0);
+            //kernel::sort0_by_key<T, Tv, isAscending>(pVal, pKey);
+            compute::command_queue c_queue(getQueue()());
+            compute::context c_context(getContext()());
+
+            // Create buffer iterators for seq
+            compute::buffer pSeq_buf((*pSeq.data)());
+            compute::buffer_iterator<unsigned> seq0 = compute::make_buffer_iterator<unsigned>(pSeq_buf, 0);
+            compute::buffer_iterator<unsigned> seqN = compute::make_buffer_iterator<unsigned>(pSeq_buf, elements);
+            // Create buffer iterators for key and val
+            compute::buffer pKey_buf((*pKey.data)());
+            compute::buffer pVal_buf((*pVal.data)());
+            compute::buffer_iterator<Tk> key0 = compute::make_buffer_iterator<Tk>(pKey_buf, 0);
+            compute::buffer_iterator<Tk> keyN = compute::make_buffer_iterator<Tk>(pKey_buf, elements);
+            compute::buffer_iterator<Tv> val0 = compute::make_buffer_iterator<Tv>(pVal_buf, 0);
+            compute::buffer_iterator<Tv> valN = compute::make_buffer_iterator<Tv>(pVal_buf, elements);
+
+            // Sort By Key for descending is stable in the reverse
+            // (greater) order. Sorting in ascending with negated values
+            // will give the right result
+            if(!isAscending) compute::transform(key0, keyN, key0, flipFunction<Tk>(), c_queue);
+
+            // Create a copy of the pKey buffer
+            cl::Buffer* cKey = bufferAlloc(elements * sizeof(Tk));
+            compute::buffer cKey_buf((*cKey)());
+            compute::buffer_iterator<Tk> cKey0 = compute::make_buffer_iterator<Tk>(cKey_buf, 0);
+            compute::buffer_iterator<Tk> cKeyN = compute::make_buffer_iterator<Tk>(cKey_buf, elements);
+            compute::copy(key0, keyN, cKey0, c_queue);
+
+            // FIRST SORT
+            compute::sort_by_key(key0, keyN, seq0, c_queue);
+            compute::sort_by_key(cKey0, cKeyN, val0, c_queue);
+
+            // Create a copy of the seq buffer after first sort
+            cl::Buffer* cSeq = bufferAlloc(elements * sizeof(unsigned));
+            compute::buffer cSeq_buf((*cSeq)());
+            compute::buffer_iterator<unsigned> cSeq0 = compute::make_buffer_iterator<unsigned>(cSeq_buf, 0);
+            compute::buffer_iterator<unsigned> cSeqN = compute::make_buffer_iterator<unsigned>(cSeq_buf, elements);
+            compute::copy(seq0, seqN, cSeq0, c_queue);
+
+            // SECOND SORT
+            // First call will sort key, second sort will sort val
+            // Needs to be ascending (true) in order to maintain the indices properly
+            //kernel::sort0_by_key<Tv, T, true>(pKey, pVal);
+            compute::sort_by_key(seq0, seqN, key0, c_queue);
+            compute::sort_by_key(cSeq0, cSeqN, val0, c_queue);
+
+            // If descending, flip it back
+            if(!isAscending) compute::transform(key0, keyN, key0, flipFunction<Tk>(), c_queue);
+
+            //// No need of doing moddims here because the original Array<T>
+            //// dimensions have not been changed
+            ////val.modDims(inDims);
+
+            CL_DEBUG_FINISH(getQueue());
+            bufferFree(Seq);
+            bufferFree(cSeq);
+            bufferFree(cKey);
         }
 
         template<typename Tk, typename Tv>

--- a/src/backend/opencl/kernel/sparse.hpp
+++ b/src/backend/opencl/kernel/sparse.hpp
@@ -43,223 +43,209 @@ namespace opencl
         template<typename T>
         void coo2dense(Param out, const Param values, const Param rowIdx, const Param colIdx)
         {
-            try {
+            std::string ref_name =
+                std::string("coo2dense_") +
+                std::string(dtype_traits<T>::getName()) +
+                std::string("_") +
+                std::to_string(REPEAT);
 
-                std::string ref_name =
-                    std::string("coo2dense_") +
-                    std::string(dtype_traits<T>::getName()) +
-                    std::string("_") +
-                    std::to_string(REPEAT);
+            int device = getActiveDeviceId();
+            auto idx = kernelCaches[device].find(ref_name);
+            kc_entry_t entry;
 
-                int device = getActiveDeviceId();
-                auto idx = kernelCaches[device].find(ref_name);
-                kc_entry_t entry;
+            if (idx == kernelCaches[device].end()) {
+                std::ostringstream options;
+                options << " -D T="        << dtype_traits<T>::getName()
+                        << " -D reps="     << REPEAT
+                        ;
 
-                if (idx == kernelCaches[device].end()) {
-                    std::ostringstream options;
-                    options << " -D T="        << dtype_traits<T>::getName()
-                            << " -D reps="     << REPEAT
-                            ;
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
 
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
+                Program prog;
+                buildProgram(prog, coo2dense_cl, coo2dense_cl_len, options.str());
+                entry.prog   = new Program(prog);
+                entry.ker = new Kernel(*entry.prog, "coo2dense_kernel");
+            } else {
+                entry = idx->second;
+            };
 
-                    Program prog;
-                    buildProgram(prog, coo2dense_cl, coo2dense_cl_len, options.str());
-                    entry.prog   = new Program(prog);
-                    entry.ker = new Kernel(*entry.prog, "coo2dense_kernel");
-                } else {
-                    entry = idx->second;
-                };
+            auto coo2denseOp = KernelFunctor<Buffer, const KParam,
+                                        const Buffer, const KParam,
+                                        const Buffer, const KParam,
+                                        const Buffer, const KParam>
+                                      (*entry.ker);
 
-                auto coo2denseOp = KernelFunctor<Buffer, const KParam,
-                                           const Buffer, const KParam,
-                                           const Buffer, const KParam,
-                                           const Buffer, const KParam>
-                                          (*entry.ker);
+            NDRange local(THREADS_PER_GROUP, 1, 1);
 
-                NDRange local(THREADS_PER_GROUP, 1, 1);
+            NDRange global(divup(out.info.dims[0], local[0] * REPEAT) * THREADS_PER_GROUP, 1, 1);
 
-                NDRange global(divup(out.info.dims[0], local[0] * REPEAT) * THREADS_PER_GROUP, 1, 1);
+            coo2denseOp(EnqueueArgs(getQueue(), global, local),
+                    *out.data, out.info,
+                    *values.data, values.info,
+                    *rowIdx.data, rowIdx.info,
+                    *colIdx.data, colIdx.info);
 
-                coo2denseOp(EnqueueArgs(getQueue(), global, local),
-                       *out.data, out.info,
-                       *values.data, values.info,
-                       *rowIdx.data, rowIdx.info,
-                       *colIdx.data, colIdx.info);
-
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-            }
+            CL_DEBUG_FINISH(getQueue());
         }
 
         template<typename T>
         void csr2dense(Param output, const Param values, const Param rowIdx, const Param colIdx)
         {
-            try {
-                const int MAX_GROUPS = 4096;
-                int M = rowIdx.info.dims[0] - 1;
-                //FIXME: This needs to be based non nonzeros per row
-                int threads = 64;
+            const int MAX_GROUPS = 4096;
+            int M = rowIdx.info.dims[0] - 1;
+            //FIXME: This needs to be based non nonzeros per row
+            int threads = 64;
 
-                std::string ref_name =
-                    std::string("csr2dense_") +
-                    std::string(dtype_traits<T>::getName()) +
-                    std::string("_") +
-                    std::to_string(threads);
+            std::string ref_name =
+                std::string("csr2dense_") +
+                std::string(dtype_traits<T>::getName()) +
+                std::string("_") +
+                std::to_string(threads);
 
-                int device = getActiveDeviceId();
-                auto idx = kernelCaches[device].find(ref_name);
-                kc_entry_t entry;
+            int device = getActiveDeviceId();
+            auto idx = kernelCaches[device].find(ref_name);
+            kc_entry_t entry;
 
-                if (idx == kernelCaches[device].end()) {
+            if (idx == kernelCaches[device].end()) {
 
-                    std::ostringstream options;
-                    options << " -D T=" << dtype_traits<T>::getName();
-                    options << " -D THREADS=" << threads;
+                std::ostringstream options;
+                options << " -D T=" << dtype_traits<T>::getName();
+                options << " -D THREADS=" << threads;
 
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-
-                    const char *ker_strs[] = {csr2dense_cl};
-                    const int   ker_lens[] = {csr2dense_cl_len};
-
-                    Program prog;
-                    buildProgram(prog, 1, ker_strs, ker_lens, options.str());
-                    entry.prog = new Program(prog);
-                    entry.ker  = new Kernel(*entry.prog, "csr2dense");
-                } else {
-                    entry = idx->second;
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
                 }
 
-                NDRange local(threads, 1);
-                int groups_x = std::min((int)(divup(M, local[0])), MAX_GROUPS);
-                NDRange global(local[0] * groups_x, 1);
-                auto csr2dense_kernel = *entry.ker;
-                auto csr2dense_func = KernelFunctor<Buffer,
-                                                    Buffer, Buffer, Buffer,
-                                                    int> (csr2dense_kernel);
+                const char *ker_strs[] = {csr2dense_cl};
+                const int   ker_lens[] = {csr2dense_cl_len};
 
-                csr2dense_func(EnqueueArgs(getQueue(), global, local),
-                               *output.data, *values.data, *rowIdx.data, *colIdx.data, M);
-
-                CL_DEBUG_FINISH(getQueue());
-
-            } catch(cl::Error err) {
-                CL_TO_AF_ERROR(err);
+                Program prog;
+                buildProgram(prog, 1, ker_strs, ker_lens, options.str());
+                entry.prog = new Program(prog);
+                entry.ker  = new Kernel(*entry.prog, "csr2dense");
+            } else {
+                entry = idx->second;
             }
+
+            NDRange local(threads, 1);
+            int groups_x = std::min((int)(divup(M, local[0])), MAX_GROUPS);
+            NDRange global(local[0] * groups_x, 1);
+            auto csr2dense_kernel = *entry.ker;
+            auto csr2dense_func = KernelFunctor<Buffer,
+                                                Buffer, Buffer, Buffer,
+                                                int> (csr2dense_kernel);
+
+            csr2dense_func(EnqueueArgs(getQueue(), global, local),
+                            *output.data, *values.data, *rowIdx.data, *colIdx.data, M);
+
+            CL_DEBUG_FINISH(getQueue());
         }
 
         template<typename T>
         void dense2csr(Param values, Param rowIdx, Param colIdx, const Param dense)
         {
-            try {
-                int num_rows = dense.info.dims[0];
-                int num_cols = dense.info.dims[1];
-                int dense_elements = num_rows * num_cols;
-                Param sd1, rd1, sd0;
-                // sd1 contains output of scan along dim 1 of dense
-                sd1.data = bufferAlloc(dense_elements * sizeof(int));
-                // rd1 contains output of nonzero count along dim 1 along dense
-                rd1.data = bufferAlloc(num_rows * sizeof(int));
-                // sd0 contains output of exclusive scan rd1
-                sd0 = rowIdx;
+            int num_rows = dense.info.dims[0];
+            int num_cols = dense.info.dims[1];
+            int dense_elements = num_rows * num_cols;
+            Param sd1, rd1, sd0;
+            // sd1 contains output of scan along dim 1 of dense
+            sd1.data = bufferAlloc(dense_elements * sizeof(int));
+            // rd1 contains output of nonzero count along dim 1 along dense
+            rd1.data = bufferAlloc(num_rows * sizeof(int));
+            // sd0 contains output of exclusive scan rd1
+            sd0 = rowIdx;
 
-                sd1.info.offset = 0;
-                rd1.info.offset = 0;
+            sd1.info.offset = 0;
+            rd1.info.offset = 0;
 
-                sd1.info.dims[0] = num_rows;
-                rd1.info.dims[0] = num_rows;
+            sd1.info.dims[0] = num_rows;
+            rd1.info.dims[0] = num_rows;
 
-                sd1.info.dims[1] = num_cols;
-                rd1.info.dims[1] = 1;
+            sd1.info.dims[1] = num_cols;
+            rd1.info.dims[1] = 1;
 
-                sd1.info.dims[2] = 1;
-                rd1.info.dims[2] = 1;
+            sd1.info.dims[2] = 1;
+            rd1.info.dims[2] = 1;
 
-                sd1.info.dims[3] = 1;
-                rd1.info.dims[3] = 1;
+            sd1.info.dims[3] = 1;
+            rd1.info.dims[3] = 1;
 
-                sd1.info.strides[0] = 1;
-                rd1.info.strides[0] = 1;
-                for (int i = 1; i < 4; i++) {
-                    sd1.info.strides[i] = sd1.info.dims[i - 1] * sd1.info.strides[i - 1];
-                    rd1.info.strides[i] = rd1.info.dims[i - 1] * rd1.info.strides[i - 1];
-                }
-
-                scan_dim<T, int, af_notzero_t, true>(sd1, dense, 1);
-                reduce_dim<T, int, af_notzero_t>(rd1, dense, 0, 0, 1);
-                scan_first<int, int, af_add_t, false>(sd0, rd1);
-
-                int nnz = values.info.dims[0];
-                getQueue().enqueueWriteBuffer(*sd0.data, CL_TRUE,
-                                              sd0.info.offset + (rowIdx.info.dims[0] - 1) * sizeof(int),
-                                              sizeof(int),
-                                              (void *)&nnz);
-
-                std::string ref_name =
-                    std::string("dense2csr_") +
-                    std::string(dtype_traits<T>::getName());
-
-                int device = getActiveDeviceId();
-                auto idx = kernelCaches[device].find(ref_name);
-                kc_entry_t entry;
-
-                if (idx == kernelCaches[device].end()) {
-
-                    std::ostringstream options;
-                    options << " -D T=" << dtype_traits<T>::getName();
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-                    if (std::is_same<T, cfloat>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D IS_CPLX=1";
-                    } else {
-                        options << " -D IS_CPLX=0";
-                    }
-
-                    const char *ker_strs[] = {dense2csr_cl};
-                    const int   ker_lens[] = {dense2csr_cl_len};
-
-                    Program prog;
-                    buildProgram(prog, 1, ker_strs, ker_lens, options.str());
-                    entry.prog = new Program(prog);
-                    entry.ker  = new Kernel(*entry.prog, "dense2csr_split_kernel");
-
-                    kernelCaches[device][ref_name] = entry;
-                } else {
-                    entry = idx->second;
-                }
-
-                NDRange local(THREADS_X, THREADS_Y);
-                int groups_x = divup(dense.info.dims[0], local[0]);
-                int groups_y = divup(dense.info.dims[1], local[1]);
-                NDRange global(groups_x * local[0], groups_y * local[1]);
-                auto dense2csr_split = KernelFunctor<Buffer, Buffer,
-                                                     Buffer, KParam,
-                                                     Buffer, KParam,
-                                                     Buffer>(*entry.ker);
-
-                dense2csr_split(EnqueueArgs(getQueue(), global, local),
-                                *values.data, *colIdx.data,
-                                *dense.data, dense.info,
-                                *sd1.data, sd1.info,
-                                *sd0.data);
-
-                CL_DEBUG_FINISH(getQueue());
-
-                bufferFree(rd1.data);
-                bufferFree(sd1.data);
-            } catch (cl::Error &err) {
-                CL_TO_AF_ERROR(err);
+            sd1.info.strides[0] = 1;
+            rd1.info.strides[0] = 1;
+            for (int i = 1; i < 4; i++) {
+                sd1.info.strides[i] = sd1.info.dims[i - 1] * sd1.info.strides[i - 1];
+                rd1.info.strides[i] = rd1.info.dims[i - 1] * rd1.info.strides[i - 1];
             }
+
+            scan_dim<T, int, af_notzero_t, true>(sd1, dense, 1);
+            reduce_dim<T, int, af_notzero_t>(rd1, dense, 0, 0, 1);
+            scan_first<int, int, af_add_t, false>(sd0, rd1);
+
+            int nnz = values.info.dims[0];
+            getQueue().enqueueWriteBuffer(*sd0.data, CL_TRUE,
+                                          sd0.info.offset + (rowIdx.info.dims[0] - 1) * sizeof(int),
+                                          sizeof(int),
+                                          (void *)&nnz);
+
+            std::string ref_name =
+                std::string("dense2csr_") +
+                std::string(dtype_traits<T>::getName());
+
+            int device = getActiveDeviceId();
+            auto idx = kernelCaches[device].find(ref_name);
+            kc_entry_t entry;
+
+            if (idx == kernelCaches[device].end()) {
+
+                std::ostringstream options;
+                options << " -D T=" << dtype_traits<T>::getName();
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
+                if (std::is_same<T, cfloat>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D IS_CPLX=1";
+                } else {
+                    options << " -D IS_CPLX=0";
+                }
+
+                const char *ker_strs[] = {dense2csr_cl};
+                const int   ker_lens[] = {dense2csr_cl_len};
+
+                Program prog;
+                buildProgram(prog, 1, ker_strs, ker_lens, options.str());
+                entry.prog = new Program(prog);
+                entry.ker  = new Kernel(*entry.prog, "dense2csr_split_kernel");
+
+                kernelCaches[device][ref_name] = entry;
+            } else {
+                entry = idx->second;
+            }
+
+            NDRange local(THREADS_X, THREADS_Y);
+            int groups_x = divup(dense.info.dims[0], local[0]);
+            int groups_y = divup(dense.info.dims[1], local[1]);
+            NDRange global(groups_x * local[0], groups_y * local[1]);
+            auto dense2csr_split = KernelFunctor<Buffer, Buffer,
+                                                  Buffer, KParam,
+                                                  Buffer, KParam,
+                                                  Buffer>(*entry.ker);
+
+            dense2csr_split(EnqueueArgs(getQueue(), global, local),
+                            *values.data, *colIdx.data,
+                            *dense.data, dense.info,
+                            *sd1.data, sd1.info,
+                            *sd0.data);
+
+            CL_DEBUG_FINISH(getQueue());
+
+            bufferFree(rd1.data);
+            bufferFree(sd1.data);
         }
 
         template<typename T>
@@ -267,48 +253,43 @@ namespace opencl
                        const Param ivalues, const cl::Buffer *iindex,
                        const Param swapIdx)
         {
-            try {
-                std::string ref_name =
-                    std::string("swapIndex_kernel_") +
-                    std::string(dtype_traits<T>::getName());
+            std::string ref_name =
+                std::string("swapIndex_kernel_") +
+                std::string(dtype_traits<T>::getName());
 
-                int device = getActiveDeviceId();
-                auto idx = kernelCaches[device].find(ref_name);
-                kc_entry_t entry;
+            int device = getActiveDeviceId();
+            auto idx = kernelCaches[device].find(ref_name);
+            kc_entry_t entry;
 
-                if (idx == kernelCaches[device].end()) {
-                    std::ostringstream options;
-                    options << " -D T="        << dtype_traits<T>::getName();
+            if (idx == kernelCaches[device].end()) {
+                std::ostringstream options;
+                options << " -D T="        << dtype_traits<T>::getName();
 
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
 
-                    Program prog;
-                    buildProgram(prog, csr2coo_cl, csr2coo_cl_len, options.str());
-                    entry.prog   = new Program(prog);
-                    entry.ker = new Kernel(*entry.prog, "swapIndex_kernel");
-                } else {
-                    entry = idx->second;
-                };
+                Program prog;
+                buildProgram(prog, csr2coo_cl, csr2coo_cl_len, options.str());
+                entry.prog   = new Program(prog);
+                entry.ker = new Kernel(*entry.prog, "swapIndex_kernel");
+            } else {
+                entry = idx->second;
+            };
 
-                auto swapIndexOp = KernelFunctor<Buffer, Buffer,
-                                                 const Buffer, const Buffer, const Buffer,
-                                                 const int> (*entry.ker);
+            auto swapIndexOp = KernelFunctor<Buffer, Buffer,
+                                              const Buffer, const Buffer, const Buffer,
+                                              const int> (*entry.ker);
 
-                NDRange global(ovalues.info.dims[0], 1, 1);
+            NDRange global(ovalues.info.dims[0], 1, 1);
 
-                swapIndexOp(EnqueueArgs(getQueue(), global),
-                            *ovalues.data, *oindex.data,
-                            *ivalues.data, *iindex,
-                            *swapIdx.data, ovalues.info.dims[0]);
+            swapIndexOp(EnqueueArgs(getQueue(), global),
+                        *ovalues.data, *oindex.data,
+                        *ivalues.data, *iindex,
+                        *swapIdx.data, ovalues.info.dims[0]);
 
-                CL_DEBUG_FINISH(getQueue());
-
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-            }
+            CL_DEBUG_FINISH(getQueue());
         }
 
         template<typename T>
@@ -316,68 +297,63 @@ namespace opencl
                      const Param ivalues, const Param irowIdx, const Param icolIdx,
                      Param index)
         {
-            try {
-                const int MAX_GROUPS = 4096;
-                int M = irowIdx.info.dims[0] - 1;
-                //FIXME: This needs to be based non nonzeros per row
-                int threads = 64;
+            const int MAX_GROUPS = 4096;
+            int M = irowIdx.info.dims[0] - 1;
+            //FIXME: This needs to be based non nonzeros per row
+            int threads = 64;
 
-                std::string ref_name =
-                    std::string("csr2coo_") +
-                    std::string(dtype_traits<T>::getName());
+            std::string ref_name =
+                std::string("csr2coo_") +
+                std::string(dtype_traits<T>::getName());
 
-                int device = getActiveDeviceId();
-                auto idx = kernelCaches[device].find(ref_name);
-                kc_entry_t entry;
+            int device = getActiveDeviceId();
+            auto idx = kernelCaches[device].find(ref_name);
+            kc_entry_t entry;
 
-                if (idx == kernelCaches[device].end()) {
+            if (idx == kernelCaches[device].end()) {
 
-                    std::ostringstream options;
-                    options << " -D T=" << dtype_traits<T>::getName();
+                std::ostringstream options;
+                options << " -D T=" << dtype_traits<T>::getName();
 
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-
-                    const char *ker_strs[] = {csr2coo_cl};
-                    const int   ker_lens[] = {csr2coo_cl_len};
-
-                    Program prog;
-                    buildProgram(prog, 1, ker_strs, ker_lens, options.str());
-                    entry.prog = new Program(prog);
-                    entry.ker  = new Kernel(*entry.prog, "csr2coo");
-                } else {
-                    entry = idx->second;
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
                 }
 
-                cl::Buffer *scratch = bufferAlloc(orowIdx.info.dims[0] * sizeof(int));
+                const char *ker_strs[] = {csr2coo_cl};
+                const int   ker_lens[] = {csr2coo_cl_len};
 
-                NDRange local(threads, 1);
-                int groups_x = std::min((int)(divup(M, local[0])), MAX_GROUPS);
-                NDRange global(local[0] * groups_x, 1);
-                auto csr2coo_kernel = *entry.ker;
-                auto csr2coo_func = KernelFunctor<Buffer, Buffer,
-                                                  const Buffer, const Buffer,
-                                                  int> (csr2coo_kernel);
-
-                csr2coo_func(EnqueueArgs(getQueue(), global, local),
-                               *scratch, *ocolIdx.data,
-                               *irowIdx.data, *icolIdx.data, M);
-
-                // Now we need to sort this into column major
-                kernel::sort0ByKeyIterative<int, int>(ocolIdx, index, true);
-
-                // Now use index to sort values and rows
-                kernel::swapIndex<T>(ovalues, orowIdx, ivalues, scratch, index);
-
-                CL_DEBUG_FINISH(getQueue());
-
-                bufferFree(scratch);
-
-            } catch(cl::Error err) {
-                CL_TO_AF_ERROR(err);
+                Program prog;
+                buildProgram(prog, 1, ker_strs, ker_lens, options.str());
+                entry.prog = new Program(prog);
+                entry.ker  = new Kernel(*entry.prog, "csr2coo");
+            } else {
+                entry = idx->second;
             }
+
+            cl::Buffer *scratch = bufferAlloc(orowIdx.info.dims[0] * sizeof(int));
+
+            NDRange local(threads, 1);
+            int groups_x = std::min((int)(divup(M, local[0])), MAX_GROUPS);
+            NDRange global(local[0] * groups_x, 1);
+            auto csr2coo_kernel = *entry.ker;
+            auto csr2coo_func = KernelFunctor<Buffer, Buffer,
+                                              const Buffer, const Buffer,
+                                              int> (csr2coo_kernel);
+
+            csr2coo_func(EnqueueArgs(getQueue(), global, local),
+                            *scratch, *ocolIdx.data,
+                            *irowIdx.data, *icolIdx.data, M);
+
+            // Now we need to sort this into column major
+            kernel::sort0ByKeyIterative<int, int>(ocolIdx, index, true);
+
+            // Now use index to sort values and rows
+            kernel::swapIndex<T>(ovalues, orowIdx, ivalues, scratch, index);
+
+            CL_DEBUG_FINISH(getQueue());
+
+            bufferFree(scratch);
         }
 
         template<typename T>
@@ -385,52 +361,47 @@ namespace opencl
                      const Param ivalues, const Param irowIdx, const Param icolIdx,
                      Param index, Param rowCopy, const int M)
         {
-            try {
-                // Now we need to sort this into column major
-                kernel::sort0ByKeyIterative<int, int>(rowCopy, index, true);
+            // Now we need to sort this into column major
+            kernel::sort0ByKeyIterative<int, int>(rowCopy, index, true);
 
-                // Now use index to sort values and rows
-                kernel::swapIndex<T>(ovalues, ocolIdx, ivalues, icolIdx.data, index);
+            // Now use index to sort values and rows
+            kernel::swapIndex<T>(ovalues, ocolIdx, ivalues, icolIdx.data, index);
 
-                CL_DEBUG_FINISH(getQueue());
+            CL_DEBUG_FINISH(getQueue());
 
-                std::string ref_name =
-                    std::string("csrReduce_kernel_") +
-                    std::string(dtype_traits<T>::getName());
+            std::string ref_name =
+                std::string("csrReduce_kernel_") +
+                std::string(dtype_traits<T>::getName());
 
-                int device = getActiveDeviceId();
-                auto idx = kernelCaches[device].find(ref_name);
-                kc_entry_t entry;
+            int device = getActiveDeviceId();
+            auto idx = kernelCaches[device].find(ref_name);
+            kc_entry_t entry;
 
-                if (idx == kernelCaches[device].end()) {
-                    std::ostringstream options;
-                    options << " -D T="        << dtype_traits<T>::getName();
+            if (idx == kernelCaches[device].end()) {
+                std::ostringstream options;
+                options << " -D T="        << dtype_traits<T>::getName();
 
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
 
-                    Program prog;
-                    buildProgram(prog, csr2coo_cl, csr2coo_cl_len, options.str());
-                    entry.prog   = new Program(prog);
-                    entry.ker = new Kernel(*entry.prog, "csrReduce_kernel");
-                } else {
-                    entry = idx->second;
-                };
+                Program prog;
+                buildProgram(prog, csr2coo_cl, csr2coo_cl_len, options.str());
+                entry.prog   = new Program(prog);
+                entry.ker = new Kernel(*entry.prog, "csrReduce_kernel");
+            } else {
+                entry = idx->second;
+            };
 
-                auto csrReduceOp = KernelFunctor<Buffer, const Buffer, const int, const int> (*entry.ker);
+            auto csrReduceOp = KernelFunctor<Buffer, const Buffer, const int, const int> (*entry.ker);
 
-                NDRange global(irowIdx.info.dims[0], 1, 1);
+            NDRange global(irowIdx.info.dims[0], 1, 1);
 
-                csrReduceOp(EnqueueArgs(getQueue(), global),
-                            *orowIdx.data, *rowCopy.data, M, ovalues.info.dims[0]);
+            csrReduceOp(EnqueueArgs(getQueue(), global),
+                        *orowIdx.data, *rowCopy.data, M, ovalues.info.dims[0]);
 
-                CL_DEBUG_FINISH(getQueue());
-
-            } catch(cl::Error err) {
-                CL_TO_AF_ERROR(err);
-            }
+            CL_DEBUG_FINISH(getQueue());
         }
     }
 }

--- a/src/backend/opencl/kernel/susan.hpp
+++ b/src/backend/opencl/kernel/susan.hpp
@@ -41,50 +41,45 @@ void susan(cl::Buffer* out, const cl::Buffer* in,
            const unsigned idim0, const unsigned idim1,
            const float t, const float g, const unsigned edge)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*> suProg;
-        static std::map<int, Kernel*>  suKernel;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*> suProg;
+    static std::map<int, Kernel*>  suKernel;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
+    std::call_once( compileFlags[device], [device] () {
 
-                const size_t LOCAL_MEM_SIZE = (SUSAN_THREADS_X+2*radius)*(SUSAN_THREADS_Y+2*radius);
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName()
-                        << " -D LOCAL_MEM_SIZE=" << LOCAL_MEM_SIZE
-                        << " -D BLOCK_X="<< SUSAN_THREADS_X
-                        << " -D BLOCK_Y="<< SUSAN_THREADS_Y
-                        << " -D RADIUS="<< radius
-                        << " -D RESPONSE";
+            const size_t LOCAL_MEM_SIZE = (SUSAN_THREADS_X+2*radius)*(SUSAN_THREADS_Y+2*radius);
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName()
+                    << " -D LOCAL_MEM_SIZE=" << LOCAL_MEM_SIZE
+                    << " -D BLOCK_X="<< SUSAN_THREADS_X
+                    << " -D BLOCK_Y="<< SUSAN_THREADS_Y
+                    << " -D RADIUS="<< radius
+                    << " -D RESPONSE";
 
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
+            }
 
-                cl::Program prog;
-                buildProgram(prog, susan_cl, susan_cl_len, options.str());
-                suProg[device]   = new Program(prog);
-                suKernel[device] = new Kernel(*suProg[device], "susan_responses");
-            });
+            cl::Program prog;
+            buildProgram(prog, susan_cl, susan_cl_len, options.str());
+            suProg[device]   = new Program(prog);
+            suKernel[device] = new Kernel(*suProg[device], "susan_responses");
+        });
 
-        auto susanOp = KernelFunctor<Buffer, Buffer,
-                                   unsigned,
-                                   unsigned, unsigned,
-                                   float, float, unsigned>(*suKernel[device]);
+    auto susanOp = KernelFunctor<Buffer, Buffer,
+                                unsigned,
+                                unsigned, unsigned,
+                                float, float, unsigned>(*suKernel[device]);
 
-        NDRange local(SUSAN_THREADS_X, SUSAN_THREADS_Y);
-        NDRange global(divup(idim0-2*edge, local[0])*local[0],
-                       divup(idim1-2*edge, local[1])*local[1]);
+    NDRange local(SUSAN_THREADS_X, SUSAN_THREADS_Y);
+    NDRange global(divup(idim0-2*edge, local[0])*local[0],
+                    divup(idim1-2*edge, local[1])*local[1]);
 
-        susanOp(EnqueueArgs(getQueue(), global, local), *out, *in, in_off, idim0, idim1, t, g, edge);
+    susanOp(EnqueueArgs(getQueue(), global, local), *out, *in, in_off, idim0, idim1, t, g, edge);
 
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
 }
 
 template<typename T>
@@ -93,51 +88,46 @@ unsigned nonMaximal(cl::Buffer* x_out, cl::Buffer* y_out, cl::Buffer* resp_out,
                     const unsigned edge, const unsigned max_corners)
 {
     unsigned corners_found = 0;
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*> nmProg;
-        static std::map<int, Kernel*>  nmKernel;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*> nmProg;
+    static std::map<int, Kernel*>  nmKernel;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once( compileFlags[device], [device] () {
+    std::call_once( compileFlags[device], [device] () {
 
-                std::ostringstream options;
-                options << " -D T=" << dtype_traits<T>::getName()
-                        << " -D NONMAX";
+            std::ostringstream options;
+            options << " -D T=" << dtype_traits<T>::getName()
+                    << " -D NONMAX";
 
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
+            }
 
-                cl::Program prog;
-                buildProgram(prog, susan_cl, susan_cl_len, options.str());
-                nmProg[device]   = new Program(prog);
-                nmKernel[device] = new Kernel(*nmProg[device], "non_maximal");
-            });
+            cl::Program prog;
+            buildProgram(prog, susan_cl, susan_cl_len, options.str());
+            nmProg[device]   = new Program(prog);
+            nmKernel[device] = new Kernel(*nmProg[device], "non_maximal");
+        });
 
-        cl::Buffer *d_corners_found = bufferAlloc(sizeof(unsigned));
-        getQueue().enqueueWriteBuffer(*d_corners_found, CL_TRUE, 0, sizeof(unsigned), &corners_found);
+    cl::Buffer *d_corners_found = bufferAlloc(sizeof(unsigned));
+    getQueue().enqueueWriteBuffer(*d_corners_found, CL_TRUE, 0, sizeof(unsigned), &corners_found);
 
-        auto nonMaximalOp = KernelFunctor<Buffer, Buffer, Buffer, Buffer,
-                                        unsigned, unsigned, Buffer,
-                                        unsigned, unsigned>(*nmKernel[device]);
+    auto nonMaximalOp = KernelFunctor<Buffer, Buffer, Buffer, Buffer,
+                                    unsigned, unsigned, Buffer,
+                                    unsigned, unsigned>(*nmKernel[device]);
 
-        NDRange local(SUSAN_THREADS_X, SUSAN_THREADS_Y);
-        NDRange global(divup(idim0-2*edge, local[0])*local[0],
-                       divup(idim1-2*edge, local[1])*local[1]);
+    NDRange local(SUSAN_THREADS_X, SUSAN_THREADS_Y);
+    NDRange global(divup(idim0-2*edge, local[0])*local[0],
+                    divup(idim1-2*edge, local[1])*local[1]);
 
-        nonMaximalOp(EnqueueArgs(getQueue(), global, local),
-                     *x_out, *y_out, *resp_out, *d_corners_found,
-                     idim0, idim1, *resp_in, edge, max_corners);
+    nonMaximalOp(EnqueueArgs(getQueue(), global, local),
+                  *x_out, *y_out, *resp_out, *d_corners_found,
+                  idim0, idim1, *resp_in, edge, max_corners);
 
-        getQueue().enqueueReadBuffer(*d_corners_found, CL_TRUE, 0, sizeof(unsigned), &corners_found);
-        bufferFree(d_corners_found);
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
+    getQueue().enqueueReadBuffer(*d_corners_found, CL_TRUE, 0, sizeof(unsigned), &corners_found);
+    bufferFree(d_corners_found);
     return corners_found;
 }
 

--- a/src/backend/opencl/kernel/transform.hpp
+++ b/src/backend/opencl/kernel/transform.hpp
@@ -57,102 +57,97 @@ namespace opencl
                        const Param tf, bool isInverse,
                        bool isPerspective, af_interp_type method)
         {
-            try {
 
-                typedef typename dtype_traits<T>::base_type BT;
+            typedef typename dtype_traits<T>::base_type BT;
 
-                std::string ref_name =
-                    std::string("transform_") +
-                    std::string(dtype_traits<T>::getName()) +
-                    std::string("_") +
-                    std::to_string(isInverse) +
-                    std::string("_") +
-                    std::to_string(isPerspective) +
-                    std::string("_") +
-                    std::to_string(order);
+            std::string ref_name =
+                std::string("transform_") +
+                std::string(dtype_traits<T>::getName()) +
+                std::string("_") +
+                std::to_string(isInverse) +
+                std::string("_") +
+                std::to_string(isPerspective) +
+                std::string("_") +
+                std::to_string(order);
 
-                int device = getActiveDeviceId();
-                auto idx = kernelCaches[device].find(ref_name);
-                kc_entry_t entry;
+            int device = getActiveDeviceId();
+            auto idx = kernelCaches[device].find(ref_name);
+            kc_entry_t entry;
 
-                if (idx == kernelCaches[device].end()) {
-                    ToNumStr<T> toNumStr;
-                    std::ostringstream options;
-                    options << " -D T="           << dtype_traits<T>::getName()
-                            << " -D INVERSE="     << (isInverse ? 1 : 0)
-                            << " -D PERSPECTIVE=" << (isPerspective ? 1 : 0)
-                            << " -D ZERO="        << toNumStr(scalar<T>(0));
-                    options << " -D InterpInTy=" << dtype_traits<T>::getName();
-                    options << " -D InterpValTy="  << dtype_traits<vtype_t<T>>::getName();
-                    options << " -D InterpPosTy=" << dtype_traits<wtype_t<BT>>::getName();
+            if (idx == kernelCaches[device].end()) {
+                ToNumStr<T> toNumStr;
+                std::ostringstream options;
+                options << " -D T="           << dtype_traits<T>::getName()
+                        << " -D INVERSE="     << (isInverse ? 1 : 0)
+                        << " -D PERSPECTIVE=" << (isPerspective ? 1 : 0)
+                        << " -D ZERO="        << toNumStr(scalar<T>(0));
+                options << " -D InterpInTy=" << dtype_traits<T>::getName();
+                options << " -D InterpValTy="  << dtype_traits<vtype_t<T>>::getName();
+                options << " -D InterpPosTy=" << dtype_traits<wtype_t<BT>>::getName();
 
-                    if((af_dtype) dtype_traits<T>::af_type == c32 ||
-                       (af_dtype) dtype_traits<T>::af_type == c64) {
-                        options << " -D IS_CPLX=1";
-                        options << " -D TB=" << dtype_traits<BT>::getName();
-                    } else {
-                        options << " -D IS_CPLX=0";
-                    }
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-
-                    options << " -D INTERP_ORDER=" << order;
-                    addInterpEnumOptions(options);
-
-                    const char *ker_strs[] = {interp_cl, transform_cl};
-                    const int   ker_lens[] = {interp_cl_len, transform_cl_len};
-                    Program prog;
-                    buildProgram(prog, 2, ker_strs, ker_lens, options.str());
-                    entry.prog = new Program(prog);
-                    entry.ker = new Kernel(*entry.prog, "transform_kernel");
+                if((af_dtype) dtype_traits<T>::af_type == c32 ||
+                    (af_dtype) dtype_traits<T>::af_type == c64) {
+                    options << " -D IS_CPLX=1";
+                    options << " -D TB=" << dtype_traits<BT>::getName();
                 } else {
-                    entry = idx->second;
+                    options << " -D IS_CPLX=0";
+                }
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
                 }
 
-                auto transformOp = KernelFunctor<Buffer, const KParam,
-                                                 const Buffer, const KParam,
-                                                 const Buffer, const KParam,
-                                                 const int, const int, const int, const int,
-                                                 const int, const int, const int, const int>(*entry.ker);
+                options << " -D INTERP_ORDER=" << order;
+                addInterpEnumOptions(options);
 
-                const int nImg2 = in.info.dims[2];
-                const int nImg3 = in.info.dims[3];
-                const int nTfs2 = tf.info.dims[2];
-                const int nTfs3 = tf.info.dims[3];
-
-                NDRange local(TX, TY, 1);
-
-                int batchImg2 = 1;
-                if(nImg2 != nTfs2)
-                    batchImg2 = min(nImg2, TI);
-
-                const int blocksXPerImage = divup(out.info.dims[0], local[0]);
-                const int blocksYPerImage = divup(out.info.dims[1], local[1]);
-
-                int global_x = local[0]
-                             * blocksXPerImage
-                             * (nImg2 / batchImg2);
-                int global_y = local[1]
-                             * blocksYPerImage
-                             * nImg3;
-                int global_z = local[2]
-                             * max((nTfs2 / nImg2), 1)
-                             * max((nTfs3 / nImg3), 1);
-
-                NDRange global(global_x, global_y, global_z);
-
-                transformOp(EnqueueArgs(getQueue(), global, local),
-                            *out.data, out.info, *in.data, in.info, *tf.data, tf.info,
-                            nImg2, nImg3, nTfs2, nTfs3, batchImg2,
-                            blocksXPerImage, blocksYPerImage, (int)method);
-
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
+                const char *ker_strs[] = {interp_cl, transform_cl};
+                const int   ker_lens[] = {interp_cl_len, transform_cl_len};
+                Program prog;
+                buildProgram(prog, 2, ker_strs, ker_lens, options.str());
+                entry.prog = new Program(prog);
+                entry.ker = new Kernel(*entry.prog, "transform_kernel");
+            } else {
+                entry = idx->second;
             }
+
+            auto transformOp = KernelFunctor<Buffer, const KParam,
+                                              const Buffer, const KParam,
+                                              const Buffer, const KParam,
+                                              const int, const int, const int, const int,
+                                              const int, const int, const int, const int>(*entry.ker);
+
+            const int nImg2 = in.info.dims[2];
+            const int nImg3 = in.info.dims[3];
+            const int nTfs2 = tf.info.dims[2];
+            const int nTfs3 = tf.info.dims[3];
+
+            NDRange local(TX, TY, 1);
+
+            int batchImg2 = 1;
+            if(nImg2 != nTfs2)
+                batchImg2 = min(nImg2, TI);
+
+            const int blocksXPerImage = divup(out.info.dims[0], local[0]);
+            const int blocksYPerImage = divup(out.info.dims[1], local[1]);
+
+            int global_x = local[0]
+                          * blocksXPerImage
+                          * (nImg2 / batchImg2);
+            int global_y = local[1]
+                          * blocksYPerImage
+                          * nImg3;
+            int global_z = local[2]
+                          * max((nTfs2 / nImg2), 1)
+                          * max((nTfs3 / nImg3), 1);
+
+            NDRange global(global_x, global_y, global_z);
+
+            transformOp(EnqueueArgs(getQueue(), global, local),
+                        *out.data, out.info, *in.data, in.info, *tf.data, tf.info,
+                        nImg2, nImg3, nTfs2, nTfs3, batchImg2,
+                        blocksXPerImage, blocksYPerImage, (int)method);
+
+            CL_DEBUG_FINISH(getQueue());
         }
     }
 }

--- a/src/backend/opencl/kernel/transpose.hpp
+++ b/src/backend/opencl/kernel/transpose.hpp
@@ -40,56 +40,51 @@ static const int THREADS_Y = 256 / TILE_DIM;
 template<typename T, bool conjugate, bool IS32MULTIPLE>
 void transpose(Param out, const Param in)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*>  trsProgs;
-        static std::map<int, Kernel*> trsKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*>  trsProgs;
+    static std::map<int, Kernel*> trsKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once(compileFlags[device], [device] () {
+    std::call_once(compileFlags[device], [device] () {
 
-                std::ostringstream options;
-                options << " -D TILE_DIM=" << TILE_DIM
-                        << " -D THREADS_Y=" << THREADS_Y
-                        << " -D IS32MULTIPLE=" << IS32MULTIPLE
-                        << " -D DOCONJUGATE=" << (conjugate && af::iscplx<T>())
-                        << " -D T=" << dtype_traits<T>::getName();
+            std::ostringstream options;
+            options << " -D TILE_DIM=" << TILE_DIM
+                    << " -D THREADS_Y=" << THREADS_Y
+                    << " -D IS32MULTIPLE=" << IS32MULTIPLE
+                    << " -D DOCONJUGATE=" << (conjugate && af::iscplx<T>())
+                    << " -D T=" << dtype_traits<T>::getName();
 
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
+            }
 
-                cl::Program prog;
-                buildProgram(prog, transpose_cl, transpose_cl_len, options.str());
-                trsProgs[device] = new Program(prog);
+            cl::Program prog;
+            buildProgram(prog, transpose_cl, transpose_cl_len, options.str());
+            trsProgs[device] = new Program(prog);
 
-                trsKernels[device] = new Kernel(*trsProgs[device], "transpose");
-            });
+            trsKernels[device] = new Kernel(*trsProgs[device], "transpose");
+        });
 
 
-        NDRange local(THREADS_X, THREADS_Y);
+    NDRange local(THREADS_X, THREADS_Y);
 
-        int blk_x = divup(in.info.dims[0], TILE_DIM);
-        int blk_y = divup(in.info.dims[1], TILE_DIM);
+    int blk_x = divup(in.info.dims[0], TILE_DIM);
+    int blk_y = divup(in.info.dims[1], TILE_DIM);
 
-        // launch batch * blk_x blocks along x dimension
-        NDRange global(blk_x * local[0] * in.info.dims[2],
-                       blk_y * local[1] * in.info.dims[3]);
+    // launch batch * blk_x blocks along x dimension
+    NDRange global(blk_x * local[0] * in.info.dims[2],
+                    blk_y * local[1] * in.info.dims[3]);
 
-        auto transposeOp = KernelFunctor<Buffer, const KParam,
-                                       const Buffer, const KParam,
-                                       const int, const int> (*trsKernels[device]);
+    auto transposeOp = KernelFunctor<Buffer, const KParam,
+                                    const Buffer, const KParam,
+                                    const int, const int> (*trsKernels[device]);
 
-        transposeOp(EnqueueArgs(getQueue(), global, local),
-                    *out.data, out.info, *in.data, in.info, blk_x, blk_y);
+    transposeOp(EnqueueArgs(getQueue(), global, local),
+                *out.data, out.info, *in.data, in.info, blk_x, blk_y);
 
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
+    CL_DEBUG_FINISH(getQueue());
 }
 
 }

--- a/src/backend/opencl/kernel/transpose_inplace.hpp
+++ b/src/backend/opencl/kernel/transpose_inplace.hpp
@@ -40,54 +40,49 @@ static const int THREADS_Y = 256 / TILE_DIM;
 template<typename T, bool conjugate, bool IS32MULTIPLE>
 void transpose_inplace(Param in)
 {
-    try {
-        static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
-        static std::map<int, Program*>  transposeProgs;
-        static std::map<int, Kernel*> transposeKernels;
+    static std::once_flag compileFlags[DeviceManager::MAX_DEVICES];
+    static std::map<int, Program*>  transposeProgs;
+    static std::map<int, Kernel*> transposeKernels;
 
-        int device = getActiveDeviceId();
+    int device = getActiveDeviceId();
 
-        std::call_once(compileFlags[device], [device] () {
+    std::call_once(compileFlags[device], [device] () {
 
-                std::ostringstream options;
-                options << " -D TILE_DIM=" << TILE_DIM
-                        << " -D THREADS_Y=" << THREADS_Y
-                        << " -D IS32MULTIPLE=" << IS32MULTIPLE
-                        << " -D DOCONJUGATE=" << (conjugate && af::iscplx<T>())
-                        << " -D T=" << dtype_traits<T>::getName();
+            std::ostringstream options;
+            options << " -D TILE_DIM=" << TILE_DIM
+                    << " -D THREADS_Y=" << THREADS_Y
+                    << " -D IS32MULTIPLE=" << IS32MULTIPLE
+                    << " -D DOCONJUGATE=" << (conjugate && af::iscplx<T>())
+                    << " -D T=" << dtype_traits<T>::getName();
 
-                if (std::is_same<T, double>::value ||
-                    std::is_same<T, cdouble>::value) {
-                    options << " -D USE_DOUBLE";
-                }
+            if (std::is_same<T, double>::value ||
+                std::is_same<T, cdouble>::value) {
+                options << " -D USE_DOUBLE";
+            }
 
-                cl::Program prog;
-                buildProgram(prog, transpose_inplace_cl, transpose_inplace_cl_len, options.str());
-                transposeProgs[device] = new Program(prog);
+            cl::Program prog;
+            buildProgram(prog, transpose_inplace_cl, transpose_inplace_cl_len, options.str());
+            transposeProgs[device] = new Program(prog);
 
-                transposeKernels[device] = new Kernel(*transposeProgs[device], "transpose_inplace");
-            });
+            transposeKernels[device] = new Kernel(*transposeProgs[device], "transpose_inplace");
+        });
 
 
-        NDRange local(THREADS_X, THREADS_Y);
+    NDRange local(THREADS_X, THREADS_Y);
 
-        int blk_x = divup(in.info.dims[0], TILE_DIM);
-        int blk_y = divup(in.info.dims[1], TILE_DIM);
+    int blk_x = divup(in.info.dims[0], TILE_DIM);
+    int blk_y = divup(in.info.dims[1], TILE_DIM);
 
-        // launch batch * blk_x blocks along x dimension
-        NDRange global(blk_x * local[0] * in.info.dims[2],
-                       blk_y * local[1] * in.info.dims[3]);
+    // launch batch * blk_x blocks along x dimension
+    NDRange global(blk_x * local[0] * in.info.dims[2],
+                    blk_y * local[1] * in.info.dims[3]);
 
-        auto transposeOp = KernelFunctor<Buffer, const KParam,
-                                       const int, const int> (*transposeKernels[device]);
+    auto transposeOp = KernelFunctor<Buffer, const KParam,
+                                    const int, const int> (*transposeKernels[device]);
 
-        transposeOp(EnqueueArgs(getQueue(), global, local), *in.data, in.info, blk_x, blk_y);
+    transposeOp(EnqueueArgs(getQueue(), global, local), *in.data, in.info, blk_x, blk_y);
 
-        CL_DEBUG_FINISH(getQueue());
-    } catch (cl::Error err) {
-        CL_TO_AF_ERROR(err);
-        throw;
-    }
+    CL_DEBUG_FINISH(getQueue());
 }
 
 }

--- a/src/backend/opencl/kernel/unwrap.hpp
+++ b/src/backend/opencl/kernel/unwrap.hpp
@@ -41,77 +41,72 @@ namespace opencl
                     const dim_t px, const dim_t py,
                     const dim_t nx, const bool is_column)
         {
-            try {
-                std::string ref_name =
-                    std::string("unwrap_") +
-                    std::string(dtype_traits<T>::getName()) +
-                    std::string("_") +
-                    std::to_string(is_column);
+            std::string ref_name =
+                std::string("unwrap_") +
+                std::string(dtype_traits<T>::getName()) +
+                std::string("_") +
+                std::to_string(is_column);
 
-                int device = getActiveDeviceId();
-                kc_t::iterator idx = kernelCaches[device].find(ref_name);
+            int device = getActiveDeviceId();
+            kc_t::iterator idx = kernelCaches[device].find(ref_name);
 
-                kc_entry_t entry;
-                if (idx == kernelCaches[device].end()) {
+            kc_entry_t entry;
+            if (idx == kernelCaches[device].end()) {
 
-                    ToNumStr<T> toNumStr;
-                    std::ostringstream options;
-                    options << " -D is_column=" << is_column
-                            << " -D ZERO=" << toNumStr(scalar<T>(0))
-                            << " -D T="    << dtype_traits<T>::getName();
+                ToNumStr<T> toNumStr;
+                std::ostringstream options;
+                options << " -D is_column=" << is_column
+                        << " -D ZERO=" << toNumStr(scalar<T>(0))
+                        << " -D T="    << dtype_traits<T>::getName();
 
-                    if (std::is_same<T, double>::value ||
-                        std::is_same<T, cdouble>::value) {
-                        options << " -D USE_DOUBLE";
-                    }
-
-                    Program prog;
-                    buildProgram(prog, unwrap_cl, unwrap_cl_len, options.str());
-
-                    entry.prog = new Program(prog);
-                    entry.ker = new Kernel(*entry.prog, "unwrap_kernel");
-
-                    kernelCaches[device][ref_name] = entry;
-                } else {
-                    entry = idx->second;
+                if (std::is_same<T, double>::value ||
+                    std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
                 }
 
-                dim_t TX = 1, TY = 1;
-                dim_t BX = 1;
-                const dim_t BY = out.info.dims[2] * out.info.dims[3];
-                dim_t reps = 1;
+                Program prog;
+                buildProgram(prog, unwrap_cl, unwrap_cl_len, options.str());
 
-                if (is_column) {
-                    TX = std::min(THREADS_PER_GROUP, nextpow2(out.info.dims[0]));
-                    TY = THREADS_PER_GROUP / TX;
-                    BX = divup(out.info.dims[1], TY);
-                    reps = divup((wx * wy), TX);
-                } else {
-                    TX = THREADS_X;
-                    TY = THREADS_Y;
-                    BX = divup(out.info.dims[0], TX);
-                    reps = divup((wx * wy), TY);
-                }
+                entry.prog = new Program(prog);
+                entry.ker = new Kernel(*entry.prog, "unwrap_kernel");
 
-                NDRange local(TX, TY);
-                NDRange global(local[0] * BX,
-                               local[1] * BY);
-
-                auto unwrapOp = KernelFunctor<Buffer, const KParam,
-                                            const Buffer, const KParam,
-                                            const int, const int,
-                                            const int, const int,
-                                            const int, const int,
-                                            const int, const int> (*entry.ker);
-
-                unwrapOp(EnqueueArgs(getQueue(), global, local),
-                       *out.data, out.info, *in.data, in.info, wx, wy, sx, sy, px, py, nx, reps);
-
-                CL_DEBUG_FINISH(getQueue());
-            } catch (cl::Error err) {
-                CL_TO_AF_ERROR(err);
-                throw;
+                kernelCaches[device][ref_name] = entry;
+            } else {
+                entry = idx->second;
             }
+
+            dim_t TX = 1, TY = 1;
+            dim_t BX = 1;
+            const dim_t BY = out.info.dims[2] * out.info.dims[3];
+            dim_t reps = 1;
+
+            if (is_column) {
+                TX = std::min(THREADS_PER_GROUP, nextpow2(out.info.dims[0]));
+                TY = THREADS_PER_GROUP / TX;
+                BX = divup(out.info.dims[1], TY);
+                reps = divup((wx * wy), TX);
+            } else {
+                TX = THREADS_X;
+                TY = THREADS_Y;
+                BX = divup(out.info.dims[0], TX);
+                reps = divup((wx * wy), TY);
+            }
+
+            NDRange local(TX, TY);
+            NDRange global(local[0] * BX,
+                            local[1] * BY);
+
+            auto unwrapOp = KernelFunctor<Buffer, const KParam,
+                                        const Buffer, const KParam,
+                                        const int, const int,
+                                        const int, const int,
+                                        const int, const int,
+                                        const int, const int> (*entry.ker);
+
+            unwrapOp(EnqueueArgs(getQueue(), global, local),
+                    *out.data, out.info, *in.data, in.info, wx, wy, sx, sy, px, py, nx, reps);
+
+            CL_DEBUG_FINISH(getQueue());
         }
     }
 }

--- a/src/backend/opencl/kernel/where.hpp
+++ b/src/backend/opencl/kernel/where.hpp
@@ -92,82 +92,78 @@ namespace kernel
     template<typename T>
     static void where(Param &out, Param &in)
     {
-        try {
-            uint threads_x = nextpow2(std::max(32u, (uint)in.info.dims[0]));
-            threads_x = std::min(threads_x, THREADS_PER_GROUP);
-            uint threads_y = THREADS_PER_GROUP / threads_x;
+        uint threads_x = nextpow2(std::max(32u, (uint)in.info.dims[0]));
+        threads_x = std::min(threads_x, THREADS_PER_GROUP);
+        uint threads_y = THREADS_PER_GROUP / threads_x;
 
-            uint groups_x = divup(in.info.dims[0], threads_x * REPEAT);
-            uint groups_y = divup(in.info.dims[1], threads_y);
+        uint groups_x = divup(in.info.dims[0], threads_x * REPEAT);
+        uint groups_y = divup(in.info.dims[1], threads_y);
 
-            Param rtmp;
-            Param otmp;
+        Param rtmp;
+        Param otmp;
 
-            rtmp.info.dims[0] = groups_x;
-            otmp.info.dims[0] = in.info.dims[0];
+        rtmp.info.dims[0] = groups_x;
+        otmp.info.dims[0] = in.info.dims[0];
 
-            rtmp.info.strides[0] = 1;
-            otmp.info.strides[0] = 1;
+        rtmp.info.strides[0] = 1;
+        otmp.info.strides[0] = 1;
 
-            rtmp.info.offset = 0;
-            otmp.info.offset = 0;
+        rtmp.info.offset = 0;
+        otmp.info.offset = 0;
 
-            for (int k = 1; k < 4; k++) {
-                rtmp.info.dims[k] = in.info.dims[k];
-                rtmp.info.strides[k] = rtmp.info.strides[k - 1] * rtmp.info.dims[k - 1];
+        for (int k = 1; k < 4; k++) {
+            rtmp.info.dims[k] = in.info.dims[k];
+            rtmp.info.strides[k] = rtmp.info.strides[k - 1] * rtmp.info.dims[k - 1];
 
-                otmp.info.dims[k] = in.info.dims[k];
-                otmp.info.strides[k] = otmp.info.strides[k - 1] * otmp.info.dims[k - 1];
-            }
-
-            int rtmp_elements = rtmp.info.strides[3] * rtmp.info.dims[3];
-            rtmp.data = bufferAlloc(rtmp_elements * sizeof(uint));
-
-            int otmp_elements = otmp.info.strides[3] * otmp.info.dims[3];
-            otmp.data = bufferAlloc(otmp_elements * sizeof(uint));
-
-            scan_first_launcher<T, uint, af_notzero_t>(otmp, rtmp, in,
-                                                       false,
-                                                       groups_x, groups_y,
-                                                       threads_x);
-
-            // Linearize the dimensions and perform scan
-            Param ltmp = rtmp;
-            ltmp.info.offset = 0;
-            ltmp.info.dims[0] = rtmp_elements;
-            for (int k = 1; k < 4; k++) {
-                ltmp.info.dims[k] = 1;
-                ltmp.info.strides[k] = rtmp_elements;
-            }
-
-            scan_first<uint, uint, af_add_t>(ltmp, ltmp);
-
-            // Get output size and allocate output
-            uint total;
-            getQueue().enqueueReadBuffer(*rtmp.data, CL_TRUE,
-                                         sizeof(uint) * (rtmp_elements - 1),
-                                         sizeof(uint),
-                                         &total);
-
-
-            out.data = bufferAlloc(total * sizeof(uint));
-
-            out.info.dims[0] = total;
-            out.info.strides[0] = 1;
-            for (int k = 1; k < 4; k++) {
-                out.info.dims[k] = 1;
-                out.info.strides[k] = total;
-            }
-
-            if (total > 0) {
-                get_out_idx<T>(out.data, otmp, rtmp, in, threads_x, groups_x, groups_y);
-            }
-
-            bufferFree(rtmp.data);
-            bufferFree(otmp.data);
-        } catch (cl::Error err) {
-            CL_TO_AF_ERROR(err);
+            otmp.info.dims[k] = in.info.dims[k];
+            otmp.info.strides[k] = otmp.info.strides[k - 1] * otmp.info.dims[k - 1];
         }
+
+        int rtmp_elements = rtmp.info.strides[3] * rtmp.info.dims[3];
+        rtmp.data = bufferAlloc(rtmp_elements * sizeof(uint));
+
+        int otmp_elements = otmp.info.strides[3] * otmp.info.dims[3];
+        otmp.data = bufferAlloc(otmp_elements * sizeof(uint));
+
+        scan_first_launcher<T, uint, af_notzero_t>(otmp, rtmp, in,
+                                                    false,
+                                                    groups_x, groups_y,
+                                                    threads_x);
+
+        // Linearize the dimensions and perform scan
+        Param ltmp = rtmp;
+        ltmp.info.offset = 0;
+        ltmp.info.dims[0] = rtmp_elements;
+        for (int k = 1; k < 4; k++) {
+            ltmp.info.dims[k] = 1;
+            ltmp.info.strides[k] = rtmp_elements;
+        }
+
+        scan_first<uint, uint, af_add_t>(ltmp, ltmp);
+
+        // Get output size and allocate output
+        uint total;
+        getQueue().enqueueReadBuffer(*rtmp.data, CL_TRUE,
+                                      sizeof(uint) * (rtmp_elements - 1),
+                                      sizeof(uint),
+                                      &total);
+
+
+        out.data = bufferAlloc(total * sizeof(uint));
+
+        out.info.dims[0] = total;
+        out.info.strides[0] = 1;
+        for (int k = 1; k < 4; k++) {
+            out.info.dims[k] = 1;
+            out.info.strides[k] = total;
+        }
+
+        if (total > 0) {
+            get_out_idx<T>(out.data, otmp, rtmp, in, threads_x, groups_x, groups_y);
+        }
+
+        bufferFree(rtmp.data);
+        bufferFree(otmp.data);
     }
 }
 }

--- a/src/backend/opencl/lu.cpp
+++ b/src/backend/opencl/lu.cpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #include <lu.hpp>
-#include <err_common.hpp>
+#include <err_opencl.hpp>
 
 #if defined(WITH_OPENCL_LINEAR_ALGEBRA)
 #include <kernel/lu_split.hpp>
@@ -43,58 +43,50 @@ Array<int> convertPivot(int *ipiv, int in_sz, int out_sz)
 template<typename T>
 void lu(Array<T> &lower, Array<T> &upper, Array<int> &pivot, const Array<T> &in)
 {
-    try {
-        if(OpenCLCPUOffload()) {
-            return cpu::lu(lower, upper, pivot, in);
-        }
-
-        dim4 iDims = in.dims();
-        int M = iDims[0];
-        int N = iDims[1];
-        int MN = std::min(M, N);
-
-        Array<T> in_copy = copyArray<T>(in);
-        pivot = lu_inplace(in_copy);
-
-        // SPLIT into lower and upper
-        dim4 ldims(M, MN);
-        dim4 udims(MN, N);
-        lower = createEmptyArray<T>(ldims);
-        upper = createEmptyArray<T>(udims);
-        kernel::lu_split<T>(lower, upper, in_copy);
-
-    } catch (cl::Error &err) {
-        CL_TO_AF_ERROR(err);
+    if(OpenCLCPUOffload()) {
+        return cpu::lu(lower, upper, pivot, in);
     }
+
+    dim4 iDims = in.dims();
+    int M = iDims[0];
+    int N = iDims[1];
+    int MN = std::min(M, N);
+
+    Array<T> in_copy = copyArray<T>(in);
+    pivot = lu_inplace(in_copy);
+
+    // SPLIT into lower and upper
+    dim4 ldims(M, MN);
+    dim4 udims(MN, N);
+    lower = createEmptyArray<T>(ldims);
+    upper = createEmptyArray<T>(udims);
+    kernel::lu_split<T>(lower, upper, in_copy);
+
 }
 
 template<typename T>
 Array<int> lu_inplace(Array<T> &in, const bool convert_pivot)
 {
-    try {
-        if(OpenCLCPUOffload()) {
-            return cpu::lu_inplace(in, convert_pivot);
-        }
-
-        initBlas();
-        dim4 iDims = in.dims();
-        int M = iDims[0];
-        int N = iDims[1];
-        int MN = std::min(M, N);
-        std::vector<int> ipiv(MN);
-
-        cl::Buffer *in_buf = in.get();
-        int info = 0;
-        magma_getrf_gpu<T>(M, N, (*in_buf)(), in.getOffset(), in.strides()[1],
-                           &ipiv[0], getQueue()(), &info);
-
-        if (!convert_pivot) return createHostDataArray<int>(dim4(MN), &ipiv[0]);
-
-        Array<int> pivot = convertPivot(&ipiv[0], MN, M);
-        return pivot;
-    } catch(cl::Error &err) {
-        CL_TO_AF_ERROR(err);
+    if(OpenCLCPUOffload()) {
+        return cpu::lu_inplace(in, convert_pivot);
     }
+
+    initBlas();
+    dim4 iDims = in.dims();
+    int M = iDims[0];
+    int N = iDims[1];
+    int MN = std::min(M, N);
+    std::vector<int> ipiv(MN);
+
+    cl::Buffer *in_buf = in.get();
+    int info = 0;
+    magma_getrf_gpu<T>(M, N, (*in_buf)(), in.getOffset(), in.strides()[1],
+                        &ipiv[0], getQueue()(), &info);
+
+    if (!convert_pivot) return createHostDataArray<int>(dim4(MN), &ipiv[0]);
+
+    Array<int> pivot = convertPivot(&ipiv[0], MN, M);
+    return pivot;
 }
 
 bool isLAPACKAvailable()

--- a/src/backend/opencl/magma/magma_cpu_blas.h
+++ b/src/backend/opencl/magma/magma_cpu_blas.h
@@ -9,7 +9,7 @@
 
 #ifndef MAGMA_CPU_BLAS
 #define MAGMA_CPU_BLAS
-#include <err_common.hpp>
+#include <err_opencl.hpp>
 #include <defines.hpp>
 #include "magma_types.h"
 

--- a/src/backend/opencl/magma/magma_cpu_lapack.h
+++ b/src/backend/opencl/magma/magma_cpu_lapack.h
@@ -10,7 +10,7 @@
 #ifndef MAGMA_CPU_LAPACK
 #define MAGMA_CPU_LAPACK
 
-#include <err_common.hpp>
+#include <err_opencl.hpp>
 #include <defines.hpp>
 #include "magma_types.h"
 

--- a/src/backend/opencl/memory.cpp
+++ b/src/backend/opencl/memory.cpp
@@ -95,20 +95,12 @@ MemoryManager::MemoryManager() :
 
 void *MemoryManager::nativeAlloc(const size_t bytes)
 {
-    try {
-        return (void *)(new cl::Buffer(getContext(), CL_MEM_READ_WRITE, bytes));
-    } catch(cl::Error err) {
-        CL_TO_AF_ERROR(err);
-    }
+    return (void *)(new cl::Buffer(getContext(), CL_MEM_READ_WRITE, bytes));
 }
 
 void MemoryManager::nativeFree(void *ptr)
 {
-    try {
-        delete (cl::Buffer *)ptr;
-    } catch(cl::Error err) {
-        CL_TO_AF_ERROR(err);
-    }
+    delete (cl::Buffer *)ptr;
 }
 
 static MemoryManager &getMemoryManager()
@@ -137,29 +129,20 @@ MemoryManagerPinned::MemoryManagerPinned() :
 void *MemoryManagerPinned::nativeAlloc(const size_t bytes)
 {
     void *ptr = NULL;
-    try {
-        cl::Buffer buf= cl::Buffer(getContext(), CL_MEM_ALLOC_HOST_PTR, bytes);
-        ptr = getQueue().enqueueMapBuffer(buf, true, CL_MAP_READ | CL_MAP_WRITE, 0, bytes);
-        pinned_maps[opencl::getActiveDeviceId()][ptr] = buf;
-    } catch(cl::Error err) {
-        CL_TO_AF_ERROR(err);
-    }
+    cl::Buffer buf= cl::Buffer(getContext(), CL_MEM_ALLOC_HOST_PTR, bytes);
+    ptr = getQueue().enqueueMapBuffer(buf, true, CL_MAP_READ | CL_MAP_WRITE, 0, bytes);
+    pinned_maps[opencl::getActiveDeviceId()][ptr] = buf;
     return ptr;
 }
 
 void MemoryManagerPinned::nativeFree(void *ptr)
 {
-    try {
-        int n = opencl::getActiveDeviceId();
-        auto iter = pinned_maps[n].find(ptr);
+    int n = opencl::getActiveDeviceId();
+    auto iter = pinned_maps[n].find(ptr);
 
-        if (iter != pinned_maps[n].end()) {
-            getQueue().enqueueUnmapMemObject(pinned_maps[n][ptr], ptr);
-            pinned_maps[n].erase(iter);
-        }
-
-    } catch(cl::Error err) {
-        CL_TO_AF_ERROR(err);
+    if (iter != pinned_maps[n].end()) {
+        getQueue().enqueueUnmapMemObject(pinned_maps[n][ptr], ptr);
+        pinned_maps[n].erase(iter);
     }
 }
 

--- a/src/backend/opencl/qr.cpp
+++ b/src/backend/opencl/qr.cpp
@@ -8,7 +8,6 @@
  ********************************************************/
 
 #include <qr.hpp>
-#include <err_common.hpp>
 #include <err_opencl.hpp>
 #include <blas.hpp>
 #include <copy.hpp>
@@ -29,94 +28,85 @@ namespace opencl
 template<typename T>
 void qr(Array<T> &q, Array<T> &r, Array<T> &t, const Array<T> &orig)
 {
-    try {
-        if(OpenCLCPUOffload()) {
-            return cpu::qr(q, r, t, orig);
-        }
-
-        initBlas();
-        dim4 iDims = orig.dims();
-        int M = iDims[0];
-        int N = iDims[1];
-
-        dim4 pDims(M, std::max(M, N));
-        Array<T> in = padArray<T, T>(orig, pDims, scalar<T>(0));  //copyArray<T>(orig);
-        in.resetDims(iDims);
-
-        int MN = std::min(M, N);
-        int NB = magma_get_geqrf_nb<T>(M);
-
-        int NUM = (2*MN + ((N+31)/32)*32)*NB;
-        Array<T> tmp = createEmptyArray<T>(dim4(NUM));
-
-        std::vector<T> h_tau(MN);
-
-        int info = 0;
-        cl::Buffer *in_buf = in.get();
-        cl::Buffer *dT = tmp.get();
-
-        magma_geqrf3_gpu<T>(M, N,
-                           (*in_buf)(), in.getOffset(), in.strides()[1],
-                           &h_tau[0], (*dT)(), tmp.getOffset(), getQueue()(), &info);
-
-        r = createEmptyArray<T>(in.dims());
-        kernel::triangle<T, true, false>(r, in);
-
-        cl::Buffer *r_buf = r.get();
-        magmablas_swapdblk<T>(MN - 1, NB,
-                              ( *r_buf)(), r.getOffset(),
-                              r.strides()[1], 1,
-                              (*dT)(), tmp.getOffset() + MN * NB,
-                              NB, 0, getQueue()());
-
-        q = in; // No need to copy
-        q.resetDims(dim4(M, M));
-        cl::Buffer *q_buf = q.get();
-
-        magma_ungqr_gpu<T>(q.dims()[0], q.dims()[1], std::min(M, N),
-                           (*q_buf)(), q.getOffset(), q.strides()[1],
-                           &h_tau[0],
-                           (*dT)(), tmp.getOffset(), NB, getQueue()(), &info);
-
-        t = createHostDataArray(dim4(MN), &h_tau[0]);
-    } catch(cl::Error &err) {
-        CL_TO_AF_ERROR(err);
+    if(OpenCLCPUOffload()) {
+        return cpu::qr(q, r, t, orig);
     }
+
+    initBlas();
+    dim4 iDims = orig.dims();
+    int M = iDims[0];
+    int N = iDims[1];
+
+    dim4 pDims(M, std::max(M, N));
+    Array<T> in = padArray<T, T>(orig, pDims, scalar<T>(0));  //copyArray<T>(orig);
+    in.resetDims(iDims);
+
+    int MN = std::min(M, N);
+    int NB = magma_get_geqrf_nb<T>(M);
+
+    int NUM = (2*MN + ((N+31)/32)*32)*NB;
+    Array<T> tmp = createEmptyArray<T>(dim4(NUM));
+
+    std::vector<T> h_tau(MN);
+
+    int info = 0;
+    cl::Buffer *in_buf = in.get();
+    cl::Buffer *dT = tmp.get();
+
+    magma_geqrf3_gpu<T>(M, N,
+                        (*in_buf)(), in.getOffset(), in.strides()[1],
+                        &h_tau[0], (*dT)(), tmp.getOffset(), getQueue()(), &info);
+
+    r = createEmptyArray<T>(in.dims());
+    kernel::triangle<T, true, false>(r, in);
+
+    cl::Buffer *r_buf = r.get();
+    magmablas_swapdblk<T>(MN - 1, NB,
+                          ( *r_buf)(), r.getOffset(),
+                          r.strides()[1], 1,
+                          (*dT)(), tmp.getOffset() + MN * NB,
+                          NB, 0, getQueue()());
+
+    q = in; // No need to copy
+    q.resetDims(dim4(M, M));
+    cl::Buffer *q_buf = q.get();
+
+    magma_ungqr_gpu<T>(q.dims()[0], q.dims()[1], std::min(M, N),
+                        (*q_buf)(), q.getOffset(), q.strides()[1],
+                        &h_tau[0],
+                        (*dT)(), tmp.getOffset(), NB, getQueue()(), &info);
+
+    t = createHostDataArray(dim4(MN), &h_tau[0]);
 }
 
 template<typename T>
 Array<T> qr_inplace(Array<T> &in)
 {
-    try {
-        if(OpenCLCPUOffload()) {
-            return cpu::qr_inplace(in);
-        }
-
-        initBlas();
-        dim4 iDims = in.dims();
-        int M = iDims[0];
-        int N = iDims[1];
-        int MN = std::min(M, N);
-
-        getQueue().finish(); // FIXME: Does this need to be here?
-        cl::CommandQueue Queue2(getContext(), getDevice());
-        cl_command_queue queues[] = {getQueue()(), Queue2()};
-
-
-        std::vector<T> h_tau(MN);
-        cl::Buffer *in_buf = in.get();
-
-        int info = 0;
-        magma_geqrf2_gpu<T>(M, N, (*in_buf)(),
-                            in.getOffset(), in.strides()[1],
-                            &h_tau[0], queues, &info);
-
-        Array<T> t = createHostDataArray(dim4(MN), &h_tau[0]);
-        return t;
-
-    } catch(cl::Error &err) {
-        CL_TO_AF_ERROR(err);
+    if(OpenCLCPUOffload()) {
+        return cpu::qr_inplace(in);
     }
+
+    initBlas();
+    dim4 iDims = in.dims();
+    int M = iDims[0];
+    int N = iDims[1];
+    int MN = std::min(M, N);
+
+    getQueue().finish(); // FIXME: Does this need to be here?
+    cl::CommandQueue Queue2(getContext(), getDevice());
+    cl_command_queue queues[] = {getQueue()(), Queue2()};
+
+
+    std::vector<T> h_tau(MN);
+    cl::Buffer *in_buf = in.get();
+
+    int info = 0;
+    magma_geqrf2_gpu<T>(M, N, (*in_buf)(),
+                        in.getOffset(), in.strides()[1],
+                        &h_tau[0], queues, &info);
+
+    Array<T> t = createHostDataArray(dim4(MN), &h_tau[0]);
+    return t;
 }
 
 #define INSTANTIATE_QR(T)                                                                           \

--- a/src/backend/opencl/scan.cpp
+++ b/src/backend/opencl/scan.cpp
@@ -23,25 +23,19 @@ namespace opencl
     {
         Array<To> out = createEmptyArray<To>(in.dims());
 
-        try {
-            Param Out = out;
-            Param In  =   in;
+        Param Out = out;
+        Param In  =   in;
 
-            if (inclusive_scan) {
-                if (dim == 0)
-                    kernel::scan_first<Ti, To, op, true>(Out, In);
-                else
-                    kernel::scan_dim  <Ti, To, op, true>(Out, In, dim);
-            } else {
-                if (dim == 0)
-                    kernel::scan_first<Ti, To, op, false>(Out, In);
-                else
-                    kernel::scan_dim  <Ti, To, op, false>(Out, In, dim);
-            }
-
-        } catch (cl::Error &ex) {
-
-            CL_TO_AF_ERROR(ex);
+        if (inclusive_scan) {
+            if (dim == 0)
+                kernel::scan_first<Ti, To, op, true>(Out, In);
+            else
+                kernel::scan_dim  <Ti, To, op, true>(Out, In, dim);
+        } else {
+            if (dim == 0)
+                kernel::scan_first<Ti, To, op, false>(Out, In);
+            else
+                kernel::scan_dim  <Ti, To, op, false>(Out, In, dim);
         }
 
         return out;

--- a/src/backend/opencl/scan_by_key.cpp
+++ b/src/backend/opencl/scan_by_key.cpp
@@ -23,28 +23,21 @@ namespace opencl
     {
         Array<To> out = createEmptyArray<To>(in.dims());
 
-        try {
-            Param Out = out;
-            Param Key = key;
-            Param In  =   in;
+        Param Out = out;
+        Param Key = key;
+        Param In  =   in;
 
-            if (inclusive_scan) {
-                if (dim == 0)
-                    kernel::scan_first<Ti, Tk, To, op, true>(Out, In, Key);
-                else
-                    kernel::scan_dim  <Ti, Tk, To, op, true>(Out, In, Key, dim);
-            } else {
-                if (dim == 0)
-                    kernel::scan_first<Ti, Tk, To, op, false>(Out, In, Key);
-                else
-                    kernel::scan_dim  <Ti, Tk, To, op, false>(Out, In, Key, dim);
-            }
-
-        } catch (cl::Error &ex) {
-
-            CL_TO_AF_ERROR(ex);
+        if (inclusive_scan) {
+            if (dim == 0)
+                kernel::scan_first<Ti, Tk, To, op, true>(Out, In, Key);
+            else
+                kernel::scan_dim  <Ti, Tk, To, op, true>(Out, In, Key, dim);
+        } else {
+            if (dim == 0)
+                kernel::scan_first<Ti, Tk, To, op, false>(Out, In, Key);
+            else
+                kernel::scan_dim  <Ti, Tk, To, op, false>(Out, In, Key, dim);
         }
-
         return out;
     }
 

--- a/src/backend/opencl/solve.cpp
+++ b/src/backend/opencl/solve.cpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include <err_common.hpp>
+#include <err_opencl.hpp>
 #include <solve.hpp>
 
 #if defined(WITH_OPENCL_LINEAR_ALGEBRA)
@@ -300,25 +300,21 @@ Array<T> triangleSolve(const Array<T> &A, const Array<T> &b, const af_mat_prop o
 template<typename T>
 Array<T> solve(const Array<T> &a, const Array<T> &b, const af_mat_prop options)
 {
-    try {
-        if(OpenCLCPUOffload()) {
-            return cpu::solve(a, b, options);
-        }
+    if(OpenCLCPUOffload()) {
+        return cpu::solve(a, b, options);
+    }
 
-        initBlas();
+    initBlas();
 
-        if (options & AF_MAT_UPPER ||
-            options & AF_MAT_LOWER) {
-            return triangleSolve<T>(a, b, options);
-        }
+    if (options & AF_MAT_UPPER ||
+        options & AF_MAT_LOWER) {
+        return triangleSolve<T>(a, b, options);
+    }
 
-        if(a.dims()[0] == a.dims()[1]) {
-            return generalSolve<T>(a, b);
-        } else {
-            return leastSquares<T>(a, b);
-        }
-    } catch(cl::Error &err) {
-        CL_TO_AF_ERROR(err);
+    if(a.dims()[0] == a.dims()[1]) {
+        return generalSolve<T>(a, b);
+    } else {
+        return leastSquares<T>(a, b);
     }
 }
 

--- a/src/backend/opencl/sparse.cpp
+++ b/src/backend/opencl/sparse.cpp
@@ -17,7 +17,7 @@
 #include <cast.hpp>
 #include <complex.hpp>
 #include <copy.hpp>
-#include <err_common.hpp>
+#include <err_opencl.hpp>
 #include <lookup.hpp>
 #include <math.hpp>
 #include <platform.hpp>


### PR DESCRIPTION
This removes the CL_TO_AF_ERROR macro and the try/catch blocks from the OpenCL backend. This is done by redefining the CATCHALL macro to look for cl::Error exceptions in addition to the standard ArrayFire Exceptions.

