### PR TITLE
BUGFIX: Fix OpenCL tests on Windows for CUDA9

### DIFF
--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -373,8 +373,8 @@ target_include_directories(afopencl
   )
 
 add_dependencies(afopencl ${cl_kernel_targets})
-add_dependencies(opencl_scan_by_key ${cl_kernel_targets} cl2hpp)
-add_dependencies(opencl_sort_by_key ${cl_kernel_targets} cl2hpp)
+add_dependencies(opencl_scan_by_key ${cl_kernel_targets} cl2hpp Boost::boost)
+add_dependencies(opencl_sort_by_key ${cl_kernel_targets} cl2hpp Boost::boost)
 
 set_target_properties(afopencl PROPERTIES POSITION_INDEPENDENT_CODE ON)
 

--- a/src/backend/opencl/kernel/scan_by_key/CMakeLists.txt
+++ b/src/backend/opencl/kernel/scan_by_key/CMakeLists.txt
@@ -25,7 +25,7 @@ foreach(SBK_BINARY_OP ${SBK_BINARY_OPS})
         "${CMAKE_CURRENT_SOURCE_DIR}/kernel/scan_dim_by_key_impl.hpp")
 
     add_dependencies(opencl_scan_by_key_${SBK_BINARY_OP}
-                        ${cl_kernel_targets} OpenCL::cl2hpp)
+                        ${cl_kernel_targets} OpenCL::cl2hpp Boost::boost)
 
     target_include_directories(opencl_scan_by_key_${SBK_BINARY_OP}
       PRIVATE
@@ -38,6 +38,7 @@ foreach(SBK_BINARY_OP ${SBK_BINARY_OPS})
         ${CMAKE_CURRENT_BINARY_DIR}
         $<TARGET_PROPERTY:OpenCL::OpenCL,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:OpenCL::cl2hpp,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:Boost::boost,INTERFACE_INCLUDE_DIRECTORIES>
       )
 
     set_target_properties(opencl_scan_by_key_${SBK_BINARY_OP}

--- a/src/backend/opencl/platform.hpp
+++ b/src/backend/opencl/platform.hpp
@@ -30,6 +30,14 @@
 #include <memory.hpp>
 #include <GraphicsResourceManager.hpp>
 
+namespace boost {
+  template<typename T> class shared_ptr;
+
+  namespace compute {
+    class program_cache;
+  }
+}
+
 // Forward declaration from clFFT.h
 struct clfftSetupData_;
 typedef clfftSetupData_ clfftSetupData;
@@ -198,5 +206,8 @@ class DeviceManager
         std::unique_ptr<GraphicsResourceManager> gfxManagers[MAX_DEVICES];
 #endif
         std::unique_ptr<clfftSetupData> mFFTSetup;
+
+        using BoostProgCache = boost::shared_ptr<boost::compute::program_cache>;
+        std::vector<BoostProgCache*> mBoostProgCacheVector;
 };
 }


### PR DESCRIPTION
The issue fixed in this commit started happening on Windows platform with CUDA9.

Both boost::compute::program_cache and ArrayFire contexts are static variables. The boost cache was being cleaned up after ArrayFire released the corresponding OpenCL contexts.

This fix keeps a pointer to the shared_ptr to boost::compute::program_cache and leaks it on Windows platform to circumvent the problem.