### PR TITLE
Fix approx tests for single precision. Reduce memory requirements

### DIFF
--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -7,24 +7,33 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include <gtest/gtest.h>
-#include <af/signal.h>
-#include <arrayfire.h>
-#include <af/dim4.hpp>
 #include <af/defines.h>
+#include <af/dim4.hpp>
+#include <af/signal.h>
 #include <af/traits.hpp>
-#include <vector>
-#include <iostream>
-#include <string>
+
+#include <gtest/gtest.h>
 #include <testHelpers.hpp>
 
-using std::vector;
-using std::string;
-using std::cout;
-using std::endl;
-using std::abs;
-using af::cfloat;
+#include <iostream>
+#include <string>
+#include <vector>
+
+using af::abs;
+using af::approx2;
+using af::array;
 using af::cdouble;
+using af::cfloat;
+using af::dim4;
+using af::dtype_traits;
+using af::randu;
+using af::seq;
+using af::span;
+using af::sum;
+
+using std::abs;
+using std::string;
+using std::vector;
 
 template<typename T>
 class Approx2 : public ::testing::Test
@@ -213,22 +222,21 @@ void approx2ArgsTestPrecision(string pTestFile, const unsigned resultIdx, const 
 //
 TEST(Approx2, CPP)
 {
-    if (noDoubleTests<float>()) return;
     const unsigned resultIdx = 1;
-#define BT af::dtype_traits<float>::base_type
-    vector<af::dim4> numDims;
+#define BT dtype_traits<float>::base_type
+    vector<dim4> numDims;
     vector<vector<BT> > in;
     vector<vector<float> > tests;
     readTests<BT, float, float>(string(TEST_DIR"/approx/approx2.test"),numDims,in,tests);
 
-    af::dim4 idims = numDims[0];
-    af::dim4 pdims = numDims[1];
-    af::dim4 qdims = numDims[2];
+    dim4 idims = numDims[0];
+    dim4 pdims = numDims[1];
+    dim4 qdims = numDims[2];
 
-    af::array input(idims,&(in[0].front()));
-    af::array pos0(pdims,&(in[1].front()));
-    af::array pos1(qdims,&(in[2].front()));
-    af::array output = af::approx2(input, pos0, pos1, AF_INTERP_LINEAR, 0);
+    array input(idims,&(in[0].front()));
+    array pos0(pdims,&(in[1].front()));
+    array pos1(qdims,&(in[2].front()));
+    array output = approx2(input, pos0, pos1, AF_INTERP_LINEAR, 0);
 
     // Get result
     float* outData = new float[tests[resultIdx].size()];
@@ -250,25 +258,24 @@ TEST(Approx2, CPP)
 
 TEST(Approx2Cubic, CPP)
 {
-    if (noDoubleTests<float>()) return;
     const unsigned resultIdx = 0;
-#define BT af::dtype_traits<float>::base_type
-    vector<af::dim4> numDims;
+#define BT dtype_traits<float>::base_type
+    vector<dim4> numDims;
     vector<vector<BT> > in;
     vector<vector<float> > tests;
     readTests<BT, float, float>(string(TEST_DIR"/approx/approx2_cubic.test"),numDims,in,tests);
 
-    af::dim4 idims = numDims[0];
-    af::dim4 pdims = numDims[1];
-    af::dim4 qdims = numDims[2];
+    dim4 idims = numDims[0];
+    dim4 pdims = numDims[1];
+    dim4 qdims = numDims[2];
 
-    af::array input(idims,&(in[0].front()));
+    array input(idims,&(in[0].front()));
     input = input.T();
-    af::array pos0(pdims,&(in[1].front()));
-    af::array pos1(qdims,&(in[2].front()));
+    array pos0(pdims,&(in[1].front()));
+    array pos1(qdims,&(in[2].front()));
     pos0 = tile(pos0, 1, pos0.dims(0));
     pos1 = tile(pos1.T(), pos1.dims(0));
-    af::array output = af::approx2(input, pos0, pos1, AF_INTERP_BICUBIC_SPLINE, 0).T();
+    array output = approx2(input, pos0, pos1, AF_INTERP_BICUBIC_SPLINE, 0).T();
 
     // Get result
     float* outData = new float[tests[resultIdx].size()];
@@ -299,52 +306,48 @@ TEST(Approx2Cubic, CPP)
 
 TEST(Approx2, CPPNearestBatch)
 {
-    if (noDoubleTests<float>()) return;
+    array input = randu(200, 100, 10);
+    array pos   = input.dims(0) * randu(100, 100, 10);
+    array qos   = input.dims(1) * randu(100, 100, 10);
 
-    af::array input = af::randu(200, 100, 10);
-    af::array pos   = input.dims(0) * af::randu(100, 100, 10);
-    af::array qos   = input.dims(1) * af::randu(100, 100, 10);
+    array outBatch = approx2(input, pos, qos, AF_INTERP_NEAREST);
 
-    af::array outBatch = af::approx2(input, pos, qos, AF_INTERP_NEAREST);
-
-    af::array outSerial(pos.dims());
-    for(int i = 0; i < pos.dims(2); i++) {
-        outSerial(af::span, af::span, i) = af::approx2(input(af::span, af::span, i),
-            pos(af::span, af::span, i), qos(af::span, af::span, i), AF_INTERP_NEAREST);
+    array outSerial(pos.dims());
+    for (int i = 0; i < pos.dims(2); i++) {
+        outSerial(span, span, i) = approx2(input(span, span, i),
+            pos(span, span, i), qos(span, span, i), AF_INTERP_NEAREST);
     }
 
-    af::array outGFOR(pos.dims());
-    gfor(af::seq i, pos.dims(2)) {
-        outGFOR(af::span, af::span, i) = af::approx2(input(af::span, af::span, i),
-            pos(af::span, af::span, i), qos(af::span, af::span, i), AF_INTERP_NEAREST);
+    array outGFOR(pos.dims());
+    gfor(seq i, pos.dims(2)) {
+        outGFOR(span, span, i) = approx2(input(span, span, i),
+            pos(span, span, i), qos(span, span, i), AF_INTERP_NEAREST);
     }
 
-    ASSERT_NEAR(0, af::sum<double>(af::abs(outBatch - outSerial)), 1e-3);
-    ASSERT_NEAR(0, af::sum<double>(af::abs(outBatch - outGFOR)), 1e-3);
+    ASSERT_NEAR(0, sum<float>(abs(outBatch - outSerial)), 1e-3);
+    ASSERT_NEAR(0, sum<float>(abs(outBatch - outGFOR)), 1e-3);
 }
 
 TEST(Approx2, CPPLinearBatch)
 {
-    if (noDoubleTests<float>()) return;
+    array input = randu(200, 100, 10);
+    array pos   = input.dims(0) * randu(100, 100, 10);
+    array qos   = input.dims(1) * randu(100, 100, 10);
 
-    af::array input = af::randu(200, 100, 10);
-    af::array pos   = input.dims(0) * af::randu(100, 100, 10);
-    af::array qos   = input.dims(1) * af::randu(100, 100, 10);
+    array outBatch = approx2(input, pos, qos, AF_INTERP_LINEAR);
 
-    af::array outBatch = af::approx2(input, pos, qos, AF_INTERP_LINEAR);
-
-    af::array outSerial(pos.dims());
-    for(int i = 0; i < pos.dims(2); i++) {
-        outSerial(af::span, af::span, i) = af::approx2(input(af::span, af::span, i),
-            pos(af::span, af::span, i), qos(af::span, af::span, i), AF_INTERP_LINEAR);
+    array outSerial(pos.dims());
+    for (int i = 0; i < pos.dims(2); i++) {
+        outSerial(span, span, i) = approx2(input(span, span, i),
+            pos(span, span, i), qos(span, span, i), AF_INTERP_LINEAR);
     }
 
-    af::array outGFOR(pos.dims());
-    gfor(af::seq i, pos.dims(2)) {
-        outGFOR(af::span, af::span, i) = af::approx2(input(af::span, af::span, i),
-            pos(af::span, af::span, i), qos(af::span, af::span, i), AF_INTERP_LINEAR);
+    array outGFOR(pos.dims());
+    gfor(seq i, pos.dims(2)) {
+        outGFOR(span, span, i) = approx2(input(span, span, i),
+            pos(span, span, i), qos(span, span, i), AF_INTERP_LINEAR);
     }
 
-    ASSERT_NEAR(0, af::sum<double>(af::abs(outBatch - outSerial)), 1e-3);
-    ASSERT_NEAR(0, af::sum<double>(af::abs(outBatch - outGFOR)), 1e-3);
+    ASSERT_NEAR(0, sum<float>(abs(outBatch - outSerial)), 1e-3);
+    ASSERT_NEAR(0, sum<float>(abs(outBatch - outGFOR)), 1e-3);
 }


### PR DESCRIPTION
Tests on OSX builds were sometimes failing because the approx tests were using af::sum<double> and Iris Pro does not support double precision. 