### PR TITLE
Reorganize GUI installer components hierarchy

### DIFF
--- a/CMakeModules/CPackConfig.cmake
+++ b/CMakeModules/CPackConfig.cmake
@@ -130,29 +130,56 @@ cpack_add_install_type(Development DISPLAY_NAME "Development")
 cpack_add_install_type(Extra DISPLAY_NAME "Extra")
 cpack_add_install_type(Runtime DISPLAY_NAME "Runtime")
 
+cpack_add_component_group(backends
+  DISPLAY_NAME "ArrayFire"
+  DESCRIPTION "ArrayFire Backend Libraries"
+  EXPANDED)
+cpack_add_component_group(cpu_backend
+  DISPLAY_NAME "CPU Backend"
+  DESCRIPTION "Libraries and dependencies of CPU Backend"
+  PARENT_GROUP backends)
+cpack_add_component_group(cuda_backend
+  DISPLAY_NAME "CUDA Backend"
+  DESCRIPTION "Libraries and dependencies of CUDA Backend"
+  PARENT_GROUP backends)
+cpack_add_component_group(opencl_backend
+  DISPLAY_NAME "OpenCL Backend"
+  DESCRIPTION "Libraries and dependencies of OpenCL Backend"
+  PARENT_GROUP backends)
+
 set(PACKAGE_MKL_DEPS OFF)
 
 if ((USE_CPU_MKL OR USE_OPENCL_MKL) AND TARGET MKL::MKL)
   set(PACKAGE_MKL_DEPS ON)
-  cpack_add_component(mkl_dependencies HIDDEN
+  cpack_add_component(mkl_dependencies
+    DISPLAY_NAME "Intel MKL"
+	DESCRIPTION "Intel Math Kernel Libraries for FFTW, BLAS and LAPACK routines"
+	GROUP backends
     INSTALL_TYPES Development Runtime)
 endif ()
 
 cpack_add_component(common_backend_dependencies
-  HIDDEN
+  DISPLAY_NAME "Dependencies"
+  DESCRIPTION "Libraries that are commonly required by all ArrayFire backends"
+  GROUP backends
   INSTALL_TYPES Development Runtime)
 
-cpack_add_component(opencl_dependencies HIDDEN
+cpack_add_component(opencl_dependencies
+  DISPLAY_NAME "OpenCL Dependencies"
+  DESCRIPTION "Libraries required by OpenCL Backend"
+  GROUP opencl_backend
   INSTALL_TYPES Development Runtime)
   
 cpack_add_component(cuda_dependencies
   DISPLAY_NAME "CUDA Dependencies"
   DESCRIPTION "CUDA Runtime and libraries required for the CUDA backend."
+  GROUP cuda_backend
   INSTALL_TYPES Development Runtime)
 
 cpack_add_component(cuda
   DISPLAY_NAME "CUDA Backend"
   DESCRIPTION "This Backend allows you to take advantage of the CUDA enabled GPUs to run ArrayFire code. Please make sure you have CUDA toolkit installed or install CUDA dependencies component."
+  GROUP cuda_backend
   DEPENDS common_backend_dependencies cuda_dependencies
   INSTALL_TYPES Development Runtime)
 
@@ -171,22 +198,26 @@ endif ()
 cpack_add_component(cpu
   DISPLAY_NAME "CPU Backend"
   DESCRIPTION "This Backend allows you to run ArrayFire code on native CPUs."
+  GROUP cpu_backend
   DEPENDS ${cpu_deps_comps}
   INSTALL_TYPES Development Runtime)
 
 cpack_add_component(opencl
   DISPLAY_NAME "OpenCL Backend"
   DESCRIPTION "This Backend allows you to take advantage of OpenCL capable GPUs to run ArrayFire code. Currently ArrayFire does not support OpenCL for the Intel CPU on OSX."
+  GROUP opencl_backend
   DEPENDS ${ocl_deps_comps}
   INSTALL_TYPES Development Runtime)
 
 cpack_add_component(unified
   DISPLAY_NAME "Unified Backend"
   DESCRIPTION "This Backend allows you to choose the platform(cpu, cuda, opencl) at runtime. This option requires at least one of the three backends to be installed to work properly."
+  GROUP backends
   INSTALL_TYPES Development Runtime)
 cpack_add_component(headers
   DISPLAY_NAME "C/C++ Headers"
   DESCRIPTION "Headers for the ArrayFire Libraries."
+  GROUP backends
   INSTALL_TYPES Development)
 cpack_add_component(cmake
   DISPLAY_NAME "CMake Support"
@@ -239,6 +270,10 @@ get_native_path(sift_lic_path "${CMAKE_SOURCE_DIR}/LICENSES/OpenSIFT License.txt
 get_native_path(bsd3_lic_path "${CMAKE_SOURCE_DIR}/LICENSES/BSD 3-Clause.txt")
 get_native_path(issl_lic_path "${CMAKE_SOURCE_DIR}/LICENSES/ISSL License.txt")
 
+cpack_ifw_configure_component_group(backends)
+cpack_ifw_configure_component_group(cpu_backend)
+cpack_ifw_configure_component_group(cuda_backend)
+cpack_ifw_configure_component_group(opencl_backend)
 if (PACKAGE_MKL_DEPS)
   cpack_ifw_configure_component(mkl_dependencies)
 endif ()


### PR DESCRIPTION
After this change, the GUI components will have the following hierarchy.

- ArrayFire
     * CPU
           - CPU Backend
     * CUDA
           - CUDA Backend
           - CUDA Dependencies
     * OpenCL
           - OpenCL Backend
           - OpenCL Dependencies
     * Intel MKL
     * C/C++ Headers
     * Unified Backend
     * Dependencies
- CMake Support
- Licenses
- ArrayFire Examples

Deselecting a dependency will automatically uncheck the component that requires the deselected dependency.