### PR TITLE
 Improve counter handling for CBRNGs

### DIFF
--- a/src/backend/cpu/kernel/random_engine.hpp
+++ b/src/backend/cpu/kernel/random_engine.hpp
@@ -101,8 +101,10 @@ namespace kernel
     {
         uint hi = seed>>32;
         uint lo = seed;
-        uint key[2] = {(uint)counter, hi};
-        uint ctr[4] = {(uint)counter, 0, 0, lo};
+        uint hic = counter>>32;
+        uint loc = counter;
+        uint key[2] = {lo, hi};
+        uint ctr[4] = {loc, hic, 0, 0};
 
         int reset = (4*sizeof(uint))/sizeof(T);
         for (int i = 0; i < (int)elements; i += reset) {
@@ -119,14 +121,17 @@ namespace kernel
     {
         uint hi = seed>>32;
         uint lo = seed;
-        uint key[2] = {(uint)counter, hi};
-        uint ctr[2] = {(uint)counter, lo};
+        uint hic = counter>>32;
+        uint loc = counter;
+        uint key[2] = {lo, hi};
+        uint ctr[2] = {loc, hic};
         uint val[2];
 
         int reset = (2*sizeof(uint))/sizeof(T);
         for (int i = 0; i < (int)elements; i += reset) {
             threefry(key, ctr, val);
-            ++ctr[0]; ++key[0];
+            ++ctr[0];
+            ctr[1] += (ctr[0] == 0);
             int lim = (reset < (int)(elements - i))? reset : (int)(elements - i);
             for (int j = 0; j < lim; ++j) {
                 out[i + j] = transform<T>(val, j);
@@ -162,8 +167,10 @@ namespace kernel
     {
         uint hi = seed>>32;
         uint lo = seed;
-        uint key[2] = {(uint)counter, hi};
-        uint ctr[4] = {(uint)counter, 0, 0, lo};
+        uint hic = counter>>32;
+        uint loc = counter;
+        uint key[2] = {lo, hi};
+        uint ctr[4] = {loc, hic, 0, 0};
         T temp[(4*sizeof(uint))/sizeof(T)];
 
         int reset = (4*sizeof(uint))/sizeof(T);
@@ -182,17 +189,21 @@ namespace kernel
     {
         uint hi = seed>>32;
         uint lo = seed;
-        uint key[2] = {(uint)counter, hi};
-        uint ctr[2] = {(uint)counter, lo};
+        uint hic = counter>>32;
+        uint loc = counter;
+        uint key[2] = {lo, hi};
+        uint ctr[2] = {loc, hic};
         uint val[4];
         T temp[(4*sizeof(uint))/sizeof(T)];
 
         int reset = (4*sizeof(uint))/sizeof(T);
         for (int i = 0; i < (int)elements; i += reset) {
             threefry(key, ctr, val);
-            ++ctr[0]; ++key[0];
+            ++ctr[0];
+            ctr[1] += (ctr[0] == 0);
             threefry(key, ctr, val+2);
-            ++ctr[0]; ++key[0];
+            ++ctr[0];
+            ctr[1] += (ctr[0] == 0);
             boxMullerTransform(val, temp);
             int lim = (reset < (int)(elements - i))? reset : (int)(elements - i);
             for (int j = 0; j < lim; ++j) {

--- a/src/backend/cuda/kernel/random_engine.hpp
+++ b/src/backend/cuda/kernel/random_engine.hpp
@@ -400,7 +400,7 @@ namespace kernel
     }
 
     template <typename T>
-    __global__ void uniformPhilox(T *out, uint hi, uint lo, uint hic, unit loc, uint elementsPerBlock, uint elements)
+    __global__ void uniformPhilox(T *out, uint hi, uint lo, uint hic, uint loc, uint elementsPerBlock, uint elements)
     {
         uint index = blockIdx.x*elementsPerBlock + threadIdx.x;
         uint key[2] = {lo, hi};
@@ -501,7 +501,7 @@ namespace kernel
     }
 
     template <typename T>
-    __global__ void normalPhilox(T *out, uint hi, uint lo, uint hic, unit loc, uint elementsPerBlock, uint elements)
+    __global__ void normalPhilox(T *out, uint hi, uint lo, uint hic, uint loc, uint elementsPerBlock, uint elements)
     {
         uint index = blockIdx.x*elementsPerBlock + threadIdx.x;
         uint key[2] = {lo, hi};
@@ -519,7 +519,7 @@ namespace kernel
     }
 
     template <typename T>
-    __global__ void normalThreefry(T *out, uint hi, uint lo, uint hic, unit loc, uint elementsPerBlock, uint elements)
+    __global__ void normalThreefry(T *out, uint hi, uint lo, uint hic, uint loc, uint elementsPerBlock, uint elements)
     {
         uint index = blockIdx.x*elementsPerBlock + threadIdx.x;
         uint key[2] = {lo, hi};

--- a/src/backend/cuda/kernel/random_engine.hpp
+++ b/src/backend/cuda/kernel/random_engine.hpp
@@ -426,15 +426,16 @@ namespace kernel
         ctr[0] += index;
         ctr[1] += (ctr[0] < loc);
         uint o[4];
+
+	threefry(key, ctr, o);
+	uint step = elementsPerBlock / 2;
+	ctr[0] += step;
+	ctr[1] += (ctr[0] < step);
+	threefry(key, ctr, o + 2);
+
         if (blockIdx.x != (gridDim.x - 1)) {
-            threefry(key, ctr, o);
-            ctr[0] += elements;
-            threefry(key, ctr, o + 2);
             writeOut128Bytes(out, index, o[0], o[1], o[2], o[3]);
         } else {
-            threefry(key, ctr, o);
-            ctr[0] += elements;
-            threefry(key, ctr, o + 2);
             partialWriteOut128Bytes(out, index, o[0], o[1], o[2], o[3], elements);
         }
     }
@@ -527,15 +528,16 @@ namespace kernel
         ctr[0] += index;
         ctr[1] += (ctr[0] < loc);
         uint o[4];
-        if (blockIdx.x != (gridDim.x - 1)) {
-            threefry(key, ctr, o);
-            ctr[0] += elements;
-            threefry(key, ctr, o + 2);
+
+	threefry(key, ctr, o);
+	uint step = elementsPerBlock / 2;
+	ctr[0] += step;
+	ctr[1] += (ctr[0] < step);
+	threefry(key, ctr, o + 2);
+
+	if (blockIdx.x != (gridDim.x - 1)) {
             boxMullerWriteOut128Bytes(out, index, o[0], o[1], o[2], o[3]);
         } else {
-            threefry(key, ctr, o);
-            ctr[0] += elements;
-            threefry(key, ctr, o + 2);
             partialBoxMullerWriteOut128Bytes(out, index, o[0], o[1], o[2], o[3], elements);
         }
     }

--- a/src/backend/opencl/kernel/random_engine.hpp
+++ b/src/backend/opencl/kernel/random_engine.hpp
@@ -146,15 +146,17 @@ namespace opencl
 
             uint hi = seed>>32;
             uint lo = seed;
+	    uint hic = counter>>32;
+	    uint loc = counter;
 
             NDRange local(THREADS, 1);
             NDRange global(THREADS * groups, 1);
 
             if ((type == AF_RANDOM_ENGINE_PHILOX_4X32_10) || (type == AF_RANDOM_ENGINE_THREEFRY_2X32_16)) {
                 Kernel ker = get_random_engine_kernel<T>(type, kerIdx, elementsPerBlock);
-                auto randomEngineOp = KernelFunctor<cl::Buffer, uint, uint, uint, uint>(ker);
+                auto randomEngineOp = KernelFunctor<cl::Buffer, uint, uint, uint, uint, uint>(ker);
                 randomEngineOp(EnqueueArgs(getQueue(), global, local),
-                        out, elements, counter, hi, lo);
+			       out, elements, hic, loc, hi, lo);
             }
 
             counter += elements;

--- a/src/backend/opencl/kernel/random_engine_philox.cl
+++ b/src/backend/opencl/kernel/random_engine_philox.cl
@@ -93,14 +93,18 @@ void philox(uint key[2], uint ctr[4])
 }
 
 __kernel void generate(__global T *output, unsigned elements,
-        unsigned counter, unsigned hi, unsigned lo)
+        unsigned hic, unsigned loc, unsigned hi, unsigned lo)
 {
     unsigned gid = get_group_id(0);
     unsigned off = get_local_size(0);
     unsigned index =  gid * ELEMENTS_PER_BLOCK + get_local_id(0);
 
-    uint key[2] = {index+counter, hi};
-    uint ctr[4] = {index+counter, 0, 0, lo};
+    uint key[2] = {lo, hi};
+    uint ctr[4] = {loc, hic, 0, 0};
+    ctr[0] += index;
+    ctr[1] += (ctr[0] < loc);
+    ctr[2] += (ctr[1] < hic);
+
     philox(key, ctr);
 
     if (gid != get_num_groups(0) - 1) {

--- a/src/backend/opencl/kernel/random_engine_threefry.cl
+++ b/src/backend/opencl/kernel/random_engine_threefry.cl
@@ -117,18 +117,23 @@ inline void threefry(uint k[2], uint c[2], uint X[2])
 }
 
 __kernel void generate(__global T *output, unsigned elements,
-        unsigned counter, unsigned hi, unsigned lo)
+        unsigned hic, unsigned loc, unsigned hi, unsigned lo)
 {
     unsigned gid = get_group_id(0);
     unsigned off = get_local_size(0);
     unsigned index =  gid * ELEMENTS_PER_BLOCK + get_local_id(0);
 
-    uint key[2] = {index+counter, hi};
-    uint ctr[2] = {index+counter, lo};
+    uint key[2] = {lo, hi};
+    uint ctr[2] = {loc, hic};
     uint o[4];
 
+    ctr[0] += index;
+    ctr[1] += (ctr[0] < index);
+
     threefry(key, ctr, o);
-    ctr[0] += elements;
+    uint step = ELEMENTS_PER_BLOCK / 2;
+    ctr[0] += step;
+    ctr[1] += (ctr[0] < step);
     threefry(key, ctr, o+2);
 
     if (gid != get_num_groups(0) - 1) {

--- a/test/random.cpp
+++ b/test/random.cpp
@@ -494,15 +494,19 @@ void testRandomEngineUniformChi2(randomEngineType type)
     for (int i = 0; i < steps; ++i) {
         array step_hist = af::histogram(af::randu(elem, ty, r), bins, 0.0, 1.0);
         T step_chi2 = chi2_statistic<T>(step_hist, expected);
-        bool step = step_chi2 > lower && step_chi2 < upper;
-        ASSERT_TRUE(step || prev_step);
-        prev_step = step;
+        if (!prev_step) {
+          EXPECT_GT(step_chi2, lower) << "at step: " << i;
+          EXPECT_LT(step_chi2, upper) << "at step: " << i;
+        }
+        prev_step = step_chi2 > lower && step_chi2 < upper;
 
         total_hist += step_hist;
         T total_chi2 = chi2_statistic<T>(total_hist, expected);
-        bool total = total_chi2 > lower && total_chi2 < upper;
-        ASSERT_TRUE(total || prev_total);
-        prev_total = total;
+        if (!prev_total) {
+          EXPECT_GT(total_chi2, lower) << "at step: " << i;
+          EXPECT_LT(total_chi2, upper) << "at step: " << i;
+        }
+        prev_total = total_chi2 > lower && total_chi2 < upper;
     }
 }
 

--- a/test/random.cpp
+++ b/test/random.cpp
@@ -427,3 +427,37 @@ TYPED_TEST(RandomEngineSeed, mersenneSeedUniform)
 {
     testRandomEngineSeed<TypeParam>(AF_RANDOM_ENGINE_MERSENNE_GP11213);
 }
+
+template <typename T>
+void testRandomEnginePeriod(randomEngineType type)
+{
+    if (noDoubleTests<T>()) return;
+    af::dtype ty = (af::dtype)af::dtype_traits<T>::af_type;
+
+    uint elem = 1024*1024;
+    uint steps = 4*1024;
+    af::randomEngine r(type, 0);
+
+    af::array first = af::randu(elem, ty, r);
+
+    for (int i = 0; i < steps; ++i) {
+        af::array step = af::randu(elem, ty, r);
+        bool different = !af::allTrue<bool>(first == step);
+        ASSERT_TRUE(different);
+    }
+}
+
+TYPED_TEST(RandomEngine, DISABLED_philoxRandomEnginePeriod)
+{
+    testRandomEnginePeriod<TypeParam>(AF_RANDOM_ENGINE_PHILOX_4X32_10);
+}
+
+TYPED_TEST(RandomEngine, DISABLED_threefryRandomEnginePeriod)
+{
+    testRandomEnginePeriod<TypeParam>(AF_RANDOM_ENGINE_THREEFRY_2X32_16);
+}
+
+TYPED_TEST(RandomEngine, DISABLED_mersenneRandomEnginePeriod)
+{
+    testRandomEnginePeriod<TypeParam>(AF_RANDOM_ENGINE_MERSENNE_GP11213);
+}

--- a/test/random_practrand.cpp
+++ b/test/random_practrand.cpp
@@ -1,0 +1,27 @@
+// Generate random bits and send them to STDOUT.
+// Suitable for testing with PractRand, c.f. http://pracrand.sourceforge.net/
+// and http://www.pcg-random.org/posts/how-to-test-with-practrand.html
+// Commandline arguments: backend, device, rng_type
+// Example:
+// random_practrand 0 0 200 | RNG_test stdin32
+#include <cstdio>
+#include <cstdint>
+#include <arrayfire.h>
+
+int main(int argc, char ** argv) {
+  int backend = argc > 1 ? atoi(argv[1]) : 0;
+  af::setBackend(static_cast<af::Backend>(backend));
+  int device = argc > 2 ? atoi(argv[2]) : 0;
+  af::setDevice(device);
+  int rng = argc > 3 ? atoi(argv[3]) : 100;
+  af::setDefaultRandomEngineType(static_cast<af::randomEngineType>(rng)); 	
+  
+  af::setSeed(0xfe47fe0cc078ec30ULL);
+  int samples = 1024 * 1024;
+  while (1) {
+    af::array values = af::randu(samples, u32);
+    uint32_t *pvalues = values.host<uint32_t>();
+    fwrite((void*) pvalues, samples * sizeof(*pvalues), 1, stdout);
+    free(pvalues);
+  }
+}


### PR DESCRIPTION
This is a partial fix for #2007. For all three backends, the following changes have been made:

* Use the full 64 bits of the counter
* Separate counter and key/seed
* Check for carry when increasing counter

Note that the CUDA backend is completely untested. Both CPU and OpenCL backend now pass the test programs mentioned in #2007 as well as the `random` unit tests. I was not able to add tests like these as unit tests due to their excessive run-time.

Still open:
* Philox could use 128 bit for counting
* Philox returns 4 and Threefry returns 2 `uint` values per counter, but the `counter` is increased with the number of `elements` produced
* Philox on CPU does not really count within the loop. Instead the output from the previous round is used.