### PR TITLE
Fix GLFW3 library name during install on OSX

### DIFF
--- a/CMakeModules/osx_install/InstallTool.cmake
+++ b/CMakeModules/osx_install/InstallTool.cmake
@@ -2,8 +2,7 @@
 EXECUTE_PROCESS( COMMAND otool -L ${CMAKE_CURRENT_BINARY_DIR}/package/lib/libforge.dylib
                  COMMAND grep glfw
                  COMMAND cut -d\  -f1
-                 COMMAND xargs -Jglfwlib install_name_tool -change glfwlib /usr/local/lib/libglfw3.dylib ${CMAKE_CURRENT_BINARY_DIR}/package/lib/libforge.dylib
+                 COMMAND xargs -Jglfwlib install_name_tool -change glfwlib /usr/local/lib/libglfw.dylib ${CMAKE_CURRENT_BINARY_DIR}/package/lib/libforge.dylib
                  OUTPUT_FILE /tmp/af.out
                  ERROR_FILE /tmp/af.err
 )
-

--- a/CMakeModules/osx_install/forge_scripts/postinstall
+++ b/CMakeModules/osx_install/forge_scripts/postinstall
@@ -45,9 +45,9 @@ else
     echo "Homebrew/Versions already present in brew tap." >> $err_file
 fi
 
-GLFW_INSTALLED=$(su $user -c "$brew ls --versions glfw3" | grep "glfw3") || true
+GLFW_INSTALLED=$(su $user -c "$brew ls --versions glfw" | grep "glfw") || true
 if [[ -z "${GLFW_INSTALLED}" ]]; then
-    echo "Installing GLFW3" >> $err_file
+    echo "Installing GLFW" >> $err_file
     echo "-------------------" >> $err_file
     su $user -c "$brew install glfw" >> $err_file 2>&1 || deps_err
     echo "-------------------" >> $err_file


### PR DESCRIPTION
The glfw library has been renamed on OSX from glfw3 to glfw.