### PR TITLE
osx_install/forge_scripts/postinstall: Grabbing correct glfw package

### DIFF
--- a/CMakeModules/osx_install/forge_scripts/postinstall
+++ b/CMakeModules/osx_install/forge_scripts/postinstall
@@ -49,7 +49,7 @@ GLFW_INSTALLED=$(su $user -c "$brew ls --versions glfw3" | grep "glfw3") || true
 if [[ -z "${GLFW_INSTALLED}" ]]; then
     echo "Installing GLFW3" >> $err_file
     echo "-------------------" >> $err_file
-    su $user -c "$brew install glfw3" >> $err_file 2>&1 || deps_err
+    su $user -c "$brew install glfw" >> $err_file 2>&1 || deps_err
     echo "-------------------" >> $err_file
 else
     echo "GLFW Version ${GLFW_INSTALLED} is already installed." >> $err_file


### PR DESCRIPTION
The brew package manager renamed the GLFW packge from `glfw3` to `glfw`. This
pull request reflects these changes in our `postinstall` script.