### PR TITLE
Workaround enqueueReadBuffer bug on OSX

### DIFF
--- a/src/backend/opencl/copy.cpp
+++ b/src/backend/opencl/copy.cpp
@@ -39,6 +39,9 @@ namespace opencl
             offset = 0;
         }
 
+#ifdef OS_MAC
+        getQueue().finish();
+#endif
         //FIXME: Add checks
         getQueue().enqueueReadBuffer(buf, CL_TRUE,
                                      sizeof(T) * offset,
@@ -219,6 +222,9 @@ namespace opencl
     T getScalar(const Array<T> &in)
     {
         T retVal;
+#ifdef OS_MAC
+        getQueue().finish();
+#endif
         getQueue().enqueueReadBuffer(*in.get(), CL_TRUE, sizeof(T) * in.getOffset(), sizeof(T), &retVal);
         return retVal;
     }

--- a/src/backend/opencl/kernel/canny.hpp
+++ b/src/backend/opencl/kernel/canny.hpp
@@ -224,6 +224,9 @@ void edgeTrackingHysteresis(Param output, const Param strong, const Param weak)
                     *output.data, output.info, blk_x, blk_y, *d_continue);
         CL_DEBUG_FINISH(getQueue());
 
+#ifdef OS_MAC
+        getQueue().finish();
+#endif
         getQueue().enqueueReadBuffer(*d_continue, CL_TRUE, 0, sizeof(int), &notFinished);
     }
 

--- a/src/backend/opencl/kernel/fast.hpp
+++ b/src/backend/opencl/kernel/fast.hpp
@@ -136,6 +136,9 @@ void fast(const unsigned arc_length,
     CL_DEBUG_FINISH(getQueue());
 
     unsigned total;
+#ifdef OS_MAC
+    getQueue().finish();
+#endif
     getQueue().enqueueReadBuffer(*d_total, CL_TRUE, 0, sizeof(unsigned), &total);
     total = total < max_feat ? total : max_feat;
 

--- a/src/backend/opencl/kernel/harris.hpp
+++ b/src/backend/opencl/kernel/harris.hpp
@@ -262,6 +262,9 @@ void harris(unsigned* corners_out,
          min_r, border_len, corner_lim);
     CL_DEBUG_FINISH(getQueue());
 
+#ifdef OS_MAC
+    getQueue().finish();
+#endif
     getQueue().enqueueReadBuffer(*d_corners_found, CL_TRUE, 0, sizeof(unsigned), &corners_found);
 
     bufferFree(d_responses);

--- a/src/backend/opencl/kernel/homography.hpp
+++ b/src/backend/opencl/kernel/homography.hpp
@@ -193,6 +193,9 @@ int computeH(Param bestH, Param H, Param err, Param x_src, Param y_src,
 
             CL_DEBUG_FINISH(getQueue());
 
+#ifdef OS_MAC
+            getQueue().finish();
+#endif
             getQueue().enqueueReadBuffer(*finalMedian, CL_TRUE, 0, sizeof(float), &minMedian);
             getQueue().enqueueReadBuffer(*finalIdx, CL_TRUE, 0, sizeof(unsigned), &minIdx);
 
@@ -200,6 +203,9 @@ int computeH(Param bestH, Param H, Param err, Param x_src, Param y_src,
             bufferFree(finalIdx);
         }
         else {
+#ifdef OS_MAC
+          getQueue().finish();
+#endif
             getQueue().enqueueReadBuffer(*median.data, CL_TRUE, 0, sizeof(float), &minMedian);
             getQueue().enqueueReadBuffer(*idx.data, CL_TRUE, 0, sizeof(unsigned), &minIdx);
         }
@@ -228,6 +234,9 @@ int computeH(Param bestH, Param H, Param err, Param x_src, Param y_src,
 
         kernel::reduce<unsigned, unsigned, af_add_t>(totalInliers, inliers, 0, false, 0.0);
 
+#ifdef OS_MAC
+        getQueue().finish();
+#endif
         getQueue().enqueueReadBuffer(*totalInliers.data, CL_TRUE, 0, sizeof(unsigned), &inliersH);
 
         bufferFree(totalInliers.data);

--- a/src/backend/opencl/kernel/ireduce.hpp
+++ b/src/backend/opencl/kernel/ireduce.hpp
@@ -381,6 +381,9 @@ namespace kernel
             unique_ptr<T[]> h_ptr(new T[tmp_elements]);
             unique_ptr<uint[]> h_iptr(new uint[tmp_elements]);
 
+#ifdef OS_MAC
+            getQueue().finish();
+#endif
             getQueue().enqueueReadBuffer(*tmp.data, CL_TRUE, 0, sizeof(T) * tmp_elements, h_ptr.get());
             getQueue().enqueueReadBuffer(*tidx, CL_TRUE, 0, sizeof(uint) * tmp_elements, h_iptr.get());
 
@@ -414,6 +417,9 @@ namespace kernel
             unique_ptr<T[]> h_ptr(new T[in_elements]);
             T* h_ptr_raw = h_ptr.get();
 
+#ifdef OS_MAC
+            getQueue().finish();
+#endif
             getQueue().enqueueReadBuffer(*in.data, CL_TRUE, sizeof(T) * in.info.offset,
                                           sizeof(T) * in_elements, h_ptr_raw);
 

--- a/src/backend/opencl/kernel/orb.hpp
+++ b/src/backend/opencl/kernel/orb.hpp
@@ -275,6 +275,9 @@ void orb(unsigned* out_feat, Param& x_out, Param& y_out, Param& score_out,
               block_size, k_thr, patch_size);
         CL_DEBUG_FINISH(getQueue());
 
+#ifdef OS_MAC
+        getQueue().finish();
+#endif
         getQueue().enqueueReadBuffer(*d_usable_feat, CL_TRUE, 0, sizeof(unsigned), &usable_feat);
 
         if (lvl_feat > 0) { //This is just to supress warnings

--- a/src/backend/opencl/kernel/reduce.hpp
+++ b/src/backend/opencl/kernel/reduce.hpp
@@ -317,6 +317,9 @@ namespace kernel
 
             reduce_first_launcher<Ti, To, op>(tmp, in, groups_x, groups_y, threads_x, change_nan, nanval);
 
+#ifdef OS_MAC
+            getQueue().finish();
+#endif
             unique_ptr<To[]> h_ptr(new To[tmp_elements]);
             getQueue().enqueueReadBuffer(*tmp.data, CL_TRUE, 0, sizeof(To) * tmp_elements, h_ptr.get());
 
@@ -331,6 +334,9 @@ namespace kernel
 
         } else {
 
+#ifdef OS_MAC
+            getQueue().finish();
+#endif
             unique_ptr<Ti[]> h_ptr(new Ti[in_elements]);
             getQueue().enqueueReadBuffer(*in.data, CL_TRUE, sizeof(Ti) * in.info.offset,
                                           sizeof(Ti) * in_elements, h_ptr.get());

--- a/src/backend/opencl/kernel/regions.hpp
+++ b/src/backend/opencl/kernel/regions.hpp
@@ -150,6 +150,9 @@ void regions(Param out, Param in)
               *out.data, out.info, *d_continue);
         CL_DEBUG_FINISH(getQueue());
 
+#ifdef OS_MAC
+        getQueue().finish();
+#endif
         getQueue().enqueueReadBuffer(*d_continue, CL_TRUE, 0, sizeof(int), &h_continue);
     }
 

--- a/src/backend/opencl/kernel/sift_nonfree.hpp
+++ b/src/backend/opencl/kernel/sift_nonfree.hpp
@@ -520,6 +520,9 @@ void sift(unsigned* out_feat, unsigned* out_dlen, Param& x_out, Param& y_out,
               cl::Local((SIFT_THREADS_X+2) * (SIFT_THREADS_Y+2) * 3 * sizeof(float)));
         CL_DEBUG_FINISH(getQueue());
 
+#ifdef OS_MAC
+        getQueue().finish();
+#endif
         getQueue().enqueueReadBuffer(*d_count, CL_TRUE, 0, sizeof(unsigned), &extrema_feat);
         extrema_feat = min(extrema_feat, max_feat);
 
@@ -562,6 +565,9 @@ void sift(unsigned* out_feat, unsigned* out_dlen, Param& x_out, Param& y_out,
         bufferFree(d_extrema_y);
         bufferFree(d_extrema_layer);
 
+#ifdef OS_MAC
+        getQueue().finish();
+#endif
         getQueue().enqueueReadBuffer(*d_count, CL_TRUE, 0, sizeof(unsigned), &interp_feat);
         interp_feat = min(interp_feat, extrema_feat);
 
@@ -629,6 +635,9 @@ void sift(unsigned* out_feat, unsigned* out_dlen, Param& x_out, Param& y_out,
               *d_interp_response, *d_interp_size, interp_feat);
         CL_DEBUG_FINISH(getQueue());
 
+#ifdef OS_MAC
+        getQueue().finish();
+#endif
         getQueue().enqueueReadBuffer(*d_count, CL_TRUE, 0, sizeof(unsigned), &nodup_feat);
         nodup_feat = min(nodup_feat, interp_feat);
 
@@ -673,6 +682,9 @@ void sift(unsigned* out_feat, unsigned* out_dlen, Param& x_out, Param& y_out,
         bufferFree(d_nodup_response);
         bufferFree(d_nodup_size);
 
+#ifdef OS_MAC
+        getQueue().finish();
+#endif
         getQueue().enqueueReadBuffer(*d_count, CL_TRUE, 0, sizeof(unsigned), &oriented_feat);
         oriented_feat = min(oriented_feat, max_oriented_feat);
 

--- a/src/backend/opencl/kernel/susan.hpp
+++ b/src/backend/opencl/kernel/susan.hpp
@@ -117,6 +117,9 @@ unsigned nonMaximal(cl::Buffer* x_out, cl::Buffer* y_out, cl::Buffer* resp_out,
                  *x_out, *y_out, *resp_out, *d_corners_found,
                  idim0, idim1, *resp_in, edge, max_corners);
 
+#ifdef OS_MAC
+    getQueue().finish();
+#endif
     getQueue().enqueueReadBuffer(*d_corners_found, CL_TRUE, 0, sizeof(unsigned), &corners_found);
     bufferFree(d_corners_found);
 

--- a/src/backend/opencl/kernel/where.hpp
+++ b/src/backend/opencl/kernel/where.hpp
@@ -128,10 +128,13 @@ static void where(Param &out, Param &in)
     }
 
     scan_first<uint, uint, af_add_t>(ltmp, ltmp);
+    #ifdef OS_MAC
+    getQueue().finish();
+    #endif
 
     // Get output size and allocate output
     uint total;
-    getQueue().enqueueReadBuffer(*rtmp.data, CL_TRUE,
+    getQueue().enqueueReadBuffer(*ltmp.data, CL_TRUE,
                                   sizeof(uint) * (rtmp_elements - 1),
                                   sizeof(uint),
                                   &total);

--- a/src/backend/opencl/plot.cpp
+++ b/src/backend/opencl/plot.cpp
@@ -56,6 +56,9 @@ void copy_plot(const Array<T> &P, forge::Plot* plot)
         glBindBuffer(GL_ARRAY_BUFFER, plot->vertices());
         GLubyte* ptr = (GLubyte*)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
         if (ptr) {
+#ifdef OS_MAC
+            getQueue().finish();
+#endif
             getQueue().enqueueReadBuffer(*P.get(), CL_TRUE, 0, plot->verticesSize(), ptr);
             glUnmapBuffer(GL_ARRAY_BUFFER);
         }

--- a/src/backend/opencl/surface.cpp
+++ b/src/backend/opencl/surface.cpp
@@ -56,6 +56,9 @@ void copy_surface(const Array<T> &P, forge::Surface* surface)
         glBindBuffer(GL_ARRAY_BUFFER, surface->vertices());
         GLubyte* ptr = (GLubyte*)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
         if (ptr) {
+#ifdef OS_MAC
+            getQueue().finish();
+#endif
             getQueue().enqueueReadBuffer(*P.get(), CL_TRUE, 0, surface->verticesSize(), ptr);
             glUnmapBuffer(GL_ARRAY_BUFFER);
         }

--- a/src/backend/opencl/vector_field.cpp
+++ b/src/backend/opencl/vector_field.cpp
@@ -58,6 +58,9 @@ void copy_vector_field(const Array<T> &points, const Array<T> &directions,
         glBindBuffer(GL_ARRAY_BUFFER, vector_field->vertices());
         GLubyte* pPtr = (GLubyte*)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
         if (pPtr) {
+#ifdef OS_MAC
+            getQueue().finish();
+#endif
             getQueue().enqueueReadBuffer(*points.get(), CL_TRUE, 0, vector_field->verticesSize(), pPtr);
             glUnmapBuffer(GL_ARRAY_BUFFER);
         }
@@ -66,6 +69,9 @@ void copy_vector_field(const Array<T> &points, const Array<T> &directions,
         glBindBuffer(GL_ARRAY_BUFFER, vector_field->directions());
         GLubyte* dPtr = (GLubyte*)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
         if (dPtr) {
+#ifdef OS_MAC
+          getQueue().finish();
+#endif
             getQueue().enqueueReadBuffer(*directions.get(), CL_TRUE, 0, vector_field->directionsSize(), dPtr);
             glUnmapBuffer(GL_ARRAY_BUFFER);
         }


### PR DESCRIPTION
There seems to be an issue on OSX where the enqueueReadBuffer operation is not
waiting for the previous operations to complete before executing the read
operation. This seems to happen even when passing the CL_TRUE parameter to the
blocking_call parameter of the function. I am not able to produce this issue
in a standalone application.