### PR TITLE
Fixed PVS-Studio issues

### DIFF
--- a/src/api/c/homography.cpp
+++ b/src/api/c/homography.cpp
@@ -71,7 +71,7 @@ af_err af_homography(af_array *H, int *inliers,
         ARG_ASSERT(1, (xsdims[0] > 0));
         ARG_ASSERT(2, (ysdims[0] == xsdims[0]));
         ARG_ASSERT(3, (xddims[0] > 0));
-        ARG_ASSERT(4, (yddims[0] == yddims[0]));
+        ARG_ASSERT(4, (yddims[0] == xddims[0]));
 
         ARG_ASSERT(5, (inlier_thr >= 0.1f));
         ARG_ASSERT(6, (iterations > 0));

--- a/src/api/c/median.cpp
+++ b/src/api/c/median.cpp
@@ -45,7 +45,7 @@ static double median(const af_array& in)
         if (input.isFloating()) {
             return division(result[0] + result[1], 2.0);
         } else {
-            return division(result[0] + result[1], 2.0);
+            return division((float)result[0] + (float)result[1], 2.0);
         }
     }
 

--- a/src/api/c/reduce.cpp
+++ b/src/api/c/reduce.cpp
@@ -213,7 +213,7 @@ static af_err reduce_all_type(double *real, double *imag, const af_array in)
 
         ARG_ASSERT(0, real != NULL);
         *real = 0;
-        if (!imag) *imag = 0;
+        if (imag) *imag = 0;
 
         switch(type) {
         case f32:  *real = (double)reduce_all<op, float  , To>(in); break;
@@ -461,7 +461,7 @@ static af_err ireduce_all_common(double *real_val, double *imag_val,
         ARG_ASSERT(3, in_info.ndims() > 0);
         ARG_ASSERT(0, real_val != NULL);
         *real_val = 0;
-        if (!imag_val) *imag_val = 0;
+        if (imag_val) *imag_val = 0;
 
         cfloat  cfval;
         cdouble cdval;

--- a/src/api/c/solve.cpp
+++ b/src/api/c/solve.cpp
@@ -40,7 +40,7 @@ af_err af_solve(af_array *out, const af_array a, const af_array b, const af_mat_
         af_dtype b_type = b_info.getType();
 
         dim4 adims = a_info.dims();
-        dim4 bdims = a_info.dims();
+        dim4 bdims = b_info.dims();
 
         ARG_ASSERT(1, a_info.isFloating());                       // Only floating and complex types
         ARG_ASSERT(2, b_info.isFloating());                       // Only floating and complex types
@@ -110,7 +110,7 @@ af_err af_solve_lu(af_array *out, const af_array a,
         af_dtype b_type = b_info.getType();
 
         dim4 adims = a_info.dims();
-        dim4 bdims = a_info.dims();
+        dim4 bdims = b_info.dims();
 
         ARG_ASSERT(1, a_info.isFloating());                       // Only floating and complex types
         ARG_ASSERT(2, b_info.isFloating());                       // Only floating and complex types


### PR DESCRIPTION
We have found and fixed some bugs using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/
We suggests having a look at the emails, sent from @pvs-studio.com.
V501 There are identical sub-expressions to the left and to the right of the '==' operator: yddims[0] == yddims[0] afcpu homography.cpp 74
V522 Dereferencing of the null pointer 'imag' might take place. afcpu reduce.cpp 216
V522 Dereferencing of the null pointer 'imag_val' might take place. afcpu reduce.cpp 464
V523 The 'then' statement is equivalent to the 'else' statement. afcpu median.cpp 47
V656 Variables 'adims', 'bdims' are initialized through the call to the same function. It's probably an error or un-optimized code. Consider inspecting the 'a_info.dims()' expression. Check lines: 42, 43. afcpu solve.cpp 43
V656 Variables 'adims', 'bdims' are initialized through the call to the same function. It's probably an error or un-optimized code. Consider inspecting the 'a_info.dims()' expression. Check lines: 112, 113. afcpu solve.cpp 113