### PR TITLE
Add a default constructor for Param. Fixes var issue #2117

### DIFF
--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -312,11 +312,11 @@ namespace opencl
 
     template<typename T>
     Array<T>
-    createDeviceDataArray(const dim4 &size, const void *data)
+    createDeviceDataArray(const dim4 &size, const void *data, bool copy)
     {
         verifyDoubleSupport<T>();
 
-        return Array<T>(size, (cl_mem)(data), 0, false);
+        return Array<T>(size, (cl_mem)(data), 0, copy);
     }
 
     template<typename T>
@@ -405,7 +405,7 @@ namespace opencl
 
 #define INSTANTIATE(T)                                                  \
     template       Array<T>  createHostDataArray<T>   (const dim4 &size, const T * const data); \
-    template       Array<T>  createDeviceDataArray<T> (const dim4 &size, const void *data); \
+    template       Array<T>  createDeviceDataArray<T> (const dim4 &size, const void *data, bool copy); \
     template       Array<T>  createValueArray<T>      (const dim4 &size, const T &value); \
     template       Array<T>  createEmptyArray<T>      (const dim4 &size); \
     template       Array<T>  *initArray<T      >      ();               \

--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -46,7 +46,7 @@ namespace opencl
     Array<T> createHostDataArray(const af::dim4 &size, const T * const data);
 
     template<typename T>
-    Array<T> createDeviceDataArray(const af::dim4 &size, const void *data);
+    Array<T> createDeviceDataArray(const af::dim4 &size, const void *data, bool copy = false);
 
     // Copies data to an existing Array object from a host pointer
     template<typename T>
@@ -223,7 +223,7 @@ namespace opencl
                            {strides()[0], strides()[1], strides()[2], strides()[3]},
                            getOffset()};
 
-            Param out((cl::Buffer *)this->get(), info);
+            Param out{(cl::Buffer *)this->get(), info};
             return out;
         }
 
@@ -266,7 +266,7 @@ namespace opencl
 
         friend Array<T> createValueArray<T>(const af::dim4 &size, const T& value);
         friend Array<T> createHostDataArray<T>(const af::dim4 &size, const T * const data);
-        friend Array<T> createDeviceDataArray<T>(const af::dim4 &size, const void *data);
+        friend Array<T> createDeviceDataArray<T>(const af::dim4 &size, const void *data, bool copy);
 
         friend Array<T> *initArray<T>();
         friend Array<T> createEmptyArray<T>(const af::dim4 &size);

--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -223,7 +223,7 @@ namespace opencl
                            {strides()[0], strides()[1], strides()[2], strides()[3]},
                            getOffset()};
 
-            Param out = {(cl::Buffer *)this->get(), info};
+            Param out((cl::Buffer *)this->get(), info);
             return out;
         }
 

--- a/src/backend/opencl/Param.cpp
+++ b/src/backend/opencl/Param.cpp
@@ -14,15 +14,17 @@
 
 namespace opencl
 {
-    Param makeParam(cl_mem mem, int off, int dims[4], int strides[4])
-    {
-        Param out;
-        out.data = new cl::Buffer(mem);
-        out.info.offset = off;
-        for (int i = 0; i < 4; i++) {
-            out.info.dims[i] = dims[i];
-            out.info.strides[i] = strides[i];
-        }
-        return out;
+    Param::Param() : data(nullptr), info{{0, 0, 0, 0}, {0, 0, 0, 0}, 0} {}
+    Param::Param(cl::Buffer *data_, KParam info_) : data(data_), info(info_){}
+
+    Param makeParam(cl_mem mem, int off, int dims[4], int strides[4]) {
+         Param out;
+         out.data = new cl::Buffer(mem);
+         out.info.offset = off;
+         for (int i = 0; i < 4; i++) {
+             out.info.dims[i] = dims[i];
+             out.info.strides[i] = strides[i];
+         }
+         return out;
     }
 }

--- a/src/backend/opencl/Param.hpp
+++ b/src/backend/opencl/Param.hpp
@@ -18,9 +18,17 @@ namespace opencl
     {
         cl::Buffer *data;
         KParam info;
-        Param() : data(nullptr), info{{0, 0, 0, 0}, {0, 0, 0, 0}, 0} {}
-        Param(cl::Buffer *data_, KParam info_) : data(data_), info(info_) {}
+        Param& operator=(const Param& other) = default;
+        Param(const Param& other) = default;
+        Param(Param&& other) = default;
+
+        // DEPRECATED("Use Array<T>")
+        Param();
+        // DEPRECATED("Use Array<T>")
+        Param(cl::Buffer *data_, KParam info_);
+        ~Param() = default;
     };
 
+    // DEPRECATED("Use Array<T>")
     Param makeParam(cl_mem mem, int off, int dims[4], int strides[4]);
 }

--- a/src/backend/opencl/Param.hpp
+++ b/src/backend/opencl/Param.hpp
@@ -14,11 +14,13 @@
 namespace opencl
 {
 
-    typedef struct
+    struct Param
     {
         cl::Buffer *data;
         KParam info;
-    } Param;
+        Param() : data(nullptr), info{{0, 0, 0, 0}, {0, 0, 0, 0}, 0} {}
+        Param(cl::Buffer *data_, KParam info_) : data(data_), info(info_) {}
+    };
 
     Param makeParam(cl_mem mem, int off, int dims[4], int strides[4]);
 }

--- a/src/backend/opencl/kernel/mean.hpp
+++ b/src/backend/opencl/kernel/mean.hpp
@@ -278,7 +278,7 @@ void mean_dim(Param out, Param in, Param inWeight, int dim)
         groups_all[dim] = 1;
         mean_dim_launcher<Ti, Tw, To>(out, owt, tmpOut, tmpWeight, dim, threads_y, groups_all);
     } else {
-        Array<Tw> tmpWeight = createEmptyArray<Tw>(0);
+        Param tmpWeight;
         mean_dim_launcher<Ti, Tw, To>(out, tmpWeight, in, inWeight, dim, threads_y, groups_all);
     }
 

--- a/src/backend/opencl/kernel/mean.hpp
+++ b/src/backend/opencl/kernel/mean.hpp
@@ -476,7 +476,7 @@ void mean_weighted(Param out, Param in, Param inWeight, int dim)
 template<typename Ti, typename Tw, typename To>
 void mean(Param out, Param in, int dim)
 {
-    Array<Tw> noWeight = createEmptyArray<Tw>(dim4(0, 0, 0, 0));
+    Param noWeight;
     mean_weighted<Ti, Tw, To>(out, in, noWeight, dim);
 }
 
@@ -576,8 +576,8 @@ To mean_all(Param in)
         uint groups_y = divup(in.info.dims[1], threads_y);
 
         Array<To> tmpOut = createEmptyArray<To>(groups_x);
-        Array<To> iWt = createEmptyArray<To>(0);
         Array<Tw> tmpCt = createEmptyArray<Tw>(groups_x);
+        Param iWt;
 
         mean_first_launcher<Ti, Tw, To>(tmpOut, tmpCt, in, iWt, threads_x, groups_x, groups_y);
 

--- a/test/var.cpp
+++ b/test/var.cpp
@@ -162,3 +162,12 @@ TYPED_TEST(Var, DimCPPSmall)
         }
     }
 }
+
+TEST(Var, ISSUE2117) {
+  using namespace af;
+
+  array myArray = constant(1, 1000, 3000);
+  myArray = af::var(myArray, true, 1);
+
+  ASSERT_NEAR(0.0f, sum<float>(myArray), 0.000001);
+}


### PR DESCRIPTION
Fixes #2117 

The issue appeared because the temporary Param struct was uninitialized.