### PR TITLE
Remove recursive mutexes and locks on driver APIs

### DIFF
--- a/src/backend/common/MemoryManager.hpp
+++ b/src/backend/common/MemoryManager.hpp
@@ -24,7 +24,7 @@
 
 namespace common
 {
-using mutex_t      = std::recursive_mutex;
+using mutex_t      = std::mutex;
 using lock_guard_t = std::lock_guard<mutex_t>;
 
 const unsigned MAX_BUFFERS   = 1000;

--- a/src/backend/cpu/memory.cpp
+++ b/src/backend/cpu/memory.cpp
@@ -151,7 +151,6 @@ MemoryManager::MemoryManager()
 
 MemoryManager::~MemoryManager()
 {
-    common::lock_guard_t lock(this->memory_mutex);
     for (int n = 0; n < cpu::getDeviceCount(); n++) {
         try {
             cpu::setDevice(n);

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -298,8 +298,6 @@ std::vector<char> compileToPTX(const char *ker_name, string jit_ker)
 
 static kc_entry_t compileKernel(const char *ker_name, string jit_ker)
 {
-    lock_guard<recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
-
     const size_t linkLogSize = 1024;
     char linkInfo[linkLogSize] = {0};
     char linkError[linkLogSize] = {0};
@@ -459,7 +457,6 @@ void evalNodes(vector<Param<T>>& outputs, vector<Node *> output_nodes)
     args.push_back((void *)&blocks_x_total);
     args.push_back((void *)&num_odims);
 
-    lock_guard<recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
     CU_CHECK(cuLaunchKernel(ker,
                             blocks_x,
                             blocks_y,

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -178,7 +178,6 @@ size_t MemoryManager::getMaxMemorySize(int id)
 
 void *MemoryManager::nativeAlloc(const size_t bytes)
 {
-    lock_guard<recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
     void *ptr = NULL;
     CUDA_CHECK(cudaMalloc(&ptr, bytes));
     return ptr;
@@ -186,7 +185,6 @@ void *MemoryManager::nativeAlloc(const size_t bytes)
 
 void MemoryManager::nativeFree(void *ptr)
 {
-    lock_guard<recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
     cudaError_t err = cudaFree(ptr);
     if (err != cudaErrorCudartUnloading) {
         CUDA_CHECK(err);
@@ -217,7 +215,6 @@ size_t MemoryManagerPinned::getMaxMemorySize(int id)
 
 void *MemoryManagerPinned::nativeAlloc(const size_t bytes)
 {
-    lock_guard<recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
     void *ptr;
     CUDA_CHECK(cudaMallocHost(&ptr, bytes));
     return ptr;
@@ -225,7 +222,6 @@ void *MemoryManagerPinned::nativeAlloc(const size_t bytes)
 
 void MemoryManagerPinned::nativeFree(void *ptr)
 {
-    lock_guard<recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
     cudaError_t err = cudaFreeHost(ptr);
     if (err != cudaErrorCudartUnloading) {
         CUDA_CHECK(err);

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -156,7 +156,6 @@ MemoryManager::MemoryManager()
 
 MemoryManager::~MemoryManager()
 {
-    common::lock_guard_t lock(this->memory_mutex);
     for (int n = 0; n < cuda::getDeviceCount(); n++) {
         try {
             cuda::setDevice(n);

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -282,10 +282,6 @@ unsigned getMaxJitSize()
     return length;
 }
 
-std::recursive_mutex& getDriverApiMutex(int device) {
-  return DeviceManager::getInstance().driver_api_mutex[device];
-}
-
 int& tlocalActiveDeviceId()
 {
     thread_local int activeDeviceId = 0;

--- a/src/backend/cuda/platform.hpp
+++ b/src/backend/cuda/platform.hpp
@@ -19,7 +19,6 @@
 #include <cusparse.hpp>
 
 #include <memory>
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -41,8 +40,6 @@ bool isDoubleSupported(int device);
 void devprop(char* d_name, char* d_platform, char *d_toolkit, char* d_compute);
 
 unsigned getMaxJitSize();
-
-std::recursive_mutex& getDriverApiMutex(int device);
 
 int getDeviceCount();
 
@@ -114,8 +111,6 @@ class DeviceManager
         friend GraphicsResourceManager& interopManager();
 #endif
 
-        friend std::recursive_mutex& getDriverApiMutex(int device);
-
         friend std::string getDeviceInfo(int device);
 
         friend std::string getPlatformInfo();
@@ -147,8 +142,6 @@ class DeviceManager
         // variables
         DeviceManager(DeviceManager const&);
         void operator=(DeviceManager const&);
-
-        std::recursive_mutex driver_api_mutex[MAX_DEVICES];
 
         // Attributes
         std::vector<cudaDevice_t> cuDevices;

--- a/src/backend/cuda/sparse_blas.cpp
+++ b/src/backend/cuda/sparse_blas.cpp
@@ -142,11 +142,6 @@ Array<T> matmul(const common::SparseArray<T> lhs, const Array<T> rhs,
 
     dim4 rStrides = rhs.strides();
 
-    // NOTE: The cuSparse library seems to be using the driver API in the
-    // implementation. This is causing issues with our JIT kernel generation.
-    // This may be a bug in the cuSparse library.
-    std::lock_guard<std::recursive_mutex> lock(getDriverApiMutex(getActiveDeviceId()));
-
     // Create Sparse Matrix Descriptor
     cusparseMatDescr_t descr = 0;
     CUSPARSE_CHECK(cusparseCreateMatDescr(&descr));


### PR DESCRIPTION
Recursive mutexs are known to promote poor design choices. This commit
removes the need for recursive mutexes in the memory manager and
OpenCL backends.