### PR TITLE
Rename WITH_<backend>_LINEAR_ALGEBRA to WITH_LINEAR_ALGEBRA

### DIFF
--- a/src/backend/common/CMakeLists.txt
+++ b/src/backend/common/CMakeLists.txt
@@ -87,6 +87,9 @@ if(LAPACK_FOUND)
   target_include_directories(afcommon_lapack_interface
     INTERFACE ${LAPACK_INCLUDE_DIR})
 
+  target_compile_definitions(afcommon_lapack_interface
+    INTERFACE WITH_LINEAR_ALGEBRA)
+
   target_link_libraries(afcommon_lapack_interface
     INTERFACE
       ${LAPACK_LIBRARIES})

--- a/src/backend/cpu/cholesky.cpp
+++ b/src/backend/cpu/cholesky.cpp
@@ -10,7 +10,7 @@
 #include <cholesky.hpp>
 #include <common/err_common.hpp>
 
-#if defined(WITH_CPU_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 
 #include <af/dim4.hpp>
 #include <handle.hpp>
@@ -93,7 +93,7 @@ INSTANTIATE_CH(cdouble)
 
 }
 
-#else
+#else  // WITH_LINEAR_ALGEBRA
 
 namespace cpu
 {
@@ -122,4 +122,4 @@ INSTANTIATE_CH(cdouble)
 
 }
 
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/cpu/inverse.cpp
+++ b/src/backend/cpu/inverse.cpp
@@ -90,7 +90,7 @@ namespace cpu
 template<typename T>
 Array<T> inverse(const Array<T> &in)
 {
-    AF_ERROR("Linear Algebra is diabled on CPU",
+    AF_ERROR("Linear Algebra is disabled on CPU",
               AF_ERR_NOT_CONFIGURED);
 }
 

--- a/src/backend/cpu/inverse.cpp
+++ b/src/backend/cpu/inverse.cpp
@@ -10,7 +10,7 @@
 #include <inverse.hpp>
 #include <common/err_common.hpp>
 
-#if defined(WITH_CPU_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 
 #include <af/dim4.hpp>
 #include <handle.hpp>
@@ -82,7 +82,7 @@ INSTANTIATE(cdouble)
 
 }
 
-#else
+#else  // WITH_LINEAR_ALGEBRA
 
 namespace cpu
 {
@@ -104,4 +104,4 @@ INSTANTIATE(cdouble)
 
 }
 
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/cpu/lu.cpp
+++ b/src/backend/cpu/lu.cpp
@@ -10,7 +10,7 @@
 #include <lu.hpp>
 #include <common/err_common.hpp>
 
-#if defined(WITH_CPU_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <af/dim4.hpp>
 #include <handle.hpp>
 #include <kernel/lu.hpp>
@@ -97,7 +97,7 @@ bool isLAPACKAvailable()
 
 }
 
-#else
+#else  // WITH_LINEAR_ALGEBRA
 
 namespace cpu
 {
@@ -121,7 +121,7 @@ bool isLAPACKAvailable()
 
 }
 
-#endif
+#endif  // WITH_LINEAR_ALGEBRA
 
 namespace cpu
 {

--- a/src/backend/cpu/qr.cpp
+++ b/src/backend/cpu/qr.cpp
@@ -10,7 +10,7 @@
 #include <qr.hpp>
 #include <common/err_common.hpp>
 
-#if defined(WITH_CPU_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <af/dim4.hpp>
 #include <handle.hpp>
 #include <cassert>
@@ -106,7 +106,7 @@ Array<T> qr_inplace(Array<T> &in)
 
 }
 
-#else
+#else  // WITH_LINEAR_ALGEBRA
 
 namespace cpu
 {
@@ -125,7 +125,7 @@ Array<T> qr_inplace(Array<T> &in)
 
 }
 
-#endif
+#endif  // WITH_LINEAR_ALGEBRA
 
 namespace cpu
 {

--- a/src/backend/cpu/solve.cpp
+++ b/src/backend/cpu/solve.cpp
@@ -172,13 +172,13 @@ template<typename T>
 Array<T> solveLU(const Array<T> &A, const Array<int> &pivot,
                  const Array<T> &b, const af_mat_prop options)
 {
-    AF_ERROR("Linear Algebra is diabled on CPU", AF_ERR_NOT_CONFIGURED);
+    AF_ERROR("Linear Algebra is disabled on CPU", AF_ERR_NOT_CONFIGURED);
 }
 
 template<typename T>
 Array<T> solve(const Array<T> &a, const Array<T> &b, const af_mat_prop options)
 {
-    AF_ERROR("Linear Algebra is diabled on CPU", AF_ERR_NOT_CONFIGURED);
+    AF_ERROR("Linear Algebra is disabled on CPU", AF_ERR_NOT_CONFIGURED);
 }
 
 }

--- a/src/backend/cpu/solve.cpp
+++ b/src/backend/cpu/solve.cpp
@@ -10,7 +10,7 @@
 #include <solve.hpp>
 #include <common/err_common.hpp>
 
-#if defined(WITH_CPU_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <af/dim4.hpp>
 #include <handle.hpp>
 #include <cassert>
@@ -163,7 +163,7 @@ Array<T> solve(const Array<T> &a, const Array<T> &b, const af_mat_prop options)
 
 }
 
-#else
+#else  // WITH_LINEAR_ALGEBRA
 
 namespace cpu
 {
@@ -183,7 +183,7 @@ Array<T> solve(const Array<T> &a, const Array<T> &b, const af_mat_prop options)
 
 }
 
-#endif
+#endif  // WITH_LINEAR_ALGEBRA
 
 namespace cpu
 {

--- a/src/backend/cpu/svd.cpp
+++ b/src/backend/cpu/svd.cpp
@@ -12,7 +12,7 @@
 #include <common/err_common.hpp>
 #include <err_cpu.hpp>
 
-#if defined(WITH_CPU_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <lapack_helper.hpp>
 #include <copy.hpp>
 #include <platform.hpp>
@@ -99,7 +99,7 @@ void svd(Array<Tr> &s, Array<T> &u, Array<T> &vt, const Array<T> &in)
 
 }
 
-#else
+#else  // WITH_LINEAR_ALGEBRA
 
 namespace cpu
 {
@@ -118,7 +118,7 @@ void svdInPlace(Array<Tr> &s, Array<T> &u, Array<T> &vt, Array<T> &in)
 
 }
 
-#endif
+#endif  // WITH_LINEAR_ALGEBRA
 
 namespace cpu
 {

--- a/src/backend/opencl/blas.cpp
+++ b/src/backend/opencl/blas.cpp
@@ -21,7 +21,7 @@
 // Includes one of the supported OpenCL BLAS back-ends (e.g. clBLAS, CLBlast)
 #include <magma/magma_blas.h>
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <cpu/cpu_blas.hpp>
 #endif
 
@@ -54,7 +54,7 @@ template<typename T>
 Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
                 af_mat_prop optLhs, af_mat_prop optRhs)
 {
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
     if(OpenCLCPUOffload(false)) {   // Do not force offload gemm on OSX Intel devices
         return cpu::matmul(lhs, rhs, optLhs, optRhs);
     }

--- a/src/backend/opencl/cholesky.cpp
+++ b/src/backend/opencl/cholesky.cpp
@@ -12,7 +12,7 @@
 #include <blas.hpp>
 #include <copy.hpp>
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <magma/magma.h>
 #include <triangle.hpp>
 #include <platform.hpp>
@@ -69,7 +69,7 @@ INSTANTIATE_CH(cdouble)
 
 }
 
-#else
+#else  // WITH_LINEAR_ALGEBRA
 
 namespace opencl
 {
@@ -98,4 +98,4 @@ INSTANTIATE_CH(cdouble)
 
 }
 
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/cpu/cpu_blas.cpp
+++ b/src/backend/opencl/cpu/cpu_blas.cpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <cpu/cpu_helper.hpp>
 #include <cpu/cpu_blas.hpp>
 #include <math.hpp>
@@ -208,4 +208,4 @@ INSTANTIATE_BLAS(cdouble)
 
 }
 }
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/cpu/cpu_cholesky.cpp
+++ b/src/backend/opencl/cpu/cpu_cholesky.cpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <cpu/cpu_helper.hpp>
 #include <cpu/cpu_cholesky.hpp>
 #include <cpu/cpu_triangle.hpp>
@@ -81,4 +81,4 @@ INSTANTIATE_CH(cdouble)
 
 }
 }
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/cpu/cpu_helper.hpp
+++ b/src/backend/opencl/cpu/cpu_helper.hpp
@@ -18,7 +18,7 @@
 //********************************************************/
 // LAPACK
 //********************************************************/
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 
 #define lapack_complex_float opencl::cfloat
 #define lapack_complex_double opencl::cdouble
@@ -40,6 +40,6 @@
     #endif
 #endif
 
-#endif // WITH_OPENCL_LINEAR_ALGEBRA
+#endif  // WITH_LINEAR_ALGEBRA
 
-#endif
+#endif  // AF_OPENCL_CPU

--- a/src/backend/opencl/cpu/cpu_inverse.cpp
+++ b/src/backend/opencl/cpu/cpu_inverse.cpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <cpu/cpu_helper.hpp>
 #include <cpu/cpu_inverse.hpp>
 #include <cpu/cpu_lu.hpp>
@@ -73,4 +73,4 @@ INSTANTIATE(cdouble)
 
 }
 }
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/cpu/cpu_lu.cpp
+++ b/src/backend/opencl/cpu/cpu_lu.cpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <cpu/cpu_helper.hpp>
 #include <cpu/cpu_lu.hpp>
 #include <math.hpp>
@@ -175,4 +175,4 @@ INSTANTIATE_LU(cdouble)
 
 }
 }
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/cpu/cpu_qr.cpp
+++ b/src/backend/opencl/cpu/cpu_qr.cpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <cpu/cpu_helper.hpp>
 #include <cpu/cpu_qr.hpp>
 #include <cpu/cpu_triangle.hpp>
@@ -115,4 +115,4 @@ INSTANTIATE_QR(cdouble)
 
 }
 }
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/cpu/cpu_solve.cpp
+++ b/src/backend/opencl/cpu/cpu_solve.cpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <cpu/cpu_helper.hpp>
 #include <cpu/cpu_solve.hpp>
 #include <copy.hpp>
@@ -173,4 +173,4 @@ INSTANTIATE_SOLVE(cdouble)
 
 }
 }
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/cpu/cpu_sparse_blas.cpp
+++ b/src/backend/opencl/cpu/cpu_sparse_blas.cpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <cpu/cpu_sparse_blas.hpp>
 
 #include <stdexcept>
@@ -532,4 +532,4 @@ INSTANTIATE_SPARSE(cdouble)
 
 }
 }
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/cpu/cpu_svd.cpp
+++ b/src/backend/opencl/cpu/cpu_svd.cpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <cpu/cpu_helper.hpp>
 #include <cpu/cpu_svd.hpp>
 #include <copy.hpp>
@@ -109,4 +109,4 @@ namespace cpu
     INSTANTIATE_SVD(cdouble, double)
 }
 }
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/cpu/cpu_triangle.hpp
+++ b/src/backend/opencl/cpu/cpu_triangle.hpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #ifndef CPU_LAPACK_TRIANGLE
 #define CPU_LAPACK_TRIANGLE
 
@@ -54,4 +54,4 @@ void triangle(T *o, const T *i, const dim4 odm, const dim4 ost, const dim4 ist)
 }
 
 #endif
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/inverse.cpp
+++ b/src/backend/opencl/inverse.cpp
@@ -11,7 +11,7 @@
 #include <solve.hpp>
 #include <identity.hpp>
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <platform.hpp>
 #include <cpu/cpu_inverse.hpp>
 
@@ -39,7 +39,7 @@ INSTANTIATE(cdouble)
 
 }
 
-#else
+#else  // WITH_LINEAR_ALGEBRA
 
 namespace opencl
 {

--- a/src/backend/opencl/lu.cpp
+++ b/src/backend/opencl/lu.cpp
@@ -10,7 +10,7 @@
 #include <lu.hpp>
 #include <err_opencl.hpp>
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <kernel/lu_split.hpp>
 #include <copy.hpp>
 #include <blas.hpp>
@@ -104,7 +104,7 @@ INSTANTIATE_LU(cdouble)
 
 }
 
-#else
+#else  // WITH_LINEAR_ALGEBRA
 
 namespace opencl
 {
@@ -137,4 +137,4 @@ INSTANTIATE_LU(cdouble)
 
 }
 
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/qr.cpp
+++ b/src/backend/opencl/qr.cpp
@@ -12,7 +12,7 @@
 #include <blas.hpp>
 #include <copy.hpp>
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 
 #include <magma/magma.h>
 #include <magma/magma_helper.h>
@@ -118,7 +118,7 @@ INSTANTIATE_QR(cdouble)
 
 }
 
-#else
+#else  // WITH_LINEAR_ALGEBRA
 
 namespace opencl
 {
@@ -146,4 +146,4 @@ INSTANTIATE_QR(cdouble)
 
 }
 
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/solve.cpp
+++ b/src/backend/opencl/solve.cpp
@@ -339,14 +339,14 @@ template<typename T>
 Array<T> solveLU(const Array<T> &A, const Array<int> &pivot,
                  const Array<T> &b, const af_mat_prop options)
 {
-    AF_ERROR("Linear Algebra is diabled on OpenCL",
+    AF_ERROR("Linear Algebra is disabled on OpenCL",
              AF_ERR_NOT_CONFIGURED);
 }
 
 template<typename T>
 Array<T> solve(const Array<T> &a, const Array<T> &b, const af_mat_prop options)
 {
-    AF_ERROR("Linear Algebra is diabled on OpenCL",
+    AF_ERROR("Linear Algebra is disabled on OpenCL",
               AF_ERR_NOT_CONFIGURED);
 }
 

--- a/src/backend/opencl/solve.cpp
+++ b/src/backend/opencl/solve.cpp
@@ -10,7 +10,7 @@
 #include <err_opencl.hpp>
 #include <solve.hpp>
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <magma/magma.h>
 #include <magma/magma_blas.h>
 #include <magma/magma_data.h>
@@ -330,7 +330,7 @@ INSTANTIATE_SOLVE(double)
 INSTANTIATE_SOLVE(cdouble)
 }
 
-#else
+#else  // WITH_LINEAR_ALGEBRA
 
 namespace opencl
 {
@@ -363,4 +363,4 @@ INSTANTIATE_SOLVE(cdouble)
 
 }
 
-#endif
+#endif  // WITH_LINEAR_ALGEBRA

--- a/src/backend/opencl/sparse_blas.cpp
+++ b/src/backend/opencl/sparse_blas.cpp
@@ -26,9 +26,9 @@
 #include <platform.hpp>
 #include <transpose.hpp>
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 #include <cpu/cpu_sparse_blas.hpp>
-#endif
+#endif  // WITH_LINEAR_ALGEBRA
 
 namespace opencl
 {
@@ -39,7 +39,7 @@ template<typename T>
 Array<T> matmul(const common::SparseArray<T> lhs, const Array<T> rhsIn,
                 af_mat_prop optLhs, af_mat_prop optRhs)
 {
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
     if(OpenCLCPUOffload(false)) {   // Do not force offload gemm on OSX Intel devices
         return cpu::matmul(lhs, rhsIn, optLhs, optRhs);
     }

--- a/src/backend/opencl/svd.cpp
+++ b/src/backend/opencl/svd.cpp
@@ -15,7 +15,7 @@
 #include <blas.hpp>
 #include <transpose.hpp>
 
-#if defined(WITH_OPENCL_LINEAR_ALGEBRA)
+#if defined(WITH_LINEAR_ALGEBRA)
 
 #include <magma/magma.h>
 #include <magma/magma_cpu_lapack.h>
@@ -238,7 +238,7 @@ INSTANTIATE(cdouble, double)
 
 }
 
-#else
+#else  // WITH_LINEAR_ALGEBRA
 
 namespace opencl
 {
@@ -266,4 +266,4 @@ INSTANTIATE(cdouble, double)
 
 }
 
-#endif
+#endif  // WITH_LINEAR_ALGEBRA


### PR DESCRIPTION
This commit renames the WITH_<backend>_LINEAR_ALGEBRA to
WITH_LINEAR_ALGEBRA. This also fixes issue #1974 where
the WITH_CPU_LINEAR_ALGEBRA was missing from the CMake scripts