### PR TITLE
Remove enqueue operations from scan kernels on the CPU.

### DIFF
--- a/src/backend/cpu/kernel/scan.hpp
+++ b/src/backend/cpu/kernel/scan.hpp
@@ -29,9 +29,8 @@ struct scan_dim
         const int D1 = D - 1;
         for (dim_t i = 0; i < odims[D1]; i++) {
             scan_dim<op, Ti, To, D1, inclusive_scan> func;
-            getQueue().enqueue(func,
-                    out, outOffset + i * ostrides[D1],
-                    in, inOffset + i * istrides[D1], dim);
+            func(out, outOffset + i * ostrides[D1], in,
+                 inOffset + i * istrides[D1], dim);
             if (D1 == dim) break;
         }
     }

--- a/src/backend/cpu/kernel/scan_by_key.hpp
+++ b/src/backend/cpu/kernel/scan_by_key.hpp
@@ -34,10 +34,9 @@ struct scan_dim_by_key
         const int D1 = D - 1;
         for (dim_t i = 0; i < odims[D1]; i++) {
             scan_dim_by_key<op, Ti, Tk, To, D1> func(inclusive_scan);
-            getQueue().enqueue(func,
-                    out, outOffset + i * ostrides[D1],
-                    key, keyOffset + i * kstrides[D1],
-                    in, inOffset + i * istrides[D1], dim);
+            func(out, outOffset + i * ostrides[D1], key,
+                 keyOffset + i * kstrides[D1], in, inOffset + i * istrides[D1],
+                 dim);
             if (D1 == dim) break;
         }
     }


### PR DESCRIPTION
The scan kernels(files included in src/backend/cpu/kernel) were
enqueueing functions into the cpu queue from within the worker
thread. This may have been causing deadlocks if the queue became
too large or used too much memory.

Fixes #2115 