### PR TITLE
Change static objects into pointers to fix release issues on Windows

### DIFF
--- a/src/api/c/canny.cpp
+++ b/src/api/c/canny.cpp
@@ -173,9 +173,9 @@ template<typename T>
 af_array cannyHelper(const Array<T> in, const float t1, const af_canny_threshold ct,
                      const float t2, const unsigned sw, const bool isf)
 {
-    static const std::vector<float> v = {-0.11021f, -0.23691f, -0.30576f, -0.23691f, -0.11021f};
-    Array<float> cFilter= detail::createHostDataArray<float>(dim4(5, 1), v.data());
-    Array<float> rFilter= detail::createHostDataArray<float>(dim4(1, 5), v.data());
+    static const float v[] = {-0.11021f, -0.23691f, -0.30576f, -0.23691f, -0.11021f};
+    Array<float> cFilter= detail::createHostDataArray<float>(dim4(5, 1), v);
+    Array<float> rFilter= detail::createHostDataArray<float>(dim4(1, 5), v);
 
     // Run separable convolution to smooth the input image
     Array<float> smt = detail::convolve2<float, float, false>(cast<float, T>(in), cFilter, rFilter);

--- a/src/api/cpp/random.cpp
+++ b/src/api/cpp/random.cpp
@@ -76,14 +76,14 @@ namespace af
         return engine;
     }
 
-    AFAPI array randu(const dim4 &dims, const dtype ty, randomEngine &r)
+    array randu(const dim4 &dims, const dtype ty, randomEngine &r)
     {
         af_array out;
         AF_THROW(af_random_uniform(&out, dims.ndims(), dims.get(), ty, r.get()));
         return array(out);
     }
 
-    AFAPI array randn(const dim4 &dims, const dtype ty, randomEngine &r)
+    array randn(const dim4 &dims, const dtype ty, randomEngine &r)
     {
         af_array out;
         AF_THROW(af_random_normal(&out, dims.ndims(), dims.get(), ty, r.get()));

--- a/src/api/unified/symbol_manager.cpp
+++ b/src/api/unified/symbol_manager.cpp
@@ -20,10 +20,10 @@ using std::replace;
 namespace unified
 {
 
-static const string LIB_AF_BKND_NAME[NUM_BACKENDS] = {"cpu", "cuda", "opencl"};
+static const char* LIB_AF_BKND_NAME[NUM_BACKENDS] = {"cpu", "cuda", "opencl"};
 #if defined(OS_WIN)
-static const string LIB_AF_BKND_PREFIX = "af";
-static const string LIB_AF_BKND_SUFFIX = ".dll";
+static const char* LIB_AF_BKND_PREFIX = "af";
+static const char* LIB_AF_BKND_SUFFIX = ".dll";
 #define RTLD_LAZY 0
 #else
 #if defined(__APPLE__)
@@ -31,20 +31,20 @@ static const string LIB_AF_BKND_SUFFIX = ".dll";
 #else
 #define SO_SUFFIX_HELPER(VER) ".so." #VER
 #endif // APPLE
-static const string LIB_AF_BKND_PREFIX = "libaf";
+static const char* LIB_AF_BKND_PREFIX = "libaf";
 
 #define GET_SO_SUFFIX(VER) SO_SUFFIX_HELPER(VER)
-static const string LIB_AF_BKND_SUFFIX = GET_SO_SUFFIX(AF_VERSION_MAJOR);
+static const char* LIB_AF_BKND_SUFFIX = GET_SO_SUFFIX(AF_VERSION_MAJOR);
 #endif
 
-static const string LIB_AF_ENVARS[NUM_ENV_VARS] = {"AF_PATH", "AF_BUILD_PATH"};
-static const string LIB_AF_RPATHS[NUM_ENV_VARS] = {"/lib/", "/src/backend/"};
+static const char* LIB_AF_ENVARS[NUM_ENV_VARS] = {"AF_PATH", "AF_BUILD_PATH"};
+static const char* LIB_AF_RPATHS[NUM_ENV_VARS] = {"/lib/", "/src/backend/"};
 static const bool LIB_AF_RPATH_SUFFIX[NUM_ENV_VARS] = {false, true};
 
 inline string getBkndLibName(const int backend_index)
 {
     int i = backend_index >=0 && backend_index<NUM_BACKENDS ? backend_index : 0;
-    return LIB_AF_BKND_PREFIX + LIB_AF_BKND_NAME[i] + LIB_AF_BKND_SUFFIX;
+    return string(LIB_AF_BKND_PREFIX) + LIB_AF_BKND_NAME[i] + LIB_AF_BKND_SUFFIX;
 }
 
 /*flag parameter is not used on windows platform */
@@ -84,7 +84,7 @@ LibHandle openDynLibrary(const int bknd_idx, int flag=RTLD_LAZY)
         for (int i=0; i<NUM_ENV_VARS; ++i) {
             string abs_path = getEnvVar(LIB_AF_ENVARS[i])
                                  + LIB_AF_RPATHS[i]
-                                 + (LIB_AF_RPATH_SUFFIX[i] ? LIB_AF_BKND_NAME[bknd_idx]+"/" : "")
+                                 + (LIB_AF_RPATH_SUFFIX[i] ? LIB_AF_BKND_NAME[bknd_idx]+ string("/") : "")
                                  + bkndLibName;
 #if defined(OS_WIN)
             replace(abs_path.begin(), abs_path.end(), '/', '\\');

--- a/src/backend/common/MemoryManager.hpp
+++ b/src/backend/common/MemoryManager.hpp
@@ -14,6 +14,8 @@
 #include <util.hpp>
 
 #include <algorithm>
+
+// TODO(umar): Remove iostream
 #include <iomanip>
 #include <iostream>
 #include <mutex>
@@ -298,9 +300,9 @@ class MemoryManager
 
         std::cout << msg << std::endl;
 
-        static const std::string head("|     POINTER      |    SIZE    |  AF LOCK  | USER LOCK |");
-        static const std::string line(head.size(), '-');
-        std::cout << line << std::endl << head << std::endl << line << std::endl;
+        printf("---------------------------------------------------------\n"
+               "|     POINTER      |    SIZE    |  AF LOCK  | USER LOCK |\n"
+               "---------------------------------------------------------\n");
 
         for(auto& kv : current.locked_map) {
             std::string status_mngr("Yes");
@@ -343,7 +345,7 @@ class MemoryManager
             }
         }
 
-        std::cout << line << std::endl;
+        printf("---------------------------------------------------------\n");
     }
 
     void bufferInfo(size_t *alloc_bytes, size_t *alloc_buffers,

--- a/src/backend/cpu/Array.cpp
+++ b/src/backend/cpu/Array.cpp
@@ -23,7 +23,6 @@
 namespace cpu
 {
 
-const int MAX_TNJ_LEN = 20;
 using TNJ::BufferNode;
 using TNJ::Node;
 using TNJ::Node_ptr;

--- a/src/backend/cpu/kernel/reduce.hpp
+++ b/src/backend/cpu/kernel/reduce.hpp
@@ -23,7 +23,7 @@ struct reduce_dim
                     const int dim, bool change_nan, double nanval)
     {
         static const int D1 = D - 1;
-        static reduce_dim<op, Ti, To, D1> reduce_dim_next;
+        reduce_dim<op, Ti, To, D1> reduce_dim_next;
 
         const af::dim4 ostrides = out.strides();
         const af::dim4 istrides = in.strides();

--- a/src/backend/cpu/platform.cpp
+++ b/src/backend/cpu/platform.cpp
@@ -257,21 +257,21 @@ bool& evalFlag()
     return flag;
 }
 
+DeviceManager::DeviceManager()
+    : queues(MAX_QUEUES)
+    , memManager(new MemoryManager()) {}
+
+
 MemoryManager& memoryManager()
 {
-    static std::once_flag flag;
-
     DeviceManager& inst = DeviceManager::getInstance();
-
-    std::call_once(flag, [&]() { inst.memManager.reset(new MemoryManager()); });
-
-    return *(inst.memManager.get());
+    return *(inst.memManager);
 }
 
 DeviceManager& DeviceManager::getInstance()
 {
-    static DeviceManager my_instance;
-    return my_instance;
+    static DeviceManager* my_instance = new DeviceManager();
+    return *my_instance;
 }
 
 }

--- a/src/backend/cpu/platform.hpp
+++ b/src/backend/cpu/platform.hpp
@@ -128,18 +128,17 @@ class DeviceManager
         CPUInfo getCPUInfo() const;
 
     private:
-        DeviceManager() {}
-
+        DeviceManager();
         // Following two declarations are required to
         // avoid copying accidental copy/assignment
         // of instance returned by getInstance to other
         // variables
-        DeviceManager(DeviceManager const&);
-        void operator=(DeviceManager const&);
+        DeviceManager(DeviceManager const&) = delete;
+        void operator=(DeviceManager const&) = delete;
 
         // Attributes
+        std::vector<queue> queues;
         const CPUInfo cinfo;
         std::unique_ptr<MemoryManager> memManager;
-        std::array<queue, MAX_QUEUES> queues;
 };
 }

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -392,8 +392,8 @@ bool DeviceManager::checkGraphicsInteropCapability()
 
 DeviceManager& DeviceManager::getInstance()
 {
-    static DeviceManager my_instance;
-    return my_instance;
+    static DeviceManager *my_instance = new DeviceManager();
+    return *my_instance;
 }
 
 MemoryManager& memoryManager()

--- a/src/backend/opencl/kernel/harris.hpp
+++ b/src/backend/opencl/kernel/harris.hpp
@@ -88,7 +88,7 @@ template<typename T>
 std::tuple<cl::Kernel*, cl::Kernel*, cl::Kernel*, cl::Kernel*>
 getHarrisKernels()
 {
-    static const std::string kernelNames[4] =
+    static const char* kernelNames[4] =
         {"second_order_deriv", "keep_corners", "harris_responses", "non_maximal"};
 
     kc_entry_t entries[4];
@@ -114,7 +114,7 @@ getHarrisKernels()
         for (int i=0; i<4; ++i)
         {
             entries[i].prog = new Program(prog);
-            entries[i].ker  = new Kernel(*entries[i].prog, kernelNames[i].c_str());
+            entries[i].ker  = new Kernel(*entries[i].prog, kernelNames[i]);
 
             std::string name = kernelNames[i] +
                 std::string("_") + std::string(dtype_traits<T>::getName());

--- a/src/backend/opencl/kernel/homography.hpp
+++ b/src/backend/opencl/kernel/homography.hpp
@@ -39,7 +39,7 @@ template<typename T, af_homography_type htype>
 std::array<cl::Kernel*, 5> getHomographyKernels()
 {
     static const unsigned NUM_KERNELS = 5;
-    static const std::string kernelNames[NUM_KERNELS] =
+    static const char* kernelNames[NUM_KERNELS] =
         {"compute_homography", "eval_homography", "compute_median",
          "find_min_median", "compute_lmeds_inliers"};
 
@@ -79,7 +79,7 @@ std::array<cl::Kernel*, 5> getHomographyKernels()
         for (unsigned i=0; i<NUM_KERNELS; ++i)
         {
             entries[i].prog = new Program(prog);
-            entries[i].ker  = new Kernel(*entries[i].prog, kernelNames[i].c_str());
+            entries[i].ker  = new Kernel(*entries[i].prog, kernelNames[i]);
 
             std::string name = kernelNames[i] + std::string("_") +
                 std::string(dtype_traits<T>::getName()) +

--- a/src/backend/opencl/kernel/orb.hpp
+++ b/src/backend/opencl/kernel/orb.hpp
@@ -89,7 +89,7 @@ template<typename T>
 std::tuple<cl::Kernel*, cl::Kernel*, cl::Kernel*, cl::Kernel*>
 getOrbKernels()
 {
-    static const std::string kernelNames[4] =
+    static const char* kernelNames[4] =
         {"harris_response", "keep_features", "centroid_angle", "extract_orb"};
 
     kc_entry_t entries[4];
@@ -117,7 +117,7 @@ getOrbKernels()
         for (int i=0; i<4; ++i)
         {
             entries[i].prog = new Program(prog);
-            entries[i].ker  = new Kernel(*entries[i].prog, kernelNames[i].c_str());
+            entries[i].ker  = new Kernel(*entries[i].prog, kernelNames[i]);
 
             std::string name = kernelNames[i] +
                 std::string("_") + std::string(dtype_traits<T>::getName());

--- a/src/backend/opencl/kernel/regions.hpp
+++ b/src/backend/opencl/kernel/regions.hpp
@@ -55,7 +55,7 @@ getRegionsKernels()
     static const int block_dim = 16;
     static const int num_warps = 8;
     static const unsigned NUM_KERNELS = 3;
-    static const std::string kernelNames[NUM_KERNELS] =
+    static const char* kernelNames[NUM_KERNELS] =
         {"initial_label", "final_relabel", "update_equiv"};
 
     kc_entry_t entries[NUM_KERNELS];
@@ -98,7 +98,7 @@ getRegionsKernels()
         for (unsigned i=0; i<NUM_KERNELS; ++i)
         {
             entries[i].prog = new Program(prog);
-            entries[i].ker  = new Kernel(*entries[i].prog, kernelNames[i].c_str());
+            entries[i].ker  = new Kernel(*entries[i].prog, kernelNames[i]);
 
             std::string name = kernelNames[i] + std::string("_") +
                 std::string(dtype_traits<T>::getName()) +

--- a/src/backend/opencl/kernel/sift_nonfree.hpp
+++ b/src/backend/opencl/kernel/sift_nonfree.hpp
@@ -399,7 +399,7 @@ template<typename T>
 std::array<cl::Kernel*, 7> getSiftKernels()
 {
     static const unsigned NUM_KERNELS = 7;
-    static const std::string kernelNames[NUM_KERNELS] =
+    static const char* kernelNames[NUM_KERNELS] =
         {"sub", "detectExtrema", "interpolateExtrema", "calcOrientation", "removeDuplicates",
          "computeDescriptor", "computeGLOHDescriptor"};
 
@@ -424,7 +424,7 @@ std::array<cl::Kernel*, 7> getSiftKernels()
         for (unsigned i=0; i<NUM_KERNELS; ++i)
         {
             entries[i].prog = new Program(prog);
-            entries[i].ker  = new Kernel(*entries[i].prog, kernelNames[i].c_str());
+            entries[i].ker  = new Kernel(*entries[i].prog, kernelNames[i]);
 
             std::string name = kernelNames[i] + std::string("_") +
                 std::string(dtype_traits<T>::getName());

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -61,9 +61,9 @@ using cl::Device;
 namespace opencl
 {
 #if defined (OS_MAC)
-static const std::string CL_GL_SHARING_EXT = "cl_APPLE_gl_sharing";
+static const char* CL_GL_SHARING_EXT = "cl_APPLE_gl_sharing";
 #else
-static const std::string CL_GL_SHARING_EXT = "cl_khr_gl_sharing";
+static const char* CL_GL_SHARING_EXT = "cl_khr_gl_sharing";
 #endif
 
 static const std::string get_system(void)
@@ -744,8 +744,8 @@ kc_entry_t kernelCache(int device, const std::string& key)
 
 DeviceManager& DeviceManager::getInstance()
 {
-    static DeviceManager my_instance;
-    return my_instance;
+    static DeviceManager* my_instance = new DeviceManager();
+    return *my_instance;
 }
 
 DeviceManager::~DeviceManager()

--- a/src/backend/opencl/types.hpp
+++ b/src/backend/opencl/types.hpp
@@ -21,6 +21,8 @@
 #include <cmath>
 #include <type_util.hpp>
 
+using std::string;
+
 namespace opencl
 {
 typedef cl_float2   cfloat;
@@ -50,8 +52,8 @@ struct ToNumStr<float>
 {
     inline std::string operator()(float val)
     {
-        static const std::string PINF = "+INFINITY";
-        static const std::string NINF = "-INFINITY";
+        static const char* PINF = "+INFINITY";
+        static const char* NINF = "-INFINITY";
         if (std::isinf(val)) {
             return val < 0 ? NINF : PINF;
         }
@@ -64,10 +66,10 @@ struct ToNumStr<double>
 {
     inline std::string operator()(double val)
     {
-        static const std::string PINF = "+INFINITY";
-        static const std::string NINF = "-INFINITY";
+        static const char* PINF = "+INFINITY";
+        static const char* NINF = "-INFINITY";
         if (std::isinf(val)) {
-            return val < 0 ? NINF : PINF;
+            return string(val < 0 ? NINF : PINF);
         }
         return std::to_string(val);
     }
@@ -79,7 +81,6 @@ struct ToNumStr<cfloat>
     inline std::string operator()(cfloat val)
     {
         ToNumStr<float> realStr;
-        static const std::string INF = "INFINITY";
         std::stringstream s;
         s << "{";
         s << realStr(val.s[0]);
@@ -96,7 +97,6 @@ struct ToNumStr<cdouble>
     inline std::string operator()(cdouble val)
     {
         ToNumStr<double> realStr;
-        static const std::string INF = "INFINITY";
         std::stringstream s;
         s << "{";
         s << realStr(val.s[0]);


### PR DESCRIPTION
Windows terminates threads before the queue threads and other resources are
released. This causes deadlocks with the condition_variables in the async_queue
objects. This is a bug in Visual Studio/Windows that is documented here:

https://connect.microsoft.com/VisualStudio/feedback/details/747145

This will leak some resources but these resources will be released by the
operating system on exit.