### PR TITLE
Set homebrew glbinding dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(Doxygen)
 
 # Graphics dependencies
 if (APPLE)
-  set(glbinding_DIR /usr/local/opt/glbinding)
+  set(glbinding_DIR dirname $(brew list glbinding | grep config))
 endif ()
 find_package(glbinding QUIET)
 find_package(Boost)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ find_package(LAPACKE)
 find_package(Doxygen)
 
 # Graphics dependencies
+if (APPLE)
+  set(glbinding_DIR /usr/local/opt/glbinding)
+endif ()
 find_package(glbinding QUIET)
 find_package(Boost)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(Doxygen)
 
 # Graphics dependencies
 if (APPLE)
-  set(glbinding_DIR dirname $(brew list glbinding | grep config))
+  set(glbinding_DIR /usr/local/opt/glbinding)
 endif ()
 find_package(glbinding QUIET)
 find_package(Boost)


### PR DESCRIPTION
If `glbinding` gets installed with homebrew we need to tell cmake where the config file is. I was not able to get it to work with 
```
execute_process(COMMAND brew list glbinding
                             COMMAND grep config 
                             COMMAND xargs dirname
                             RESULT_VARIABLE glbinding_DIR
)
```
which is why we have a hardcoded path here. However, if the lib is installed via homebrew on OSX 10.12 this is where the config file lives (as tested on 2 mac machines). I don't like the hardcoded path, and if someone has better ideas by all means!