### PR TITLE
Updated CLBlast to 1.1.0

### DIFF
--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -7,7 +7,7 @@ SET(byproducts ${clBLAS_location})
 ExternalProject_Add(
     CLBlast-ext
     GIT_REPOSITORY https://github.com/cnugteren/CLBlast.git
-    GIT_TAG 0.10.0
+    GIT_TAG 1.1.0
     PREFIX "${prefix}"
     INSTALL_DIR "${prefix}"
     UPDATE_COMMAND ""


### PR DESCRIPTION
CLBlast is a non-default BLAS OpenCL back-end in ArrayFire. The current version of the library fetched by CMake is 0.10.0 from November 2016. This small PR updates CLBlast to the latest version 1.1.0 and should fix many bugs and improve performance. [See here for the the full changelog](https://github.com/CNugteren/CLBlast/releases).