### PR TITLE
fix inconsistent behaviour of replace & replace_scalar

### DIFF
--- a/src/api/c/replace.cpp
+++ b/src/api/c/replace.cpp
@@ -77,7 +77,7 @@ af_err af_replace(af_array a, const af_array cond, const af_array b)
 template<typename T>
 void replace_scalar(af_array a, const af_array cond, const double b)
 {
-    select_scalar<T, true>(getWritableArray<T>(a), getArray<char>(cond), getArray<T>(a), b);
+    select_scalar<T, false>(getWritableArray<T>(a), getArray<char>(cond), getArray<T>(a), b);
 }
 
 af_err af_replace_scalar(af_array a, const af_array cond, const double b)

--- a/test/replace.cpp
+++ b/test/replace.cpp
@@ -93,7 +93,7 @@ void replaceScalarTest(const dim4 &dims)
     cond.host(&hcond[0]);
 
     for (int i = 0; i < num; i++) {
-        ASSERT_EQ(hc[i], hcond[i] ? T(b) : ha[i]);
+        ASSERT_EQ(hc[i], hcond[i] ? ha[i] : T(b));
     }
 }
 
@@ -116,7 +116,7 @@ TEST(Replace, NaN)
     a(seq(a.dims(0) / 2), span, span, span) = af::NaN;
     array c = a.copy();
     float b = 0;
-    replace(c, isNaN(c), b);
+    replace(c, !isNaN(c), b);
 
     int num = (int)a.elements();
 
@@ -127,7 +127,7 @@ TEST(Replace, NaN)
     c.host(&hc[0]);
 
     for (int i = 0; i < num; i++) {
-        ASSERT_EQ(hc[i], std::isnan(ha[i]) ? b : ha[i]);
+        ASSERT_EQ(hc[i], ( std::isnan(ha[i]) ? b : ha[i]) );
     }
 }
 


### PR DESCRIPTION
Fixes #1772 

replace(output, cond, input) where input is af::array works as
expected(output has input where cond is false). However, if the
input is a scalar parameter, then the output has inverse behaviour.
This change fixes this inconsistency.

Afer this change, output will have values from input when cond is
false irrespective of whether input is af::array or scalar.