### PR TITLE
Fix morphology fns to handle even size kernels

### DIFF
--- a/src/backend/cpu/copy.cpp
+++ b/src/backend/cpu/copy.cpp
@@ -108,7 +108,10 @@ INSTANTIATE_COPY_ARRAY_COMPLEX(cdouble)
 #define SPECILIAZE_UNUSED_COPYARRAY(SRC_T, DST_T) \
     template<> void copyArray<SRC_T, DST_T>(Array<DST_T> &out, Array<SRC_T> const &in) \
     {\
-        CPU_NOT_SUPPORTED();\
+        char errMessage[1024];                                              \
+        snprintf(errMessage, sizeof(errMessage),                            \
+                "CPU copyArray<"#SRC_T","#DST_T"> is not supported\n");    \
+        CPU_NOT_SUPPORTED(errMessage);                                      \
     }
 
 SPECILIAZE_UNUSED_COPYARRAY(cfloat , double)

--- a/src/backend/cpu/err_cpu.hpp
+++ b/src/backend/cpu/err_cpu.hpp
@@ -9,7 +9,7 @@
 
 #include <common/err_common.hpp>
 
-#define CPU_NOT_SUPPORTED() do {                        \
+#define CPU_NOT_SUPPORTED(message) do {                 \
         throw SupportError(__PRETTY_FUNCTION__,         \
-                __AF_FILENAME__, __LINE__, "CPU");      \
+                __AF_FILENAME__, __LINE__, message);    \
     } while(0)

--- a/src/backend/cpu/kernel/morph.hpp
+++ b/src/backend/cpu/kernel/morph.hpp
@@ -17,7 +17,6 @@ namespace cpu
 {
 namespace kernel
 {
-
 template<typename T, bool IsDilation>
 void morph(Param<T> out, CParam<T> in, CParam<T> mask)
 {
@@ -141,7 +140,5 @@ void morph3d(Param<T> out, CParam<T> in, CParam<T> mask)
         inData  += istrides[3];
     }
 }
-
-
 }
 }

--- a/src/backend/cpu/morph.cpp
+++ b/src/backend/cpu/morph.cpp
@@ -19,7 +19,6 @@ using af::dim4;
 
 namespace cpu
 {
-
 template<typename T, bool isDilation>
 Array<T> morph(const Array<T> &in, const Array<T> &mask)
 {
@@ -60,5 +59,4 @@ INSTANTIATE(uint  )
 INSTANTIATE(uchar )
 INSTANTIATE(ushort)
 INSTANTIATE(short )
-
 }

--- a/src/backend/cpu/morph.hpp
+++ b/src/backend/cpu/morph.hpp
@@ -11,11 +11,9 @@
 
 namespace cpu
 {
-
 template<typename T, bool isDilation>
 Array<T> morph(const Array<T> &in, const Array<T> &mask);
 
 template<typename T, bool isDilation>
 Array<T> morph3d(const Array<T> &in, const Array<T> &mask);
-
 }

--- a/src/backend/cpu/nearest_neighbour.cpp
+++ b/src/backend/cpu/nearest_neighbour.cpp
@@ -27,7 +27,7 @@ void nearest_neighbour(Array<uint>& idx, Array<To>& dist,
                        const af_match_type dist_type)
 {
     if (n_dist > 1) {
-        CPU_NOT_SUPPORTED();
+        CPU_NOT_SUPPORTED("\nNumber of smallest distances can't be <1\n");
     }
 
     idx.eval();

--- a/src/backend/cuda/copy.cu
+++ b/src/backend/cuda/copy.cu
@@ -179,7 +179,10 @@ namespace cuda
 #define SPECILIAZE_UNUSED_COPYARRAY(SRC_T, DST_T) \
     template<> void copyArray<SRC_T, DST_T>(Array<DST_T> &out, Array<SRC_T> const &in) \
     {\
-        CUDA_NOT_SUPPORTED();\
+        char errMessage[1024];                                              \
+        snprintf(errMessage, sizeof(errMessage),                            \
+                "CUDA copyArray<"#SRC_T","#DST_T"> is not supported\n");    \
+        CUDA_NOT_SUPPORTED(errMessage);                                     \
     }
 
     SPECILIAZE_UNUSED_COPYARRAY(cfloat, double)

--- a/src/backend/cuda/err_cuda.hpp
+++ b/src/backend/cuda/err_cuda.hpp
@@ -12,9 +12,9 @@
 #include <common/defines.hpp>
 #include <common/err_common.hpp>
 
-#define CUDA_NOT_SUPPORTED() do {                       \
+#define CUDA_NOT_SUPPORTED(message) do {                \
         throw SupportError(__PRETTY_FUNCTION__,         \
-                __AF_FILENAME__, __LINE__, "CUDA");     \
+                __AF_FILENAME__, __LINE__, message);    \
     } while(0)
 
 #define CUDA_CHECK(fn) do {                                         \

--- a/src/backend/cuda/kernel/bilateral.hpp
+++ b/src/backend/cuda/kernel/bilateral.hpp
@@ -134,7 +134,10 @@ void bilateral(Param<outType> out, CParam<inType> in, float s_sigma, float c_sig
 
     size_t MAX_SHRD_SIZE = cuda::getDeviceProp(cuda::getActiveDeviceId()).sharedMemPerBlock;
     if (total_shrd_size > MAX_SHRD_SIZE) {
-        CUDA_NOT_SUPPORTED();
+        char errMessage[256];
+        snprintf(errMessage, sizeof(errMessage),
+                 "\nCUDA Bilateral filter doesn't support %f spatial sigma\n", s_sigma);
+        CUDA_NOT_SUPPORTED(errMessage);
     }
 
     CUDA_LAUNCH_SMEM((bilateralKernel<inType, outType>), blocks, threads, total_shrd_size,

--- a/src/backend/cuda/kernel/convolve.cu
+++ b/src/backend/cuda/kernel/convolve.cu
@@ -327,7 +327,13 @@ void conv2Helper(const conv_kparam_t &p, Param<T> out, CParam<T> sig, int f1)
         case  3: conv2Helper<T, aT, expand, f0,  3>(p, out, sig); break;
         case  4: conv2Helper<T, aT, expand, f0,  4>(p, out, sig); break;
         case  5: conv2Helper<T, aT, expand, f0,  5>(p, out, sig); break;
-        default: CUDA_NOT_SUPPORTED();
+        default:
+            {
+                char errMessage[256];
+                snprintf(errMessage, sizeof(errMessage),
+                        "\nCUDA Convolution doesn't support %dx%d kernel\n", f0, f1);
+                CUDA_NOT_SUPPORTED(errMessage);
+            };
     }
 }
 
@@ -355,10 +361,22 @@ void conv2Helper(const conv_kparam_t &p, Param<T> out, CParam<T> sig, int f0, in
                              case 15: conv2Helper<T, aT, expand, 15, 15>(p, out, sig); break;
                              case 16: conv2Helper<T, aT, expand, 16, 16>(p, out, sig); break;
                              case 17: conv2Helper<T, aT, expand, 17, 17>(p, out, sig); break;
-                             default: CUDA_NOT_SUPPORTED();
+                             default:
+                                {
+                                    char errMessage[256];
+                                    snprintf(errMessage, sizeof(errMessage),
+                                            "\nCUDA 2D convolution doesn't support %dx%d kernel\n", f0, f1);
+                                    CUDA_NOT_SUPPORTED(errMessage);
+                                };
                          }
-                     } else
-                         CUDA_NOT_SUPPORTED();
+                     } else {
+                        {
+                            char errMessage[256];
+                            snprintf(errMessage, sizeof(errMessage),
+                                    "\nCUDA 2D convolution doesn't support rectangular kernels\n");
+                            CUDA_NOT_SUPPORTED(errMessage);
+                        };
+                     }
                  } break;
     }
 }
@@ -476,7 +494,13 @@ void convolve_nd(Param<T> out, CParam<T> signal, CParam<aT> filt, AF_BATCH_KIND 
         case 3: if ((filt.dims[0]*filt.dims[1]*filt.dims[2]) > (MCFL3 * MCFL3 * MCFL3)) callKernel = false; break;
     }
 
-    if (!callKernel) { CUDA_NOT_SUPPORTED(); }
+    if (!callKernel) {
+        char errMessage[256];
+        snprintf(errMessage, sizeof(errMessage),
+                 "\nCUDA N Dimensional Convolution doesn't support %dx%dx%d kernel\n",
+                 filt.dims[0], filt.dims[1], filt.dims[2]);
+        CUDA_NOT_SUPPORTED(errMessage);
+    }
 
     conv_kparam_t param;
     for (int i=0; i<3; ++i) {

--- a/src/backend/cuda/kernel/convolve_separable.cu
+++ b/src/backend/cuda/kernel/convolve_separable.cu
@@ -16,10 +16,8 @@
 
 namespace cuda
 {
-
 namespace kernel
 {
-
 static const int THREADS_X = 16;
 static const int THREADS_Y = 16;
 
@@ -118,8 +116,12 @@ void convolve2(Param<T> out, CParam<T> signal, CParam<accType> filter)
 {
     int fLen = filter.dims[0] * filter.dims[1] * filter.dims[2] * filter.dims[3];
     if(fLen > kernel::MAX_SCONV_FILTER_LEN) {
-        // call upon fft
-        CUDA_NOT_SUPPORTED();
+        // TODO call upon fft
+        char errMessage[256];
+        snprintf(errMessage, sizeof(errMessage),
+                 "\nCUDA convolution supports max kernel size of %d\n",
+                 kernel::MAX_SCONV_FILTER_LEN);
+        CUDA_NOT_SUPPORTED(errMessage);
     }
 
     dim3 threads(THREADS_X, THREADS_Y);
@@ -166,7 +168,13 @@ void convolve2(Param<T> out, CParam<T> signal, CParam<accType> filter)
         case 29: conv2Helper<T, accType, conv_dim, expand, 29>(blocks, threads, out, signal, blk_x, blk_y); break;
         case 30: conv2Helper<T, accType, conv_dim, expand, 30>(blocks, threads, out, signal, blk_x, blk_y); break;
         case 31: conv2Helper<T, accType, conv_dim, expand, 31>(blocks, threads, out, signal, blk_x, blk_y); break;
-        default: CUDA_NOT_SUPPORTED();
+        default:
+            {
+                char errMessage[256];
+                snprintf(errMessage, sizeof(errMessage),
+                        "\nCUDA Separable convolution doesn't support %d kernel\n", fLen);
+                CUDA_NOT_SUPPORTED(errMessage);
+            };
     }
 
    POST_LAUNCH_CHECK();
@@ -191,7 +199,5 @@ INSTANTIATE(ushort ,   float)
 INSTANTIATE(short  ,   float)
 INSTANTIATE(uintl  ,   float)
 INSTANTIATE(intl   ,   float)
-
 }
-
 }

--- a/src/backend/cuda/kernel/morph.hpp
+++ b/src/backend/cuda/kernel/morph.hpp
@@ -18,10 +18,8 @@
 
 namespace cuda
 {
-
 namespace kernel
 {
-
 static const int MAX_MORPH_FILTER_LEN = 17;
 // cFilter is used by both 2d morph and 3d morph
 // Maximum kernel size supported for 2d morph is 19x19*8 = 2888
@@ -68,8 +66,8 @@ static __global__ void morphKernel(Param<T> out, CParam<T> in,
     T * shrdMem = shared.getPointer();
 
     // calculate necessary offset and window parameters
-    const int halo   = windLen/2;
-    const int padding= 2*halo;
+    const int halo     = windLen/2;
+    const int padding  = (windLen%2==0 ? (windLen-1) : (2*(windLen/2)));
     const int shrdLen  = blockDim.x + padding + 1;
     const int shrdLen1 = blockDim.y + padding;
 
@@ -158,13 +156,13 @@ static __global__ void morph3DKernel(Param<T> out, CParam<T> in, int nBBS)
     T * shrdMem = shared.getPointer();
 
     const int halo      = windLen/2;
-    const int padding   = 2*halo;
+    const int padding   = (windLen%2==0 ? (windLen-1) : (2*(windLen/2)));
 
     const int se_area   = windLen*windLen;
     const int shrdLen   = blockDim.x + padding + 1;
     const int shrdLen1  = blockDim.y + padding;
     const int shrdLen2  = blockDim.z + padding;
-    const int shrdArea  = shrdLen * (blockDim.y+padding);
+    const int shrdArea  = shrdLen * shrdLen1;
 
     // gfor batch offsets
     unsigned batchId = blockIdx.x / nBBS;
@@ -239,22 +237,30 @@ void morph(Param<T> out, CParam<T> in, int windLen)
     dim3 blocks(blk_x * in.dims[2], blk_y * in.dims[3]);
 
     // calculate shared memory size
-    int halo      = windLen/2;
-    int padding   = 2*halo;
+    int padding   = (windLen%2==0 ? (windLen-1) : (2*(windLen/2)));
     int shrdLen   = kernel::THREADS_X + padding + 1; // +1 for to avoid bank conflicts
     int shrdSize  = shrdLen * (kernel::THREADS_Y + padding) * sizeof(T);
 
     switch(windLen) {
-        case  3: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 3>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
-        case  5: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 5>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
-        case  7: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 7>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
-        case  9: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 9>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
-        case 11: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,11>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
-        case 13: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,13>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
-        case 15: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,15>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
-        case 17: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,17>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
-        case 19: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,19>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
-        default: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 3>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case  2: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,  2>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case  3: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,  3>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case  4: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,  4>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case  5: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,  5>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case  6: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,  6>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case  7: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,  7>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case  8: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,  8>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case  9: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation,  9>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case 10: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 10>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case 11: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 11>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case 12: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 12>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case 13: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 13>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case 14: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 14>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case 15: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 15>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case 16: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 16>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case 17: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 17>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case 18: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 18>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        case 19: CUDA_LAUNCH_SMEM((morphKernel<T, isDilation, 19>), blocks, threads, shrdSize, out, in, blk_x, blk_y); break;
+        default: CUDA_NOT_SUPPORTED(); break;
     }
 
     POST_LAUNCH_CHECK();
@@ -271,20 +277,21 @@ void morph3d(Param<T> out, CParam<T> in, int windLen)
     dim3 blocks(blk_x * in.dims[3], blk_y, blk_z);
 
     // calculate shared memory size
-    int halo      = windLen/2;
-    int padding   = 2*halo;
+    int padding   = (windLen%2==0 ? (windLen-1) : (2*(windLen/2)));
     int shrdLen   = kernel::CUBE_X + padding + 1; // +1 for to avoid bank conflicts
     int shrdSize  = shrdLen * (kernel::CUBE_Y + padding) * (kernel::CUBE_Z + padding) * sizeof(T);
 
     switch(windLen) {
+        case  2: CUDA_LAUNCH_SMEM((morph3DKernel<T, isDilation, 2>), blocks, threads, shrdSize, out, in, blk_x); break;
         case  3: CUDA_LAUNCH_SMEM((morph3DKernel<T, isDilation, 3>), blocks, threads, shrdSize, out, in, blk_x); break;
+        case  4: CUDA_LAUNCH_SMEM((morph3DKernel<T, isDilation, 4>), blocks, threads, shrdSize, out, in, blk_x); break;
         case  5: CUDA_LAUNCH_SMEM((morph3DKernel<T, isDilation, 5>), blocks, threads, shrdSize, out, in, blk_x); break;
+        case  6: CUDA_LAUNCH_SMEM((morph3DKernel<T, isDilation, 6>), blocks, threads, shrdSize, out, in, blk_x); break;
         case  7: CUDA_LAUNCH_SMEM((morph3DKernel<T, isDilation, 7>), blocks, threads, shrdSize, out, in, blk_x); break;
-        default: CUDA_LAUNCH_SMEM((morph3DKernel<T, isDilation, 3>), blocks, threads, shrdSize, out, in, blk_x); break;
+        default: CUDA_NOT_SUPPORTED(); break;
     }
 
     POST_LAUNCH_CHECK();
 }
-
 }
 }

--- a/src/backend/cuda/kernel/nearest_neighbour.hpp
+++ b/src/backend/cuda/kernel/nearest_neighbour.hpp
@@ -434,7 +434,10 @@ void nearest_neighbour(Param<uint> idx,
     const To max_dist = maxval<To>();
 
     if (feat_len > THREADS) {
-        CUDA_NOT_SUPPORTED();
+        char errMessage[256];
+        snprintf(errMessage, sizeof(errMessage),
+                 "CUDA Maximum number of features supported in nearest_neighbor is %d\n", THREADS);
+        CUDA_NOT_SUPPORTED(errMessage);
     }
 
     const dim_t sample_dim = (dist_dim == 0) ? 1 : 0;

--- a/src/backend/cuda/morph.hpp
+++ b/src/backend/cuda/morph.hpp
@@ -11,11 +11,9 @@
 
 namespace cuda
 {
-
 template<typename T, bool isDilation>
 Array<T> morph(const Array<T> &in, const Array<T> &mask);
 
 template<typename T, bool isDilation>
 Array<T> morph3d(const Array<T> &in, const Array<T> &mask);
-
 }

--- a/src/backend/cuda/morph3d_impl.hpp
+++ b/src/backend/cuda/morph3d_impl.hpp
@@ -17,7 +17,6 @@ using af::dim4;
 
 namespace cuda
 {
-
 template<typename T, bool isDilation>
 Array<T> morph3d(const Array<T> &in, const Array<T> &mask)
 {
@@ -44,7 +43,6 @@ Array<T> morph3d(const Array<T> &in, const Array<T> &mask)
     return out;
 }
 
-}
-
 #define INSTANTIATE(T, ISDILATE)                                        \
     template Array<T> morph3d<T, ISDILATE>(const Array<T> &in, const Array<T> &mask);
+}

--- a/src/backend/cuda/morph3d_impl.hpp
+++ b/src/backend/cuda/morph3d_impl.hpp
@@ -24,10 +24,10 @@ Array<T> morph3d(const Array<T> &in, const Array<T> &mask)
     const dim4 mdims = mask.dims();
 
     if (mdims[0] != mdims[1] || mdims[0] != mdims[2])
-        AF_ERROR("Only cube masks are supported in CUDA backend", AF_ERR_SIZE);
+        CUDA_NOT_SUPPORTED("Only cubic masks are supported");
 
     if (mdims[0] > 7)
-        AF_ERROR("Upto 7x7x7 kernels are only supported in CUDA backend", AF_ERR_SIZE);
+        CUDA_NOT_SUPPORTED("Kernels > 7x7x7 not supported");
 
     Array<T> out       = createEmptyArray<T>(in.dims());
 

--- a/src/backend/cuda/morph_impl.hpp
+++ b/src/backend/cuda/morph_impl.hpp
@@ -24,9 +24,10 @@ Array<T>  morph(const Array<T> &in, const Array<T> &mask)
     const dim4 mdims = mask.dims();
 
     if (mdims[0] != mdims[1])
-        AF_ERROR("Only square masks are supported in cuda morph currently", AF_ERR_SIZE);
+        CUDA_NOT_SUPPORTED("Rectangular masks are not supported");
+
     if (mdims[0] > 19)
-        AF_ERROR("Upto 19x19 square kernels are only supported in cuda currently", AF_ERR_SIZE);
+        CUDA_NOT_SUPPORTED("Kernels > 19x19 are not supported");
 
     Array<T> out = createEmptyArray<T>(in.dims());
 

--- a/src/backend/cuda/morph_impl.hpp
+++ b/src/backend/cuda/morph_impl.hpp
@@ -17,7 +17,6 @@ using af::dim4;
 
 namespace cuda
 {
-
 template<typename T, bool isDilation>
 Array<T>  morph(const Array<T> &in, const Array<T> &mask)
 {
@@ -44,7 +43,6 @@ Array<T>  morph(const Array<T> &in, const Array<T> &mask)
     return out;
 }
 
-}
-
 #define INSTANTIATE(T, ISDILATE)                                        \
     template Array<T> morph  <T, ISDILATE>(const Array<T> &in, const Array<T> &mask);
+}

--- a/src/backend/opencl/convolve.cpp
+++ b/src/backend/opencl/convolve.cpp
@@ -52,7 +52,13 @@ Array<T> convolve(Array<T> const& signal, Array<accT> const& filter, AF_BATCH_KI
         case 3: if ((fDims[0]*fDims[1]*fDims[2]) > (MCFL3 * MCFL3 * MCFL3)) callKernel = false; break;
     }
 
-    if(!callKernel) { OPENCL_NOT_SUPPORTED(); }
+    if(!callKernel) {
+        char errMessage[256];
+        snprintf(errMessage, sizeof(errMessage),
+                 "\nOpenCL N Dimensional Convolution doesn't support %dx%dx%d kernel\n",
+                 fDims[0], fDims[1], fDims[2]);
+        OPENCL_NOT_SUPPORTED(errMessage);
+    }
 
     kernel::convolve_nd<T, accT, baseDim, expand>(out, signal, filter, kind);
 

--- a/src/backend/opencl/convolve_separable.cpp
+++ b/src/backend/opencl/convolve_separable.cpp
@@ -26,8 +26,12 @@ Array<T> convolve2(Array<T> const& signal, Array<accT> const& c_filter, Array<ac
 
     if ((cflen > kernel::MAX_SCONV_FILTER_LEN) ||
         (rflen > kernel::MAX_SCONV_FILTER_LEN)) {
-        // call upon fft
-        OPENCL_NOT_SUPPORTED();
+        // TODO call upon fft
+        char errMessage[256];
+        snprintf(errMessage, sizeof(errMessage),
+                "\nOpenCL Separable convolution doesn't support %d(coloumn) %d(row) filters\n",
+                 cflen, rflen);
+        OPENCL_NOT_SUPPORTED(errMessage);
     }
 
     const dim4 sDims = signal.dims();

--- a/src/backend/opencl/copy.cpp
+++ b/src/backend/opencl/copy.cpp
@@ -191,7 +191,10 @@ namespace opencl
 #define SPECILIAZE_UNUSED_COPYARRAY(SRC_T, DST_T) \
     template<> void copyArray<SRC_T, DST_T>(Array<DST_T> &out, Array<SRC_T> const &in) \
     {\
-        OPENCL_NOT_SUPPORTED();\
+        char errMessage[1024];                                              \
+        snprintf(errMessage, sizeof(errMessage),                            \
+                "OpenCL copyArray<"#SRC_T","#DST_T"> is not supported\n");  \
+        OPENCL_NOT_SUPPORTED(errMessage);                                   \
     }
 
     SPECILIAZE_UNUSED_COPYARRAY(cfloat, double)

--- a/src/backend/opencl/err_opencl.hpp
+++ b/src/backend/opencl/err_opencl.hpp
@@ -14,9 +14,9 @@
 #include <platform.hpp>
 #include <types.hpp>
 
-#define OPENCL_NOT_SUPPORTED() do {                     \
+#define OPENCL_NOT_SUPPORTED(message) do {              \
         throw SupportError(__PRETTY_FUNCTION__,         \
-                __AF_FILENAME__, __LINE__, "OpenCL");   \
+                __AF_FILENAME__, __LINE__, message);    \
     } while(0)
 
 namespace opencl

--- a/src/backend/opencl/kernel/bilateral.hpp
+++ b/src/backend/opencl/kernel/bilateral.hpp
@@ -84,7 +84,10 @@ void bilateral(Param out, const Param in, float s_sigma, float c_sigma)
     size_t localMemSize   = (num_shrd_elems + num_gauss_elems)*sizeof(outType);
     size_t MaxLocalSize   = getDevice(getActiveDeviceId()).getInfo<CL_DEVICE_LOCAL_MEM_SIZE>();
     if (localMemSize>MaxLocalSize) {
-        OPENCL_NOT_SUPPORTED();
+        char errMessage[256];
+        snprintf(errMessage, sizeof(errMessage),
+                 "\nOpenCL Bilateral filter doesn't support %f spatial sigma\n", s_sigma);
+        OPENCL_NOT_SUPPORTED(errMessage);
     }
 
     bilateralOp(EnqueueArgs(getQueue(), global, local),

--- a/src/backend/opencl/kernel/morph.cl
+++ b/src/backend/opencl/kernel/morph.cl
@@ -33,8 +33,11 @@ void morph(__global T *              out,
            KParam                  iInfo,
            __constant const T *   d_filt,
            __local T *          localMem,
-           int nBBS0, int nBBS1)
+           int nBBS0, int nBBS1, int windLen)
 {
+    if (SeLength>0)
+        windLen = SeLength;
+
     const int halo     = windLen/2;
     const int padding  = (windLen%2==0 ? (windLen-1) : (2*(windLen/2)));
     const int shrdLen  = get_local_size(0) + padding + 1;
@@ -125,9 +128,9 @@ void morph3d(__global T *         out,
              __local T *          localMem,
              int             nBBS)
 {
-    const int halo      = windLen/2;
-    const int padding   = (windLen%2==0 ? (windLen-1) : (2*(windLen/2)));
-    const int se_area   = windLen*windLen;
+    const int halo      = SeLength/2;
+    const int padding   = (SeLength%2==0 ? (SeLength-1) : (2*(SeLength/2)));
+    const int se_area   = SeLength*SeLength;
     const int shrdLen   = get_local_size(0) + padding + 1;
     const int shrdLen1  = get_local_size(1) + padding;
     const int shrdLen2  = get_local_size(2) + padding;
@@ -170,15 +173,15 @@ void morph3d(__global T *         out,
 
     T acc = init;
 #pragma unroll
-    for(int wk=0; wk<windLen; ++wk) {
+    for(int wk=0; wk<SeLength; ++wk) {
         int koff   = wk*se_area;
         int w_koff = (k+wk-halo)*shrdArea;
 #pragma unroll
-        for(int wj=0; wj<windLen; ++wj) {
-        int joff   = wj*windLen;
+        for(int wj=0; wj<SeLength; ++wj) {
+        int joff   = wj*SeLength;
         int w_joff = (j+wj-halo)*shrdLen;
 #pragma unroll
-            for(int wi=0; wi<windLen; ++wi) {
+            for(int wi=0; wi<SeLength; ++wi) {
                 T cur  = localMem[w_koff+w_joff + i+wi-halo];
                 if (d_filt[koff+joff+wi]) {
                     if (isDilation)

--- a/src/backend/opencl/kernel/morph.cl
+++ b/src/backend/opencl/kernel/morph.cl
@@ -35,10 +35,10 @@ void morph(__global T *              out,
            __local T *          localMem,
            int nBBS0, int nBBS1)
 {
-    const int halo   = windLen/2;
-    const int padding= 2*halo;
-    const int shrdLen = get_local_size(0) + padding + 1;
-    const int shrdLen1= get_local_size(1) + padding;
+    const int halo     = windLen/2;
+    const int padding  = (windLen%2==0 ? (windLen-1) : (2*(windLen/2)));
+    const int shrdLen  = get_local_size(0) + padding + 1;
+    const int shrdLen1 = get_local_size(1) + padding;
 
     // gfor batch offsets
     int b2 = get_group_id(0) / nBBS0;
@@ -125,14 +125,13 @@ void morph3d(__global T *         out,
              __local T *          localMem,
              int             nBBS)
 {
-    const int halo   = windLen/2;
-    const int padding= 2*halo;
-
+    const int halo      = windLen/2;
+    const int padding   = (windLen%2==0 ? (windLen-1) : (2*(windLen/2)));
     const int se_area   = windLen*windLen;
     const int shrdLen   = get_local_size(0) + padding + 1;
     const int shrdLen1  = get_local_size(1) + padding;
     const int shrdLen2  = get_local_size(2) + padding;
-    const int shrdArea  = shrdLen * (get_local_size(1)+padding);
+    const int shrdArea  = shrdLen * shrdLen1;
 
     // gfor batch offsets
     int batchId    = get_group_id(0) / nBBS;

--- a/src/backend/opencl/kernel/morph.hpp
+++ b/src/backend/opencl/kernel/morph.hpp
@@ -40,7 +40,7 @@ static const int CUBE_X    =  8;
 static const int CUBE_Y    =  8;
 static const int CUBE_Z    =  4;
 
-template<typename T, bool isDilation, int windLen>
+template<typename T, bool isDilation, int SeLength>
 std::string generateOptionsString()
 {
     ToNumStr<T> toNumStr;
@@ -49,24 +49,26 @@ std::string generateOptionsString()
     options << " -D T=" << dtype_traits<T>::getName()
         << " -D isDilation="<< isDilation
         << " -D init=" << toNumStr(init)
-        << " -D windLen=" << windLen;
+        << " -D SeLength=" << SeLength;
     if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
         options << " -D USE_DOUBLE";
     return options.str();
 }
 
-template<typename T, bool isDilation, int windLen>
-void morph(Param out, const Param in, const Param mask)
+template<typename T, bool isDilation, int SeLength=0>
+void morph(Param out, const Param in, const Param mask, int windLen=0)
 {
     std::string refName = std::string("morph_") +
         std::string(dtype_traits<T>::getName()) +
-        std::to_string(isDilation) + std::to_string(windLen);
+        std::to_string(isDilation) + std::to_string(SeLength);
+
+    windLen = (SeLength>0 ? SeLength : windLen);
 
     int device = getActiveDeviceId();
     kc_entry_t entry = kernelCache(device, refName);
 
     if (entry.prog==0 && entry.ker==0) {
-        std::string options = generateOptionsString<T, isDilation, windLen>();
+        std::string options = generateOptionsString<T, isDilation, SeLength>();
         const char* ker_strs[] = {morph_cl};
         const int   ker_lens[] = {morph_cl_len};
         Program prog;
@@ -77,7 +79,7 @@ void morph(Param out, const Param in, const Param mask)
     }
 
     auto morphOp = KernelFunctor< Buffer, KParam, Buffer, KParam, Buffer, cl::LocalSpaceArg,
-                                  int, int >(*entry.ker);
+                                  int, int, int >(*entry.ker);
 
     NDRange local(THREADS_X, THREADS_Y);
 
@@ -98,27 +100,27 @@ void morph(Param out, const Param in, const Param mask)
 
     morphOp(EnqueueArgs(getQueue(), global, local),
             *out.data, out.info, *in.data, in.info, *mBuff,
-            cl::Local(locSize*sizeof(T)), blk_x, blk_y);
+            cl::Local(locSize*sizeof(T)), blk_x, blk_y, windLen);
 
     bufferFree(mBuff);
 
     CL_DEBUG_FINISH(getQueue());
 }
 
-template<typename T, bool isDilation, int windLen>
+template<typename T, bool isDilation, int SeLength>
 void morph3d(Param       out,
         const Param      in,
         const Param      mask)
 {
     std::string refName = std::string("morph3d_") +
         std::string(dtype_traits<T>::getName()) +
-        std::to_string(isDilation) + std::to_string(windLen);
+        std::to_string(isDilation) + std::to_string(SeLength);
 
     int device = getActiveDeviceId();
     kc_entry_t entry = kernelCache(device, refName);
 
     if (entry.prog==0 && entry.ker==0) {
-        std::string options = generateOptionsString<T, isDilation, windLen>();
+        std::string options = generateOptionsString<T, isDilation, SeLength>();
         const char* ker_strs[] = {morph_cl};
         const int   ker_lens[] = {morph_cl_len};
         Program prog;
@@ -140,12 +142,12 @@ void morph3d(Param       out,
     NDRange global(blk_x * CUBE_X * in.info.dims[3], blk_y * CUBE_Y, blk_z * CUBE_Z);
 
     // copy mask/filter to constant memory
-    cl_int se_size   = sizeof(T)*windLen*windLen*windLen;
+    cl_int se_size   = sizeof(T)*SeLength*SeLength*SeLength;
     cl::Buffer *mBuff = bufferAlloc(se_size);
     getQueue().enqueueCopyBuffer(*mask.data, *mBuff, 0, 0, se_size);
 
     // calculate shared memory size
-    const int padding = (windLen%2==0 ? (windLen-1) : (2*(windLen/2)));
+    const int padding = (SeLength%2==0 ? (SeLength-1) : (2*(SeLength/2)));
     const int locLen  = CUBE_X+padding+1;
     const int locArea = locLen *(CUBE_Y+padding);
     const int locSize = locArea*(CUBE_Z+padding);

--- a/src/backend/opencl/kernel/morph.hpp
+++ b/src/backend/opencl/kernel/morph.hpp
@@ -92,8 +92,7 @@ void morph(Param out, const Param in, const Param mask)
     getQueue().enqueueCopyBuffer(*mask.data, *mBuff, 0, 0, se_size);
 
     // calculate shared memory size
-    const int halo    = windLen/2;
-    const int padding = 2*halo;
+    const int padding = (windLen%2==0 ? (windLen-1) : (2*(windLen/2)));
     const int locLen  = THREADS_X + padding + 1;
     const int locSize = locLen * (THREADS_Y+padding);
 
@@ -146,8 +145,7 @@ void morph3d(Param       out,
     getQueue().enqueueCopyBuffer(*mask.data, *mBuff, 0, 0, se_size);
 
     // calculate shared memory size
-    const int halo    = windLen/2;
-    const int padding = 2*halo;
+    const int padding = (windLen%2==0 ? (windLen-1) : (2*(windLen/2)));
     const int locLen  = CUBE_X+padding+1;
     const int locArea = locLen *(CUBE_Y+padding);
     const int locSize = locArea*(CUBE_Z+padding);

--- a/src/backend/opencl/morph.hpp
+++ b/src/backend/opencl/morph.hpp
@@ -11,11 +11,9 @@
 
 namespace opencl
 {
-
 template<typename T, bool isDilation>
 Array<T> morph(const Array<T> &in, const Array<T> &mask);
 
 template<typename T, bool isDilation>
 Array<T> morph3d(const Array<T> &in, const Array<T> &mask);
-
 }

--- a/src/backend/opencl/morph3d_impl.hpp
+++ b/src/backend/opencl/morph3d_impl.hpp
@@ -39,7 +39,7 @@ Array<T> morph3d(const Array<T> &in, const Array<T> &mask)
         case  5: kernel::morph3d<T, isDilation,  5>(out, in, mask); break;
         case  6: kernel::morph3d<T, isDilation,  6>(out, in, mask); break;
         case  7: kernel::morph3d<T, isDilation,  7>(out, in, mask); break;
-        default: OPENCL_NOT_SUPPORTED(); break;
+        default: assert(mdims[0] < 7 & "Kernel size should be haandled above."); break;
     }
 
     return out;

--- a/src/backend/opencl/morph3d_impl.hpp
+++ b/src/backend/opencl/morph3d_impl.hpp
@@ -25,9 +25,10 @@ Array<T> morph3d(const Array<T> &in, const Array<T> &mask)
     const dim4 mdims    = mask.dims();
 
     if (mdims[0]!=mdims[1] || mdims[0]!=mdims[2])
-        AF_ERROR("Only cube masks are supported in opencl morph currently", AF_ERR_SIZE);
+        OPENCL_NOT_SUPPORTED("Only cubic masks are supported");
+
     if (mdims[0]>7)
-        AF_ERROR("Upto 7x7x7 kernels are only supported in opencl currently", AF_ERR_SIZE);
+        OPENCL_NOT_SUPPORTED("Kernels > 7x7x7 masks are not supported");
 
     const dim4 dims= in.dims();
     Array<T> out   = createEmptyArray<T>(dims);

--- a/src/backend/opencl/morph3d_impl.hpp
+++ b/src/backend/opencl/morph3d_impl.hpp
@@ -18,7 +18,6 @@ using af::dim4;
 
 namespace opencl
 {
-
 template<typename T, bool isDilation>
 Array<T> morph3d(const Array<T> &in, const Array<T> &mask)
 {
@@ -34,16 +33,18 @@ Array<T> morph3d(const Array<T> &in, const Array<T> &mask)
     Array<T> out   = createEmptyArray<T>(dims);
 
     switch(mdims[0]) {
+        case  2: kernel::morph3d<T, isDilation,  2>(out, in, mask); break;
         case  3: kernel::morph3d<T, isDilation,  3>(out, in, mask); break;
+        case  4: kernel::morph3d<T, isDilation,  4>(out, in, mask); break;
         case  5: kernel::morph3d<T, isDilation,  5>(out, in, mask); break;
+        case  6: kernel::morph3d<T, isDilation,  6>(out, in, mask); break;
         case  7: kernel::morph3d<T, isDilation,  7>(out, in, mask); break;
-        default: kernel::morph3d<T, isDilation,  3>(out, in, mask); break;
+        default: OPENCL_NOT_SUPPORTED(); break;
     }
 
     return out;
 }
 
-}
-
 #define INSTANTIATE(T, ISDILATE)                                                 \
     template Array<T> morph3d<T, ISDILATE>(const Array<T> &in, const Array<T> &mask);
+}

--- a/src/backend/opencl/morph_impl.hpp
+++ b/src/backend/opencl/morph_impl.hpp
@@ -18,7 +18,6 @@ using af::dim4;
 
 namespace opencl
 {
-
 template<typename T, bool isDilation>
 Array<T> morph(const Array<T> &in, const Array<T> &mask)
 {
@@ -34,22 +33,30 @@ Array<T> morph(const Array<T> &in, const Array<T> &mask)
     Array<T> out   = createEmptyArray<T>(dims);
 
     switch(mdims[0]) {
+        case  2: kernel::morph<T, isDilation,  2>(out, in, mask); break;
         case  3: kernel::morph<T, isDilation,  3>(out, in, mask); break;
+        case  4: kernel::morph<T, isDilation,  4>(out, in, mask); break;
         case  5: kernel::morph<T, isDilation,  5>(out, in, mask); break;
+        case  6: kernel::morph<T, isDilation,  6>(out, in, mask); break;
         case  7: kernel::morph<T, isDilation,  7>(out, in, mask); break;
+        case  8: kernel::morph<T, isDilation,  8>(out, in, mask); break;
         case  9: kernel::morph<T, isDilation,  9>(out, in, mask); break;
+        case 10: kernel::morph<T, isDilation, 10>(out, in, mask); break;
         case 11: kernel::morph<T, isDilation, 11>(out, in, mask); break;
+        case 12: kernel::morph<T, isDilation, 12>(out, in, mask); break;
         case 13: kernel::morph<T, isDilation, 13>(out, in, mask); break;
+        case 14: kernel::morph<T, isDilation, 14>(out, in, mask); break;
         case 15: kernel::morph<T, isDilation, 15>(out, in, mask); break;
+        case 16: kernel::morph<T, isDilation, 16>(out, in, mask); break;
         case 17: kernel::morph<T, isDilation, 17>(out, in, mask); break;
+        case 18: kernel::morph<T, isDilation, 18>(out, in, mask); break;
         case 19: kernel::morph<T, isDilation, 19>(out, in, mask); break;
-        default: kernel::morph<T, isDilation,  3>(out, in, mask); break;
+        default: OPENCL_NOT_SUPPORTED(); break;
     }
 
     return out;
 }
 
-}
-
 #define INSTANTIATE(T, ISDILATE)                                                 \
     template Array<T> morph  <T, ISDILATE>(const Array<T> &in, const Array<T> &mask);
+}

--- a/src/backend/opencl/morph_impl.hpp
+++ b/src/backend/opencl/morph_impl.hpp
@@ -42,16 +42,7 @@ Array<T> morph(const Array<T> &in, const Array<T> &mask)
         case  8: kernel::morph<T, isDilation,  8>(out, in, mask); break;
         case  9: kernel::morph<T, isDilation,  9>(out, in, mask); break;
         case 10: kernel::morph<T, isDilation, 10>(out, in, mask); break;
-        case 11: kernel::morph<T, isDilation, 11>(out, in, mask); break;
-        case 12: kernel::morph<T, isDilation, 12>(out, in, mask); break;
-        case 13: kernel::morph<T, isDilation, 13>(out, in, mask); break;
-        case 14: kernel::morph<T, isDilation, 14>(out, in, mask); break;
-        case 15: kernel::morph<T, isDilation, 15>(out, in, mask); break;
-        case 16: kernel::morph<T, isDilation, 16>(out, in, mask); break;
-        case 17: kernel::morph<T, isDilation, 17>(out, in, mask); break;
-        case 18: kernel::morph<T, isDilation, 18>(out, in, mask); break;
-        case 19: kernel::morph<T, isDilation, 19>(out, in, mask); break;
-        default: OPENCL_NOT_SUPPORTED(); break;
+        default: kernel::morph<T, isDilation>(out, in, mask, mdims[0]); break;
     }
 
     return out;

--- a/src/backend/opencl/morph_impl.hpp
+++ b/src/backend/opencl/morph_impl.hpp
@@ -25,9 +25,10 @@ Array<T> morph(const Array<T> &in, const Array<T> &mask)
     const dim4 mdims    = mask.dims();
 
     if (mdims[0]!=mdims[1])
-        AF_ERROR("Only square masks are supported in opencl morph currently", AF_ERR_SIZE);
+        OPENCL_NOT_SUPPORTED("Rectangular masks are not suported");
+
     if (mdims[0]>19)
-        AF_ERROR("Upto 19x19 square kernels are only supported in opencl currently", AF_ERR_SIZE);
+        OPENCL_NOT_SUPPORTED("Kernels > 19x19 are not supported");
 
     const dim4 dims = in.dims();
     Array<T> out   = createEmptyArray<T>(dims);

--- a/test/morph.cpp
+++ b/test/morph.cpp
@@ -454,3 +454,21 @@ TEST(Morph, EdgeIssue1564)
         ASSERT_EQ((int)outData[i], goldData[i]);
     }
 }
+
+TEST(Morph, UnsupportedKernel2D)
+{
+    const unsigned ndims = 2;
+    const dim_t dims[2] = {10, 10};
+    const dim_t kdims[2] = {32, 32};
+
+    af_array in, mask, out;
+
+    ASSERT_EQ(AF_SUCCESS, af_constant(&mask, 1.0, ndims, kdims, f32));
+    ASSERT_EQ(AF_SUCCESS, af_randu(&in, ndims, dims, f32));
+
+#if defined(AF_CPU)
+    ASSERT_EQ(AF_SUCCESS, af_dilate(&out, in, mask));
+#else
+    ASSERT_EQ(AF_ERR_NOT_SUPPORTED, af_dilate(&out, in, mask));
+#endif
+}

--- a/test/morph.cpp
+++ b/test/morph.cpp
@@ -96,6 +96,15 @@ TYPED_TEST(Morph, Erode3x3)
     morphTest<TypeParam, false, false>(string(TEST_DIR"/morph/erode3x3.test"));
 }
 
+TYPED_TEST(Morph, Dilate4x4)
+{
+    morphTest<TypeParam, true, false>(string(TEST_DIR"/morph/dilate4x4.test"));
+}
+TYPED_TEST(Morph, Erode4x4)
+{
+    morphTest<TypeParam, false, false>(string(TEST_DIR"/morph/erode4x4.test"));
+}
+
 TYPED_TEST(Morph, Dilate3x3_Batch)
 {
     morphTest<TypeParam, true, false>(string(TEST_DIR"/morph/dilate3x3_batch.test"));
@@ -114,6 +123,15 @@ TYPED_TEST(Morph, Dilate3x3x3)
 TYPED_TEST(Morph, Erode3x3x3)
 {
     morphTest<TypeParam, false, true>(string(TEST_DIR"/morph/erode3x3x3.test"));
+}
+
+TYPED_TEST(Morph, Dilate4x4x4)
+{
+    morphTest<TypeParam, true, true>(string(TEST_DIR"/morph/dilate4x4x4.test"));
+}
+TYPED_TEST(Morph, Erode4x4x4)
+{
+    morphTest<TypeParam, false, true>(string(TEST_DIR"/morph/erode4x4x4.test"));
 }
 
 template<typename T, bool isDilation, bool isColor>

--- a/test/morph.cpp
+++ b/test/morph.cpp
@@ -100,6 +100,12 @@ TYPED_TEST(Morph, Dilate4x4)
 {
     morphTest<TypeParam, true, false>(string(TEST_DIR"/morph/dilate4x4.test"));
 }
+
+TYPED_TEST(Morph, Dilate12x12)
+{
+    morphTest<TypeParam, true, false>(string(TEST_DIR"/morph/dilate12x12.test"));
+}
+
 TYPED_TEST(Morph, Erode4x4)
 {
     morphTest<TypeParam, false, false>(string(TEST_DIR"/morph/erode4x4.test"));
@@ -129,6 +135,7 @@ TYPED_TEST(Morph, Dilate4x4x4)
 {
     morphTest<TypeParam, true, true>(string(TEST_DIR"/morph/dilate4x4x4.test"));
 }
+
 TYPED_TEST(Morph, Erode4x4x4)
 {
     morphTest<TypeParam, false, true>(string(TEST_DIR"/morph/erode4x4x4.test"));


### PR DESCRIPTION
Fixes #1940 

Also, reduces the compilation time by reducing morph template instantiations.