### PR TITLE
Fix output dimensions in mean cuda kernel

### DIFF
--- a/src/backend/cuda/kernel/mean.hpp
+++ b/src/backend/cuda/kernel/mean.hpp
@@ -210,6 +210,7 @@ namespace kernel
 
         if (blocks_dim[dim] > 1) {
           dim4 dims(4, out.dims);
+          dims[dim] = blocks_dim[dim];
           tmpOut = createEmptyArray<To>(dims);
           tmpWt  = createEmptyArray<Tw>(dims);
         }

--- a/test/mean.cpp
+++ b/test/mean.cpp
@@ -321,3 +321,26 @@ TEST(WeightedMean, Broadacst)
         ASSERT_NEAR(hc[i], hd[i], 1E-5);
     }
 }
+
+TEST(Mean, Issue2093)
+{
+  using namespace af;
+
+  const int NELEMS = 512;
+
+  array data = randu(1, NELEMS);
+  array wts  = constant(1.0f, 1, NELEMS);
+  vector<float> hdata(NELEMS);
+  data.host(hdata.data());
+
+  array out = mean(data, wts, 1);
+  float outVal;
+  out.host(&outVal);
+
+  float expected = 0.0;
+  for (size_t i=0; i<NELEMS; ++i)
+      expected += hdata[i];
+  expected /= NELEMS;
+
+  ASSERT_NEAR(outVal, expected, 0.001);
+}


### PR DESCRIPTION
Fixes #2093 

This fix needs to go into v3.6 as this is broken in master alone during refactor and not on v3.5 branch.