### PR TITLE
Change Array<T> variables to Param<T> on the queue for CPU backend

### DIFF
--- a/src/backend/cpu/Array.cpp
+++ b/src/backend/cpu/Array.cpp
@@ -53,6 +53,7 @@ Array<T>::Array(dim4 dims, const T * const in_data, bool is_device, bool copy_de
     static_assert(std::is_standard_layout<Array<T>>::value, "Array<T> must be a standard layout type");
     static_assert(offsetof(Array<T>, info) == 0, "Array<T>::info must be the first member variable of Array<T>");
     if (!is_device || copy_device) {
+        // Ensure the memory being written to isnt used anywhere else.
         getQueue().sync();
         std::copy(in_data, in_data + dims.elements(), data.get());
     }
@@ -85,6 +86,7 @@ Array<T>::Array(af::dim4 dims, af::dim4 strides, dim_t offset_,
     owner(true)
 {
     if (!is_device) {
+        // Ensure the memory being written to isnt used anywhere else.
         getQueue().sync();
         std::copy(in_data, in_data + info.total(), data.get());
     }
@@ -294,6 +296,7 @@ writeHostDataArray(Array<T> &arr, const T * const data, const size_t bytes)
         arr = copyArray<T>(arr);
     }
     arr.eval();
+    // Ensure the memory being written to isnt used anywhere else.
     getQueue().sync();
     memcpy(arr.get(), data, bytes);
 }

--- a/src/backend/cpu/Param.hpp
+++ b/src/backend/cpu/Param.hpp
@@ -1,5 +1,5 @@
 /*******************************************************
- * Copyright (c) 2014, ArrayFire
+ * Copyright (c) 2017, ArrayFire
  * All rights reserved.
  *
  * This file is distributed under 3-clause BSD license.
@@ -74,5 +74,27 @@ public:
         return CParam<T>(const_cast<T *>(ptr), dims, strides);
     }
 };
+
+template<typename T> class Array;
+
+template<typename T>
+T toParam(const T &val)
+{
+    return val;
+}
+
+
+template<typename T>
+Param<T> toParam(Array<T> &val)
+{
+    return (Param<T>)(val);
+}
+
+
+template<typename T>
+CParam<T> toParam(const Array<T> &val)
+{
+    return (CParam<T>)(val);
+}
 
 }

--- a/src/backend/cpu/Param.hpp
+++ b/src/backend/cpu/Param.hpp
@@ -116,19 +116,20 @@ public:
 
 template<typename T> class Array;
 
+// These functions are needed to convert Array<T> to Param<T> when queueing up functions.
+// This is necessary because the memory used by Array<T> can be put back into the queue faster.
+// This is fine becacuse we only have 1 compute queue. This ensures there's no race conditions.
 template<typename T>
 T toParam(const T &val)
 {
     return val;
 }
 
-
 template<typename T>
 Param<T> toParam(Array<T> &val)
 {
     return (Param<T>)(val);
 }
-
 
 template<typename T>
 CParam<T> toParam(const Array<T> &val)

--- a/src/backend/cpu/Param.hpp
+++ b/src/backend/cpu/Param.hpp
@@ -1,0 +1,78 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+#include <af/defines.h>
+#include <af/dim4.hpp>
+#include <backend.hpp>
+
+namespace cpu
+{
+
+using af::dim4;
+
+template<typename T>
+class CParam
+{
+private:
+    const T *ptr;
+
+public:
+    dim4 dims;
+    dim4 strides;
+
+    CParam(const T *iptr, const dim4 &idims, const dim4 &istrides) :
+        ptr(iptr)
+    {
+        for (int i = 0; i < 4; i++) {
+            dims[i] = idims[i];
+            strides[i] = istrides[i];
+        }
+    }
+    const T *get() const
+    {
+        return ptr;
+    }
+};
+
+template<typename T>
+class Param
+{
+private:
+    T *ptr;
+public:
+    dim4 dims;
+    dim4 strides;
+
+public:
+    Param() : ptr(nullptr)
+    {
+    }
+
+    Param(T *iptr, const dim4 &idims, const dim4 &istrides) :
+        ptr(iptr)
+    {
+        for (int i = 0; i < 4; i++) {
+            dims[i] = idims[i];
+            strides[i] = istrides[i];
+        }
+    }
+
+    T *get()
+    {
+        return ptr;
+    }
+
+    operator CParam<T>() const
+    {
+        return CParam<T>(const_cast<T *>(ptr), dims, strides);
+    }
+};
+
+}

--- a/src/backend/cpu/Param.hpp
+++ b/src/backend/cpu/Param.hpp
@@ -21,23 +21,43 @@ template<typename T>
 class CParam
 {
 private:
-    const T *ptr;
+    const T *m_ptr;
+    dim4 m_dims;
+    dim4 m_strides;
 
 public:
-    dim4 dims;
-    dim4 strides;
-
     CParam(const T *iptr, const dim4 &idims, const dim4 &istrides) :
-        ptr(iptr)
+        m_ptr(iptr)
     {
         for (int i = 0; i < 4; i++) {
-            dims[i] = idims[i];
-            strides[i] = istrides[i];
+            m_dims[i] = idims[i];
+            m_strides[i] = istrides[i];
         }
     }
+
     const T *get() const
     {
-        return ptr;
+        return m_ptr;
+    }
+
+    dim4 dims() const
+    {
+        return m_dims;
+    }
+
+    dim4 strides() const
+    {
+        return m_strides;
+    }
+
+    int dims(int i) const
+    {
+        return m_dims[i];
+    }
+
+    int strides(int i) const
+    {
+        return m_strides[i];
     }
 };
 
@@ -45,33 +65,52 @@ template<typename T>
 class Param
 {
 private:
-    T *ptr;
-public:
-    dim4 dims;
-    dim4 strides;
+    T *m_ptr;
+    dim4 m_dims;
+    dim4 m_strides;
 
 public:
-    Param() : ptr(nullptr)
+    Param() : m_ptr(nullptr)
     {
     }
 
     Param(T *iptr, const dim4 &idims, const dim4 &istrides) :
-        ptr(iptr)
+        m_ptr(iptr)
     {
         for (int i = 0; i < 4; i++) {
-            dims[i] = idims[i];
-            strides[i] = istrides[i];
+            m_dims[i] = idims[i];
+            m_strides[i] = istrides[i];
         }
     }
 
     T *get()
     {
-        return ptr;
+        return m_ptr;
     }
 
     operator CParam<T>() const
     {
-        return CParam<T>(const_cast<T *>(ptr), dims, strides);
+        return CParam<T>(const_cast<T *>(m_ptr), m_dims, m_strides);
+    }
+
+    dim4 dims() const
+    {
+        return m_dims;
+    }
+
+    dim4 strides() const
+    {
+        return m_strides;
+    }
+
+    int dims(int i) const
+    {
+        return m_dims[i];
+    }
+
+    int strides(int i) const
+    {
+        return m_strides[i];
     }
 };
 

--- a/src/backend/cpu/assign.cpp
+++ b/src/backend/cpu/assign.cpp
@@ -46,8 +46,9 @@ void assign(Array<T>& out, const af_index_t idxrs[], const Array<T>& rhs)
         }
     }
 
-    getQueue().enqueue(kernel::assign<T>, out, rhs, std::move(isSeq),
-            std::move(seqs), std::move(idxArrs));
+    vector<CParam<uint>> idxParams(idxArrs.begin(), idxArrs.end());
+    getQueue().enqueue(kernel::assign<T>, out, out.getDataDims(), rhs, std::move(isSeq),
+            std::move(seqs), std::move(idxParams));
 }
 
 #define INSTANTIATE(T) \

--- a/src/backend/cpu/blas.cpp
+++ b/src/backend/cpu/blas.cpp
@@ -170,8 +170,8 @@ Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
         auto alpha = getScale<T, 1>();
         auto beta  = getScale<T, 0>();
 
-        dim4 lStrides = left.strides;
-        dim4 rStrides = right.strides;
+        dim4 lStrides = left.strides();
+        dim4 rStrides = right.strides();
 
         if(rDims[bColDim] == 1) {
             gemv_func<T>()(
@@ -190,7 +190,7 @@ Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
                 reinterpret_cast<CBT*>(left.get()), lStrides[1],
                 reinterpret_cast<CBT*>(right.get()), rStrides[1],
                 beta,
-                reinterpret_cast<BT*>(output.get()), output.dims[0]);
+                reinterpret_cast<BT*>(output.get()), output.dims(0));
         }
     };
     getQueue().enqueue(func, out, lhs, rhs);

--- a/src/backend/cpu/blas.cpp
+++ b/src/backend/cpu/blas.cpp
@@ -166,12 +166,12 @@ Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
     using CBT = const typename blas_base<T>::type;
 
     Array<T> out = createEmptyArray<T>(af::dim4(M, N, 1, 1));
-    auto func = [=] (Array<T> output, const Array<T> left, const Array<T> right) {
+    auto func = [=] (Param<T> output, CParam<T> left, CParam<T> right) {
         auto alpha = getScale<T, 1>();
         auto beta  = getScale<T, 0>();
 
-        dim4 lStrides = left.strides();
-        dim4 rStrides = right.strides();
+        dim4 lStrides = left.strides;
+        dim4 rStrides = right.strides;
 
         if(rDims[bColDim] == 1) {
             gemv_func<T>()(
@@ -190,7 +190,7 @@ Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
                 reinterpret_cast<CBT*>(left.get()), lStrides[1],
                 reinterpret_cast<CBT*>(right.get()), rStrides[1],
                 beta,
-                reinterpret_cast<BT*>(output.get()), output.dims()[0]);
+                reinterpret_cast<BT*>(output.get()), output.dims[0]);
         }
     };
     getQueue().enqueue(func, out, lhs, rhs);

--- a/src/backend/cpu/cholesky.cpp
+++ b/src/backend/cpu/cholesky.cpp
@@ -62,6 +62,7 @@ template<typename T>
 int cholesky_inplace(Array<T> &in, const bool is_upper)
 {
     in.eval();
+    getQueue().sync();
 
     dim4 iDims = in.dims();
     int N = iDims[0];
@@ -70,13 +71,7 @@ int cholesky_inplace(Array<T> &in, const bool is_upper)
     if(is_upper)
         uplo = 'U';
 
-    int info = 0;
-    auto func = [&] (int& info, Array<T>& in) {
-        info = potrf_func<T>()(AF_LAPACK_COL_MAJOR, uplo, N, in.get(), in.strides()[1]);
-    };
-
-    getQueue().enqueue(func, info, in);
-    getQueue().sync();
+    int info = potrf_func<T>()(AF_LAPACK_COL_MAJOR, uplo, N, in.get(), in.strides()[1]);
 
     return info;
 }

--- a/src/backend/cpu/cholesky.cpp
+++ b/src/backend/cpu/cholesky.cpp
@@ -76,6 +76,7 @@ int cholesky_inplace(Array<T> &in, const bool is_upper)
     };
 
     getQueue().enqueue(func, &info, in);
+    // Ensure the value of info has been written into info.
     getQueue().sync();
 
     return info;

--- a/src/backend/cpu/convolve.cpp
+++ b/src/backend/cpu/convolve.cpp
@@ -78,8 +78,9 @@ Array<T> convolve2(Array<T> const& signal, Array<accT> const& c_filter, Array<ac
     }
 
     Array<T> out  = createEmptyArray<T>(oDims);
+    Array<T> temp = createEmptyArray<T>(tDims);
 
-    getQueue().enqueue(kernel::convolve2<T, accT, expand>, out, signal, c_filter, r_filter, tDims);
+    getQueue().enqueue(kernel::convolve2<T, accT, expand>, out, signal, c_filter, r_filter, temp);
 
     return out;
 }

--- a/src/backend/cpu/copy.cpp
+++ b/src/backend/cpu/copy.cpp
@@ -28,6 +28,7 @@ template<typename T>
 void copyData(T *to, const Array<T> &from)
 {
     from.eval();
+    // Ensure all operations on 'from' are complete before copying data to host.
     getQueue().sync();
     if(from.isLinear()) {
         // FIXME: Check for errors / exceptions

--- a/src/backend/cpu/fast.cpp
+++ b/src/backend/cpu/fast.cpp
@@ -70,8 +70,8 @@ unsigned fast(Array<float> &x_out, Array<float> &y_out, Array<float> &score_out,
 
         count = 0;
         kernel::non_maximal(V, x, y,
-                    x_total, y_total, score_total,
-                    &count, feat_found, edge);
+                            x_total, y_total, score_total,
+                            &count, feat_found, edge);
 
         feat_found = std::min(max_feat, count);
     } else {

--- a/src/backend/cpu/fft.cpp
+++ b/src/backend/cpu/fft.cpp
@@ -29,7 +29,7 @@ template<typename T, int rank, bool direction>
 void fft_inplace(Array<T> &in)
 {
     in.eval();
-    getQueue().enqueue(kernel::fft_inplace<T, rank, direction>, in);
+    getQueue().enqueue(kernel::fft_inplace<T, rank, direction>, in, in.getDataDims());
 }
 
 template<typename Tc, typename Tr, int rank>
@@ -41,7 +41,7 @@ Array<Tc> fft_r2c(const Array<Tr> &in)
     odims[0] = odims[0] / 2 + 1;
     Array<Tc> out = createEmptyArray<Tc>(odims);
 
-    getQueue().enqueue(kernel::fft_r2c<Tc, Tr, rank>, out, in);
+    getQueue().enqueue(kernel::fft_r2c<Tc, Tr, rank>, out, out.getDataDims(), in, in.getDataDims());
 
     return out;
 }
@@ -52,7 +52,10 @@ Array<Tr> fft_c2r(const Array<Tc> &in, const dim4 &odims)
     in.eval();
 
     Array<Tr> out = createEmptyArray<Tr>(odims);
-    getQueue().enqueue(kernel::fft_c2r<Tr, Tc, rank>, out, in, odims);
+    getQueue().enqueue(kernel::fft_c2r<Tr, Tc, rank>,
+                       out, out.getDataDims(),
+                       in, in.getDataDims(),
+                       odims);
 
     return out;
 }

--- a/src/backend/cpu/fftconvolve.cpp
+++ b/src/backend/cpu/fftconvolve.cpp
@@ -92,12 +92,12 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
     for (int i=0; i<baseDim; ++i)
         fftDims[i] = fft_dims[i];
 
-    auto upstream_dft = [=] (Array<convT> packed, const dim4 fftDims) {
+    auto upstream_dft = [=] (Param<convT> packed, const dim4 fftDims) {
         int fft_dims[baseDim];
         for (int i=0; i<baseDim; ++i)
             fft_dims[i] = fftDims[i];
-        const dim4 packed_dims = packed.dims();
-        const af::dim4 packed_strides = packed.strides();
+        const dim4 packed_dims = packed.dims;
+        const af::dim4 packed_strides = packed.strides;
         // Compute forward FFT
         if (isDouble) {
             fftw_plan plan = fftw_plan_many_dft(baseDim,
@@ -143,12 +143,12 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
                        filter_tmp_dims, filter_tmp_strides,
                        kind, offset);
 
-    auto upstream_idft = [=] (Array<convT> packed, const dim4 fftDims) {
+    auto upstream_idft = [=] (Param<convT> packed, const dim4 fftDims) {
         int fft_dims[baseDim];
         for (int i=0; i<baseDim; ++i)
             fft_dims[i] = fftDims[i];
-        const dim4 packed_dims = packed.dims();
-        const af::dim4 packed_strides = packed.strides();
+        const dim4 packed_dims = packed.dims;
+        const af::dim4 packed_strides = packed.strides;
         // Compute inverse FFT
         if (isDouble) {
             fftw_plan plan = fftw_plan_many_dft(baseDim,

--- a/src/backend/cpu/fftconvolve.cpp
+++ b/src/backend/cpu/fftconvolve.cpp
@@ -96,8 +96,8 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
         int fft_dims[baseDim];
         for (int i=0; i<baseDim; ++i)
             fft_dims[i] = fftDims[i];
-        const dim4 packed_dims = packed.dims;
-        const af::dim4 packed_strides = packed.strides;
+        const dim4 packed_dims = packed.dims();
+        const af::dim4 packed_strides = packed.strides();
         // Compute forward FFT
         if (isDouble) {
             fftw_plan plan = fftw_plan_many_dft(baseDim,
@@ -147,8 +147,8 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
         int fft_dims[baseDim];
         for (int i=0; i<baseDim; ++i)
             fft_dims[i] = fftDims[i];
-        const dim4 packed_dims = packed.dims;
-        const af::dim4 packed_strides = packed.strides;
+        const dim4 packed_dims = packed.dims();
+        const af::dim4 packed_strides = packed.strides();
         // Compute inverse FFT
         if (isDouble) {
             fftw_plan plan = fftw_plan_many_dft(baseDim,

--- a/src/backend/cpu/harris.cpp
+++ b/src/backend/cpu/harris.cpp
@@ -50,7 +50,7 @@ unsigned harris(Array<float> &x_out, Array<float> &y_out, Array<float> &resp_out
     Array<T> iy = createEmptyArray<T>(idims);
 
     // Compute first order derivatives
-    getQueue().enqueue(gradient<T>, iy, ix, in);
+    gradient<T>(iy, ix, in);
 
     Array<T> ixx = createEmptyArray<T>(idims);
     Array<T> ixy = createEmptyArray<T>(idims);
@@ -108,9 +108,9 @@ unsigned harris(Array<float> &x_out, Array<float> &y_out, Array<float> &resp_out
         y_out = createEmptyArray<float>(dim4(corners_out));
         resp_out = createEmptyArray<float>(dim4(corners_out));
 
-        auto copyFunc = [=](Array<float> x_out, Array<float> y_out,
-                            Array<float> outResponses, const Array<float> x_crnrs,
-                            const Array<float> y_crnrs, const Array<float> inResponses,
+        auto copyFunc = [=](Param<float> x_out, Param<float> y_out,
+                            Param<float> outResponses, CParam<float> x_crnrs,
+                            CParam<float> y_crnrs, CParam<float> inResponses,
                             const unsigned corners_out) {
             memcpy(x_out.get(), x_crnrs.get(), corners_out * sizeof(float));
             memcpy(y_out.get(), y_crnrs.get(), corners_out * sizeof(float));

--- a/src/backend/cpu/index.cpp
+++ b/src/backend/cpu/index.cpp
@@ -54,9 +54,10 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[])
     }
 
     Array<T> out = createEmptyArray<T>(oDims);
+    std::vector<CParam<uint>> idxParams(idxArrs.begin(), idxArrs.end());
 
-
-    getQueue().enqueue(kernel::index<T>, out, in, std::move(isSeq), std::move(seqs), std::move(idxArrs));
+    getQueue().enqueue(kernel::index<T>, out, in, in.getDataDims(),
+                       std::move(isSeq), std::move(seqs), std::move(idxParams));
 
     return out;
 }

--- a/src/backend/cpu/inverse.cpp
+++ b/src/backend/cpu/inverse.cpp
@@ -65,8 +65,8 @@ Array<T> inverse(const Array<T> &in)
 
     auto func = [=] (Param<T> A, Param<int> pivot, int M) {
         getri_func<T>()(AF_LAPACK_COL_MAJOR, M,
-                A.get(), A.strides[1],
-                pivot.get());
+                        A.get(), A.strides(1),
+                        pivot.get());
     };
     getQueue().enqueue(func, A, pivot, M);
 

--- a/src/backend/cpu/inverse.cpp
+++ b/src/backend/cpu/inverse.cpp
@@ -63,9 +63,9 @@ Array<T> inverse(const Array<T> &in)
     Array<T> A = copyArray<T>(in);
     Array<int> pivot = lu_inplace<T>(A, false);
 
-    auto func = [=] (Array<T> A, Array<int> pivot, int M) {
+    auto func = [=] (Param<T> A, Param<int> pivot, int M) {
         getri_func<T>()(AF_LAPACK_COL_MAJOR, M,
-                A.get(), A.strides()[1],
+                A.get(), A.strides[1],
                 pivot.get());
     };
     getQueue().enqueue(func, A, pivot, M);

--- a/src/backend/cpu/ireduce.cpp
+++ b/src/backend/cpu/ireduce.cpp
@@ -21,8 +21,8 @@ namespace cpu
 {
 
 template<af_op_t op, typename T>
-using ireduce_dim_func = std::function<void(Array<T>, Array<uint>, const dim_t,
-                                            const Array<T>, const dim_t, const int)>;
+using ireduce_dim_func = std::function<void(Param<T>, Param<uint>, const dim_t,
+                                            CParam<T>, const dim_t, const int)>;
 
 template<af_op_t op, typename T>
 void ireduce(Array<T> &out, Array<uint> &loc, const Array<T> &in, const int dim)

--- a/src/backend/cpu/join.cpp
+++ b/src/backend/cpu/join.cpp
@@ -68,38 +68,39 @@ Array<T> join(const int dim, const std::vector<Array<T>> &inputs)
         }
     }
 
+    std::vector<CParam<T>> inputParams(inputs.begin(), inputs.end());
     Array<T> out = createEmptyArray<T>(odims);
 
     switch(n_arrays) {
         case 1:
-            getQueue().enqueue(kernel::join<T, 1>, dim, out, inputs);
+            getQueue().enqueue(kernel::join<T, 1>, dim, out, inputParams);
             break;
         case 2:
-            getQueue().enqueue(kernel::join<T, 2>, dim, out, inputs);
+            getQueue().enqueue(kernel::join<T, 2>, dim, out, inputParams);
             break;
         case 3:
-            getQueue().enqueue(kernel::join<T, 3>, dim, out, inputs);
+            getQueue().enqueue(kernel::join<T, 3>, dim, out, inputParams);
             break;
         case 4:
-            getQueue().enqueue(kernel::join<T, 4>, dim, out, inputs);
+            getQueue().enqueue(kernel::join<T, 4>, dim, out, inputParams);
             break;
         case 5:
-            getQueue().enqueue(kernel::join<T, 5>, dim, out, inputs);
+            getQueue().enqueue(kernel::join<T, 5>, dim, out, inputParams);
             break;
         case 6:
-            getQueue().enqueue(kernel::join<T, 6>, dim, out, inputs);
+            getQueue().enqueue(kernel::join<T, 6>, dim, out, inputParams);
             break;
         case 7:
-            getQueue().enqueue(kernel::join<T, 7>, dim, out, inputs);
+            getQueue().enqueue(kernel::join<T, 7>, dim, out, inputParams);
             break;
         case 8:
-            getQueue().enqueue(kernel::join<T, 8>, dim, out, inputs);
+            getQueue().enqueue(kernel::join<T, 8>, dim, out, inputParams);
             break;
         case 9:
-            getQueue().enqueue(kernel::join<T, 9>, dim, out, inputs);
+            getQueue().enqueue(kernel::join<T, 9>, dim, out, inputParams);
             break;
         case 10:
-            getQueue().enqueue(kernel::join<T,10>, dim, out, inputs);
+            getQueue().enqueue(kernel::join<T,10>, dim, out, inputParams);
             break;
     }
 

--- a/src/backend/cpu/kernel/Array.hpp
+++ b/src/backend/cpu/kernel/Array.hpp
@@ -21,8 +21,8 @@ namespace kernel
 template<typename T>
 void evalMultiple(std::vector<Param<T>> arrays, std::vector<TNJ::Node_ptr> output_nodes_)
 {
-    af::dim4 odims = arrays[0].dims;
-    af::dim4 ostrs = arrays[0].strides;
+    af::dim4 odims = arrays[0].dims();
+    af::dim4 ostrs = arrays[0].strides();
 
     TNJ::Node_map_t nodes;
     std::vector<T *> ptrs;
@@ -42,7 +42,7 @@ void evalMultiple(std::vector<Param<T>> arrays, std::vector<TNJ::Node_ptr> outpu
     }
 
     if (is_linear) {
-        int num = arrays[0].dims.elements();
+        int num = arrays[0].dims().elements();
         for (int i = 0; i < num; i++) {
             for (int n = 0; n < (int)full_nodes.size(); n++) {
                 full_nodes[n]->calc(i);
@@ -82,8 +82,8 @@ void evalArray(Param<T> arr, TNJ::Node_ptr node)
 {
     T *ptr = arr.get();
 
-    af::dim4 odims = arr.dims;
-    af::dim4 ostrs = arr.strides;
+    af::dim4 odims = arr.dims();
+    af::dim4 ostrs = arr.strides();
 
     TNJ::Node_map_t nodes;
     node->getNodesMap(nodes);
@@ -98,7 +98,7 @@ void evalArray(Param<T> arr, TNJ::Node_ptr node)
 
     TNJ::TNode<T> *output_node = reinterpret_cast<TNJ::TNode<T> *>(full_nodes.back());
     if (is_linear) {
-        int num = arr.dims.elements();
+        int num = arr.dims().elements();
         for (int i = 0; i < num; i++) {
             for (int n = 0; n < (int)full_nodes.size(); n++) {
                 full_nodes[n]->calc(i);

--- a/src/backend/cpu/kernel/approx.hpp
+++ b/src/backend/cpu/kernel/approx.hpp
@@ -24,13 +24,13 @@ void approx1(Param<InT> output, CParam<InT> input,
     InT * out = output.get();
     const LocT *xpos = xposition.get();
 
-    const af::dim4 odims     = output.dims;
-    const af::dim4 idims     = input.dims;
-    const af::dim4 xdims     = xposition.dims;
+    const af::dim4 odims     = output.dims();
+    const af::dim4 idims     = input.dims();
+    const af::dim4 xdims     = xposition.dims();
 
-    const af::dim4 ostrides  = output.strides;
-    const af::dim4 istrides  = input.strides;
-    const af::dim4 xstrides  = xposition.strides;
+    const af::dim4 ostrides  = output.strides();
+    const af::dim4 istrides  = input.strides();
+    const af::dim4 xstrides  = xposition.strides();
 
     Interp1<InT, LocT, order> interp;
     bool batch = !(xdims[1] == 1 && xdims[2] == 1 && xdims[3] == 1);
@@ -76,13 +76,13 @@ void approx2(Param<InT> output, CParam<InT> input,
     const LocT *xpos = xposition.get();
     const LocT *ypos = yposition.get();
 
-    af::dim4 const odims     = output.dims;
-    af::dim4 const idims     = input.dims;
-    af::dim4 const xdims     = xposition.dims;
-    af::dim4 const ostrides  = output.strides;
-    af::dim4 const istrides  = input.strides;
-    af::dim4 const xstrides  = xposition.strides;
-    af::dim4 const ystrides  = yposition.strides;
+    af::dim4 const odims     = output.dims();
+    af::dim4 const idims     = input.dims();
+    af::dim4 const xdims     = xposition.dims();
+    af::dim4 const ostrides  = output.strides();
+    af::dim4 const istrides  = input.strides();
+    af::dim4 const xstrides  = xposition.strides();
+    af::dim4 const ystrides  = yposition.strides();
 
     Interp2<InT, LocT, order> interp;
     bool batch = !(xdims[2] == 1 && xdims[3] == 1);

--- a/src/backend/cpu/kernel/approx.hpp
+++ b/src/backend/cpu/kernel/approx.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <math.hpp>
 #include "interp.hpp"
 
@@ -18,19 +18,19 @@ namespace kernel
 {
 
 template<typename InT, typename LocT, int order>
-void approx1(Array<InT> output, const Array<InT> input,
-             const Array<LocT> xposition, const float offGrid, af_interp_type method)
+void approx1(Param<InT> output, CParam<InT> input,
+             CParam<LocT> xposition, const float offGrid, af_interp_type method)
 {
     InT * out = output.get();
     const LocT *xpos = xposition.get();
 
-    const af::dim4 odims     = output.dims();
-    const af::dim4 idims     = input.dims();
-    const af::dim4 xdims     = xposition.dims();
+    const af::dim4 odims     = output.dims;
+    const af::dim4 idims     = input.dims;
+    const af::dim4 xdims     = xposition.dims;
 
-    const af::dim4 ostrides  = output.strides();
-    const af::dim4 istrides  = input.strides();
-    const af::dim4 xstrides  = xposition.strides();
+    const af::dim4 ostrides  = output.strides;
+    const af::dim4 istrides  = input.strides;
+    const af::dim4 xstrides  = xposition.strides;
 
     Interp1<InT, LocT, order> interp;
     bool batch = !(xdims[1] == 1 && xdims[2] == 1 && xdims[3] == 1);
@@ -68,21 +68,21 @@ void approx1(Array<InT> output, const Array<InT> input,
 }
 
 template<typename InT, typename LocT, int order>
-void approx2(Array<InT> output, const Array<InT> input,
-             const Array<LocT> xposition, const Array<LocT> yposition,
+void approx2(Param<InT> output, CParam<InT> input,
+             CParam<LocT> xposition, CParam<LocT> yposition,
              float const offGrid, af_interp_type method)
 {
     InT * out = output.get();
     const LocT *xpos = xposition.get();
     const LocT *ypos = yposition.get();
 
-    af::dim4 const odims     = output.dims();
-    af::dim4 const idims     = input.dims();
-    af::dim4 const xdims     = xposition.dims();
-    af::dim4 const ostrides  = output.strides();
-    af::dim4 const istrides  = input.strides();
-    af::dim4 const xstrides  = xposition.strides();
-    af::dim4 const ystrides  = yposition.strides();
+    af::dim4 const odims     = output.dims;
+    af::dim4 const idims     = input.dims;
+    af::dim4 const xdims     = xposition.dims;
+    af::dim4 const ostrides  = output.strides;
+    af::dim4 const istrides  = input.strides;
+    af::dim4 const xstrides  = xposition.strides;
+    af::dim4 const ystrides  = yposition.strides;
 
     Interp2<InT, LocT, order> interp;
     bool batch = !(xdims[2] == 1 && xdims[3] == 1);

--- a/src/backend/cpu/kernel/assign.hpp
+++ b/src/backend/cpu/kernel/assign.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 #include <vector>
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 
 namespace cpu
@@ -18,17 +18,17 @@ namespace kernel
 {
 
 template<typename T>
-void assign(Array<T> out, Array<T> const rhs, std::vector<bool> const isSeq,
-            std::vector<af_seq> const seqs, std::vector< Array<uint> > const idxArrs)
+void assign(Param<T> out, af::dim4 dDims,
+            CParam<T> rhs, std::vector<bool> const isSeq,
+            std::vector<af_seq> const seqs, std::vector< CParam<uint> > idxArrs)
 {
-    af::dim4 dDims = out.getDataDims();
-    af::dim4 pDims = out.dims();
+    af::dim4 pDims = out.dims;
     // retrieve dimensions & strides for array to which rhs is being copied to
     af::dim4 dst_offsets = toOffset(seqs, dDims);
     af::dim4 dst_strides = toStride(seqs, dDims);
     // retrieve rhs array dimenesions & strides
-    af::dim4 src_dims    = rhs.dims();
-    af::dim4 src_strides = rhs.strides();
+    af::dim4 src_dims    = rhs.dims;
+    af::dim4 src_strides = rhs.strides;
     // declare pointers to af_array index data
     uint const * const ptr0 = idxArrs[0].get();
     uint const * const ptr1 = idxArrs[1].get();

--- a/src/backend/cpu/kernel/assign.hpp
+++ b/src/backend/cpu/kernel/assign.hpp
@@ -22,13 +22,13 @@ void assign(Param<T> out, af::dim4 dDims,
             CParam<T> rhs, std::vector<bool> const isSeq,
             std::vector<af_seq> const seqs, std::vector< CParam<uint> > idxArrs)
 {
-    af::dim4 pDims = out.dims;
+    af::dim4 pDims = out.dims();
     // retrieve dimensions & strides for array to which rhs is being copied to
     af::dim4 dst_offsets = toOffset(seqs, dDims);
     af::dim4 dst_strides = toStride(seqs, dDims);
     // retrieve rhs array dimenesions & strides
-    af::dim4 src_dims    = rhs.dims;
-    af::dim4 src_strides = rhs.strides;
+    af::dim4 src_dims    = rhs.dims();
+    af::dim4 src_strides = rhs.strides();
     // declare pointers to af_array index data
     uint const * const ptr0 = idxArrs[0].get();
     uint const * const ptr1 = idxArrs[1].get();

--- a/src/backend/cpu/kernel/bilateral.hpp
+++ b/src/backend/cpu/kernel/bilateral.hpp
@@ -20,9 +20,9 @@ namespace kernel
 template<typename OutT, typename InT, bool IsColor>
 void bilateral(Param<OutT> out, CParam<InT> in, float const s_sigma, float const c_sigma)
 {
-    af::dim4 const dims     = in.dims;
-    af::dim4 const istrides = in.strides;
-    af::dim4 const ostrides = out.strides;
+    af::dim4 const dims     = in.dims();
+    af::dim4 const istrides = in.strides();
+    af::dim4 const ostrides = out.strides();
 
     // clamp spatical and chromatic sigma's
     float space_       = std::min(11.5f, std::max(s_sigma, 0.f));

--- a/src/backend/cpu/kernel/bilateral.hpp
+++ b/src/backend/cpu/kernel/bilateral.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 #include <cmath>
 
@@ -18,11 +18,11 @@ namespace kernel
 {
 
 template<typename OutT, typename InT, bool IsColor>
-void bilateral(Array<OutT> out, Array<InT> const in, float const s_sigma, float const c_sigma)
+void bilateral(Param<OutT> out, CParam<InT> in, float const s_sigma, float const c_sigma)
 {
-    af::dim4 const dims     = in.dims();
-    af::dim4 const istrides = in.strides();
-    af::dim4 const ostrides = out.strides();
+    af::dim4 const dims     = in.dims;
+    af::dim4 const istrides = in.strides;
+    af::dim4 const ostrides = out.strides;
 
     // clamp spatical and chromatic sigma's
     float space_       = std::min(11.5f, std::max(s_sigma, 0.f));

--- a/src/backend/cpu/kernel/canny.hpp
+++ b/src/backend/cpu/kernel/canny.hpp
@@ -21,8 +21,8 @@ template<typename T>
 void nonMaxSuppression(Param<T> output, CParam<T> magnitude,
                        CParam<T> dxParam, CParam<T> dyParam)
 {
-    const af::dim4 dims    = magnitude.dims;
-    const af::dim4 strides = magnitude.strides;
+    const af::dim4 dims    = magnitude.dims();
+    const af::dim4 strides = magnitude.strides();
 
           T* out = output.get();
     const T* mag = magnitude.get();
@@ -161,7 +161,7 @@ void traceEdge(T* out, const T* strong, const T* weak, int t, int width)
 template<typename T>
 void edgeTrackingHysteresis(Param<T> out, CParam<T> strong, CParam<T> weak)
 {
-    const af::dim4 dims = strong.dims;
+    const af::dim4 dims = strong.dims();
 
     dim_t t    = dims[0] + 1;   // skip the first coloumn and first element of second coloumn
     dim_t jMax = dims[1] - 1;   // max Y value to traverse, ignore right coloumn

--- a/src/backend/cpu/kernel/canny.hpp
+++ b/src/backend/cpu/kernel/canny.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <cassert>
 #include <list>
 #include <array>
@@ -18,16 +18,16 @@ namespace cpu
 namespace kernel
 {
 template<typename T>
-void nonMaxSuppression(Array<T> output, const Array<T> magnitude,
-                       const Array<T> dxArray, const Array<T> dyArray)
+void nonMaxSuppression(Param<T> output, CParam<T> magnitude,
+                       CParam<T> dxParam, CParam<T> dyParam)
 {
-    const af::dim4 dims    = magnitude.dims();
-    const af::dim4 strides = magnitude.strides();
+    const af::dim4 dims    = magnitude.dims;
+    const af::dim4 strides = magnitude.strides;
 
           T* out = output.get();
     const T* mag = magnitude.get();
-    const T* dX  = dxArray.get();
-    const T* dY  = dyArray.get();
+    const T* dX  = dxParam.get();
+    const T* dY  = dyParam.get();
 
     for(dim_t b3=0; b3<dims[3]; ++b3) {
         for(dim_t b2=0; b2<dims[2]; ++b2) {
@@ -159,9 +159,9 @@ void traceEdge(T* out, const T* strong, const T* weak, int t, int width)
 
 
 template<typename T>
-void edgeTrackingHysteresis(Array<T> out, const Array<T> strong, const Array<T> weak)
+void edgeTrackingHysteresis(Param<T> out, CParam<T> strong, CParam<T> weak)
 {
-    const af::dim4 dims = strong.dims();
+    const af::dim4 dims = strong.dims;
 
     dim_t t    = dims[0] + 1;   // skip the first coloumn and first element of second coloumn
     dim_t jMax = dims[1] - 1;   // max Y value to traverse, ignore right coloumn

--- a/src/backend/cpu/kernel/convolve.hpp
+++ b/src/backend/cpu/kernel/convolve.hpp
@@ -128,13 +128,13 @@ void convolve_nd(Param<InT> out, CParam<InT> signal, CParam<AccT> filter, AF_BAT
     InT const * const iptr = signal.get();
     AccT const * const fptr = filter.get();
 
-    af::dim4 const oDims = out.dims;
-    af::dim4 const sDims = signal.dims;
-    af::dim4 const fDims = filter.dims;
+    af::dim4 const oDims = out.dims();
+    af::dim4 const sDims = signal.dims();
+    af::dim4 const fDims = filter.dims();
 
-    af::dim4 const oStrides = out.strides;
-    af::dim4 const sStrides = signal.strides;
-    af::dim4 const fStrides = filter.strides;
+    af::dim4 const oStrides = out.strides();
+    af::dim4 const sStrides = signal.strides();
+    af::dim4 const fStrides = filter.strides();
 
     dim_t out_step[4]  = {0, 0, 0, 0}; /* first value is never used, and declared for code simplicity */
     dim_t in_step[4]   = {0, 0, 0, 0}; /* first value is never used, and declared for code simplicity */
@@ -227,15 +227,15 @@ void convolve2(Param<InT> out, CParam<InT> signal,
                CParam<AccT> c_filter, CParam<AccT> r_filter,
                Param<InT> temp)
 {
-    dim_t cflen = (dim_t)c_filter.dims.elements();
-    dim_t rflen = (dim_t)r_filter.dims.elements();
+    dim_t cflen = (dim_t)c_filter.dims().elements();
+    dim_t rflen = (dim_t)r_filter.dims().elements();
 
-    auto oDims = out.dims;
-    auto sDims = signal.dims;
+    auto oDims = out.dims();
+    auto sDims = signal.dims();
 
-    auto oStrides = out.strides;
-    auto sStrides = signal.strides;
-    auto tStrides = temp.strides;
+    auto oStrides = out.strides();
+    auto sStrides = signal.strides();
+    auto tStrides = temp.strides();
 
     for (dim_t b3=0; b3<oDims[3]; ++b3) {
 
@@ -250,12 +250,12 @@ void convolve2(Param<InT> out, CParam<InT> signal,
             InT *optr = out.get()  + b2*oStrides[2] + o_b3Off;
 
             convolve2_separable<InT, AccT, 0, Expand>(tptr, iptr, c_filter.get(),
-                    temp.dims, sDims, sDims, cflen,
-                    tStrides, sStrides, c_filter.strides[0]);
+                                                      temp.dims(), sDims, sDims, cflen,
+                                                      tStrides, sStrides, c_filter.strides(0));
 
             convolve2_separable<InT, AccT, 1, Expand>(optr, tptr, r_filter.get(),
-                    oDims, temp.dims, sDims, rflen,
-                    oStrides, tStrides, r_filter.strides[0]);
+                                                      oDims, temp.dims(), sDims, rflen,
+                                                      oStrides, tStrides, r_filter.strides(0));
         }
     }
 }

--- a/src/backend/cpu/kernel/convolve.hpp
+++ b/src/backend/cpu/kernel/convolve.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -122,19 +122,19 @@ void one2one_3d(InT *optr, InT const * const iptr, AccT const * const fptr, af::
 }
 
 template<typename InT, typename AccT, dim_t baseDim, bool Expand>
-void convolve_nd(Array<InT> out, Array<InT> const signal, Array<AccT> const filter, AF_BATCH_KIND kind)
+void convolve_nd(Param<InT> out, CParam<InT> signal, CParam<AccT> filter, AF_BATCH_KIND kind)
 {
     InT * optr = out.get();
     InT const * const iptr = signal.get();
     AccT const * const fptr = filter.get();
 
-    af::dim4 const oDims = out.dims();
-    af::dim4 const sDims = signal.dims();
-    af::dim4 const fDims = filter.dims();
+    af::dim4 const oDims = out.dims;
+    af::dim4 const sDims = signal.dims;
+    af::dim4 const fDims = filter.dims;
 
-    af::dim4 const oStrides = out.strides();
-    af::dim4 const sStrides = signal.strides();
-    af::dim4 const fStrides = filter.strides();
+    af::dim4 const oStrides = out.strides;
+    af::dim4 const sStrides = signal.strides;
+    af::dim4 const fStrides = filter.strides;
 
     dim_t out_step[4]  = {0, 0, 0, 0}; /* first value is never used, and declared for code simplicity */
     dim_t in_step[4]   = {0, 0, 0, 0}; /* first value is never used, and declared for code simplicity */
@@ -223,21 +223,19 @@ void convolve2_separable(InT *optr, InT const * const iptr, AccT const * const f
 }
 
 template<typename InT, typename AccT, bool Expand>
-void convolve2(Array<InT> out, Array<InT> const signal,
-               Array<AccT> const c_filter, Array<AccT> const r_filter,
-               af::dim4 const tDims)
+void convolve2(Param<InT> out, CParam<InT> signal,
+               CParam<AccT> c_filter, CParam<AccT> r_filter,
+               Param<InT> temp)
 {
-    Array<InT> temp = createEmptyArray<InT>(tDims);
+    dim_t cflen = (dim_t)c_filter.dims.elements();
+    dim_t rflen = (dim_t)r_filter.dims.elements();
 
-    dim_t cflen = (dim_t)c_filter.elements();
-    dim_t rflen = (dim_t)r_filter.elements();
+    auto oDims = out.dims;
+    auto sDims = signal.dims;
 
-    auto oDims = out.dims();
-    auto sDims = signal.dims();
-
-    auto oStrides = out.strides();
-    auto sStrides = signal.strides();
-    auto tStrides = temp.strides();
+    auto oStrides = out.strides;
+    auto sStrides = signal.strides;
+    auto tStrides = temp.strides;
 
     for (dim_t b3=0; b3<oDims[3]; ++b3) {
 
@@ -252,12 +250,12 @@ void convolve2(Array<InT> out, Array<InT> const signal,
             InT *optr = out.get()  + b2*oStrides[2] + o_b3Off;
 
             convolve2_separable<InT, AccT, 0, Expand>(tptr, iptr, c_filter.get(),
-                    tDims, sDims, sDims, cflen,
-                    tStrides, sStrides, c_filter.strides()[0]);
+                    temp.dims, sDims, sDims, cflen,
+                    tStrides, sStrides, c_filter.strides[0]);
 
             convolve2_separable<InT, AccT, 1, Expand>(optr, tptr, r_filter.get(),
-                    oDims, tDims, sDims, rflen,
-                    oStrides, tStrides, r_filter.strides()[0]);
+                    oDims, temp.dims, sDims, rflen,
+                    oStrides, tStrides, r_filter.strides[0]);
         }
     }
 }

--- a/src/backend/cpu/kernel/copy.hpp
+++ b/src/backend/cpu/kernel/copy.hpp
@@ -41,10 +41,10 @@ void stridedCopy(T* dst, af::dim4 const & ostrides, T const * src,
 template<typename OutT, typename InT>
 void copyElemwise(Param<OutT> dst, CParam<InT> src, OutT default_value, double factor)
 {
-    af::dim4 src_dims       = src.dims;
-    af::dim4 dst_dims       = dst.dims;
-    af::dim4 src_strides    = src.strides;
-    af::dim4 dst_strides    = dst.strides;
+    af::dim4 src_dims       = src.dims();
+    af::dim4 dst_dims       = dst.dims();
+    af::dim4 src_strides    = src.strides();
+    af::dim4 dst_strides    = dst.strides();
 
     InT const * const src_ptr = src.get();
     OutT * dst_ptr      = dst.get();
@@ -100,10 +100,10 @@ struct CopyImpl<T, T>
 {
     static void copy(Param<T> dst, CParam<T> src)
     {
-        af::dim4 src_dims       = src.dims;
-        af::dim4 dst_dims       = dst.dims;
-        af::dim4 src_strides    = src.strides;
-        af::dim4 dst_strides    = dst.strides;
+        af::dim4 src_dims       = src.dims();
+        af::dim4 dst_dims       = dst.dims();
+        af::dim4 src_strides    = src.strides();
+        af::dim4 dst_strides    = dst.strides();
 
         T const * src_ptr = src.get();
         T * dst_ptr       = dst.get();

--- a/src/backend/cpu/kernel/copy.hpp
+++ b/src/backend/cpu/kernel/copy.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <math.hpp>
 
 namespace cpu
@@ -39,12 +39,12 @@ void stridedCopy(T* dst, af::dim4 const & ostrides, T const * src,
 }
 
 template<typename OutT, typename InT>
-void copyElemwise(Array<OutT> dst, Array<InT> const src, OutT default_value, double factor)
+void copyElemwise(Param<OutT> dst, CParam<InT> src, OutT default_value, double factor)
 {
-    af::dim4 src_dims       = src.dims();
-    af::dim4 dst_dims       = dst.dims();
-    af::dim4 src_strides    = src.strides();
-    af::dim4 dst_strides    = dst.strides();
+    af::dim4 src_dims       = src.dims;
+    af::dim4 dst_dims       = dst.dims;
+    af::dim4 src_strides    = src.strides;
+    af::dim4 dst_strides    = dst.strides;
 
     InT const * const src_ptr = src.get();
     OutT * dst_ptr      = dst.get();
@@ -89,7 +89,7 @@ void copyElemwise(Array<OutT> dst, Array<InT> const src, OutT default_value, dou
 template<typename OutT, typename InT>
 struct CopyImpl
 {
-    static void copy(Array<OutT> dst, Array<InT> const src)
+    static void copy(Param<OutT> dst, CParam<InT> src)
     {
         copyElemwise(dst, src, scalar<OutT>(0), 1.0);
     }
@@ -98,12 +98,12 @@ struct CopyImpl
 template<typename T>
 struct CopyImpl<T, T>
 {
-    static void copy(Array<T> dst, Array<T> const src)
+    static void copy(Param<T> dst, CParam<T> src)
     {
-        af::dim4 src_dims       = src.dims();
-        af::dim4 dst_dims       = dst.dims();
-        af::dim4 src_strides    = src.strides();
-        af::dim4 dst_strides    = dst.strides();
+        af::dim4 src_dims       = src.dims;
+        af::dim4 dst_dims       = dst.dims;
+        af::dim4 src_strides    = src.strides;
+        af::dim4 dst_strides    = dst.strides;
 
         T const * src_ptr = src.get();
         T * dst_ptr       = dst.get();
@@ -153,7 +153,7 @@ struct CopyImpl<T, T>
 };
 
 template<typename OutT, typename InT>
-void copy(Array<OutT> dst, Array<InT> const src)
+void copy(Param<OutT> dst, CParam<InT> src)
 {
     CopyImpl<OutT, InT>::copy(dst, src);
 }

--- a/src/backend/cpu/kernel/diagonal.hpp
+++ b/src/backend/cpu/kernel/diagonal.hpp
@@ -18,8 +18,8 @@ namespace kernel
 template<typename T>
 void diagCreate(Param<T> out, CParam<T> in, int const num)
 {
-    int batch = in.dims[1];
-    int size  = out.dims[0];
+    int batch = in.dims(1);
+    int size  = out.dims(0);
 
     T const * iptr = in.get();
     T * optr = out.get();
@@ -31,31 +31,31 @@ void diagCreate(Param<T> out, CParam<T> in, int const num)
                 if (i == j - num) {
                     val = (num > 0) ? iptr[i] : iptr[j];
                 }
-                optr[i + j * out.strides[1]] = val;
+                optr[i + j * out.strides(1)] = val;
             }
         }
-        optr += out.strides[2];
-        iptr += in.strides[1];
+        optr += out.strides(2);
+        iptr += in.strides(1);
     }
 }
 
 template<typename T>
 void diagExtract(Param<T> out, CParam<T> in, int const num)
 {
-    dim4 const odims = out.dims;
-    dim4 const idims = in.dims;
+    dim4 const odims = out.dims();
+    dim4 const idims = in.dims();
 
-    int const i_off = (num > 0) ? (num * in.strides[1]) : (-num);
+    int const i_off = (num > 0) ? (num * in.strides(1)) : (-num);
 
     for (int l = 0; l < (int)odims[3]; l++) {
 
         for (int k = 0; k < (int)odims[2]; k++) {
-            const T *iptr = in.get() + l * in.strides[3] + k * in.strides[2] + i_off;
-            T *optr = out.get() + l * out.strides[3] + k * out.strides[2];
+            const T *iptr = in.get() + l * in.strides(3) + k * in.strides(2) + i_off;
+            T *optr = out.get() + l * out.strides(3) + k * out.strides(2);
 
             for (int i = 0; i < (int)odims[0]; i++) {
                 T val = scalar<T>(0);
-                if (i < idims[0] && i < idims[1]) val =  iptr[i * in.strides[1] + i];
+                if (i < idims[0] && i < idims[1]) val =  iptr[i * in.strides(1) + i];
                 optr[i] = val;
             }
         }

--- a/src/backend/cpu/kernel/diagonal.hpp
+++ b/src/backend/cpu/kernel/diagonal.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,10 +16,10 @@ namespace kernel
 {
 
 template<typename T>
-void diagCreate(Array<T> out, Array<T> const in, int const num)
+void diagCreate(Param<T> out, CParam<T> in, int const num)
 {
-    int batch = in.dims()[1];
-    int size  = out.dims()[0];
+    int batch = in.dims[1];
+    int size  = out.dims[0];
 
     T const * iptr = in.get();
     T * optr = out.get();
@@ -31,31 +31,31 @@ void diagCreate(Array<T> out, Array<T> const in, int const num)
                 if (i == j - num) {
                     val = (num > 0) ? iptr[i] : iptr[j];
                 }
-                optr[i + j * out.strides()[1]] = val;
+                optr[i + j * out.strides[1]] = val;
             }
         }
-        optr += out.strides()[2];
-        iptr += in.strides()[1];
+        optr += out.strides[2];
+        iptr += in.strides[1];
     }
 }
 
 template<typename T>
-void diagExtract(Array<T> out, Array<T> const in, int const num)
+void diagExtract(Param<T> out, CParam<T> in, int const num)
 {
-    dim4 const odims = out.dims();
-    dim4 const idims = in.dims();
+    dim4 const odims = out.dims;
+    dim4 const idims = in.dims;
 
-    int const i_off = (num > 0) ? (num * in.strides()[1]) : (-num);
+    int const i_off = (num > 0) ? (num * in.strides[1]) : (-num);
 
     for (int l = 0; l < (int)odims[3]; l++) {
 
         for (int k = 0; k < (int)odims[2]; k++) {
-            const T *iptr = in.get() + l * in.strides()[3] + k * in.strides()[2] + i_off;
-            T *optr = out.get() + l * out.strides()[3] + k * out.strides()[2];
+            const T *iptr = in.get() + l * in.strides[3] + k * in.strides[2] + i_off;
+            T *optr = out.get() + l * out.strides[3] + k * out.strides[2];
 
             for (int i = 0; i < (int)odims[0]; i++) {
                 T val = scalar<T>(0);
-                if (i < idims[0] && i < idims[1]) val =  iptr[i * in.strides()[1] + i];
+                if (i < idims[0] && i < idims[1]) val =  iptr[i * in.strides[1] + i];
                 optr[i] = val;
             }
         }

--- a/src/backend/cpu/kernel/diff.hpp
+++ b/src/backend/cpu/kernel/diff.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 
 namespace cpu
@@ -17,9 +17,9 @@ namespace kernel
 {
 
 template<typename T>
-void diff1(Array<T> out, Array<T> const in, int const dim)
+void diff1(Param<T> out, CParam<T> in, int const dim)
 {
-    af::dim4 dims = out.dims();
+    af::dim4 dims = out.dims;
     // Bool for dimension
     bool is_dim0 = dim == 0;
     bool is_dim1 = dim == 1;
@@ -35,11 +35,11 @@ void diff1(Array<T> out, Array<T> const in, int const dim)
             for(dim_t j = 0; j < dims[1]; j++) {
                 for(dim_t i = 0; i < dims[0]; i++) {
                     // Operation: out[index] = in[index + 1 * dim_size] - in[index]
-                    int idx = getIdx(in.strides(), i, j, k, l);
-                    int jdx = getIdx(in.strides(),
+                    int idx = getIdx(in.strides, i, j, k, l);
+                    int jdx = getIdx(in.strides,
                             i + is_dim0, j + is_dim1,
                             k + is_dim2, l + is_dim3);
-                    int odx = getIdx(out.strides(), i, j, k, l);
+                    int odx = getIdx(out.strides, i, j, k, l);
                     outPtr[odx] = inPtr[jdx] - inPtr[idx];
                 }
             }
@@ -48,9 +48,9 @@ void diff1(Array<T> out, Array<T> const in, int const dim)
 }
 
 template<typename T>
-void diff2(Array<T> out, Array<T> const in, int const dim)
+void diff2(Param<T> out, CParam<T> in, int const dim)
 {
-    af::dim4 dims = out.dims();
+    af::dim4 dims = out.dims;
     // Bool for dimension
     bool is_dim0 = dim == 0;
     bool is_dim1 = dim == 1;
@@ -66,14 +66,14 @@ void diff2(Array<T> out, Array<T> const in, int const dim)
             for(dim_t j = 0; j < dims[1]; j++) {
                 for(dim_t i = 0; i < dims[0]; i++) {
                     // Operation: out[index] = in[index + 1 * dim_size] - in[index]
-                    int idx = getIdx(in.strides(), i, j, k, l);
-                    int jdx = getIdx(in.strides(),
+                    int idx = getIdx(in.strides, i, j, k, l);
+                    int jdx = getIdx(in.strides,
                             i + is_dim0, j + is_dim1,
                             k + is_dim2, l + is_dim3);
-                    int kdx = getIdx(in.strides(),
+                    int kdx = getIdx(in.strides,
                             i + 2 * is_dim0, j + 2 * is_dim1,
                             k + 2 * is_dim2, l + 2 * is_dim3);
-                    int odx = getIdx(out.strides(), i, j, k, l);
+                    int odx = getIdx(out.strides, i, j, k, l);
                     outPtr[odx] = inPtr[kdx] + inPtr[idx] - inPtr[jdx] - inPtr[jdx];
                 }
             }

--- a/src/backend/cpu/kernel/diff.hpp
+++ b/src/backend/cpu/kernel/diff.hpp
@@ -19,7 +19,7 @@ namespace kernel
 template<typename T>
 void diff1(Param<T> out, CParam<T> in, int const dim)
 {
-    af::dim4 dims = out.dims;
+    af::dim4 dims = out.dims();
     // Bool for dimension
     bool is_dim0 = dim == 0;
     bool is_dim1 = dim == 1;
@@ -35,11 +35,11 @@ void diff1(Param<T> out, CParam<T> in, int const dim)
             for(dim_t j = 0; j < dims[1]; j++) {
                 for(dim_t i = 0; i < dims[0]; i++) {
                     // Operation: out[index] = in[index + 1 * dim_size] - in[index]
-                    int idx = getIdx(in.strides, i, j, k, l);
-                    int jdx = getIdx(in.strides,
+                    int idx = getIdx(in.strides(), i, j, k, l);
+                    int jdx = getIdx(in.strides(),
                             i + is_dim0, j + is_dim1,
                             k + is_dim2, l + is_dim3);
-                    int odx = getIdx(out.strides, i, j, k, l);
+                    int odx = getIdx(out.strides(), i, j, k, l);
                     outPtr[odx] = inPtr[jdx] - inPtr[idx];
                 }
             }
@@ -50,7 +50,7 @@ void diff1(Param<T> out, CParam<T> in, int const dim)
 template<typename T>
 void diff2(Param<T> out, CParam<T> in, int const dim)
 {
-    af::dim4 dims = out.dims;
+    af::dim4 dims = out.dims();
     // Bool for dimension
     bool is_dim0 = dim == 0;
     bool is_dim1 = dim == 1;
@@ -66,14 +66,14 @@ void diff2(Param<T> out, CParam<T> in, int const dim)
             for(dim_t j = 0; j < dims[1]; j++) {
                 for(dim_t i = 0; i < dims[0]; i++) {
                     // Operation: out[index] = in[index + 1 * dim_size] - in[index]
-                    int idx = getIdx(in.strides, i, j, k, l);
-                    int jdx = getIdx(in.strides,
+                    int idx = getIdx(in.strides(), i, j, k, l);
+                    int jdx = getIdx(in.strides(),
                             i + is_dim0, j + is_dim1,
                             k + is_dim2, l + is_dim3);
-                    int kdx = getIdx(in.strides,
+                    int kdx = getIdx(in.strides(),
                             i + 2 * is_dim0, j + 2 * is_dim1,
                             k + 2 * is_dim2, l + 2 * is_dim3);
-                    int odx = getIdx(out.strides, i, j, k, l);
+                    int odx = getIdx(out.strides(), i, j, k, l);
                     outPtr[odx] = inPtr[kdx] + inPtr[idx] - inPtr[jdx] - inPtr[jdx];
                 }
             }

--- a/src/backend/cpu/kernel/dot.hpp
+++ b/src/backend/cpu/kernel/dot.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <complex>
 
 namespace cpu
@@ -23,10 +23,10 @@ template<> cfloat  conj<cfloat> (cfloat  c) { return std::conj(c); }
 template<> cdouble conj<cdouble>(cdouble c) { return std::conj(c); }
 
 template<typename T, bool conjugate, bool both_conjugate>
-void dot(Array<T> output, const Array<T> lhs, const Array<T> rhs,
+void dot(Param<T> output, CParam<T> lhs, CParam<T> rhs,
          af_mat_prop optLhs, af_mat_prop optRhs)
 {
-    int N = lhs.dims()[0];
+    int N = lhs.dims[0];
 
     T out = 0;
     const T *pL = lhs.get();

--- a/src/backend/cpu/kernel/dot.hpp
+++ b/src/backend/cpu/kernel/dot.hpp
@@ -26,7 +26,7 @@ template<typename T, bool conjugate, bool both_conjugate>
 void dot(Param<T> output, CParam<T> lhs, CParam<T> rhs,
          af_mat_prop optLhs, af_mat_prop optRhs)
 {
-    int N = lhs.dims[0];
+    int N = lhs.dims(0);
 
     T out = 0;
     const T *pL = lhs.get();

--- a/src/backend/cpu/kernel/exampleFunction.hpp
+++ b/src/backend/cpu/kernel/exampleFunction.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 
 namespace cpu
@@ -17,18 +17,18 @@ namespace kernel
 {
 
 template<typename T>
-void exampleFunction(Array<T> out, Array<T> const a, Array<T> const b, const af_someenum_t method)
+void exampleFunction(Param<T> out, CParam<T> a, CParam<T> b, const af_someenum_t method)
 {
-    dim4 oDims    = out.dims();
+    dim4 oDims    = out.dims;
 
-    dim4 aStrides = a.strides();        // you can retrieve strides
-    dim4 bStrides = b.strides();
-    dim4 oStrides = out.strides();
+    dim4 aStrides = a.strides;        // you can retrieve strides
+    dim4 bStrides = b.strides;
+    dim4 oStrides = out.strides;
 
-    const T* src1 = a.get();            // cpu::Array<T>::get returns the pointer to the
-                                        // memory allocated for that Array (with proper offsets)
-    const T* src2 = b.get();            // cpu::Array<T>::get returns the pointer to the
-                                        // memory allocated for that Array (with proper offsets)
+    const T* src1 = a.get();            // cpu::Param<T>::get returns the pointer to the
+                                        // memory allocated for that Param (with proper offsets)
+    const T* src2 = b.get();            // cpu::Param<T>::get returns the pointer to the
+                                        // memory allocated for that Param (with proper offsets)
     T* dst = out.get();
 
     // Implement your algorithm and write results to dst

--- a/src/backend/cpu/kernel/exampleFunction.hpp
+++ b/src/backend/cpu/kernel/exampleFunction.hpp
@@ -19,11 +19,11 @@ namespace kernel
 template<typename T>
 void exampleFunction(Param<T> out, CParam<T> a, CParam<T> b, const af_someenum_t method)
 {
-    dim4 oDims    = out.dims;
+    dim4 oDims    = out.dims();
 
-    dim4 aStrides = a.strides;        // you can retrieve strides
-    dim4 bStrides = b.strides;
-    dim4 oStrides = out.strides;
+    dim4 aStrides = a.strides();        // you can retrieve strides
+    dim4 bStrides = b.strides();
+    dim4 oStrides = out.strides();
 
     const T* src1 = a.get();            // cpu::Param<T>::get returns the pointer to the
                                         // memory allocated for that Param (with proper offsets)

--- a/src/backend/cpu/kernel/fast.hpp
+++ b/src/backend/cpu/kernel/fast.hpp
@@ -87,7 +87,7 @@ void locate_features(CParam<T> in, Param<float> score,
                      unsigned const arc_length, unsigned const nonmax,
                      unsigned const max_feat, unsigned const edge)
 {
-    af::dim4 in_dims = in.dims;
+    af::dim4 in_dims = in.dims();
     T const * in_ptr = in.get();
 
     for (int y = edge; y < (int)(in_dims[0] - edge); y++) {
@@ -182,7 +182,7 @@ void non_maximal(CParam<float> score, CParam<float> x_in, CParam<float> y_in,
     float const * x_in_ptr = x_in.get();
     float const * y_in_ptr = y_in.get();
 
-    af::dim4 score_dims = score.dims;
+    af::dim4 score_dims = score.dims();
 
     for (unsigned k = 0; k < total_feat; k++) {
         unsigned x = static_cast<unsigned>(round(x_in_ptr[k]));

--- a/src/backend/cpu/kernel/fast.hpp
+++ b/src/backend/cpu/kernel/fast.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 
 namespace cpu
@@ -81,13 +81,13 @@ inline double abs_diff(double x, double y)
 }
 
 template<typename T>
-void locate_features(Array<T> const & in, Array<float> & score,
-                     Array<float> & x_out, Array<float> & y_out,
-                     Array<float> & score_out, unsigned* count, float const thr,
+void locate_features(CParam<T> in, Param<float> score,
+                     Param<float> x_out, Param<float> y_out,
+                     Param<float> score_out, unsigned* count, float const thr,
                      unsigned const arc_length, unsigned const nonmax,
                      unsigned const max_feat, unsigned const edge)
 {
-    af::dim4 in_dims = in.dims();
+    af::dim4 in_dims = in.dims;
     T const * in_ptr = in.get();
 
     for (int y = edge; y < (int)(in_dims[0] - edge); y++) {
@@ -174,15 +174,15 @@ void locate_features(Array<T> const & in, Array<float> & score,
     }
 }
 
-void non_maximal(Array<float> const & score, const Array<float> & x_in, const Array<float> & y_in,
-                 Array<float> & x_out, Array<float> & y_out, Array<float> & score_out,
+void non_maximal(CParam<float> score, CParam<float> x_in, CParam<float> y_in,
+                 Param<float> x_out, Param<float> y_out, Param<float> score_out,
                  unsigned* count, unsigned const total_feat, unsigned const edge)
 {
     float const * score_ptr = score.get();
     float const * x_in_ptr = x_in.get();
     float const * y_in_ptr = y_in.get();
 
-    af::dim4 score_dims = score.dims();
+    af::dim4 score_dims = score.dims;
 
     for (unsigned k = 0; k < total_feat; k++) {
         unsigned x = static_cast<unsigned>(round(x_in_ptr[k]));

--- a/src/backend/cpu/kernel/fft.hpp
+++ b/src/backend/cpu/kernel/fft.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <fftw3.h>
 
 namespace cpu
@@ -70,17 +70,17 @@ TRANSFORM_REAL(fftw , double, cdouble, c2r)
 
 
 template<typename T, int rank, bool direction>
-void fft_inplace(Array<T> in)
+void fft_inplace(Param<T> in, const af::dim4 iDataDims)
 {
     int t_dims[rank];
     int in_embed[rank];
 
-    const af::dim4 idims = in.dims();
+    const af::dim4 idims = in.dims;
 
     computeDims<rank>(t_dims  , idims);
-    computeDims<rank>(in_embed , in.getDataDims());
+    computeDims<rank>(in_embed , iDataDims);
 
-    const af::dim4 istrides = in.strides();
+    const af::dim4 istrides = in.strides;
 
     typedef typename fftw_transform<T>::ctype_t ctype_t;
     typename fftw_transform<T>::plan_t plan;
@@ -109,20 +109,20 @@ void fft_inplace(Array<T> in)
 }
 
 template<typename Tc, typename Tr, int rank>
-void fft_r2c(Array<Tc> out, const Array<Tr> in)
+void fft_r2c(Param<Tc> out, const af::dim4 oDataDims, CParam<Tr> in, const af::dim4 iDataDims)
 {
-    af::dim4 idims = in.dims();
+    af::dim4 idims = in.dims;
 
     int t_dims[rank];
     int in_embed[rank];
     int out_embed[rank];
 
     computeDims<rank>(t_dims  , idims);
-    computeDims<rank>(in_embed , in.getDataDims());
-    computeDims<rank>(out_embed , out.getDataDims());
+    computeDims<rank>(in_embed , iDataDims);
+    computeDims<rank>(out_embed , oDataDims);
 
-    const af::dim4 istrides = in.strides();
-    const af::dim4 ostrides = out.strides();
+    const af::dim4 istrides = in.strides;
+    const af::dim4 ostrides = out.strides;
 
     typedef typename fftw_real_transform<Tc, Tr>::ctype_t ctype_t;
     typename fftw_real_transform<Tc, Tr>::plan_t plan;
@@ -150,18 +150,20 @@ void fft_r2c(Array<Tc> out, const Array<Tr> in)
 }
 
 template<typename Tr, typename Tc, int rank>
-void fft_c2r(Array<Tr> out, const Array<Tc> in, const af::dim4 odims)
+void fft_c2r(Param<Tr> out, const af::dim4 oDataDims,
+             CParam<Tc> in, const af::dim4 iDataDims,
+             const af::dim4 odims)
 {
     int t_dims[rank];
     int in_embed[rank];
     int out_embed[rank];
 
     computeDims<rank>(t_dims  , odims);
-    computeDims<rank>(in_embed , in.getDataDims());
-    computeDims<rank>(out_embed , out.getDataDims());
+    computeDims<rank>(in_embed , iDataDims);
+    computeDims<rank>(out_embed , oDataDims);
 
-    const af::dim4 istrides = in.strides();
-    const af::dim4 ostrides = out.strides();
+    const af::dim4 istrides = in.strides;
+    const af::dim4 ostrides = out.strides;
 
     typedef typename fftw_real_transform<Tr, Tc>::ctype_t ctype_t;
     typename fftw_real_transform<Tr, Tc>::plan_t plan;

--- a/src/backend/cpu/kernel/fft.hpp
+++ b/src/backend/cpu/kernel/fft.hpp
@@ -75,12 +75,12 @@ void fft_inplace(Param<T> in, const af::dim4 iDataDims)
     int t_dims[rank];
     int in_embed[rank];
 
-    const af::dim4 idims = in.dims;
+    const af::dim4 idims = in.dims();
 
     computeDims<rank>(t_dims  , idims);
     computeDims<rank>(in_embed , iDataDims);
 
-    const af::dim4 istrides = in.strides;
+    const af::dim4 istrides = in.strides();
 
     typedef typename fftw_transform<T>::ctype_t ctype_t;
     typename fftw_transform<T>::plan_t plan;
@@ -111,7 +111,7 @@ void fft_inplace(Param<T> in, const af::dim4 iDataDims)
 template<typename Tc, typename Tr, int rank>
 void fft_r2c(Param<Tc> out, const af::dim4 oDataDims, CParam<Tr> in, const af::dim4 iDataDims)
 {
-    af::dim4 idims = in.dims;
+    af::dim4 idims = in.dims();
 
     int t_dims[rank];
     int in_embed[rank];
@@ -121,8 +121,8 @@ void fft_r2c(Param<Tc> out, const af::dim4 oDataDims, CParam<Tr> in, const af::d
     computeDims<rank>(in_embed , iDataDims);
     computeDims<rank>(out_embed , oDataDims);
 
-    const af::dim4 istrides = in.strides;
-    const af::dim4 ostrides = out.strides;
+    const af::dim4 istrides = in.strides();
+    const af::dim4 ostrides = out.strides();
 
     typedef typename fftw_real_transform<Tc, Tr>::ctype_t ctype_t;
     typename fftw_real_transform<Tc, Tr>::plan_t plan;
@@ -162,8 +162,8 @@ void fft_c2r(Param<Tr> out, const af::dim4 oDataDims,
     computeDims<rank>(in_embed , iDataDims);
     computeDims<rank>(out_embed , oDataDims);
 
-    const af::dim4 istrides = in.strides;
-    const af::dim4 ostrides = out.strides;
+    const af::dim4 istrides = in.strides();
+    const af::dim4 ostrides = out.strides();
 
     typedef typename fftw_real_transform<Tr, Tc>::ctype_t ctype_t;
     typename fftw_real_transform<Tr, Tc>::plan_t plan;

--- a/src/backend/cpu/kernel/fftconvolve.hpp
+++ b/src/backend/cpu/kernel/fftconvolve.hpp
@@ -20,8 +20,8 @@ void packData(Param<To> out, const af::dim4 od, const af::dim4 os, CParam<Ti> in
 {
     To* out_ptr = out.get();
 
-    const af::dim4 id = in.dims;
-    const af::dim4 is = in.strides;
+    const af::dim4 id = in.dims();
+    const af::dim4 is = in.strides();
     const Ti* in_ptr = in.get();
 
     int id0_half = divup(id[0], 2);
@@ -57,8 +57,8 @@ void padArray(Param<To> out, const af::dim4 od, const af::dim4 os,
               CParam<Ti> in, const dim_t offset)
 {
     To* out_ptr = out.get() + offset;
-    const af::dim4 id = in.dims;
-    const af::dim4 is = in.strides;
+    const af::dim4 id = in.dims();
+    const af::dim4 is = in.strides();
     const Ti* in_ptr = in.get();
 
     for (int d3 = 0; d3 < (int)od[3]; d3++) {
@@ -220,10 +220,10 @@ void reorder(Param<T> out, Param<convT> packed,
              bool expand, AF_BATCH_KIND kind)
 {
     T* out_ptr = out.get();
-    const af::dim4 out_dims = out.dims;
-    const af::dim4 out_strides = out.strides;
+    const af::dim4 out_dims = out.dims();
+    const af::dim4 out_strides = out.strides();
 
-    const af::dim4 filter_dims = filter.dims;
+    const af::dim4 filter_dims = filter.dims();
 
     convT* packed_ptr = packed.get();
     convT* sig_tmp_ptr    = packed_ptr;

--- a/src/backend/cpu/kernel/fftconvolve.hpp
+++ b/src/backend/cpu/kernel/fftconvolve.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,12 +16,12 @@ namespace kernel
 {
 
 template<typename To, typename Ti>
-void packData(Array<To> out, const af::dim4 od, const af::dim4 os, Array<Ti> const in)
+void packData(Param<To> out, const af::dim4 od, const af::dim4 os, CParam<Ti> in)
 {
     To* out_ptr = out.get();
 
-    const af::dim4 id = in.dims();
-    const af::dim4 is = in.strides();
+    const af::dim4 id = in.dims;
+    const af::dim4 is = in.strides;
     const Ti* in_ptr = in.get();
 
     int id0_half = divup(id[0], 2);
@@ -53,12 +53,12 @@ void packData(Array<To> out, const af::dim4 od, const af::dim4 os, Array<Ti> con
 }
 
 template<typename To, typename Ti>
-void padArray(Array<To> out, const af::dim4 od, const af::dim4 os,
-              Array<Ti> const in, const dim_t offset)
+void padArray(Param<To> out, const af::dim4 od, const af::dim4 os,
+              CParam<Ti> in, const dim_t offset)
 {
     To* out_ptr = out.get() + offset;
-    const af::dim4 id = in.dims();
-    const af::dim4 is = in.strides();
+    const af::dim4 id = in.dims;
+    const af::dim4 is = in.strides;
     const Ti* in_ptr = in.get();
 
     for (int d3 = 0; d3 < (int)od[3]; d3++) {
@@ -85,7 +85,7 @@ void padArray(Array<To> out, const af::dim4 od, const af::dim4 os,
 }
 
 template<typename T>
-void complexMultiply(Array<T> packed, const af::dim4 sig_dims, const af::dim4 sig_strides,
+void complexMultiply(Param<T> packed, const af::dim4 sig_dims, const af::dim4 sig_strides,
                      const af::dim4 fit_dims, const af::dim4 fit_strides,
                      AF_BATCH_KIND kind, const dim_t offset)
 {
@@ -213,17 +213,17 @@ void reorderHelper(To* out_ptr, const af::dim4& od, const af::dim4& os,
 }
 
 template<typename T, typename convT, bool roundOut, int baseDim>
-void reorder(Array<T> out, Array<convT> packed,
-             const Array<T> filter, const dim_t sig_half_d0, const dim_t fftScale,
+void reorder(Param<T> out, Param<convT> packed,
+             CParam<T> filter, const dim_t sig_half_d0, const dim_t fftScale,
              const dim4 sig_tmp_dims, const dim4 sig_tmp_strides,
              const dim4 filter_tmp_dims, const dim4 filter_tmp_strides,
              bool expand, AF_BATCH_KIND kind)
 {
     T* out_ptr = out.get();
-    const af::dim4 out_dims = out.dims();
-    const af::dim4 out_strides = out.strides();
+    const af::dim4 out_dims = out.dims;
+    const af::dim4 out_strides = out.strides;
 
-    const af::dim4 filter_dims = filter.dims();
+    const af::dim4 filter_dims = filter.dims;
 
     convT* packed_ptr = packed.get();
     convT* sig_tmp_ptr    = packed_ptr;

--- a/src/backend/cpu/kernel/gradient.hpp
+++ b/src/backend/cpu/kernel/gradient.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,17 +16,17 @@ namespace kernel
 {
 
 template<typename T>
-void gradient(Array<T> grad0, Array<T> grad1, Array<T> const in)
+void gradient(Param<T> grad0, Param<T> grad1, CParam<T> in)
 {
-    const af::dim4 dims = in.dims();
+    const af::dim4 dims = in.dims;
 
     T *d_grad0    = grad0.get();
     T *d_grad1    = grad1.get();
     const T *d_in = in.get();
 
-    const af::dim4 inst = in.strides();
-    const af::dim4 g0st = grad0.strides();
-    const af::dim4 g1st = grad1.strides();
+    const af::dim4 inst = in.strides;
+    const af::dim4 g0st = grad0.strides;
+    const af::dim4 g1st = grad1.strides;
 
     T v5 = scalar<T>(0.5);
     T v1 = scalar<T>(1.0);

--- a/src/backend/cpu/kernel/gradient.hpp
+++ b/src/backend/cpu/kernel/gradient.hpp
@@ -18,15 +18,15 @@ namespace kernel
 template<typename T>
 void gradient(Param<T> grad0, Param<T> grad1, CParam<T> in)
 {
-    const af::dim4 dims = in.dims;
+    const af::dim4 dims = in.dims();
 
     T *d_grad0    = grad0.get();
     T *d_grad1    = grad1.get();
     const T *d_in = in.get();
 
-    const af::dim4 inst = in.strides;
-    const af::dim4 g0st = grad0.strides;
-    const af::dim4 g1st = grad1.strides;
+    const af::dim4 inst = in.strides();
+    const af::dim4 g0st = grad0.strides();
+    const af::dim4 g1st = grad1.strides();
 
     T v5 = scalar<T>(0.5);
     T v1 = scalar<T>(1.0);

--- a/src/backend/cpu/kernel/harris.hpp
+++ b/src/backend/cpu/kernel/harris.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 
 namespace cpu
@@ -17,8 +17,8 @@ namespace kernel
 {
 
 template<typename T>
-void second_order_deriv(Array<T> ixx, Array<T> ixy, Array<T> iyy,
-                        const unsigned in_len, const Array<T> ix, const Array<T> iy)
+void second_order_deriv(Param<T> ixx, Param<T> ixy, Param<T> iyy,
+                        const unsigned in_len, CParam<T> ix, CParam<T> iy)
 {
     T* ixx_out     = ixx.get();
     T* ixy_out     = ixy.get();
@@ -33,8 +33,8 @@ void second_order_deriv(Array<T> ixx, Array<T> ixy, Array<T> iyy,
 }
 
 template<typename T>
-void harris_responses(Array<T> resp, const unsigned idim0, const unsigned idim1,
-                      const Array<T> ixx, const Array<T> ixy, const Array<T> iyy,
+void harris_responses(Param<T> resp, const unsigned idim0, const unsigned idim1,
+                      CParam<T> ixx, CParam<T> ixy, CParam<T> iyy,
                       const float k_thr, const unsigned border_len)
 {
     T* resp_out      = resp.get();
@@ -58,8 +58,8 @@ void harris_responses(Array<T> resp, const unsigned idim0, const unsigned idim1,
 }
 
 template<typename T>
-void non_maximal(Array<float> xOut, Array<float> yOut, Array<float> respOut, unsigned* count,
-                 const unsigned idim0, const unsigned idim1, const Array<T> respIn,
+void non_maximal(Param<float> xOut, Param<float> yOut, Param<float> respOut, unsigned* count,
+                 const unsigned idim0, const unsigned idim1, CParam<T> respIn,
                  const float min_resp, const unsigned border_len, const unsigned max_corners)
 {
     float* x_out = xOut.get();
@@ -98,9 +98,9 @@ void non_maximal(Array<float> xOut, Array<float> yOut, Array<float> respOut, uns
     }
 }
 
-static void keep_corners(Array<float> xOut, Array<float> yOut, Array<float> respOut,
-                         const Array<float> xIn, const Array<float> yIn,
-                         const Array<float> respIn, const Array<unsigned> respIdx,
+static void keep_corners(Param<float> xOut, Param<float> yOut, Param<float> respOut,
+                         CParam<float> xIn, CParam<float> yIn,
+                         CParam<float> respIn, CParam<unsigned> respIdx,
                          const unsigned n_corners)
 {
     float* x_out = xOut.get();

--- a/src/backend/cpu/kernel/histogram.hpp
+++ b/src/backend/cpu/kernel/histogram.hpp
@@ -19,11 +19,11 @@ template<typename OutT, typename InT, bool IsLinear>
 void histogram(Param<OutT> out, CParam<InT> in,
                unsigned const nbins, double const minval, double const maxval)
 {
-    dim4 const outDims   = out.dims;
+    dim4 const outDims   = out.dims();
     float const step     = (maxval - minval)/(float)nbins;
-    dim4 const inDims    = in.dims;
-    dim4 const iStrides  = in.strides;
-    dim4 const oStrides  = out.strides;
+    dim4 const inDims    = in.dims();
+    dim4 const iStrides  = in.strides();
+    dim4 const oStrides  = out.strides();
     dim_t const nElems   = inDims[0]*inDims[1];
 
 

--- a/src/backend/cpu/kernel/histogram.hpp
+++ b/src/backend/cpu/kernel/histogram.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,14 +16,14 @@ namespace kernel
 {
 
 template<typename OutT, typename InT, bool IsLinear>
-void histogram(Array<OutT> out, Array<InT> const in,
+void histogram(Param<OutT> out, CParam<InT> in,
                unsigned const nbins, double const minval, double const maxval)
 {
-    dim4 const outDims   = out.dims();
+    dim4 const outDims   = out.dims;
     float const step     = (maxval - minval)/(float)nbins;
-    dim4 const inDims    = in.dims();
-    dim4 const iStrides  = in.strides();
-    dim4 const oStrides  = out.strides();
+    dim4 const inDims    = in.dims;
+    dim4 const iStrides  = in.strides;
+    dim4 const oStrides  = out.strides;
     dim_t const nElems   = inDims[0]*inDims[1];
 
 

--- a/src/backend/cpu/kernel/hsv_rgb.hpp
+++ b/src/backend/cpu/kernel/hsv_rgb.hpp
@@ -8,7 +8,7 @@
 ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <cmath>
 
 namespace cpu
@@ -17,11 +17,11 @@ namespace kernel
 {
 
 template<typename T>
-void hsv2rgb(Array<T> out, Array<T> const in)
+void hsv2rgb(Param<T> out, CParam<T> in)
 {
-    const af::dim4 dims    = in.dims();
-    const af::dim4 strides = in.strides();
-    dim_t obStride  = out.strides()[3];
+    const af::dim4 dims    = in.dims;
+    const af::dim4 strides = in.strides;
+    dim_t obStride  = out.strides[3];
     dim_t coff      = strides[2];
     dim_t bCount    = dims[3];
 
@@ -69,11 +69,11 @@ void hsv2rgb(Array<T> out, Array<T> const in)
 }
 
 template<typename T>
-void rgb2hsv(Array<T> out, Array<T> const in)
+void rgb2hsv(Param<T> out, CParam<T> in)
 {
-    const af::dim4 dims    = in.dims();
-    const af::dim4 strides = in.strides();
-    af::dim4 oStrides      = out.strides();
+    const af::dim4 dims    = in.dims;
+    const af::dim4 strides = in.strides;
+    af::dim4 oStrides      = out.strides;
     dim_t bCount    = dims[3];
 
     for(dim_t b=0; b<bCount; ++b) {

--- a/src/backend/cpu/kernel/hsv_rgb.hpp
+++ b/src/backend/cpu/kernel/hsv_rgb.hpp
@@ -19,9 +19,9 @@ namespace kernel
 template<typename T>
 void hsv2rgb(Param<T> out, CParam<T> in)
 {
-    const af::dim4 dims    = in.dims;
-    const af::dim4 strides = in.strides;
-    dim_t obStride  = out.strides[3];
+    const af::dim4 dims    = in.dims();
+    const af::dim4 strides = in.strides();
+    dim_t obStride  = out.strides(3);
     dim_t coff      = strides[2];
     dim_t bCount    = dims[3];
 
@@ -71,9 +71,9 @@ void hsv2rgb(Param<T> out, CParam<T> in)
 template<typename T>
 void rgb2hsv(Param<T> out, CParam<T> in)
 {
-    const af::dim4 dims    = in.dims;
-    const af::dim4 strides = in.strides;
-    af::dim4 oStrides      = out.strides;
+    const af::dim4 dims    = in.dims();
+    const af::dim4 strides = in.strides();
+    af::dim4 oStrides      = out.strides();
     dim_t bCount    = dims[3];
 
     for(dim_t b=0; b<bCount; ++b) {

--- a/src/backend/cpu/kernel/identity.hpp
+++ b/src/backend/cpu/kernel/identity.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <math.hpp>
 
 namespace cpu
@@ -17,10 +17,10 @@ namespace kernel
 {
 
 template<typename T>
-void identity(Array<T> out)
+void identity(Param<T> out)
 {
     T *ptr = out.get();
-    const af::dim4 out_dims  = out.dims();
+    const af::dim4 out_dims  = out.dims;
 
     for (dim_t k = 0; k < out_dims[2] * out_dims[3]; k++) {
         for (dim_t j = 0; j < out_dims[1]; j++) {

--- a/src/backend/cpu/kernel/identity.hpp
+++ b/src/backend/cpu/kernel/identity.hpp
@@ -20,7 +20,7 @@ template<typename T>
 void identity(Param<T> out)
 {
     T *ptr = out.get();
-    const af::dim4 out_dims  = out.dims;
+    const af::dim4 out_dims  = out.dims();
 
     for (dim_t k = 0; k < out_dims[2] * out_dims[3]; k++) {
         for (dim_t j = 0; j < out_dims[1]; j++) {

--- a/src/backend/cpu/kernel/iir.hpp
+++ b/src/backend/cpu/kernel/iir.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,31 +16,31 @@ namespace kernel
 {
 
 template<typename T>
-void iir(Array<T> y, Array<T> c, Array<T> const a)
+void iir(Param<T> y, Param<T> c, CParam<T> a)
 {
-    dim4 ydims = c.dims();
-    int num_a = a.dims()[0];
+    dim4 ydims = c.dims;
+    int num_a = a.dims[0];
 
     for (int l = 0; l < (int)ydims[3]; l++) {
-        dim_t yidx3 = l * y.strides()[3];
-        dim_t cidx3 = l * c.strides()[3];
-        dim_t aidx3 = l * a.strides()[3];
+        dim_t yidx3 = l * y.strides[3];
+        dim_t cidx3 = l * c.strides[3];
+        dim_t aidx3 = l * a.strides[3];
 
         for (int k = 0; k < (int)ydims[2]; k++) {
 
-            dim_t yidx2 = k * y.strides()[2] + yidx3;
-            dim_t cidx2 = k * c.strides()[2] + cidx3;
-            dim_t aidx2 = k * a.strides()[2] + aidx3;
+            dim_t yidx2 = k * y.strides[2] + yidx3;
+            dim_t cidx2 = k * c.strides[2] + cidx3;
+            dim_t aidx2 = k * a.strides[2] + aidx3;
 
             for (int j = 0; j < (int)ydims[1]; j++) {
 
-                dim_t yidx1 = j * y.strides()[1] + yidx2;
-                dim_t cidx1 = j * c.strides()[1] + cidx2;
-                dim_t aidx1 = j * a.strides()[1] + aidx2;
+                dim_t yidx1 = j * y.strides[1] + yidx2;
+                dim_t cidx1 = j * c.strides[1] + cidx2;
+                dim_t aidx1 = j * a.strides[1] + aidx2;
 
                 std::vector<T> h_z(num_a);
 
-                const T *h_a = a.get() + (a.ndims() > 1 ? aidx1 : 0);
+                const T *h_a = a.get() + (a.dims.ndims() > 1 ? aidx1 : 0);
                 T *h_c = c.get() + cidx1;
                 T *h_y = y.get() + yidx1;
 

--- a/src/backend/cpu/kernel/iir.hpp
+++ b/src/backend/cpu/kernel/iir.hpp
@@ -18,29 +18,29 @@ namespace kernel
 template<typename T>
 void iir(Param<T> y, Param<T> c, CParam<T> a)
 {
-    dim4 ydims = c.dims;
-    int num_a = a.dims[0];
+    dim4 ydims = c.dims();
+    int num_a = a.dims(0);
 
     for (int l = 0; l < (int)ydims[3]; l++) {
-        dim_t yidx3 = l * y.strides[3];
-        dim_t cidx3 = l * c.strides[3];
-        dim_t aidx3 = l * a.strides[3];
+        dim_t yidx3 = l * y.strides(3);
+        dim_t cidx3 = l * c.strides(3);
+        dim_t aidx3 = l * a.strides(3);
 
         for (int k = 0; k < (int)ydims[2]; k++) {
 
-            dim_t yidx2 = k * y.strides[2] + yidx3;
-            dim_t cidx2 = k * c.strides[2] + cidx3;
-            dim_t aidx2 = k * a.strides[2] + aidx3;
+            dim_t yidx2 = k * y.strides(2) + yidx3;
+            dim_t cidx2 = k * c.strides(2) + cidx3;
+            dim_t aidx2 = k * a.strides(2) + aidx3;
 
             for (int j = 0; j < (int)ydims[1]; j++) {
 
-                dim_t yidx1 = j * y.strides[1] + yidx2;
-                dim_t cidx1 = j * c.strides[1] + cidx2;
-                dim_t aidx1 = j * a.strides[1] + aidx2;
+                dim_t yidx1 = j * y.strides(1) + yidx2;
+                dim_t cidx1 = j * c.strides(1) + cidx2;
+                dim_t aidx1 = j * a.strides(1) + aidx2;
 
                 std::vector<T> h_z(num_a);
 
-                const T *h_a = a.get() + (a.dims.ndims() > 1 ? aidx1 : 0);
+                const T *h_a = a.get() + (a.dims().ndims() > 1 ? aidx1 : 0);
                 T *h_c = c.get() + cidx1;
                 T *h_y = y.get() + yidx1;
 

--- a/src/backend/cpu/kernel/index.hpp
+++ b/src/backend/cpu/kernel/index.hpp
@@ -22,11 +22,11 @@ void index(Param<T> out, CParam<T> in, const af::dim4 dDims,
            std::vector<bool> const isSeq, std::vector<af_seq> const seqs,
            std::vector<CParam<uint>> idxArrs)
 {
-    const af::dim4 iDims    = in.dims;
+    const af::dim4 iDims    = in.dims();
     const af::dim4 iOffs    = toOffset(seqs, dDims);
     const af::dim4 iStrds   = toStride(seqs, dDims);
-    const af::dim4 oDims    = out.dims;
-    const af::dim4 oStrides = out.strides;
+    const af::dim4 oDims    = out.dims();
+    const af::dim4 oStrides = out.strides();
     const T *src        = in.get();
     T *dst        = out.get();
     const uint* ptr0    = idxArrs[0].get();

--- a/src/backend/cpu/kernel/index.hpp
+++ b/src/backend/cpu/kernel/index.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 #include <vector>
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 
 namespace cpu
@@ -18,16 +18,15 @@ namespace kernel
 {
 
 template<typename T>
-void index(Array<T> out, Array<T> const in,
+void index(Param<T> out, CParam<T> in, const af::dim4 dDims,
            std::vector<bool> const isSeq, std::vector<af_seq> const seqs,
-           std::vector< Array<uint> > const idxArrs)
+           std::vector<CParam<uint>> idxArrs)
 {
-    const af::dim4 iDims    = in.dims();
-    const af::dim4 dDims    = in.getDataDims();
+    const af::dim4 iDims    = in.dims;
     const af::dim4 iOffs    = toOffset(seqs, dDims);
     const af::dim4 iStrds   = toStride(seqs, dDims);
-    const af::dim4 oDims    = out.dims();
-    const af::dim4 oStrides = out.strides();
+    const af::dim4 oDims    = out.dims;
+    const af::dim4 oStrides = out.strides;
     const T *src        = in.get();
     T *dst        = out.get();
     const uint* ptr0    = idxArrs[0].get();

--- a/src/backend/cpu/kernel/interp.hpp
+++ b/src/backend/cpu/kernel/interp.hpp
@@ -96,14 +96,14 @@ struct Interp1<InT, LocT, 1>
                     af_interp_type  method, int batch, bool clamp)
     {
         const InT *inptr = in.get();
-        const dim4 idims = in.dims;
-        const dim4 istrides = in.strides;
+        const dim4 idims = in.dims();
+        const dim4 istrides = in.strides();
         int xid = (method == AF_INTERP_LOWER ? std::floor(x) : std::round(x));
         bool cond = xid >= 0 && xid < idims[0];
         if (clamp) xid = std::max(0, std::min(xid, (int)idims[0]));
 
         InT *outptr = out.get();
-        const dim4 ostrides = out.strides;
+        const dim4 ostrides = out.strides();
         int idx = ioff + xid;
 
         for (int n = 0; n < batch; n++) {
@@ -126,10 +126,10 @@ struct Interp1<InT, LocT, 2>
         const LocT off_x = x - grid_x;    // fractional offset
         const int idx = ioff + grid_x;
         const InT *inptr = in.get();
-        const dim4 idims = in.dims;
-        const dim4 istrides = in.strides;
+        const dim4 idims = in.dims();
+        const dim4 istrides = in.strides();
         InT *outptr = out.get();
-        const dim4 ostrides = out.strides;
+        const dim4 ostrides = out.strides();
 
         bool cond[2] = {true, grid_x + 1 < idims[0]};
         int  offx[2] = {0 , cond[1] ? 1 : 0};
@@ -165,10 +165,10 @@ struct Interp1<InT, LocT, 3>
         const LocT off_x = x - grid_x;    // fractional offset
         const int idx = ioff + grid_x;
         const InT *inptr = in.get();
-        const dim4 idims = in.dims;
-        const dim4 istrides = in.strides;
+        const dim4 idims = in.dims();
+        const dim4 istrides = in.strides();
         InT *outptr = out.get();
-        const dim4 ostrides = out.strides;
+        const dim4 ostrides = out.strides();
 
         bool cond[4] = {grid_x - 1 >= 0, true, grid_x + 1 < idims[0], grid_x + 2 < idims[0]};
         int  off[4]  = {cond[0] ? -1 : 0, 0, cond[2] ? 1 : 0, cond[3] ? 2 : (cond[2] ? 1 : 0)};
@@ -199,11 +199,11 @@ struct Interp2<InT, LocT, 1>
                     af_interp_type  method, int nimages, bool clamp)
     {
         const InT *inptr = in.get();
-        const dim4 istrides = in.strides;
-        const dim4 idims = in.dims;
+        const dim4 istrides = in.strides();
+        const dim4 idims = in.dims();
 
         InT *outptr = out.get();
-        const dim4 ostrides = out.strides;
+        const dim4 ostrides = out.strides();
 
         int xid = (method == AF_INTERP_LOWER ? std::floor(x) : std::round(x));
         int yid = (method == AF_INTERP_LOWER ? std::floor(y) : std::round(y));
@@ -235,11 +235,11 @@ struct Interp2<InT, LocT, 2>
         typedef vtype_t<InT> VT;
 
         const InT *inptr = in.get();
-        const dim4 idims = in.dims;
-        const dim4 istrides = in.strides;
+        const dim4 idims = in.dims();
+        const dim4 istrides = in.strides();
 
         InT *outptr = out.get();
-        const dim4 ostrides = out.strides;
+        const dim4 ostrides = out.strides();
 
         const int grid_x = floor(x);
         const LocT off_x = x - grid_x;
@@ -290,11 +290,11 @@ struct Interp2<InT, LocT, 3>
         typedef vtype_t<InT> VT;
 
         const InT *inptr = in.get();
-        const dim4 idims = in.dims;
-        const dim4 istrides = in.strides;
+        const dim4 idims = in.dims();
+        const dim4 istrides = in.strides();
 
         InT *outptr = out.get();
-        const dim4 ostrides = out.strides;
+        const dim4 ostrides = out.strides();
 
         const int grid_x = floor(x);
         const LocT off_x = x - grid_x;

--- a/src/backend/cpu/kernel/interp.hpp
+++ b/src/backend/cpu/kernel/interp.hpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <math.hpp>
 #include <af/constants.h>
 #include <type_traits>
@@ -91,19 +91,19 @@ struct Interp1
 template<typename InT, typename LocT>
 struct Interp1<InT, LocT, 1>
 {
-    void operator()(Array<InT> &out, int ooff,
-                    const Array<InT> &in, int ioff, LocT x,
+    void operator()(Param<InT> &out, int ooff,
+                    CParam<InT> &in, int ioff, LocT x,
                     af_interp_type  method, int batch, bool clamp)
     {
         const InT *inptr = in.get();
-        const dim4 idims = in.dims();
-        const dim4 istrides = in.strides();
+        const dim4 idims = in.dims;
+        const dim4 istrides = in.strides;
         int xid = (method == AF_INTERP_LOWER ? std::floor(x) : std::round(x));
         bool cond = xid >= 0 && xid < idims[0];
         if (clamp) xid = std::max(0, std::min(xid, (int)idims[0]));
 
         InT *outptr = out.get();
-        const dim4 ostrides = out.strides();
+        const dim4 ostrides = out.strides;
         int idx = ioff + xid;
 
         for (int n = 0; n < batch; n++) {
@@ -116,8 +116,8 @@ struct Interp1<InT, LocT, 1>
 template<typename InT, typename LocT>
 struct Interp1<InT, LocT, 2>
 {
-    void operator()(Array<InT> &out, int ooff,
-                    const Array<InT> &in, int ioff, LocT x,
+    void operator()(Param<InT> &out, int ooff,
+                    CParam<InT> &in, int ioff, LocT x,
                     af_interp_type  method, int batch, bool clamp)
     {
         typedef vtype_t<InT> VT;
@@ -126,10 +126,10 @@ struct Interp1<InT, LocT, 2>
         const LocT off_x = x - grid_x;    // fractional offset
         const int idx = ioff + grid_x;
         const InT *inptr = in.get();
-        const dim4 idims = in.dims();
-        const dim4 istrides = in.strides();
+        const dim4 idims = in.dims;
+        const dim4 istrides = in.strides;
         InT *outptr = out.get();
-        const dim4 ostrides = out.strides();
+        const dim4 ostrides = out.strides;
 
         bool cond[2] = {true, grid_x + 1 < idims[0]};
         int  offx[2] = {0 , cond[1] ? 1 : 0};
@@ -155,8 +155,8 @@ struct Interp1<InT, LocT, 2>
 template<typename InT, typename LocT>
 struct Interp1<InT, LocT, 3>
 {
-    void operator()(Array<InT> &out, int ooff,
-                    const Array<InT> &in, int ioff, LocT x,
+    void operator()(Param<InT> &out, int ooff,
+                    CParam<InT> &in, int ioff, LocT x,
                     af_interp_type  method, int batch, bool clamp)
     {
         typedef vtype_t<InT> VT;
@@ -165,10 +165,10 @@ struct Interp1<InT, LocT, 3>
         const LocT off_x = x - grid_x;    // fractional offset
         const int idx = ioff + grid_x;
         const InT *inptr = in.get();
-        const dim4 idims = in.dims();
-        const dim4 istrides = in.strides();
+        const dim4 idims = in.dims;
+        const dim4 istrides = in.strides;
         InT *outptr = out.get();
-        const dim4 ostrides = out.strides();
+        const dim4 ostrides = out.strides;
 
         bool cond[4] = {grid_x - 1 >= 0, true, grid_x + 1 < idims[0], grid_x + 2 < idims[0]};
         int  off[4]  = {cond[0] ? -1 : 0, 0, cond[2] ? 1 : 0, cond[3] ? 2 : (cond[2] ? 1 : 0)};
@@ -194,16 +194,16 @@ struct Interp2
 template<typename InT, typename LocT>
 struct Interp2<InT, LocT, 1>
 {
-    void operator()(Array<InT> &out, int ooff,
-                    const Array<InT> &in, int ioff, LocT x, LocT y,
+    void operator()(Param<InT> &out, int ooff,
+                    CParam<InT> &in, int ioff, LocT x, LocT y,
                     af_interp_type  method, int nimages, bool clamp)
     {
         const InT *inptr = in.get();
-        const dim4 istrides = in.strides();
-        const dim4 idims = in.dims();
+        const dim4 istrides = in.strides;
+        const dim4 idims = in.dims;
 
         InT *outptr = out.get();
-        const dim4 ostrides = out.strides();
+        const dim4 ostrides = out.strides;
 
         int xid = (method == AF_INTERP_LOWER ? std::floor(x) : std::round(x));
         int yid = (method == AF_INTERP_LOWER ? std::floor(y) : std::round(y));
@@ -228,18 +228,18 @@ struct Interp2<InT, LocT, 1>
 template<typename InT, typename LocT>
 struct Interp2<InT, LocT, 2>
 {
-    void operator()(Array<InT> &out, int ooff,
-                    const Array<InT> &in, int ioff, LocT x, LocT y,
+    void operator()(Param<InT> &out, int ooff,
+                    CParam<InT> &in, int ioff, LocT x, LocT y,
                     af_interp_type  method, int nimages, bool clamp)
     {
         typedef vtype_t<InT> VT;
 
         const InT *inptr = in.get();
-        const dim4 idims = in.dims();
-        const dim4 istrides = in.strides();
+        const dim4 idims = in.dims;
+        const dim4 istrides = in.strides;
 
         InT *outptr = out.get();
-        const dim4 ostrides = out.strides();
+        const dim4 ostrides = out.strides;
 
         const int grid_x = floor(x);
         const LocT off_x = x - grid_x;
@@ -283,18 +283,18 @@ struct Interp2<InT, LocT, 2>
 template<typename InT, typename LocT>
 struct Interp2<InT, LocT, 3>
 {
-    void operator()(Array<InT> &out, int ooff,
-                    const Array<InT> &in, int ioff, LocT x, LocT y,
+    void operator()(Param<InT> &out, int ooff,
+                    CParam<InT> &in, int ioff, LocT x, LocT y,
                     af_interp_type  method, int nimages, bool clamp)
     {
         typedef vtype_t<InT> VT;
 
         const InT *inptr = in.get();
-        const dim4 idims = in.dims();
-        const dim4 istrides = in.strides();
+        const dim4 idims = in.dims;
+        const dim4 istrides = in.strides;
 
         InT *outptr = out.get();
-        const dim4 ostrides = out.strides();
+        const dim4 ostrides = out.strides;
 
         const int grid_x = floor(x);
         const LocT off_x = x - grid_x;

--- a/src/backend/cpu/kernel/iota.hpp
+++ b/src/backend/cpu/kernel/iota.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,11 +16,11 @@ namespace kernel
 {
 
 template<typename T>
-void iota(Array<T> output, const af::dim4 &sdims, const af::dim4 &tdims)
+void iota(Param<T> output, const af::dim4 &sdims, const af::dim4 &tdims)
 {
-    const af::dim4 dims    = output.dims();
+    const af::dim4 dims    = output.dims;
     T* out             = output.get();
-    const af::dim4 strides = output.strides();
+    const af::dim4 strides = output.strides;
 
     for(dim_t w = 0; w < dims[3]; w++) {
         dim_t offW = w * strides[3];

--- a/src/backend/cpu/kernel/iota.hpp
+++ b/src/backend/cpu/kernel/iota.hpp
@@ -18,9 +18,9 @@ namespace kernel
 template<typename T>
 void iota(Param<T> output, const af::dim4 &sdims, const af::dim4 &tdims)
 {
-    const af::dim4 dims    = output.dims;
+    const af::dim4 dims    = output.dims();
     T* out             = output.get();
-    const af::dim4 strides = output.strides;
+    const af::dim4 strides = output.strides();
 
     for(dim_t w = 0; w < dims[3]; w++) {
         dim_t offW = w * strides[3];

--- a/src/backend/cpu/kernel/ireduce.hpp
+++ b/src/backend/cpu/kernel/ireduce.hpp
@@ -68,9 +68,9 @@ struct ireduce_dim
     void operator()(Param<T> output, Param<uint> locParam, const dim_t outOffset,
                     CParam<T> input, const dim_t inOffset, const int dim)
     {
-        const af::dim4 odims    = output.dims;
-        const af::dim4 ostrides = output.strides;
-        const af::dim4 istrides = input.strides;
+        const af::dim4 odims    = output.dims();
+        const af::dim4 ostrides = output.strides();
+        const af::dim4 istrides = input.strides();
         const int D1 = D - 1;
         for (dim_t i = 0; i < odims[D1]; i++) {
             ireduce_dim<op, T, D1>()(output, locParam, outOffset + i * ostrides[D1],
@@ -85,8 +85,8 @@ struct ireduce_dim<op, T, 0>
     void operator()(Param<T> output, Param<uint> locParam, const dim_t outOffset,
                     CParam<T> input, const dim_t inOffset, const int dim)
     {
-        const af::dim4 idims = input.dims;
-        const af::dim4 istrides = input.strides;
+        const af::dim4 idims = input.dims();
+        const af::dim4 istrides = input.strides();
 
         T const * const in = input.get();
         T * out = output.get();

--- a/src/backend/cpu/kernel/ireduce.hpp
+++ b/src/backend/cpu/kernel/ireduce.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -65,15 +65,15 @@ struct MinMaxOp<af_max_t, T>
 template<af_op_t op, typename T, int D>
 struct ireduce_dim
 {
-    void operator()(Array<T> output, Array<uint> locArray, const dim_t outOffset,
-                    const Array<T> input, const dim_t inOffset, const int dim)
+    void operator()(Param<T> output, Param<uint> locParam, const dim_t outOffset,
+                    CParam<T> input, const dim_t inOffset, const int dim)
     {
-        const af::dim4 odims    = output.dims();
-        const af::dim4 ostrides = output.strides();
-        const af::dim4 istrides = input.strides();
+        const af::dim4 odims    = output.dims;
+        const af::dim4 ostrides = output.strides;
+        const af::dim4 istrides = input.strides;
         const int D1 = D - 1;
         for (dim_t i = 0; i < odims[D1]; i++) {
-            ireduce_dim<op, T, D1>()(output, locArray, outOffset + i * ostrides[D1],
+            ireduce_dim<op, T, D1>()(output, locParam, outOffset + i * ostrides[D1],
                                      input, inOffset + i * istrides[D1], dim);
         }
     }
@@ -82,15 +82,15 @@ struct ireduce_dim
 template<af_op_t op, typename T>
 struct ireduce_dim<op, T, 0>
 {
-    void operator()(Array<T> output, Array<uint> locArray, const dim_t outOffset,
-                    const Array<T> input, const dim_t inOffset, const int dim)
+    void operator()(Param<T> output, Param<uint> locParam, const dim_t outOffset,
+                    CParam<T> input, const dim_t inOffset, const int dim)
     {
-        const af::dim4 idims = input.dims();
-        const af::dim4 istrides = input.strides();
+        const af::dim4 idims = input.dims;
+        const af::dim4 istrides = input.strides;
 
         T const * const in = input.get();
         T * out = output.get();
-        uint * loc = locArray.get();
+        uint * loc = locParam.get();
 
         dim_t stride = istrides[dim];
         MinMaxOp<op, T> Op(in[inOffset], 0);

--- a/src/backend/cpu/kernel/join.hpp
+++ b/src/backend/cpu/kernel/join.hpp
@@ -61,34 +61,34 @@ void join(Param<Tx> out, const int dim, CParam<Tx> first, CParam<Ty> second)
     const Ty* sptr = second.get();
 
     af::dim4 zero(0,0,0,0);
-    const af::dim4 odims = out.dims;
-    const af::dim4 fdims = first.dims;
-    const af::dim4 sdims = second.dims;
+    const af::dim4 odims = out.dims();
+    const af::dim4 fdims = first.dims();
+    const af::dim4 sdims = second.dims();
 
     switch(dim) {
         case 0:
             join_append<Tx, Tx, 0>(outPtr, fptr, zero,
-                    odims, fdims, out.strides, first.strides);
+                                   odims, fdims, out.strides(), first.strides());
             join_append<Tx, Ty, 0>(outPtr, sptr, calcOffset<0>(fdims),
-                    odims, sdims, out.strides, second.strides);
+                                   odims, sdims, out.strides(), second.strides());
             break;
         case 1:
             join_append<Tx, Tx, 1>(outPtr, fptr, zero,
-                    odims, fdims, out.strides, first.strides);
+                                   odims, fdims, out.strides(), first.strides());
             join_append<Tx, Ty, 1>(outPtr, sptr, calcOffset<1>(fdims),
-                    odims, sdims, out.strides, second.strides);
+                                   odims, sdims, out.strides(), second.strides());
             break;
         case 2:
             join_append<Tx, Tx, 2>(outPtr, fptr, zero,
-                    odims, fdims, out.strides, first.strides);
+                                   odims, fdims, out.strides(), first.strides());
             join_append<Tx, Ty, 2>(outPtr, sptr, calcOffset<2>(fdims),
-                    odims, sdims, out.strides, second.strides);
+                                   odims, sdims, out.strides(), second.strides());
             break;
         case 3:
             join_append<Tx, Tx, 3>(outPtr, fptr, zero,
-                    odims, fdims, out.strides, first.strides);
+                                   odims, fdims, out.strides(), first.strides());
             join_append<Tx, Ty, 3>(outPtr, sptr, calcOffset<3>(fdims),
-                    odims, sdims, out.strides, second.strides);
+                                   odims, sdims, out.strides(), second.strides());
             break;
     }
 }
@@ -101,38 +101,38 @@ void join(const int dim, Param<T> out, const std::vector<CParam<T>> inputs)
     switch(dim) {
         case 0:
             join_append<T, T, 0>(out.get(), inputs[0].get(), zero,
-                        out.dims, inputs[0].dims, out.strides, inputs[0].strides);
+                        out.dims(), inputs[0].dims(), out.strides(), inputs[0].strides());
             for(int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims;
+                d += inputs[i - 1].dims();
                 join_append<T, T, 0>(out.get(), inputs[i].get(), calcOffset<0>(d),
-                        out.dims, inputs[i].dims, out.strides, inputs[i].strides);
+                        out.dims(), inputs[i].dims(), out.strides(), inputs[i].strides());
             }
             break;
         case 1:
             join_append<T, T, 1>(out.get(), inputs[0].get(), zero,
-                        out.dims, inputs[0].dims, out.strides, inputs[0].strides);
+                        out.dims(), inputs[0].dims(), out.strides(), inputs[0].strides());
             for(int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims;
+                d += inputs[i - 1].dims();
                 join_append<T, T, 1>(out.get(), inputs[i].get(), calcOffset<1>(d),
-                        out.dims, inputs[i].dims, out.strides, inputs[i].strides);
+                        out.dims(), inputs[i].dims(), out.strides(), inputs[i].strides());
             }
             break;
         case 2:
             join_append<T, T, 2>(out.get(), inputs[0].get(), zero,
-                        out.dims, inputs[0].dims, out.strides, inputs[0].strides);
+                        out.dims(), inputs[0].dims(), out.strides(), inputs[0].strides());
             for(int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims;
+                d += inputs[i - 1].dims();
                 join_append<T, T, 2>(out.get(), inputs[i].get(), calcOffset<2>(d),
-                        out.dims, inputs[i].dims, out.strides, inputs[i].strides);
+                        out.dims(), inputs[i].dims(), out.strides(), inputs[i].strides());
             }
             break;
         case 3:
             join_append<T, T, 3>(out.get(), inputs[0].get(), zero,
-                        out.dims, inputs[0].dims, out.strides, inputs[0].strides);
+                        out.dims(), inputs[0].dims(), out.strides(), inputs[0].strides());
             for(int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims;
+                d += inputs[i - 1].dims();
                 join_append<T, T, 3>(out.get(), inputs[i].get(), calcOffset<3>(d),
-                        out.dims, inputs[i].dims, out.strides, inputs[i].strides);
+                        out.dims(), inputs[i].dims(), out.strides(), inputs[i].strides());
             }
             break;
     }

--- a/src/backend/cpu/kernel/join.hpp
+++ b/src/backend/cpu/kernel/join.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -54,85 +54,85 @@ void join_append(To *out, const Tx *X, const af::dim4 &offset,
 }
 
 template<typename Tx, typename Ty>
-void join(Array<Tx> out, const int dim, const Array<Tx> first, const Array<Ty> second)
+void join(Param<Tx> out, const int dim, CParam<Tx> first, CParam<Ty> second)
 {
     Tx* outPtr = out.get();
     const Tx* fptr = first.get();
     const Ty* sptr = second.get();
 
     af::dim4 zero(0,0,0,0);
-    const af::dim4 odims = out.dims();
-    const af::dim4 fdims = first.dims();
-    const af::dim4 sdims = second.dims();
+    const af::dim4 odims = out.dims;
+    const af::dim4 fdims = first.dims;
+    const af::dim4 sdims = second.dims;
 
     switch(dim) {
         case 0:
             join_append<Tx, Tx, 0>(outPtr, fptr, zero,
-                    odims, fdims, out.strides(), first.strides());
+                    odims, fdims, out.strides, first.strides);
             join_append<Tx, Ty, 0>(outPtr, sptr, calcOffset<0>(fdims),
-                    odims, sdims, out.strides(), second.strides());
+                    odims, sdims, out.strides, second.strides);
             break;
         case 1:
             join_append<Tx, Tx, 1>(outPtr, fptr, zero,
-                    odims, fdims, out.strides(), first.strides());
+                    odims, fdims, out.strides, first.strides);
             join_append<Tx, Ty, 1>(outPtr, sptr, calcOffset<1>(fdims),
-                    odims, sdims, out.strides(), second.strides());
+                    odims, sdims, out.strides, second.strides);
             break;
         case 2:
             join_append<Tx, Tx, 2>(outPtr, fptr, zero,
-                    odims, fdims, out.strides(), first.strides());
+                    odims, fdims, out.strides, first.strides);
             join_append<Tx, Ty, 2>(outPtr, sptr, calcOffset<2>(fdims),
-                    odims, sdims, out.strides(), second.strides());
+                    odims, sdims, out.strides, second.strides);
             break;
         case 3:
             join_append<Tx, Tx, 3>(outPtr, fptr, zero,
-                    odims, fdims, out.strides(), first.strides());
+                    odims, fdims, out.strides, first.strides);
             join_append<Tx, Ty, 3>(outPtr, sptr, calcOffset<3>(fdims),
-                    odims, sdims, out.strides(), second.strides());
+                    odims, sdims, out.strides, second.strides);
             break;
     }
 }
 
 template<typename T, int n_arrays>
-void join(const int dim, Array<T> out, const std::vector<Array<T>> inputs)
+void join(const int dim, Param<T> out, const std::vector<CParam<T>> inputs)
 {
     af::dim4 zero(0,0,0,0);
     af::dim4 d = zero;
     switch(dim) {
         case 0:
             join_append<T, T, 0>(out.get(), inputs[0].get(), zero,
-                        out.dims(), inputs[0].dims(), out.strides(), inputs[0].strides());
+                        out.dims, inputs[0].dims, out.strides, inputs[0].strides);
             for(int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims();
+                d += inputs[i - 1].dims;
                 join_append<T, T, 0>(out.get(), inputs[i].get(), calcOffset<0>(d),
-                        out.dims(), inputs[i].dims(), out.strides(), inputs[i].strides());
+                        out.dims, inputs[i].dims, out.strides, inputs[i].strides);
             }
             break;
         case 1:
             join_append<T, T, 1>(out.get(), inputs[0].get(), zero,
-                        out.dims(), inputs[0].dims(), out.strides(), inputs[0].strides());
+                        out.dims, inputs[0].dims, out.strides, inputs[0].strides);
             for(int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims();
+                d += inputs[i - 1].dims;
                 join_append<T, T, 1>(out.get(), inputs[i].get(), calcOffset<1>(d),
-                        out.dims(), inputs[i].dims(), out.strides(), inputs[i].strides());
+                        out.dims, inputs[i].dims, out.strides, inputs[i].strides);
             }
             break;
         case 2:
             join_append<T, T, 2>(out.get(), inputs[0].get(), zero,
-                        out.dims(), inputs[0].dims(), out.strides(), inputs[0].strides());
+                        out.dims, inputs[0].dims, out.strides, inputs[0].strides);
             for(int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims();
+                d += inputs[i - 1].dims;
                 join_append<T, T, 2>(out.get(), inputs[i].get(), calcOffset<2>(d),
-                        out.dims(), inputs[i].dims(), out.strides(), inputs[i].strides());
+                        out.dims, inputs[i].dims, out.strides, inputs[i].strides);
             }
             break;
         case 3:
             join_append<T, T, 3>(out.get(), inputs[0].get(), zero,
-                        out.dims(), inputs[0].dims(), out.strides(), inputs[0].strides());
+                        out.dims, inputs[0].dims, out.strides, inputs[0].strides);
             for(int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims();
+                d += inputs[i - 1].dims;
                 join_append<T, T, 3>(out.get(), inputs[i].get(), calcOffset<3>(d),
-                        out.dims(), inputs[i].dims(), out.strides(), inputs[i].strides());
+                        out.dims, inputs[i].dims, out.strides, inputs[i].strides);
             }
             break;
     }
@@ -140,4 +140,3 @@ void join(const int dim, Array<T> out, const std::vector<Array<T>> inputs)
 
 }
 }
-

--- a/src/backend/cpu/kernel/lookup.hpp
+++ b/src/backend/cpu/kernel/lookup.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 #include <vector>
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 
 namespace cpu
@@ -18,13 +18,13 @@ namespace kernel
 {
 
 template<typename InT, typename IndexT>
-void lookup(Array<InT> out, Array<InT> const input,
-            Array<IndexT> const indices, unsigned const dim)
+void lookup(Param<InT> out, CParam<InT> input,
+            CParam<IndexT> indices, unsigned const dim)
 {
-    const af::dim4 iDims    = input.dims();
-    const af::dim4 oDims    = out.dims();
-    const af::dim4 iStrides = input.strides();
-    const af::dim4 oStrides = out.strides();
+    const af::dim4 iDims    = input.dims;
+    const af::dim4 oDims    = out.dims;
+    const af::dim4 iStrides = input.strides;
+    const af::dim4 oStrides = out.strides;
     const InT *inPtr   = input.get();
     const IndexT *idxPtr = indices.get();
 

--- a/src/backend/cpu/kernel/lookup.hpp
+++ b/src/backend/cpu/kernel/lookup.hpp
@@ -21,10 +21,10 @@ template<typename InT, typename IndexT>
 void lookup(Param<InT> out, CParam<InT> input,
             CParam<IndexT> indices, unsigned const dim)
 {
-    const af::dim4 iDims    = input.dims;
-    const af::dim4 oDims    = out.dims;
-    const af::dim4 iStrides = input.strides;
-    const af::dim4 oStrides = out.strides;
+    const af::dim4 iDims    = input.dims();
+    const af::dim4 oDims    = out.dims();
+    const af::dim4 iStrides = input.strides();
+    const af::dim4 oStrides = out.strides();
     const InT *inPtr   = input.get();
     const IndexT *idxPtr = indices.get();
 

--- a/src/backend/cpu/kernel/lu.hpp
+++ b/src/backend/cpu/kernel/lu.hpp
@@ -22,12 +22,12 @@ void lu_split(Param<T> lower, Param<T> upper, CParam<T> in)
     T *u = upper.get();
     const T *i = in.get();
 
-    af::dim4 ldm = lower.dims;
-    af::dim4 udm = upper.dims;
-    af::dim4 idm = in.dims;
-    af::dim4 lst = lower.strides;
-    af::dim4 ust = upper.strides;
-    af::dim4 ist = in.strides;
+    af::dim4 ldm = lower.dims();
+    af::dim4 udm = upper.dims();
+    af::dim4 idm = in.dims();
+    af::dim4 lst = lower.strides();
+    af::dim4 ust = upper.strides();
+    af::dim4 ist = in.strides();
 
     for(dim_t ow = 0; ow < idm[3]; ow++) {
         const dim_t lW = ow * lst[3];
@@ -68,7 +68,7 @@ void convertPivot(Param<int> p, Param<int> pivot)
 {
     int *d_pi = pivot.get();
     int *d_po = p.get();
-    dim_t d0  = pivot.dims[0];
+    dim_t d0  = pivot.dims(0);
     for(int j = 0; j < (int)d0; j++) {
         // 1 indexed in pivot
         std::swap(d_po[j], d_po[d_pi[j] - 1]);

--- a/src/backend/cpu/kernel/lu.hpp
+++ b/src/backend/cpu/kernel/lu.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,18 +16,18 @@ namespace kernel
 {
 
 template<typename T>
-void lu_split(Array<T> lower, Array<T> upper, const Array<T> in)
+void lu_split(Param<T> lower, Param<T> upper, CParam<T> in)
 {
     T *l = lower.get();
     T *u = upper.get();
     const T *i = in.get();
 
-    af::dim4 ldm = lower.dims();
-    af::dim4 udm = upper.dims();
-    af::dim4 idm = in.dims();
-    af::dim4 lst = lower.strides();
-    af::dim4 ust = upper.strides();
-    af::dim4 ist = in.strides();
+    af::dim4 ldm = lower.dims;
+    af::dim4 udm = upper.dims;
+    af::dim4 idm = in.dims;
+    af::dim4 lst = lower.strides;
+    af::dim4 ust = upper.strides;
+    af::dim4 ist = in.strides;
 
     for(dim_t ow = 0; ow < idm[3]; ow++) {
         const dim_t lW = ow * lst[3];
@@ -64,11 +64,11 @@ void lu_split(Array<T> lower, Array<T> upper, const Array<T> in)
     }
 }
 
-void convertPivot(Array<int> p, Array<int> pivot)
+void convertPivot(Param<int> p, Param<int> pivot)
 {
     int *d_pi = pivot.get();
     int *d_po = p.get();
-    dim_t d0  = pivot.dims()[0];
+    dim_t d0  = pivot.dims[0];
     for(int j = 0; j < (int)d0; j++) {
         // 1 indexed in pivot
         std::swap(d_po[j], d_po[d_pi[j] - 1]);

--- a/src/backend/cpu/kernel/match_template.hpp
+++ b/src/backend/cpu/kernel/match_template.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,22 +16,22 @@ namespace kernel
 {
 
 template<typename OutT, typename InT, af_match_type MatchT>
-void matchTemplate(Array<OutT> out, const Array<InT> sImg, const Array<InT> tImg)
+void matchTemplate(Param<OutT> out, CParam<InT> sImg, CParam<InT> tImg)
 {
-    const af::dim4 sDims = sImg.dims();
-    const af::dim4 tDims = tImg.dims();
-    const af::dim4 sStrides = sImg.strides();
-    const af::dim4 tStrides = tImg.strides();
+    const af::dim4 sDims = sImg.dims;
+    const af::dim4 tDims = tImg.dims;
+    const af::dim4 sStrides = sImg.strides;
+    const af::dim4 tStrides = tImg.strides;
 
     const dim_t tDim0  = tDims[0];
     const dim_t tDim1  = tDims[1];
     const dim_t sDim0  = sDims[0];
     const dim_t sDim1  = sDims[1];
 
-    const af::dim4 oStrides = out.strides();
+    const af::dim4 oStrides = out.strides;
 
     OutT tImgMean = OutT(0);
-    dim_t winNumElements = tImg.elements();
+    dim_t winNumElements = tImg.dims.elements();
     bool needMean = MatchT==AF_ZSAD || MatchT==AF_LSAD ||
         MatchT==AF_ZSSD || MatchT==AF_LSSD ||
         MatchT==AF_ZNCC;

--- a/src/backend/cpu/kernel/match_template.hpp
+++ b/src/backend/cpu/kernel/match_template.hpp
@@ -18,20 +18,20 @@ namespace kernel
 template<typename OutT, typename InT, af_match_type MatchT>
 void matchTemplate(Param<OutT> out, CParam<InT> sImg, CParam<InT> tImg)
 {
-    const af::dim4 sDims = sImg.dims;
-    const af::dim4 tDims = tImg.dims;
-    const af::dim4 sStrides = sImg.strides;
-    const af::dim4 tStrides = tImg.strides;
+    const af::dim4 sDims = sImg.dims();
+    const af::dim4 tDims = tImg.dims();
+    const af::dim4 sStrides = sImg.strides();
+    const af::dim4 tStrides = tImg.strides();
 
     const dim_t tDim0  = tDims[0];
     const dim_t tDim1  = tDims[1];
     const dim_t sDim0  = sDims[0];
     const dim_t sDim1  = sDims[1];
 
-    const af::dim4 oStrides = out.strides;
+    const af::dim4 oStrides = out.strides();
 
     OutT tImgMean = OutT(0);
-    dim_t winNumElements = tImg.dims.elements();
+    dim_t winNumElements = tImg.dims().elements();
     bool needMean = MatchT==AF_ZSAD || MatchT==AF_LSAD ||
         MatchT==AF_ZSSD || MatchT==AF_LSSD ||
         MatchT==AF_ZNCC;

--- a/src/backend/cpu/kernel/meanshift.hpp
+++ b/src/backend/cpu/kernel/meanshift.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <vector>
 #include <utility.hpp>
 
@@ -18,12 +18,12 @@ namespace kernel
 {
 
 template<typename T, bool IsColor>
-void meanShift(Array<T> out, const Array<T> in, const float s_sigma,
+void meanShift(Param<T> out, CParam<T> in, const float s_sigma,
                const float c_sigma, const unsigned iter)
 {
-    const af::dim4 dims     = in.dims();
-    const af::dim4 istrides = in.strides();
-    const af::dim4 ostrides = out.strides();
+    const af::dim4 dims     = in.dims;
+    const af::dim4 istrides = in.strides;
+    const af::dim4 ostrides = out.strides;
 
     const dim_t bCount   = (IsColor ? 1 : dims[2]);
     const dim_t channels = (IsColor ? dims[2] : 1);

--- a/src/backend/cpu/kernel/meanshift.hpp
+++ b/src/backend/cpu/kernel/meanshift.hpp
@@ -21,9 +21,9 @@ template<typename T, bool IsColor>
 void meanShift(Param<T> out, CParam<T> in, const float s_sigma,
                const float c_sigma, const unsigned iter)
 {
-    const af::dim4 dims     = in.dims;
-    const af::dim4 istrides = in.strides;
-    const af::dim4 ostrides = out.strides;
+    const af::dim4 dims     = in.dims();
+    const af::dim4 istrides = in.strides();
+    const af::dim4 ostrides = out.strides();
 
     const dim_t bCount   = (IsColor ? 1 : dims[2]);
     const dim_t channels = (IsColor ? dims[2] : 1);

--- a/src/backend/cpu/kernel/medfilt.hpp
+++ b/src/backend/cpu/kernel/medfilt.hpp
@@ -20,9 +20,9 @@ namespace kernel
 template<typename T, af_border_type Pad>
 void medfilt1(Param<T> out, CParam<T> in, dim_t w_wid)
 {
-    const af::dim4 dims     = in.dims;
-    const af::dim4 istrides = in.strides;
-    const af::dim4 ostrides = out.strides;
+    const af::dim4 dims     = in.dims();
+    const af::dim4 istrides = in.strides();
+    const af::dim4 ostrides = out.strides();
 
     std::vector<T> wind_vals;
     wind_vals.reserve(w_wid);
@@ -88,9 +88,9 @@ void medfilt1(Param<T> out, CParam<T> in, dim_t w_wid)
 template<typename T, af_border_type Pad>
 void medfilt2(Param<T> out, CParam<T> in, dim_t w_len, dim_t w_wid)
 {
-    const af::dim4 dims     = in.dims;
-    const af::dim4 istrides = in.strides;
-    const af::dim4 ostrides = out.strides;
+    const af::dim4 dims     = in.dims();
+    const af::dim4 istrides = in.strides();
+    const af::dim4 ostrides = out.strides();
 
     std::vector<T> wind_vals;
     wind_vals.reserve(w_len*w_wid);

--- a/src/backend/cpu/kernel/medfilt.hpp
+++ b/src/backend/cpu/kernel/medfilt.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <vector>
 #include <algorithm>
 
@@ -18,11 +18,11 @@ namespace kernel
 {
 
 template<typename T, af_border_type Pad>
-void medfilt1(Array<T> out, const Array<T> in, dim_t w_wid)
+void medfilt1(Param<T> out, CParam<T> in, dim_t w_wid)
 {
-    const af::dim4 dims     = in.dims();
-    const af::dim4 istrides = in.strides();
-    const af::dim4 ostrides = out.strides();
+    const af::dim4 dims     = in.dims;
+    const af::dim4 istrides = in.strides;
+    const af::dim4 ostrides = out.strides;
 
     std::vector<T> wind_vals;
     wind_vals.reserve(w_wid);
@@ -86,11 +86,11 @@ void medfilt1(Array<T> out, const Array<T> in, dim_t w_wid)
 
 
 template<typename T, af_border_type Pad>
-void medfilt2(Array<T> out, const Array<T> in, dim_t w_len, dim_t w_wid)
+void medfilt2(Param<T> out, CParam<T> in, dim_t w_len, dim_t w_wid)
 {
-    const af::dim4 dims     = in.dims();
-    const af::dim4 istrides = in.strides();
-    const af::dim4 ostrides = out.strides();
+    const af::dim4 dims     = in.dims;
+    const af::dim4 istrides = in.strides;
+    const af::dim4 ostrides = out.strides;
 
     std::vector<T> wind_vals;
     wind_vals.reserve(w_len*w_wid);

--- a/src/backend/cpu/kernel/moments.hpp
+++ b/src/backend/cpu/kernel/moments.hpp
@@ -23,9 +23,9 @@ template<typename T>
 void moments(Param<float> output, CParam<T> input, af_moment_type moment)
 {
     T const * const in       = input.get();
-    af::dim4  const idims    = input.dims;
-    af::dim4  const istrides = input.strides;
-    af::dim4  const ostrides = output.strides;
+    af::dim4  const idims    = input.dims();
+    af::dim4  const istrides = input.strides();
+    af::dim4  const ostrides = output.strides();
 
     float *out = output.get();
 

--- a/src/backend/cpu/kernel/moments.hpp
+++ b/src/backend/cpu/kernel/moments.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 #include <af/defines.h>
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 #include <math.hpp>
 
@@ -20,12 +20,12 @@ namespace kernel
 
 
 template<typename T>
-void moments(Array<float> &output, Array<T> const &input, af_moment_type moment)
+void moments(Param<float> output, CParam<T> input, af_moment_type moment)
 {
     T const * const in       = input.get();
-    af::dim4  const idims    = input.dims();
-    af::dim4  const istrides = input.strides();
-    af::dim4  const ostrides = output.strides();
+    af::dim4  const idims    = input.dims;
+    af::dim4  const istrides = input.strides;
+    af::dim4  const ostrides = output.strides;
 
     float *out = output.get();
 

--- a/src/backend/cpu/kernel/morph.hpp
+++ b/src/backend/cpu/kernel/morph.hpp
@@ -21,11 +21,11 @@ namespace kernel
 template<typename T, bool IsDilation>
 void morph(Param<T> out, CParam<T> in, CParam<T> mask)
 {
-    const af::dim4 ostrides = out.strides;
-    const af::dim4 istrides = in.strides;
-    const af::dim4 fstrides = mask.strides;
-    const af::dim4 dims     = in.dims;
-    const af::dim4 window   = mask.dims;
+    const af::dim4 ostrides = out.strides();
+    const af::dim4 istrides = in.strides();
+    const af::dim4 fstrides = mask.strides();
+    const af::dim4 dims     = in.dims();
+    const af::dim4 window   = mask.dims();
     const T*   filter   = mask.get();
     const dim_t R0      = window[0]/2;
     const dim_t R1      = window[1]/2;
@@ -81,15 +81,15 @@ void morph(Param<T> out, CParam<T> in, CParam<T> mask)
 template<typename T, bool IsDilation>
 void morph3d(Param<T> out, CParam<T> in, CParam<T> mask)
 {
-    const af::dim4 dims     = in.dims;
-    const af::dim4 window   = mask.dims;
+    const af::dim4 dims     = in.dims();
+    const af::dim4 window   = mask.dims();
     const dim_t R0      = window[0]/2;
     const dim_t R1      = window[1]/2;
     const dim_t R2      = window[2]/2;
-    const af::dim4 istrides = in.strides;
-    const af::dim4 fstrides = mask.strides;
+    const af::dim4 istrides = in.strides();
+    const af::dim4 fstrides = mask.strides();
     const dim_t bCount  = dims[3];
-    const af::dim4 ostrides = out.strides;
+    const af::dim4 ostrides = out.strides();
     T* outData          = out.get();
     const T*   inData   = in.get();
     const T*   filter   = mask.get();

--- a/src/backend/cpu/kernel/morph.hpp
+++ b/src/backend/cpu/kernel/morph.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 #include <limits>
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 #include <ops.hpp>
 
@@ -19,13 +19,13 @@ namespace kernel
 {
 
 template<typename T, bool IsDilation>
-void morph(Array<T> out, Array<T> const in, Array<T> const mask)
+void morph(Param<T> out, CParam<T> in, CParam<T> mask)
 {
-    const af::dim4 ostrides = out.strides();
-    const af::dim4 istrides = in.strides();
-    const af::dim4 fstrides = mask.strides();
-    const af::dim4 dims     = in.dims();
-    const af::dim4 window   = mask.dims();
+    const af::dim4 ostrides = out.strides;
+    const af::dim4 istrides = in.strides;
+    const af::dim4 fstrides = mask.strides;
+    const af::dim4 dims     = in.dims;
+    const af::dim4 window   = mask.dims;
     const T*   filter   = mask.get();
     const dim_t R0      = window[0]/2;
     const dim_t R1      = window[1]/2;
@@ -79,17 +79,17 @@ void morph(Array<T> out, Array<T> const in, Array<T> const mask)
 }
 
 template<typename T, bool IsDilation>
-void morph3d(Array<T> out, Array<T> const in, Array<T> const mask)
+void morph3d(Param<T> out, CParam<T> in, CParam<T> mask)
 {
-    const af::dim4 dims     = in.dims();
-    const af::dim4 window   = mask.dims();
+    const af::dim4 dims     = in.dims;
+    const af::dim4 window   = mask.dims;
     const dim_t R0      = window[0]/2;
     const dim_t R1      = window[1]/2;
     const dim_t R2      = window[2]/2;
-    const af::dim4 istrides = in.strides();
-    const af::dim4 fstrides = mask.strides();
+    const af::dim4 istrides = in.strides;
+    const af::dim4 fstrides = mask.strides;
     const dim_t bCount  = dims[3];
-    const af::dim4 ostrides = out.strides();
+    const af::dim4 ostrides = out.strides;
     T* outData          = out.get();
     const T*   inData   = in.get();
     const T*   filter   = mask.get();

--- a/src/backend/cpu/kernel/nearest_neighbour.hpp
+++ b/src/backend/cpu/kernel/nearest_neighbour.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -86,13 +86,13 @@ struct dist_op<ushort, To, AF_SHD>
 };
 
 template<typename T, typename To, af_match_type dist_type>
-void nearest_neighbour(Array<uint> idx, Array<To> dist,
-                       const Array<T> query, const Array<T> train,
+void nearest_neighbour(Param<uint> idx, Param<To> dist,
+                       CParam<T> query, CParam<T> train,
                        const uint dist_dim, const uint n_dist)
 {
     uint sample_dim = (dist_dim == 0) ? 1 : 0;
-    const dim4 qDims = query.dims();
-    const dim4 tDims = train.dims();
+    const dim4 qDims = query.dims;
+    const dim4 tDims = train.dims;
 
     const unsigned distLength = qDims[dist_dim];
     const unsigned nQuery = qDims[sample_dim];

--- a/src/backend/cpu/kernel/nearest_neighbour.hpp
+++ b/src/backend/cpu/kernel/nearest_neighbour.hpp
@@ -91,8 +91,8 @@ void nearest_neighbour(Param<uint> idx, Param<To> dist,
                        const uint dist_dim, const uint n_dist)
 {
     uint sample_dim = (dist_dim == 0) ? 1 : 0;
-    const dim4 qDims = query.dims;
-    const dim4 tDims = train.dims;
+    const dim4 qDims = query.dims();
+    const dim4 tDims = train.dims();
 
     const unsigned distLength = qDims[dist_dim];
     const unsigned nQuery = qDims[sample_dim];

--- a/src/backend/cpu/kernel/orb.hpp
+++ b/src/backend/cpu/kernel/orb.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 
 namespace cpu
@@ -319,12 +319,12 @@ void harris_response(
     const float* scl_in,
     const unsigned total_feat,
     unsigned* usable_feat,
-    const Array<T>& image,
+    CParam<T> image,
     const unsigned block_size,
     const float k_thr,
     const unsigned patch_size)
 {
-    const af::dim4 idims = image.dims();
+    const af::dim4 idims = image.dims;
     const T* image_ptr = image.get();
     for (unsigned f = 0; f < total_feat; f++) {
         unsigned x, y;
@@ -395,10 +395,10 @@ void centroid_angle(
     const float* y_in,
     float* orientation_out,
     const unsigned total_feat,
-    const Array<T>& image,
+    CParam<T> image,
     const unsigned patch_size)
 {
-    const af::dim4 idims = image.dims();
+    const af::dim4 idims = image.dims;
     const T* image_ptr = image.get();
     for (unsigned f = 0; f < total_feat; f++) {
         unsigned x = (unsigned)round(x_in[f]);
@@ -433,10 +433,10 @@ inline T get_pixel(
     const unsigned size,
     const int dist_x,
     const int dist_y,
-    const Array<T>& image,
+    CParam<T> image,
     const unsigned patch_size)
 {
-    const af::dim4 idims = image.dims();
+    const af::dim4 idims = image.dims;
     const T* image_ptr = image.get();
     float ori_sin = sin(ori);
     float ori_cos = cos(ori);
@@ -457,11 +457,11 @@ void extract_orb(
     float* y_in_out,
     const float* ori_in,
     float* size_out,
-    const Array<T>& image,
+    CParam<T> image,
     const float scl,
     const unsigned patch_size)
 {
-    const af::dim4 idims = image.dims();
+    const af::dim4 idims = image.dims;
     for (unsigned f = 0; f < n_feat; f++) {
         unsigned x = (unsigned)round(x_in_out[f]);
         unsigned y = (unsigned)round(y_in_out[f]);

--- a/src/backend/cpu/kernel/orb.hpp
+++ b/src/backend/cpu/kernel/orb.hpp
@@ -324,7 +324,7 @@ void harris_response(
     const float k_thr,
     const unsigned patch_size)
 {
-    const af::dim4 idims = image.dims;
+    const af::dim4 idims = image.dims();
     const T* image_ptr = image.get();
     for (unsigned f = 0; f < total_feat; f++) {
         unsigned x, y;
@@ -398,7 +398,7 @@ void centroid_angle(
     CParam<T> image,
     const unsigned patch_size)
 {
-    const af::dim4 idims = image.dims;
+    const af::dim4 idims = image.dims();
     const T* image_ptr = image.get();
     for (unsigned f = 0; f < total_feat; f++) {
         unsigned x = (unsigned)round(x_in[f]);
@@ -436,7 +436,7 @@ inline T get_pixel(
     CParam<T> image,
     const unsigned patch_size)
 {
-    const af::dim4 idims = image.dims;
+    const af::dim4 idims = image.dims();
     const T* image_ptr = image.get();
     float ori_sin = sin(ori);
     float ori_cos = cos(ori);
@@ -461,7 +461,7 @@ void extract_orb(
     const float scl,
     const unsigned patch_size)
 {
-    const af::dim4 idims = image.dims;
+    const af::dim4 idims = image.dims();
     for (unsigned f = 0; f < n_feat; f++) {
         unsigned x = (unsigned)round(x_in_out[f]);
         unsigned y = (unsigned)round(y_in_out[f]);

--- a/src/backend/cpu/kernel/random_engine.hpp
+++ b/src/backend/cpu/kernel/random_engine.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <Array.hpp>
+#include <Param.hpp>
 #include <err_cpu.hpp>
 #include <kernel/random_engine_philox.hpp>
 #include <kernel/random_engine_threefry.hpp>

--- a/src/backend/cpu/kernel/range.hpp
+++ b/src/backend/cpu/kernel/range.hpp
@@ -20,8 +20,8 @@ void range(Param<T> output)
 {
     T* out = output.get();
 
-    const dim4 dims = output.dims;
-    const dim4 strides = output.strides;
+    const dim4 dims = output.dims();
+    const dim4 strides = output.strides();
 
     for(dim_t w = 0; w < dims[3]; w++) {
         dim_t offW = w * strides[3];

--- a/src/backend/cpu/kernel/range.hpp
+++ b/src/backend/cpu/kernel/range.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,12 +16,12 @@ namespace kernel
 {
 
 template<typename T, int dim>
-void range(Array<T> output)
+void range(Param<T> output)
 {
     T* out = output.get();
 
-    const dim4 dims = output.dims();
-    const dim4 strides = output.strides();
+    const dim4 dims = output.dims;
+    const dim4 strides = output.strides;
 
     for(dim_t w = 0; w < dims[3]; w++) {
         dim_t offW = w * strides[3];

--- a/src/backend/cpu/kernel/reduce.hpp
+++ b/src/backend/cpu/kernel/reduce.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -18,16 +18,16 @@ namespace kernel
 template<af_op_t op, typename Ti, typename To, int D>
 struct reduce_dim
 {
-    void operator()(Array<To> out, const dim_t outOffset,
-                    const Array<Ti> in, const dim_t inOffset,
+    void operator()(Param<To> out, const dim_t outOffset,
+                    CParam<Ti> in, const dim_t inOffset,
                     const int dim, bool change_nan, double nanval)
     {
         static const int D1 = D - 1;
         static reduce_dim<op, Ti, To, D1> reduce_dim_next;
 
-        const af::dim4 ostrides = out.strides();
-        const af::dim4 istrides = in.strides();
-        const af::dim4 odims    = out.dims();
+        const af::dim4 ostrides = out.strides;
+        const af::dim4 istrides = in.strides;
+        const af::dim4 odims    = out.dims;
 
         for (dim_t i = 0; i < odims[D1]; i++) {
             reduce_dim_next(out, outOffset + i * ostrides[D1],
@@ -43,12 +43,12 @@ struct reduce_dim<op, Ti, To, 0>
 
     Transform<Ti, To, op> transform;
     Binary<To, op> reduce;
-    void operator()(Array<To> out, const dim_t outOffset,
-                    const Array<Ti> in, const dim_t inOffset,
+    void operator()(Param<To> out, const dim_t outOffset,
+                    CParam<Ti> in, const dim_t inOffset,
                     const int dim, bool change_nan, double nanval)
     {
-        const af::dim4 istrides = in.strides();
-        const af::dim4 idims    = in.dims();
+        const af::dim4 istrides = in.strides;
+        const af::dim4 idims    = in.dims;
 
         To * const outPtr = out.get() + outOffset;
         Ti const * const inPtr = in.get() + inOffset;

--- a/src/backend/cpu/kernel/reduce.hpp
+++ b/src/backend/cpu/kernel/reduce.hpp
@@ -25,9 +25,9 @@ struct reduce_dim
         static const int D1 = D - 1;
         static reduce_dim<op, Ti, To, D1> reduce_dim_next;
 
-        const af::dim4 ostrides = out.strides;
-        const af::dim4 istrides = in.strides;
-        const af::dim4 odims    = out.dims;
+        const af::dim4 ostrides = out.strides();
+        const af::dim4 istrides = in.strides();
+        const af::dim4 odims    = out.dims();
 
         for (dim_t i = 0; i < odims[D1]; i++) {
             reduce_dim_next(out, outOffset + i * ostrides[D1],
@@ -47,8 +47,8 @@ struct reduce_dim<op, Ti, To, 0>
                     CParam<Ti> in, const dim_t inOffset,
                     const int dim, bool change_nan, double nanval)
     {
-        const af::dim4 istrides = in.strides;
-        const af::dim4 idims    = in.dims;
+        const af::dim4 istrides = in.strides();
+        const af::dim4 idims    = in.dims();
 
         To * const outPtr = out.get() + outOffset;
         Ti const * const inPtr = in.get() + inOffset;

--- a/src/backend/cpu/kernel/regions.hpp
+++ b/src/backend/cpu/kernel/regions.hpp
@@ -99,7 +99,7 @@ static void setUnion(LabelNode<T>* x, LabelNode<T>* y)
 template<typename T>
 void regions(Param<T> out, CParam<char> in, af_connectivity connectivity)
 {
-    const af::dim4 inDims = in.dims;
+    const af::dim4 inDims = in.dims();
     const char *inPtr  = in.get();
     T *outPtr = out.get();
 

--- a/src/backend/cpu/kernel/regions.hpp
+++ b/src/backend/cpu/kernel/regions.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <memory.hpp>
 
 namespace cpu
@@ -97,9 +97,9 @@ static void setUnion(LabelNode<T>* x, LabelNode<T>* y)
 }
 
 template<typename T>
-void regions(Array<T> out, const Array<char> in, af_connectivity connectivity)
+void regions(Param<T> out, CParam<char> in, af_connectivity connectivity)
 {
-    const af::dim4 inDims = in.dims();
+    const af::dim4 inDims = in.dims;
     const char *inPtr  = in.get();
     T *outPtr = out.get();
 

--- a/src/backend/cpu/kernel/reorder.hpp
+++ b/src/backend/cpu/kernel/reorder.hpp
@@ -21,8 +21,8 @@ void reorder(Param<T> out, CParam<T> in, const af::dim4 oDims, const af::dim4 rd
     T* outPtr = out.get();
     const T* inPtr = in.get();
 
-    const af::dim4 ist = in.strides;
-    const af::dim4 ost = out.strides;
+    const af::dim4 ist = in.strides();
+    const af::dim4 ost = out.strides();
 
 
     dim_t ids[4]  = {0};

--- a/src/backend/cpu/kernel/reorder.hpp
+++ b/src/backend/cpu/kernel/reorder.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,13 +16,13 @@ namespace kernel
 {
 
 template<typename T>
-void reorder(Array<T> out, const Array<T> in, const af::dim4 oDims, const af::dim4 rdims)
+void reorder(Param<T> out, CParam<T> in, const af::dim4 oDims, const af::dim4 rdims)
 {
     T* outPtr = out.get();
     const T* inPtr = in.get();
 
-    const af::dim4 ist = in.strides();
-    const af::dim4 ost = out.strides();
+    const af::dim4 ist = in.strides;
+    const af::dim4 ost = out.strides;
 
 
     dim_t ids[4]  = {0};

--- a/src/backend/cpu/kernel/resize.hpp
+++ b/src/backend/cpu/kernel/resize.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -155,14 +155,14 @@ struct resize_op<T, AF_INTERP_LOWER>
 };
 
 template<typename T, af_interp_type method>
-void resize(Array<T> out, const Array<T> in)
+void resize(Param<T> out, CParam<T> in)
 {
-    af::dim4 idims    = in.dims();
-    af::dim4 odims    = out.dims();
+    af::dim4 idims    = in.dims;
+    af::dim4 odims    = out.dims;
     const T *inPtr    = in.get();
           T *outPtr   = out.get();
-    af::dim4 ostrides = out.strides();
-    af::dim4 istrides = in.strides();
+    af::dim4 ostrides = out.strides;
+    af::dim4 istrides = in.strides;
 
     resize_op<T, method> op;
     for(dim_t y = 0; y < odims[1]; y++) {

--- a/src/backend/cpu/kernel/resize.hpp
+++ b/src/backend/cpu/kernel/resize.hpp
@@ -157,12 +157,12 @@ struct resize_op<T, AF_INTERP_LOWER>
 template<typename T, af_interp_type method>
 void resize(Param<T> out, CParam<T> in)
 {
-    af::dim4 idims    = in.dims;
-    af::dim4 odims    = out.dims;
+    af::dim4 idims    = in.dims();
+    af::dim4 odims    = out.dims();
     const T *inPtr    = in.get();
           T *outPtr   = out.get();
-    af::dim4 ostrides = out.strides;
-    af::dim4 istrides = in.strides;
+    af::dim4 ostrides = out.strides();
+    af::dim4 istrides = in.strides();
 
     resize_op<T, method> op;
     for(dim_t y = 0; y < odims[1]; y++) {

--- a/src/backend/cpu/kernel/rotate.hpp
+++ b/src/backend/cpu/kernel/rotate.hpp
@@ -26,10 +26,10 @@ void rotate(Param<T> output, CParam<T> input,
     typedef wtype_t<BT> WT;
     Interp2<T, WT, order> interp;
 
-    const af::dim4 odims    = output.dims;
-    const af::dim4 idims    = input.dims;
-    const af::dim4 ostrides = output.strides;
-    const af::dim4 istrides = input.strides;
+    const af::dim4 odims    = output.dims();
+    const af::dim4 idims    = input.dims();
+    const af::dim4 ostrides = output.strides();
+    const af::dim4 istrides = input.strides();
 
     const float c = cos(-theta), s = sin(-theta);
     float tx, ty;

--- a/src/backend/cpu/kernel/rotate.hpp
+++ b/src/backend/cpu/kernel/rotate.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <math.hpp>
 #include <err_cpu.hpp>
 #include "interp.hpp"
@@ -19,17 +19,17 @@ namespace kernel
 {
 
 template<typename T, int order>
-void rotate(Array<T> output, const Array<T> input,
+void rotate(Param<T> output, CParam<T> input,
             const float theta, af_interp_type method)
 {
     typedef typename dtype_traits<T>::base_type BT;
     typedef wtype_t<BT> WT;
     Interp2<T, WT, order> interp;
 
-    const af::dim4 odims    = output.dims();
-    const af::dim4 idims    = input.dims();
-    const af::dim4 ostrides = output.strides();
-    const af::dim4 istrides = input.strides();
+    const af::dim4 odims    = output.dims;
+    const af::dim4 idims    = input.dims;
+    const af::dim4 ostrides = output.strides;
+    const af::dim4 istrides = input.strides;
 
     const float c = cos(-theta), s = sin(-theta);
     float tx, ty;

--- a/src/backend/cpu/kernel/scan.hpp
+++ b/src/backend/cpu/kernel/scan.hpp
@@ -22,9 +22,9 @@ struct scan_dim
                     CParam<Ti> in, dim_t inOffset,
                     const int dim) const
     {
-        const dim4 odims    = out.dims;
-        const dim4 ostrides = out.strides;
-        const dim4 istrides = in.strides;
+        const dim4 odims    = out.dims();
+        const dim4 ostrides = out.strides();
+        const dim4 istrides = in.strides();
 
         const int D1 = D - 1;
         for (dim_t i = 0; i < odims[D1]; i++) {
@@ -47,9 +47,9 @@ struct scan_dim<op, Ti, To, 0, inclusive_scan>
         const Ti* in = input.get() + inOffset;
               To* out= output.get()+ outOffset;
 
-        const dim4 ostrides = output.strides;
-        const dim4 istrides = input.strides;
-        const dim4 idims    = input.dims;
+        const dim4 ostrides = output.strides();
+        const dim4 istrides = input.strides();
+        const dim4 idims    = input.dims();
 
         dim_t istride = istrides[dim];
         dim_t ostride = ostrides[dim];

--- a/src/backend/cpu/kernel/scan.hpp
+++ b/src/backend/cpu/kernel/scan.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -18,13 +18,13 @@ namespace kernel
 template<af_op_t op, typename Ti, typename To, int D, bool inclusive_scan>
 struct scan_dim
 {
-    void operator()(Array<To> out, dim_t outOffset,
-                    const Array<Ti> in, dim_t inOffset,
+    void operator()(Param<To> out, dim_t outOffset,
+                    CParam<Ti> in, dim_t inOffset,
                     const int dim) const
     {
-        const dim4 odims    = out.dims();
-        const dim4 ostrides = out.strides();
-        const dim4 istrides = in.strides();
+        const dim4 odims    = out.dims;
+        const dim4 ostrides = out.strides;
+        const dim4 istrides = in.strides;
 
         const int D1 = D - 1;
         for (dim_t i = 0; i < odims[D1]; i++) {
@@ -40,16 +40,16 @@ struct scan_dim
 template<af_op_t op, typename Ti, typename To, bool inclusive_scan>
 struct scan_dim<op, Ti, To, 0, inclusive_scan>
 {
-    void operator()(Array<To> output, dim_t outOffset,
-                    const Array<Ti> input,  dim_t inOffset,
+    void operator()(Param<To> output, dim_t outOffset,
+                    CParam<Ti> input,  dim_t inOffset,
                     const int dim) const
     {
         const Ti* in = input.get() + inOffset;
               To* out= output.get()+ outOffset;
 
-        const dim4 ostrides = output.strides();
-        const dim4 istrides = input.strides();
-        const dim4 idims    = input.dims();
+        const dim4 ostrides = output.strides;
+        const dim4 istrides = input.strides;
+        const dim4 idims    = input.dims;
 
         dim_t istride = istrides[dim];
         dim_t ostride = ostrides[dim];

--- a/src/backend/cpu/kernel/scan_by_key.hpp
+++ b/src/backend/cpu/kernel/scan_by_key.hpp
@@ -26,10 +26,10 @@ struct scan_dim_by_key
                     CParam<Ti> in, dim_t inOffset,
                     const int dim) const
     {
-        const dim4 odims    = out.dims;
-        const dim4 ostrides = out.strides;
-        const dim4 kstrides = key.strides;
-        const dim4 istrides = in.strides;
+        const dim4 odims    = out.dims();
+        const dim4 ostrides = out.strides();
+        const dim4 kstrides = key.strides();
+        const dim4 istrides = in.strides();
 
         const int D1 = D - 1;
         for (dim_t i = 0; i < odims[D1]; i++) {
@@ -58,10 +58,10 @@ struct scan_dim_by_key<op, Ti, Tk, To, 0>
         const Tk* key = keyinput.get() + keyOffset;
               To* out = output.get()   + outOffset;
 
-        const dim4 ostrides = output.strides;
-        const dim4 kstrides = keyinput.strides;
-        const dim4 istrides = input.strides;
-        const dim4 idims    = input.dims;
+        const dim4 ostrides = output.strides();
+        const dim4 kstrides = keyinput.strides();
+        const dim4 istrides = input.strides();
+        const dim4 idims    = input.dims();
 
         dim_t istride = istrides[dim];
         dim_t kstride = kstrides[dim];

--- a/src/backend/cpu/kernel/scan_by_key.hpp
+++ b/src/backend/cpu/kernel/scan_by_key.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -21,15 +21,15 @@ struct scan_dim_by_key
     bool inclusive_scan;
     scan_dim_by_key(bool inclusiveSanKey) : inclusive_scan(inclusiveSanKey) {}
 
-    void operator()(Array<To> out, dim_t outOffset,
-                    const Array<Tk> key, dim_t keyOffset,
-                    const Array<Ti> in, dim_t inOffset,
+    void operator()(Param<To> out, dim_t outOffset,
+                    CParam<Tk> key, dim_t keyOffset,
+                    CParam<Ti> in, dim_t inOffset,
                     const int dim) const
     {
-        const dim4 odims    = out.dims();
-        const dim4 ostrides = out.strides();
-        const dim4 kstrides = key.strides();
-        const dim4 istrides = in.strides();
+        const dim4 odims    = out.dims;
+        const dim4 ostrides = out.strides;
+        const dim4 kstrides = key.strides;
+        const dim4 istrides = in.strides;
 
         const int D1 = D - 1;
         for (dim_t i = 0; i < odims[D1]; i++) {
@@ -49,19 +49,19 @@ struct scan_dim_by_key<op, Ti, Tk, To, 0>
     bool inclusive_scan;
     scan_dim_by_key(bool inclusiveSanKey) : inclusive_scan(inclusiveSanKey) {}
 
-    void operator()(Array<To> output, dim_t outOffset,
-                    const Array<Tk> keyinput, dim_t keyOffset,
-                    const Array<Ti> input, dim_t inOffset,
+    void operator()(Param<To> output, dim_t outOffset,
+                    CParam<Tk> keyinput, dim_t keyOffset,
+                    CParam<Ti> input, dim_t inOffset,
                     const int dim) const
     {
         const Ti* in  = input.get()    + inOffset;
         const Tk* key = keyinput.get() + keyOffset;
               To* out = output.get()   + outOffset;
 
-        const dim4 ostrides = output.strides();
-        const dim4 kstrides = keyinput.strides();
-        const dim4 istrides = input.strides();
-        const dim4 idims    = input.dims();
+        const dim4 ostrides = output.strides;
+        const dim4 kstrides = keyinput.strides;
+        const dim4 istrides = input.strides;
+        const dim4 idims    = input.dims;
 
         dim_t istride = istrides[dim];
         dim_t kstride = kstrides[dim];

--- a/src/backend/cpu/kernel/select.hpp
+++ b/src/backend/cpu/kernel/select.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,18 +16,18 @@ namespace kernel
 {
 
 template<typename T>
-void select(Array<T> out, const Array<char> cond, const Array<T> a, const Array<T> b)
+void select(Param<T> out, CParam<char> cond, CParam<T> a, CParam<T> b)
 {
-    af::dim4 adims = a.dims();
-    af::dim4 astrides = a.strides();
-    af::dim4 bdims = b.dims();
-    af::dim4 bstrides = b.strides();
+    af::dim4 adims = a.dims;
+    af::dim4 astrides = a.strides;
+    af::dim4 bdims = b.dims;
+    af::dim4 bstrides = b.strides;
 
-    af::dim4 cdims = cond.dims();
-    af::dim4 cstrides = cond.strides();
+    af::dim4 cdims = cond.dims;
+    af::dim4 cstrides = cond.strides;
 
-    af::dim4 odims = out.dims();
-    af::dim4 ostrides = out.strides();
+    af::dim4 odims = out.dims;
+    af::dim4 ostrides = out.strides;
 
     bool is_a_same[] = {adims[0] == odims[0], adims[1] == odims[1],
         adims[2] == odims[2], adims[3] == odims[3]};
@@ -78,13 +78,13 @@ void select(Array<T> out, const Array<char> cond, const Array<T> a, const Array<
 }
 
 template<typename T, bool flip>
-void select_scalar(Array<T> out, const Array<char> cond, const Array<T> a, const double b)
+void select_scalar(Param<T> out, CParam<char> cond, CParam<T> a, const double b)
 {
-    af::dim4 astrides = a.strides();
-    af::dim4 cstrides = cond.strides();
+    af::dim4 astrides = a.strides;
+    af::dim4 cstrides = cond.strides;
 
-    af::dim4 odims = out.dims();
-    af::dim4 ostrides = out.strides();
+    af::dim4 odims = out.dims;
+    af::dim4 ostrides = out.strides;
 
     const T *aptr = a.get();
     T *optr = out.get();

--- a/src/backend/cpu/kernel/select.hpp
+++ b/src/backend/cpu/kernel/select.hpp
@@ -18,16 +18,16 @@ namespace kernel
 template<typename T>
 void select(Param<T> out, CParam<char> cond, CParam<T> a, CParam<T> b)
 {
-    af::dim4 adims = a.dims;
-    af::dim4 astrides = a.strides;
-    af::dim4 bdims = b.dims;
-    af::dim4 bstrides = b.strides;
+    af::dim4 adims = a.dims();
+    af::dim4 astrides = a.strides();
+    af::dim4 bdims = b.dims();
+    af::dim4 bstrides = b.strides();
 
-    af::dim4 cdims = cond.dims;
-    af::dim4 cstrides = cond.strides;
+    af::dim4 cdims = cond.dims();
+    af::dim4 cstrides = cond.strides();
 
-    af::dim4 odims = out.dims;
-    af::dim4 ostrides = out.strides;
+    af::dim4 odims = out.dims();
+    af::dim4 ostrides = out.strides();
 
     bool is_a_same[] = {adims[0] == odims[0], adims[1] == odims[1],
         adims[2] == odims[2], adims[3] == odims[3]};
@@ -80,11 +80,11 @@ void select(Param<T> out, CParam<char> cond, CParam<T> a, CParam<T> b)
 template<typename T, bool flip>
 void select_scalar(Param<T> out, CParam<char> cond, CParam<T> a, const double b)
 {
-    af::dim4 astrides = a.strides;
-    af::dim4 cstrides = cond.strides;
+    af::dim4 astrides = a.strides();
+    af::dim4 cstrides = cond.strides();
 
-    af::dim4 odims = out.dims;
-    af::dim4 ostrides = out.strides;
+    af::dim4 odims = out.dims();
+    af::dim4 ostrides = out.strides();
 
     const T *aptr = a.get();
     T *optr = out.get();

--- a/src/backend/cpu/kernel/shift.hpp
+++ b/src/backend/cpu/kernel/shift.hpp
@@ -27,9 +27,9 @@ void shift(Param<T> out, CParam<T> in, const af::dim4 sdims)
     T* outPtr = out.get();
     const T* inPtr = in.get();
 
-    const af::dim4 oDims = out.dims;
-    const af::dim4 ist   = in.strides;
-    const af::dim4 ost   = out.strides;
+    const af::dim4 oDims = out.dims();
+    const af::dim4 ist   = in.strides();
+    const af::dim4 ost   = out.strides();
 
     int sdims_[4];
     // Need to do this because we are mapping output to input in the kernel

--- a/src/backend/cpu/kernel/shift.hpp
+++ b/src/backend/cpu/kernel/shift.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <cassert>
 
 namespace cpu
@@ -22,14 +22,14 @@ static inline dim_t simple_mod(const dim_t i, const dim_t dim)
 }
 
 template<typename T>
-void shift(Array<T> out, const Array<T> in, const af::dim4 sdims)
+void shift(Param<T> out, CParam<T> in, const af::dim4 sdims)
 {
     T* outPtr = out.get();
     const T* inPtr = in.get();
 
-    const af::dim4 oDims = out.dims();
-    const af::dim4 ist   = in.strides();
-    const af::dim4 ost   = out.strides();
+    const af::dim4 oDims = out.dims;
+    const af::dim4 ist   = in.strides;
+    const af::dim4 ost   = out.strides;
 
     int sdims_[4];
     // Need to do this because we are mapping output to input in the kernel

--- a/src/backend/cpu/kernel/sift_nonfree.hpp
+++ b/src/backend/cpu/kernel/sift_nonfree.hpp
@@ -177,12 +177,12 @@ void gaussian1D(T* out, const int dim, double sigma=0.0)
 }
 
 template<typename T>
-Param<T> gauss_filter(float sigma)
+Array<T> gauss_filter(float sigma)
 {
     // Using 6-sigma rule
     unsigned gauss_len = std::min((unsigned)round(sigma * 6 + 1) | 1, 31u);
 
-    Param<T> filter = createEmptyArray<T>(gauss_len);
+    Array<T> filter = createEmptyArray<T>(gauss_len);
     gaussian1D((T*)getDevicePtr(filter), gauss_len, sigma);
 
     return filter;
@@ -218,9 +218,9 @@ void gaussianElimination(float* A, float* b, float* x)
 
 template<typename T>
 void sub(
-    Param<T>& out,
-    CParam<T>& in1,
-    CParam<T>& in2)
+    Array<T>& out,
+    const Array<T>& in1,
+    const Array<T>& in2)
 {
     size_t nel = in1.elements();
     T* out_ptr = out.get();
@@ -244,14 +244,14 @@ void detectExtrema(
     float* y_out,
     unsigned* layer_out,
     unsigned* counter,
-    CParam<T>& prev,
-    CParam<T>& center,
-    CParam<T>& next,
+    const Array<T>& prev,
+    const Array<T>& center,
+    const Array<T>& next,
     const unsigned layer,
     const unsigned max_feat,
     const float threshold)
 {
-    const af::dim4 idims = center.dims;
+    const af::dim4 idims = center.dims();
     const T* prev_ptr    = prev.get();
     const T* center_ptr  = center.get();
     const T* next_ptr    = next.get();
@@ -308,7 +308,7 @@ void interpolateExtrema(
     const float* y_in,
     const unsigned* layer_in,
     const unsigned extrema_feat,
-    std::vector< Param<T> >& dog_pyr,
+    std::vector< Array<T> >& dog_pyr,
     const unsigned max_feat,
     const unsigned octave,
     const unsigned n_layers,
@@ -333,7 +333,7 @@ void interpolateExtrema(
         const T* center_ptr = dog_pyr[octave*(n_layers+2) + layer].get();
         const T* next_ptr   = dog_pyr[octave*(n_layers+2) + layer+1].get();
 
-        af::dim4 idims = dog_pyr[octave*(n_layers+2)].dims;
+        af::dim4 idims = dog_pyr[octave*(n_layers+2)].dims();
 
         bool converges = true;
 
@@ -477,7 +477,7 @@ void calcOrientation(
     const float* response_in,
     const float* size_in,
     const unsigned total_feat,
-    const std::vector< Param<T> >& gauss_pyr,
+    const std::vector< Array<T> >& gauss_pyr,
     const unsigned max_feat,
     const unsigned octave,
     const unsigned n_layers,
@@ -507,13 +507,13 @@ void calcOrientation(
         const float exp_denom = 2.f * sigma * sigma;
 
         // Points img to correct Gaussian pyramid layer
-        CParam<T> img = gauss_pyr[octave*(n_layers+3) + layer];
+        const Array<T> img = gauss_pyr[octave*(n_layers+3) + layer];
         const T* img_ptr = img.get();
 
         for (int i = 0; i < OriHistBins; i++)
             hist[i] = 0.f;
 
-        af::dim4 idims = img.dims;
+        af::dim4 idims = img.dims();
 
         // Calculate orientation histogram
         for (int l = 0; l < len*len; l++) {
@@ -621,7 +621,7 @@ void computeDescriptor(
     const float* size_in,
     const float* ori_in,
     const unsigned total_feat,
-    const std::vector< Param<T> >& gauss_pyr,
+    const std::vector< Array<T> >& gauss_pyr,
     const int d,
     const int n,
     const float scale,
@@ -639,9 +639,9 @@ void computeDescriptor(
         const int fy = round(y_in[f] * scale);
 
         // Points img to correct Gaussian pyramid layer
-        Param<T> img = gauss_pyr[octave*(n_layers+3) + layer];
+        Array<T> img = gauss_pyr[octave*(n_layers+3) + layer];
         const T* img_ptr = img.get();
-        af::dim4 idims = img.dims;
+        af::dim4 idims = img.dims();
 
         float cos_t = cos(ori);
         float sin_t = sin(ori);
@@ -738,7 +738,7 @@ void computeGLOHDescriptor(
     const float* size_in,
     const float* ori_in,
     const unsigned total_feat,
-    const std::vector< Param<T> >& gauss_pyr,
+    const std::vector< Array<T> >& gauss_pyr,
     const int d,
     const unsigned rb,
     const unsigned ab,
@@ -758,9 +758,9 @@ void computeGLOHDescriptor(
         const int fy = round(y_in[f] * scale);
 
         // Points img to correct Gaussian pyramid layer
-        Param<T> img = gauss_pyr[octave*(n_layers+3) + layer];
+        Array<T> img = gauss_pyr[octave*(n_layers+3) + layer];
         const T* img_ptr = img.get();
-        af::dim4 idims = img.dims;
+        af::dim4 idims = img.dims();
 
         float cos_t = cos(ori);
         float sin_t = sin(ori);
@@ -867,22 +867,22 @@ void computeGLOHDescriptor(
 #undef IPTR
 
 template<typename T, typename convAccT>
-Param<T> createInitialImage(
-    CParam<T>& img,
+Array<T> createInitialImage(
+    const Array<T>& img,
     const float init_sigma,
     const bool double_input)
 {
-    af::dim4 idims = img.dims;
+    af::dim4 idims = img.dims();
 
-    Param<T> init_img = createEmptyArray<T>(af::dim4());
+    Array<T> init_img = createEmptyArray<T>(af::dim4());
 
     float s = (double_input) ? std::max((float)sqrt(init_sigma * init_sigma - InitSigma * InitSigma * 4), 0.1f)
                              : std::max((float)sqrt(init_sigma * init_sigma - InitSigma * InitSigma), 0.1f);
 
-    Param<T> filter = gauss_filter<T>(s);
+    Array<T> filter = gauss_filter<T>(s);
 
     if (double_input) {
-        Param<T> double_img = resize<T>(img, idims[0] * 2, idims[1] * 2, AF_INTERP_BILINEAR);
+        Array<T> double_img = resize<T>(img, idims[0] * 2, idims[1] * 2, AF_INTERP_BILINEAR);
         init_img = convolve2<T, convAccT, false>(double_img, filter, filter);
     }
     else {
@@ -893,8 +893,8 @@ Param<T> createInitialImage(
 }
 
 template<typename T, typename convAccT>
-std::vector< Param<T> > buildGaussPyr(
-    CParam<T>& init_img,
+std::vector< Array<T> > buildGaussPyr(
+    const Array<T>& init_img,
     const unsigned n_octaves,
     const unsigned n_layers,
     const float init_sigma)
@@ -911,7 +911,7 @@ std::vector< Param<T> > buildGaussPyr(
     }
 
     // Gaussian Pyramid
-    std::vector< Param<T> > gauss_pyr(n_octaves * (n_layers+3), createEmptyArray<T>(af::dim4()));
+    std::vector< Array<T> > gauss_pyr(n_octaves * (n_layers+3), createEmptyArray<T>(af::dim4()));
     for (unsigned o = 0; o < n_octaves; o++) {
         for (unsigned l = 0; l < n_layers+3; l++) {
             unsigned src_idx = (l == 0) ? (o-1)*(n_layers+3) + n_layers : o*(n_layers+3) + l-1;
@@ -921,11 +921,11 @@ std::vector< Param<T> > buildGaussPyr(
                 gauss_pyr[idx] = init_img;
             }
             else if (l == 0) {
-                af::dim4 sdims = gauss_pyr[src_idx].dims;
+                af::dim4 sdims = gauss_pyr[src_idx].dims();
                 gauss_pyr[idx] = resize<T>(gauss_pyr[src_idx], sdims[0] / 2, sdims[1] / 2, AF_INTERP_BILINEAR);
             }
             else {
-                Param<T> filter = gauss_filter<T>(sig_layers[l]);
+                Array<T> filter = gauss_filter<T>(sig_layers[l]);
 
                 gauss_pyr[idx] = convolve2<T, convAccT, false>(gauss_pyr[src_idx], filter, filter);
             }
@@ -936,20 +936,20 @@ std::vector< Param<T> > buildGaussPyr(
 }
 
 template<typename T>
-std::vector< Param<T> > buildDoGPyr(
-    std::vector< Param<T> >& gauss_pyr,
+std::vector< Array<T> > buildDoGPyr(
+    std::vector< Array<T> >& gauss_pyr,
     const unsigned n_octaves,
     const unsigned n_layers)
 {
     // DoG Pyramid
-    std::vector< Param<T> > dog_pyr(n_octaves * (n_layers+2), createEmptyArray<T>(af::dim4()));
+    std::vector< Array<T> > dog_pyr(n_octaves * (n_layers+2), createEmptyArray<T>(af::dim4()));
     for (unsigned o = 0; o < n_octaves; o++) {
         for (unsigned l = 0; l < n_layers+2; l++) {
             unsigned idx    = o*(n_layers+2) + l;
             unsigned bottom = o*(n_layers+3) + l;
             unsigned top    = o*(n_layers+3) + l+1;
 
-            dog_pyr[idx] = createEmptyArray<T>(gauss_pyr[bottom].dims);
+            dog_pyr[idx] = createEmptyArray<T>(gauss_pyr[bottom].dims());
 
             sub<T>(dog_pyr[idx], gauss_pyr[top], gauss_pyr[bottom]);
         }
@@ -960,9 +960,9 @@ std::vector< Param<T> > buildDoGPyr(
 
 
 template<typename T, typename convAccT>
-unsigned sift_impl(Param<float>& x, Param<float>& y, Param<float>& score,
-                   Param<float>& ori, Param<float>& size, Param<float>& desc,
-                   CParam<T>& in, const unsigned n_layers,
+unsigned sift_impl(Array<float>& x, Array<float>& y, Array<float>& score,
+                   Array<float>& ori, Array<float>& size, Array<float>& desc,
+                   const Array<T>& in, const unsigned n_layers,
                    const float contrast_thr, const float edge_thr,
                    const float init_sigma, const bool double_input,
                    const float img_scale, const float feature_ratio,
@@ -970,18 +970,18 @@ unsigned sift_impl(Param<float>& x, Param<float>& y, Param<float>& score,
 {
     in.eval();
     getQueue().sync();
-    af::dim4 idims = in.dims;
+    af::dim4 idims = in.dims();
 
     unsigned min_dim = min(idims[0], idims[1]);
     if (double_input) min_dim *= 2;
 
     const unsigned n_octaves = floor(log(min_dim) / log(2)) - 2;
 
-    Param<T> init_img = createInitialImage<T, convAccT>(in, init_sigma, double_input);
+    Array<T> init_img = createInitialImage<T, convAccT>(in, init_sigma, double_input);
 
-    std::vector< Param<T> > gauss_pyr = buildGaussPyr<T, convAccT>(init_img, n_octaves, n_layers, init_sigma);
+    std::vector< Array<T> > gauss_pyr = buildGaussPyr<T, convAccT>(init_img, n_octaves, n_layers, init_sigma);
 
-    std::vector< Param<T> > dog_pyr = buildDoGPyr<T>(gauss_pyr, n_octaves, n_layers);
+    std::vector< Array<T> > dog_pyr = buildDoGPyr<T>(gauss_pyr, n_octaves, n_layers);
 
     std::vector<float*> x_pyr(n_octaves, NULL);
     std::vector<float*> y_pyr(n_octaves, NULL);
@@ -1000,7 +1000,7 @@ unsigned sift_impl(Param<float>& x, Param<float>& y, Param<float>& score,
     const unsigned desc_len = (compute_GLOH) ? (1 + (rb-1) * ab) * hb : d*d*n;
 
     for (unsigned i = 0; i < n_octaves; i++) {
-        af::dim4 ddims = dog_pyr[i*(n_layers+2)].dims;
+        af::dim4 ddims = dog_pyr[i*(n_layers+2)].dims();
         if (ddims[0]-2*ImgBorder < 1 ||
             ddims[1]-2*ImgBorder < 1)
             continue;

--- a/src/backend/cpu/kernel/sift_nonfree.hpp
+++ b/src/backend/cpu/kernel/sift_nonfree.hpp
@@ -949,7 +949,7 @@ std::vector< Array<T> > buildDoGPyr(
             unsigned bottom = o*(n_layers+3) + l;
             unsigned top    = o*(n_layers+3) + l+1;
 
-            dog_pyr[idx] = createEmptyArray<T>(gauss_pyr[bottom].dims());
+            dog_pyr[idx] = createEmptyArray<T>(gauss_pyr[bottom].dims(););
 
             sub<T>(dog_pyr[idx], gauss_pyr[top], gauss_pyr[bottom]);
         }

--- a/src/backend/cpu/kernel/sift_nonfree.hpp
+++ b/src/backend/cpu/kernel/sift_nonfree.hpp
@@ -949,7 +949,7 @@ std::vector< Array<T> > buildDoGPyr(
             unsigned bottom = o*(n_layers+3) + l;
             unsigned top    = o*(n_layers+3) + l+1;
 
-            dog_pyr[idx] = createEmptyArray<T>(gauss_pyr[bottom].dims(););
+            dog_pyr[idx] = createEmptyArray<T>(gauss_pyr[bottom].dims());
 
             sub<T>(dog_pyr[idx], gauss_pyr[top], gauss_pyr[bottom]);
         }

--- a/src/backend/cpu/kernel/sobel.hpp
+++ b/src/backend/cpu/kernel/sobel.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <cassert>
 
 namespace cpu
@@ -17,11 +17,11 @@ namespace kernel
 {
 
 template<typename Ti, typename To, bool isDX>
-void derivative(Array<To> output, const Array<Ti> input)
+void derivative(Param<To> output, CParam<Ti> input)
 {
-    const af::dim4 dims    = input.dims();
-    const af::dim4 istrides = input.strides();
-    const af::dim4 ostrides = output.strides();
+    const af::dim4 dims    = input.dims;
+    const af::dim4 istrides = input.strides;
+    const af::dim4 ostrides = output.strides;
 
     for(dim_t b3=0; b3<dims[3]; ++b3) {
         To* optr     = output.get() + b3 * ostrides[3];

--- a/src/backend/cpu/kernel/sobel.hpp
+++ b/src/backend/cpu/kernel/sobel.hpp
@@ -19,9 +19,9 @@ namespace kernel
 template<typename Ti, typename To, bool isDX>
 void derivative(Param<To> output, CParam<Ti> input)
 {
-    const af::dim4 dims    = input.dims;
-    const af::dim4 istrides = input.strides;
-    const af::dim4 ostrides = output.strides;
+    const af::dim4 dims    = input.dims();
+    const af::dim4 istrides = input.strides();
+    const af::dim4 ostrides = output.strides();
 
     for(dim_t b3=0; b3<dims[3]; ++b3) {
         To* optr     = output.get() + b3 * ostrides[3];

--- a/src/backend/cpu/kernel/sort.hpp
+++ b/src/backend/cpu/kernel/sort.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <math.hpp>
 #include <algorithm>
 #include <numeric>
@@ -22,7 +22,7 @@ namespace kernel
 
 // Based off of http://stackoverflow.com/a/12399290
 template<typename T>
-void sort0Iterative(Array<T> val, bool isAscending)
+void sort0Iterative(Param<T> val, bool isAscending)
 {
     // initialize original index locations
     T *val_ptr = val.get();
@@ -31,16 +31,16 @@ void sort0Iterative(Array<T> val, bool isAscending)
     if(isAscending) { op = std::less<T>(); }
 
     T *comp_ptr = nullptr;
-    for(dim_t w = 0; w < val.dims()[3]; w++) {
-        dim_t valW = w * val.strides()[3];
-        for(dim_t z = 0; z < val.dims()[2]; z++) {
-            dim_t valWZ = valW + z * val.strides()[2];
-            for(dim_t y = 0; y < val.dims()[1]; y++) {
+    for(dim_t w = 0; w < val.dims[3]; w++) {
+        dim_t valW = w * val.strides[3];
+        for(dim_t z = 0; z < val.dims[2]; z++) {
+            dim_t valWZ = valW + z * val.strides[2];
+            for(dim_t y = 0; y < val.dims[1]; y++) {
 
-                dim_t valOffset = valWZ + y * val.strides()[1];
+                dim_t valOffset = valWZ + y * val.strides[1];
 
                 comp_ptr = val_ptr + valOffset;
-                std::sort(comp_ptr, comp_ptr + val.dims()[0], op);
+                std::sort(comp_ptr, comp_ptr + val.dims[0], op);
             }
         }
     }

--- a/src/backend/cpu/kernel/sort.hpp
+++ b/src/backend/cpu/kernel/sort.hpp
@@ -31,16 +31,16 @@ void sort0Iterative(Param<T> val, bool isAscending)
     if(isAscending) { op = std::less<T>(); }
 
     T *comp_ptr = nullptr;
-    for(dim_t w = 0; w < val.dims[3]; w++) {
-        dim_t valW = w * val.strides[3];
-        for(dim_t z = 0; z < val.dims[2]; z++) {
-            dim_t valWZ = valW + z * val.strides[2];
-            for(dim_t y = 0; y < val.dims[1]; y++) {
+    for(dim_t w = 0; w < val.dims(3); w++) {
+        dim_t valW = w * val.strides(3);
+        for(dim_t z = 0; z < val.dims(2); z++) {
+            dim_t valWZ = valW + z * val.strides(2);
+            for(dim_t y = 0; y < val.dims(1); y++) {
 
-                dim_t valOffset = valWZ + y * val.strides[1];
+                dim_t valOffset = valWZ + y * val.strides(1);
 
                 comp_ptr = val_ptr + valOffset;
-                std::sort(comp_ptr, comp_ptr + val.dims[0], op);
+                std::sort(comp_ptr, comp_ptr + val.dims(0), op);
             }
         }
     }

--- a/src/backend/cpu/kernel/sort_by_key.hpp
+++ b/src/backend/cpu/kernel/sort_by_key.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <err_cpu.hpp>
 
 namespace cpu
@@ -17,13 +17,13 @@ namespace kernel
 {
 
 template<typename Tk, typename Tv>
-void sort0ByKeyIterative(Array<Tk> okey, Array<Tv> oval, bool isAscending);
+void sort0ByKeyIterative(Param<Tk> okey, Param<Tv> oval, bool isAscending);
 
 template<typename Tk, typename Tv>
-void sortByKeyBatched(Array<Tk> okey, Array<Tv> oval, const int dim, bool isAscending);
+void sortByKeyBatched(Param<Tk> okey, Param<Tv> oval, const int dim, bool isAscending);
 
 template<typename Tk, typename Tv>
-void sort0ByKey(Array<Tk> okey, Array<Tv> oval, bool isAscending);
+void sort0ByKey(Param<Tk> okey, Param<Tv> oval, bool isAscending);
 
 }
 }

--- a/src/backend/cpu/kernel/sort_by_key_impl.hpp
+++ b/src/backend/cpu/kernel/sort_by_key_impl.hpp
@@ -34,21 +34,21 @@ void sort0ByKeyIterative(Param<Tk> okey, Param<Tv> oval, bool isAscending)
 
     typedef IndexPair<Tk, Tv> CurrentPair;
 
-    dim_t size = okey.dims[0];
+    dim_t size = okey.dims(0);
     std::vector<CurrentPair> pairKeyVal(size);
 
-    for(dim_t w = 0; w < okey.dims[3]; w++) {
-        dim_t okeyW = w * okey.strides[3];
-        dim_t ovalW = w * oval.strides[3];
+    for(dim_t w = 0; w < okey.dims(3); w++) {
+        dim_t okeyW = w * okey.strides(3);
+        dim_t ovalW = w * oval.strides(3);
 
-        for(dim_t z = 0; z < okey.dims[2]; z++) {
-            dim_t okeyWZ = okeyW + z * okey.strides[2];
-            dim_t ovalWZ = ovalW + z * oval.strides[2];
+        for(dim_t z = 0; z < okey.dims(2); z++) {
+            dim_t okeyWZ = okeyW + z * okey.strides(2);
+            dim_t ovalWZ = ovalW + z * oval.strides(2);
 
-            for(dim_t y = 0; y < okey.dims[1]; y++) {
+            for(dim_t y = 0; y < okey.dims(1); y++) {
 
-                dim_t okeyOffset = okeyWZ + y * okey.strides[1];
-                dim_t ovalOffset = ovalWZ + y * oval.strides[1];
+                dim_t okeyOffset = okeyWZ + y * okey.strides(1);
+                dim_t ovalOffset = ovalWZ + y * oval.strides(1);
 
                 Tk *okey_col_ptr = okey_ptr + okeyOffset;
                 Tv *oval_col_ptr = oval_ptr + ovalOffset;
@@ -77,7 +77,7 @@ void sort0ByKeyIterative(Param<Tk> okey, Param<Tv> oval, bool isAscending)
 template<typename Tk, typename Tv>
 void sortByKeyBatched(Param<Tk> okey, Param<Tv> oval, const int dim, bool isAscending)
 {
-    af::dim4 inDims = okey.dims;
+    af::dim4 inDims = okey.dims();
 
     af::dim4 tileDims(1);
     af::dim4 seqDims = inDims;
@@ -116,7 +116,7 @@ void sortByKeyBatched(Param<Tk> okey, Param<Tv> oval, const int dim, bool isAsce
     Tv *oval_ptr = oval.get();
 
     typedef KeyIndexPair<Tk, Tv> CurrentTuple;
-    size_t size = okey.dims.elements();
+    size_t size = okey.dims().elements();
     std::vector<CurrentTuple> tupleKeyValIdx(size);
 
     for(unsigned i = 0; i < size; i++) {
@@ -133,7 +133,7 @@ void sortByKeyBatched(Param<Tk> okey, Param<Tv> oval, const int dim, bool isAsce
 
     std::stable_sort(tupleKeyValIdx.begin(), tupleKeyValIdx.end(), KIPCompareK<Tk, Tv, true>());
 
-    for(unsigned x = 0; x < okey.dims.elements(); x++) {
+    for(unsigned x = 0; x < okey.dims().elements(); x++) {
         okey_ptr[x] = std::get<0>(tupleKeyValIdx[x]);
         oval_ptr[x] = std::get<1>(tupleKeyValIdx[x]);
     }
@@ -143,7 +143,7 @@ void sortByKeyBatched(Param<Tk> okey, Param<Tv> oval, const int dim, bool isAsce
 template<typename Tk, typename Tv>
 void sort0ByKey(Param<Tk> okey, Param<Tv> oval, bool isAscending)
 {
-    int higherDims =  okey.dims[1] * okey.dims[2] * okey.dims[3];
+    int higherDims =  okey.dims(1) * okey.dims(2) * okey.dims(3);
     // TODO Make a better heurisitic
     if(higherDims > 4)
         kernel::sortByKeyBatched<Tk, Tv>(okey, oval, 0, isAscending);

--- a/src/backend/cpu/kernel/sort_by_key_impl.hpp
+++ b/src/backend/cpu/kernel/sort_by_key_impl.hpp
@@ -10,13 +10,15 @@
 #pragma once
 #include <kernel/sort_by_key.hpp>
 #include <kernel/sort_helper.hpp>
-#include <Array.hpp>
+#include <Param.hpp>
 #include <math.hpp>
 #include <algorithm>
 #include <numeric>
 #include <queue>
 #include <err_cpu.hpp>
 #include <functional>
+#include <tuple>
+#include <utility>
 
 namespace cpu
 {
@@ -24,7 +26,7 @@ namespace kernel
 {
 
 template<typename Tk, typename Tv>
-void sort0ByKeyIterative(Array<Tk> okey, Array<Tv> oval, bool isAscending)
+void sort0ByKeyIterative(Param<Tk> okey, Param<Tv> oval, bool isAscending)
 {
     // Get pointers and initialize original index locations
     Tk *okey_ptr = okey.get();
@@ -32,22 +34,21 @@ void sort0ByKeyIterative(Array<Tk> okey, Array<Tv> oval, bool isAscending)
 
     typedef IndexPair<Tk, Tv> CurrentPair;
 
-    dim_t size = okey.dims()[0];
-    size_t bytes = size * sizeof(CurrentPair);
-    CurrentPair *pairKeyVal = (CurrentPair *)memAlloc<char>(bytes);
+    dim_t size = okey.dims[0];
+    std::vector<CurrentPair> pairKeyVal(size);
 
-    for(dim_t w = 0; w < okey.dims()[3]; w++) {
-        dim_t okeyW = w * okey.strides()[3];
-        dim_t ovalW = w * oval.strides()[3];
+    for(dim_t w = 0; w < okey.dims[3]; w++) {
+        dim_t okeyW = w * okey.strides[3];
+        dim_t ovalW = w * oval.strides[3];
 
-        for(dim_t z = 0; z < okey.dims()[2]; z++) {
-            dim_t okeyWZ = okeyW + z * okey.strides()[2];
-            dim_t ovalWZ = ovalW + z * oval.strides()[2];
+        for(dim_t z = 0; z < okey.dims[2]; z++) {
+            dim_t okeyWZ = okeyW + z * okey.strides[2];
+            dim_t ovalWZ = ovalW + z * oval.strides[2];
 
-            for(dim_t y = 0; y < okey.dims()[1]; y++) {
+            for(dim_t y = 0; y < okey.dims[1]; y++) {
 
-                dim_t okeyOffset = okeyWZ + y * okey.strides()[1];
-                dim_t ovalOffset = ovalWZ + y * oval.strides()[1];
+                dim_t okeyOffset = okeyWZ + y * okey.strides[1];
+                dim_t ovalOffset = ovalWZ + y * oval.strides[1];
 
                 Tk *okey_col_ptr = okey_ptr + okeyOffset;
                 Tv *oval_col_ptr = oval_ptr + ovalOffset;
@@ -57,9 +58,9 @@ void sort0ByKeyIterative(Array<Tk> okey, Array<Tv> oval, bool isAscending)
                 }
 
                 if(isAscending) {
-                    std::stable_sort(pairKeyVal, pairKeyVal + size, IPCompare<Tk, Tv, true>());
+                    std::stable_sort(pairKeyVal.begin(), pairKeyVal.end(), IPCompare<Tk, Tv, true>());
                 } else {
-                    std::stable_sort(pairKeyVal, pairKeyVal + size, IPCompare<Tk, Tv, false>());
+                    std::stable_sort(pairKeyVal.begin(), pairKeyVal.end(), IPCompare<Tk, Tv, false>());
                 }
 
                 for(unsigned x = 0; x < size; x++) {
@@ -70,25 +71,24 @@ void sort0ByKeyIterative(Array<Tk> okey, Array<Tv> oval, bool isAscending)
         }
     }
 
-    memFree((char *)pairKeyVal);
     return;
 }
 
 template<typename Tk, typename Tv>
-void sortByKeyBatched(Array<Tk> okey, Array<Tv> oval, const int dim, bool isAscending)
+void sortByKeyBatched(Param<Tk> okey, Param<Tv> oval, const int dim, bool isAscending)
 {
-    af::dim4 inDims = okey.dims();
+    af::dim4 inDims = okey.dims;
 
     af::dim4 tileDims(1);
     af::dim4 seqDims = inDims;
     tileDims[dim] = inDims[dim];
     seqDims[dim] = 1;
 
-    uint* key = memAlloc<uint>(inDims.elements());
+    std::vector<uint> key(inDims.elements());
     // IOTA
     {
         af::dim4 dims    = inDims;
-        uint* out        = key;
+        uint* out        = key.data();
         af::dim4 strides(1);
         for(int i = 1; i < 4; i++)
             strides[i] = strides[i-1] * dims[i-1];
@@ -116,38 +116,34 @@ void sortByKeyBatched(Array<Tk> okey, Array<Tv> oval, const int dim, bool isAsce
     Tv *oval_ptr = oval.get();
 
     typedef KeyIndexPair<Tk, Tv> CurrentTuple;
-    size_t size = okey.elements();
-    size_t bytes = okey.elements() * sizeof(CurrentTuple);
-    CurrentTuple *tupleKeyValIdx = (CurrentTuple *)memAlloc<char>(bytes);
+    size_t size = okey.dims.elements();
+    std::vector<CurrentTuple> tupleKeyValIdx(size);
 
     for(unsigned i = 0; i < size; i++) {
         tupleKeyValIdx[i] = std::make_tuple(okey_ptr[i], oval_ptr[i], key[i]);
     }
 
-    memFree(key); // key is no longer required
 
     if(isAscending) {
-      std::stable_sort(tupleKeyValIdx, tupleKeyValIdx + size, KIPCompareV<Tk, Tv, true>());
+        std::stable_sort(tupleKeyValIdx.begin(), tupleKeyValIdx.end(), KIPCompareV<Tk, Tv, true>());
     }
     else {
-      std::stable_sort(tupleKeyValIdx, tupleKeyValIdx + size, KIPCompareV<Tk, Tv, false>());
+        std::stable_sort(tupleKeyValIdx.begin(), tupleKeyValIdx.end(), KIPCompareV<Tk, Tv, false>());
     }
 
-    std::stable_sort(tupleKeyValIdx, tupleKeyValIdx + size, KIPCompareK<Tk, Tv, true>());
+    std::stable_sort(tupleKeyValIdx.begin(), tupleKeyValIdx.end(), KIPCompareK<Tk, Tv, true>());
 
-    for(unsigned x = 0; x < okey.elements(); x++) {
+    for(unsigned x = 0; x < okey.dims.elements(); x++) {
         okey_ptr[x] = std::get<0>(tupleKeyValIdx[x]);
         oval_ptr[x] = std::get<1>(tupleKeyValIdx[x]);
     }
 
-    memFree((char *)tupleKeyValIdx);
-    return;
 }
 
 template<typename Tk, typename Tv>
-void sort0ByKey(Array<Tk> okey, Array<Tv> oval, bool isAscending)
+void sort0ByKey(Param<Tk> okey, Param<Tv> oval, bool isAscending)
 {
-    int higherDims =  okey.dims()[1] * okey.dims()[2] * okey.dims()[3];
+    int higherDims =  okey.dims[1] * okey.dims[2] * okey.dims[3];
     // TODO Make a better heurisitic
     if(higherDims > 4)
         kernel::sortByKeyBatched<Tk, Tv>(okey, oval, 0, isAscending);
@@ -156,10 +152,10 @@ void sort0ByKey(Array<Tk> okey, Array<Tv> oval, bool isAscending)
 }
 
 #define INSTANTIATE(Tk, Tv)                                                             \
-    template void sort0ByKey<Tk, Tv>(Array<Tk> okey, Array<Tv> oval, bool isAscending); \
-    template void sort0ByKeyIterative<Tk, Tv>(Array<Tk> okey, Array<Tv> oval,           \
+    template void sort0ByKey<Tk, Tv>(Param<Tk> okey, Param<Tv> oval, bool isAscending); \
+    template void sort0ByKeyIterative<Tk, Tv>(Param<Tk> okey, Param<Tv> oval,           \
                                               bool isAscending);                        \
-    template void sortByKeyBatched<Tk, Tv>(Array<Tk> okey, Array<Tv> oval,              \
+    template void sortByKeyBatched<Tk, Tv>(Param<Tk> okey, Param<Tv> oval,              \
                                            const int dim, bool isAscending);
 
 #define INSTANTIATE1(Tk) \

--- a/src/backend/cpu/kernel/sort_helper.hpp
+++ b/src/backend/cpu/kernel/sort_helper.hpp
@@ -8,6 +8,7 @@
  ********************************************************/
 
 #include <err_cpu.hpp>
+#include <tuple>
 
 namespace cpu
 {

--- a/src/backend/cpu/kernel/sparse.hpp
+++ b/src/backend/cpu/kernel/sparse.hpp
@@ -30,9 +30,9 @@ void coo2dense(Param<T> output,
 
     T * outPtr = output.get();
 
-    af::dim4 ostrides = output.strides;
+    af::dim4 ostrides = output.strides();
 
-    int nNZ = values.dims[0];
+    int nNZ = values.dims(0);
     for(int i = 0; i < nNZ; i++) {
         T   v = vPtr[i];
         int r = rPtr[i];
@@ -53,8 +53,8 @@ void dense_csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
     int     * rPtr = rowIdx.get();
     int     * cPtr = colIdx.get();
 
-    int stride = in.strides[1];
-    af::dim4 dims = in.dims;
+    int stride = in.strides(1);
+    af::dim4 dims = in.dims();
 
     int offset = 0;
     for (int i = 0; i < dims[0]; ++i) {
@@ -78,9 +78,9 @@ void csr_dense(Param<T> out,
     const int *rPtr = rowIdx.get();
     const int *cPtr = colIdx.get();
 
-    int stride = out.strides[1];
+    int stride = out.strides(1);
 
-    int r = rowIdx.dims[0];
+    int r = rowIdx.dims(0);
     for (int i = 0; i < r - 1; i++) {
         for (int ii = rPtr[i]; ii < rPtr[i+1]; ++ii) {
             int j = cPtr[ii];
@@ -120,14 +120,14 @@ void csr_coo(Param<T> ovalues, Param<int> orowIdx, Param<int> ocolIdx,
     const int *icPtr = icolIdx.get();
 
     // Create cordinate form of the row array
-    for(int i = 0; i < (int)irowIdx.dims.elements() - 1; i++) {
+    for(int i = 0; i < (int)irowIdx.dims().elements() - 1; i++) {
         std::fill_n(orPtr + irPtr[i], irPtr[i + 1] - irPtr[i], i);
     }
 
     // Sort the coordinate form using column index
     // Uses code from sort_by_key kernels
     typedef SpKeyIndexPair<T> CurrentPair;
-    int size = ovalues.dims[0];
+    int size = ovalues.dims(0);
     std::vector<CurrentPair> pairKeyVal(size);
 
     for(int x = 0; x < size; x++) {
@@ -136,7 +136,7 @@ void csr_coo(Param<T> ovalues, Param<int> orowIdx, Param<int> ocolIdx,
 
     std::stable_sort(pairKeyVal.begin(), pairKeyVal.end(), SpKIPCompareK<T>());
 
-    for(int x = 0; x < (int)ovalues.dims.elements(); x++) {
+    for(int x = 0; x < (int)ovalues.dims().elements(); x++) {
         std::tie(ocPtr[x], ovPtr[x], orPtr[x]) = pairKeyVal[x];
     }
 
@@ -157,7 +157,7 @@ void coo_csr(Param<T> ovalues, Param<int> orowIdx, Param<int> ocolIdx,
     // Sort the colidx and values based on rowIdx
     // Uses code from sort_by_key kernels
     typedef SpKeyIndexPair<T> CurrentPair;
-    int size = ovalues.dims[0];
+    int size = ovalues.dims(0);
     std::vector<CurrentPair>pairKeyVal(size);
 
     for(int x = 0; x < size; x++) {
@@ -167,14 +167,14 @@ void coo_csr(Param<T> ovalues, Param<int> orowIdx, Param<int> ocolIdx,
     std::stable_sort(pairKeyVal.begin(), pairKeyVal.end(), SpKIPCompareK<T>());
 
     ovPtr[0] = 0;
-    for(int x = 0; x < (int)ovalues.dims.elements(); x++) {
+    for(int x = 0; x < (int)ovalues.dims().elements(); x++) {
         int row = -2; // Some value that will make orPtr[row + 1] error out
         std::tie(row, ovPtr[x], ocPtr[x]) = pairKeyVal[x];
         orPtr[row + 1]++;
     }
 
     // Compress row storage
-    for(int x = 1; x < (int)orowIdx.dims.elements(); x++) {
+    for(int x = 1; x < (int)orowIdx.dims().elements(); x++) {
         orPtr[x] += orPtr[x - 1];
     }
 }

--- a/src/backend/cpu/kernel/sparse.hpp
+++ b/src/backend/cpu/kernel/sparse.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 #include <math.hpp>
 #include <kernel/sort_helper.hpp>
@@ -21,18 +21,18 @@ namespace kernel
 {
 
 template<typename T>
-void coo2dense(Array<T> output,
-               Array<T> const values, Array<int> const rowIdx, Array<int> const colIdx)
+void coo2dense(Param<T> output,
+               CParam<T> values, CParam<int> rowIdx, CParam<int> colIdx)
 {
-    T   const * const vPtr = values.get();
-    int const * const rPtr = rowIdx.get();
-    int const * const cPtr = colIdx.get();
+    const T *vPtr = values.get();
+    const int * rPtr = rowIdx.get();
+    const int * cPtr = colIdx.get();
 
     T * outPtr = output.get();
 
-    af::dim4 ostrides = output.strides();
+    af::dim4 ostrides = output.strides;
 
-    int nNZ = values.dims()[0];
+    int nNZ = values.dims[0];
     for(int i = 0; i < nNZ; i++) {
         T   v = vPtr[i];
         int r = rPtr[i];
@@ -45,56 +45,50 @@ void coo2dense(Array<T> output,
 }
 
 template<typename T>
-struct dense_csr
+void dense_csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
+               CParam<T> in)
 {
-    void operator()(Array<T> values, Array<int> rowIdx, Array<int> colIdx,
-                    Array<T> const in)
-    {
-        T const * const iPtr = in.get();
-        T       * const vPtr = values.get();
-        int     * const rPtr = rowIdx.get();
-        int     * const cPtr = colIdx.get();
+    const T * iPtr = in.get();
+    T       * vPtr = values.get();
+    int     * rPtr = rowIdx.get();
+    int     * cPtr = colIdx.get();
 
-        int stride = in.strides()[1];
-        af::dim4 dims = in.dims();
+    int stride = in.strides[1];
+    af::dim4 dims = in.dims;
 
-        int offset = 0;
-        for (int i = 0; i < dims[0]; ++i) {
-            rPtr[i] = offset;
-            for (int j = 0; j < dims[1]; ++j) {
-                if (iPtr[j*stride + i] != scalar<T>(0)) {
-                    vPtr[offset] = iPtr[j*stride + i];
-                    cPtr[offset++] = j;
-                }
+    int offset = 0;
+    for (int i = 0; i < dims[0]; ++i) {
+        rPtr[i] = offset;
+        for (int j = 0; j < dims[1]; ++j) {
+            if (iPtr[j*stride + i] != scalar<T>(0)) {
+                vPtr[offset] = iPtr[j*stride + i];
+                cPtr[offset++] = j;
             }
         }
-        rPtr[dims[0]] = offset;
     }
-};
+    rPtr[dims[0]] = offset;
+}
 
 template<typename T>
-struct csr_dense
+void csr_dense(Param<T> out,
+                CParam<T> values, CParam<int> rowIdx, CParam<int> colIdx)
 {
-    void operator()(Array<T> out,
-                    Array<T> const values, Array<int> const rowIdx, Array<int> const colIdx)
-    {
-        T         * const oPtr = out.get();
-        T   const * const vPtr = values.get();
-        int const * const rPtr = rowIdx.get();
-        int const * const cPtr = colIdx.get();
+    T   *oPtr = out.get();
+    const T   *vPtr = values.get();
+    const int *rPtr = rowIdx.get();
+    const int *cPtr = colIdx.get();
 
-        int stride = out.strides()[1];
+    int stride = out.strides[1];
 
-        int r = rowIdx.dims()[0];
-        for (int i = 0; i < r - 1; i++) {
-            for (int ii = rPtr[i]; ii < rPtr[i+1]; ++ii) {
-                int j = cPtr[ii];
-                T v = vPtr[ii];
-                oPtr[j*stride + i] = v;
-            }
+    int r = rowIdx.dims[0];
+    for (int i = 0; i < r - 1; i++) {
+        for (int ii = rPtr[i]; ii < rPtr[i+1]; ++ii) {
+            int j = cPtr[ii];
+            T v = vPtr[ii];
+            oPtr[j*stride + i] = v;
         }
     }
-};
+}
 
 // Modified code from sort helper
 template <typename T>
@@ -113,81 +107,76 @@ struct SpKIPCompareK
 };
 
 template<typename T>
-void csr_coo(Array<T> ovalues, Array<int> orowIdx, Array<int> ocolIdx,
-             Array<T> const ivalues, Array<int> const irowIdx, Array<int> const icolIdx)
+void csr_coo(Param<T> ovalues, Param<int> orowIdx, Param<int> ocolIdx,
+             CParam<T> ivalues, CParam<int> irowIdx, CParam<int> icolIdx)
 {
     // First calculate the linear index
-    T         * const ovPtr = ovalues.get();
-    int       * const orPtr = orowIdx.get();
-    int       * const ocPtr = ocolIdx.get();
+    T         * ovPtr = ovalues.get();
+    int       * orPtr = orowIdx.get();
+    int       * ocPtr = ocolIdx.get();
 
-    T   const * const ivPtr = ivalues.get();
-    int const * const irPtr = irowIdx.get();
-    int const * const icPtr = icolIdx.get();
+    const T   *ivPtr = ivalues.get();
+    const int *irPtr = irowIdx.get();
+    const int *icPtr = icolIdx.get();
 
     // Create cordinate form of the row array
-    for(int i = 0; i < (int)irowIdx.elements() - 1; i++) {
+    for(int i = 0; i < (int)irowIdx.dims.elements() - 1; i++) {
         std::fill_n(orPtr + irPtr[i], irPtr[i + 1] - irPtr[i], i);
     }
 
     // Sort the coordinate form using column index
     // Uses code from sort_by_key kernels
     typedef SpKeyIndexPair<T> CurrentPair;
-    int size = ovalues.dims()[0];
-    size_t bytes = size * sizeof(CurrentPair);
-    CurrentPair *pairKeyVal = (CurrentPair *)memAlloc<char>(bytes);
+    int size = ovalues.dims[0];
+    std::vector<CurrentPair> pairKeyVal(size);
 
     for(int x = 0; x < size; x++) {
        pairKeyVal[x] = std::make_tuple(icPtr[x], ivPtr[x], orPtr[x]);
     }
 
-    std::stable_sort(pairKeyVal, pairKeyVal + size, SpKIPCompareK<T>());
+    std::stable_sort(pairKeyVal.begin(), pairKeyVal.end(), SpKIPCompareK<T>());
 
-    for(int x = 0; x < (int)ovalues.elements(); x++) {
+    for(int x = 0; x < (int)ovalues.dims.elements(); x++) {
         std::tie(ocPtr[x], ovPtr[x], orPtr[x]) = pairKeyVal[x];
     }
 
-    memFree((char *)pairKeyVal);
 }
 
 template<typename T>
-void coo_csr(Array<T> ovalues, Array<int> orowIdx, Array<int> ocolIdx,
-             Array<T> const ivalues, Array<int> const irowIdx, Array<int> const icolIdx)
+void coo_csr(Param<T> ovalues, Param<int> orowIdx, Param<int> ocolIdx,
+             CParam<T> ivalues, CParam<int> irowIdx, CParam<int> icolIdx)
 {
-    T         * const ovPtr = ovalues.get();
-    int       * const orPtr = orowIdx.get();
-    int       * const ocPtr = ocolIdx.get();
+    T   * ovPtr = ovalues.get();
+    int *orPtr = orowIdx.get();
+    int *ocPtr = ocolIdx.get();
 
-    T   const * const ivPtr = ivalues.get();
-    int const * const irPtr = irowIdx.get();
-    int const * const icPtr = icolIdx.get();
+    const T   *ivPtr = ivalues.get();
+    const int *irPtr = irowIdx.get();
+    const int *icPtr = icolIdx.get();
 
     // Sort the colidx and values based on rowIdx
     // Uses code from sort_by_key kernels
     typedef SpKeyIndexPair<T> CurrentPair;
-    int size = ovalues.dims()[0];
-    size_t bytes = size * sizeof(CurrentPair);
-    CurrentPair *pairKeyVal = (CurrentPair *)memAlloc<char>(bytes);
+    int size = ovalues.dims[0];
+    std::vector<CurrentPair>pairKeyVal(size);
 
     for(int x = 0; x < size; x++) {
        pairKeyVal[x] = std::make_tuple(irPtr[x], ivPtr[x], icPtr[x]);
     }
 
-    std::stable_sort(pairKeyVal, pairKeyVal + size, SpKIPCompareK<T>());
+    std::stable_sort(pairKeyVal.begin(), pairKeyVal.end(), SpKIPCompareK<T>());
 
     ovPtr[0] = 0;
-    for(int x = 0; x < (int)ovalues.elements(); x++) {
+    for(int x = 0; x < (int)ovalues.dims.elements(); x++) {
         int row = -2; // Some value that will make orPtr[row + 1] error out
         std::tie(row, ovPtr[x], ocPtr[x]) = pairKeyVal[x];
         orPtr[row + 1]++;
     }
 
     // Compress row storage
-    for(int x = 1; x < (int)orowIdx.elements(); x++) {
+    for(int x = 1; x < (int)orowIdx.dims.elements(); x++) {
         orPtr[x] += orPtr[x - 1];
     }
-
-    memFree((char *)pairKeyVal);
 }
 
 }

--- a/src/backend/cpu/kernel/sparse_arith.hpp
+++ b/src/backend/cpu/kernel/sparse_arith.hpp
@@ -73,14 +73,14 @@ void sparseArithOpD(Param<T> output,
     const int * rPtr = rowIdx.get();
     const int * cPtr = colIdx.get();
 
-    dim4 odims    = output.dims;
-    dim4 ostrides = output.strides;
-    dim4 hstrides = rhs.strides;
+    dim4 odims    = output.dims();
+    dim4 ostrides = output.strides();;
+    dim4 hstrides = rhs.strides();;
 
     std::vector<int> temp;
     if(type == AF_STORAGE_CSR) {
-        temp.resize(values.dims.elements());
-        for(int i = 0; i < rowIdx.dims[0] - 1; i++) {
+        temp.resize(values.dims().elements());
+        for(int i = 0; i < rowIdx.dims(0) - 1; i++) {
             for(int ii = rPtr[i]; ii < rPtr[i + 1]; ii++) {
                 temp[ii] = i;
             }
@@ -91,7 +91,7 @@ void sparseArithOpD(Param<T> output,
     const int *xx = (type == AF_STORAGE_CSR) ? temp.data() : rPtr;
     const int *yy = (type == AF_STORAGE_CSC) ? temp.data() : cPtr;
 
-    for(int i = 0; i < (int)values.dims.elements(); i++) {
+    for(int i = 0; i < (int)values.dims().elements(); i++) {
         // Bad index data
         if(xx[i] >= odims[0] || yy [i]>= odims[1]) continue;
 
@@ -113,13 +113,13 @@ void sparseArithOpS(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
 
     const T   * hPtr = rhs.get();
 
-    dim4 dims     = rhs.dims;
-    dim4 hstrides = rhs.strides;
+    dim4 dims     = rhs.dims();
+    dim4 hstrides = rhs.strides();
 
     std::vector<int> temp;
     if(type == AF_STORAGE_CSR) {
-        temp.resize(values.dims.elements());
-        for(int i = 0; i < rowIdx.dims[0] - 1; i++) {
+        temp.resize(values.dims().elements());
+        for(int i = 0; i < rowIdx.dims(0) - 1; i++) {
             for(int ii = rPtr[i]; ii < rPtr[i + 1]; ii++) {
                 temp[ii] = i;
             }
@@ -130,7 +130,7 @@ void sparseArithOpS(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
     const int *xx = (type == AF_STORAGE_CSR) ? temp.data() : rPtr;
     const int *yy = (type == AF_STORAGE_CSC) ? temp.data() : cPtr;
 
-    for(int i = 0; i < (int)values.dims.elements(); i++) {
+    for(int i = 0; i < (int)values.dims().elements(); i++) {
         // Bad index data
         if(xx[i] >= dims[0] || yy [i]>= dims[1]) continue;
 

--- a/src/backend/cpu/kernel/sparse_arith.hpp
+++ b/src/backend/cpu/kernel/sparse_arith.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <math.hpp>
 
 namespace cpu
@@ -62,9 +62,9 @@ struct arith_op<T, af_div_t>
 };
 
 template<typename T, af_op_t op, af_storage type>
-void sparseArithOpD(Array<T> output,
-                    const Array<T> values, const Array<int> rowIdx, const Array<int> colIdx,
-                    const Array<T> rhs, const bool reverse = false)
+void sparseArithOpD(Param<T> output,
+                    CParam<T> values, CParam<int> rowIdx, CParam<int> colIdx,
+                    CParam<T> rhs, const bool reverse = false)
 {
     T * oPtr = output.get();
     const T   * hPtr = rhs.get();
@@ -73,14 +73,14 @@ void sparseArithOpD(Array<T> output,
     const int * rPtr = rowIdx.get();
     const int * cPtr = colIdx.get();
 
-    dim4 odims    = output.dims();
-    dim4 ostrides = output.strides();
-    dim4 hstrides = rhs.strides();
+    dim4 odims    = output.dims;
+    dim4 ostrides = output.strides;
+    dim4 hstrides = rhs.strides;
 
     std::vector<int> temp;
     if(type == AF_STORAGE_CSR) {
-        temp.resize(values.elements());
-        for(int i = 0; i < rowIdx.dims()[0] - 1; i++) {
+        temp.resize(values.dims.elements());
+        for(int i = 0; i < rowIdx.dims[0] - 1; i++) {
             for(int ii = rPtr[i]; ii < rPtr[i + 1]; ii++) {
                 temp[ii] = i;
             }
@@ -91,7 +91,7 @@ void sparseArithOpD(Array<T> output,
     const int *xx = (type == AF_STORAGE_CSR) ? temp.data() : rPtr;
     const int *yy = (type == AF_STORAGE_CSC) ? temp.data() : cPtr;
 
-    for(int i = 0; i < (int)values.elements(); i++) {
+    for(int i = 0; i < (int)values.dims.elements(); i++) {
         // Bad index data
         if(xx[i] >= odims[0] || yy [i]>= odims[1]) continue;
 
@@ -104,8 +104,8 @@ void sparseArithOpD(Array<T> output,
 }
 
 template<typename T, af_op_t op, af_storage type>
-void sparseArithOpS(Array<T> values, Array<int> rowIdx, Array<int> colIdx,
-                    const Array<T> rhs, const bool reverse = false)
+void sparseArithOpS(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
+                    CParam<T> rhs, const bool reverse = false)
 {
           T   * vPtr = values.get();
     const int * rPtr = rowIdx.get();
@@ -113,13 +113,13 @@ void sparseArithOpS(Array<T> values, Array<int> rowIdx, Array<int> colIdx,
 
     const T   * hPtr = rhs.get();
 
-    dim4 dims     = rhs.dims();
-    dim4 hstrides = rhs.strides();
+    dim4 dims     = rhs.dims;
+    dim4 hstrides = rhs.strides;
 
     std::vector<int> temp;
     if(type == AF_STORAGE_CSR) {
-        temp.resize(values.elements());
-        for(int i = 0; i < rowIdx.dims()[0] - 1; i++) {
+        temp.resize(values.dims.elements());
+        for(int i = 0; i < rowIdx.dims[0] - 1; i++) {
             for(int ii = rPtr[i]; ii < rPtr[i + 1]; ii++) {
                 temp[ii] = i;
             }
@@ -130,7 +130,7 @@ void sparseArithOpS(Array<T> values, Array<int> rowIdx, Array<int> colIdx,
     const int *xx = (type == AF_STORAGE_CSR) ? temp.data() : rPtr;
     const int *yy = (type == AF_STORAGE_CSC) ? temp.data() : cPtr;
 
-    for(int i = 0; i < (int)values.elements(); i++) {
+    for(int i = 0; i < (int)values.dims.elements(); i++) {
         // Bad index data
         if(xx[i] >= dims[0] || yy [i]>= dims[1]) continue;
 
@@ -143,4 +143,3 @@ void sparseArithOpS(Array<T> values, Array<int> rowIdx, Array<int> colIdx,
 
 }
 }
-

--- a/src/backend/cpu/kernel/susan.hpp
+++ b/src/backend/cpu/kernel/susan.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,7 +16,7 @@ namespace kernel
 {
 
 template<typename T>
-void susan_responses(Array<T> output, const Array<T> input,
+void susan_responses(Param<T> output, CParam<T> input,
                      const unsigned idim0, const unsigned idim1,
                      const int radius, const float t, const float g,
                      const unsigned border_len)
@@ -52,9 +52,9 @@ void susan_responses(Array<T> output, const Array<T> input,
 }
 
 template<typename T>
-void non_maximal(Array<float> xcoords, Array<float> ycoords, Array<float> response,
+void non_maximal(Param<float> xcoords, Param<float> ycoords, Param<float> response,
                  shared_ptr<unsigned> counter, const unsigned idim0, const unsigned idim1,
-                 const Array<T> input, const unsigned border_len, const unsigned max_corners)
+                 CParam<T> input, const unsigned border_len, const unsigned max_corners)
 {
     float* x_out    = xcoords.get();
     float* y_out    = ycoords.get();

--- a/src/backend/cpu/kernel/tile.hpp
+++ b/src/backend/cpu/kernel/tile.hpp
@@ -22,10 +22,10 @@ void tile(Param<T> out, CParam<T> in)
     T* outPtr = out.get();
     const T* inPtr = in.get();
 
-    const af::dim4 iDims = in.dims;
-    const af::dim4 oDims = out.dims;
-    const af::dim4 ist = in.strides;
-    const af::dim4 ost = out.strides;
+    const af::dim4 iDims = in.dims();
+    const af::dim4 oDims = out.dims();
+    const af::dim4 ist = in.strides();
+    const af::dim4 ost = out.strides();
 
     for(dim_t ow = 0; ow < oDims[3]; ow++) {
         const dim_t iw = ow % iDims[3];

--- a/src/backend/cpu/kernel/tile.hpp
+++ b/src/backend/cpu/kernel/tile.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,16 +16,16 @@ namespace kernel
 {
 
 template<typename T>
-void tile(Array<T> out, const Array<T> in)
+void tile(Param<T> out, CParam<T> in)
 {
 
     T* outPtr = out.get();
     const T* inPtr = in.get();
 
-    const af::dim4 iDims = in.dims();
-    const af::dim4 oDims = out.dims();
-    const af::dim4 ist = in.strides();
-    const af::dim4 ost = out.strides();
+    const af::dim4 iDims = in.dims;
+    const af::dim4 oDims = out.dims;
+    const af::dim4 ist = in.strides;
+    const af::dim4 ost = out.strides;
 
     for(dim_t ow = 0; ow < oDims[3]; ow++) {
         const dim_t iw = ow % iDims[3];

--- a/src/backend/cpu/kernel/transform.hpp
+++ b/src/backend/cpu/kernel/transform.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <err_cpu.hpp>
 #include <type_traits>
 #include "interp.hpp"
@@ -69,20 +69,20 @@ void calc_transform_inverse(T *tmat, const T *tmat_ptr, const bool inverse,
 }
 
 template<typename T, int order>
-void transform(Array<T> output, const Array<T> input,
-               const Array<float> transform, const bool inverse,
+void transform(Param<T> output, CParam<T> input,
+               CParam<float> transform, const bool inverse,
                const bool perspective,
                af_interp_type method)
 {
     typedef typename dtype_traits<T>::base_type BT;
     typedef wtype_t<BT> WT;
 
-    const af::dim4 idims    = input.dims();
-    const af::dim4 odims    = output.dims();
-    const af::dim4 tdims    = transform.dims();
-    const af::dim4 tstrides = transform.strides();
-    const af::dim4 istrides = input.strides();
-    const af::dim4 ostrides = output.strides();
+    const af::dim4 idims    = input.dims;
+    const af::dim4 odims    = output.dims;
+    const af::dim4 tdims    = transform.dims;
+    const af::dim4 tstrides = transform.strides;
+    const af::dim4 istrides = input.strides;
+    const af::dim4 ostrides = output.strides;
 
     T * out = output.get();
     const float* tf = transform.get();

--- a/src/backend/cpu/kernel/transform.hpp
+++ b/src/backend/cpu/kernel/transform.hpp
@@ -77,12 +77,12 @@ void transform(Param<T> output, CParam<T> input,
     typedef typename dtype_traits<T>::base_type BT;
     typedef wtype_t<BT> WT;
 
-    const af::dim4 idims    = input.dims;
-    const af::dim4 odims    = output.dims;
-    const af::dim4 tdims    = transform.dims;
-    const af::dim4 tstrides = transform.strides;
-    const af::dim4 istrides = input.strides;
-    const af::dim4 ostrides = output.strides;
+    const af::dim4 idims    = input.dims();
+    const af::dim4 odims    = output.dims();
+    const af::dim4 tdims    = transform.dims();
+    const af::dim4 tstrides = transform.strides();
+    const af::dim4 istrides = input.strides();
+    const af::dim4 ostrides = output.strides();
 
     T * out = output.get();
     const float* tf = transform.get();

--- a/src/backend/cpu/kernel/transpose.hpp
+++ b/src/backend/cpu/kernel/transpose.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <utility.hpp>
 #include <err_cpu.hpp>
 
@@ -37,11 +37,11 @@ cdouble getConjugate(const cdouble &in)
 }
 
 template<typename T, bool conjugate>
-void transpose(Array<T> output, const Array<T> input)
+void transpose(Param<T> output, CParam<T> input)
 {
-    const dim4 odims    = output.dims();
-    const dim4 ostrides = output.strides();
-    const dim4 istrides = input.strides();
+    const dim4 odims    = output.dims;
+    const dim4 ostrides = output.strides;
+    const dim4 istrides = input.strides;
 
     T * out = output.get();
     T const * const in = input.get();
@@ -71,16 +71,16 @@ void transpose(Array<T> output, const Array<T> input)
 }
 
 template<typename T>
-void transpose(Array<T> out, const Array<T> in, const bool conjugate)
+void transpose(Param<T> out, CParam<T> in, const bool conjugate)
 {
     return (conjugate ? transpose<T, true>(out, in) : transpose<T, false>(out, in));
 }
 
 template<typename T, bool conjugate>
-void transpose_inplace(Array<T> input)
+void transpose_inplace(Param<T> input)
 {
-    const dim4 idims    = input.dims();
-    const dim4 istrides = input.strides();
+    const dim4 idims    = input.dims;
+    const dim4 istrides = input.strides;
 
     T * in = input.get();
 
@@ -112,7 +112,7 @@ void transpose_inplace(Array<T> input)
 }
 
 template<typename T>
-void transpose_inplace(Array<T> in, const bool conjugate)
+void transpose_inplace(Param<T> in, const bool conjugate)
 {
     return (conjugate ? transpose_inplace<T, true >(in) : transpose_inplace<T, false>(in));
 }

--- a/src/backend/cpu/kernel/transpose.hpp
+++ b/src/backend/cpu/kernel/transpose.hpp
@@ -39,9 +39,9 @@ cdouble getConjugate(const cdouble &in)
 template<typename T, bool conjugate>
 void transpose(Param<T> output, CParam<T> input)
 {
-    const dim4 odims    = output.dims;
-    const dim4 ostrides = output.strides;
-    const dim4 istrides = input.strides;
+    const dim4 odims    = output.dims();
+    const dim4 ostrides = output.strides();
+    const dim4 istrides = input.strides();
 
     T * out = output.get();
     T const * const in = input.get();
@@ -79,8 +79,8 @@ void transpose(Param<T> out, CParam<T> in, const bool conjugate)
 template<typename T, bool conjugate>
 void transpose_inplace(Param<T> input)
 {
-    const dim4 idims    = input.dims;
-    const dim4 istrides = input.strides;
+    const dim4 idims    = input.dims();
+    const dim4 istrides = input.strides();
 
     T * in = input.get();
 

--- a/src/backend/cpu/kernel/triangle.hpp
+++ b/src/backend/cpu/kernel/triangle.hpp
@@ -21,10 +21,10 @@ void triangle(Param<T> out, CParam<T> in)
     T *o = out.get();
     const T *i = in.get();
 
-    af::dim4 odm = out.dims;
+    af::dim4 odm = out.dims();
 
-    af::dim4 ost = out.strides;
-    af::dim4 ist = in.strides;
+    af::dim4 ost = out.strides();
+    af::dim4 ist = in.strides();
 
     for(dim_t ow = 0; ow < odm[3]; ow++) {
         const dim_t oW = ow * ost[3];

--- a/src/backend/cpu/kernel/triangle.hpp
+++ b/src/backend/cpu/kernel/triangle.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 
 namespace cpu
 {
@@ -16,15 +16,15 @@ namespace kernel
 {
 
 template<typename T, bool is_upper, bool is_unit_diag>
-void triangle(Array<T> out, const Array<T> in)
+void triangle(Param<T> out, CParam<T> in)
 {
     T *o = out.get();
     const T *i = in.get();
 
-    af::dim4 odm = out.dims();
+    af::dim4 odm = out.dims;
 
-    af::dim4 ost = out.strides();
-    af::dim4 ist = in.strides();
+    af::dim4 ost = out.strides;
+    af::dim4 ist = in.strides;
 
     for(dim_t ow = 0; ow < odm[3]; ow++) {
         const dim_t oW = ow * ost[3];

--- a/src/backend/cpu/kernel/unwrap.hpp
+++ b/src/backend/cpu/kernel/unwrap.hpp
@@ -23,10 +23,10 @@ void unwrap_dim(Param<T> out, CParam<T> in, const dim_t wx, const dim_t wy,
     const T *inPtr = in.get();
     T *outPtr      = out.get();
 
-    af::dim4 idims    = in.dims;
-    af::dim4 odims    = out.dims;
-    af::dim4 istrides = in.strides;
-    af::dim4 ostrides = out.strides;
+    af::dim4 idims    = in.dims();
+    af::dim4 odims    = out.dims();
+    af::dim4 istrides = in.strides();
+    af::dim4 ostrides = out.strides();
 
     dim_t nx = (idims[0] + 2 * px - wx) / sx + 1;
 

--- a/src/backend/cpu/kernel/unwrap.hpp
+++ b/src/backend/cpu/kernel/unwrap.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <err_cpu.hpp>
 
 namespace cpu
@@ -17,16 +17,16 @@ namespace kernel
 {
 
 template<typename T, int d>
-void unwrap_dim(Array<T> out, const Array<T> in, const dim_t wx, const dim_t wy,
+void unwrap_dim(Param<T> out, CParam<T> in, const dim_t wx, const dim_t wy,
                 const dim_t sx, const dim_t sy, const dim_t px, const dim_t py)
 {
     const T *inPtr = in.get();
     T *outPtr      = out.get();
 
-    af::dim4 idims    = in.dims();
-    af::dim4 odims    = out.dims();
-    af::dim4 istrides = in.strides();
-    af::dim4 ostrides = out.strides();
+    af::dim4 idims    = in.dims;
+    af::dim4 odims    = out.dims;
+    af::dim4 istrides = in.strides;
+    af::dim4 ostrides = out.strides;
 
     dim_t nx = (idims[0] + 2 * px - wx) / sx + 1;
 

--- a/src/backend/cpu/kernel/wrap.hpp
+++ b/src/backend/cpu/kernel/wrap.hpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
+#include <Param.hpp>
 #include <err_cpu.hpp>
 
 namespace cpu
@@ -17,16 +17,16 @@ namespace kernel
 {
 
 template<typename T, int d>
-void wrap_dim(Array<T> out, const Array<T> in, const dim_t wx, const dim_t wy,
+void wrap_dim(Param<T> out, CParam<T> in, const dim_t wx, const dim_t wy,
               const dim_t sx, const dim_t sy, const dim_t px, const dim_t py)
 {
     const T *inPtr = in.get();
     T *outPtr      = out.get();
 
-    af::dim4 idims    = in.dims();
-    af::dim4 odims    = out.dims();
-    af::dim4 istrides = in.strides();
-    af::dim4 ostrides = out.strides();
+    af::dim4 idims    = in.dims;
+    af::dim4 odims    = out.dims;
+    af::dim4 istrides = in.strides;
+    af::dim4 ostrides = out.strides;
 
     dim_t nx = (odims[0] + 2 * px - wx) / sx + 1;
 

--- a/src/backend/cpu/kernel/wrap.hpp
+++ b/src/backend/cpu/kernel/wrap.hpp
@@ -23,10 +23,10 @@ void wrap_dim(Param<T> out, CParam<T> in, const dim_t wx, const dim_t wy,
     const T *inPtr = in.get();
     T *outPtr      = out.get();
 
-    af::dim4 idims    = in.dims;
-    af::dim4 odims    = out.dims;
-    af::dim4 istrides = in.strides;
-    af::dim4 ostrides = out.strides;
+    af::dim4 idims    = in.dims();
+    af::dim4 odims    = out.dims();
+    af::dim4 istrides = in.strides();
+    af::dim4 ostrides = out.strides();
 
     dim_t nx = (odims[0] + 2 * px - wx) / sx + 1;
 

--- a/src/backend/cpu/lu.cpp
+++ b/src/backend/cpu/lu.cpp
@@ -75,8 +75,8 @@ Array<int> lu_inplace(Array<T> &in, const bool convert_pivot)
     Array<int> pivot = createEmptyArray<int>(af::dim4(min(iDims[0], iDims[1]), 1, 1, 1));
 
     auto func = [=] (Param<T> in, Param<int> pivot) {
-        dim4 iDims = in.dims;
-        getrf_func<T>()(AF_LAPACK_COL_MAJOR, iDims[0], iDims[1], in.get(), in.strides[1], pivot.get());
+        dim4 iDims = in.dims();
+        getrf_func<T>()(AF_LAPACK_COL_MAJOR, iDims[0], iDims[1], in.get(), in.strides(1), pivot.get());
     };
     getQueue().enqueue(func, in, pivot);
 

--- a/src/backend/cpu/lu.cpp
+++ b/src/backend/cpu/lu.cpp
@@ -74,9 +74,9 @@ Array<int> lu_inplace(Array<T> &in, const bool convert_pivot)
     dim4 iDims = in.dims();
     Array<int> pivot = createEmptyArray<int>(af::dim4(min(iDims[0], iDims[1]), 1, 1, 1));
 
-    auto func = [=] (Array<T> in, Array<int> pivot) {
-        dim4 iDims = in.dims();
-        getrf_func<T>()(AF_LAPACK_COL_MAJOR, iDims[0], iDims[1], in.get(), in.strides()[1], pivot.get());
+    auto func = [=] (Param<T> in, Param<int> pivot) {
+        dim4 iDims = in.dims;
+        getrf_func<T>()(AF_LAPACK_COL_MAJOR, iDims[0], iDims[1], in.get(), in.strides[1], pivot.get());
     };
     getQueue().enqueue(func, in, pivot);
 

--- a/src/backend/cpu/memory.cpp
+++ b/src/backend/cpu/memory.cpp
@@ -57,26 +57,14 @@ template<typename T>
 T* memAlloc(const size_t &elements)
 {
     T *ptr = nullptr;
-
-    try {
-        ptr = (T *)memoryManager().alloc(elements * sizeof(T), false);
-    } catch(...) {
-        getQueue().sync();
-        ptr = (T *)memoryManager().alloc(elements * sizeof(T), false);
-    }
+    ptr = (T *)memoryManager().alloc(elements * sizeof(T), false);
     return ptr;
 }
 
 void* memAllocUser(const size_t &bytes)
 {
     void *ptr = nullptr;
-
-    try {
-        ptr = memoryManager().alloc(bytes, true);
-    } catch(...) {
-        getQueue().sync();
-        ptr = memoryManager().alloc(bytes, true);
-    }
+    ptr = memoryManager().alloc(bytes, true);
     return ptr;
 }
 
@@ -109,7 +97,6 @@ void memUnlock(const void *ptr)
 void deviceMemoryInfo(size_t *alloc_bytes, size_t *alloc_buffers,
                       size_t *lock_bytes,  size_t *lock_buffers)
 {
-    getQueue().sync();
     memoryManager().bufferInfo(alloc_bytes, alloc_buffers,
                                   lock_bytes,  lock_buffers);
 }
@@ -189,6 +176,7 @@ void *MemoryManager::nativeAlloc(const size_t bytes)
 
 void MemoryManager::nativeFree(void *ptr)
 {
+    getQueue().sync();
     return free((void *)ptr);
 }
 }

--- a/src/backend/cpu/memory.cpp
+++ b/src/backend/cpu/memory.cpp
@@ -176,6 +176,7 @@ void *MemoryManager::nativeAlloc(const size_t bytes)
 
 void MemoryManager::nativeFree(void *ptr)
 {
+    // Make sure this pointer is not being used on the queue before freeing the memory.
     getQueue().sync();
     return free((void *)ptr);
 }

--- a/src/backend/cpu/platform.hpp
+++ b/src/backend/cpu/platform.hpp
@@ -128,7 +128,7 @@ class DeviceManager
         CPUInfo getCPUInfo() const;
 
     private:
-        DeviceManager() {}
+        DeviceManager() : queues(MAX_QUEUES){}
 
         // Following two declarations are required to
         // avoid copying accidental copy/assignment
@@ -136,10 +136,18 @@ class DeviceManager
         // variables
         DeviceManager(DeviceManager const&);
         void operator=(DeviceManager const&);
+        // And the destructor is needed because rule of three:
+        // http://en.cppreference.com/w/cpp/language/rule_of_three
+        ~DeviceManager() {
+            for(auto &q : queues) q.sync();
+            memManager.release();
+            queues.clear();
+        }
 
         // Attributes
+        // DO NOT MOVE QUEUES! This has to be destroyed last, meaning it needs to be defined first.
+        std::vector<queue> queues;
         const CPUInfo cinfo;
         std::unique_ptr<MemoryManager> memManager;
-        std::array<queue, MAX_QUEUES> queues;
 };
 }

--- a/src/backend/cpu/qr.cpp
+++ b/src/backend/cpu/qr.cpp
@@ -80,7 +80,7 @@ void qr(Array<T> &q, Array<T> &r, Array<T> &t, const Array<T> &in)
     triangle<T, true, false>(r, q);
 
     auto func = [=] (Param<T> q, Param<T> t, int M, int N) {
-        gqr_func<T>()(AF_LAPACK_COL_MAJOR, M, M, min(M, N), q.get(), q.strides[1], t.get());
+        gqr_func<T>()(AF_LAPACK_COL_MAJOR, M, M, min(M, N), q.get(), q.strides(1), t.get());
     };
     q.resetDims(dim4(M, M));
     getQueue().enqueue(func, q, t, M, N);
@@ -97,7 +97,7 @@ Array<T> qr_inplace(Array<T> &in)
     Array<T> t = createEmptyArray<T>(af::dim4(min(M, N), 1, 1, 1));
 
     auto func = [=] (Param<T> in, Param<T> t, int M, int N) {
-        geqrf_func<T>()(AF_LAPACK_COL_MAJOR, M, N, in.get(), in.strides[1], t.get());
+        geqrf_func<T>()(AF_LAPACK_COL_MAJOR, M, N, in.get(), in.strides(1), t.get());
     };
     getQueue().enqueue(func, in, t, M, N);
 

--- a/src/backend/cpu/qr.cpp
+++ b/src/backend/cpu/qr.cpp
@@ -79,8 +79,8 @@ void qr(Array<T> &q, Array<T> &r, Array<T> &t, const Array<T> &in)
 
     triangle<T, true, false>(r, q);
 
-    auto func = [=] (Array<T> q, Array<T> t, int M, int N) {
-        gqr_func<T>()(AF_LAPACK_COL_MAJOR, M, M, min(M, N), q.get(), q.strides()[1], t.get());
+    auto func = [=] (Param<T> q, Param<T> t, int M, int N) {
+        gqr_func<T>()(AF_LAPACK_COL_MAJOR, M, M, min(M, N), q.get(), q.strides[1], t.get());
     };
     q.resetDims(dim4(M, M));
     getQueue().enqueue(func, q, t, M, N);
@@ -96,8 +96,8 @@ Array<T> qr_inplace(Array<T> &in)
     int N      = iDims[1];
     Array<T> t = createEmptyArray<T>(af::dim4(min(M, N), 1, 1, 1));
 
-    auto func = [=] (Array<T> in, Array<T> t, int M, int N) {
-        geqrf_func<T>()(AF_LAPACK_COL_MAJOR, M, N, in.get(), in.strides()[1], t.get());
+    auto func = [=] (Param<T> in, Param<T> t, int M, int N) {
+        geqrf_func<T>()(AF_LAPACK_COL_MAJOR, M, N, in.get(), in.strides[1], t.get());
     };
     getQueue().enqueue(func, in, t, M, N);
 

--- a/src/backend/cpu/queue.hpp
+++ b/src/backend/cpu/queue.hpp
@@ -48,6 +48,30 @@ typedef async_queue queue_impl;
 
 namespace cpu {
 
+template<typename T> class Array;
+template<typename T> class Param;
+template<typename T> class CParam;
+
+template<typename T>
+T toParam(const T &val)
+{
+    return val;
+}
+
+
+template<typename T>
+Param<T> toParam(Array<T> &val)
+{
+    return (Param<T>)(val);
+}
+
+
+template<typename T>
+CParam<T> toParam(const Array<T> &val)
+{
+    return (CParam<T>)(val);
+}
+
 /// Wraps the async_queue class
 class queue
 {
@@ -62,8 +86,8 @@ public:
     void enqueue(const F func, Args... args)
     {
         count++;
-        if(sync_calls) { func( args... ); }
-        else           { aQueue.enqueue( func, args... ); }
+        if(sync_calls) { func(toParam(args)... ); }
+        else           { aQueue.enqueue(func, toParam(args)... ); }
 #ifndef NDEBUG
         sync();
 #else

--- a/src/backend/cpu/queue.hpp
+++ b/src/backend/cpu/queue.hpp
@@ -9,6 +9,7 @@
 
 #include <util.hpp>
 #include <memory.hpp>
+#include <Param.hpp>
 
 //FIXME: Is there a better way to check for std::future not being supported ?
 #if defined(AF_DISABLE_CPU_ASYNC) || (defined(__GNUC__) && (__GCC_ATOMIC_INT_LOCK_FREE < 2 || __GCC_ATOMIC_POINTER_LOCK_FREE < 2))
@@ -47,30 +48,6 @@ typedef async_queue queue_impl;
 #pragma once
 
 namespace cpu {
-
-template<typename T> class Array;
-template<typename T> class Param;
-template<typename T> class CParam;
-
-template<typename T>
-T toParam(const T &val)
-{
-    return val;
-}
-
-
-template<typename T>
-Param<T> toParam(Array<T> &val)
-{
-    return (Param<T>)(val);
-}
-
-
-template<typename T>
-CParam<T> toParam(const Array<T> &val)
-{
-    return (CParam<T>)(val);
-}
 
 /// Wraps the async_queue class
 class queue

--- a/src/backend/cpu/reduce.cpp
+++ b/src/backend/cpu/reduce.cpp
@@ -37,8 +37,8 @@ namespace cpu
 {
 
 template<af_op_t op, typename Ti, typename To>
-using reduce_dim_func = std::function<void(Array<To>, const dim_t,
-                                           const Array<Ti>, const dim_t,
+using reduce_dim_func = std::function<void(Param<To>, const dim_t,
+                                           CParam<Ti>, const dim_t,
                                            const int, bool, double)>;
 
 template<af_op_t op, typename Ti, typename To>

--- a/src/backend/cpu/solve.cpp
+++ b/src/backend/cpu/solve.cpp
@@ -86,8 +86,8 @@ Array<T> solveLU(const Array<T> &A, const Array<int> &pivot,
 
     auto func = [=] (Param<T> A, Param<T> B, Param<int> pivot, int N, int NRHS) {
         getrs_func<T>()(AF_LAPACK_COL_MAJOR, 'N',
-                        N, NRHS, A.get(), A.strides[1],
-                        pivot.get(), B.get(), B.strides[1]);
+                        N, NRHS, A.get(), A.strides(1),
+                        pivot.get(), B.get(), B.strides(1));
     };
     getQueue().enqueue(func, A, B, pivot, N, NRHS);
 
@@ -110,8 +110,8 @@ Array<T> triangleSolve(const Array<T> &A, const Array<T> &b, const af_mat_prop o
                         'N', // transpose flag
                         options & AF_MAT_DIAG_UNIT ? 'U' : 'N',
                         N, NRHS,
-                        A.get(), A.strides[1],
-                        B.get(), B.strides[1]);
+                        A.get(), A.strides(1),
+                        B.get(), B.strides(1));
     };
     getQueue().enqueue(func, A, B, N, NRHS, options);
 
@@ -140,18 +140,18 @@ Array<T> solve(const Array<T> &a, const Array<T> &b, const af_mat_prop options)
         Array<int> pivot = createEmptyArray<int>(dim4(N, 1, 1));
 
         auto func = [=] (Param<T> A, Param<T> B, Param<int> pivot, int N, int K) {
-            gesv_func<T>()(AF_LAPACK_COL_MAJOR, N, K, A.get(), A.strides[1],
-                           pivot.get(), B.get(), B.strides[1]);
+            gesv_func<T>()(AF_LAPACK_COL_MAJOR, N, K, A.get(), A.strides(1),
+                           pivot.get(), B.get(), B.strides(1));
         };
         getQueue().enqueue(func, A, B, pivot, N, K);
     } else {
         auto func = [=] (Param<T> A, Param<T> B, int M, int N, int K) {
-            int sM = A.strides[1];
-            int sN = A.strides[2] / sM;
+            int sM = A.strides(1);
+            int sN = A.strides(2) / sM;
 
             gels_func<T>()(AF_LAPACK_COL_MAJOR, 'N',
                     M, N, K,
-                    A.get(), A.strides[1],
+                    A.get(), A.strides(1),
                     B.get(), max(sM, sN));
         };
         B.resetDims(dim4(N, K));

--- a/src/backend/cpu/sparse.cpp
+++ b/src/backend/cpu/sparse.cpp
@@ -245,10 +245,10 @@ Array<T> sparseConvertStorageToDense(const SparseArray<T> &in_)
         int j1 = 1, j2 = 0;
         const int job[] = {1, j1, j2, 2, num, 1};
 
-        const int M = dense.dims()[0];
-        const int N = dense.dims()[1];
+        const int M = dense.dims[0];
+        const int N = dense.dims[1];
 
-        int ldd = dense.strides()[1];
+        int ldd = dense.strides[1];
 
         int info = 0;
 

--- a/src/backend/cpu/sparse.cpp
+++ b/src/backend/cpu/sparse.cpp
@@ -189,10 +189,10 @@ SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in_)
         int j1 = 1, j2 = 0;
         const int job[] = {0, j1, j2, 2, num, 1};
 
-        const int M = in.dims[0];
-        const int N = in.dims[1];
+        const int M = in.dims(0);
+        const int N = in.dims(1);
 
-        int ldd = in.strides[1];
+        int ldd = in.strides(1);
 
         int info = 0;
 
@@ -245,10 +245,10 @@ Array<T> sparseConvertStorageToDense(const SparseArray<T> &in_)
         int j1 = 1, j2 = 0;
         const int job[] = {1, j1, j2, 2, num, 1};
 
-        const int M = dense.dims[0];
-        const int N = dense.dims[1];
+        const int M = dense.dims(0);
+        const int N = dense.dims(1);
 
-        int ldd = dense.strides[1];
+        int ldd = dense.strides(1);
 
         int info = 0;
 

--- a/src/backend/cpu/sparse.cpp
+++ b/src/backend/cpu/sparse.cpp
@@ -182,26 +182,22 @@ SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in_)
     SparseArray<T> sparse_ = createEmptySparseArray<T>(in_.dims(), nNZ, AF_STORAGE_CSR);
     sparse_.eval();
 
-    auto func = [=] (SparseArray<T> sparse, const Array<T> in) {
+    auto func = [=] (Param<T> values, Param<int> rowIdx, Param<int> colIdx, int num, CParam<T> in) {
         // Read: https://software.intel.com/en-us/node/520848
         // But job description is incorrect with regards to job[1]
         // 0 implies row major and 1 implies column major
         int j1 = 1, j2 = 0;
-        const int job[] = {0, j1, j2, 2, (int)sparse.elements(), 1};
+        const int job[] = {0, j1, j2, 2, num, 1};
 
-        const int M = in.dims()[0];
-        const int N = in.dims()[1];
+        const int M = in.dims[0];
+        const int N = in.dims[1];
 
-        int ldd = in.strides()[1];
+        int ldd = in.strides[1];
 
         int info = 0;
 
         // Have to mess up all const correctness because MKL dnscsr function
         // is bidirectional and has input/output on all pointers
-        Array<T  > &values = sparse.getValues();
-        Array<int> &rowIdx = sparse.getRowIdx();
-        Array<int> &colIdx = sparse.getColIdx();
-
         dnscsr_func<T>()(
                 job, &M, &N,
                 reinterpret_cast<ptr_type<T>>(const_cast<T*>(in.get())), &ldd,
@@ -211,7 +207,12 @@ SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in_)
                 &info);
     };
 
-    getQueue().enqueue(func, sparse_, in_);
+
+    Array<T  > &values = sparse_.getValues();
+    Array<int> &rowIdx = sparse_.getRowIdx();
+    Array<int> &colIdx = sparse_.getColIdx();
+
+    getQueue().enqueue(func, values, rowIdx, colIdx, (int)sparse_.elements(), in_);
 
     if(stype == AF_STORAGE_CSR)
         return sparse_;
@@ -235,12 +236,14 @@ Array<T> sparseConvertStorageToDense(const SparseArray<T> &in_)
     Array<T> dense_ = createValueArray<T>(in_.dims(), scalar<T>(0));
     dense_.eval();
 
-    auto func = [=] (Array<T> dense, const SparseArray<T> in) {
+    auto func = [=] (Param<T> dense,
+                     CParam<T> values, CParam<int> rowIdx,
+                     CParam<int> colIdx, int num) {
         // Read: https://software.intel.com/en-us/node/520848
         // But job description is incorrect with regards to job[1]
         // 0 implies row major and 1 implies column major
         int j1 = 1, j2 = 0;
-        const int job[] = {1, j1, j2, 2, (int)dense.elements(), 1};
+        const int job[] = {1, j1, j2, 2, num, 1};
 
         const int M = dense.dims()[0];
         const int N = dense.dims()[1];
@@ -248,10 +251,6 @@ Array<T> sparseConvertStorageToDense(const SparseArray<T> &in_)
         int ldd = dense.strides()[1];
 
         int info = 0;
-
-        Array<T  > values = in.getValues();
-        Array<int> rowIdx = in.getRowIdx();
-        Array<int> colIdx = in.getColIdx();
 
         // Have to mess up all const correctness because MKL dnscsr function
         // is bidirectional and has input/output on all pointers
@@ -264,7 +263,11 @@ Array<T> sparseConvertStorageToDense(const SparseArray<T> &in_)
                 &info);
     };
 
-    getQueue().enqueue(func, dense_, in_);
+    Array<T  > values = in_.getValues();
+    Array<int> rowIdx = in_.getRowIdx();
+    Array<int> colIdx = in_.getColIdx();
+
+    getQueue().enqueue(func, dense_, values, rowIdx, colIdx, (int)in_.elements());
 
     if(stype == AF_STORAGE_CSR)
         return dense_;
@@ -288,20 +291,15 @@ SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in_)
     SparseArray<T> sparse_ = createEmptySparseArray<T>(in_.dims(), nNZ, AF_STORAGE_CSR);
     sparse_.eval();
 
-    auto func = [=] (SparseArray<T> sparse, const Array<T> in) {
-        Array<T  > values = sparse.getValues();
-        Array<int> rowIdx = sparse.getRowIdx();
-        Array<int> colIdx = sparse.getColIdx();
-
-        kernel::dense_csr<T>()(values, rowIdx, colIdx, in);
-    };
-
-    getQueue().enqueue(func, sparse_, in_);
+    Array<T  > values = sparse_.getValues();
+    Array<int> rowIdx = sparse_.getRowIdx();
+    Array<int> colIdx = sparse_.getColIdx();
 
     if(stype == AF_STORAGE_CSR)
-        return sparse_;
+        getQueue().enqueue(kernel::dense_csr<T>, values, rowIdx, colIdx, in_);
     else
         AF_ERROR("CPU Backend only supports Dense to CSR or COO", AF_ERR_NOT_SUPPORTED);
+
 
     return sparse_;
 }
@@ -314,20 +312,14 @@ Array<T> sparseConvertStorageToDense(const SparseArray<T> &in_)
     Array<T> dense_ = createValueArray<T>(in_.dims(), scalar<T>(0));
     dense_.eval();
 
-    auto func = [=] (Array<T> dense, const SparseArray<T> in) {
-        Array<T  > values = in.getValues();
-        Array<int> rowIdx = in.getRowIdx();
-        Array<int> colIdx = in.getColIdx();
-
-        kernel::csr_dense<T>()(dense, values, rowIdx, colIdx);
-    };
-
-    getQueue().enqueue(func, dense_, in_);
+    Array<T  > values = in_.getValues();
+    Array<int> rowIdx = in_.getRowIdx();
+    Array<int> colIdx = in_.getColIdx();
 
     if(stype == AF_STORAGE_CSR)
-        return dense_;
+        getQueue().enqueue(kernel::csr_dense<T>, dense_, values, rowIdx, colIdx);
     else
-        AF_ERROR("CPU Backend only supports Dense to CSR or COO", AF_ERR_NOT_SUPPORTED);
+        AF_ERROR("CPU Backend only supports CSR or COO to Dense", AF_ERR_NOT_SUPPORTED);
 
     return dense_;
 }
@@ -347,8 +339,8 @@ SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in)
     SparseArray<T> converted = createEmptySparseArray<T>(in.dims(), (int)in.getNNZ(), dest);
     converted.eval();
 
-    function<void (Array<T>, Array<int>, Array<int>,
-                   Array<T> const, Array<int> const, Array<int> const)
+    function<void (Param<T>, Param<int>, Param<int>,
+                   CParam<T>, CParam<int>, CParam<int>)
             > converter;
 
     if(src == AF_STORAGE_CSR && dest == AF_STORAGE_COO) {

--- a/src/backend/cpu/sparse_blas.cpp
+++ b/src/backend/cpu/sparse_blas.cpp
@@ -244,13 +244,15 @@ Array<T> matmul(const common::SparseArray<T> lhs, const Array<T> rhs,
         int ldb = right.strides[1];
         int ldc = output.strides[1];
 
-        int *pB = rowIdx.get();
-        int *pE = rowIdx.get() + 1;
+        int *pB = const_cast<int *>(rowIdx.get());
+        int *pE = pB + 1;
+        T *vptr = const_cast<T *>(values.get());
 
         sparse_matrix_t csrLhs;
         create_csr_func<T>()(&csrLhs, SPARSE_INDEX_BASE_ZERO, sdim0, sdim1,
-                             pB, pE, colIdx.get(),
-                             reinterpret_cast<ptr_type<T>>(values.get()));
+                             pB, pE,
+                             const_cast<int *>(colIdx.get()),
+                             reinterpret_cast<ptr_type<T>>(vptr));
 
         struct matrix_descr descrLhs;
         descrLhs.type = SPARSE_MATRIX_TYPE_GENERAL;

--- a/src/backend/cpu/sparse_blas.cpp
+++ b/src/backend/cpu/sparse_blas.cpp
@@ -241,8 +241,8 @@ Array<T> matmul(const common::SparseArray<T> lhs, const Array<T> rhs,
         auto alpha = getScale<T, 1>();
         auto beta  = getScale<T, 0>();
 
-        int ldb = right.strides[1];
-        int ldc = output.strides[1];
+        int ldb = right.strides(1);
+        int ldc = output.strides(1);
 
         int *pB = const_cast<int *>(rowIdx.get());
         int *pE = pB + 1;
@@ -328,7 +328,7 @@ void mv(Param<T> output,
 
     T* outPtr = output.get();
 
-    for (int i = 0; i < rowIdx.dims[0]-1; ++i) {
+    for (int i = 0; i < rowIdx.dims(0)-1; ++i) {
         outPtr[i] = scalar<T>(0);
         for (int j = rowPtr[i]; j < rowPtr[i+1]; ++j) {
             //If stride[0] of right is not 1 then rightPtr[colPtr[j]*stride]
@@ -359,7 +359,7 @@ void mtv(Param<T> output,
         outPtr[i] = scalar<T>(0);
     }
 
-    for (int i = 0; i < rowIdx.dims[0]-1; ++i) {
+    for (int i = 0; i < rowIdx.dims(0)-1; ++i) {
         for (int j = rowPtr[i]; j < rowPtr[i+1]; ++j) {
             //If stride[0] of right is not 1 then rightPtr[i*stride]
             if (conjugate) {
@@ -387,7 +387,7 @@ void mm(Param<T> output,
     T *outPtr = output.get();
 
     for (int o = 0; o < N; ++o) {
-        for (int i = 0; i < rowIdx.dims[0]-1; ++i) {
+        for (int i = 0; i < rowIdx.dims(0)-1; ++i) {
             outPtr[i] = scalar<T>(0);
             for (int j = rowPtr[i]; j < rowPtr[i+1]; ++j) {
                 //If stride[0] of right is not 1 then rightPtr[colPtr[j]*stride]
@@ -423,7 +423,7 @@ void mtm(Param<T> output,
             outPtr[i] = scalar<T>(0);
         }
 
-        for (int i = 0; i < rowIdx.dims[0]-1; ++i) {
+        for (int i = 0; i < rowIdx.dims(0)-1; ++i) {
             for (int j = rowPtr[i]; j < rowPtr[i+1]; ++j) {
                 //If stride[0] of right is not 1 then rightPtr[i*stride]
                 if (conjugate) {
@@ -465,8 +465,8 @@ Array<T> matmul(const common::SparseArray<T> lhs, const Array<T> rhs,
                      CParam<int> rowIdx,
                      CParam<int> colIdx,
                      CParam<T> right) {
-        int ldb = right.strides[1];
-        int ldc = output.strides[1];
+        int ldb = right.strides(1);
+        int ldc = output.strides(1);
 
         if(rDims[rColDim] == 1) {
             if (lOpts == SPARSE_OPERATION_NON_TRANSPOSE) {

--- a/src/backend/cpu/svd.cpp
+++ b/src/backend/cpu/svd.cpp
@@ -73,18 +73,18 @@ void svdInPlace(Array<Tr> &s, Array<T> &u, Array<T> &vt, Array<T> &in)
     vt.eval();
     in.eval();
 
-    auto func = [=] (Array<Tr> s, Array<T> u, Array<T> vt, Array<T> in) {
-        dim4 iDims = in.dims();
+    auto func = [=] (Param<Tr> s, Param<T> u, Param<T> vt, Param<T> in) {
+        dim4 iDims = in.dims;
         int M = iDims[0];
         int N = iDims[1];
 
 #if defined(USE_MKL) || defined(__APPLE__)
-        svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', M, N, in.get(), in.strides()[1],
-                s.get(), u.get(), u.strides()[1], vt.get(), vt.strides()[1]);
+        svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', M, N, in.get(), in.strides[1],
+                s.get(), u.get(), u.strides[1], vt.get(), vt.strides[1]);
 #else
         std::vector<Tr> superb(std::min(M, N));
-        svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', 'A', M, N, in.get(), in.strides()[1],
-                s.get(), u.get(), u.strides()[1], vt.get(), vt.strides()[1], &superb[0]);
+        svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', 'A', M, N, in.get(), in.strides[1],
+                s.get(), u.get(), u.strides[1], vt.get(), vt.strides[1], &superb[0]);
 #endif
     };
     getQueue().enqueue(func, s, u, vt, in);

--- a/src/backend/cpu/svd.cpp
+++ b/src/backend/cpu/svd.cpp
@@ -74,17 +74,17 @@ void svdInPlace(Array<Tr> &s, Array<T> &u, Array<T> &vt, Array<T> &in)
     in.eval();
 
     auto func = [=] (Param<Tr> s, Param<T> u, Param<T> vt, Param<T> in) {
-        dim4 iDims = in.dims;
+        dim4 iDims = in.dims();
         int M = iDims[0];
         int N = iDims[1];
 
 #if defined(USE_MKL) || defined(__APPLE__)
-        svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', M, N, in.get(), in.strides[1],
-                s.get(), u.get(), u.strides[1], vt.get(), vt.strides[1]);
+        svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', M, N, in.get(), in.strides(1),
+                s.get(), u.get(), u.strides(1), vt.get(), vt.strides(1));
 #else
         std::vector<Tr> superb(std::min(M, N));
-        svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', 'A', M, N, in.get(), in.strides[1],
-                s.get(), u.get(), u.strides[1], vt.get(), vt.strides[1], &superb[0]);
+        svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', 'A', M, N, in.get(), in.strides(1),
+                s.get(), u.get(), u.strides(1), vt.get(), vt.strides(1), &superb[0]);
 #endif
     };
     getQueue().enqueue(func, s, u, vt, in);


### PR DESCRIPTION
This change allows us to efficiently reuse memory allocated on the same queue for cpu backend