### PR TITLE
Add cmaps missing in arrayfire but in Forge

### DIFF
--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -424,12 +424,16 @@ typedef enum {
 ////////////////////////////////////////////////////////////////////////////////
 typedef enum {
     AF_COLORMAP_DEFAULT = 0,    ///< Default grayscale map
-    AF_COLORMAP_SPECTRUM= 1,    ///< Spectrum map
-    AF_COLORMAP_COLORS  = 2,    ///< Colors
+    AF_COLORMAP_SPECTRUM= 1,    ///< Spectrum map (390nm-830nm, in sRGB colorspace)
+    AF_COLORMAP_COLORS  = 2,    ///< Colors, aka. Rainbow
     AF_COLORMAP_RED     = 3,    ///< Red hue map
     AF_COLORMAP_MOOD    = 4,    ///< Mood map
     AF_COLORMAP_HEAT    = 5,    ///< Heat map
-    AF_COLORMAP_BLUE    = 6     ///< Blue hue map
+    AF_COLORMAP_BLUE    = 6,    ///< Blue hue map
+    AF_COLORMAP_INFERNO = 7,    ///< Perceptually uniform shades of black-red-yellow 
+    AF_COLORMAP_MAGMA   = 8,    ///< Perceptually uniform shades of black-red-white 
+    AF_COLORMAP_PLASMA  = 9,    ///< Perceptually uniform shades of blue-red-yellow 
+    AF_COLORMAP_VIRIDIS = 10    ///< Perceptually uniform shades of blue-green-yellow 
 } af_colormap;
 
 #if AF_API_VERSION >= 32

--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -430,10 +430,10 @@ typedef enum {
     AF_COLORMAP_MOOD    = 4,    ///< Mood map
     AF_COLORMAP_HEAT    = 5,    ///< Heat map
     AF_COLORMAP_BLUE    = 6,    ///< Blue hue map
-    AF_COLORMAP_INFERNO = 7,    ///< Perceptually uniform shades of black-red-yellow 
-    AF_COLORMAP_MAGMA   = 8,    ///< Perceptually uniform shades of black-red-white 
-    AF_COLORMAP_PLASMA  = 9,    ///< Perceptually uniform shades of blue-red-yellow 
-    AF_COLORMAP_VIRIDIS = 10    ///< Perceptually uniform shades of blue-green-yellow 
+    AF_COLORMAP_INFERNO = 7,    ///< Perceptually uniform shades of black-red-yellow
+    AF_COLORMAP_MAGMA   = 8,    ///< Perceptually uniform shades of black-red-white
+    AF_COLORMAP_PLASMA  = 9,    ///< Perceptually uniform shades of blue-red-yellow
+    AF_COLORMAP_VIRIDIS = 10    ///< Perceptually uniform shades of blue-green-yellow
 } af_colormap;
 
 #if AF_API_VERSION >= 32


### PR DESCRIPTION
Sync the `af_colormap` enum with the similar one in Forge.

I have to admit that this PR was written through the GH web interface because I never used arrayfire (yet ;)?), so please correct me if I am wrong! This change looks like a (very) low-hanging fruit, as it is simply a matter of adding a few missing entries compared to the [`fg_color_map` enum in the Forge `define.h`](http://arrayfire.org/forge/defines_8h.htm), is it not? By doing so, arrayfire users would gain access to the *perceptually uniform* colormaps that were originally designed for Matplotlib a while ago, and have started to spread among other projects. In my opinion, this would be a neat small additional feature for arrayfire, but I may be biased here ;) (regular Matplotlib user here...).

Being there, I also added (as comments) a couple information that were in the Forge header file, but not the arrayfire one.

PS: I opened this PR against the master branch because I did not find any `devel` branch as mentioned in the [contributing guidelines](https://github.com/arrayfire/arrayfire/wiki/Contribute-code-using-github)