### PR TITLE
add missing template specialisations for sparse arith ops

### DIFF
--- a/src/backend/cpu/sparse_arith.cpp
+++ b/src/backend/cpu/sparse_arith.cpp
@@ -120,6 +120,14 @@ SparseArray<T> arithOpS(const SparseArray<T> &lhs, const Array<T> &rhs, const bo
                                             const bool reverse);                                    \
     template Array<T> arithOpD<T, af_sub_t>(const SparseArray<T> &lhs, const Array<T> &rhs,         \
                                            const bool reverse);                                     \
+    template Array<T> arithOpD<T, af_mul_t>(const SparseArray<T> &lhs, const Array<T> &rhs,         \
+                                            const bool reverse);                                    \
+    template Array<T> arithOpD<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,         \
+                                            const bool reverse);                                    \
+    template SparseArray<T> arithOpS<T, af_add_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+                                                  const bool reverse);                              \
+    template SparseArray<T> arithOpS<T, af_sub_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+                                                  const bool reverse);                              \
     template SparseArray<T> arithOpS<T, af_mul_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
                                                   const bool reverse);                              \
     template SparseArray<T> arithOpS<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \

--- a/src/backend/cuda/sparse_arith.cu
+++ b/src/backend/cuda/sparse_arith.cu
@@ -108,6 +108,14 @@ SparseArray<T> arithOpS(const SparseArray<T> &lhs, const Array<T> &rhs, const bo
                                             const bool reverse);                                    \
     template Array<T> arithOpD<T, af_sub_t>(const SparseArray<T> &lhs, const Array<T> &rhs,         \
                                             const bool reverse);                                    \
+    template Array<T> arithOpD<T, af_mul_t>(const SparseArray<T> &lhs, const Array<T> &rhs,         \
+                                            const bool reverse);                                    \
+    template Array<T> arithOpD<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,         \
+                                            const bool reverse);                                    \
+    template SparseArray<T> arithOpS<T, af_add_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+                                                  const bool reverse);                              \
+    template SparseArray<T> arithOpS<T, af_sub_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+                                                  const bool reverse);                              \
     template SparseArray<T> arithOpS<T, af_mul_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
                                                   const bool reverse);                              \
     template SparseArray<T> arithOpS<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \

--- a/src/backend/opencl/sparse_arith.cpp
+++ b/src/backend/opencl/sparse_arith.cpp
@@ -108,6 +108,14 @@ SparseArray<T> arithOpS(const SparseArray<T> &lhs, const Array<T> &rhs, const bo
                                             const bool reverse);                                    \
     template Array<T> arithOpD<T, af_sub_t>(const SparseArray<T> &lhs, const Array<T> &rhs,         \
                                             const bool reverse);                                    \
+    template Array<T> arithOpD<T, af_mul_t>(const SparseArray<T> &lhs, const Array<T> &rhs,         \
+                                            const bool reverse);                                    \
+    template Array<T> arithOpD<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,         \
+                                            const bool reverse);                                    \
+    template SparseArray<T> arithOpS<T, af_add_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+                                                  const bool reverse);                              \
+    template SparseArray<T> arithOpS<T, af_sub_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+                                                  const bool reverse);                              \
     template SparseArray<T> arithOpS<T, af_mul_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
                                                   const bool reverse);                              \
     template SparseArray<T> arithOpS<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \


### PR DESCRIPTION
* Add af_mul_t, af_div_t op specialisation for opencl::arithOpD
* Add af_add_t, af_sub_t op specialisation for opencl::arithOpS

The above missing specialisations are causing linking errors on Windows platform in Debug mode builds.