### PR TITLE
Update configuring_arrayfire_environment.md: Fixed wrong description of default behavior when AF_MEM_DEBUG is not set.

### DIFF
--- a/docs/pages/configuring_arrayfire_environment.md
+++ b/docs/pages/configuring_arrayfire_environment.md
@@ -148,7 +148,7 @@ AF_MEM_DEBUG {#af_mem_debug}
 When AF_MEM_DEBUG is set to 1 (or anything not equal to 0), the caching mechanism in the memory manager is disabled.
 The device buffers are allocated using native functions as needed and freed when going out of scope.
 
-When the environment variable is not set, it is treated to be non zero.
+When the environment variable is not set, it is treated to be zero.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 AF_MEM_DEBUG=1 ./myprogram


### PR DESCRIPTION
Fixed wrong description of default behavior when AF_MEM_DEBUG is not set.