### PR TITLE
Increase `svd_dense` test thresholds on macOS.

### DIFF
--- a/test/svd_dense.cpp
+++ b/test/svd_dense.cpp
@@ -81,7 +81,11 @@ void svdTest(const int M, const int N)
     AA.host(&hAA[0]);
 
     for (int i = 0; i < M * N; i++) {
+#if defined(OS_MAC)
+        ASSERT_NEAR(get_val(hA[i]), get_val(hAA[i]), 2E-3);
+#else
         ASSERT_NEAR(get_val(hA[i]), get_val(hAA[i]), 1E-3);
+#endif
     }
 }
 


### PR DESCRIPTION
Relaxing this threshold on macOS to prevent occasional test failures.