### PR TITLE
Workaround for ternary operator bug in vs2015

### DIFF
--- a/src/backend/cpu/harris.cpp
+++ b/src/backend/cpu/harris.cpp
@@ -83,9 +83,8 @@ unsigned harris(Array<float> &x_out, Array<float> &y_out, Array<float> &resp_out
     kernel::non_maximal<T>(xCorners, yCorners, respCorners, &corners_found,
                    idims[0], idims[1], responses, min_r, border_len, corner_lim);
 
-    const unsigned corners_out = (max_corners > 0) ?
-                                 min(corners_found, max_corners) :
-                                 min(corners_found, corner_lim);
+    const unsigned corners_out = min(corners_found,
+                                    (max_corners > 0) ? max_corners : corner_lim);
     if (corners_out == 0)
         return 0;
 

--- a/src/backend/cpu/kernel/sift_nonfree.hpp
+++ b/src/backend/cpu/kernel/sift_nonfree.hpp
@@ -972,8 +972,9 @@ unsigned sift_impl(Array<float>& x, Array<float>& y, Array<float>& score,
     getQueue().sync();
     af::dim4 idims = in.dims();
 
-    const unsigned min_dim = (double_input) ? min(idims[0]*2, idims[1]*2)
-        : min(idims[0], idims[1]);
+    unsigned min_dim = min(idims[0], idims[1]);
+    if (double_input) min_dim *= 2;
+
     const unsigned n_octaves = floor(log(min_dim) / log(2)) - 2;
 
     Array<T> init_img = createInitialImage<T, convAccT>(in, init_sigma, double_input);

--- a/src/backend/cuda/kernel/harris.hpp
+++ b/src/backend/cuda/kernel/harris.hpp
@@ -312,8 +312,7 @@ void harris(unsigned* corners_out,
     memFree(d_responses);
     memFree(d_corners_found);
 
-    if (max_corners > 0) { *corners_out = min(corners_found, max_corners); }
-    else                 { *corners_out = min(corners_found, corner_lim);  }
+    *corners_out = min(corners_found, (max_corners > 0) ? max_corners : corner_lim);
 
     if (*corners_out == 0)
         return;

--- a/src/backend/cuda/kernel/harris.hpp
+++ b/src/backend/cuda/kernel/harris.hpp
@@ -312,9 +312,8 @@ void harris(unsigned* corners_out,
     memFree(d_responses);
     memFree(d_corners_found);
 
-    *corners_out = (max_corners > 0) ?
-                   min(corners_found, max_corners) :
-                   min(corners_found, corner_lim);
+    if (max_corners > 0) { *corners_out = min(corners_found, max_corners); }
+    else                 { *corners_out = min(corners_found, corner_lim);  }
 
     if (*corners_out == 0)
         return;

--- a/src/backend/cuda/kernel/sift_nonfree.hpp
+++ b/src/backend/cuda/kernel/sift_nonfree.hpp
@@ -1324,8 +1324,9 @@ void sift(unsigned* out_feat,
           const float feature_ratio,
           const bool compute_GLOH)
 {
-    const unsigned min_dim = (double_input) ? min(img.dims[0]*2, img.dims[1]*2)
-                                            : min(img.dims[0], img.dims[1]);
+    unsigned min_dim = min(img.dims[0], img.dims[1]);
+    if (double_input) min_dim *= 2;
+
     const unsigned n_octaves = floor(log(min_dim) / log(2)) - 2;
 
     Param<T> init_img = createInitialImage<T, convAccT>(img, init_sigma, double_input);

--- a/src/backend/opencl/kernel/harris.hpp
+++ b/src/backend/opencl/kernel/harris.hpp
@@ -249,12 +249,8 @@ void harris(unsigned* corners_out,
     bufferFree(d_responses);
     bufferFree(d_corners_found);
 
-    *corners_out = (max_corners > 0) ?
-                    min(corners_found, max_corners) :
-                    min(corners_found, corner_lim);
-
-    if (*corners_out == 0)
-        return;
+    *corners_out = min(corners_found, (max_corners > 0) ? max_corners : corner_lim);
+    if (*corners_out == 0) return;
 
     // Set output Param info
     x_out.info.dims[0] = y_out.info.dims[0] = resp_out.info.dims[0] = *corners_out;

--- a/src/backend/opencl/kernel/sift_nonfree.hpp
+++ b/src/backend/opencl/kernel/sift_nonfree.hpp
@@ -450,8 +450,9 @@ void sift(unsigned* out_feat,
             cgKernel[device] = new Kernel(*siftProgs[device], "computeGLOHDescriptor");
         });
 
-    const unsigned min_dim = (double_input) ? min(img.info.dims[0]*2, img.info.dims[1]*2)
-                                            : min(img.info.dims[0], img.info.dims[1]);
+    unsigned min_dim = min(img.info.dims[0], img.info.dims[1]);
+    if (double_input) min_dim *= 2;
+
     const unsigned n_octaves = floor(log(min_dim) / log(2)) - 2;
 
     Param init_img = createInitialImage<T, convAccT>(img, init_sigma, double_input);


### PR DESCRIPTION
The ternary operator was not working correctly in vs2015.

build arrayfire windows ci