### PR TITLE
Remove cmake_policy line from examples

### DIFF
--- a/examples/benchmarks/CMakeLists.txt
+++ b/examples/benchmarks/CMakeLists.txt
@@ -6,7 +6,6 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.5)
 project(ArrayFire-Example-Benchmarks
   VERSION 3.5.0
   LANGUAGES CXX)

--- a/examples/computer_vision/CMakeLists.txt
+++ b/examples/computer_vision/CMakeLists.txt
@@ -6,7 +6,6 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.5)
 project(ArrayFire-Example-Computer-Vision
   VERSION 3.5.0
   LANGUAGES CXX)

--- a/examples/financial/CMakeLists.txt
+++ b/examples/financial/CMakeLists.txt
@@ -6,7 +6,6 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.5)
 project(ArrayFire-Example-Financial
   VERSION 3.5.0
   LANGUAGES CXX)

--- a/examples/getting_started/CMakeLists.txt
+++ b/examples/getting_started/CMakeLists.txt
@@ -6,7 +6,6 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.5)
 project(ArrayFire-Example-Getting-Started
   VERSION 3.5.0
   LANGUAGES CXX)

--- a/examples/graphics/CMakeLists.txt
+++ b/examples/graphics/CMakeLists.txt
@@ -6,7 +6,6 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.5)
 project(ArrayFire-Example-Graphics
   VERSION 3.5.0
   LANGUAGES CXX)

--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -6,7 +6,6 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.5)
 project(ArrayFire-Example-HelloWorld
   VERSION 3.5.0
   LANGUAGES CXX)

--- a/examples/image_processing/CMakeLists.txt
+++ b/examples/image_processing/CMakeLists.txt
@@ -6,7 +6,6 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.5)
 project(ArrayFire-Example-Image-Processing
   VERSION 3.5.0
   LANGUAGES CXX)

--- a/examples/lin_algebra/CMakeLists.txt
+++ b/examples/lin_algebra/CMakeLists.txt
@@ -6,7 +6,6 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.5)
 project(ArrayFire-Example-Linear-Algebra
   VERSION 3.5.0
   LANGUAGES CXX)

--- a/examples/machine_learning/CMakeLists.txt
+++ b/examples/machine_learning/CMakeLists.txt
@@ -6,7 +6,6 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.5)
 project(ArrayFire-Example-Linear-Algebra
   VERSION 3.5.0
   LANGUAGES CXX)

--- a/examples/pde/CMakeLists.txt
+++ b/examples/pde/CMakeLists.txt
@@ -6,7 +6,6 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.5)
 project(ArrayFire-Example-PDE
   VERSION 3.5.0
   LANGUAGES CXX)

--- a/examples/unified/CMakeLists.txt
+++ b/examples/unified/CMakeLists.txt
@@ -6,7 +6,6 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.0)
-cmake_policy(VERSION 3.5)
 project(ArrayFire-Example-Unified
   VERSION 3.5.0
   LANGUAGES CXX)


### PR DESCRIPTION
The cmake_policy line was targeting a policy that was greater than
the minimum required version for the CMake file.