### PR TITLE
BUGFIX: Converting driver_api_mutex to be recursive

### DIFF
--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -38,6 +38,7 @@ using std::hash;
 using std::lock_guard;
 using std::map;
 using std::mutex;
+using std::recursive_mutex;
 using std::string;
 using std::stringstream;
 using std::unique_ptr;
@@ -270,7 +271,7 @@ std::vector<char> compileToPTX(const char *ker_name, string jit_ker)
 
 static kc_entry_t compileKernel(const char *ker_name, string jit_ker)
 {
-    lock_guard<mutex> lock(getDriverApiMutex(getActiveDeviceId()));
+    lock_guard<recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
 
     const size_t linkLogSize = 1024;
     char linkInfo[linkLogSize] = {0};
@@ -422,7 +423,7 @@ void evalNodes(vector<Param<T> >&outputs, vector<Node *> output_nodes)
     args.push_back((void *)&blocks_y_);
     args.push_back((void *)&num_odims);
 
-    lock_guard<mutex> lock(getDriverApiMutex(getActiveDeviceId()));
+    lock_guard<recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
     CU_CHECK(cuLaunchKernel(ker,
                             blocks_x,
                             blocks_y,

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -28,7 +28,7 @@
 #endif
 
 using std::lock_guard;
-using std::mutex;
+using std::recursive_mutex;
 
 namespace cuda
 {
@@ -173,7 +173,7 @@ size_t MemoryManager::getMaxMemorySize(int id)
 
 void *MemoryManager::nativeAlloc(const size_t bytes)
 {
-    lock_guard<mutex> lock(getDriverApiMutex(getActiveDeviceId()));
+    lock_guard<recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
     void *ptr = NULL;
     CUDA_CHECK(cudaMalloc(&ptr, bytes));
     return ptr;
@@ -181,7 +181,7 @@ void *MemoryManager::nativeAlloc(const size_t bytes)
 
 void MemoryManager::nativeFree(void *ptr)
 {
-    lock_guard<mutex> lock(getDriverApiMutex(getActiveDeviceId()));
+    lock_guard<recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
     cudaError_t err = cudaFree(ptr);
     if (err != cudaErrorCudartUnloading) {
         CUDA_CHECK(err);
@@ -212,7 +212,7 @@ size_t MemoryManagerPinned::getMaxMemorySize(int id)
 
 void *MemoryManagerPinned::nativeAlloc(const size_t bytes)
 {
-    lock_guard<mutex> lock(getDriverApiMutex(getActiveDeviceId()));
+    lock_guard<recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
     void *ptr;
     CUDA_CHECK(cudaMallocHost(&ptr, bytes));
     return ptr;
@@ -220,7 +220,7 @@ void *MemoryManagerPinned::nativeAlloc(const size_t bytes)
 
 void MemoryManagerPinned::nativeFree(void *ptr)
 {
-    lock_guard<mutex> lock(getDriverApiMutex(getActiveDeviceId()));
+    lock_guard<recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
     cudaError_t err = cudaFreeHost(ptr);
     if (err != cudaErrorCudartUnloading) {
         CUDA_CHECK(err);

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -283,7 +283,7 @@ unsigned getMaxJitSize()
     return length;
 }
 
-std::mutex& getDriverApiMutex(int device) {
+std::recursive_mutex& getDriverApiMutex(int device) {
   return DeviceManager::getInstance().driver_api_mutex[device];
 }
 

--- a/src/backend/cuda/platform.hpp
+++ b/src/backend/cuda/platform.hpp
@@ -43,7 +43,7 @@ void devprop(char* d_name, char* d_platform, char *d_toolkit, char* d_compute);
 
 unsigned getMaxJitSize();
 
-std::mutex& getDriverApiMutex(int device);
+std::recursive_mutex& getDriverApiMutex(int device);
 
 int getDeviceCount();
 
@@ -115,7 +115,7 @@ class DeviceManager
         friend GraphicsResourceManager& interopManager();
 #endif
 
-        friend std::mutex& getDriverApiMutex(int device);
+        friend std::recursive_mutex& getDriverApiMutex(int device);
 
         friend std::string getDeviceInfo(int device);
 
@@ -149,7 +149,7 @@ class DeviceManager
         DeviceManager(DeviceManager const&);
         void operator=(DeviceManager const&);
 
-        std::mutex driver_api_mutex[MAX_DEVICES];
+        std::recursive_mutex driver_api_mutex[MAX_DEVICES];
 
         // Attributes
         std::vector<cudaDevice_t> cuDevices;

--- a/src/backend/cuda/sparse_blas.cpp
+++ b/src/backend/cuda/sparse_blas.cpp
@@ -145,7 +145,7 @@ Array<T> matmul(const common::SparseArray<T> lhs, const Array<T> rhs,
     // NOTE: The cuSparse library seems to be using the driver API in the
     // implementation. This is causing issues with our JIT kernel generation.
     // This may be a bug in the cuSparse library.
-    std::lock_guard<std::mutex> lock(getDriverApiMutex(getActiveDeviceId()));
+    std::lock_guard<std::recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
 
     // Create Sparse Matrix Descriptor
     cusparseMatDescr_t descr = 0;


### PR DESCRIPTION
This solves the issue when sparse blas is called with a JIT'd array

- Fixes #1866 