### PR TITLE
BUGFIX: correct assets path in examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,4 +265,6 @@ if(BUILD_TEST)
 endif()
 
 conditional_directory(BUILD_TESTING test)
+
+set(ASSETS_DIR "${ArrayFire_SOURCE_DIR}/assets")
 conditional_directory(BUILD_EXAMPLES examples)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,6 +4,18 @@ project(ArrayFire-Examples
   VERSION 3.5.0
   LANGUAGES CXX)
 
+if (NOT ASSETS_DIR)
+    set(ASSETS_DIR ""
+        CACHE PATH
+        "
+        Assets are the images and data files required by the examples. ASSETS_DIR
+        should point to the path where theses files are available on the build machine.
+
+        You can download or clone the assets git repository from the following
+        url: https://github.com/arrayfire/assets
+        ")
+endif (NOT ASSETS_DIR)
+
 if(WIN32)
   add_definitions(-DWIN32_LEAN_AND_MEAN)
   unset(CMAKE_RUNTIME_OUTPUT_DIRECTORY)

--- a/examples/computer_vision/CMakeLists.txt
+++ b/examples/computer_vision/CMakeLists.txt
@@ -6,8 +6,7 @@ project(ArrayFire-Example-Computer-Vision
 
 find_package(ArrayFire)
 
-set(ASSETS_DIR "${ArrayFire_SOURCE_DIR}/assets")
-add_definitions(-DASSETS_DIR=\"${ASSETS_DIR}\")
+add_definitions("-DASSETS_DIR=\"${ASSETS_DIR}\"")
 
 if (ArrayFire_CPU_FOUND)
   # FAST examples

--- a/examples/graphics/CMakeLists.txt
+++ b/examples/graphics/CMakeLists.txt
@@ -6,6 +6,8 @@ project(ArrayFire-Example-Graphics
 
 find_package(ArrayFire)
 
+add_definitions("-DASSETS_DIR=\"${ASSETS_DIR}\"")
+
 if(ArrayFire_CPU_FOUND)
   # Conway Game of Life
   add_executable(conway_cpu conway.cpp)


### PR DESCRIPTION
Fixes #2013 

ASSETS_DIR was not set to a proper path earlier in image_processing
and machine_learning examples due to which the examples which use
images failed during image loads.