### PR TITLE
BUGFIX: make af_lookup behavior consistent across backends

### DIFF
--- a/src/backend/cuda/kernel/lookup.hpp
+++ b/src/backend/cuda/kernel/lookup.hpp
@@ -16,15 +16,11 @@
 
 namespace cuda
 {
-
 namespace kernel
 {
-
-static const int THREADS = 256;
-
+static const int THREADS   = 256;
 static const int THREADS_X = 32;
 static const int THREADS_Y = 8;
-
 static const int THRD_LOAD = THREADS_X/THREADS_Y;
 
 template<typename in_t, typename idx_t>
@@ -79,16 +75,17 @@ void lookupND(Param<in_t> out, CParam<in_t> in, CParam<idx_t> indices,
 template<typename in_t, typename idx_t, unsigned dim>
 void lookup(Param<in_t> out, CParam<in_t> in, CParam<idx_t> indices, int nDims)
 {
-    if (nDims==1) {
+    /* find which dimension has non-zero # of elements */
+    int vDim = 0;
+    for (int i=0; i<4; i++) {
+        if (in.dims[i]==1)
+            vDim++;
+        else
+            break;
+    }
+
+    if (dim==0 && nDims==1 && dim==vDim) {
         const dim3 threads(THREADS, 1);
-        /* find which dimension has non-zero # of elements */
-        int vDim = 0;
-        for (int i=0; i<4; i++) {
-            if (in.dims[i]==1)
-                vDim++;
-            else
-                break;
-        }
 
         int blks = divup(out.dims[vDim], THREADS*THRD_LOAD);
 
@@ -112,7 +109,5 @@ void lookup(Param<in_t> out, CParam<in_t> in, CParam<idx_t> indices, int nDims)
 
     POST_LAUNCH_CHECK();
 }
-
 }
-
 }

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -709,6 +709,15 @@ TEST(lookup, largeDim)
     af::array output = af::lookup(input, indices);
 }
 
+TEST(lookup, Issue2009)
+{
+    af::array a   = af::range(af::dim4(1000, 1));
+    af::array idx = af::constant(0, 1, u32);
+    af::array b   = af::lookup(a, idx, 1);
+
+    ASSERT_EQ(true, af::allTrue<bool>(a==b));
+}
+
 TEST(SeqIndex, CPP_END)
 {
     using af::array;


### PR DESCRIPTION
Fixes #2009

CUDA backend results of af_lookup were different from CPU/OpenCL
for Vector input arrays when the indexing dimension is not along
the same dimension as the input array data.