### PR TITLE
Fix invalid access while exiting with an error in flight

### DIFF
--- a/src/api/c/err_common.cpp
+++ b/src/api/c/err_common.cpp
@@ -239,8 +239,8 @@ af_err processException()
 
 std::string& get_global_error_string()
 {
-    thread_local std::string global_error_string = std::string("");
-    return global_error_string;
+    thread_local std::string *global_error_string = new std::string("");
+    return *global_error_string;
 }
 
 const char *af_err_to_string(const af_err err)


### PR DESCRIPTION
This change fixes an error with the convolution example when
an error was thrown as the arrays were being released. Since these arrays
were created before the global_error_string object they were released after
the error string object was deleted. This caused a segfault sometimes when
the release operation returns an error when the driver's resources have
been released.