### PR TITLE
Fix cpu errors caused by order of deletion in the device manager

### DIFF
--- a/src/backend/cpu/platform.hpp
+++ b/src/backend/cpu/platform.hpp
@@ -128,8 +128,7 @@ class DeviceManager
         CPUInfo getCPUInfo() const;
 
     private:
-        DeviceManager() {
-        }
+        DeviceManager() {}
 
         // Following two declarations are required to
         // avoid copying accidental copy/assignment
@@ -140,8 +139,7 @@ class DeviceManager
 
         // Attributes
         const CPUInfo cinfo;
-        std::array<queue, MAX_QUEUES> queues;
-
         std::unique_ptr<MemoryManager> memManager;
+        std::array<queue, MAX_QUEUES> queues;
 };
 }


### PR DESCRIPTION
The order of deletion of the queues and the memory manager should be reversed. The memory manager may still be required by the functions in the async_queue and therefore the memory manager should be deleted after the queue. This PR will change the order of deletion.