### PR TITLE
Make TNJ faster by increasing cache locality of function pointers.

### DIFF
--- a/src/backend/cpu/TNJ/BinaryNode.hpp
+++ b/src/backend/cpu/TNJ/BinaryNode.hpp
@@ -12,6 +12,7 @@
 #include <vector>
 #include <math.hpp>
 #include "Node.hpp"
+#include <array>
 
 namespace cpu
 {
@@ -19,9 +20,14 @@ namespace cpu
     template<typename To, typename Ti, af_op_t op>
     struct BinOp
     {
-        To eval(Ti lhs, Ti rhs)
+        void eval(TNJ::array<To> &out,
+                  const TNJ::array<Ti> &lhs,
+                  const TNJ::array<Ti> &rhs,
+                  int lim)
         {
-            return scalar<To>(0);
+            for (int i = 0; i < lim; i++) {
+                out[i] = scalar<To>(0);
+            }
         }
     };
 
@@ -44,14 +50,14 @@ namespace TNJ
         {
         }
 
-        void calc(int x, int y, int z, int w)
+        void calc(int x, int y, int z, int w, int lim)
         {
-            this->m_val = m_op.eval(m_lhs->m_val, m_rhs->m_val);
+            m_op.eval(this->m_val, m_lhs->m_val, m_rhs->m_val, lim);
         }
 
-        void calc(int idx)
+        void calc(int idx, int lim)
         {
-            this->m_val = m_op.eval(m_lhs->m_val, m_rhs->m_val);
+            m_op.eval(this->m_val, m_lhs->m_val, m_rhs->m_val, lim);
         }
     };
 

--- a/src/backend/cpu/TNJ/BufferNode.hpp
+++ b/src/backend/cpu/TNJ/BufferNode.hpp
@@ -58,19 +58,26 @@ namespace TNJ
                            });
         }
 
-        void calc(int x, int y, int z, int w)
+        void calc(int x, int y, int z, int w, int lim)
         {
             dim_t l_off = 0;
             l_off += (w < (int)m_dims[3]) * w * m_strides[3];
             l_off += (z < (int)m_dims[2]) * z * m_strides[2];
             l_off += (y < (int)m_dims[1]) * y * m_strides[1];
-            l_off += (x < (int)m_dims[0]) * x;
-            this->m_val = m_ptr[l_off];
+            T *in_ptr = m_ptr + l_off;
+            T *out_ptr = this->m_val.data();
+            for(int i = 0; i < lim; i++) {
+                out_ptr[i] = in_ptr[((x + i) < m_dims[0]) ? (x + i) : 0];
+            }
         }
 
-        void calc(int idx)
+        void calc(int idx, int lim)
         {
-            this->m_val = m_ptr[idx];
+            T *in_ptr = m_ptr + idx;
+            T *out_ptr = this->m_val.data();
+            for(int i = 0; i < lim; i++) {
+                out_ptr[i] = in_ptr[i];
+            }
         }
 
         void getInfo(unsigned &len, unsigned &buf_count, unsigned &bytes)

--- a/src/backend/cpu/TNJ/Node.hpp
+++ b/src/backend/cpu/TNJ/Node.hpp
@@ -20,7 +20,9 @@ namespace cpu
 namespace TNJ
 {
 
+    static const int VECTOR_LENGTH = 256;
     static const int MAX_CHILDREN = 2;
+
     class Node;
     using std::shared_ptr;
     using std::vector;
@@ -28,6 +30,10 @@ namespace TNJ
 
     typedef std::unordered_map<Node *, int> Node_map_t;
     typedef Node_map_t::iterator Node_map_iter;
+
+    template<typename T>
+    using array = std::array<T, VECTOR_LENGTH>;
+
 
     class Node
     {
@@ -61,11 +67,11 @@ namespace TNJ
 
         int getHeight() { return m_height; }
 
-        virtual void calc(int x, int y, int z, int w)
+        virtual void calc(int x, int y, int z, int w, int lim)
         {
         }
 
-        virtual void calc(int idx)
+        virtual void calc(int idx, int lim)
         {
         }
 
@@ -84,12 +90,12 @@ namespace TNJ
     class TNode : public Node
     {
     public:
-        T m_val;
+        alignas(16) TNJ::array<T> m_val;
     public:
         TNode(T val, const int height, const std::array<Node_ptr, MAX_CHILDREN> children) :
-            Node(height, children),
-            m_val(val)
+            Node(height, children)
             {
+                m_val.fill(val);
             }
     };
 

--- a/src/backend/cpu/TNJ/UnaryNode.hpp
+++ b/src/backend/cpu/TNJ/UnaryNode.hpp
@@ -15,13 +15,15 @@
 
 namespace cpu
 {
-
     template<typename To, typename Ti, af_op_t op>
     struct UnOp
     {
-        To eval(Ti in)
+        void eval(TNJ::array<To> &out,
+                  const TNJ::array<Ti> &in, int lim)
         {
-            return scalar<To>(0);
+            for (int i = 0; i < lim; i++) {
+                out[i] = To(in[i]);
+            }
         }
     };
 
@@ -33,7 +35,7 @@ namespace TNJ
     {
 
     protected:
-        UnOp <To, Ti, op> m_op;
+        UnOp<To, Ti, op> m_op;
         TNode<Ti> *m_child;
 
     public:
@@ -43,15 +45,14 @@ namespace TNJ
         {
         }
 
-
-        void calc(int x, int y, int z, int w)
+        void calc(int x, int y, int z, int w, int lim)
         {
-            this->m_val = m_op.eval(m_child->m_val);
+            m_op.eval(this->m_val, m_child->m_val, lim);
         }
 
-        void calc(int idx)
+        void calc(int idx, int lim)
         {
-            this->m_val = m_op.eval(m_child->m_val);
+            m_op.eval(this->m_val, m_child->m_val, lim);
         }
 
     };

--- a/src/backend/cpu/arith.hpp
+++ b/src/backend/cpu/arith.hpp
@@ -21,9 +21,14 @@ namespace cpu
     template<typename T>                        \
     struct BinOp<T, T, OP>                      \
     {                                           \
-        T eval(T lhs, T rhs)                    \
+        void eval(TNJ::array<T> &out,           \
+                  const TNJ::array<T> &lhs,     \
+                  const TNJ::array<T> &rhs,     \
+                  int lim)                      \
         {                                       \
-            return lhs op rhs;                  \
+            for (int i = 0; i < lim; i++) {     \
+                out[i] = lhs[i] op rhs[i];      \
+            }                                   \
         }                                       \
     };                                          \
 
@@ -53,9 +58,14 @@ template<> STATIC_ double __rem<double>(double lhs, double rhs) { return remaind
     template<typename T>                        \
     struct BinOp<T, T, OP>                      \
     {                                           \
-        T eval(T lhs, T rhs)                    \
+        void eval(TNJ::array<T> &out,           \
+                  const TNJ::array<T> &lhs,     \
+                  const TNJ::array<T> &rhs,     \
+                  int lim)                      \
         {                                       \
-            return FN(lhs, rhs);                \
+            for (int i = 0; i < lim; i++) {     \
+                out[i] = FN(lhs[i] , rhs[i]);   \
+            }                                   \
         }                                       \
     };                                          \
 

--- a/src/backend/cpu/cast.hpp
+++ b/src/backend/cpu/cast.hpp
@@ -23,57 +23,86 @@ namespace cpu
 template<typename To, typename Ti>
 struct UnOp<To, Ti, af_cast_t>
 {
-    To eval(Ti in)
+    void eval(TNJ::array<To> &out,
+              const TNJ::array<Ti> &in, int lim)
     {
-        return To(in);
+        for (int i = 0; i < lim; i++) {
+            out[i] = To(in[i]);
+        }
     }
 };
 
 template<typename To>
 struct UnOp<To, std::complex<float>, af_cast_t>
 {
-    To eval(std::complex<float> in)
+    typedef std::complex<float> Ti;
+    void eval(TNJ::array<To> &out,
+              const TNJ::array<Ti> &in, int lim)
     {
-        return To(std::abs(in));
+        for (int i = 0; i < lim; i++) {
+            out[i] = To(std::abs(in[i]));
+        }
     }
 };
 
 template<typename To>
 struct UnOp<To, std::complex<double>, af_cast_t>
 {
-    To eval(std::complex<double> in)
+    typedef std::complex<double> Ti;
+    void eval(TNJ::array<To> &out,
+              const TNJ::array<Ti> &in, int lim)
     {
-        return To(std::abs(in));
+        for (int i = 0; i < lim; i++) {
+            out[i] = To(std::abs(in[i]));
+        }
     }
 };
+
+// DO NOT REMOVE THE TWO SPECIALIZATIONS BELOW
+// These specializations are required because we partially specialize when Ti = std::complex<T>
+// The partial specializations above expect output to be real.
+// so they To(std::abs(v)) instead of To(v) which results in incorrect values when To is complex.
 
 template<>
 struct UnOp<std::complex<float>, std::complex<double>, af_cast_t>
 {
-    std::complex<float> eval(std::complex<double> in)
+    typedef std::complex<double> Ti;
+    typedef std::complex<float> To;
+    void eval(TNJ::array<To> &out,
+              const TNJ::array<Ti> &in, int lim)
     {
-        return std::complex<float>(in);
+        for (int i = 0; i < lim; i++) {
+            out[i] = To(in[i]);
+        }
     }
 };
 
 template<>
 struct UnOp<std::complex<double>, std::complex<float>, af_cast_t>
 {
-    std::complex<double> eval(std::complex<float> in)
+    typedef std::complex<float> Ti;
+    typedef std::complex<double> To;
+    void eval(TNJ::array<To> &out,
+              const TNJ::array<Ti> &in, int lim)
     {
-        return std::complex<double>(in);
+        for (int i = 0; i < lim; i++) {
+            out[i] = To(in[i]);
+        }
     }
 };
 
-#define CAST_B8(T)                              \
-    template<>                                  \
-    struct UnOp<char, T, af_cast_t>             \
-    {                                           \
-        char eval(T in)                         \
-        {                                       \
-            return char(in != 0);               \
-        }                                       \
-    };                                          \
+#define CAST_B8(T)                                      \
+    template<>                                          \
+    struct UnOp<char, T, af_cast_t>                     \
+    {                                                   \
+        void eval(TNJ::array<char> &out,                \
+                  const TNJ::array<T> &in, int lim)     \
+        {                                               \
+            for (int i = 0; i < lim; i++) {             \
+                out[i] = char(in[i] != 0);              \
+            }                                           \
+        }                                               \
+    };                                                  \
 
 CAST_B8(float)
 CAST_B8(double)

--- a/src/backend/cpu/complex.hpp
+++ b/src/backend/cpu/complex.hpp
@@ -21,9 +21,14 @@ namespace cpu
     template<typename To, typename Ti>
     struct BinOp<To, Ti, af_cplx2_t>
     {
-        To eval(Ti lhs, Ti rhs)
+        void eval(TNJ::array<To> &out,
+                  const TNJ::array<Ti> &lhs,
+                  const TNJ::array<Ti> &rhs,
+                  int lim)
         {
-            return To(lhs, rhs);
+            for (int i = 0; i < lim; i++) {
+                out[i] = To(lhs[i], rhs[i]);
+            }
         }
     };
 
@@ -40,15 +45,18 @@ namespace cpu
                                        reinterpret_cast<TNJ::Node *>(node)));
     }
 
-#define CPLX_UNARY_FN(op)                       \
-    template<typename To, typename Ti>          \
-    struct UnOp<To, Ti, af_##op##_t>            \
-    {                                           \
-        To eval(Ti in)                          \
-        {                                       \
-            return std::op(in);                 \
-        }                                       \
-    };                                          \
+#define CPLX_UNARY_FN(op)                               \
+    template<typename To, typename Ti>                  \
+    struct UnOp<To, Ti, af_##op##_t>                    \
+    {                                                   \
+        void eval(TNJ::array<To> &out,                  \
+                  const TNJ::array<Ti> &in, int lim)    \
+        {                                               \
+            for (int i = 0; i < lim; i++) {             \
+                out[i] = std::op(in[i]);                \
+            }                                           \
+        }                                               \
+    };                                                  \
 
     CPLX_UNARY_FN(real)
     CPLX_UNARY_FN(imag)

--- a/src/backend/cpu/kernel/Array.hpp
+++ b/src/backend/cpu/kernel/Array.hpp
@@ -43,16 +43,21 @@ void evalMultiple(std::vector<Array<T>> arrays)
     }
 
     if (is_linear) {
-        int num = arrays[0].elements();
-        for (int i = 0; i < num; i++) {
+        int num = arrays[0].dims().elements();
+        int cnum = TNJ::VECTOR_LENGTH * std::ceil(double(num) / TNJ::VECTOR_LENGTH);
+        for (int i = 0; i < cnum; i += TNJ::VECTOR_LENGTH) {
+            int lim = std::min(TNJ::VECTOR_LENGTH, num - i);
             for (int n = 0; n < (int)full_nodes.size(); n++) {
-                full_nodes[n]->calc(i);
+                full_nodes[n]->calc(i, lim);
             }
             for (int n = 0; n < (int)output_nodes.size(); n++) {
-                ptrs[n][i] = output_nodes[n]->m_val;
+                std::copy(output_nodes[n]->m_val.begin(),
+                          output_nodes[n]->m_val.begin() + lim,
+                          ptrs[n] + i);
             }
         }
     } else {
+
         for (int w = 0; w < (int)odims[3]; w++) {
             dim_t offw = w * ostrs[3];
 
@@ -62,14 +67,19 @@ void evalMultiple(std::vector<Array<T>> arrays)
                 for (int y = 0; y < (int)odims[1]; y++) {
                     dim_t offy = y * ostrs[1] + offz;
 
-                    for (int x = 0; x < (int)odims[0]; x++) {
+                    int dim0 = odims[0];
+                    int cdim0 = TNJ::VECTOR_LENGTH * std::ceil(double(dim0) / TNJ::VECTOR_LENGTH);
+                    for (int x = 0; x < (int)cdim0; x += TNJ::VECTOR_LENGTH) {
+                        int lim = std::min(TNJ::VECTOR_LENGTH, dim0 - x);
                         dim_t id = x + offy;
 
                         for (int n = 0; n < (int)full_nodes.size(); n++) {
-                            full_nodes[n]->calc(x, y, z, w);
+                            full_nodes[n]->calc(x, y, z, w, lim);
                         }
                         for (int n = 0; n < (int)output_nodes.size(); n++) {
-                            ptrs[n][id] = output_nodes[n]->m_val;
+                            std::copy(output_nodes[n]->m_val.begin(),
+                                      output_nodes[n]->m_val.begin() + lim,
+                                      ptrs[n] + id);
                         }
                     }
                 }
@@ -81,53 +91,7 @@ void evalMultiple(std::vector<Array<T>> arrays)
 template<typename T>
 void evalArray(Array<T> arr)
 {
-    arr.setId(cpu::getActiveDeviceId());
-    T *ptr = arr.data.get();
-
-    af::dim4 odims = arr.dims();
-    af::dim4 ostrs = arr.strides();
-
-    TNJ::Node_map_t nodes;
-    std::vector<TNJ::Node *> full_nodes;
-    full_nodes.reserve(1024);
-    arr.node->getNodesMap(nodes, full_nodes);
-
-    bool is_linear = true;
-    for(auto node : full_nodes) {
-        is_linear &= node->isLinear(odims.get());
-    }
-
-    TNJ::TNode<T> *output_node = reinterpret_cast<TNJ::TNode<T> *>(full_nodes.back());
-    if (is_linear) {
-        int num = arr.elements();
-        for (int i = 0; i < num; i++) {
-            for (int n = 0; n < (int)full_nodes.size(); n++) {
-                full_nodes[n]->calc(i);
-            }
-            ptr[i] = output_node->m_val;
-        }
-    } else {
-        for (int w = 0; w < (int)odims[3]; w++) {
-            dim_t offw = w * ostrs[3];
-
-            for (int z = 0; z < (int)odims[2]; z++) {
-                dim_t offz = z * ostrs[2] + offw;
-
-                for (int y = 0; y < (int)odims[1]; y++) {
-                    dim_t offy = y * ostrs[1] + offz;
-
-                    for (int x = 0; x < (int)odims[0]; x++) {
-                        dim_t id = x + offy;
-
-                        for (int n = 0; n < (int)full_nodes.size(); n++) {
-                            full_nodes[n]->calc(x, y, z, w);
-                        }
-                        ptr[id] = output_node->m_val;
-                    }
-                }
-            }
-        }
-    }
+    evalMultiple<T>({arr});
 }
 
 }

--- a/src/backend/cpu/logic.hpp
+++ b/src/backend/cpu/logic.hpp
@@ -21,9 +21,14 @@ namespace cpu
     template<typename T>                        \
     struct BinOp<char, T, OP>                   \
     {                                           \
-        char eval(T lhs, T rhs)                 \
+        void eval(TNJ::array<char> &out,        \
+                  const TNJ::array<T> &lhs,     \
+                  const TNJ::array<T> &rhs,     \
+                  int lim)                      \
         {                                       \
-            return lhs op rhs;                  \
+            for (int i = 0; i < lim; i++) {     \
+                out[i] = lhs[i] op rhs[i];      \
+            }                                   \
         }                                       \
     };                                          \
 
@@ -39,16 +44,23 @@ namespace cpu
 
 #undef LOGIC_FN
 
-#define LOGIC_CPLX_FN(T, OP, op)                    \
-    template<>                                      \
-    struct BinOp<char, std::complex<T>, OP>         \
-    {                                               \
-        char eval(std::complex<T> lhs,              \
-                  std::complex<T> rhs)              \
-        {                                           \
-            return std::abs(lhs) op std::abs(rhs);  \
-        }                                           \
-    };                                              \
+#define LOGIC_CPLX_FN(T, OP, op)                \
+    template<>                                  \
+    struct BinOp<char, std::complex<T>, OP>     \
+    {                                           \
+        typedef std::complex<T> Ti;             \
+        void eval(TNJ::array<char> &out,        \
+                  const TNJ::array<Ti> &lhs,    \
+                  const TNJ::array<Ti> &rhs,    \
+                  int lim)                      \
+        {                                       \
+            for (int i = 0; i < lim; i++) {     \
+                T lhs_mag = std::abs(lhs[i]);   \
+                T rhs_mag = std::abs(rhs[i]);   \
+                out[i] = lhs_mag op rhs_mag;    \
+            }                                   \
+        }                                       \
+    };                                          \
 
 LOGIC_CPLX_FN(float, af_lt_t, <)
 LOGIC_CPLX_FN(float, af_le_t, <=)
@@ -85,9 +97,14 @@ LOGIC_CPLX_FN(double, af_or_t, ||)
     template<typename T>                        \
     struct BinOp<T, T, OP>                      \
     {                                           \
-        T eval(T lhs, T rhs)                    \
+        void eval(TNJ::array<T> &out,           \
+                  const TNJ::array<T> &lhs,     \
+                  const TNJ::array<T> &rhs,     \
+                  int lim)                      \
         {                                       \
-            return lhs op rhs;                  \
+            for (int i = 0; i < lim; i++) {     \
+                out[i] = lhs[i] op rhs[i];      \
+            }                                   \
         }                                       \
     };                                          \
 

--- a/src/backend/cpu/unary.hpp
+++ b/src/backend/cpu/unary.hpp
@@ -15,7 +15,12 @@
 
 namespace cpu
 {
-#define sign(in) std::signbit(in)
+
+template<typename T>
+T sign(T in)
+{
+    return T(std::signbit(in));
+}
 
 template<typename T>
 T sigmoid(T in)
@@ -23,56 +28,61 @@ T sigmoid(T in)
     return (1.0) / (1 + std::exp(-in));
 }
 
-#define UNARY_FN(op)                            \
-    template<typename T>                        \
-    struct UnOp<T, T, af_##op##_t>              \
-    {                                           \
-        T eval(T in)                            \
-        {                                       \
-            return op(in);                      \
-        }                                       \
-    };                                          \
+#define UNARY_OP_FN(op, fn)                         \
+    template<typename T>                            \
+    struct UnOp<T, T, af_##op##_t>                  \
+    {                                               \
+        void eval(TNJ::array<T> &out,               \
+                  const TNJ::array<T> &in, int lim) \
+        {                                           \
+            for (int i = 0; i < lim; i++) {         \
+                out[i] = fn(in[i]);                 \
+            }                                       \
+        }                                           \
+    };                                              \
 
-UNARY_FN(sin)
-UNARY_FN(cos)
-UNARY_FN(tan)
+#define UNARY_OP(op) UNARY_OP_FN(op, std::op)
 
-UNARY_FN(asin)
-UNARY_FN(acos)
-UNARY_FN(atan)
+UNARY_OP(sin)
+UNARY_OP(cos)
+UNARY_OP(tan)
 
-UNARY_FN(sinh)
-UNARY_FN(cosh)
-UNARY_FN(tanh)
+UNARY_OP(asin)
+UNARY_OP(acos)
+UNARY_OP(atan)
 
-UNARY_FN(asinh)
-UNARY_FN(acosh)
-UNARY_FN(atanh)
+UNARY_OP(sinh)
+UNARY_OP(cosh)
+UNARY_OP(tanh)
 
-UNARY_FN(round)
-UNARY_FN(trunc)
-UNARY_FN(sign )
-UNARY_FN(floor)
-UNARY_FN(ceil)
+UNARY_OP(asinh)
+UNARY_OP(acosh)
+UNARY_OP(atanh)
 
-UNARY_FN(exp)
-UNARY_FN(sigmoid)
-UNARY_FN(expm1)
-UNARY_FN(erf)
-UNARY_FN(erfc)
+UNARY_OP(round)
+UNARY_OP(trunc)
+UNARY_OP_FN(sign, sign)
+UNARY_OP(floor)
+UNARY_OP(ceil)
 
-UNARY_FN(log)
-UNARY_FN(log10)
-UNARY_FN(log1p)
-UNARY_FN(log2)
+UNARY_OP(exp)
+UNARY_OP_FN(sigmoid, sigmoid)
+UNARY_OP(expm1)
+UNARY_OP(erf)
+UNARY_OP(erfc)
 
-UNARY_FN(sqrt)
-UNARY_FN(cbrt)
+UNARY_OP(log)
+UNARY_OP(log10)
+UNARY_OP(log1p)
+UNARY_OP(log2)
 
-UNARY_FN(tgamma)
-UNARY_FN(lgamma)
+UNARY_OP(sqrt)
+UNARY_OP(cbrt)
 
-#undef UNARY_FN
+UNARY_OP(tgamma)
+UNARY_OP(lgamma)
+
+#undef UNARY_OP
 #undef sign
 
     template<typename T, af_op_t op>
@@ -87,15 +97,18 @@ UNARY_FN(lgamma)
 
 #define iszero(a) ((a) == 0)
 
-#define CHECK_FN(name ,op)                      \
-    template<typename T>                        \
-    struct UnOp<char, T, af_##name##_t>         \
-    {                                           \
-        char eval(T in)                         \
-        {                                       \
-            return op(in);                      \
-        }                                       \
-    };                                          \
+#define CHECK_FN(name ,op)                          \
+    template<typename T>                            \
+    struct UnOp<char, T, af_##name##_t>             \
+    {                                               \
+        void eval(TNJ::array<char> &out,            \
+                  const TNJ::array<T> &in, int lim) \
+        {                                           \
+            for (int i = 0; i < lim; i++) {         \
+                out[i] = op(in[i]);                 \
+            }                                       \
+        }                                           \
+    };                                              \
 
     CHECK_FN(isinf, std::isinf)
     CHECK_FN(isnan, std::isnan)


### PR DESCRIPTION
- [x] Fix failures in non linear "jit"
- [x] Investigate other vector lengths.
- [x] Move calc for loop into eval
- [x] Align m_val vector
--------------------------
- Fixes https://github.com/arrayfire/arrayfire/issues/1226