### PR TITLE
Prefix path for MKL and homebrew. Add platform specific CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ include(CMakeDependentOption)
 include(InternalUtils)
 include(Version)
 include(build_cl2hpp)
+include(platform)
 
 arrayfire_set_cmake_default_variables()
 
@@ -65,16 +66,6 @@ mark_as_advanced(
 # TODO(umar): Add definitions should not be used. Instead use
 arrayfire_get_platform_definitions(platform_definitions)
 add_definitions(${platform_definitions})
-
-if(WIN32)
-  #TODO(umar): create a single place for compiler specific settings
-  # C4251: Warnings about dll interfaces. Thrown by glbinding, may be fixed in
-  #        the future
-  # C4068: Warnings about unknown pragmas
-  # C4275: Warnings about using non-exported classes as base class of an
-  #        exported class
-  add_compile_options(/wd4251 /wd4068 /wd4275)
-endif()
 
 if(BUILD_GRAPHICS)
   include(build_forge)

--- a/CMakeModules/platform.cmake
+++ b/CMakeModules/platform.cmake
@@ -1,0 +1,38 @@
+# Copyright (c) 2017, ArrayFire
+# All rights reserved.
+#
+# This file is distributed under 3-clause BSD license.
+# The complete license agreement can be obtained at:
+# http://arrayfire.com/licenses/BSD-3-Clause
+
+# Platform specific settings
+#
+# Add paths and flags specific platforms. This can inc
+
+if(APPLE)
+  # Some homebrew libraries(glbinding) are not installed in directories that
+  # CMake searches by default.
+  set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};/usr/local/opt")
+
+  # Default path for Intel MKL libraries
+  set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};/opt/intel/mkl/lib")
+endif()
+
+if(UNIX AND NOT APPLE)
+  # Default path for Intel MKL libraries
+  set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};/opt/intel/mkl/lib/intel64")
+endif()
+
+if(WIN32)
+  # C4251: Warnings about dll interfaces. Thrown by glbinding, may be fixed in
+  #        the future
+  # C4068: Warnings about unknown pragmas
+  # C4275: Warnings about using non-exported classes as base class of an
+  #        exported class
+  add_compile_options(/wd4251 /wd4068 /wd4275)
+
+  # Default path for Intel MKL libraries
+  set(CMAKE_PREFIX_PATH "${CMAKE_PREFIX_PATH};"
+    "C:/Program Files (x86)/IntelSWTools/compilers_and_libraries/windows/mkl;"
+    "C:/Program Files (x86)/IntelSWTools/compilers_and_libraries/windows/mkl/lib/intel64")
+endif()


### PR DESCRIPTION
Set prefix path for known libraries that cannot be found by CMake's default
behavior. This addresses issues with MKL and glbinding downloaded via homebrew.

This commit also moves platform specific variables to a single file.