### PR TITLE
Disable native_exp for double precision in OpenCL

### DIFF
--- a/src/backend/opencl/kernel/bilateral.cl
+++ b/src/backend/opencl/kernel/bilateral.cl
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if USE_NATIVE_EXP
+#ifdef USE_NATIVE_EXP
 #define EXP native_exp
 #else
 #define EXP exp

--- a/src/backend/opencl/kernel/bilateral.hpp
+++ b/src/backend/opencl/kernel/bilateral.hpp
@@ -47,16 +47,15 @@ void bilateral(Param out, const Param in, float s_sigma, float c_sigma)
     kc_entry_t entry = kernelCache(device, refName);
 
     if (entry.prog==0 && entry.ker==0) {
-        bool use_native_exp = (getActivePlatform() != AFCL_PLATFORM_POCL
-                && getActivePlatform() != AFCL_PLATFORM_APPLE);
         std::ostringstream options;
         options << " -D inType=" << dtype_traits<inType>::getName()
             << " -D outType=" << dtype_traits<outType>::getName();
         if (std::is_same<inType, double>::value ||
                 std::is_same<inType, cdouble>::value) {
             options << " -D USE_DOUBLE";
+        } else {
+            options << " -D USE_NATIVE_EXP";
         }
-        options << " -D USE_NATIVE_EXP=" << (int)use_native_exp;
 
         const char* ker_strs[] = {bilateral_cl};
         const int   ker_lens[] = {bilateral_cl_len};


### PR DESCRIPTION
Change to not using native_exp for type double instead of checking the platform.

native_exp is not officially defined for input type double, this seems cleaner than adding more platforms for disabling it. 
This will work for POCL and will probably work for OSX - will have to see the ci tests.