### PR TITLE
BUGFIX: Enable thread-safe flags for Boost::compute upstream

### DIFF
--- a/CMakeModules/boost_package.cmake
+++ b/CMakeModules/boost_package.cmake
@@ -37,5 +37,5 @@ endif()
 
 # NOTE: BOOST_CHRONO_HEADER_ONLY is required for Windows because otherwise it
 # will try to link with libboost-chrono.
-set_target_properties(Boost::boost PROPERTIES
-  INTERFACE_COMPILE_DEFINITIONS BOOST_CHRONO_HEADER_ONLY)
+set_target_properties(Boost::boost PROPERTIES INTERFACE_COMPILE_DEFINITIONS
+  "BOOST_CHRONO_HEADER_ONLY;BOOST_COMPUTE_THREAD_SAFE;BOOST_COMPUTE_HAVE_THREAD_LOCAL")

--- a/test/threading.cpp
+++ b/test/threading.cpp
@@ -654,7 +654,7 @@ TEST(Threading, DISABLED_MemoryManagerStressTest)
   }
 }
 
-TEST(Threading, BoostCompute)
+TEST(Threading, DISABLED_Sort)
 {
     cleanSlate(); // Clean up everything done so far
 
@@ -664,11 +664,9 @@ TEST(Threading, BoostCompute)
 
     for (int i=0; i<THREAD_COUNT; ++i) {
         tests.emplace_back([] {
-            for (int k=0; k<100; ++k) {
-                array a = randu(100, 100);
+            array a = randu(100, 100);
+            for (int k=0; k<100; ++k)
                 array b = sort(a);
-                array c = sort(a, 1, false);
-            }
         });
     }
 

--- a/test/threading.cpp
+++ b/test/threading.cpp
@@ -560,7 +560,7 @@ void cppMatMulCheck(int targetDevice, string TestFile)
     }
 }
 
-#define TEST_FOR_TYPE(TypeName)                                         \
+#define TEST_BLAS_FOR_TYPE(TypeName)                                         \
     tests.emplace_back(cppMatMulCheck<TypeName, false>,                             \
             nextTargetDeviceId()%numDevices, TEST_DIR "/blas/Basic.test");          \
     tests.emplace_back(cppMatMulCheck<TypeName, false>,                             \
@@ -579,12 +579,12 @@ TEST(Threading, BLAS)
     int numDevices = 1;
     ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
 
-    TEST_FOR_TYPE(      float);
-    TEST_FOR_TYPE( af::cfloat);
+    TEST_BLAS_FOR_TYPE(      float);
+    TEST_BLAS_FOR_TYPE( af::cfloat);
 
     if (noDoubleTests<double>()) {
-        TEST_FOR_TYPE(     double);
-        TEST_FOR_TYPE(af::cdouble);
+        TEST_BLAS_FOR_TYPE(     double);
+        TEST_BLAS_FOR_TYPE(af::cdouble);
     }
 
     for (size_t testId=0; testId<tests.size(); ++testId)
@@ -652,4 +652,26 @@ TEST(Threading, DISABLED_MemoryManagerStressTest)
   for (auto& t : threads) {
     t.join();
   }
+}
+
+TEST(Threading, BoostCompute)
+{
+    cleanSlate(); // Clean up everything done so far
+
+    vector<std::thread> tests;
+
+    ASSERT_EQ(AF_SUCCESS, af_set_device(0));
+
+    for (int i=0; i<THREAD_COUNT; ++i) {
+        tests.emplace_back([] {
+            for (int k=0; k<100; ++k) {
+                array a = randu(100, 100);
+                array b = sort(a);
+                array c = sort(a, 1, false);
+            }
+        });
+    }
+
+    for (auto& t: tests)
+        if (t.joinable()) t.join();
 }


### PR DESCRIPTION
Fixes #2016 