### PR TITLE
Add missing include

### DIFF
--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -10,6 +10,7 @@
 /// This file contains platform independent utility functions
 
 #include <iosfwd>
+#include <string>
 
 #pragma once
 


### PR DESCRIPTION
Fixes build of unified backend on windows (#1977)

`std:string `is used in `utils.hpp ` but not included. This passes in most cases because` <string>` is included elsewhere, but fails for the unified backend on windows. 