### PR TITLE
Fix max allowable window size in af_unwrap

### DIFF
--- a/src/api/c/unwrap.cpp
+++ b/src/api/c/unwrap.cpp
@@ -34,8 +34,8 @@ af_err af_unwrap(af_array *out, const af_array in, const dim_t wx, const dim_t w
         af_dtype type = info.getType();
         af::dim4 idims = info.dims();
 
-        ARG_ASSERT(2, wx > 0 && wx <= idims[0] + px);
-        ARG_ASSERT(3, wy > 0 && wy <= idims[1] + py);
+        ARG_ASSERT(2, wx > 0 && wx <= idims[0] + 2 * px);
+        ARG_ASSERT(3, wy > 0 && wy <= idims[1] + 2 * py);
         ARG_ASSERT(4, sx > 0);
         ARG_ASSERT(5, sy > 0);
         ARG_ASSERT(6, px >= 0 && px < wx);

--- a/test/unwrap.cpp
+++ b/test/unwrap.cpp
@@ -138,7 +138,8 @@ void unwrapTest(string pTestFile, const unsigned resultIdx,
 
    // FIXME: This test is faulty after fixing the copy paste errors in unwrap
    // UNWRAP_INIT(UnwrapSmall44, unwrap_small, 44, 15, 10, 15, 10, 14,  9);
-
+    UNWRAP_INIT(UnwrapSmall45, unwrap_small, 45, 18, 16, 18, 16,  1,  0);
+    UNWRAP_INIT(UnwrapSmall46, unwrap_small, 46, 16, 18, 16, 18,  0,  1);
 ///////////////////////////////// CPP ////////////////////////////////////
 //
 TEST(Unwrap, CPP)


### PR DESCRIPTION
As padding is added a both sides of a dimension, the max allowable window size
should be dim_size + 2 * padding

 fixes #1852 