### PR TITLE
Change the order of the enum values to change order for 0 and 1

### DIFF
--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -476,9 +476,9 @@ typedef enum {
 } af_diffusion_eq;
 
 typedef enum {
-    AF_TOPK_MAX     = 1,  ///< Top k max values
-    AF_TOPK_MIN     = 2,  ///< Top k min values
-    AF_TOPK_DEFAULT = 0   ///< Default option
+    AF_TOPK_MIN     = 1,  ///< Top k min values
+    AF_TOPK_MAX     = 2,  ///< Top k max values
+    AF_TOPK_DEFAULT = 0   ///< Default option (max)
 } af_topk_function;
 #endif
 


### PR DESCRIPTION
Change the order so that the topk function values change when passing in the
default value of 0 to 1. Previously the behavior was the same for 0 and 1
which could cause confusion.