### PR TITLE
Max grid dimensions for cuda backend

### DIFF
--- a/src/backend/cuda/kernel/approx.hpp
+++ b/src/backend/cuda/kernel/approx.hpp
@@ -23,92 +23,104 @@ namespace cuda
         static const int TY = 16;
         static const int THREADS = 256;
 
-        ///////////////////////////////////////////////////////////////////////////
-        // Approx Kernel
-        ///////////////////////////////////////////////////////////////////////////
-        template<typename Ty, typename Tp, int order>
+        // \param largeYWDim true denotes 2nd & 4th dimensions greater than device limits
+        // \param iterPerBlockY number of iterations along grid.Y per block
+        template<typename Ty, typename Tp, int order, bool largeYWDim>
         __global__
         void approx1_kernel(Param<Ty> out, CParam<Ty> in, CParam<Tp> xpos,
                             const float offGrid, const int blocksMatX, const bool batch,
-                            af_interp_type method)
+                            af_interp_type method, int iterPerBlockY)
         {
-            const int idw = blockIdx.y / out.dims[2];
-            const int idz = blockIdx.y - idw * out.dims[2];
-
             const int idy = blockIdx.x / blocksMatX;
             const int blockIdx_x = blockIdx.x - idy * blocksMatX;
             const int idx = blockIdx_x * blockDim.x + threadIdx.x;
 
-            if (idx >= out.dims[0] || idy >= out.dims[1] ||
-                idz >= out.dims[2] || idw >= out.dims[3])
-                return;
+            // For smaller kernels statically set iterPerPlockY
+            // to 1 (register count optimization)
+            if(!largeYWDim) { iterPerBlockY = 1; }
 
-            const int omId = idw * out.strides[3] + idz * out.strides[2]
-                                               + idy * out.strides[1] + idx;
-            int xmid = idx;
-            if(batch) xmid += idw * xpos.strides[3] + idz * xpos.strides[2] + idy * xpos.strides[1];
+            for(int ib = 0; ib < iterPerBlockY; ++ib) {
+                const int idw = (blockIdx.y + ib * gridDim.y) / out.dims[2];
+                const int idz = (blockIdx.y + ib * gridDim.y) - idw * out.dims[2];
 
-            const Tp x = xpos.ptr[xmid];
-            if (x < 0 || in.dims[0] < x+1) {
-                out.ptr[omId] = scalar<Ty>(offGrid);
-                return;
+                if (idx >= out.dims[0] || idy >= out.dims[1] ||
+                    idz >= out.dims[2] || idw >= out.dims[3])
+                    return;
+
+                const int omId = idw * out.strides[3] + idz * out.strides[2]
+                                                   + idy * out.strides[1] + idx;
+                int xmid = idx;
+                if(batch) xmid += idw * xpos.strides[3] + idz * xpos.strides[2] + idy * xpos.strides[1];
+
+                const Tp x = xpos.ptr[xmid];
+                if (x < 0 || in.dims[0] < x+1) {
+                    out.ptr[omId] = scalar<Ty>(offGrid);
+                    return;
+                }
+
+                int ioff = idw * in.strides[3] + idz * in.strides[2] + idy * in.strides[1];
+
+                // FIXME: Only cubic interpolation is doing clamping
+                // We need to make it consistent across all methods
+                // Not changing the behavior because tests will fail
+                bool clamp = order == 3;
+
+                Interp1<Ty, Tp, order> interp;
+                interp(out, omId, in, ioff, x, method, 1, clamp);
             }
-
-            int ioff = idw * in.strides[3] + idz * in.strides[2] + idy * in.strides[1];
-
-            // FIXME: Only cubic interpolation is doing clamping
-            // We need to make it consistent across all methods
-            // Not changing the behavior because tests will fail
-            bool clamp = order == 3;
-
-            Interp1<Ty, Tp, order> interp;
-            interp(out, omId, in, ioff, x, method, 1, clamp);
         }
 
-        template<typename Ty, typename Tp, int order>
+        // \param largeYWDim true denotes 2nd & 4th dimensions greater than device limits
+        // \param iterPerBlockY number of iterations along grid.Y per block
+        template<typename Ty, typename Tp, int order, bool largeYWDim>
         __global__
         void approx2_kernel(Param<Ty> out, CParam<Ty> in,
                             CParam<Tp> xpos, CParam<Tp> ypos, const float offGrid,
                             const int blocksMatX, const int blocksMatY, const bool batch,
-                            af_interp_type method)
+                            af_interp_type method, int iterPerBlockY)
         {
             const int idz = blockIdx.x / blocksMatX;
-            const int idw = blockIdx.y / blocksMatY;
+            const int blockIdx_x = blockIdx.x - idz * blocksMatX;
+            const int idx = threadIdx.x + blockIdx_x * blockDim.x;
 
-            int blockIdx_x = blockIdx.x - idz * blocksMatX;
-            int blockIdx_y = blockIdx.y - idw * blocksMatY;
+            // For smaller kernels statically set iterPerPlockY
+            // to 1 (register count optimization)
+            if(!largeYWDim) { iterPerBlockY = 1; }
 
-            int idx = threadIdx.x + blockIdx_x * blockDim.x;
-            int idy = threadIdx.y + blockIdx_y * blockDim.y;
+            for(int ib = 0; ib < iterPerBlockY; ++ib) {
+                const int idw = (blockIdx.y + ib * gridDim.y) / blocksMatY;
+                const int blockIdx_y = (blockIdx.y + ib * gridDim.y) - idw * blocksMatY;
+                const int idy = threadIdx.y + blockIdx_y * blockDim.y;
 
-            if (idx >= out.dims[0] || idy >= out.dims[1] ||
-                idz >= out.dims[2] || idw >= out.dims[3])
-                return;
+                if (idx >= out.dims[0] || idy >= out.dims[1] ||
+                    idz >= out.dims[2] || idw >= out.dims[3])
+                    return;
 
-            const int omId = idw * out.strides[3] + idz * out.strides[2]
-                + idy * out.strides[1] + idx;
-            int xmid = idy * xpos.strides[1] + idx;
-            int ymid = idy * ypos.strides[1] + idx;
-            if(batch) {
-                xmid += idw * xpos.strides[3] + idz * xpos.strides[2];
-                ymid += idw * ypos.strides[3] + idz * ypos.strides[2];
+                const int omId = idw * out.strides[3] + idz * out.strides[2]
+                    + idy * out.strides[1] + idx;
+                int xmid = idy * xpos.strides[1] + idx;
+                int ymid = idy * ypos.strides[1] + idx;
+                if(batch) {
+                    xmid += idw * xpos.strides[3] + idz * xpos.strides[2];
+                    ymid += idw * ypos.strides[3] + idz * ypos.strides[2];
+                }
+
+                const Tp x = xpos.ptr[xmid], y = ypos.ptr[ymid];
+                if (x < 0 || y < 0 || in.dims[0] < x+1 || in.dims[1] < y+1) {
+                    out.ptr[omId] = scalar<Ty>(offGrid);
+                    return;
+                }
+
+                int ioff = idw * in.strides[3] + idz * in.strides[2];
+
+                // FIXME: Only cubic interpolation is doing clamping
+                // We need to make it consistent across all methods
+                // Not changing the behavior because tests will fail
+                bool clamp = order == 3;
+
+                Interp2<Ty, Tp, order> interp;
+                interp(out, omId, in, ioff, x, y, method, 1, clamp);
             }
-
-            const Tp x = xpos.ptr[xmid], y = ypos.ptr[ymid];
-            if (x < 0 || y < 0 || in.dims[0] < x+1 || in.dims[1] < y+1) {
-                out.ptr[omId] = scalar<Ty>(offGrid);
-                return;
-            }
-
-            int ioff = idw * in.strides[3] + idz * in.strides[2];
-
-            // FIXME: Only cubic interpolation is doing clamping
-            // We need to make it consistent across all methods
-            // Not changing the behavior because tests will fail
-            bool clamp = order == 3;
-
-            Interp2<Ty, Tp, order> interp;
-            interp(out, omId, in, ioff, x, y, method, 1, clamp);
         }
 
         ///////////////////////////////////////////////////////////////////////////
@@ -125,8 +137,16 @@ namespace cuda
 
             bool batch = !(xpos.dims[1] == 1 && xpos.dims[2] == 1 && xpos.dims[3] == 1);
 
-            CUDA_LAUNCH((approx1_kernel<Ty, Tp, order>), blocks, threads,
-                        out, in, xpos, offGrid, blocksPerMat, batch, method);
+            const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            const int iterPerBlockY = divup(blocks.y, maxBlocksY);
+            if(iterPerBlockY > 1) {
+                blocks.y = maxBlocksY;
+                CUDA_LAUNCH((approx1_kernel<Ty, Tp, order, true>), blocks, threads,
+                            out, in, xpos, offGrid, blocksPerMat, batch, method, iterPerBlockY);
+            } else {
+                CUDA_LAUNCH((approx1_kernel<Ty, Tp, order, false>), blocks, threads,
+                            out, in, xpos, offGrid, blocksPerMat, batch, method, iterPerBlockY);
+            }
             POST_LAUNCH_CHECK();
         }
 
@@ -142,8 +162,16 @@ namespace cuda
 
             bool batch = !(xpos.dims[2] == 1 && xpos.dims[3] == 1);
 
-            CUDA_LAUNCH((approx2_kernel<Ty, Tp, order>), blocks, threads,
-                        out, in, xpos, ypos, offGrid, blocksPerMatX, blocksPerMatY, batch, method);
+            const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            const int iterPerBlockY = divup(blocks.y, maxBlocksY);
+            if(iterPerBlockY > 1) {
+                blocks.y = maxBlocksY;
+                CUDA_LAUNCH((approx2_kernel<Ty, Tp, order, true>), blocks, threads,
+                        out, in, xpos, ypos, offGrid, blocksPerMatX, blocksPerMatY, batch, method, iterPerBlockY);
+            } else {
+                CUDA_LAUNCH((approx2_kernel<Ty, Tp, order, false>), blocks, threads,
+                        out, in, xpos, ypos, offGrid, blocksPerMatX, blocksPerMatY, batch, method, iterPerBlockY);
+            }
             POST_LAUNCH_CHECK();
         }
     }

--- a/src/backend/cuda/kernel/approx.hpp
+++ b/src/backend/cuda/kernel/approx.hpp
@@ -122,11 +122,9 @@ namespace cuda
             bool batch = !(xpos.dims[1] == 1 && xpos.dims[2] == 1 && xpos.dims[3] == 1);
 
             const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-            const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-            if(blocksPerMatZ > 1) {
-                blocks.y = maxBlocksY;
-                blocks.z = blocksPerMatZ;
-            }
+            blocks.z = divup(blocks.y, maxBlocksY);
+            blocks.y = divup(blocks.y, blocks.z);
+
             CUDA_LAUNCH((approx1_kernel<Ty, Tp, order>), blocks, threads,
                             out, in, xpos, offGrid, blocksPerMat, batch, method);
             POST_LAUNCH_CHECK();
@@ -145,11 +143,9 @@ namespace cuda
             bool batch = !(xpos.dims[2] == 1 && xpos.dims[3] == 1);
 
             const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-            const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-            if(blocksPerMatZ > 1) {
-                blocks.y = maxBlocksY;
-                blocks.z = blocksPerMatZ;
-            }
+            blocks.z = divup(blocks.y, maxBlocksY);
+            blocks.y = divup(blocks.y, blocks.z);
+
             CUDA_LAUNCH((approx2_kernel<Ty, Tp, order>), blocks, threads,
                         out, in, xpos, ypos, offGrid, blocksPerMatX, blocksPerMatY, batch, method);
             POST_LAUNCH_CHECK();

--- a/src/backend/cuda/kernel/convolve.cu
+++ b/src/backend/cuda/kernel/convolve.cu
@@ -56,6 +56,8 @@ void convolve1(Param<T> out, CParam<T> signal, int fLen,
     const unsigned b1 = blockIdx.x/nBBS0;   /* [0 {1} 2 3] */
     const unsigned b3 = (blockIdx.y + blockIdx.z * gridDim.y) / nBBS1;   /* [0 1 2 {3}] */
     const unsigned b2 = (blockIdx.y + blockIdx.z * gridDim.y) - nBBS1*b3;/* [0 1 {2} 3] */
+    if(b2 >= out.dims[2] || b3 >= out.dims[3])
+        return;
 
     T *dst = (T *)out.ptr + (b1 * out.strides[1] +  /* activated with batched input signal */
                              o1 * out.strides[1] +  /* activated with batched input filter */
@@ -127,6 +129,9 @@ void convolve2(Param<T> out, CParam<T> signal, int nBBS0,
     int ly  = threadIdx.y;
     int gx  = THREADS_X * (blockIdx.x-b0*nBBS0) + lx;
     int gy  = THREADS_Y * ((blockIdx.y + blockIdx.z * gridDim.y) -b1*nBBS1) + ly;
+
+    if(b1 >= out.dims[3])
+        return;
 
     int s0 = signal.strides[0];
     int s1 = signal.strides[1];

--- a/src/backend/cuda/kernel/diagonal.hpp
+++ b/src/backend/cuda/kernel/diagonal.hpp
@@ -89,12 +89,9 @@ namespace kernel
         int blocks_z = out.dims[2];
         dim3 blocks(blocks_x, out.dims[3] * blocks_z);
 
-        const int maxBlocksY   = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-        const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-        if(blocksPerMatZ > 1) {
-            blocks.y = maxBlocksY;
-            blocks.z = blocksPerMatZ;
-        }
+        const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+        blocks.z = divup(blocks.y, maxBlocksY);
+        blocks.y = divup(blocks.y, blocks.z);
 
         CUDA_LAUNCH((diagExtractKernel<T>), blocks, threads, out, in, num, blocks_z);
         POST_LAUNCH_CHECK();

--- a/src/backend/cuda/kernel/diff.hpp
+++ b/src/backend/cuda/kernel/diff.hpp
@@ -43,10 +43,10 @@ namespace cuda
                          const unsigned blocksPerMatX, const unsigned blocksPerMatY)
         {
             unsigned idz = blockIdx.x / blocksPerMatX;
-            unsigned idw = blockIdx.y / blocksPerMatY;
+            unsigned idw = (blockIdx.y + blockIdx.z * gridDim.y) / blocksPerMatY;
 
             unsigned blockIdx_x = blockIdx.x - idz * blocksPerMatX;
-            unsigned blockIdx_y = blockIdx.y - idw * blocksPerMatY;
+            unsigned blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - idw * blocksPerMatY;
 
             unsigned idx = threadIdx.x + blockIdx_x * blockDim.x;
             unsigned idy = threadIdx.y + blockIdx_y * blockDim.y;
@@ -88,6 +88,12 @@ namespace cuda
 
             const int oElem = out.dims[0] * out.dims[1] * out.dims[2] * out.dims[3];
 
+            const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
+            if(blocksPerMatZ > 1) {
+                blocks.y = maxBlocksY;
+                blocks.z = blocksPerMatZ;
+            }
             CUDA_LAUNCH((diff_kernel<T, dim, isDiff2>), blocks, threads,
                 out, in, oElem, blocksPerMatX, blocksPerMatY);
 

--- a/src/backend/cuda/kernel/diff.hpp
+++ b/src/backend/cuda/kernel/diff.hpp
@@ -88,16 +88,14 @@ namespace cuda
 
             const int oElem = out.dims[0] * out.dims[1] * out.dims[2] * out.dims[3];
 
-            const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-            const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-            if(blocksPerMatZ > 1) {
-                blocks.y = maxBlocksY;
-                blocks.z = blocksPerMatZ;
-            }
+            const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            blocks.z = divup(blocks.y, maxBlocksY);
+            blocks.y = divup(blocks.y, blocks.z);
+
             CUDA_LAUNCH((diff_kernel<T, dim, isDiff2>), blocks, threads,
                 out, in, oElem, blocksPerMatX, blocksPerMatY);
 
             POST_LAUNCH_CHECK();
         }
-}
+    }
 }

--- a/src/backend/cuda/kernel/gradient.hpp
+++ b/src/backend/cuda/kernel/gradient.hpp
@@ -107,12 +107,10 @@ namespace cuda
                         blocksPerMatY * in.dims[3],
                         1);
 
-            const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-            const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-            if(blocksPerMatZ > 1) {
-                blocks.y = maxBlocksY;
-                blocks.z = blocksPerMatZ;
-            }
+            const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            blocks.z = divup(blocks.y, maxBlocksY);
+            blocks.y = divup(blocks.y, blocks.z);
+
             CUDA_LAUNCH((gradient_kernel<T>), blocks, threads,
                     grad0, grad1, in, blocksPerMatX, blocksPerMatY);
             POST_LAUNCH_CHECK();

--- a/src/backend/cuda/kernel/hsv_rgb.hpp
+++ b/src/backend/cuda/kernel/hsv_rgb.hpp
@@ -33,7 +33,7 @@ void convert(Param<T> out, CParam<T> in, int nBBS)
     int gx = blockDim.x * (blockIdx.x-batchId*nBBS) + threadIdx.x;
     int gy = blockDim.y * (blockIdx.y + blockIdx.z * gridDim.y) + threadIdx.y;
 
-    if (gx < out.dims[0] && gy < out.dims[1]) {
+    if (gx < out.dims[0] && gy < out.dims[1] && batchId < out.dims[3]) {
 
         int oIdx0 = gx + gy * out.strides[1];
         int oIdx1 = oIdx0 + out.strides[2];

--- a/src/backend/cuda/kernel/hsv_rgb.hpp
+++ b/src/backend/cuda/kernel/hsv_rgb.hpp
@@ -105,12 +105,9 @@ void hsv2rgb_convert(Param<T> out, CParam<T> in)
     // parameter would be along 4th dimension
     dim3 blocks(blk_x*in.dims[3], blk_y);
 
-    const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-    const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-    if(blocksPerMatZ > 1) {
-        blocks.y = maxBlocksY;
-        blocks.z = blocksPerMatZ;
-    }
+    const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+    blocks.z = divup(blocks.y, maxBlocksY);
+    blocks.y = divup(blocks.y, blocks.z);
 
     CUDA_LAUNCH((convert<T, isHSV2RGB>), blocks, threads, out, in, blk_x);
 

--- a/src/backend/cuda/kernel/identity.hpp
+++ b/src/backend/cuda/kernel/identity.hpp
@@ -24,10 +24,10 @@ namespace kernel
     static void identity_kernel(Param<T> out, int blocks_x, int blocks_y)
     {
         const dim_t idz = blockIdx.x / blocks_x;
-        const dim_t idw = blockIdx.y / blocks_y;
+        const dim_t idw = (blockIdx.y + blockIdx.z * gridDim.y) / blocks_y;
 
         const dim_t blockIdx_x = blockIdx.x - idz * blocks_x;
-        const dim_t blockIdx_y = blockIdx.y - idw * blocks_y;
+        const dim_t blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - idw * blocks_y;
 
         const dim_t idx = threadIdx.x + blockIdx_x * blockDim.x;
         const dim_t idy = threadIdx.y + blockIdx_y * blockDim.y;
@@ -54,6 +54,12 @@ namespace kernel
         int blocks_y = divup(out.dims[1], threads.y);
         dim3 blocks(blocks_x * out.dims[2], blocks_y * out.dims[3]);
 
+        const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+        const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
+        if(blocksPerMatZ > 1) {
+            blocks.y = maxBlocksY;
+            blocks.z = blocksPerMatZ;
+        }
         CUDA_LAUNCH((identity_kernel<T>), blocks, threads, out, blocks_x, blocks_y);
         POST_LAUNCH_CHECK();
     }

--- a/src/backend/cuda/kernel/identity.hpp
+++ b/src/backend/cuda/kernel/identity.hpp
@@ -54,12 +54,10 @@ namespace kernel
         int blocks_y = divup(out.dims[1], threads.y);
         dim3 blocks(blocks_x * out.dims[2], blocks_y * out.dims[3]);
 
-        const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-        const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-        if(blocksPerMatZ > 1) {
-            blocks.y = maxBlocksY;
-            blocks.z = blocksPerMatZ;
-        }
+        const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+        blocks.z = divup(blocks.y, maxBlocksY);
+        blocks.y = divup(blocks.y, blocks.z);
+
         CUDA_LAUNCH((identity_kernel<T>), blocks, threads, out, blocks_x, blocks_y);
         POST_LAUNCH_CHECK();
     }

--- a/src/backend/cuda/kernel/index.hpp
+++ b/src/backend/cuda/kernel/index.hpp
@@ -76,12 +76,11 @@ void index(Param<T> out, CParam<T> in, const IndexKernelParam_t& p)
     int blks_y = divup(out.dims[1], threads.y);
 
     dim3 blocks(blks_x*out.dims[2], blks_y*out.dims[3]);
-    const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-    const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-    if(blocksPerMatZ > 1) {
-        blocks.y = maxBlocksY;
-        blocks.z = blocksPerMatZ;
-    }
+
+    const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+    blocks.z = divup(blocks.y, maxBlocksY);
+    blocks.y = divup(blocks.y, blocks.z);
+
     CUDA_LAUNCH((indexKernel<T>), blocks, threads, out, in, p, blks_x, blks_y);
 
     POST_LAUNCH_CHECK();

--- a/src/backend/cuda/kernel/iota.hpp
+++ b/src/backend/cuda/kernel/iota.hpp
@@ -24,43 +24,48 @@ namespace cuda
         static const unsigned TILEX = 512;
         static const unsigned TILEY = 32;
 
-        template<typename T>
+        template<typename T, bool largeYWDim>
         __global__
         void iota_kernel(Param<T> out,
                          const int s0, const int s1, const int s2, const int s3,
                          const int t0, const int t1, const int t2, const int t3,
-                         const int blocksPerMatX, const int blocksPerMatY)
+                         const int blocksPerMatX, const int blocksPerMatY, int iterPerBlockY)
         {
             const int oz = blockIdx.x / blocksPerMatX;
-            const int ow = blockIdx.y / blocksPerMatY;
-
             const int blockIdx_x = blockIdx.x - oz * blocksPerMatX;
-            const int blockIdx_y = blockIdx.y - ow * blocksPerMatY;
-
             const int xx = threadIdx.x + blockIdx_x * blockDim.x;
-            const int yy = threadIdx.y + blockIdx_y * blockDim.y;
 
-            if(xx >= out.dims[0] ||
-               yy >= out.dims[1] ||
-               oz >= out.dims[2] ||
-               ow >= out.dims[3])
-                return;
+            // For smaller kernels statically set iterPerPlockY
+            // to 1 (register count optimization)
+            if(!largeYWDim) { iterPerBlockY = 1; }
 
-            const int ozw = ow * out.strides[3] + oz * out.strides[2];
+            for(int ib = 0; ib < iterPerBlockY; ++ib) {
+                const int ow = (blockIdx.y + ib * gridDim.y) / blocksPerMatY;
+                const int blockIdx_y = (blockIdx.y + ib * gridDim.y) - ow * blocksPerMatY;
+                const int yy = threadIdx.y + blockIdx_y * blockDim.y;
 
-            T val = (ow % s3) * s2 * s1 * s0;
-            val  += (oz % s2) * s1 * s0;
+                if(xx >= out.dims[0] ||
+                   yy >= out.dims[1] ||
+                   oz >= out.dims[2] ||
+                   ow >= out.dims[3])
+                    return;
 
-            const int incy = blocksPerMatY * blockDim.y;
-            const int incx = blocksPerMatX * blockDim.x;
+                const int ozw = ow * out.strides[3] + oz * out.strides[2];
 
-            for(int oy = yy; oy < out.dims[1]; oy += incy) {
-                int oyzw = ozw + oy * out.strides[1];
-                T valY = val + (oy % s1) * s0;
-                for(int ox = xx; ox < out.dims[0]; ox += incx) {
-                    int oidx = oyzw + ox;
+                T val = (ow % s3) * s2 * s1 * s0;
+                val  += (oz % s2) * s1 * s0;
 
-                    out.ptr[oidx] = valY + (ox % s0);
+                const int incy = blocksPerMatY * blockDim.y;
+                const int incx = blocksPerMatX * blockDim.x;
+
+                for(int oy = yy; oy < out.dims[1]; oy += incy) {
+                    int oyzw = ozw + oy * out.strides[1];
+                    T valY = val + (oy % s1) * s0;
+                    for(int ox = xx; ox < out.dims[0]; ox += incx) {
+                        int oidx = oyzw + ox;
+
+                        out.ptr[oidx] = valY + (ox % s0);
+                    }
                 }
             }
         }
@@ -80,9 +85,19 @@ namespace cuda
                         blocksPerMatY * out.dims[3],
                         1);
 
-            CUDA_LAUNCH((iota_kernel<T>), blocks, threads,
-                    out, sdims[0], sdims[1], sdims[2], sdims[3],
-                    tdims[0], tdims[1], tdims[2], tdims[3], blocksPerMatX, blocksPerMatY);
+            const int maxBlocksY   = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            const int iterPerBlockY = divup(blocks.y, maxBlocksY);
+            if(iterPerBlockY > 1) {
+                blocks.y = maxBlocksY;
+                CUDA_LAUNCH((iota_kernel<T, true>), blocks, threads,
+                        out, sdims[0], sdims[1], sdims[2], sdims[3],
+                        tdims[0], tdims[1], tdims[2], tdims[3], blocksPerMatX, blocksPerMatY, iterPerBlockY);
+            } else {
+                CUDA_LAUNCH((iota_kernel<T, false>), blocks, threads,
+                        out, sdims[0], sdims[1], sdims[2], sdims[3],
+                        tdims[0], tdims[1], tdims[2], tdims[3], blocksPerMatX, blocksPerMatY, iterPerBlockY);
+            }
+
             POST_LAUNCH_CHECK();
         }
     }

--- a/src/backend/cuda/kernel/iota.hpp
+++ b/src/backend/cuda/kernel/iota.hpp
@@ -80,13 +80,10 @@ namespace cuda
                         blocksPerMatY * out.dims[3],
                         1);
 
-            const int maxBlocksY   = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-            const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
+            const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            blocks.z = divup(blocks.y, maxBlocksY);
+            blocks.y = divup(blocks.y, blocks.z);
 
-            if(blocksPerMatZ > 1) {
-                blocks.y = maxBlocksY;
-                blocks.z = blocksPerMatZ;
-            }
             CUDA_LAUNCH((iota_kernel<T>), blocks, threads,
                     out, sdims[0], sdims[1], sdims[2], sdims[3],
                     tdims[0], tdims[1], tdims[2], tdims[3], blocksPerMatX, blocksPerMatY);

--- a/src/backend/cuda/kernel/iota.hpp
+++ b/src/backend/cuda/kernel/iota.hpp
@@ -24,48 +24,42 @@ namespace cuda
         static const unsigned TILEX = 512;
         static const unsigned TILEY = 32;
 
-        template<typename T, bool largeYWDim>
+        template<typename T>
         __global__
         void iota_kernel(Param<T> out,
                          const int s0, const int s1, const int s2, const int s3,
                          const int t0, const int t1, const int t2, const int t3,
-                         const int blocksPerMatX, const int blocksPerMatY, int iterPerBlockY)
+                         const int blocksPerMatX, const int blocksPerMatY)
         {
             const int oz = blockIdx.x / blocksPerMatX;
             const int blockIdx_x = blockIdx.x - oz * blocksPerMatX;
             const int xx = threadIdx.x + blockIdx_x * blockDim.x;
 
-            // For smaller kernels statically set iterPerPlockY
-            // to 1 (register count optimization)
-            if(!largeYWDim) { iterPerBlockY = 1; }
+            const int ow = (blockIdx.y + blockIdx.z * gridDim.y) / blocksPerMatY;
+            const int blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - ow * blocksPerMatY;
+            const int yy = threadIdx.y + blockIdx_y * blockDim.y;
 
-            for(int ib = 0; ib < iterPerBlockY; ++ib) {
-                const int ow = (blockIdx.y + ib * gridDim.y) / blocksPerMatY;
-                const int blockIdx_y = (blockIdx.y + ib * gridDim.y) - ow * blocksPerMatY;
-                const int yy = threadIdx.y + blockIdx_y * blockDim.y;
+            if(xx >= out.dims[0] ||
+               yy >= out.dims[1] ||
+               oz >= out.dims[2] ||
+               ow >= out.dims[3])
+                return;
 
-                if(xx >= out.dims[0] ||
-                   yy >= out.dims[1] ||
-                   oz >= out.dims[2] ||
-                   ow >= out.dims[3])
-                    return;
+            const int ozw = ow * out.strides[3] + oz * out.strides[2];
 
-                const int ozw = ow * out.strides[3] + oz * out.strides[2];
+            T val = (ow % s3) * s2 * s1 * s0;
+            val  += (oz % s2) * s1 * s0;
 
-                T val = (ow % s3) * s2 * s1 * s0;
-                val  += (oz % s2) * s1 * s0;
+            const int incy = blocksPerMatY * blockDim.y;
+            const int incx = blocksPerMatX * blockDim.x;
 
-                const int incy = blocksPerMatY * blockDim.y;
-                const int incx = blocksPerMatX * blockDim.x;
+            for(int oy = yy; oy < out.dims[1]; oy += incy) {
+                int oyzw = ozw + oy * out.strides[1];
+                T valY = val + (oy % s1) * s0;
+                for(int ox = xx; ox < out.dims[0]; ox += incx) {
+                    int oidx = oyzw + ox;
 
-                for(int oy = yy; oy < out.dims[1]; oy += incy) {
-                    int oyzw = ozw + oy * out.strides[1];
-                    T valY = val + (oy % s1) * s0;
-                    for(int ox = xx; ox < out.dims[0]; ox += incx) {
-                        int oidx = oyzw + ox;
-
-                        out.ptr[oidx] = valY + (ox % s0);
-                    }
+                    out.ptr[oidx] = valY + (ox % s0);
                 }
             }
         }
@@ -81,22 +75,21 @@ namespace cuda
 
             int blocksPerMatX = divup(out.dims[0], TILEX);
             int blocksPerMatY = divup(out.dims[1], TILEY);
+
             dim3 blocks(blocksPerMatX * out.dims[2],
                         blocksPerMatY * out.dims[3],
                         1);
 
             const int maxBlocksY   = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-            const int iterPerBlockY = divup(blocks.y, maxBlocksY);
-            if(iterPerBlockY > 1) {
+            const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
+
+            if(blocksPerMatZ > 1) {
                 blocks.y = maxBlocksY;
-                CUDA_LAUNCH((iota_kernel<T, true>), blocks, threads,
-                        out, sdims[0], sdims[1], sdims[2], sdims[3],
-                        tdims[0], tdims[1], tdims[2], tdims[3], blocksPerMatX, blocksPerMatY, iterPerBlockY);
-            } else {
-                CUDA_LAUNCH((iota_kernel<T, false>), blocks, threads,
-                        out, sdims[0], sdims[1], sdims[2], sdims[3],
-                        tdims[0], tdims[1], tdims[2], tdims[3], blocksPerMatX, blocksPerMatY, iterPerBlockY);
+                blocks.z = blocksPerMatZ;
             }
+            CUDA_LAUNCH((iota_kernel<T>), blocks, threads,
+                    out, sdims[0], sdims[1], sdims[2], sdims[3],
+                    tdims[0], tdims[1], tdims[2], tdims[3], blocksPerMatX, blocksPerMatY);
 
             POST_LAUNCH_CHECK();
         }

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -194,7 +194,6 @@ namespace kernel
         dim3 blocks(blocks_dim[0] * blocks_dim[2],
                     blocks_dim[1] * blocks_dim[3]);
 
-        printf("dim [%d %d %d]\n", blocks.x, blocks.y, blocks.z);
         const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
         blocks.z = divup(blocks.y, maxBlocksY);
         blocks.y = divup(blocks.y, blocks.z);
@@ -438,7 +437,6 @@ namespace kernel
     template<typename T, af_op_t op>
     void ireduce(Param<T> out, uint *olptr, CParam<T> in, int dim)
     {
-        printf("AMNIHRERERE");
         switch (dim) {
         case 0: return ireduce_first<T, op   >(out, olptr, in);
         case 1: return ireduce_dim  <T, op, 1>(out, olptr, in);

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -374,7 +374,6 @@ namespace kernel
         dim3 threads(threads_x, THREADS_PER_BLOCK / threads_x);
         dim3 blocks(blocks_x * in.dims[2],
                     blocks_y * in.dims[3]);
-        printf("[%d %d %d]\n", blocks.x, blocks.y, blocks.z);
         const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
         blocks.z = divup(blocks.y, maxBlocksY);
         blocks.y = divup(blocks.y, blocks.z);

--- a/src/backend/cuda/kernel/join.hpp
+++ b/src/backend/cuda/kernel/join.hpp
@@ -74,12 +74,10 @@ namespace cuda
                         blocksPerMatY * X.dims[3],
                         1);
 
-            const int maxBlocksY   = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-            const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-            if(blocksPerMatZ > 1) {
-                blocks.y = maxBlocksY;
-                blocks.z = blocksPerMatZ;
-            }
+            const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            blocks.z = divup(blocks.y, maxBlocksY);
+            blocks.y = divup(blocks.y, blocks.z);
+
             CUDA_LAUNCH((join_kernel<To, Tx, dim>), blocks, threads,
                        out, X, offset[0], offset[1], offset[2], offset[3],
                        blocksPerMatX, blocksPerMatY);

--- a/src/backend/cuda/kernel/join.hpp
+++ b/src/backend/cuda/kernel/join.hpp
@@ -12,7 +12,6 @@
 #include <Param.hpp>
 #include <err_cuda.hpp>
 #include <debug_cuda.hpp>
-#include <iostream>
 
 namespace cuda
 {

--- a/src/backend/cuda/kernel/lookup.hpp
+++ b/src/backend/cuda/kernel/lookup.hpp
@@ -55,10 +55,10 @@ void lookupND(Param<in_t> out, CParam<in_t> in, CParam<idx_t> indices,
     int ly = threadIdx.y;
 
     int gz = blockIdx.x/nBBS0;
-    int gw = blockIdx.y/nBBS1;
+    int gw = (blockIdx.y + blockIdx.z * gridDim.y)/nBBS1;
 
     int gx = blockDim.x * (blockIdx.x - gz*nBBS0) + lx;
-    int gy = blockDim.y * (blockIdx.y - gw*nBBS1) + ly;
+    int gy = blockDim.y * ((blockIdx.y + blockIdx.z * gridDim.y) - gw*nBBS1) + ly;
 
     const idx_t *idxPtr = (const idx_t*)indices.ptr;
 
@@ -102,6 +102,10 @@ void lookup(Param<in_t> out, CParam<in_t> in, CParam<idx_t> indices, int nDims)
         int blks_y = divup(out.dims[1], threads.y);
 
         dim3 blocks(blks_x*out.dims[2], blks_y*out.dims[3]);
+
+        const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+        blocks.z = divup(blocks.y, maxBlocksY);
+        blocks.y = divup(blocks.y, blocks.z);
 
         CUDA_LAUNCH((lookupND<in_t, idx_t, dim>), blocks, threads, out, in, indices, blks_x, blks_y);
     }

--- a/src/backend/cuda/kernel/memcopy.hpp
+++ b/src/backend/cuda/kernel/memcopy.hpp
@@ -28,8 +28,6 @@ namespace kernel
     static const uint DIMX = 32;
     static const uint DIMY =  8;
 
-    // \param largeYWDim true denotes 2nd & 4th dimensions greater than device limits
-    // \param iterPerBlockY number of iterations along grid.Y per block
     template<typename T>
     __global__ static void
     memcopy_kernel(T *out, const dims_t ostrides,

--- a/src/backend/cuda/kernel/range.hpp
+++ b/src/backend/cuda/kernel/range.hpp
@@ -82,12 +82,9 @@ namespace cuda
                         blocksPerMatY * out.dims[3],
                         1);
 
-            const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-            const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-            if(blocksPerMatZ > 1) {
-                blocks.y = maxBlocksY;
-                blocks.z = blocksPerMatZ;
-            }
+            const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            blocks.z = divup(blocks.y, maxBlocksY);
+            blocks.y = divup(blocks.y, blocks.z);
 
             CUDA_LAUNCH((range_kernel<T>), blocks, threads, out, dim, blocksPerMatX, blocksPerMatY);
             POST_LAUNCH_CHECK();

--- a/src/backend/cuda/kernel/range.hpp
+++ b/src/backend/cuda/kernel/range.hpp
@@ -34,10 +34,10 @@ namespace cuda
             const int mul3 = (dim == 3);
 
             const int oz = blockIdx.x / blocksPerMatX;
-            const int ow = blockIdx.y / blocksPerMatY;
+            const int ow = (blockIdx.y + blockIdx.z * gridDim.y) / blocksPerMatY;
 
             const int blockIdx_x = blockIdx.x - oz * blocksPerMatX;
-            const int blockIdx_y = blockIdx.y - ow * blocksPerMatY;
+            const int blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - ow * blocksPerMatY;
 
             const int xx = threadIdx.x + blockIdx_x * blockDim.x;
             const int yy = threadIdx.y + blockIdx_y * blockDim.y;
@@ -81,6 +81,13 @@ namespace cuda
             dim3 blocks(blocksPerMatX * out.dims[2],
                         blocksPerMatY * out.dims[3],
                         1);
+
+            const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
+            if(blocksPerMatZ > 1) {
+                blocks.y = maxBlocksY;
+                blocks.z = blocksPerMatZ;
+            }
 
             CUDA_LAUNCH((range_kernel<T>), blocks, threads, out, dim, blocksPerMatX, blocksPerMatY);
             POST_LAUNCH_CHECK();

--- a/src/backend/cuda/kernel/reduce.hpp
+++ b/src/backend/cuda/kernel/reduce.hpp
@@ -115,12 +115,10 @@ namespace kernel
         dim3 blocks(blocks_dim[0] * blocks_dim[2],
                     blocks_dim[1] * blocks_dim[3]);
 
-        const int maxBlocksY   = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-        const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-        if(blocksPerMatZ > 1) {
-            blocks.y = maxBlocksY;
-            blocks.z = blocksPerMatZ;
-        }
+        const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+        blocks.z = divup(blocks.y, maxBlocksY);
+        blocks.y = divup(blocks.y, blocks.z);
+
         switch (threads_y) {
         case 8:
             CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 8>), blocks, threads,
@@ -305,12 +303,10 @@ namespace kernel
 
         uint repeat = divup(in.dims[0], (blocks_x * threads_x));
 
-        const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-        const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-        if(blocksPerMatZ > 1) {
-            blocks.y = maxBlocksY;
-            blocks.z = blocksPerMatZ;
-        }
+        const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+        blocks.z = divup(blocks.y, maxBlocksY);
+        blocks.y = divup(blocks.y, blocks.z);
+
         switch (threads_x) {
         case 32:
             CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  32>), blocks, threads,

--- a/src/backend/cuda/kernel/reduce.hpp
+++ b/src/backend/cuda/kernel/reduce.hpp
@@ -23,14 +23,12 @@ namespace cuda
 {
 namespace kernel
 {
-    // \param largeYWDim true denotes 2nd & 4th dimensions greater than device limits
-    // \param iterPerBlockY number of iterations along grid.Y per block
-    template<typename Ti, typename To, af_op_t op, uint dim, uint DIMY, bool largeYWDim>
+    template<typename Ti, typename To, af_op_t op, uint dim, uint DIMY>
     __global__
     static void reduce_dim_kernel(Param<To> out,
                                   CParam <Ti> in,
                                   uint blocks_x, uint blocks_y, uint offset_dim,
-                                  bool change_nan, To nanval, int iterPerBlockY)
+                                  bool change_nan, To nanval)
     {
         const uint tidx = threadIdx.x;
         const uint tidy = threadIdx.y;
@@ -42,74 +40,68 @@ namespace kernel
 
         __shared__ To s_val[THREADS_X * DIMY];
 
-        // For smaller kernels statically set iterPerPlockY
-        // to 1 (register count optimization)
-        if(!largeYWDim) { iterPerBlockY = 1; }
+        const uint wid = (blockIdx.y + blockIdx.z * gridDim.y) / blocks_y;
+        const uint blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - (blocks_y) * wid;
+        const uint yid = blockIdx_y; // yid  of output. updated for input later.
 
-        for(int ib=0; ib < iterPerBlockY; ++ib) {
-            const uint wid = (blockIdx.y + ib * gridDim.y) / blocks_y;
-            const uint blockIdx_y = (blockIdx.y + ib * gridDim.y) - (blocks_y) * wid;
-            const uint yid = blockIdx_y; // yid  of output. updated for input later.
+        uint ids[4] = {xid, yid, zid, wid};
 
-            uint ids[4] = {xid, yid, zid, wid};
+        // There is only one element per block for out
+        // There are blockDim.y elements per block for in
+        // Hence increment ids[dim] just after offseting out and before offsetting in
+        To * const optr = out.ptr + ids[3] * out.strides[3] +
+                                    ids[2] * out.strides[2] +
+                                    ids[1] * out.strides[1] + ids[0];
 
-            // There is only one element per block for out
-            // There are blockDim.y elements per block for in
-            // Hence increment ids[dim] just after offseting out and before offsetting in
-            To * const optr = out.ptr + ids[3] * out.strides[3] +
-                                        ids[2] * out.strides[2] +
-                                        ids[1] * out.strides[1] + ids[0];
+        const uint blockIdx_dim = ids[dim];
+        ids[dim] = ids[dim] * blockDim.y + tidy;
 
-            const uint blockIdx_dim = ids[dim];
-            ids[dim] = ids[dim] * blockDim.y + tidy;
+        const Ti * iptr = in.ptr + ids[3] * in.strides[3] +
+                                   ids[2] * in.strides[2] +
+                                   ids[1] * in.strides[1] + ids[0];
 
-            const Ti * iptr = in.ptr + ids[3] * in.strides[3] +
-                                       ids[2] * in.strides[2] +
-                                       ids[1] * in.strides[1] + ids[0];
+        const uint id_dim_in = ids[dim];
+        const uint istride_dim = in.strides[dim];
 
-            const uint id_dim_in = ids[dim];
-            const uint istride_dim = in.strides[dim];
+        bool is_valid =
+            (ids[0] < in.dims[0]) &&
+            (ids[1] < in.dims[1]) &&
+            (ids[2] < in.dims[2]) &&
+            (ids[3] < in.dims[3]);
 
-            bool is_valid =
-                (ids[0] < in.dims[0]) &&
-                (ids[1] < in.dims[1]) &&
-                (ids[2] < in.dims[2]) &&
-                (ids[3] < in.dims[3]);
+        Transform<Ti, To, op> transform;
+        Binary<To, op> reduce;
+        To out_val = reduce.init();
+        for (int id = id_dim_in; is_valid && (id < in.dims[dim]); id += offset_dim * blockDim.y) {
+            To in_val = transform(*iptr);
+            if (change_nan) in_val = !IS_NAN(in_val) ? in_val : nanval;
+            out_val = reduce(in_val, out_val);
+            iptr = iptr + offset_dim * blockDim.y * istride_dim;
+        }
 
-            Transform<Ti, To, op> transform;
-            Binary<To, op> reduce;
-            To out_val = reduce.init();
-            for (int id = id_dim_in; is_valid && (id < in.dims[dim]); id += offset_dim * blockDim.y) {
-                To in_val = transform(*iptr);
-                if (change_nan) in_val = !IS_NAN(in_val) ? in_val : nanval;
-                out_val = reduce(in_val, out_val);
-                iptr = iptr + offset_dim * blockDim.y * istride_dim;
-            }
+        s_val[tid] = out_val;
 
-            s_val[tid] = out_val;
+        To *s_ptr = s_val + tid;
+        __syncthreads();
 
-            To *s_ptr = s_val + tid;
+        if (DIMY == 8) {
+            if (tidy < 4) *s_ptr = reduce(*s_ptr, s_ptr[THREADS_X * 4]);
             __syncthreads();
+        }
 
-            if (DIMY == 8) {
-                if (tidy < 4) *s_ptr = reduce(*s_ptr, s_ptr[THREADS_X * 4]);
-                __syncthreads();
-            }
+        if (DIMY >= 4) {
+            if (tidy < 2) *s_ptr = reduce(*s_ptr, s_ptr[THREADS_X * 2]);
+            __syncthreads();
+        }
 
-            if (DIMY >= 4) {
-                if (tidy < 2) *s_ptr = reduce(*s_ptr, s_ptr[THREADS_X * 2]);
-                __syncthreads();
-            }
+        if (DIMY >= 2) {
+            if (tidy < 1) *s_ptr = reduce(*s_ptr, s_ptr[THREADS_X * 1]);
+            __syncthreads();
+        }
 
-            if (DIMY >= 2) {
-                if (tidy < 1) *s_ptr = reduce(*s_ptr, s_ptr[THREADS_X * 1]);
-                __syncthreads();
-            }
-
-            if (tidy == 0 && is_valid &&
-                (blockIdx_dim < out.dims[dim])) {
-                *optr = *s_ptr;
-            }
+        if (tidy == 0 && is_valid &&
+            (blockIdx_dim < out.dims[dim])) {
+            *optr = *s_ptr;
         }
     }
 
@@ -124,47 +116,28 @@ namespace kernel
                     blocks_dim[1] * blocks_dim[3]);
 
         const int maxBlocksY   = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-        const int iterPerBlockY = divup(blocks.y, maxBlocksY);
-        if(iterPerBlockY > 1) {
+        const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
+        if(blocksPerMatZ > 1) {
             blocks.y = maxBlocksY;
-            switch (threads_y) {
-            case 8:
-                CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 8, true>), blocks, threads,
-                    out, in, blocks_dim[0], blocks_dim[1], blocks_dim[dim],
-                    change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            case 4:
-                CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 4, true>), blocks, threads,
-                    out, in, blocks_dim[0], blocks_dim[1], blocks_dim[dim],
-                    change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            case 2:
-                CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 2, true>), blocks, threads,
-                    out, in, blocks_dim[0], blocks_dim[1], blocks_dim[dim],
-                    change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            case 1:
-                CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 1, true>), blocks, threads,
-                    out, in, blocks_dim[0], blocks_dim[1], blocks_dim[dim],
-                    change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            }
-        } else {
-            switch (threads_y) {
-            case 8:
-                CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 8, false>), blocks, threads,
-                    out, in, blocks_dim[0], blocks_dim[1], blocks_dim[dim],
-                    change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            case 4:
-                CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 4, false>), blocks, threads,
-                    out, in, blocks_dim[0], blocks_dim[1], blocks_dim[dim],
-                    change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            case 2:
-                CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 2, false>), blocks, threads,
-                    out, in, blocks_dim[0], blocks_dim[1], blocks_dim[dim],
-                    change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            case 1:
-                CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 1, false>), blocks, threads,
-                    out, in, blocks_dim[0], blocks_dim[1], blocks_dim[dim],
-                    change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            }
-
+            blocks.z = blocksPerMatZ;
+        }
+        switch (threads_y) {
+        case 8:
+            CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 8>), blocks, threads,
+                out, in, blocks_dim[0], blocks_dim[1], blocks_dim[dim],
+                change_nan, scalar<To>(nanval)); break;
+        case 4:
+            CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 4>), blocks, threads,
+                out, in, blocks_dim[0], blocks_dim[1], blocks_dim[dim],
+                change_nan, scalar<To>(nanval)); break;
+        case 2:
+            CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 2>), blocks, threads,
+                out, in, blocks_dim[0], blocks_dim[1], blocks_dim[dim],
+                change_nan, scalar<To>(nanval)); break;
+        case 1:
+            CUDA_LAUNCH((reduce_dim_kernel<Ti, To, op, dim, 1>), blocks, threads,
+                out, in, blocks_dim[0], blocks_dim[1], blocks_dim[dim],
+                change_nan, scalar<To>(nanval)); break;
         }
 
         POST_LAUNCH_CHECK();
@@ -252,14 +225,12 @@ namespace kernel
     WARP_REDUCE(char)  // upcasted to int
 #endif
 
-    // \param largeYWDim true denotes 2nd & 4th dimensions greater than device limits
-    // \param iterPerBlockY number of iterations along grid.Y per block
-    template<typename Ti, typename To, af_op_t op, uint DIMX, bool largeYWDim>
+    template<typename Ti, typename To, af_op_t op, uint DIMX>
     __global__
     static void reduce_first_kernel(Param<To> out,
                                     CParam<Ti>  in,
                                     uint blocks_x, uint blocks_y, uint repeat,
-                                    bool change_nan, To nanval, int iterPerBlockY) {
+                                    bool change_nan, To nanval) {
 
         const uint tidx = threadIdx.x;
         const uint tidy = threadIdx.y;
@@ -274,59 +245,53 @@ namespace kernel
 
         __shared__ To s_val[THREADS_PER_BLOCK];
 
-        // For smaller kernels statically set iterPerPlockY
-        // to 1 (register count optimization)
-        if(!largeYWDim) { iterPerBlockY = 1; }
+        const uint wid = (blockIdx.y + blockIdx.z * gridDim.y) / blocks_y;
+        const uint blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - (blocks_y) * wid;
+        const uint yid = blockIdx_y * blockDim.y + tidy;
 
-        for(int ib=0; ib < iterPerBlockY; ++ib) {
-            const uint wid = (blockIdx.y + ib * gridDim.y) / blocks_y;
-            const uint blockIdx_y = (blockIdx.y + ib * gridDim.y) - (blocks_y) * wid;
-            const uint yid = blockIdx_y * blockDim.y + tidy;
+        const Ti * const iptr = in.ptr + (wid *  in.strides[3] + zid *  in.strides[2] + yid *  in.strides[1]);
 
-            const Ti * const iptr = in.ptr + (wid *  in.strides[3] + zid *  in.strides[2] + yid *  in.strides[1]);
-
-            if (yid >= in.dims[1] ||
-                zid >= in.dims[2] ||
-                wid >= in.dims[3]) return;
+        if (yid >= in.dims[1] ||
+            zid >= in.dims[2] ||
+            wid >= in.dims[3]) return;
 
 
-            int lim = min((int)(xid + repeat * DIMX), in.dims[0]);
+        int lim = min((int)(xid + repeat * DIMX), in.dims[0]);
 
-            To out_val = reduce.init();
-            for (int id = xid; id < lim; id += DIMX) {
-                To in_val = transform(iptr[id]);
-                if (change_nan) in_val = !IS_NAN(in_val) ? in_val : nanval;
-                out_val = reduce(in_val, out_val);
-            }
-
-            s_val[tid] = out_val;
-
-            __syncthreads();
-            To *s_ptr = s_val + tidy * DIMX;
-
-            if (DIMX == 256) {
-                if (tidx < 128)
-                    s_ptr[tidx] = reduce(s_ptr[tidx], s_ptr[tidx + 128]);
-                __syncthreads();
-            }
-
-            if (DIMX >= 128) {
-                if (tidx <  64) s_ptr[tidx] = reduce(s_ptr[tidx], s_ptr[tidx +  64]);
-                __syncthreads();
-            }
-
-            if (DIMX >=  64) {
-                if (tidx <  32) s_ptr[tidx] = reduce(s_ptr[tidx], s_ptr[tidx +  32]);
-                __syncthreads();
-            }
-
-
-            out_val = WarpReduce<To, op>()(s_ptr, tidx);
-
-            To * const optr = out.ptr + (wid * out.strides[3] + zid * out.strides[2] + yid * out.strides[1]);
-            if (tidx == 0)
-                optr[blockIdx_x] = out_val;
+        To out_val = reduce.init();
+        for (int id = xid; id < lim; id += DIMX) {
+            To in_val = transform(iptr[id]);
+            if (change_nan) in_val = !IS_NAN(in_val) ? in_val : nanval;
+            out_val = reduce(in_val, out_val);
         }
+
+        s_val[tid] = out_val;
+
+        __syncthreads();
+        To *s_ptr = s_val + tidy * DIMX;
+
+        if (DIMX == 256) {
+            if (tidx < 128)
+                s_ptr[tidx] = reduce(s_ptr[tidx], s_ptr[tidx + 128]);
+            __syncthreads();
+        }
+
+        if (DIMX >= 128) {
+            if (tidx <  64) s_ptr[tidx] = reduce(s_ptr[tidx], s_ptr[tidx +  64]);
+            __syncthreads();
+        }
+
+        if (DIMX >=  64) {
+            if (tidx <  32) s_ptr[tidx] = reduce(s_ptr[tidx], s_ptr[tidx +  32]);
+            __syncthreads();
+        }
+
+
+        out_val = WarpReduce<To, op>()(s_ptr, tidx);
+
+        To * const optr = out.ptr + (wid * out.strides[3] + zid * out.strides[2] + yid * out.strides[1]);
+        if (tidx == 0)
+            optr[blockIdx_x] = out_val;
     }
 
     template<typename Ti, typename To, af_op_t op>
@@ -341,38 +306,24 @@ namespace kernel
         uint repeat = divup(in.dims[0], (blocks_x * threads_x));
 
         const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-        const int iterPerBlockY = divup(blocks.y, maxBlocksY);
-        if(iterPerBlockY > 1) {
+        const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
+        if(blocksPerMatZ > 1) {
             blocks.y = maxBlocksY;
-            switch (threads_x) {
-            case 32:
-                CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  32, true>), blocks, threads,
-                    out, in, blocks_x, blocks_y, repeat, change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            case 64:
-                CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  64, true>), blocks, threads,
-                    out, in, blocks_x, blocks_y, repeat, change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            case 128:
-                CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  128, true>), blocks, threads,
-                    out, in, blocks_x, blocks_y, repeat, change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            case 256:
-                CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  256, true>), blocks, threads,
-                    out, in, blocks_x, blocks_y, repeat, change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            }
-        } else {
-            switch (threads_x) {
-            case 32:
-                CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  32, false>), blocks, threads,
-                    out, in, blocks_x, blocks_y, repeat, change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            case 64:
-                CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  64, false>), blocks, threads,
-                    out, in, blocks_x, blocks_y, repeat, change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            case 128:
-                CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  128, false>), blocks, threads,
-                    out, in, blocks_x, blocks_y, repeat, change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            case 256:
-                CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  256, false>), blocks, threads,
-                    out, in, blocks_x, blocks_y, repeat, change_nan, scalar<To>(nanval), iterPerBlockY); break;
-            }
+            blocks.z = blocksPerMatZ;
+        }
+        switch (threads_x) {
+        case 32:
+            CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  32>), blocks, threads,
+                out, in, blocks_x, blocks_y, repeat, change_nan, scalar<To>(nanval)); break;
+        case 64:
+            CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  64>), blocks, threads,
+                out, in, blocks_x, blocks_y, repeat, change_nan, scalar<To>(nanval)); break;
+        case 128:
+            CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  128>), blocks, threads,
+                out, in, blocks_x, blocks_y, repeat, change_nan, scalar<To>(nanval)); break;
+        case 256:
+            CUDA_LAUNCH((reduce_first_kernel<Ti, To, op,  256>), blocks, threads,
+                out, in, blocks_x, blocks_y, repeat, change_nan, scalar<To>(nanval)); break;
         }
 
         POST_LAUNCH_CHECK();

--- a/src/backend/cuda/kernel/scan_dim.hpp
+++ b/src/backend/cuda/kernel/scan_dim.hpp
@@ -37,9 +37,9 @@ namespace kernel
         const int tid  = tidy * THREADS_X + tidx;
 
         const int zid = blockIdx.x / blocks_x;
-        const int wid = blockIdx.y / blocks_y;
+        const int wid = (blockIdx.y + blockIdx.z * gridDim.y) / blocks_y;
         const int blockIdx_x = blockIdx.x - (blocks_x) * zid;
-        const int blockIdx_y = blockIdx.y - (blocks_y) * wid;
+        const int blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - (blocks_y) * wid;
         const int xid = blockIdx_x * blockDim.x + tidx;
         const int yid = blockIdx_y; // yid  of output. updated for input later.
 
@@ -141,9 +141,9 @@ namespace kernel
         const int tidy = threadIdx.y;
 
         const int zid = blockIdx.x / blocks_x;
-        const int wid = blockIdx.y / blocks_y;
+        const int wid = (blockIdx.y + blockIdx.z * gridDim.y) / blocks_y;
         const int blockIdx_x = blockIdx.x - (blocks_x) * zid;
-        const int blockIdx_y = blockIdx.y - (blocks_y) * wid;
+        const int blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - (blocks_y) * wid;
         const int xid = blockIdx_x * blockDim.x + tidx;
         const int yid = blockIdx_y; // yid  of output. updated for input later.
 
@@ -198,6 +198,10 @@ namespace kernel
         dim3 blocks(blocks_all[0] * blocks_all[2],
                     blocks_all[1] * blocks_all[3]);
 
+        const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+        blocks.z = divup(blocks.y, maxBlocksY);
+        blocks.y = divup(blocks.y, blocks.z);
+
         uint lim = divup(out.dims[dim], (threads_y * blocks_all[dim]));
 
         switch (threads_y) {
@@ -231,6 +235,10 @@ namespace kernel
 
         dim3 blocks(blocks_all[0] * blocks_all[2],
                     blocks_all[1] * blocks_all[3]);
+
+        const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+        blocks.z = divup(blocks.y, maxBlocksY);
+        blocks.y = divup(blocks.y, blocks.z);
 
         uint lim = divup(out.dims[dim], (threads_y * blocks_all[dim]));
 

--- a/src/backend/cuda/kernel/scan_first.hpp
+++ b/src/backend/cuda/kernel/scan_first.hpp
@@ -34,9 +34,9 @@ namespace kernel
         const int tidy = threadIdx.y;
 
         const int zid = blockIdx.x / blocks_x;
-        const int wid = blockIdx.y / blocks_y;
+        const int wid = (blockIdx.y + blockIdx.z * gridDim.y) / blocks_y;
         const int blockIdx_x = blockIdx.x - (blocks_x) * zid;
-        const int blockIdx_y = blockIdx.y - (blocks_y) * wid;
+        const int blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - (blocks_y) * wid;
         const int xid = blockIdx_x * blockDim.x * lim + tidx;
         const int yid = blockIdx_y * blockDim.y + tidy;
 
@@ -125,9 +125,9 @@ namespace kernel
         const int tidy = threadIdx.y;
 
         const int zid = blockIdx.x / blocks_x;
-        const int wid = blockIdx.y / blocks_y;
+        const int wid = (blockIdx.y + blockIdx.z * gridDim.y) / blocks_y;
         const int blockIdx_x = blockIdx.x - (blocks_x) * zid;
-        const int blockIdx_y = blockIdx.y - (blocks_y) * wid;
+        const int blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - (blocks_y) * wid;
         const int xid = blockIdx_x * blockDim.x * lim + tidx;
         const int yid = blockIdx_y * blockDim.y + tidy;
 
@@ -167,6 +167,10 @@ namespace kernel
         dim3 blocks(blocks_x * out.dims[2],
                     blocks_y * out.dims[3]);
 
+        const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+        blocks.z = divup(blocks.y, maxBlocksY);
+        blocks.y = divup(blocks.y, blocks.z);
+
         uint lim = divup(out.dims[0], (threads_x * blocks_x));
 
         switch (threads_x) {
@@ -200,6 +204,10 @@ namespace kernel
         dim3 threads(threads_x, THREADS_PER_BLOCK / threads_x);
         dim3 blocks(blocks_x * out.dims[2],
                     blocks_y * out.dims[3]);
+
+        const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+        blocks.z = divup(blocks.y, maxBlocksY);
+        blocks.y = divup(blocks.y, blocks.z);
 
         uint lim = divup(out.dims[0], (threads_x * blocks_x));
 

--- a/src/backend/cuda/kernel/select.hpp
+++ b/src/backend/cuda/kernel/select.hpp
@@ -101,12 +101,10 @@ namespace cuda
             dim3 blocks(blk_x * out.dims[2],
                         blk_y * out.dims[3]);
 
-            const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-            const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-            if(blocksPerMatZ > 1) {
-                blocks.y = maxBlocksY;
-                blocks.z = blocksPerMatZ;
-            }
+            const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            blocks.z = divup(blocks.y, maxBlocksY);
+            blocks.y = divup(blocks.y, blocks.z);
+
             if (is_same) {
                 CUDA_LAUNCH((select_kernel<T, true>), blocks, threads,
                             out, cond, a, b, blk_x, blk_y);

--- a/src/backend/cuda/kernel/shift.hpp
+++ b/src/backend/cuda/kernel/shift.hpp
@@ -37,10 +37,10 @@ namespace cuda
                             const int blocksPerMatX, const int blocksPerMatY)
         {
             const int oz = blockIdx.x / blocksPerMatX;
-            const int ow = blockIdx.y / blocksPerMatY;
+            const int ow = (blockIdx.y + blockIdx.z * gridDim.y) / blocksPerMatY;
 
             const int blockIdx_x = blockIdx.x - oz * blocksPerMatX;
-            const int blockIdx_y = blockIdx.y - ow * blocksPerMatY;
+            const int blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - ow * blocksPerMatY;
 
             const int xx = threadIdx.x + blockIdx_x * blockDim.x;
             const int yy = threadIdx.y + blockIdx_y * blockDim.y;
@@ -86,6 +86,10 @@ namespace cuda
             dim3 blocks(blocksPerMatX * out.dims[2],
                         blocksPerMatY * out.dims[3],
                         1);
+
+            const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            blocks.z = divup(blocks.y, maxBlocksY);
+            blocks.y = divup(blocks.y, blocks.z);
 
             int sdims_[4];
             // Need to do this because we are mapping output to input in the kernel

--- a/src/backend/cuda/kernel/tile.hpp
+++ b/src/backend/cuda/kernel/tile.hpp
@@ -78,12 +78,10 @@ namespace cuda
                         blocksPerMatY * out.dims[3],
                         1);
 
-            const int maxBlocksY    = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
-            const int blocksPerMatZ = divup(blocks.y, maxBlocksY);
-            if(blocksPerMatZ > 1) {
-                blocks.y = maxBlocksY;
-                blocks.z = blocksPerMatZ;
-            }
+            const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+            blocks.z = divup(blocks.y, maxBlocksY);
+            blocks.y = divup(blocks.y, blocks.z);
+
             CUDA_LAUNCH((tile_kernel<T>), blocks, threads, out, in, blocksPerMatX, blocksPerMatY);
             POST_LAUNCH_CHECK();
         }

--- a/src/backend/cuda/kernel/transpose.hpp
+++ b/src/backend/cuda/kernel/transpose.hpp
@@ -30,7 +30,7 @@ namespace kernel
         else return in;
     }
 
-    // Kernel is going access original data in colleased format
+    // Kernel is going access original data in coaleasced format
     template<typename T, bool conjugate, bool is32Multiple>
     __global__
     void transpose(Param<T> out, CParam<T> in,
@@ -54,24 +54,24 @@ namespace kernel
         const int batchId_x = blockIdx.x / blocksPerMatX;
         const int blockIdx_x = (blockIdx.x - batchId_x * blocksPerMatX);
 
-        const int batchId_y = blockIdx.y / blocksPerMatY;
-        const int blockIdx_y = (blockIdx.y - batchId_y * blocksPerMatY);
+        const int batchId_y = (blockIdx.y + blockIdx.z * gridDim.y) / blocksPerMatY;
+        const int blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - (batchId_y * blocksPerMatY);
 
         const int x0 = TILE_DIM * blockIdx_x;
         const int y0 = TILE_DIM * blockIdx_y;
 
         // calculate global indices
-        int gx      = lx + x0;
-        int gy      = ly + y0;
+        int gx = lx + x0;
+        int gy = ly + y0;
 
-        // offset in and out based on batch id
+        //offset in and out based on batch id
         in.ptr  += batchId_x *  in.strides[2] + batchId_y *  in.strides[3];
         out.ptr += batchId_x * out.strides[2] + batchId_y * out.strides[3];
 
 #pragma unroll
         for (int repeat = 0; repeat < TILE_DIM; repeat += THREADS_Y) {
             int gy_ = gy+repeat;
-            if (is32Multiple || (gx<iDim0 && gy_<iDim1))
+            if ((gx<iDim0 && gy_<iDim1))
                 shrdMem[ly + repeat][lx] = in.ptr[gy_ * iStride1 + gx];
         }
         __syncthreads();
@@ -100,11 +100,15 @@ namespace kernel
         int blk_y = divup(in.dims[1],TILE_DIM);
         // launch batch * blk_x blocks along x dimension
         dim3 blocks(blk_x * in.dims[2], blk_y * in.dims[3]);
+        const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+        blocks.z = divup(blocks.y, maxBlocksY);
+        blocks.y = divup(blocks.y, blocks.z);
 
-        if (in.dims[0] % TILE_DIM == 0 && in.dims[1] % TILE_DIM == 0)
+        if (in.dims[0] % TILE_DIM == 0 && in.dims[1] % TILE_DIM == 0) {
             CUDA_LAUNCH((transpose<T, conjugate, true >), blocks, threads, out, in, blk_x, blk_y);
-        else
+        } else {
             CUDA_LAUNCH((transpose<T, conjugate, false>), blocks, threads, out, in, blk_x, blk_y);
+        }
 
         POST_LAUNCH_CHECK();
     }

--- a/src/backend/cuda/kernel/transpose.hpp
+++ b/src/backend/cuda/kernel/transpose.hpp
@@ -42,6 +42,7 @@ namespace kernel
         const int oDim1 = out.dims[1];
         const int iDim0 = in.dims[0];
         const int iDim1 = in.dims[1];
+        const int iDim3 = in.dims[3];
 
         // calculate strides
         const int oStride1 = out.strides[1];
@@ -57,6 +58,8 @@ namespace kernel
         const int batchId_y = (blockIdx.y + blockIdx.z * gridDim.y) / blocksPerMatY;
         const int blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - (batchId_y * blocksPerMatY);
 
+        if(batchId_y >= iDim3) return;
+
         const int x0 = TILE_DIM * blockIdx_x;
         const int y0 = TILE_DIM * blockIdx_y;
 
@@ -71,7 +74,7 @@ namespace kernel
 #pragma unroll
         for (int repeat = 0; repeat < TILE_DIM; repeat += THREADS_Y) {
             int gy_ = gy+repeat;
-            if ((gx<iDim0 && gy_<iDim1))
+            if (is32Multiple || (gx<iDim0 && gy_<iDim1))
                 shrdMem[ly + repeat][lx] = in.ptr[gy_ * iStride1 + gx];
         }
         __syncthreads();

--- a/src/backend/cuda/kernel/transpose.hpp
+++ b/src/backend/cuda/kernel/transpose.hpp
@@ -42,7 +42,6 @@ namespace kernel
         const int oDim1 = out.dims[1];
         const int iDim0 = in.dims[0];
         const int iDim1 = in.dims[1];
-        const int iDim3 = in.dims[3];
 
         // calculate strides
         const int oStride1 = out.strides[1];
@@ -58,7 +57,8 @@ namespace kernel
         const int batchId_y = (blockIdx.y + blockIdx.z * gridDim.y) / blocksPerMatY;
         const int blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - (batchId_y * blocksPerMatY);
 
-        if(batchId_y >= iDim3) return;
+        if(batchId_x >= in.dims[2] || batchId_y >= in.dims[3])
+            return;
 
         const int x0 = TILE_DIM * blockIdx_x;
         const int y0 = TILE_DIM * blockIdx_y;

--- a/src/backend/cuda/kernel/where.hpp
+++ b/src/backend/cuda/kernel/where.hpp
@@ -37,9 +37,9 @@ namespace kernel
         const uint tidy = threadIdx.y;
 
         const uint zid = blockIdx.x / blocks_x;
-        const uint wid = blockIdx.y / blocks_y;
+        const uint wid = (blockIdx.y + blockIdx.z * gridDim.y) / blocks_y;
         const uint blockIdx_x = blockIdx.x - (blocks_x) * zid;
-        const uint blockIdx_y = blockIdx.y - (blocks_y) * wid;
+        const uint blockIdx_y = (blockIdx.y + blockIdx.z * gridDim.y) - (blocks_y) * wid;
         const uint xid = blockIdx_x * blockDim.x * lim + tidx;
         const uint yid = blockIdx_y * blockDim.y + tidy;
 
@@ -135,6 +135,10 @@ namespace kernel
                     blocks_y * in.dims[3]);
 
         uint lim = divup(otmp.dims[0], (threads_x * blocks_x));
+
+        const int maxBlocksY = cuda::getDeviceProp(cuda::getActiveDeviceId()).maxGridSize[1];
+        blocks.z = divup(blocks.y, maxBlocksY);
+        blocks.y = divup(blocks.y, blocks.z);
 
         CUDA_LAUNCH((get_out_idx<T>), blocks, threads,
                 out.ptr, otmp, rtmp, in, blocks_x, blocks_y, lim);

--- a/src/backend/cuda/kernel/wrap.hpp
+++ b/src/backend/cuda/kernel/wrap.hpp
@@ -46,7 +46,7 @@ namespace cuda
             const T *iptr =  in.ptr + idx2 *  in.strides[2] + idx3 *  in.strides[3];
 
 
-            if (oidx0 >= out.dims[0] || oidx1 >= out.dims[1]) return;
+            if (oidx0 >= out.dims[0] || oidx1 >= out.dims[1] || idx2 >= out.dims[2] || idx3 >= out.dims[3]) return;
 
             int pidx0 = oidx0 + px;
             int pidx1 = oidx1 + py;

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -405,3 +405,63 @@ TEST(Approx1, CPPCubicBatch)
     ASSERT_NEAR(0, sum<float>(abs(outBatch - outSerial)), 1e-3);
     ASSERT_NEAR(0, sum<float>(abs(outBatch - outGFOR)), 1e-3);
 }
+
+TEST(Approx1, CPPNearestMaxDims)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t largeDim = 65535 * 32 + 1;
+    af::array input = af::randu(1, largeDim);
+    af::array pos   = input.dims(0) * af::randu(1, largeDim);
+    af::array out   = af::approx1(input, pos, AF_INTERP_NEAREST);
+
+    input = af::randu(1, 1, largeDim);
+    pos   = input.dims(0) * af::randu(1, 1, largeDim);
+    out   = af::approx1(input, pos, AF_INTERP_NEAREST);
+
+    input = af::randu(1, 1, 1, largeDim);
+    pos   = input.dims(0) * af::randu(1, 1, 1, largeDim);
+    out   = af::approx1(input, pos, AF_INTERP_NEAREST);
+
+    SUCCEED();
+}
+
+TEST(Approx1, CPPLinearMaxDims)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t largeDim = 65535 * 32 + 1;
+    af::array input = af::iota(af::dim4(1, largeDim), c32);
+    af::array pos   = input.dims(0) * af::randu(1, largeDim);
+    af::array outBatch = af::approx1(input, pos, AF_INTERP_LINEAR);
+
+    input = af::iota(af::dim4(1, 1, largeDim), c32);
+    pos   = input.dims(0) * af::randu(1, 1, largeDim);
+    outBatch = af::approx1(input, pos, AF_INTERP_LINEAR);
+
+    input = af::iota(af::dim4(1, 1, 1, largeDim), c32);
+    pos   = input.dims(0) * af::randu(1, 1, 1, largeDim);
+    outBatch = af::approx1(input, pos, AF_INTERP_LINEAR);
+
+    SUCCEED();
+}
+
+TEST(Approx1, CPPCubicMaxDims)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t largeDim = 65535 * 32 + 1;
+    af::array input = af::iota(af::dim4(1, largeDim), c32);
+    af::array pos   = input.dims(0) * af::randu(1, largeDim);
+    af::array outBatch = af::approx1(input, pos, AF_INTERP_CUBIC);
+
+    input = af::iota(af::dim4(1, 1, largeDim), c32);
+    pos   = input.dims(0) * af::randu(1, 1, largeDim);
+    outBatch = af::approx1(input, pos, AF_INTERP_CUBIC);
+
+    input = af::iota(af::dim4(1, 1, 1, largeDim), c32);
+    pos   = input.dims(0) * af::randu(1, 1, 1, largeDim);
+    outBatch = af::approx1(input, pos, AF_INTERP_CUBIC);
+
+    SUCCEED();
+}

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -363,3 +363,75 @@ TEST(Approx2, CPPLinearBatch)
     ASSERT_NEAR(0, sum<float>(abs(outBatch - outSerial)), 1e-3);
     ASSERT_NEAR(0, sum<float>(abs(outBatch - outGFOR)), 1e-3);
 }
+
+TEST(Approx2, CPPNearestMaxDims)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t largeDim = 65535 * 32 + 1;
+
+    af::array input = af::randu(1, largeDim);
+    af::array pos   = input.dims(0) * af::randu(1, 10);
+    af::array qos   = input.dims(1) * af::randu(1, 10);
+    af::array out   = af::approx2(input, pos, qos, AF_INTERP_NEAREST);
+
+    input = af::randu(1, 1, largeDim);
+    pos   = input.dims(0) * af::randu(1, 1, largeDim);
+    qos   = input.dims(1) * af::randu(1, 1, largeDim);
+    out   = af::approx2(input, pos, qos, AF_INTERP_NEAREST);
+
+    input = af::randu(1, 1, 1, largeDim);
+    pos   = input.dims(0) * af::randu(1, 1, 1, largeDim);
+    qos   = input.dims(1) * af::randu(1, 1, 1, largeDim);
+    out   = af::approx2(input, pos, qos, AF_INTERP_NEAREST);
+
+    SUCCEED();
+}
+
+TEST(Approx2, CPPLinearMaxDims)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t largeDim = 65535 * 32 + 1;
+
+    af::array input = af::randu(1, largeDim);
+    af::array pos   = input.dims(0) * af::randu(1, 10);
+    af::array qos   = input.dims(1) * af::randu(1, 10);
+    af::array out   = af::approx2(input, pos, qos, AF_INTERP_LINEAR);
+
+    input = af::randu(1, 1, largeDim);
+    pos   = input.dims(0) * af::randu(1, 1, largeDim);
+    qos   = input.dims(1) * af::randu(1, 1, largeDim);
+    out   = af::approx2(input, pos, qos, AF_INTERP_LINEAR);
+
+    input = af::randu(1, 1, 1, largeDim);
+    pos   = input.dims(0) * af::randu(1, 1, 1, largeDim);
+    qos   = input.dims(1) * af::randu(1, 1, 1, largeDim);
+    out   = af::approx2(input, pos, qos, AF_INTERP_LINEAR);
+
+    SUCCEED();
+}
+
+TEST(Approx2, CPPCubicMaxDims)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t largeDim = 65535 * 32 + 1;
+
+    af::array input = af::randu(1, largeDim);
+    af::array pos   = input.dims(0) * af::randu(1, 10);
+    af::array qos   = input.dims(1) * af::randu(1, 10);
+    af::array out   = af::approx2(input, pos, qos, AF_INTERP_BICUBIC);
+
+    input = af::randu(1, 1, largeDim);
+    pos   = input.dims(0) * af::randu(1, 1, largeDim);
+    qos   = input.dims(1) * af::randu(1, 1, largeDim);
+    out   = af::approx2(input, pos, qos, AF_INTERP_BICUBIC);
+
+    input = af::randu(1, 1, 1, largeDim);
+    pos   = input.dims(0) * af::randu(1, 1, 1, largeDim);
+    qos   = input.dims(1) * af::randu(1, 1, 1, largeDim);
+    out   = af::approx2(input, pos, qos, AF_INTERP_BICUBIC);
+
+    SUCCEED();
+}

--- a/test/assign.cpp
+++ b/test/assign.cpp
@@ -859,6 +859,35 @@ TEST(Asssign, LinearCPP)
     }
 }
 
+TEST(Asssign, LinearCPPMaxDim)
+{
+    using af::array;
+
+    const size_t largeDim = 65535 * 32 + 2;
+    const float val = 3;
+
+    array a = af::randu(1, 2 * largeDim);
+    array a_copy = a.copy();
+    af::index idx = af::array(af::seq(10, largeDim+10));
+    a(af::span, idx) = val;
+
+    ASSERT_EQ(a.dims(0), a_copy.dims(0));
+
+    std::vector<float> ha(2 * largeDim);
+    std::vector<float> ha_copy(2 * largeDim);
+
+    a.host(&ha[0]);
+    a_copy.host(&ha_copy[0]);
+
+    for (unsigned int i = 0; i < 2 * largeDim; i++) {
+        if(i >= 10 && i <= largeDim + 10) {
+            ASSERT_EQ(ha[i], val) << "at " << i;
+        } else {
+            ASSERT_EQ(ha[i], ha_copy[i]) << "at " << i;
+        }
+    }
+}
+
 TEST(Asssign, LinearAssignSeq)
 {
     using af::array;

--- a/test/constant.cpp
+++ b/test/constant.cpp
@@ -98,6 +98,26 @@ void IdentityCPPCheck() {
 }
 
 template<typename T>
+void IdentityLargeDimCheck() {
+    if (noDoubleTests<T>()) return;
+
+    const size_t largeDim = 65535 * 8 + 1;
+
+    dtype dty = (dtype) dtype_traits<T>::af_type;
+    array out = af::identity(largeDim, dty);
+    ASSERT_EQ(1.f, af::sum<float>(out));
+
+    out = af::identity(1, largeDim, dty);
+    ASSERT_EQ(1.f, af::sum<float>(out));
+
+    out = af::identity(1, 1, largeDim, dty);
+    ASSERT_EQ(largeDim, af::sum<float>(out));
+
+    out = af::identity(1, 1, 1, largeDim, dty);
+    ASSERT_EQ(largeDim, af::sum<float>(out));
+}
+
+template<typename T>
 void IdentityCCheck() {
     if (noDoubleTests<T>()) return;
 
@@ -154,6 +174,11 @@ TYPED_TEST(Constant, IdentityC)
 TYPED_TEST(Constant, IdentityCPP)
 {
     IdentityCPPCheck<TypeParam>();
+}
+
+TYPED_TEST(Constant, IdentityLargeDim)
+{
+    IdentityLargeDimCheck<TypeParam>();
 }
 
 TYPED_TEST(Constant, IdentityCPPError)

--- a/test/convolve.cpp
+++ b/test/convolve.cpp
@@ -751,3 +751,78 @@ TEST(Convolve, 3D_C64)
     EXPECT_EQ(std::abs(real(acc))< 1E-3, true);
     EXPECT_EQ(std::abs(imag(acc))< 1E-3, true);
 }
+
+TEST(ConvolveLargeDim1D, CPP)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t n = 10;
+    const size_t largeDim = 65535 + 1;
+
+    float h_filter[] = {0.f, 1.f, 0.f};
+    af::array identity_filter(3, h_filter);
+    af::array signal = af::constant(1, n, 1, largeDim);
+
+    af::array output = convolve1(signal, identity_filter, AF_CONV_DEFAULT);
+    af::array output2 = output;
+    ASSERT_EQ(largeDim * n, sum<float>(output2));
+
+    signal = af::constant(1, n, 1, 1, largeDim);
+
+    output = convolve1(signal, identity_filter, AF_CONV_DEFAULT);
+    ASSERT_EQ(largeDim * n, sum<float>(output));
+}
+
+TEST(ConvolveLargeDim2D, CPP)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t n = 10;
+    const size_t largeDim = 65535 + 1;
+
+    float h_filter[] = {0.f, 0.f, 0.f,
+                        0.f, 1.f, 0.f,
+                        0.f, 0.f, 0.f};
+    af::array identity_filter(3, 3, h_filter);
+    af::array signal = af::constant(1, n, n, largeDim);
+
+    af::array output = convolve2(signal, identity_filter, AF_CONV_DEFAULT);
+    ASSERT_EQ(largeDim * n * n, sum<float>(output));
+
+    signal = af::constant(1, n, n, 1, largeDim);
+
+    output = convolve2(signal, identity_filter, AF_CONV_DEFAULT);
+    ASSERT_EQ(largeDim * n * n, sum<float>(output));
+}
+
+TEST(DISABLED_ConvolveLargeDim3D, CPP)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t n = 3;
+    const size_t largeDim = 65535 * 16 + 1;
+
+    float h_filter[] = {0.f, 0.f, 0.f,
+                        0.f, 0.f, 0.f,
+                        0.f, 0.f, 0.f,
+
+                        0.f, 0.f, 0.f,
+                        0.f, 1.f, 0.f,
+                        0.f, 0.f, 0.f,
+
+                        0.f, 0.f, 0.f,
+                        0.f, 0.f, 0.f,
+                        0.f, 0.f, 0.f};
+
+    af::array identity_filter(3, 3, 3, h_filter);
+    af::array signal = af::constant(1, n, largeDim, n);
+
+    af::array output = convolve3(signal, identity_filter, AF_CONV_DEFAULT);
+    ASSERT_EQ(1.f, product<float>(output));
+
+    signal = af::constant(1, n, n, largeDim);
+
+    output = convolve3(signal, identity_filter, AF_CONV_EXPAND);
+    //TODO: fix product by indexing
+    //ASSERT_EQ(1.f, product<float>(output));
+}

--- a/test/diagonal.cpp
+++ b/test/diagonal.cpp
@@ -54,6 +54,23 @@ TYPED_TEST(Diagonal, Create)
     }
 }
 
+TYPED_TEST(Diagonal, DISABLED_CreateLargeDim)
+{
+    if (noDoubleTests<TypeParam>()) return;
+    try {
+        af::deviceGC();
+        {
+            static const size_t largeDim = 65535 + 1;
+            array diagvals = constant(1, largeDim);
+            array out = diag(diagvals,  0, false);
+
+            ASSERT_EQ(largeDim, sum<float>(out));
+        }
+    } catch (const af::exception& ex) {
+        FAIL() << ex.what() << std::endl;
+    }
+}
+
 TYPED_TEST(Diagonal, Extract)
 {
     if (noDoubleTests<TypeParam>()) return;
@@ -75,6 +92,29 @@ TYPED_TEST(Diagonal, Extract)
                 ASSERT_EQ(input[i * data.dims(0) + i], h_out[i]);
             }
         }
+    } catch (const af::exception& ex) {
+        FAIL() << ex.what() << std::endl;
+    }
+}
+
+TYPED_TEST(Diagonal, ExtractLargeDim)
+{
+    if (noDoubleTests<TypeParam>()) return;
+
+    try {
+        static const size_t n = 10;
+        static const size_t largeDim = 65535 + 1;
+
+        array largedata = constant(1, n, n, largeDim);
+        array out = diag(largedata, 0);
+
+        ASSERT_EQ(n * largeDim, sum<float>(out));
+
+        largedata  = constant(1, n, n, 1, largeDim);
+        array out1 = diag(largedata, 0);
+
+        ASSERT_EQ(n * largeDim, sum<float>(out1));
+
     } catch (const af::exception& ex) {
         FAIL() << ex.what() << std::endl;
     }

--- a/test/diff1.cpp
+++ b/test/diff1.cpp
@@ -182,6 +182,34 @@ TYPED_TEST(Diff1,InvalidArgs)
     diff1ArgsTest<TypeParam>(string(TEST_DIR"/diff1/basic0.test"));
 }
 
+TEST(Diff1, DiffLargeDim)
+{
+    const size_t largeDim = 65535 * 32 + 1;
+
+    af::deviceGC();
+    {
+        af::array in = af::constant(1, largeDim);
+        af::array diff = af::diff1(in, 0);
+        float s = af::sum<float>(diff, 1);
+        ASSERT_EQ(s, 0.f);
+
+        in = af::constant(1, 1, largeDim);
+        diff = af::diff1(in, 1);
+        s = af::sum<float>(diff, 1);
+        ASSERT_EQ(s, 0.f);
+
+        in = af::constant(1, 1, 1, largeDim);
+        diff = af::diff1(in, 2);
+        s = af::sum<float>(diff, 1);
+        ASSERT_EQ(s, 0.f);
+
+        in = af::constant(1, 1, 1, 1, largeDim);
+        diff = af::diff1(in, 3);
+        s = af::sum<float>(diff, 1);
+        ASSERT_EQ(s, 0.f);
+    }
+}
+
 ////////////////////////////////////// CPP ////////////////////////////////////
 //
 TEST(Diff1, CPP)
@@ -195,7 +223,6 @@ TEST(Diff1, CPP)
     vector<vector<float> >   tests;
     readTests<float,float,int>(string(TEST_DIR"/diff1/matrix0.test"),numDims,in,tests);
     af::dim4 dims       = numDims[0];
-
 
     af::array input(dims, &(in[0].front()));
     af::array output = af::diff1(input, dim);

--- a/test/diff2.cpp
+++ b/test/diff2.cpp
@@ -179,6 +179,34 @@ TYPED_TEST(Diff2,InvalidArgs)
     diff2ArgsTest<TypeParam>(string(TEST_DIR"/diff2/basic0.test"));
 }
 
+TEST(Diff2, DiffLargeDim)
+{
+    const size_t largeDim = 65535 * 32 + 1;
+
+    af::deviceGC();
+    {
+        af::array in = af::constant(1, largeDim);
+        af::array diff = af::diff2(in, 0);
+        float s = af::sum<float>(diff, 1);
+        ASSERT_EQ(s, 0.f);
+
+        in = af::constant(1, 1, largeDim);
+        diff = af::diff2(in, 1);
+        s = af::sum<float>(diff, 1);
+        ASSERT_EQ(s, 0.f);
+
+        in = af::constant(1, 1, 1, largeDim);
+        diff = af::diff2(in, 2);
+        s = af::sum<float>(diff, 1);
+        ASSERT_EQ(s, 0.f);
+
+        in = af::constant(1, 1, 1, 1, largeDim);
+        diff = af::diff2(in, 3);
+        s = af::sum<float>(diff, 1);
+        ASSERT_EQ(s, 0.f);
+    }
+}
+
 ////////////////////////////////// CPP ////////////////////////////////////////
 //
 TEST(Diff2, CPP)

--- a/test/gradient.cpp
+++ b/test/gradient.cpp
@@ -154,3 +154,17 @@ TEST(Grad, CPP)
     delete[] grad0Data;
     delete[] grad1Data;
 }
+
+TEST(Grad, MaxDim)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t largeDim = 65535 * 8 + 1;
+
+    af::array input = af::constant(1, 2, largeDim);
+    af::array g0, g1;
+    af::grad(g0, g1, input);
+
+    ASSERT_EQ(0.f, af::sum<float>(g0));
+    ASSERT_EQ(0.f, af::sum<float>(g1));
+}

--- a/test/gray_rgb.cpp
+++ b/test/gray_rgb.cpp
@@ -103,3 +103,34 @@ TEST(gray_rgb, 32bit)
         ASSERT_FLOAT_EQ(b, h_rgb[i + boff]);
     }
 }
+
+TEST(rgb_gray, MaxDim)
+{
+    size_t largeDim = 65535 * 32 + 1;
+    af::array rgb = af::randu(1, largeDim, 3, u8);
+    af::array gray = af::rgb2gray(rgb);
+
+    std::vector<uchar> h_rgb(rgb.elements());
+    std::vector<float> h_gray(gray.elements());
+
+    rgb.host(&h_rgb[0]);
+    gray.host(&h_gray[0]);
+
+    int num = gray.elements();
+    int roff = 0;
+    int goff = num;
+    int boff = 2 * num;
+
+    const float rPercent=0.2126f;
+    const float gPercent=0.7152f;
+    const float bPercent=0.0722f;
+
+    for (int i = 0; i < num; i++) {
+        float res =
+            rPercent * h_rgb[i + roff] +
+            gPercent * h_rgb[i + goff] +
+            bPercent * h_rgb[i + boff];
+
+        ASSERT_FLOAT_EQ(res, h_gray[i]);
+    }
+}

--- a/test/hsv_rgb.cpp
+++ b/test/hsv_rgb.cpp
@@ -76,3 +76,73 @@ TEST(rgb2hsv, CPP)
         ASSERT_NEAR(currGoldBar[elIter], outData[elIter], 1.0e-3)<< "at: " << elIter<< std::endl;
     }
 }
+
+TEST(rgb2hsv, MaxDim)
+{
+    vector<af::dim4>      numDims;
+    vector<vector<float> >      in;
+    vector<vector<float> >   tests;
+
+    readTestsFromFile<float,float>(string(TEST_DIR"/hsv_rgb/rgb2hsv.test"), numDims, in, tests);
+
+    af::dim4 dims    = numDims[0];
+    af::array input(dims, &(in[0].front()));
+
+    const size_t largeDim = 65535 * 16 + 1;
+    unsigned int ntile = (largeDim + dims[1] - 1)/dims[1];
+    input = af::tile(input, 1, ntile);
+    af::array output = af::rgb2hsv(input);
+    af::dim4 outDims = output.dims();
+
+    float *outData = new float[outDims.elements()];
+    output.host((void*)outData);
+
+    vector<float> currGoldBar = tests[0];
+    for(int z=0; z<outDims[2]; ++z) {
+        for(int y=0; y<outDims[1]; ++y) {
+            for(int x=0; x<outDims[0]; ++x) {
+                int outIter  = (z*outDims[1]*outDims[0]) + (y*outDims[0]) + x;
+                int goldIter = (z*dims[1]*dims[0]) + ((y%dims[1])*dims[0]) + x;
+                ASSERT_NEAR(currGoldBar[goldIter], outData[outIter], 1.0e-3)<< "at: " << outIter << std::endl;
+            }
+        }
+    }
+
+    // cleanup
+    delete[] outData;
+}
+
+TEST(hsv2rgb, MaxDim)
+{
+    vector<af::dim4>      numDims;
+    vector<vector<float> >      in;
+    vector<vector<float> >   tests;
+
+    readTestsFromFile<float,float>(string(TEST_DIR"/hsv_rgb/hsv2rgb.test"), numDims, in, tests);
+
+    af::dim4 dims    = numDims[0];
+    af::array input(dims, &(in[0].front()));
+
+    const size_t largeDim = 65535 * 16 + 1;
+    unsigned int ntile = (largeDim + dims[1] - 1)/dims[1];
+    input = af::tile(input, 1, ntile);
+    af::array output = af::hsv2rgb(input);
+    af::dim4 outDims = output.dims();
+
+    float *outData = new float[outDims.elements()];
+    output.host((void*)outData);
+
+    vector<float> currGoldBar = tests[0];
+    for(int z=0; z<outDims[2]; ++z) {
+        for(int y=0; y<outDims[1]; ++y) {
+            for(int x=0; x<outDims[0]; ++x) {
+                int outIter  = (z*outDims[1]*outDims[0]) + (y*outDims[0]) + x;
+                int goldIter = (z*dims[1]*dims[0]) + ((y%dims[1])*dims[0]) + x;
+                ASSERT_NEAR(currGoldBar[goldIter], outData[outIter], 1.0e-3)<< "at: " << outIter << std::endl;
+            }
+        }
+    }
+
+    // cleanup
+    delete[] outData;
+}

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -29,22 +29,6 @@ using std::endl;
 using std::ostream_iterator;
 using af::dtype_traits;
 
-static void cleanSlate()
-{
-    size_t alloc_bytes, alloc_buffers;
-    size_t lock_bytes, lock_buffers;
-
-    af::deviceGC();
-
-    af::deviceMemInfo(&alloc_bytes, &alloc_buffers,
-                      &lock_bytes, &lock_buffers);
-
-    ASSERT_EQ(alloc_buffers, 0u);
-    ASSERT_EQ(lock_buffers, 0u);
-    ASSERT_EQ(alloc_bytes, 0u);
-    ASSERT_EQ(lock_bytes, 0u);
-}
-
 template<typename T, typename OP>
 void
 checkValues(const af_seq &seq, const T* data, const T* indexed_data, OP compair_op) {

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -29,6 +29,21 @@ using std::endl;
 using std::ostream_iterator;
 using af::dtype_traits;
 
+static void cleanSlate()
+{
+    size_t alloc_bytes, alloc_buffers;
+    size_t lock_bytes, lock_buffers;
+
+    af::deviceGC();
+
+    af::deviceMemInfo(&alloc_bytes, &alloc_buffers,
+                      &lock_bytes, &lock_buffers);
+
+    ASSERT_EQ(alloc_buffers, 0u);
+    ASSERT_EQ(lock_buffers, 0u);
+    ASSERT_EQ(alloc_bytes, 0u);
+    ASSERT_EQ(lock_bytes, 0u);
+}
 
 template<typename T, typename OP>
 void
@@ -696,6 +711,18 @@ TEST(lookup, CPP)
     }
 
     delete[] outData;
+}
+
+TEST(lookup, largeDim)
+{
+    using af::array;
+    const size_t largeDim = 65535 * 8 + 1;
+
+    cleanSlate();
+    af::array input   = af::range(af::dim4(2, largeDim));
+    af::array indices = af::constant(1, 100);
+
+    af::array output = af::lookup(input, indices);
 }
 
 TEST(SeqIndex, CPP_END)

--- a/test/iota.cpp
+++ b/test/iota.cpp
@@ -100,6 +100,10 @@ void iotaTest(const af::dim4 idims, const af::dim4 tdims)
     IOTA_INIT(Iota4D2,  25, 30, 2, 2, 3, 2, 1, 1);
     IOTA_INIT(Iota4D3,  25, 30, 2, 2, 4, 2, 4, 2);
 
+    IOTA_INIT(IotaMaxDimY,  1, 65535 * 32 + 1, 1, 1, 1, 1, 1, 1);
+    IOTA_INIT(IotaMaxDimZ,  1, 1, 65535 * 32 + 1, 1, 1, 1, 1, 1);
+    IOTA_INIT(IotaMaxDimW,  1, 1, 1, 65535 * 32 + 1, 1, 1, 1, 1);
+
 ///////////////////////////////// CPP ////////////////////////////////////
 //
 TEST(Iota, CPP)

--- a/test/join.cpp
+++ b/test/join.cpp
@@ -129,8 +129,7 @@ TEST(Join, JoinLargeDim)
         af::dim4 joined_dims = joined.dims();
 
         ASSERT_EQ(2*in_dims[0], joined_dims[0]);
-        //todo: uncomment as assert
-        //printf("%f\n", af::sum<float>((joined(0, af::span) - joined(1, af::span)).as(f32)));
+        ASSERT_EQ(0.f, af::sum<float>((joined(0, af::span) - joined(1, af::span)).as(f32)));
 
         af::array in2 = af::constant(1, (dim_t)nx, (dim_t)ny, (dim_t)2, (dim_t)nw, u8);
         joined = af::join(3, in, in);

--- a/test/join.cpp
+++ b/test/join.cpp
@@ -114,6 +114,32 @@ void joinTest(string pTestFile, const unsigned dim, const unsigned in0, const un
     JOIN_INIT(JoinSmall1, join_small, 1, 0, 2, 1);
     JOIN_INIT(JoinSmall2, join_small, 2, 0, 3, 2);
 
+TEST(Join, JoinLargeDim)
+{
+    //const int nx = 32;
+    const int nx = 1;
+    const int ny = 4 * 1024 * 1024;
+    const int nw = 4 * 1024 * 1024;
+
+    af::deviceGC();
+    {
+        af::array in = af::randu(nx, ny, u8);
+        af::array joined = af::join(0, in, in);
+        af::dim4 in_dims = in.dims();
+        af::dim4 joined_dims = joined.dims();
+
+        ASSERT_EQ(2*in_dims[0], joined_dims[0]);
+        //todo: uncomment as assert
+        //printf("%f\n", af::sum<float>((joined(0, af::span) - joined(1, af::span)).as(f32)));
+
+        af::array in2 = af::constant(1, (dim_t)nx, (dim_t)ny, (dim_t)2, (dim_t)nw, u8);
+        joined = af::join(3, in, in);
+        in_dims = in.dims();
+        joined_dims = joined.dims();
+        ASSERT_EQ(2*in_dims[3], joined_dims[3]);
+    }
+}
+
 ///////////////////////////////// CPP ////////////////////////////////////
 //
 TEST(Join, CPP)
@@ -161,7 +187,6 @@ TEST(JoinMany0, CPP)
     af::array output = af::join(0, a0, a1, a2);
     af::array gold = af::join(0, a0, af::join(0, a1, a2));
 
-
     ASSERT_EQ(af::sum<float>(output - gold), 0);
 }
 
@@ -177,6 +202,5 @@ TEST(JoinMany1, CPP)
     int dim = 1;
     af::array output = af::join(dim, a0, a1, a2, a3);
     af::array gold = af::join(dim, a0, af::join(dim, a1, af::join(dim, a2, a3)));
-
     ASSERT_EQ(af::sum<float>(output - gold), 0);
 }

--- a/test/random.cpp
+++ b/test/random.cpp
@@ -177,6 +177,29 @@ TYPED_TEST(Random,InvalidArgs)
     randuArgsTest<TypeParam>();
 }
 
+template<typename T>
+void randuDimsTest()
+{
+    if (noDoubleTests<T>()) return;
+
+    af::dim4 dims(1, 65535*32, 1, 1);
+    af::array large_rand = af::randu(dims, (af_dtype) af::dtype_traits<T>::af_type);
+    ASSERT_EQ(large_rand.dims()[1], 65535*32);
+
+    dims = af::dim4(1, 1, 65535*32, 1);
+    large_rand = af::randu(dims, (af_dtype) af::dtype_traits<T>::af_type);
+    ASSERT_EQ(large_rand.dims()[2], 65535*32);
+
+    dims = af::dim4(1, 1, 1, 65535*32);
+    large_rand = af::randu(dims, (af_dtype) af::dtype_traits<T>::af_type);
+    ASSERT_EQ(large_rand.dims()[3], 65535*32);
+}
+
+TYPED_TEST(Random,InvalidDims)
+{
+    randuDimsTest<TypeParam>();
+}
+
 ////////////////////////////////////// CPP /////////////////////////////////////
 //
 TEST(Random, CPP)

--- a/test/range.cpp
+++ b/test/range.cpp
@@ -109,6 +109,11 @@ void rangeTest(const uint x, const uint y, const uint z, const uint w, const uin
     RANGE_INIT(Range4D2,  25, 30, 2, 2, 2);
     RANGE_INIT(Range4D3,  25, 30, 2, 2, 3);
 
+    RANGE_INIT(Range1DMaxDim0, 65535 * 32 + 1, 1, 1, 1, 0);
+    RANGE_INIT(Range1DMaxDim1, 1, 65535 * 32 + 1, 1, 1, 0);
+    RANGE_INIT(Range1DMaxDim2, 1, 1, 65535 * 32 + 1, 1, 0);
+    RANGE_INIT(Range1DMaxDim3, 1, 1, 1, 65535 * 32 + 1, 0);
+
 ///////////////////////////////// CPP ////////////////////////////////////
 //
 TEST(Range, CPP)

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -161,6 +161,7 @@ TEST(Reduce,Test_Reduce_Big0)
         );
 }
 
+/*
 TEST(Reduce,Test_Reduce_Big1)
 {
     if (noDoubleTests<int>()) return;
@@ -170,11 +171,15 @@ TEST(Reduce,Test_Reduce_Big1)
         1
         );
 }
+*/
 
 /////////////////////////////////// CPP //////////////////////////////////
 //
 typedef af::array (*ReductionOp)(const af::array&, const int);
 
+using af::dim4;
+using af::iota;
+using af::constant;
 using af::sum;
 using af::min;
 using af::max;
@@ -222,12 +227,78 @@ void cppReduceTest(string pTestFile)
     }
 }
 
-#define CPP_REDUCE_TESTS(FN, FNAME, Ti, To)        \
-    TEST(Reduce, Test_##FN##_CPP)                  \
-    {                                              \
-        cppReduceTest<Ti, To, FN>(                 \
-            string(TEST_DIR"/reduce/"#FNAME".test")\
-            );                                     \
+TEST(Reduce, Test_Sum_Scalar_MaxDim)
+{
+    const size_t largeDim = 65535 * 32 * 8 + 1;
+    array A = constant(1, dim4(1, largeDim, 1, 1));
+    ASSERT_EQ(sum<float>(A, 1), largeDim);
+    A = constant(1, dim4(1, 1, largeDim, 1));
+    ASSERT_EQ(sum<float>(A, 2), largeDim);
+    A = constant(1, dim4(1, 1, 1, largeDim));
+    ASSERT_EQ(sum<float>(A, 3), largeDim);
+}
+
+TEST(Reduce, Test_Min_Scalar_MaxDim)
+{
+    const size_t largeDim = 65535 * 32 * 8 + 1;
+    array A = iota(dim4(1, largeDim, 1, 1));
+    ASSERT_EQ(min(A, 1).scalar<float>(), 0.f);
+    A = iota(dim4(1, 1, largeDim, 1));
+    ASSERT_EQ(min(A, 2).scalar<float>(), 0.f);
+    A = iota(dim4(1, 1, 1, largeDim));
+    ASSERT_EQ(min(A, 3).scalar<float>(), 0.f);
+}
+
+TEST(Reduce, Test_Max_Scalar_MaxDim)
+{
+    const size_t largeDim = 65535 * 32 * 8 + 1;
+    array A = iota(dim4(1, largeDim, 1, 1));
+    ASSERT_EQ(max(A, 1).scalar<float>(), largeDim - 1);
+    A = iota(dim4(1, 1, largeDim, 1));
+    ASSERT_EQ(max(A, 2).scalar<float>(), largeDim - 1);
+    A = iota(dim4(1, 1, 1, largeDim));
+    ASSERT_EQ(max(A, 3).scalar<float>(), largeDim - 1);
+}
+
+TEST(Reduce, Test_anyTrue_Scalar_MaxDim)
+{
+    const size_t largeDim = 65535 * 32 * 8 + 1;
+    array A = constant(1, dim4(1, largeDim, 1, 1));
+    ASSERT_EQ(anyTrue(A, 1).scalar<char>(), 1);
+    A = constant(1, dim4(1, 1, largeDim, 1));
+    ASSERT_EQ(anyTrue(A, 2).scalar<char>(), 1);
+    A = constant(1, dim4(1, 1, 1, largeDim));
+    ASSERT_EQ(anyTrue(A, 3).scalar<char>(), 1);
+}
+
+TEST(Reduce, Test_allTrue_Scalar_MaxDim)
+{
+    const size_t largeDim = 65535 * 32 * 8 + 1;
+    array A = constant(1, dim4(1, largeDim, 1, 1));
+    ASSERT_EQ(allTrue(A, 1).scalar<char>(), 1);
+    A = constant(1, dim4(1, 1, largeDim, 1));
+    ASSERT_EQ(allTrue(A, 2).scalar<char>(), 1);
+    A = constant(1, dim4(1, 1, 1, largeDim));
+    ASSERT_EQ(allTrue(A, 3).scalar<char>(), 1);
+}
+
+TEST(Reduce, Test_count_Scalar_MaxDim)
+{
+    const size_t largeDim = 65535 * 32 * 8 + 1;
+    array A = constant(1, dim4(1, largeDim, 1, 1));
+    ASSERT_EQ(count(A, 1).scalar<unsigned int>(), largeDim);
+    A = constant(1, dim4(1, 1, largeDim, 1));
+    ASSERT_EQ(count(A, 2).scalar<unsigned int>(), largeDim);
+    A = constant(1, dim4(1, 1, 1, largeDim));
+    ASSERT_EQ(count(A, 3).scalar<unsigned int>(), largeDim);
+}
+
+#define CPP_REDUCE_TESTS(FN, FNAME, Ti, To)         \
+    TEST(Reduce, Test_##FN##_CPP)                   \
+    {                                               \
+        cppReduceTest<Ti, To, FN>(                  \
+            string(TEST_DIR"/reduce/"#FNAME".test") \
+            );                                      \
     }
 
 CPP_REDUCE_TESTS(sum, sum, float, float);

--- a/test/reorder.cpp
+++ b/test/reorder.cpp
@@ -189,3 +189,17 @@ TEST(Reorder, ISSUE_1777)
         }
     }
 }
+
+TEST(Reorder, MaxDim)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t largeDim = 65535 * 32 + 1 ;
+
+    af::array input  = af::range(af::dim4(2, largeDim, 2), 2);
+    af::array output = af::reorder(input, 2, 1, 0);
+
+    af::array gold = af::range(af::dim4(2, largeDim, 2));
+
+    ASSERT_TRUE(af::allTrue<bool>(output == gold));
+}

--- a/test/scan.cpp
+++ b/test/scan.cpp
@@ -158,3 +158,50 @@ TEST(Accum, CPP)
         delete[] outData;
     }
 }
+
+TEST(Accum, MaxDim)
+{
+    const size_t largeDim = 65535 * 32 + 1;
+
+    //first dimension kernel tests
+    af::array input = af::constant(0, 2, largeDim, 2, 2);
+    input(af::span, af::seq(0, 9999), af::span, af::span) = 1;
+
+    af::array gold_first = af::constant(0, 2, largeDim, 2, 2);
+    gold_first(af::span, af::seq(0, 9999), af::span, af::span) = af::range(2, 10000, 2, 2) + 1;
+
+    af::array output_first = af::accum(input, 0);
+    ASSERT_TRUE(af::allTrue<bool>(output_first == gold_first));
+
+
+    input = af::constant(0, 2, 2, 2, largeDim);
+    input(af::span, af::span, af::span, af::seq(0, 9999)) = 1;
+
+    gold_first = af::constant(0, 2, 2, 2, largeDim);
+    gold_first(af::span, af::span, af::span, af::seq(0, 9999)) = af::range(2, 2, 2, 10000) + 1;
+
+    output_first = af::accum(input, 0);
+    ASSERT_TRUE(af::allTrue<bool>(output_first == gold_first));
+
+
+    //other dimension kernel tests
+    input = af::constant(0, 2, largeDim, 2, 2);
+    input(af::span, af::seq(0, 9999), af::span, af::span) = 1;
+
+    af::array gold_dim = af::constant(10000, 2, largeDim, 2, 2);
+    gold_dim(af::span, af::seq(0, 9999), af::span, af::span) = af::range(af::dim4(2, 10000, 2, 2), 1) + 1;
+
+    af::array output_dim = af::accum(input, 1);
+    ASSERT_TRUE(af::allTrue<bool>(output_dim == gold_dim));
+
+
+    input = af::constant(0, 2, 2, 2, largeDim);
+    input(af::span, af::span, af::span, af::seq(0, 9999)) = 1;
+
+    gold_dim = af::constant(0, 2, 2, 2, largeDim);
+    gold_dim(af::span, af::span, af::span, af::seq(0, 9999)) = af::range(af::dim4(2, 2, 2, 10000), 1) + 1;
+
+    output_dim = af::accum(input, 1);
+    ASSERT_TRUE(af::allTrue<bool>(output_dim == gold_dim));
+
+}

--- a/test/select.cpp
+++ b/test/select.cpp
@@ -241,3 +241,44 @@ TEST(Select, Issue_1730_scalar)
         }
     }
 }
+
+TEST(Select, LargeDim)
+{
+    const size_t largeDim = 65535 * 32 + 1;
+
+    af::array a    = af::constant(1, largeDim);
+    af::array b    = af::constant(0, largeDim);
+    af::array cond = af::constant(0, largeDim, b8);
+
+    af::array sel  = af::select(cond, a, b);
+    float sum = af::sum<float>(sel);
+
+    ASSERT_EQ(sum, 0.f);
+
+    a    = af::constant(1, 1, largeDim);
+    b    = af::constant(0, 1, largeDim);
+    cond = af::constant(0, 1, largeDim, b8);
+
+    sel  = af::select(cond, a, b);
+    sum = af::sum<float>(sel);
+
+    ASSERT_EQ(sum, 0.f);
+
+    a    = af::constant(1, 1, 1, largeDim);
+    b    = af::constant(0, 1, 1, largeDim);
+    cond = af::constant(0, 1, 1, largeDim, b8);
+
+    sel  = af::select(cond, a, b);
+    sum = af::sum<float>(sel);
+
+    ASSERT_EQ(sum, 0.f);
+
+    a    = af::constant(1, 1, 1, 1, largeDim);
+    b    = af::constant(0, 1, 1, 1, largeDim);
+    cond = af::constant(0, 1, 1, 1, largeDim, b8);
+
+    sel  = af::select(cond, a, b);
+    sum = af::sum<float>(sel);
+
+    ASSERT_EQ(sum, 0.f);
+}

--- a/test/shift.cpp
+++ b/test/shift.cpp
@@ -145,3 +145,23 @@ TEST(Shift, CPP)
     // Delete
     delete[] outData;
 }
+
+TEST(Shift, MaxDim)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t largeDim = 65535 * 32 + 1 ;
+    const unsigned shift_x = 1;
+
+    af::array input = af::range(af::dim4(2, largeDim));
+    af::array output = af::shift(input, shift_x);
+
+    output = af::abs(input - output);
+    ASSERT_EQ(1.f, af::product<float>(output));
+
+    input = af::range(af::dim4(2, 1, 1, largeDim));
+    output = af::shift(input, shift_x);
+
+    output = af::abs(input - output);
+    ASSERT_EQ(1.f, af::product<float>(output));
+}

--- a/test/tile.cpp
+++ b/test/tile.cpp
@@ -148,3 +148,38 @@ TEST(Tile, CPP)
     delete[] outData;
 }
 
+TEST(Tile, MaxDim)
+{
+    if (noDoubleTests<float>()) return;
+
+    const size_t largeDim = 65535 * 32 + 1;
+    const unsigned resultIdx = 0;
+    const unsigned x = 1;
+    const unsigned z = 1;
+    unsigned y = 2;
+    unsigned w = 1;
+
+    af::array input = af::constant(1, 1, largeDim);
+    af::array output = af::tile(input, x, y, z, w);
+
+    ASSERT_EQ(1, output.dims(0));
+    ASSERT_EQ(2 * largeDim, output.dims(1));
+    ASSERT_EQ(1, output.dims(2));
+    ASSERT_EQ(1, output.dims(3));
+
+    ASSERT_EQ(1.f, af::product<float>(output));
+
+    y = 1;
+    w = 2;
+
+    input  = af::constant(1, 1, 1, 1, largeDim);
+    output = af::tile(input, x, y, z, w);
+
+    ASSERT_EQ(1, output.dims(0));
+    ASSERT_EQ(1, output.dims(1));
+    ASSERT_EQ(1, output.dims(2));
+    ASSERT_EQ(2 * largeDim, output.dims(3));
+
+    ASSERT_EQ(1.f, af::product<float>(output));
+
+}

--- a/test/transpose.cpp
+++ b/test/transpose.cpp
@@ -236,6 +236,26 @@ TEST(Transpose, CPP_c32_CONJ20x20x5)
     trsCPPConjTest<cfloat>(20, 20, 5);
 }
 
+TEST(Transpose, MaxDim)
+{
+    const size_t largeDim = 65535 * 33 + 1;
+
+    af::array input  = af::range(af::dim4(2, largeDim, 1, 1));
+    af::array gold   = af::range(af::dim4(largeDim, 2, 1, 1), 1);
+    af::array output = af::transpose(input);
+
+    ASSERT_EQ(output.dims(0), (int)largeDim);
+    ASSERT_EQ(output.dims(1), 2);
+    ASSERT_TRUE(af::allTrue<bool>(output == gold));
+
+    input  = af::range(af::dim4(2, 5, 1, largeDim));
+    gold   = af::range(af::dim4(5, 2, 1, largeDim), 1);
+    output = af::transpose(input);
+
+    ASSERT_TRUE(af::allTrue<bool>(output == gold));
+}
+
+
 TEST(Transpose, GFOR)
 {
     using namespace af;

--- a/test/triangle.cpp
+++ b/test/triangle.cpp
@@ -153,6 +153,12 @@ TYPED_TEST(Triangle, Upper2DSquareUnit)
     triangleTester<TypeParam>(dim4(2048, 2048), true, true);
 }
 
+TYPED_TEST(Triangle, MaxDim)
+{
+    const size_t largeDim = 65535 * 32 + 1;
+    triangleTester<TypeParam>(dim4(2, largeDim), true, true);
+}
+
 TEST(Lower, ExtractGFOR)
 {
     using namespace af;

--- a/test/unwrap.cpp
+++ b/test/unwrap.cpp
@@ -176,3 +176,23 @@ TEST(Unwrap, CPP)
     // Delete
     delete[] outData;
 }
+
+TEST(Unwrap, MaxDim)
+{
+    const size_t largeDim = 65535 + 1;
+    af::array input = af::range(5, 5, largeDim);
+
+    const unsigned wx = 5;
+    const unsigned wy = 5;
+    const unsigned sx = 5;
+    const unsigned sy = 5;
+    const unsigned px = 0;
+    const unsigned py = 0;
+
+    af::array output = af::unwrap(input, wx, wy, sx, sy, px, py);
+
+    af::array gold = af::range(af::dim4(5, 5, 1, largeDim));
+    gold = af::moddims(gold, af::dim4(25, 1, largeDim));
+
+    ASSERT_TRUE(af::allTrue<bool>(output == gold));
+}

--- a/test/where.cpp
+++ b/test/where.cpp
@@ -122,6 +122,20 @@ TYPED_TEST(Where, CPP)
     }
 }
 
+TEST(Where, MaxDim)
+{
+    const size_t largeDim = 65535 * 32 + 2;
+
+    af::array input = af::range(af::dim4(1, largeDim), 1);
+    af::array output = where(input % 2 == 0);
+    af::array gold = 2 * af::range(largeDim/2);
+    ASSERT_TRUE(af::allTrue<bool>(output == gold));
+
+    input = af::range(af::dim4(1, 1, 1, largeDim), 3);
+    output = where(input % 2 == 0);
+    ASSERT_TRUE(af::allTrue<bool>(output == gold));
+}
+
 TEST(Where, ISSUE_1259)
 {
     af::array a = af::randu(10, 10, 10);

--- a/test/wrap.cpp
+++ b/test/wrap.cpp
@@ -178,3 +178,21 @@ void wrapTest(const dim_t ix, const dim_t iy,
     WRAP_INIT(40, 300, 100,  8, 12,  8, 12,  7, 11);
     WRAP_INIT(43, 300, 100, 15, 10, 15, 10,  0,  0);
     WRAP_INIT(44, 300, 100, 15, 10, 15, 10, 14,  9);
+
+TEST(Wrap, MaxDim)
+{
+    const size_t largeDim = 65535 + 1;
+    af::array input = af::range(5, 5, 1, largeDim);
+
+    const unsigned wx = 5;
+    const unsigned wy = 5;
+    const unsigned sx = 5;
+    const unsigned sy = 5;
+    const unsigned px = 0;
+    const unsigned py = 0;
+
+    af::array unwrapped = af::unwrap(input, wx, wy, sx, sy, px, py);
+    af::array output = af::wrap(unwrapped, 5, 5, wx, wy, sx, sy, px, py);
+
+    ASSERT_TRUE(af::allTrue<bool>(output == input));
+}

--- a/test/ycbcr_rgb.cpp
+++ b/test/ycbcr_rgb.cpp
@@ -55,6 +55,41 @@ TEST(ycbcr2rgb, CPP)
     }
 }
 
+TEST(ycbcr2rgb, MaxDim)
+{
+    vector<af::dim4>      numDims;
+    vector<vector<float> >      in;
+    vector<vector<float> >   tests;
+
+    readTestsFromFile<float,float>(string(TEST_DIR "/ycbcr_rgb/ycbcr2rgb.test"), numDims, in, tests);
+
+    af::dim4 dims    = numDims[0];
+    af::array input(dims, &(in[0].front()));
+
+    const size_t largeDim = 65535 * 16 + 1;
+    unsigned int ntile = (largeDim + dims[1] - 1)/dims[1];
+    input = af::tile(input, 1, ntile);
+    af::array output = af::ycbcr2rgb(input);
+    af::dim4 outDims = output.dims();
+
+    float *outData = new float[outDims.elements()];
+    output.host((void*)outData);
+
+    vector<float> currGoldBar = tests[0];
+    for(int z=0; z<outDims[2]; ++z) {
+        for(int y=0; y<outDims[1]; ++y) {
+            for(int x=0; x<outDims[0]; ++x) {
+                int outIter  = (z*outDims[1]*outDims[0]) + (y*outDims[0]) + x;
+                int goldIter = (z*dims[1]*dims[0]) + ((y%dims[1])*dims[0]) + x;
+                ASSERT_NEAR(currGoldBar[goldIter], outData[outIter], 1.0e-3)<< "at: " << outIter << std::endl;
+            }
+        }
+    }
+
+    // cleanup
+    delete[] outData;
+}
+
 TEST(rgb2ycbcr, CPP)
 {
     vector<af::dim4>      numDims;
@@ -75,4 +110,39 @@ TEST(rgb2ycbcr, CPP)
     for (size_t elIter=0; elIter<nElems; ++elIter) {
         ASSERT_NEAR(currGoldBar[elIter], outData[elIter], 1.0e-3)<< "at: " << elIter<< std::endl;
     }
+
+}
+
+TEST(rgb2ycbcr, MaxDim)
+{
+    vector<af::dim4>      numDims;
+    vector<vector<float> >      in;
+    vector<vector<float> >   tests;
+
+    readTestsFromFile<float,float>(string(TEST_DIR "/ycbcr_rgb/rgb2ycbcr.test"), numDims, in, tests);
+
+    af::dim4 dims    = numDims[0];
+    af::array input(dims, &(in[0].front()));
+
+    const size_t largeDim = 65535 * 16 + 1;
+    unsigned int ntile = (largeDim + dims[1] - 1)/dims[1];
+    input = af::tile(input, 1, ntile);
+    af::array output = af::rgb2ycbcr(input);
+    af::dim4 outDims = output.dims();
+
+    float *outData = new float[outDims.elements()];
+    output.host((void*)outData);
+
+    vector<float> currGoldBar = tests[0];
+    for(int z=0; z<outDims[2]; ++z) {
+        for(int y=0; y<outDims[1]; ++y) {
+            for(int x=0; x<outDims[0]; ++x) {
+                int outIter  = (z*outDims[1]*outDims[0]) + (y*outDims[0]) + x;
+                int goldIter = (z*dims[1]*dims[0]) + ((y%dims[1])*dims[0]) + x;
+                ASSERT_NEAR(currGoldBar[goldIter], outData[outIter], 1.0e-3)<< "at: " << outIter << std::endl;
+            }
+        }
+    }
+
+    delete[] outData;
 }


### PR DESCRIPTION
This is a WIP branch with updates to each kernel fixing the CUDA API's limitation for the maximum number of y-blocks.  
Related to #133 #1513 #1702 #1700 #1760
Currently, tests only test for ability to handle larger array sizes but do not check for correctness. Tests for correctness will be added as more kernels are fixed since kernels like reduce() or index() are necessary to test, but themselves don't work with larger dimensions. Lots of changes to come!