### PR TITLE
Fix mean kernel for OpenCL 1.1 devices

### DIFF
--- a/src/backend/opencl/kernel/mean.hpp
+++ b/src/backend/opencl/kernel/mean.hpp
@@ -174,7 +174,8 @@ void mean_dim_launcher(Param out, Param owt,
         if (output_weight) { options << " -D OUTPUT_WEIGHT"; }
 
         if (std::is_same<Ti, double>::value ||
-                std::is_same<Ti, cdouble>::value) {
+                std::is_same<Ti, cdouble>::value ||
+                std::is_same<To, double>::value) {
             options << " -D USE_DOUBLE";
         }
 
@@ -340,7 +341,8 @@ void mean_first_launcher(Param out, Param owt,
         if (output_weight) { options << " -D OUTPUT_WEIGHT"; }
 
         if (std::is_same<Ti, double>::value ||
-                std::is_same<Ti, cdouble>::value) {
+                std::is_same<Ti, cdouble>::value ||
+                std::is_same<To, double>::value) {
             options << " -D USE_DOUBLE";
         }
 


### PR DESCRIPTION
Enable usage of double if output is of type double 
As mentioned in https://github.com/arrayfire/arrayfire/issues/1952, cl_khr_fp32 has to be enabled to use double. This is already done if the input is double, but should be done as well if the output is double (because for int64-input the output is double, so double is used inside the kernel)