### PR TITLE
Devirtualize memory manager's destructor. Delete assignments

### DIFF
--- a/src/backend/common/MemoryManager.hpp
+++ b/src/backend/common/MemoryManager.hpp
@@ -427,8 +427,6 @@ class MemoryManager
         static_cast<T*>(this)->nativeFree(ptr);
     }
 
-    virtual ~MemoryManager() {}
-
     bool checkMemoryLimit()
     {
         const memory_info& current = this->getCurrentMemoryInfo();
@@ -436,6 +434,12 @@ class MemoryManager
     }
 
     protected:
+    MemoryManager() = delete;
+    ~MemoryManager() = default;
+    MemoryManager(const MemoryManager& other) = delete;
+    MemoryManager(const MemoryManager&& other) = delete;
+    MemoryManager& operator=(const MemoryManager& other) = delete;
+    MemoryManager& operator=(const MemoryManager&& other) = delete;
     mutex_t memory_mutex;
 };
 


### PR DESCRIPTION
Delete the assignment and copy operators in the memory manager. Make the destructor a non-virtual function