### PR TITLE
Fix minor warnings in medfilt

### DIFF
--- a/src/backend/cpu/kernel/medfilt.hpp
+++ b/src/backend/cpu/kernel/medfilt.hpp
@@ -28,7 +28,6 @@ void medfilt1(Array<T> out, const Array<T> in, dim_t w_wid)
     wind_vals.reserve(w_wid);
 
     for(int b3=0; b3<(int)dims[3]; b3++) {
-
         T const * in_ptr = in.get() + b3 * istrides[3];
         T * out_ptr = out.get() + b3 * ostrides[3];
 
@@ -95,9 +94,6 @@ void medfilt2(Array<T> out, const Array<T> in, dim_t w_len, dim_t w_wid)
 
     std::vector<T> wind_vals;
     wind_vals.reserve(w_len*w_wid);
-
-    T const * in_ptr = in.get();
-    T * out_ptr = out.get();
 
     for(int b3=0; b3<(int)dims[3]; b3++) {
         T const * in_ptr = in.get() + b3 * istrides[3];


### PR DESCRIPTION
Deleted unused variables. The variables are moved into the for loop.
[skip arrayfire ci]