### PR TITLE
fix mem corruption in cuda::findPlan()

### DIFF
--- a/src/backend/cuda/cufft.cpp
+++ b/src/backend/cuda/cufft.cpp
@@ -134,7 +134,7 @@ SharedPlan findPlan(int rank, int *n,
 
     retVal.reset(temp, [](PlanType* p) {
         cufftDestroy(*p);
-        delete p;
+        free(p);
     });
     // push the plan into plan cache
     planner.push(key_string, retVal);

--- a/src/backend/cuda/cufft.cpp
+++ b/src/backend/cuda/cufft.cpp
@@ -130,8 +130,6 @@ SharedPlan findPlan(int rank, int *n,
                                   type, batch));
     }
 
-    cufftSetStream(*temp, cuda::getActiveStream());
-
     retVal.reset(temp, [](PlanType* p) {
         cufftDestroy(*p);
         free(p);

--- a/src/backend/cuda/fft.cpp
+++ b/src/backend/cuda/fft.cpp
@@ -94,6 +94,7 @@ void fft_inplace(Array<T> &in)
                                (cufftType)cufft_transform<T>::type, batch);
 
     cufft_transform<T> transform;
+    CUFFT_CHECK(cufftSetStream(*plan.get(), cuda::getActiveStream()));
     CUFFT_CHECK(transform(*plan.get(), (T *)in.get(), in.get(), direction ? CUFFT_FORWARD : CUFFT_INVERSE));
 }
 
@@ -128,6 +129,7 @@ Array<Tc> fft_r2c(const Array<Tr> &in)
                                (cufftType)cufft_real_transform<Tc, Tr>::type, batch);
 
     cufft_real_transform<Tc, Tr> transform;
+    CUFFT_CHECK(cufftSetStream(*plan.get(), cuda::getActiveStream()));
     CUFFT_CHECK(transform(*plan.get(), (Tr *)in.get(), out.get()));
     return out;
 }
@@ -159,6 +161,7 @@ Array<Tr> fft_c2r(const Array<Tc> &in, const dim4 &odims)
                                out_embed , ostrides[0], ostrides[rank],
                                (cufftType)cufft_real_transform<Tr, Tc>::type, batch);
 
+    CUFFT_CHECK(cufftSetStream(*plan.get(), cuda::getActiveStream()));
     CUFFT_CHECK(transform(*plan.get(), (Tc *)in.get(), out.get()));
     return out;
 }


### PR DESCRIPTION
Also moved `cufftSetStream` calls to set stream before individual cufft transform invocations. This should ensure the plan execution on given thread's active device's stream.