### PR TITLE
Disable CUDA JIT debug flags on ARM archs

### DIFF
--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -282,7 +282,7 @@ std::vector<char> compileToPTX(const char *ker_name, string jit_ker)
              dev.major, dev.minor);
     const char* compiler_options[] = {
       arch.data(),
-#ifndef NDEBUG
+#if !(defined(NDEBUG) || defined(__aarch64__) || defined(__LP64__))
       "--device-debug",
       "--generate-line-info"
 #endif


### PR DESCRIPTION
Fixes #2028 
Fixes #2036 

The following test is still failing on tegra.

`./test/canny_cuda --gtest_filter=CannyEdgeDetector.OtsuThreshold`
  
  