### PR TITLE
Throw error if scalar template type doesn't match array type

### DIFF
--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -980,6 +980,10 @@ af::dtype implicit_dtype(af::dtype scalar_type, af::dtype array_type)
     }                                                               \
     template<> AFAPI T array::scalar() const                        \
     {                                                               \
+        af_dtype type = (af_dtype)af::dtype_traits<T>::af_type;     \
+        if (type != this->type())                                   \
+            AF_THROW_ERR("Requested type doesn't match array type", \
+                         AF_ERR_TYPE);                              \
         T val;                                                      \
         AF_THROW(af_get_scalar(&val, get()));                       \
         return val;                                                 \

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -520,3 +520,10 @@ TYPED_TEST(Array, Scalar)
 
     EXPECT_EQ(true, gold[0]==a.scalar<TypeParam>());
 }
+
+TEST(Array, ScalarTypeMismatch)
+{
+    array a = constant(1.0, dim4(1), f32);
+
+    EXPECT_THROW(a.scalar<int>(), af::exception);
+}


### PR DESCRIPTION
Related to #1949 