### PR TITLE
Fixes out of bound access in OpenCL scan_first_kernel

### DIFF
--- a/src/backend/opencl/kernel/scan_first.cl
+++ b/src/backend/opencl/kernel/scan_first.cl
@@ -53,7 +53,7 @@ void scan_first_kernel(__global To *oData, KParam oInfo,
 
         if (isLast) l_tmp[lidy] = val;
 
-        bool cond = ((id < oInfo.dims[0]) && cond_yzw);
+        bool cond = ((id < iInfo.dims[0]) && cond_yzw);
         val = cond ? transform(iData[id]) : init_val;
         l_val[lid] = val;
         barrier(CLK_LOCAL_MEM_FENCE);


### PR DESCRIPTION
Fixes an out of bound access in the OpenCL scan_first_kernel. This in addtion to the PR submitted to boost compute(https://github.com/boostorg/compute/pull/772) should address memory issues in sort_by_key_opencl and sparse_arith_opencl.