### PR TITLE
Reset the CMAKE_RUNTIME_OUTPUT_DIRECTORY for examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,6 +6,7 @@ project(ArrayFire-Examples
 
 if(WIN32)
   add_definitions(-DWIN32_LEAN_AND_MEAN)
+  unset(CMAKE_RUNTIME_OUTPUT_DIRECTORY)
 endif()
 
 # Some examples take too long to execute. This list is used to exclude these


### PR DESCRIPTION
The runtime output path sets the location where the binaries will be
moved once built. This is done so that the tests and the libraries
are in the same directory on the windows platform. This path is also
set for the examples but some of the example names are similar to
the tests. This causes problems because the examples may overwrite
the test binaries. This commit sets the runtime directory for the
examples.