### PR TITLE
Do not build forge if USE_SYSTEM_FORGE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(MKL)
 
 # Graphics dependencies
 find_package(glbinding QUIET)
+find_package(Forge QUIET)
 include(boost_package)
 
 option(AF_BUILD_CPU      "Build ArrayFire with a CPU backend"        ON)
@@ -87,7 +88,7 @@ mark_as_advanced(
 arrayfire_get_platform_definitions(platform_definitions)
 add_definitions(${platform_definitions})
 
-if(AF_WITH_GRAPHICS)
+if(AF_WITH_GRAPHICS AND NOT AF_USE_SYSTEM_FORGE)
   include(build_forge)
 endif()
 

--- a/src/api/c/CMakeLists.txt
+++ b/src/api/c/CMakeLists.txt
@@ -167,7 +167,9 @@ if(FreeImage_FOUND AND AF_WITH_IMAGEIO)
 endif()
 
 if(AF_WITH_GRAPHICS)
-    add_dependencies(c_api_interface forge-ext)
+    if(NOT AF_USE_SYSTEM_FORGE)
+      add_dependencies(afcommon_interface forge-ext)
+    endif()
     target_compile_definitions(c_api_interface INTERFACE WITH_GRAPHICS)
 endif()
 

--- a/src/api/c/CMakeLists.txt
+++ b/src/api/c/CMakeLists.txt
@@ -168,7 +168,7 @@ endif()
 
 if(AF_WITH_GRAPHICS)
     if(NOT AF_USE_SYSTEM_FORGE)
-      add_dependencies(afcommon_interface forge-ext)
+      add_dependencies(c_api_interface forge-ext)
     endif()
     target_compile_definitions(c_api_interface INTERFACE WITH_GRAPHICS)
 endif()

--- a/src/backend/common/CMakeLists.txt
+++ b/src/backend/common/CMakeLists.txt
@@ -81,7 +81,9 @@ if(AF_WITH_GRAPHICS)
       COMPONENT common_backend_dependencies)
   endif()
 
-  add_dependencies(afcommon_interface forge-ext)
+  if(NOT AF_USE_SYSTEM_FORGE)
+    add_dependencies(afcommon_interface forge-ext)
+  endif()
 endif()
 
 if(LAPACK_FOUND)

--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -263,7 +263,9 @@ if(AF_WITH_NONFREE)
 endif()
 
 if(AF_WITH_GRAPHICS)
-  add_dependencies(afcpu forge-ext)
+  if(NOT AF_USE_SYSTEM_FORGE)
+    add_dependencies(afcpu forge-ext)
+  endif()
   target_sources(afcpu
     PRIVATE
       hist_graphics.cpp

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -417,6 +417,9 @@ if(AF_WITH_NONFREE)
 endif()
 
 if(AF_WITH_GRAPHICS)
+  if(NOT AF_USE_SYSTEM_FORGE)
+    add_dependencies(afcuda forge-ext)
+  endif()
   target_sources(afcuda
     PRIVATE
       GraphicsResourceManager.cpp

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -424,6 +424,9 @@ if(AF_WITH_NONFREE)
 endif()
 
 if(AF_WITH_GRAPHICS)
+  if(NOT AF_USE_SYSTEM_FORGE)
+    add_dependencies(afopencl forge-ext)
+  endif()
   target_sources(afopencl
     PRIVATE
       GraphicsResourceManager.hpp


### PR DESCRIPTION
- Add missing `find_package(Forge)` call in order to be able to deduce the default value for `AF_WITH_GRAPHICS`, which uses `Forge_FOUND`.
- Only build `forge-ext` if `AF_USE_SYSTEM_FORGE` is `OFF`.
- Only add `forge-ext` dependency to individual libraries if `AF_USE_SYSTEM_FORGE` is `OFF`.