### PR TITLE
FEAT: Add support for batched matrix multiply

### DIFF
--- a/src/api/c/blas.cpp
+++ b/src/api/c/blas.cpp
@@ -124,10 +124,17 @@ af_err af_matmul(af_array *out,
             AF_ERROR("Using this property is not yet supported in matmul", AF_ERR_NOT_SUPPORTED);
         }
 
+        dim4 lDims = lhsInfo.dims();
+        dim4 rDims = rhsInfo.dims();
 
-        if (lhsInfo.ndims() > 2 ||
-            rhsInfo.ndims() > 2) {
-            AF_ERROR("matmul can not be used in batch mode", AF_ERR_BATCH);
+        if (lDims.ndims() > 2 || rDims.ndims() > 2) {
+            DIM_ASSERT(1, lDims.ndims() == rDims.ndims());
+            if (lDims[2] != rDims[2] && lDims[2] != 1 && rDims[2] != 1) {
+                AF_ERROR("Batch size mismatch along dimension 2", AF_ERR_BATCH);
+            }
+            if (lDims[3] != rDims[3] && lDims[3] != 1 && rDims[3] != 1) {
+                AF_ERROR("Batch size mismatch along dimension 3", AF_ERR_BATCH);
+            }
         }
 
         TYPE_ASSERT(lhs_type == rhs_type);

--- a/src/backend/cpu/blas.cpp
+++ b/src/backend/cpu/blas.cpp
@@ -158,33 +158,57 @@ Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
     using BT  =       typename blas_base<T>::type;
     using CBT = const typename blas_base<T>::type;
 
-    Array<T> out = createEmptyArray<T>(af::dim4(M, N, 1, 1));
+    dim_t d2 = std::max(lDims[2], rDims[2]);
+    dim_t d3 = std::max(lDims[3], rDims[3]);
+    dim4 oDims = af::dim4(M, N, d2, d3);
+    Array<T> out = createEmptyArray<T>(oDims);
+
     auto func = [=] (Param<T> output, CParam<T> left, CParam<T> right) {
         auto alpha = getScale<T, 1>();
         auto beta  = getScale<T, 0>();
 
         dim4 lStrides = left.strides();
         dim4 rStrides = right.strides();
+        dim4 oStrides = output.strides();
 
-        if(rDims[bColDim] == 1) {
-            dim_t incr = (rOpts == CblasNoTrans) ? rStrides[0] : rStrides[1];
-            gemv_func<T>()(
-                CblasColMajor, lOpts,
-                lDims[0], lDims[1],
-                alpha,
-                reinterpret_cast<CBT*>(left.get()), lStrides[1],
-                reinterpret_cast<CBT*>(right.get()), incr,
-                beta,
-                reinterpret_cast<BT*>(output.get()), 1);
-        } else {
-            gemm_func<T>()(
-                CblasColMajor, lOpts, rOpts,
-                M, N, K,
-                alpha,
-                reinterpret_cast<CBT*>(left.get()), lStrides[1],
-                reinterpret_cast<CBT*>(right.get()), rStrides[1],
-                beta,
-                reinterpret_cast<BT*>(output.get()), output.dims(0));
+        int batchSize = oDims[2] * oDims[3];
+
+        bool is_l_d2_batched = oDims[2] == lDims[2];
+        bool is_l_d3_batched = oDims[3] == lDims[3];
+        bool is_r_d2_batched = oDims[2] == rDims[2];
+        bool is_r_d3_batched = oDims[3] == rDims[3];
+
+        for (int n = 0; n < batchSize; n++) {
+            int w = n / rDims[2];
+            int z = n - w * rDims[2];
+
+            int loff = z * (is_l_d2_batched * lStrides[2]) + w * (is_l_d3_batched * lStrides[3]);
+            int roff = z * (is_r_d2_batched * rStrides[2]) + w * (is_r_d3_batched * rStrides[3]);
+
+            CBT *lptr = reinterpret_cast<CBT*>(left.get() + loff);
+            CBT *rptr = reinterpret_cast<CBT*>(right.get() + roff);
+            BT *optr = reinterpret_cast<BT*>(output.get() + z * oStrides[2] + w * oStrides[3]);
+
+            if(rDims[bColDim] == 1) {
+                dim_t incr = (optRhs == AF_MAT_NONE) ? rStrides[0] : rStrides[1];
+                gemv_func<T>()(
+                    CblasColMajor, lOpts,
+                    lDims[0], lDims[1],
+                    alpha,
+                    lptr, lStrides[1],
+                    rptr, incr,
+                    beta,
+                    optr, 1);
+            } else {
+                gemm_func<T>()(
+                    CblasColMajor, lOpts, rOpts,
+                    M, N, K,
+                    alpha,
+                    lptr, lStrides[1],
+                    rptr, rStrides[1],
+                    beta,
+                    optr, output.dims(0));
+            }
         }
     };
     getQueue().enqueue(func, out, lhs, rhs);

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -145,6 +145,7 @@ bool checkMemoryLimit()
     INSTANTIATE(uintl)
     INSTANTIATE(short)
     INSTANTIATE(ushort)
+    INSTANTIATE(void *)
 
 MemoryManager::MemoryManager()
     : common::MemoryManager<cuda::MemoryManager>(getDeviceCount(), common::MAX_BUFFERS,


### PR DESCRIPTION
- Related to #1868 
- Related to https://github.com/arrayfire/arrayfire-ml/pull/39
- Partially solves https://github.com/arrayfire/arrayfire/issues/483

This uses batchedGemm for CUDA backend, but uses a for loop for CPU and OpenCL backend.

These can be improved (in the future) by:
- Using batched gemm for CPU when using MKL 11.3 or greater
- Using CLBLAST as the default BLAS implementation for OpenCL (or copying the batched gemm code into arrayfire).