### PR TITLE
CLBlast herk/syrk fixes

### DIFF
--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -13,7 +13,7 @@ set(CLBlast_location ${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}clblast${CMAKE_
 ExternalProject_Add(
     CLBlast-ext
     GIT_REPOSITORY https://github.com/cnugteren/CLBlast.git
-    GIT_TAG 1.1.0
+    GIT_TAG 1.2.0
     PREFIX "${prefix}"
     INSTALL_DIR "${prefix}"
     UPDATE_COMMAND ""

--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -13,7 +13,7 @@ set(CLBlast_location ${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}clblast${CMAKE_
 ExternalProject_Add(
     CLBlast-ext
     GIT_REPOSITORY https://github.com/cnugteren/CLBlast.git
-    GIT_TAG 48133a0cd1a7b61b87906ec1f4608e766e20a973
+    GIT_TAG 1.1.0
     PREFIX "${prefix}"
     INSTALL_DIR "${prefix}"
     UPDATE_COMMAND ""

--- a/src/backend/opencl/err_clblast.hpp
+++ b/src/backend/opencl/err_clblast.hpp
@@ -8,6 +8,7 @@
  ********************************************************/
 
 #pragma once
+#include <mutex>
 #include <stdio.h>
 #include <common/err_common.hpp>
 #include <clblast.h>
@@ -68,6 +69,9 @@ static const char * _clblastGetResultString(clblast::StatusCode st)
     case clblast::StatusCode::kInsufficientMemoryY:        return "Vector Y's OpenCL buffer is too small";
 
     // Custom additional status codes for CLBlast
+    case clblast::StatusCode::kInvalidBatchCount:          return "The batch count needs to be positive";
+    case clblast::StatusCode::kInvalidOverrideKernel:      return "Trying to override parameters for an invalid kernel";
+    case clblast::StatusCode::kMissingOverrideParameter:   return "Missing override parameter(s) for the target kernel";
     case clblast::StatusCode::kInvalidLocalMemUsage:       return "Not enough local memory available on this device";
     case clblast::StatusCode::kNoHalfPrecision:            return "Half precision (16-bits) not supported by the device";
     case clblast::StatusCode::kNoDoublePrecision:          return "Double precision (64-bits) not supported by the device";


### PR DESCRIPTION
This is a first attempt to fix the issues in #1963. Although this might not solve everything yet, it does solve a bug: herk is now only called for clfoat/cdouble, otherwise it calls syrk. Also fixes a missing include and some missing error status-codes.