### PR TITLE
Fix variable const qualifiers in blas files

### DIFF
--- a/src/backend/cpu/blas.cpp
+++ b/src/backend/cpu/blas.cpp
@@ -163,8 +163,8 @@ Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
     int aColDim = (lOpts == CblasNoTrans) ? 1 : 0;
     int bColDim = (rOpts == CblasNoTrans) ? 1 : 0;
 
-    dim4 lDims = lhs.dims();
-    dim4 rDims = rhs.dims();
+    auto lDims = lhs.dims();
+    auto rDims = rhs.dims();
     int M = lDims[aRowDim];
     int N = rDims[bColDim];
     int K = lDims[aColDim];
@@ -174,7 +174,7 @@ Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs,
 
     dim_t d2 = std::max(lDims[2], rDims[2]);
     dim_t d3 = std::max(lDims[3], rDims[3]);
-    dim4 oDims = af::dim4(M, N, d2, d3);
+    const dim4 oDims(M, N, d2, d3);
     Array<T> out = createEmptyArray<T>(oDims);
 
     auto func = [=] (Param<T> output, CParam<T> left, CParam<T> right) {

--- a/src/backend/cpu/sparse_blas.cpp
+++ b/src/backend/cpu/sparse_blas.cpp
@@ -452,8 +452,8 @@ Array<T> matmul(const common::SparseArray<T> lhs, const Array<T> rhs,
 
     static const int rColDim = 1;
 
-    dim4 lDims = lhs.dims();
-    dim4 rDims = rhs.dims();
+    auto lDims = lhs.dims();
+    auto rDims = rhs.dims();
     int M = lDims[lRowDim];
     int N = rDims[rColDim];
 


### PR DESCRIPTION
Fixes #2148 

This fix alone cannot fix the problem with GCC8. I have sent a https://github.com/boostorg/compute/pull/776 which also is needed for OpenCL backend to compile successfully. CPU & CUDA backends however doesn't need the fix from boost-compute to compile with GCC8 successfully.