### PR TITLE
Added argument checks to af_create_sparse_array

### DIFF
--- a/include/af/array.h
+++ b/include/af/array.h
@@ -709,7 +709,7 @@ namespace af
         /**
             \brief This operator returns a reference of the original array at a given coordinate.
 
-            You can pass \ref af::seq, \ref af::array, or an int as it's parameters.
+            You can pass \ref af::seq, \ref af::array, or an int as its parameters.
             These references can be used for assignment or returning references
             to \ref af::array objects.
 
@@ -1499,7 +1499,7 @@ extern "C" {
     AFAPI af_err af_get_type(af_dtype *type, const af_array arr);
 
     /**
-        \brief Gets the dimseions of an array.
+        \brief Gets the dimensions of an array.
 
         \param[out] d0 is the output that contains the size of first dimension of \p arr
         \param[out] d1 is the output that contains the size of second dimension of \p arr

--- a/include/af/dim4.hpp
+++ b/include/af/dim4.hpp
@@ -23,7 +23,7 @@ namespace af
 class AFAPI dim4
 {
     public:
-    dim_t dims[4]; //FIXME: Make this C compatiable
+    dim_t dims[4]; //FIXME: Make this C compatible
     dim4(); //deleted
 public:
     dim4(   dim_t first,

--- a/src/api/c/handle.hpp
+++ b/src/api/c/handle.hpp
@@ -28,6 +28,8 @@ static const detail::Array<T> &
 getArray(const af_array &arr)
 {
     detail::Array<T> *A = reinterpret_cast<detail::Array<T>*>(arr);
+    if ((af_dtype)af::dtype_traits<T>::af_type != A->getType())
+        AF_ERROR("Invalid type for input array.", AF_ERR_INTERNAL);
     ARG_ASSERT(0, A->isSparse() == false);
     return *A;
 }

--- a/src/api/c/rotate.cpp
+++ b/src/api/c/rotate.cpp
@@ -21,7 +21,7 @@ template<typename T>
 static inline af_array rotate(const af_array in, const float theta, const af::dim4 &odims,
                               const af_interp_type method)
 {
-    return getHandle(rotate<T>(getArray<T>(in), theta, odims, method));
+    return getHandle(rotate<T>(castArray<T>(in), theta, odims, method));
 }
 
 
@@ -45,7 +45,7 @@ af_err af_rotate(af_array *out, const af_array in, const float theta,
 
         af_dtype itype = info.getType();
 
-        ARG_ASSERT(3, method == AF_INTERP_NEAREST  ||
+        ARG_ASSERT(4, method == AF_INTERP_NEAREST  ||
                       method == AF_INTERP_BILINEAR ||
                       method == AF_INTERP_BILINEAR_COSINE ||
                       method == AF_INTERP_BICUBIC ||

--- a/src/api/c/sparse.cpp
+++ b/src/api/c/sparse.cpp
@@ -81,9 +81,11 @@ af_err af_create_sparse_array(
         const ArrayInfo& cInfo = getInfo(colIdx);
 
         TYPE_ASSERT(vInfo.isFloating());
-        DIM_ASSERT(4, vInfo.isLinear());
-        DIM_ASSERT(5, rInfo.isLinear());
-        DIM_ASSERT(6, cInfo.isLinear());
+        DIM_ASSERT(3, vInfo.isLinear());
+        ARG_ASSERT(4, rInfo.getType() == s32);
+        DIM_ASSERT(4, rInfo.isLinear());
+        ARG_ASSERT(5, cInfo.getType() == s32);
+        DIM_ASSERT(5, cInfo.isLinear());
 
         af_array output = 0;
 

--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -312,3 +312,19 @@ CAST_TESTS(cfloat , cdouble )
 
 CAST_TESTS(cdouble, cfloat  )
 CAST_TESTS(cdouble, cdouble )
+
+
+TEST(Sparse, ISSUE_1745)
+{
+  af::array A = af::randu(4, 4);
+  A(1, af::span) = 0;
+  A(2, af::span) = 0;
+
+  af::array idx = where(A);
+  af::array data = A(idx);
+  af::array row_idx = (idx / A.dims()[0]).as(s64);
+  af::array col_idx = (idx % A.dims()[0]).as(s64);
+
+  af_array A_sparse;
+  ASSERT_EQ(AF_ERR_ARG, af_create_sparse_array(&A_sparse, A.dims(0), A.dims(1), data.get(), row_idx.get(), col_idx.get(), AF_STORAGE_CSR));
+}


### PR DESCRIPTION
- Added checks to verify that rowIdx and colIdx are of s32 type
- Fixed index argument to existing ARG_ASSERT and DIM_ASSERT checks
- Added check which causes failure if template and array types do not match in getArray()
- Fixed a few misspellings in comments across different header files
- Added corresponding test to test/sparse.cpp

Addresses issue #1745.