### PR TITLE
Cleaning up names of tests for easier filtering. Fix type errors

### DIFF
--- a/test/ocl_ext_context.cpp
+++ b/test/ocl_ext_context.cpp
@@ -129,11 +129,10 @@ TEST(OCLCheck, DevicePlatform)
     afcl::platform platform = afcl::getPlatform();
     ASSERT_NE(platform, AFCL_PLATFORM_UNKNOWN);
 }
-
+#pragma GCC diagnostic pop
 #else
 TEST(OCLExtContext, NoopCPU)
 {
 }
 #endif
 
-#pragma GCC diagnostic pop

--- a/test/qr_dense.cpp
+++ b/test/qr_dense.cpp
@@ -131,40 +131,49 @@ void qrTester(const int m, const int n, double eps)
     }
 }
 
+template<typename T>
+double eps();
 
-#define QR_BIG_TESTS(T, eps)                    \
-    TEST(QR, T##BigRect0)                       \
-    {                                           \
-        qrTester<T>(500, 1000, eps);            \
-    }                                           \
-    TEST(QR, T##BigRect0Multiple)               \
-    {                                           \
-        qrTester<T>(512, 1024, eps);            \
-    }                                           \
-    TEST(QR, T##BigRect1Multiple)               \
-    {                                           \
-        qrTester<T>(1024, 512, eps);            \
-    }                                           \
+template<>
+double eps<float>() {
+    return 1e-3;
+}
 
-QR_BIG_TESTS(float, 1E-3)
-QR_BIG_TESTS(double, 1E-5)
-QR_BIG_TESTS(cfloat, 1E-3)
-QR_BIG_TESTS(cdouble, 1E-5)
+template<>
+double eps<double>() {
+    return 1e-5;
+}
 
-#undef QR_BIG_TESTS
+template<>
+double eps<cfloat>() {
+    return 1e-3;
+}
 
-#define QR_BIG_TESTS(T, eps)                    \
-    TEST(QR, T##BigRect1)                       \
-    {                                           \
-        qrTester<T>(1000, 500, eps);            \
-    }                                           \
+template<>
+double eps<cdouble>() {
+    return 1e-5;
+}
+template<typename T>
+class QR : public ::testing::Test
+{
 
-QR_BIG_TESTS(float, 1E-3)
-QR_BIG_TESTS(double, 1E-5)
-// Fails on Windows on some devices
-#if !(defined(OS_WIN) && defined(AF_OPENCL))
-QR_BIG_TESTS(cfloat, 1E-3)
-QR_BIG_TESTS(cdouble, 1E-5)
-#endif
+};
 
-#undef QR_BIG_TESTS
+typedef ::testing::Types<float, cfloat, double, cdouble> TestTypes;
+TYPED_TEST_CASE(QR, TestTypes);
+
+TYPED_TEST(QR, RectangularLarge0) {
+    qrTester<TypeParam>(1000, 500, eps<TypeParam>());
+}
+
+TYPED_TEST(QR, RectangularMultipleOfTwoLarge0) {
+    qrTester<TypeParam>(1024, 512, eps<TypeParam>());
+}
+
+TYPED_TEST(QR, RectangularLarge1) {
+    qrTester<TypeParam>(500, 1000, eps<TypeParam>());
+}
+
+TYPED_TEST(QR, RectangularMultipleOfTwoLarge1) {
+    qrTester<TypeParam>(512, 1024, eps<TypeParam>());
+}

--- a/test/select.cpp
+++ b/test/select.cpp
@@ -242,7 +242,7 @@ TEST(Select, Issue_1730_scalar)
     }
 }
 
-TEST(Select, LargeDim)
+TEST(Select, MaxDim)
 {
     const size_t largeDim = 65535 * 32 + 1;
 

--- a/test/solve_common.hpp
+++ b/test/solve_common.hpp
@@ -56,13 +56,8 @@ void solveTester(const int m, const int n, const int k, double eps, int targetDe
     af::array B1 = af::matmul(A, X1);
     //! [ex_solve_recon]
 
-    if(noDoubleTests<T>()) {
-        ASSERT_NEAR(0, af::sum<float>(af::abs(real(B0 - B1))) / (m * k), eps);
-        ASSERT_NEAR(0, af::sum<float>(af::abs(imag(B0 - B1))) / (m * k), eps);
-    } else {
-        ASSERT_NEAR(0, af::sum<double>(af::abs(real(B0 - B1))) / (m * k), eps);
-        ASSERT_NEAR(0, af::sum<double>(af::abs(imag(B0 - B1))) / (m * k), eps);
-    }
+    ASSERT_NEAR(0, af::sum<typename af::dtype_traits<T>::base_type>(af::abs(real(B0 - B1))) / (m * k), eps);
+    ASSERT_NEAR(0, af::sum<typename af::dtype_traits<T>::base_type>(af::abs(imag(B0 - B1))) / (m * k), eps);
 }
 
 template<typename T>
@@ -93,13 +88,8 @@ void solveLUTester(const int n, const int k, double eps, int targetDevice=-1)
 
     af::array B1 = af::matmul(A, X1);
 
-    if(noDoubleTests<T>()) {
-        ASSERT_NEAR(0, af::sum<float>(af::abs(real(B0 - B1))) / (n * k), eps);
-        ASSERT_NEAR(0, af::sum<float>(af::abs(imag(B0 - B1))) / (n * k), eps);
-    } else {
-        ASSERT_NEAR(0, af::sum<double>(af::abs(real(B0 - B1))) / (n * k), eps);
-        ASSERT_NEAR(0, af::sum<double>(af::abs(imag(B0 - B1))) / (n * k), eps);
-    }
+    ASSERT_NEAR(0, af::sum<typename af::dtype_traits<T>::base_type>(af::abs(real(B0 - B1))) / (n * k), eps);
+    ASSERT_NEAR(0, af::sum<typename af::dtype_traits<T>::base_type>(af::abs(imag(B0 - B1))) / (n * k), eps);
 }
 
 template<typename T>
@@ -144,11 +134,6 @@ void solveTriangleTester(const int n, const int k, bool is_upper, double eps, in
 
     af::array B1 = af::matmul(AT, X1);
 
-    if(noDoubleTests<T>()) {
-        ASSERT_NEAR(0, af::sum<float>(af::abs(real(B0 - B1))) / (n * k), eps);
-        ASSERT_NEAR(0, af::sum<float>(af::abs(imag(B0 - B1))) / (n * k), eps);
-    } else {
-        ASSERT_NEAR(0, af::sum<double>(af::abs(real(B0 - B1))) / (n * k), eps);
-        ASSERT_NEAR(0, af::sum<double>(af::abs(imag(B0 - B1))) / (n * k), eps);
-    }
+    ASSERT_NEAR(0, af::sum<typename af::dtype_traits<T>::base_type>(af::abs(real(B0 - B1))) / (n * k), eps);
+    ASSERT_NEAR(0, af::sum<typename af::dtype_traits<T>::base_type>(af::abs(imag(B0 - B1))) / (n * k), eps);
 }

--- a/test/tile.cpp
+++ b/test/tile.cpp
@@ -153,7 +153,6 @@ TEST(Tile, MaxDim)
     if (noDoubleTests<float>()) return;
 
     const size_t largeDim = 65535 * 32 + 1;
-    const unsigned resultIdx = 0;
     const unsigned x = 1;
     const unsigned z = 1;
     unsigned y = 2;


### PR DESCRIPTION
* Refactored some of the tests
* Changed the names of LargeDim to MaxDim to keep inline with other MaxDim tests
for easier filtering
* Added comments about failures on OSX
* Fixed a few warnings