### PR TITLE
Fix #2130 and handle NaNs for complex types

### DIFF
--- a/src/api/c/ops.hpp
+++ b/src/api/c/ops.hpp
@@ -220,7 +220,7 @@ struct Transform<Ti, To, af_min_t>
 {
     __DH__ To operator ()(Ti in)
     {
-        return (To) (IS_NAN(in) ? Binary<To, af_min_t>()::init() : in);
+        return (To) (IS_NAN(in) ? Binary<To, af_min_t>::init() : in);
     }
 };
 
@@ -229,7 +229,7 @@ struct Transform<Ti, To, af_max_t>
 {
     __DH__ To operator ()(Ti in)
     {
-        return (To) (IS_NAN(in) ? Binary<To, af_max_t>()::init() : in);
+        return (To) (IS_NAN(in) ? Binary<To, af_max_t>::init() : in);
     }
 };
 

--- a/src/api/c/ops.hpp
+++ b/src/api/c/ops.hpp
@@ -220,7 +220,7 @@ struct Transform<Ti, To, af_min_t>
 {
     __DH__ To operator ()(Ti in)
     {
-        return (To) (IS_NAN(in) ? Binary<To, af_min_t>().init() : in);
+        return (To) (IS_NAN(in) ? Binary<To, af_min_t>()::init() : in);
     }
 };
 
@@ -229,7 +229,7 @@ struct Transform<Ti, To, af_max_t>
 {
     __DH__ To operator ()(Ti in)
     {
-        return (To) (IS_NAN(in) ? Binary<To, af_max_t>().init() : in);
+        return (To) (IS_NAN(in) ? Binary<To, af_max_t>()::init() : in);
     }
 };
 

--- a/src/api/c/ops.hpp
+++ b/src/api/c/ops.hpp
@@ -25,7 +25,7 @@ using namespace detail;
 template<typename T, af_op_t op>
 struct Binary
 {
-    __DH__ T init()
+    static __DH__ T init()
     {
         return detail::scalar<T>(0);
     }
@@ -39,7 +39,7 @@ struct Binary
 template<typename T>
 struct Binary<T, af_add_t>
 {
-    __DH__ T init()
+    static __DH__ T init()
     {
         return detail::scalar<T>(0);
     }
@@ -53,7 +53,7 @@ struct Binary<T, af_add_t>
 template<typename T>
 struct Binary<T, af_mul_t>
 {
-    __DH__ T init()
+    static __DH__ T init()
     {
         return detail::scalar<T>(1);
     }
@@ -67,7 +67,7 @@ struct Binary<T, af_mul_t>
 template<typename T>
 struct Binary<T, af_or_t>
 {
-    __DH__ T init()
+    static __DH__ T init()
     {
         return detail::scalar<T>(0);
     }
@@ -81,7 +81,7 @@ struct Binary<T, af_or_t>
 template<typename T>
 struct Binary<T, af_and_t>
 {
-    __DH__ T init()
+    static __DH__ T init()
     {
         return detail::scalar<T>(1);
     }
@@ -95,7 +95,7 @@ struct Binary<T, af_and_t>
 template<typename T>
 struct Binary<T, af_notzero_t>
 {
-    __DH__ T init()
+    static __DH__ T init()
     {
         return detail::scalar<T>(0);
     }
@@ -109,7 +109,7 @@ struct Binary<T, af_notzero_t>
 template<typename T>
 struct Binary<T, af_min_t>
 {
-    __DH__ T init()
+    static __DH__ T init()
     {
         return detail::maxval<T>();
     }
@@ -120,11 +120,10 @@ struct Binary<T, af_min_t>
     }
 };
 
-
 template<>
 struct Binary<char, af_min_t>
 {
-    __DH__ char init()
+    static __DH__ char init()
     {
         return 1;
     }
@@ -139,10 +138,10 @@ struct Binary<char, af_min_t>
     template<>                                  \
     struct Binary<T, af_min_t>                  \
     {                                           \
-        __DH__ T init()                         \
+        static __DH__ T init()                  \
         {                                       \
             return detail::scalar<T>(           \
-                detail::maxval<Tr>()         \
+                detail::maxval<Tr>()            \
                 );                              \
         }                                       \
                                                 \
@@ -150,7 +149,7 @@ struct Binary<char, af_min_t>
         {                                       \
             return detail::min(lhs, rhs);       \
         }                                       \
-    };                                          \
+    };
 
 SPECIALIZE_COMPLEX_MIN(cfloat, float)
 SPECIALIZE_COMPLEX_MIN(cdouble, double)
@@ -160,7 +159,7 @@ SPECIALIZE_COMPLEX_MIN(cdouble, double)
 template<typename T>
 struct Binary<T, af_max_t>
 {
-    __DH__ T init()
+    static __DH__ T init()
     {
         return detail::minval<T>();
     }
@@ -174,7 +173,7 @@ struct Binary<T, af_max_t>
 template<>
 struct Binary<char, af_max_t>
 {
-    __DH__ char init()
+    static __DH__ char init()
     {
         return 0;
     }
@@ -189,7 +188,7 @@ struct Binary<char, af_max_t>
     template<>                                  \
     struct Binary<T, af_max_t>                  \
     {                                           \
-        __DH__ T init()                         \
+        static __DH__ T init()                  \
         {                                       \
             return detail::scalar<T>(           \
                 detail::scalar<Tr>(0)           \
@@ -200,7 +199,7 @@ struct Binary<char, af_max_t>
         {                                       \
             return detail::max(lhs, rhs);       \
         }                                       \
-    };                                          \
+    };
 
 SPECIALIZE_COMPLEX_MAX(cfloat, float)
 SPECIALIZE_COMPLEX_MAX(cdouble, double)

--- a/src/backend/cpu/kernel/ireduce.hpp
+++ b/src/backend/cpu/kernel/ireduce.hpp
@@ -31,8 +31,7 @@ struct MinMaxOp
         m_val(val), m_idx(idx)
     {
         if (isNan(val)) {
-            Binary<T, op> ireduce;
-            m_val = ireduce.init();
+            m_val = Binary<T, op>::init();
         }
     }
 
@@ -57,8 +56,7 @@ struct MinMaxOp<af_max_t, T>
         m_val(val), m_idx(idx)
     {
         if (isNan(val)) {
-            Binary<T, af_max_t> ireduce;
-            m_val = ireduce.init();
+            m_val = Binary<T, af_max_t>::init();
         }
     }
 

--- a/src/backend/cpu/kernel/ireduce.hpp
+++ b/src/backend/cpu/kernel/ireduce.hpp
@@ -39,7 +39,7 @@ struct MinMaxOp
     {
         if ((cabs(val) < cabs(m_val) ||
              (cabs(val) == cabs(m_val) &&
-              idx >= m_idx)) &&
+              idx > m_idx)) &&
             !is_nan(val)) {
             m_val = val;
             m_idx = idx;
@@ -64,7 +64,7 @@ struct MinMaxOp<af_max_t, T>
     {
         if ((cabs(val) > cabs(m_val) ||
              (cabs(val) == cabs(m_val) &&
-              idx >= m_idx)) &&
+              idx <= m_idx)) &&
             !is_nan(val)) {
             m_val = val;
             m_idx = idx;

--- a/src/backend/cpu/kernel/ireduce.hpp
+++ b/src/backend/cpu/kernel/ireduce.hpp
@@ -38,8 +38,8 @@ struct MinMaxOp
     void operator()(T val, uint idx)
     {
         if ((cabs(val) < cabs(m_val) ||
-            cabs(val) == cabs(m_val)) &&
-            idx >= m_idx &&
+             (cabs(val) == cabs(m_val) &&
+              idx >= m_idx)) &&
             !is_nan(val)) {
             m_val = val;
             m_idx = idx;
@@ -63,8 +63,8 @@ struct MinMaxOp<af_max_t, T>
     void operator()(T val, uint idx)
     {
         if ((cabs(val) > cabs(m_val) ||
-            cabs(val) == cabs(m_val)) &&
-            idx >= m_idx &&
+             (cabs(val) == cabs(m_val) &&
+              idx >= m_idx)) &&
             !is_nan(val)) {
             m_val = val;
             m_idx = idx;

--- a/src/backend/cpu/kernel/ireduce.hpp
+++ b/src/backend/cpu/kernel/ireduce.hpp
@@ -38,8 +38,7 @@ struct MinMaxOp
     void operator()(T val, uint idx)
     {
         if ((cabs(val) < cabs(m_val) ||
-             (cabs(val) == cabs(m_val) &&
-              idx > m_idx)) &&
+             (cabs(val) == cabs(m_val) && idx > m_idx)) &&
             !is_nan(val)) {
             m_val = val;
             m_idx = idx;
@@ -63,8 +62,7 @@ struct MinMaxOp<af_max_t, T>
     void operator()(T val, uint idx)
     {
         if ((cabs(val) > cabs(m_val) ||
-             (cabs(val) == cabs(m_val) &&
-              idx <= m_idx)) &&
+             (cabs(val) == cabs(m_val) && idx <= m_idx)) &&
             !is_nan(val)) {
             m_val = val;
             m_idx = idx;

--- a/src/backend/cpu/kernel/ireduce.hpp
+++ b/src/backend/cpu/kernel/ireduce.hpp
@@ -20,7 +20,7 @@ template<typename T> double cabs(const T in) { return (double)in; }
 static double cabs(const char in) { return (double)(in > 0); }
 static double cabs(const cfloat &in) { return (double)abs(in); }
 static double cabs(const cdouble &in) { return (double)abs(in); }
-template<typename T> static bool isNan(T in) { return in != in; }
+template<typename T> static bool is_nan(T in) { return in != in; }
 
 template<af_op_t op, typename T>
 struct MinMaxOp
@@ -30,17 +30,17 @@ struct MinMaxOp
     MinMaxOp(T val, uint idx) :
         m_val(val), m_idx(idx)
     {
-        if (isNan(val)) {
+        if (is_nan(val)) {
             m_val = Binary<T, op>::init();
         }
     }
 
     void operator()(T val, uint idx)
     {
-        if (!isNan(val) &&
-            (cabs(val) < cabs(m_val) ||
+        if ((cabs(val) < cabs(m_val) ||
             cabs(val) == cabs(m_val)) &&
-            idx >= m_idx) {
+            idx >= m_idx &&
+            !is_nan(val)) {
             m_val = val;
             m_idx = idx;
         }
@@ -55,17 +55,17 @@ struct MinMaxOp<af_max_t, T>
     MinMaxOp(T val, uint idx) :
         m_val(val), m_idx(idx)
     {
-        if (isNan(val)) {
+        if (is_nan(val)) {
             m_val = Binary<T, af_max_t>::init();
         }
     }
 
     void operator()(T val, uint idx)
     {
-        if (!isNan(val) &&
-            (cabs(val) > cabs(m_val) ||
+        if ((cabs(val) > cabs(m_val) ||
             cabs(val) == cabs(m_val)) &&
-            idx >= m_idx) {
+            idx >= m_idx &&
+            !is_nan(val)) {
             m_val = val;
             m_idx = idx;
         }

--- a/src/backend/cpu/kernel/ireduce.hpp
+++ b/src/backend/cpu/kernel/ireduce.hpp
@@ -38,8 +38,7 @@ struct MinMaxOp
     void operator()(T val, uint idx)
     {
         if ((cabs(val) < cabs(m_val) ||
-             (cabs(val) == cabs(m_val) && idx > m_idx)) &&
-            !is_nan(val)) {
+             (cabs(val) == cabs(m_val) && idx > m_idx))) {
             m_val = val;
             m_idx = idx;
         }
@@ -62,8 +61,7 @@ struct MinMaxOp<af_max_t, T>
     void operator()(T val, uint idx)
     {
         if ((cabs(val) > cabs(m_val) ||
-             (cabs(val) == cabs(m_val) && idx <= m_idx)) &&
-            !is_nan(val)) {
+             (cabs(val) == cabs(m_val) && idx <= m_idx))) {
             m_val = val;
             m_idx = idx;
         }

--- a/src/backend/cpu/kernel/morph.hpp
+++ b/src/backend/cpu/kernel/morph.hpp
@@ -29,7 +29,7 @@ void morph(Param<T> out, CParam<T> in, CParam<T> mask)
     const dim_t R0      = window[0]/2;
     const dim_t R1      = window[1]/2;
 
-    T init = IsDilation ? Binary<T, af_max_t>().init() : Binary<T, af_min_t>().init();
+    T init = IsDilation ? Binary<T, af_max_t>::init() : Binary<T, af_min_t>::init();
 
     for(dim_t b3=0; b3<dims[3]; ++b3) {
 
@@ -93,7 +93,7 @@ void morph3d(Param<T> out, CParam<T> in, CParam<T> mask)
     const T*   inData   = in.get();
     const T*   filter   = mask.get();
 
-    T init = IsDilation ? Binary<T, af_max_t>().init() : Binary<T, af_min_t>().init();
+    T init = IsDilation ? Binary<T, af_max_t>::init() : Binary<T, af_min_t>::init();
 
     for(dim_t batchId=0; batchId<bCount; ++batchId) {
         // either channels or batch is handled by outer most loop

--- a/src/backend/cpu/kernel/reduce.hpp
+++ b/src/backend/cpu/kernel/reduce.hpp
@@ -54,7 +54,7 @@ struct reduce_dim<op, Ti, To, 0>
         Ti const * const inPtr = in.get() + inOffset;
         dim_t stride = istrides[dim];
 
-        To out_val = reduce.init();
+        To out_val = Binary<To, op>::init();
         for (dim_t i = 0; i < idims[dim]; i++) {
             To in_val = transform(inPtr[i * stride]);
             if (change_nan) in_val = IS_NAN(in_val) ? nanval : in_val;
@@ -64,7 +64,6 @@ struct reduce_dim<op, Ti, To, 0>
         *outPtr = out_val;
     }
 };
-
 
 }
 }

--- a/src/backend/cpu/kernel/scan.hpp
+++ b/src/backend/cpu/kernel/scan.hpp
@@ -57,7 +57,7 @@ struct scan_dim<op, Ti, To, 0, inclusive_scan>
         // FIXME: Change the name to something better
         Binary<To, op> scan;
 
-        To out_val = scan.init();
+        To out_val = Binary<To, op>::init();
         for (dim_t i = 0; i < idims[dim]; i++) {
             To in_val = transform(in[i * istride]);
             out_val = scan(in_val, out_val);
@@ -65,7 +65,7 @@ struct scan_dim<op, Ti, To, 0, inclusive_scan>
                 //The loop shifts the output index by 1.
                 //The last index wraps around and writes the first element.
                 if (i == (idims[dim] - 1)) {
-                    out[0] = scan.init();
+                    out[0] = Binary<To, op>::init();
                 } else {
                     out[(i + 1) * ostride] = out_val;
                 }

--- a/src/backend/cpu/kernel/scan_by_key.hpp
+++ b/src/backend/cpu/kernel/scan_by_key.hpp
@@ -70,18 +70,18 @@ struct scan_dim_by_key<op, Ti, Tk, To, 0>
         // FIXME: Change the name to something better
         Binary<To, op> scan;
 
-        To out_val = scan.init();
+        To out_val = Binary<To, op>::init();
         Tk key_val = key[0];
 
         dim_t k = !inclusive_scan;
         if (!inclusive_scan) {
-            out[0] = scan.init();
+            out[0] = Binary<To, op>::init();
         }
 
         for (dim_t i = 0; i < idims[dim] - (!inclusive_scan); i++, k++) {
             To in_val = transform(in[i * istride]);
             if (key[k * kstride] != key_val) {
-                out_val = !inclusive_scan? scan.init() : in_val;
+                out_val = !inclusive_scan? Binary<To, op>::init() : in_val;
                 key_val = key[k * kstride];
             } else {
                 out_val = scan(in_val, out_val);

--- a/src/backend/cpu/reduce.cpp
+++ b/src/backend/cpu/reduce.cpp
@@ -22,7 +22,7 @@ using af::dim4;
 template<>
 struct Binary<cdouble, af_add_t>
 {
-    cdouble init()
+    static cdouble init()
     {
         return cdouble(0,0);
     }

--- a/src/backend/cpu/reduce.cpp
+++ b/src/backend/cpu/reduce.cpp
@@ -68,7 +68,7 @@ To reduce_all(const Array<Ti> &in, bool change_nan, double nanval)
     Transform<Ti, To, op> transform;
     Binary<To, op> reduce;
 
-    To out = reduce.init();
+    To out = Binary<To, op>::init();
 
     // Decrement dimension of select dimension
     af::dim4 dims = in.dims();

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -56,8 +56,7 @@ namespace kernel
             m_val(val), m_idx(idx)
         {
             if (isNan(val)) {
-                Binary<T, op> ireduce;
-                m_val = ireduce.init();
+                m_val = Binary<T, op>::init();
             }
         }
 
@@ -81,8 +80,7 @@ namespace kernel
             m_val(val), m_idx(idx)
         {
             if (isNan(val)) {
-                Binary<T, af_max_t> ireduce;
-                m_val = ireduce.init();
+                m_val = Binary<T, af_max_t>::init();
             }
         }
 

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -23,10 +23,10 @@ namespace cuda
 namespace kernel
 {
     template<typename T> __host__ __device__ 
-    static double cabs(const T in) { return (double)in; }
+    static double cabs(const T& in) { return (double)in; }
 
     template<> __host__ __device__
-    static double cabs<char>(const char in) { return (double)(in > 0); }
+    static double cabs<char>(const char& in) { return (double)(in > 0); }
 
     template<> __host__ __device__
     static double cabs<cfloat>(const cfloat &in) { return (double)abs(in); }
@@ -35,7 +35,7 @@ namespace kernel
     static double cabs<cdouble>(const cdouble &in) { return (double)abs(in); }
 
     template<typename T> __host__ __device__ 
-    static bool isNan(T in) { return in != in; }
+    static bool isNan(const T& in) { return in != in; }
 
     template<> __host__ __device__ 
     static bool isNan<cfloat>(const cfloat &in) { 

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -63,8 +63,7 @@ namespace kernel
         __host__ __device__ void operator()(T val, uint idx)
         {
             if ((cabs(val) < cabs(m_val) ||
-                 (cabs(val) == cabs(m_val) && idx > m_idx)) &&
-                !is_nan(val)) {
+                 (cabs(val) == cabs(m_val) && idx > m_idx))) {
                 m_val = val;
                 m_idx = idx;
             }
@@ -87,8 +86,7 @@ namespace kernel
         __host__ __device__ void operator()(T val, uint idx)
         {
             if ((cabs(val) > cabs(m_val) ||
-                 (cabs(val) == cabs(m_val) && idx <= m_idx)) &&
-                !is_nan(val)) {
+                 (cabs(val) == cabs(m_val) && idx <= m_idx))) {
                 m_val = val;
                 m_idx = idx;
             }

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -22,7 +22,7 @@ namespace cuda
 {
 namespace kernel
 {
-    template<typename T> __host__ __device__ 
+    template<typename T> __host__ __device__
     static double cabs(const T& in) { return (double)in; }
 
     template<> __host__ __device__
@@ -34,17 +34,17 @@ namespace kernel
     template<> __host__ __device__
     double cabs<cdouble>(const cdouble &in) { return (double)abs(in); }
 
-    template<typename T> __host__ __device__ 
-    static bool isNan(const T& in) { return in != in; }
+    template<typename T> __host__ __device__
+    static bool is_nan(const T& in) { return in != in; }
 
-    template<> __host__ __device__ 
-    bool isNan<cfloat>(const cfloat &in) { 
+    template<> __host__ __device__
+    bool is_nan<cfloat>(const cfloat &in) {
         return in.x != in.x || in.y != in.y;
     }
 
     template<> __host__ __device__
-    bool isNan<cdouble>(const cdouble &in) { 
-        return in.x != in.x || in.y != in.y; 
+    bool is_nan<cdouble>(const cdouble &in) {
+        return in.x != in.x || in.y != in.y;
     }
 
     template<af_op_t op, typename T>
@@ -55,16 +55,16 @@ namespace kernel
         __host__ __device__ MinMaxOp(T val, uint idx) :
             m_val(val), m_idx(idx)
         {
-            if (isNan(val)) {
+            if (is_nan(val)) {
                 m_val = Binary<T, op>::init();
             }
         }
 
         __host__ __device__ void operator()(T val, uint idx)
         {
-            if (!isNan(val) &&
-                (cabs(val) < cabs(m_val) ||
-                cabs(val) == cabs(m_val))) {
+            if ((cabs(val) < cabs(m_val) ||
+                cabs(val) == cabs(m_val)) &&
+                !is_nan(val)) {
                 m_val = val;
                 m_idx = idx;
             }
@@ -79,16 +79,16 @@ namespace kernel
         __host__ __device__ MinMaxOp(T val, uint idx) :
             m_val(val), m_idx(idx)
         {
-            if (isNan(val)) {
+            if (is_nan(val)) {
                 m_val = Binary<T, af_max_t>::init();
             }
         }
 
         __host__ __device__ void operator()(T val, uint idx)
         {
-            if (!isNan(val) &&
-                (cabs(val) > cabs(m_val) ||
-                cabs(val) == cabs(m_val))) {
+            if ((cabs(val) > cabs(m_val) ||
+                cabs(val) == cabs(m_val)) &&
+                !is_nan(val)) {
                 m_val = val;
                 m_idx = idx;
             }

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -26,24 +26,24 @@ namespace kernel
     static double cabs(const T& in) { return (double)in; }
 
     template<> __host__ __device__
-    static double cabs<char>(const char& in) { return (double)(in > 0); }
+    double cabs<char>(const char& in) { return (double)(in > 0); }
 
     template<> __host__ __device__
-    static double cabs<cfloat>(const cfloat &in) { return (double)abs(in); }
+    double cabs<cfloat>(const cfloat &in) { return (double)abs(in); }
 
     template<> __host__ __device__
-    static double cabs<cdouble>(const cdouble &in) { return (double)abs(in); }
+    double cabs<cdouble>(const cdouble &in) { return (double)abs(in); }
 
     template<typename T> __host__ __device__ 
     static bool isNan(const T& in) { return in != in; }
 
     template<> __host__ __device__ 
-    static bool isNan<cfloat>(const cfloat &in) { 
+    bool isNan<cfloat>(const cfloat &in) { 
         return in.x != in.x || in.y != in.y;
     }
 
     template<> __host__ __device__
-    static bool isNan<cdouble>(const cdouble &in) { 
+    bool isNan<cdouble>(const cdouble &in) { 
         return in.x != in.x || in.y != in.y; 
     }
 

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -63,8 +63,7 @@ namespace kernel
         __host__ __device__ void operator()(T val, uint idx)
         {
             if ((cabs(val) < cabs(m_val) ||
-                 (cabs(val) == cabs(m_val) &&
-                  idx > m_idx)) &&
+                 (cabs(val) == cabs(m_val) && idx > m_idx)) &&
                 !is_nan(val)) {
                 m_val = val;
                 m_idx = idx;
@@ -88,8 +87,7 @@ namespace kernel
         __host__ __device__ void operator()(T val, uint idx)
         {
             if ((cabs(val) > cabs(m_val) ||
-                 (cabs(val) == cabs(m_val) &&
-                  idx <= m_idx)) &&
+                 (cabs(val) == cabs(m_val) && idx <= m_idx)) &&
                 !is_nan(val)) {
                 m_val = val;
                 m_idx = idx;

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -63,7 +63,8 @@ namespace kernel
         __host__ __device__ void operator()(T val, uint idx)
         {
             if ((cabs(val) < cabs(m_val) ||
-                cabs(val) == cabs(m_val)) &&
+                 (cabs(val) == cabs(m_val) &&
+                  idx > m_idx)) &&
                 !is_nan(val)) {
                 m_val = val;
                 m_idx = idx;
@@ -87,7 +88,8 @@ namespace kernel
         __host__ __device__ void operator()(T val, uint idx)
         {
             if ((cabs(val) > cabs(m_val) ||
-                cabs(val) == cabs(m_val)) &&
+                 (cabs(val) == cabs(m_val) &&
+                  idx <= m_idx)) &&
                 !is_nan(val)) {
                 m_val = val;
                 m_idx = idx;

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -22,14 +22,30 @@ namespace cuda
 {
 namespace kernel
 {
+    template<typename T> __host__ __device__ 
+    static double cabs(const T in) { return (double)in; }
 
-    template<typename T> __host__ __device__ double cabs(const T in) { return (double)in; }
-    static double __host__ __device__ cabs(const char in) { return (double)(in > 0); }
-    static double __host__ __device__ cabs(const cfloat &in) { return (double)abs(in); }
-    static double __host__ __device__ cabs(const cdouble &in) { return (double)abs(in); }
-    template<typename T> __host__ __device__ static bool isNan(T in) { return in != in; }
-    static bool __host__ __device__ isNan(const cfloat &in) { return in.x != in.x || in.y != in.y; }
-    static bool __host__ __device__ isNan(const cdouble &in) { return in.x != in.x || in.y != in.y; }
+    template<> __host__ __device__
+    static double cabs<char>(const char in) { return (double)(in > 0); }
+
+    template<> __host__ __device__
+    static double cabs<cfloat>(const cfloat &in) { return (double)abs(in); }
+
+    template<> __host__ __device__
+    static double cabs<cdouble>(const cdouble &in) { return (double)abs(in); }
+
+    template<typename T> __host__ __device__ 
+    static bool isNan(T in) { return in != in; }
+
+    template<> __host__ __device__ 
+    static bool isNan<cfloat>(const cfloat &in) { 
+        return in.x != in.x || in.y != in.y;
+    }
+
+    template<> __host__ __device__
+    static bool isNan<cdouble>(const cdouble &in) { 
+        return in.x != in.x || in.y != in.y; 
+    }
 
     template<af_op_t op, typename T>
     struct MinMaxOp
@@ -123,9 +139,7 @@ namespace kernel
             (ids[2] < in.dims[2]) &&
             (ids[3] < in.dims[3]);
 
-        Binary<T, op> ireduce;
-
-        T val = ireduce.init();
+        T val = Binary<T, op>::init();
         uint idx = id_dim_in;
 
         if (is_valid && id_dim_in < in.dims[dim]) {
@@ -315,9 +329,7 @@ namespace kernel
 
         int lim = min((int)(xid + repeat * DIMX), in.dims[0]);
 
-        Binary<T, op> ireduce;
-
-        T val = ireduce.init();
+        T val = Binary<T, op>::init();
         uint idx = xid;
 
         if (xid < lim) {

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -28,6 +28,8 @@ namespace kernel
     static double __host__ __device__ cabs(const cfloat &in) { return (double)abs(in); }
     static double __host__ __device__ cabs(const cdouble &in) { return (double)abs(in); }
     template<typename T> __host__ __device__ static bool isNan(T in) { return in != in; }
+    static bool __host__ __device__ isNan(const cfloat &in) { return in.x != in.x || in.y != in.y; }
+    static bool __host__ __device__ isNan(const cdouble &in) { return in.x != in.x || in.y != in.y; }
 
     template<af_op_t op, typename T>
     struct MinMaxOp

--- a/src/backend/cuda/kernel/mean.hpp
+++ b/src/backend/cuda/kernel/mean.hpp
@@ -95,11 +95,9 @@ namespace kernel
             (ids[3] < in.dims[3]);
 
         Transform<Ti, To, af_add_t> transform;
-        Binary<To, af_add_t> mean_obj;
-        Binary<Tw, af_add_t> weight_obj;
 
-        To val = mean_obj.init();
-        Tw weight = weight_obj.init();
+        To val = Binary<To, af_add_t>::init();
+        Tw weight = Binary<Tw, af_add_t>::init();
 
         if (is_valid && id_dim_in < in.dims[dim]) {
             val = transform(*iptr);
@@ -280,11 +278,9 @@ namespace kernel
         int lim = min((int)(xid + repeat * DIMX), in.dims[0]);
 
         Transform<Ti, To, af_add_t> transform;
-        Binary<To, af_add_t> mean_obj;
-        Binary<Tw, af_add_t> weight_obj;
 
-        To val = mean_obj.init();
-        Tw weight = weight_obj.init();
+        To val = Binary<To, af_add_t>::init();
+        Tw weight = Binary<Tw, af_add_t>::init();
 
         if (xid < lim) {
             val = transform(iptr[xid]);

--- a/src/backend/cuda/kernel/morph.hpp
+++ b/src/backend/cuda/kernel/morph.hpp
@@ -48,7 +48,7 @@ inline __device__ void load2ShrdMem(T * shrd, const T * const in,
         int gx, int gy,
         int inStride1, int inStride0)
 {
-    T val = isDilation ? Binary<T, af_max_t>().init() : Binary<T, af_min_t>().init();
+    T val = isDilation ? Binary<T, af_max_t>::init() : Binary<T, af_min_t>::init();
     if (gx>=0 && gx<dim0 && gy>=0 && gy<dim1) {
         val = in[ lIdx(gx, gy, inStride1, inStride0) ];
     }
@@ -116,7 +116,7 @@ static __global__ void morphKernel(Param<T> out, CParam<T> in,
     __syncthreads();
 
     const T * d_filt = (const T *)cFilter;
-    T acc = isDilation ? Binary<T, af_max_t>().init() : Binary<T, af_min_t>().init();
+    T acc = isDilation ? Binary<T, af_max_t>::init() : Binary<T, af_min_t>::init();
 #pragma unroll
     for(int wj=0; wj<windLen; ++wj) {
         int joff   = wj*windLen;
@@ -153,7 +153,7 @@ inline __device__ void load2ShrdVolume(T * shrd, const T * const in,
         int gx, int gy, int gz,
         int inStride2, int inStride1, int inStride0)
 {
-    T val = isDilation ? Binary<T, af_max_t>().init() : Binary<T, af_min_t>().init();
+    T val = isDilation ? Binary<T, af_max_t>::init() : Binary<T, af_min_t>::init();
     if (gx>=0 && gx<dim0 &&
         gy>=0 && gy<dim1 &&
         gz>=0 && gz<dim2) {
@@ -212,7 +212,7 @@ static __global__ void morph3DKernel(Param<T> out, CParam<T> in, int nBBS)
     int k  = lz + halo;
 
     const T * d_filt = (const T *)cFilter;
-    T acc = isDilation ? Binary<T, af_max_t>().init() : Binary<T, af_min_t>().init();
+    T acc = isDilation ? Binary<T, af_max_t>::init() : Binary<T, af_min_t>::init();
 #pragma unroll
     for(int wk=0; wk<windLen; ++wk) {
         int koff   = wk*se_area;

--- a/src/backend/cuda/kernel/reduce.hpp
+++ b/src/backend/cuda/kernel/reduce.hpp
@@ -73,7 +73,7 @@ namespace kernel
 
         Transform<Ti, To, op> transform;
         Binary<To, op> reduce;
-        To out_val = reduce.init();
+        To out_val = Binary<To, op>::init();
         for (int id = id_dim_in; is_valid && (id < in.dims[dim]); id += offset_dim * blockDim.y) {
             To in_val = transform(*iptr);
             if (change_nan) in_val = !IS_NAN(in_val) ? in_val : nanval;
@@ -217,7 +217,7 @@ namespace kernel
 
         int lim = min((int)(xid + repeat * DIMX), in.dims[0]);
 
-        To out_val = reduce.init();
+        To out_val = Binary<To, op>::init();
         for (int id = xid; id < lim; id += DIMX) {
             To in_val = transform(iptr[id]);
             if (change_nan) in_val = !IS_NAN(in_val) ? in_val : nanval;
@@ -387,7 +387,7 @@ namespace kernel
             CUDA_CHECK(cudaStreamSynchronize(cuda::getActiveStream()));
 
             Binary<To, op> reduce;
-            To out = reduce.init();
+            To out = Binary<To, op>::init();
             for (int i = 0; i < tmp_elements; i++) {
                 out = reduce(out, h_ptr_raw[i]);
             }
@@ -404,7 +404,7 @@ namespace kernel
 
             Transform<Ti, To, op> transform;
             Binary<To, op> reduce;
-            To out = reduce.init();
+            To out = Binary<To, op>::init();
             To nanval_to = scalar<To>(nanval);
 
             for (int i = 0; i < in_elements; i++) {

--- a/src/backend/cuda/kernel/scan_dim.hpp
+++ b/src/backend/cuda/kernel/scan_dim.hpp
@@ -77,7 +77,7 @@ namespace kernel
         Transform<Ti, To, op> transform;
         Binary<To, op> binop;
 
-        const To init = binop.init();
+        const To init = Binary<To, op>::init();
         To val = init;
 
         const bool isLast = (tidy == (DIMY - 1));

--- a/src/backend/cuda/kernel/scan_dim_by_key_impl.hpp
+++ b/src/backend/cuda/kernel/scan_dim_by_key_impl.hpp
@@ -99,7 +99,7 @@ namespace kernel
         Transform<Ti, To, op> transform;
         Binary<To, op> binop;
 
-        const To init = binop.init();
+        const To init = Binary<To, op>::init();
         To val = init;
 
         const bool isLast = (tidy == (DIMY - 1));
@@ -254,7 +254,7 @@ namespace kernel
         Transform<Ti, To, op> transform;
         Binary<To, op> binop;
 
-        const To init = binop.init();
+        const To init = Binary<To, op>::init();
         To val = init;
 
         const bool isLast = (tidy == (DIMY - 1));

--- a/src/backend/cuda/kernel/scan_first.hpp
+++ b/src/backend/cuda/kernel/scan_first.hpp
@@ -64,7 +64,7 @@ namespace kernel
         Transform<Ti, To, op> transform;
         Binary<To, op> binop;
 
-        const To init = binop.init();
+        const To init = Binary<To, op>::init();
         int id = xid;
         To val = init;
 

--- a/src/backend/cuda/kernel/scan_first_by_key_impl.hpp
+++ b/src/backend/cuda/kernel/scan_first_by_key_impl.hpp
@@ -44,7 +44,7 @@ namespace kernel
     {
         Transform<Ti, To, op> transform;
         Binary<To, op> binop;
-        const To init = binop.init();
+        const To init = Binary<To, op>::init();
         To val = init;
 
         const int istride = in.strides[0];
@@ -182,7 +182,7 @@ namespace kernel
     {
         Transform<Ti, To, op> transform;
         Binary<To, op> binop;
-        const To init = binop.init();
+        const To init = Binary<To, op>::init();
         To val = init;
 
         const int istride = in.strides[0];

--- a/src/backend/opencl/kernel/iops.cl
+++ b/src/backend/opencl/kernel/iops.cl
@@ -18,9 +18,9 @@
 #ifdef MIN_OP
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
-    if (!(IS_NAN(lhs[0])) && 
-        ((sabs(lhs[0]) > sabs(rhs)) ||
-        (sabs(lhs[0]) == sabs(rhs)))) {
+    if ((sabs(lhs[0]) > sabs(rhs)) ||
+        (sabs(lhs[0]) == sabs(rhs)) &&
+        !(IS_NAN(lhs[0]))) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -30,9 +30,9 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 #ifdef MAX_OP
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
-    if (!(IS_NAN(lhs[0])) &&
-        ((sabs(lhs[0]) < sabs(rhs)) ||
-        (sabs(lhs[0]) == sabs(rhs)))) {
+    if ((sabs(lhs[0]) < sabs(rhs)) ||
+        (sabs(lhs[0]) == sabs(rhs)) &&
+        !(IS_NAN(lhs[0]))) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -43,9 +43,9 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 #ifdef MIN_OP
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
-    if (!(IS_NAN(*lhs)) &&
-        ((*lhs > rhs) ||
-        (*lhs == rhs))) {
+    if (((*lhs > rhs) ||
+        (*lhs == rhs)) &&
+        !(IS_NAN(*lhs))) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -55,9 +55,9 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 #ifdef MAX_OP
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
-    if (!(IS_NAN(*lhs)) &&
-        ((*lhs < rhs) ||
-        (*lhs == rhs))) {
+    if (((*lhs < rhs) ||
+        (*lhs == rhs)) &&
+        !(IS_NAN(*lhs))) {
         *lhs = rhs;
         *lidx = ridx;
     }

--- a/src/backend/opencl/kernel/iops.cl
+++ b/src/backend/opencl/kernel/iops.cl
@@ -19,9 +19,8 @@ inline bool is_nan(T in) { return (in != in); }
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if (((sabs(lhs[0]) > sabs(rhs)) ||
-         (sabs(lhs[0]) == sabs(rhs) &&
-          *lidx < ridx)) &&
-        !is_nan(lhs[0])) {
+         (sabs(lhs[0]) == sabs(rhs) && *lidx < ridx)) &&
+        !is_nan(rhs)) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -32,9 +31,8 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if (((sabs(lhs[0]) < sabs(rhs)) ||
-         (sabs(lhs[0]) == sabs(rhs) &&
-          *lidx > ridx)) &&
-        !is_nan(lhs[0])) {
+         (sabs(lhs[0]) == sabs(rhs) && *lidx > ridx)) &&
+        !is_nan(rhs)) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -46,7 +44,7 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if (((*lhs > rhs) ||
          (*lhs == rhs && *lidx < ridx)) &&
-        !is_nan(*lhs)) {
+        !is_nan(rhs)) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -58,7 +56,7 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if (((*lhs < rhs) ||
          (*lhs == rhs && *lidx > ridx)) &&
-        !is_nan(*lhs)) {
+        !is_nan(rhs)) {
         *lhs = rhs;
         *lidx = ridx;
     }

--- a/src/backend/opencl/kernel/iops.cl
+++ b/src/backend/opencl/kernel/iops.cl
@@ -8,12 +8,19 @@
  ********************************************************/
 
 #if CPLX
+    #define IS_NAN(in) !((in.x) == (in.x)) || !((in.y) == (in.y))
+#else
+    #define IS_NAN(in) !((in) == (in))
+#endif
+
+#if CPLX
 #define sabs(in) ((in.x)*(in.x) + (in.y)*(in.y))
 #ifdef MIN_OP
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
-    if ((sabs(lhs[0]) > sabs(rhs)) ||
-        (sabs(lhs[0]) == sabs(rhs) && *lidx < ridx)) {
+    if (!(IS_NAN(lhs[0])) && 
+        ((sabs(lhs[0]) > sabs(rhs)) ||
+        (sabs(lhs[0]) == sabs(rhs)))) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -23,8 +30,9 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 #ifdef MAX_OP
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
-    if ((sabs(lhs[0]) < sabs(rhs)) ||
-        (sabs(lhs[0]) == sabs(rhs) && *lidx > ridx)) {
+    if (!(IS_NAN(lhs[0])) &&
+        ((sabs(lhs[0]) < sabs(rhs)) ||
+        (sabs(lhs[0]) == sabs(rhs)))) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -35,8 +43,9 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 #ifdef MIN_OP
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
-    if ((*lhs > rhs) ||
-        (*lhs == rhs && *lidx < ridx)) {
+    if (!(IS_NAN(*lhs)) &&
+        ((*lhs > rhs) ||
+        (*lhs == rhs))) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -46,8 +55,9 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 #ifdef MAX_OP
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
-    if ((*lhs < rhs) ||
-        (*lhs == rhs && *lidx > ridx)) {
+    if (!(IS_NAN(*lhs)) &&
+        ((*lhs < rhs) ||
+        (*lhs == rhs))) {
         *lhs = rhs;
         *lidx = ridx;
     }

--- a/src/backend/opencl/kernel/iops.cl
+++ b/src/backend/opencl/kernel/iops.cl
@@ -8,9 +8,9 @@
  ********************************************************/
 
 #if CPLX
-    #define IS_NAN(in) !((in.x) == (in.x)) || !((in.y) == (in.y))
+inline bool is_nan(T in) { return (in.x != in.x) || (in.y != in.y); }
 #else
-    #define IS_NAN(in) !((in) == (in))
+inline bool is_nan(T in) { return (in != in); }
 #endif
 
 #if CPLX
@@ -20,7 +20,7 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if ((sabs(lhs[0]) > sabs(rhs)) ||
         (sabs(lhs[0]) == sabs(rhs)) &&
-        !(IS_NAN(lhs[0]))) {
+        !is_nan(lhs[0])) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -32,20 +32,19 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if ((sabs(lhs[0]) < sabs(rhs)) ||
         (sabs(lhs[0]) == sabs(rhs)) &&
-        !(IS_NAN(lhs[0]))) {
+        !is_nan(lhs[0])) {
         *lhs = rhs;
         *lidx = ridx;
     }
 }
 #endif
 #else
-#define sabs(in) in
 #ifdef MIN_OP
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if (((*lhs > rhs) ||
         (*lhs == rhs)) &&
-        !(IS_NAN(*lhs))) {
+        !is_nan(*lhs)) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -57,7 +56,7 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if (((*lhs < rhs) ||
         (*lhs == rhs)) &&
-        !(IS_NAN(*lhs))) {
+        !is_nan(*lhs)) {
         *lhs = rhs;
         *lidx = ridx;
     }

--- a/src/backend/opencl/kernel/iops.cl
+++ b/src/backend/opencl/kernel/iops.cl
@@ -19,8 +19,7 @@ inline bool is_nan(T in) { return (in != in); }
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if (((sabs(lhs[0]) > sabs(rhs)) ||
-         (sabs(lhs[0]) == sabs(rhs) && *lidx < ridx)) &&
-        !is_nan(rhs)) {
+         (sabs(lhs[0]) == sabs(rhs) && *lidx < ridx))) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -31,8 +30,7 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if (((sabs(lhs[0]) < sabs(rhs)) ||
-         (sabs(lhs[0]) == sabs(rhs) && *lidx > ridx)) &&
-        !is_nan(rhs)) {
+         (sabs(lhs[0]) == sabs(rhs) && *lidx > ridx))) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -43,8 +41,7 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if (((*lhs > rhs) ||
-         (*lhs == rhs && *lidx < ridx)) &&
-        !is_nan(rhs)) {
+         (*lhs == rhs && *lidx < ridx))) {
         *lhs = rhs;
         *lidx = ridx;
     }
@@ -55,8 +52,7 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if (((*lhs < rhs) ||
-         (*lhs == rhs && *lidx > ridx)) &&
-        !is_nan(rhs)) {
+         (*lhs == rhs && *lidx > ridx))) {
         *lhs = rhs;
         *lidx = ridx;
     }

--- a/src/backend/opencl/kernel/iops.cl
+++ b/src/backend/opencl/kernel/iops.cl
@@ -18,8 +18,9 @@ inline bool is_nan(T in) { return (in != in); }
 #ifdef MIN_OP
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
-    if ((sabs(lhs[0]) > sabs(rhs)) ||
-        (sabs(lhs[0]) == sabs(rhs)) &&
+    if (((sabs(lhs[0]) > sabs(rhs)) ||
+         (sabs(lhs[0]) == sabs(rhs) &&
+          *lidx < ridx)) &&
         !is_nan(lhs[0])) {
         *lhs = rhs;
         *lidx = ridx;
@@ -30,8 +31,9 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 #ifdef MAX_OP
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
-    if ((sabs(lhs[0]) < sabs(rhs)) ||
-        (sabs(lhs[0]) == sabs(rhs)) &&
+    if (((sabs(lhs[0]) < sabs(rhs)) ||
+         (sabs(lhs[0]) == sabs(rhs) &&
+          *lidx > ridx)) &&
         !is_nan(lhs[0])) {
         *lhs = rhs;
         *lidx = ridx;
@@ -43,7 +45,7 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if (((*lhs > rhs) ||
-        (*lhs == rhs)) &&
+         (*lhs == rhs && *lidx < ridx)) &&
         !is_nan(*lhs)) {
         *lhs = rhs;
         *lidx = ridx;
@@ -55,7 +57,7 @@ void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 void binOp(T *lhs, uint *lidx, T rhs, uint ridx)
 {
     if (((*lhs < rhs) ||
-        (*lhs == rhs)) &&
+         (*lhs == rhs && *lidx > ridx)) &&
         !is_nan(*lhs)) {
         *lhs = rhs;
         *lidx = ridx;

--- a/src/backend/opencl/kernel/ireduce.hpp
+++ b/src/backend/opencl/kernel/ireduce.hpp
@@ -67,7 +67,6 @@ namespace kernel
 
         if (entry.prog==0 && entry.ker==0) {
 
-            Binary<T, op> ireduce;
             ToNumStr<T> toNumStr;
 
             std::ostringstream options;
@@ -75,7 +74,7 @@ namespace kernel
                 << " -D dim=" << dim
                 << " -D DIMY=" << threads_y
                 << " -D THREADS_X=" << THREADS_X
-                << " -D init=" << toNumStr(ireduce.init())
+                << " -D init=" << toNumStr(Binary<T, op>::init())
                 << " -D " << binOpName<op>()
                 << " -D CPLX=" << af::iscplx<T>()
                 << " -D IS_FIRST=" << is_first;
@@ -177,14 +176,13 @@ namespace kernel
 
         if (entry.prog==0 && entry.ker==0) {
 
-            Binary<T, op> ireduce;
             ToNumStr<T> toNumStr;
 
             std::ostringstream options;
             options << " -D T=" << dtype_traits<T>::getName()
                     << " -D DIMX=" << threads_x
                     << " -D THREADS_PER_GROUP=" << THREADS_PER_GROUP
-                    << " -D init=" << toNumStr(ireduce.init())
+                    << " -D init=" << toNumStr(Binary<T, op>::init())
                     << " -D " << binOpName<op>()
                     << " -D CPLX=" << af::iscplx<T>()
                     << " -D IS_FIRST=" << is_first;

--- a/src/backend/opencl/kernel/ireduce_first.cl
+++ b/src/backend/opencl/kernel/ireduce_first.cl
@@ -52,7 +52,7 @@ void ireduce_first_kernel(__global T *oData,
     uint out_idx = xid;
 
     if (cond && xid < lim) {
-        out_val = iData[xid];
+        if (!(IS_NAN(iData[xid]))) out_val = iData[xid];
         if (!IS_FIRST) out_idx = ilData[xid];
     }
 

--- a/src/backend/opencl/kernel/ireduce_first.cl
+++ b/src/backend/opencl/kernel/ireduce_first.cl
@@ -51,8 +51,8 @@ void ireduce_first_kernel(__global T *oData,
     T out_val = init;
     uint out_idx = xid;
 
-    if (cond && xid < lim) {
-        if (!is_nan(iData[xid])) out_val = iData[xid];
+    if (cond && xid < lim && !is_nan(iData[xid])) {
+        out_val = iData[xid];
         if (!IS_FIRST) out_idx = ilData[xid];
     }
 

--- a/src/backend/opencl/kernel/ireduce_first.cl
+++ b/src/backend/opencl/kernel/ireduce_first.cl
@@ -52,7 +52,7 @@ void ireduce_first_kernel(__global T *oData,
     uint out_idx = xid;
 
     if (cond && xid < lim) {
-        if (!(IS_NAN(iData[xid]))) out_val = iData[xid];
+        if (!is_nan(iData[xid])) out_val = iData[xid];
         if (!IS_FIRST) out_idx = ilData[xid];
     }
 

--- a/src/backend/opencl/kernel/mean.hpp
+++ b/src/backend/opencl/kernel/mean.hpp
@@ -154,7 +154,6 @@ void mean_dim_launcher(Param out, Param owt,
 
     if (entry.prog==0 && entry.ker==0) {
 
-        Binary<To, af_add_t> mean;
         ToNumStr<To> toNumStr;
         ToNumStr<Tw> twNumStr;
         Transform<uint, Tw, af_add_t> transform_weight;
@@ -166,7 +165,7 @@ void mean_dim_launcher(Param out, Param owt,
             << " -D dim=" << dim
             << " -D DIMY=" << threads_y
             << " -D THREADS_X=" << THREADS_X
-            << " -D init_To=" << toNumStr(mean.init())
+            << " -D init_To=" << toNumStr(Binary<To, af_add_t>::init())
             << " -D init_Tw=" << twNumStr(transform_weight(0))
             << " -D one_Tw=" << twNumStr(transform_weight(1));
 
@@ -322,7 +321,6 @@ void mean_first_launcher(Param out, Param owt,
 
     if (entry.prog==0 && entry.ker==0) {
 
-        Binary<To, af_add_t> mean;
         ToNumStr<To> toNumStr;
         ToNumStr<Tw> twNumStr;
         Transform<uint, Tw, af_add_t> transform_weight;
@@ -333,7 +331,7 @@ void mean_first_launcher(Param out, Param owt,
             << " -D To=" << dtype_traits<To>::getName()
             << " -D DIMX=" << threads_x
             << " -D THREADS_PER_GROUP=" << THREADS_PER_GROUP
-            << " -D init_To=" << toNumStr(mean.init())
+            << " -D init_To=" << toNumStr(Binary<To, af_add_t>::init())
             << " -D init_Tw=" << twNumStr(transform_weight(0))
             << " -D one_Tw=" << twNumStr(transform_weight(1));
 

--- a/src/backend/opencl/kernel/morph.hpp
+++ b/src/backend/opencl/kernel/morph.hpp
@@ -44,7 +44,7 @@ template<typename T, bool isDilation, int SeLength>
 std::string generateOptionsString()
 {
     ToNumStr<T> toNumStr;
-    T init = isDilation ? Binary<T, af_max_t>().init() : Binary<T, af_min_t>().init();
+    T init = isDilation ? Binary<T, af_max_t>()::init() : Binary<T, af_min_t>()::init();
     std::ostringstream options;
     options << " -D T=" << dtype_traits<T>::getName()
         << " -D isDilation="<< isDilation

--- a/src/backend/opencl/kernel/morph.hpp
+++ b/src/backend/opencl/kernel/morph.hpp
@@ -44,7 +44,7 @@ template<typename T, bool isDilation, int SeLength>
 std::string generateOptionsString()
 {
     ToNumStr<T> toNumStr;
-    T init = isDilation ? Binary<T, af_max_t>()::init() : Binary<T, af_min_t>()::init();
+    T init = isDilation ? Binary<T, af_max_t>::init() : Binary<T, af_min_t>::init();
     std::ostringstream options;
     options << " -D T=" << dtype_traits<T>::getName()
         << " -D isDilation="<< isDilation

--- a/src/backend/opencl/kernel/ops.cl
+++ b/src/backend/opencl/kernel/ops.cl
@@ -102,6 +102,10 @@ uint transform(Ti in)
 
 #ifdef MIN_OP
 
+#if CPLX
+    #define IS_NAN(in) !((in.x) == (in.x)) || !((in.y) == (in.y))
+#endif
+
 T transform(T in)
 {
     T val = init;
@@ -121,6 +125,10 @@ T binOp(T lhs, T rhs)
 #endif
 
 #ifdef MAX_OP
+
+#if CPLX
+    #define IS_NAN(in) !((in.x) == (in.x)) || !((in.y) == (in.y))
+#endif
 
 T transform(T in)
 {

--- a/src/backend/opencl/kernel/reduce.hpp
+++ b/src/backend/opencl/kernel/reduce.hpp
@@ -64,7 +64,6 @@ namespace kernel
         kc_entry_t entry = kernelCache(device, ref_name);
 
         if (entry.prog==0 && entry.ker==0) {
-            Binary<To, op> reduce;
             ToNumStr<To> toNumStr;
 
             std::ostringstream options;
@@ -74,7 +73,7 @@ namespace kernel
                     << " -D dim=" << dim
                     << " -D DIMY=" << threads_y
                     << " -D THREADS_X=" << THREADS_X
-                    << " -D init=" << toNumStr(reduce.init())
+                    << " -D init=" << toNumStr(Binary<To, op>::init())
                     << " -D " << binOpName<op>()
                     << " -D CPLX=" << af::iscplx<Ti>();
             if (std::is_same<Ti, double>::value ||
@@ -181,7 +180,6 @@ namespace kernel
 
         if (entry.prog==0 && entry.ker==0) {
 
-            Binary<To, op> reduce;
             ToNumStr<To> toNumStr;
 
             std::ostringstream options;
@@ -190,7 +188,7 @@ namespace kernel
                     << " -D T=To"
                     << " -D DIMX=" << threads_x
                     << " -D THREADS_PER_GROUP=" << THREADS_PER_GROUP
-                    << " -D init=" << toNumStr(reduce.init())
+                    << " -D init=" << toNumStr(Binary<To, op>::init())
                     << " -D " << binOpName<op>()
                     << " -D CPLX=" << af::iscplx<Ti>();
             if (std::is_same<Ti, double>::value ||
@@ -311,7 +309,7 @@ namespace kernel
             getQueue().enqueueReadBuffer(*tmp.get(), CL_TRUE, 0, sizeof(To) * tmp_elements, h_ptr.data());
 
             Binary<To, op> reduce;
-            To out = reduce.init();
+            To out = Binary<To, op>::init();
             for (int i = 0; i < (int)tmp_elements; i++) {
                 out = reduce(out, h_ptr[i]);
             }
@@ -324,7 +322,7 @@ namespace kernel
 
             Transform<Ti, To, op> transform;
             Binary<To, op> reduce;
-            To out = reduce.init();
+            To out = Binary<To, op>::init();
             To nanval_to = scalar<To>(nanval);
 
             for (int i = 0; i < (int)in_elements; i++) {

--- a/src/backend/opencl/kernel/scan_dim.hpp
+++ b/src/backend/opencl/kernel/scan_dim.hpp
@@ -59,7 +59,6 @@ namespace kernel
         kc_entry_t entry = kernelCache(device, ref_name);
 
         if (entry.prog==0 && entry.ker==0) {
-            Binary<To, op> scan;
             ToNumStr<To> toNumStr;
 
             std::ostringstream options;
@@ -69,7 +68,7 @@ namespace kernel
                     << " -D dim=" << dim
                     << " -D DIMY=" << threads_y
                     << " -D THREADS_X=" << THREADS_X
-                    << " -D init=" << toNumStr(scan.init())
+                    << " -D init=" << toNumStr(Binary<To, op>::init())
                     << " -D " << binOpName<op>()
                     << " -D CPLX=" << af::iscplx<Ti>()
                     << " -D isFinalPass=" << (int)(isFinalPass)

--- a/src/backend/opencl/kernel/scan_dim_by_key_impl.hpp
+++ b/src/backend/opencl/kernel/scan_dim_by_key_impl.hpp
@@ -62,7 +62,6 @@ namespace kernel
 
         if (entry.prog==0 && entry.ker==0) {
 
-            Binary<To, op> scan;
             ToNumStr<To> toNumStr;
 
             std::ostringstream options;
@@ -73,7 +72,7 @@ namespace kernel
                     << " -D dim=" << dim
                     << " -D DIMY=" << threads_y
                     << " -D THREADS_X=" << THREADS_X
-                    << " -D init=" << toNumStr(scan.init())
+                    << " -D init=" << toNumStr(Binary<To, op>::init())
                     << " -D " << binOpName<op>()
                     << " -D CPLX=" << af::iscplx<Ti>()
                     << " -D calculateFlags=" << calculateFlags

--- a/src/backend/opencl/kernel/scan_first.hpp
+++ b/src/backend/opencl/kernel/scan_first.hpp
@@ -63,7 +63,6 @@ namespace kernel
             const uint threads_y = THREADS_PER_GROUP / threads_x;
             const uint SHARED_MEM_SIZE = THREADS_PER_GROUP;
 
-            Binary<To, op> scan;
             ToNumStr<To> toNumStr;
 
             std::ostringstream options;
@@ -73,7 +72,7 @@ namespace kernel
                     << " -D DIMX=" << threads_x
                     << " -D DIMY=" << threads_y
                     << " -D SHARED_MEM_SIZE=" << SHARED_MEM_SIZE
-                    << " -D init=" << toNumStr(scan.init())
+                    << " -D init=" << toNumStr(Binary<To, op>::init())
                     << " -D " << binOpName<op>()
                     << " -D CPLX=" << af::iscplx<Ti>()
                     << " -D isFinalPass=" << (int)(isFinalPass)

--- a/src/backend/opencl/kernel/scan_first_by_key_impl.hpp
+++ b/src/backend/opencl/kernel/scan_first_by_key_impl.hpp
@@ -65,7 +65,6 @@ namespace kernel
             const uint threads_y = THREADS_PER_GROUP / threads_x;
             const uint SHARED_MEM_SIZE = THREADS_PER_GROUP;
 
-            Binary<To, op> scan;
             ToNumStr<To> toNumStr;
 
             std::ostringstream options;
@@ -76,7 +75,7 @@ namespace kernel
                     << " -D DIMX=" << threads_x
                     << " -D DIMY=" << threads_y
                     << " -D SHARED_MEM_SIZE=" << SHARED_MEM_SIZE
-                    << " -D init=" << toNumStr(scan.init())
+                    << " -D init=" << toNumStr(Binary<To, op>::init())
                     << " -D " << binOpName<op>()
                     << " -D CPLX=" << af::iscplx<Ti>()
                     << " -D calculateFlags=" << calculateFlags

--- a/test/binary_ops.hpp
+++ b/test/binary_ops.hpp
@@ -85,7 +85,7 @@ struct Binary<T, AF_BINARY_MAX>
     template<>                                      \
     struct Binary<T, AF_BINARY_MIN>                 \
     {                                               \
-        static T init()                                    \
+        static T init()                             \
         {                                           \
             return                                  \
             (T)(std::numeric_limits<Tr>::max());    \
@@ -105,7 +105,7 @@ SPECIALIZE_COMPLEX_MIN(std::complex<double>, double)
     template<>                                      \
     struct Binary<T, AF_BINARY_MAX>                 \
     {                                               \
-        static T init()                                    \
+        static T init()                             \
         {                                           \
             return (T)((Tr)(0));                    \
         }                                           \
@@ -124,7 +124,7 @@ SPECIALIZE_COMPLEX_MAX(std::complex<double>, double)
     template<>                                      \
     struct Binary<T, AF_BINARY_MAX>                 \
     {                                               \
-        static T init()                                    \
+        static T init()                             \
         {                                           \
             return                                  \
             (T)(-std::numeric_limits<Tr>::max());   \

--- a/test/binary_ops.hpp
+++ b/test/binary_ops.hpp
@@ -14,7 +14,7 @@ std::complex<double> max(std::complex<double> lhs, std::complex<double> rhs);
 template<typename T, af_binary_op op>
 struct Binary
 {
-    T init()
+    static T init()
     {
         return (T)(0);
     }
@@ -28,7 +28,7 @@ struct Binary
 template<typename T>
 struct Binary<T, AF_BINARY_ADD>
 {
-    T init()
+    static T init()
     {
         return (T)(0);
     }
@@ -42,7 +42,7 @@ struct Binary<T, AF_BINARY_ADD>
 template<typename T>
 struct Binary<T, AF_BINARY_MUL>
 {
-    T init()
+    static T init()
     {
         return (T)(1);
     }
@@ -56,7 +56,7 @@ struct Binary<T, AF_BINARY_MUL>
 template<typename T>
 struct Binary<T, AF_BINARY_MIN>
 {
-    T init()
+    static T init()
     {
         return std::numeric_limits<T>::max();
     }
@@ -70,7 +70,7 @@ struct Binary<T, AF_BINARY_MIN>
 template<typename T>
 struct Binary<T, AF_BINARY_MAX>
 {
-    T init()
+    static T init()
     {
         return std::numeric_limits<T>::min();
     }
@@ -85,7 +85,7 @@ struct Binary<T, AF_BINARY_MAX>
     template<>                                      \
     struct Binary<T, AF_BINARY_MIN>                 \
     {                                               \
-        T init()                                    \
+        static T init()                                    \
         {                                           \
             return                                  \
             (T)(std::numeric_limits<Tr>::max());    \
@@ -105,7 +105,7 @@ SPECIALIZE_COMPLEX_MIN(std::complex<double>, double)
     template<>                                      \
     struct Binary<T, AF_BINARY_MAX>                 \
     {                                               \
-        T init()                                    \
+        static T init()                                    \
         {                                           \
             return (T)((Tr)(0));                    \
         }                                           \
@@ -124,7 +124,7 @@ SPECIALIZE_COMPLEX_MAX(std::complex<double>, double)
     template<>                                      \
     struct Binary<T, AF_BINARY_MAX>                 \
     {                                               \
-        T init()                                    \
+        static T init()                                    \
         {                                           \
             return                                  \
             (T)(-std::numeric_limits<Tr>::max());   \

--- a/test/binary_ops.hpp
+++ b/test/binary_ops.hpp
@@ -14,7 +14,7 @@ std::complex<double> max(std::complex<double> lhs, std::complex<double> rhs);
 template<typename T, af_binary_op op>
 struct Binary
 {
-    static T init()
+    T init()
     {
         return (T)(0);
     }
@@ -28,7 +28,7 @@ struct Binary
 template<typename T>
 struct Binary<T, AF_BINARY_ADD>
 {
-    static T init()
+    T init()
     {
         return (T)(0);
     }
@@ -42,7 +42,7 @@ struct Binary<T, AF_BINARY_ADD>
 template<typename T>
 struct Binary<T, AF_BINARY_MUL>
 {
-    static T init()
+    T init()
     {
         return (T)(1);
     }
@@ -56,7 +56,7 @@ struct Binary<T, AF_BINARY_MUL>
 template<typename T>
 struct Binary<T, AF_BINARY_MIN>
 {
-    static T init()
+    T init()
     {
         return std::numeric_limits<T>::max();
     }
@@ -70,7 +70,7 @@ struct Binary<T, AF_BINARY_MIN>
 template<typename T>
 struct Binary<T, AF_BINARY_MAX>
 {
-    static T init()
+    T init()
     {
         return std::numeric_limits<T>::min();
     }
@@ -85,7 +85,7 @@ struct Binary<T, AF_BINARY_MAX>
     template<>                                      \
     struct Binary<T, AF_BINARY_MIN>                 \
     {                                               \
-        static T init()                             \
+        T init()                                    \
         {                                           \
             return                                  \
             (T)(std::numeric_limits<Tr>::max());    \
@@ -105,7 +105,7 @@ SPECIALIZE_COMPLEX_MIN(std::complex<double>, double)
     template<>                                      \
     struct Binary<T, AF_BINARY_MAX>                 \
     {                                               \
-        static T init()                             \
+        T init()                                    \
         {                                           \
             return (T)((Tr)(0));                    \
         }                                           \
@@ -124,7 +124,7 @@ SPECIALIZE_COMPLEX_MAX(std::complex<double>, double)
     template<>                                      \
     struct Binary<T, AF_BINARY_MAX>                 \
     {                                               \
-        static T init()                             \
+        T init()                                    \
         {                                           \
             return                                  \
             (T)(-std::numeric_limits<Tr>::max());   \

--- a/test/ireduce.cpp
+++ b/test/ireduce.cpp
@@ -337,3 +337,108 @@ TEST(IndexedReduce, MaxCplxNaN)
     }
 }
 
+TEST(IndexedReduce, MinPreferLargerIdxIfEqual)
+{
+    float test_data[] = {0.f, 50.f, 50.f, 0.f};
+    int len = 4;
+    array a(len, test_data);
+
+    float gold_min_val = 0.f;
+    int gold_min_idx = 3;
+
+    array min_val;
+    array min_idx;
+    min(min_val, min_idx, a);
+
+    vector<float> h_min_val(1);
+    min_val.host(&h_min_val[0]);
+
+    vector<int> h_min_idx(1);
+    min_idx.host(&h_min_idx[0]);
+
+    ASSERT_FLOAT_EQ(h_min_val[0], gold_min_val);
+    ASSERT_EQ(h_min_idx[0], gold_min_idx);
+}
+
+TEST(IndexedReduce, MaxPreferSmallerIdxIfEqual)
+{
+    float test_data[] = {0.f, 50.f, 50.f, 0.f};
+    int len = 4;
+    array a(len, test_data);
+
+    float gold_max_val = 50.f;
+    int gold_max_idx = 1;
+
+    array max_val;
+    array max_idx;
+    max(max_val, max_idx, a);
+
+    vector<float> h_max_val(1);
+    max_val.host(&h_max_val[0]);
+
+    vector<int> h_max_idx(1);
+    max_idx.host(&h_max_idx[0]);
+
+    ASSERT_FLOAT_EQ(h_max_val[0], gold_max_val);
+    ASSERT_EQ(h_max_idx[0], gold_max_idx);
+}
+
+TEST(IndexedReduce, MinCplxPreferLargerIdxIfEqual)
+{
+    float real_wnan_data[] = { 0.f, 50.f, 50.f, 0.f };
+    float imag_wnan_data[] = { 0.f, 50.f, 50.f, 0.f };
+
+    int len = 4;
+    array real_wnan(len, real_wnan_data);
+    array imag_wnan(len, imag_wnan_data);
+    array a = af::complex(real_wnan, imag_wnan);
+
+    float gold_min_real = 0.f;
+    float gold_min_imag = 0.f;
+    int gold_min_idx = 3;
+
+    array min_val;
+    array min_idx;
+    min(min_val, min_idx, a);
+
+    vector< complex<float> > h_min_val(1);
+    min_val.host(&h_min_val[0]);
+
+    vector<int> h_min_idx(1);
+    min_idx.host(&h_min_idx[0]);
+
+    ASSERT_FLOAT_EQ(h_min_val[0].real(), gold_min_real);
+    ASSERT_FLOAT_EQ(h_min_val[0].imag(), gold_min_imag);
+
+    ASSERT_EQ(h_min_idx[0], gold_min_idx);
+}
+
+TEST(IndexedReduce, MaxCplxPreferSmallerIdxIfEqual)
+{
+    float real_wnan_data[] = { 0.f, 50.f, 50.f, 0.f };
+    float imag_wnan_data[] = { 0.f, 50.f, 50.f, 0.f };
+
+    int len = 4;
+    array real_wnan(len, real_wnan_data);
+    array imag_wnan(len, imag_wnan_data);
+    array a = af::complex(real_wnan, imag_wnan);
+
+    float gold_max_real = 50.f;
+    float gold_max_imag = 50.f;
+    int gold_max_idx = 1;
+
+    array max_val;
+    array max_idx;
+    max(max_val, max_idx, a);
+
+    vector< complex<float> > h_max_val(1);
+    max_val.host(&h_max_val[0]);
+
+    vector<int> h_max_idx(1);
+    max_idx.host(&h_max_idx[0]);
+
+    ASSERT_FLOAT_EQ(h_max_val[0].real(), gold_max_real);
+    ASSERT_FLOAT_EQ(h_max_val[0].imag(), gold_max_imag);
+
+    ASSERT_EQ(h_max_idx[0], gold_max_idx);
+}

--- a/test/ireduce.cpp
+++ b/test/ireduce.cpp
@@ -197,12 +197,12 @@ TEST(IndexedReduce, MaxReduceDimensionHasSingleValue)
 
 TEST(IndexedReduce, MinNaN)
 {
-    float test_data[] = { 1, NAN, 5, 0.1, NAN, -0.5, NAN, 0 };
+    float test_data[] = { 1.f, NAN, 5.f, 0.1f, NAN, -0.5f, NAN, 0.f };
     int rows = 4;
     int cols = 2;
     array a(rows, cols, test_data);
 
-    float gold_min_val[] = { 0.1, -0.5 };
+    float gold_min_val[] = { 0.1f, -0.5f };
     int gold_min_idx[] = { 3, 1 };
 
     array min_val;
@@ -224,45 +224,45 @@ TEST(IndexedReduce, MinNaN)
     }
 }
 
-TEST(IndexedReduce, MaxNaN) 
-{ 
-    float test_data[] = { 1, NAN, 5, 0.1, NAN, -0.5, NAN, 0 }; 
-    int rows = 4; 
-    int cols = 2; 
-    array a(rows, cols, test_data); 
- 
-    float gold_max_val[] = { 5.0, 0.0 }; 
-    int gold_max_idx[] = { 2, 3 }; 
-     
-    array max_val; 
-    array max_idx; 
-    max(max_val, max_idx, a); 
- 
-    vector<float> h_max_val(cols); 
-    max_val.host(&h_max_val[0]); 
- 
-    vector<int> h_max_idx(cols); 
-    max_idx.host(&h_max_idx[0]); 
- 
-    for (int i = 0; i < cols; i++) { 
-        ASSERT_FLOAT_EQ(h_max_val[i], gold_max_val[i]); 
-    } 
- 
-    for (int i = 0; i < cols; i++) { 
-        ASSERT_EQ(h_max_idx[i], gold_max_idx[i]); 
-    } 
-} 
+TEST(IndexedReduce, MaxNaN)
+{
+    float test_data[] = { 1.f, NAN, 5.f, 0.1f, NAN, -0.5f, NAN, 0.f };
+    int rows = 4;
+    int cols = 2;
+    array a(rows, cols, test_data);
+
+    float gold_max_val[] = { 5.0f, 0.f };
+    int gold_max_idx[] = { 2, 3 };
+
+    array max_val;
+    array max_idx;
+    max(max_val, max_idx, a);
+
+    vector<float> h_max_val(cols);
+    max_val.host(&h_max_val[0]);
+
+    vector<int> h_max_idx(cols);
+    max_idx.host(&h_max_idx[0]);
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_FLOAT_EQ(h_max_val[i], gold_max_val[i]);
+    }
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_EQ(h_max_idx[i], gold_max_idx[i]);
+    }
+}
 
 TEST(IndexedReduce, MinCplxNaN)
 {
     float real_wnan_data[] = {
-        0.005, NAN, -6.3, NAN, -0.5,
-        NAN, NAN, 0.2, -1205.4, 8.9
+        0.005f, NAN, -6.3f, NAN, -0.5f,
+        NAN, NAN, 0.2f, -1205.4f, 8.9f
     };
 
     float imag_wnan_data[] = {
-        NAN, NAN, -9.0, -0.005, -0.3,
-        0.007, NAN, 0.1, NAN, 4.5
+        NAN, NAN, -9.0f, -0.005f, -0.3f,
+        0.007f, NAN, 0.1f, NAN, 4.5f
     };
 
     int rows = 5;
@@ -271,8 +271,8 @@ TEST(IndexedReduce, MinCplxNaN)
     array imag_wnan(rows, cols, imag_wnan_data);
     array a = af::complex(real_wnan, imag_wnan);
 
-    float gold_min_real[] = { -0.5, 0.2 };
-    float gold_min_imag[] = { -0.3, 0.1 };
+    float gold_min_real[] = { -0.5f, 0.2f };
+    float gold_min_imag[] = { -0.3f, 0.1f };
     int gold_min_idx[] = { 4, 2 };
 
     array min_val;
@@ -295,45 +295,45 @@ TEST(IndexedReduce, MinCplxNaN)
     }
 }
 
-TEST(IndexedReduce, MaxCplxNaN) 
-{ 
-    float real_wnan_data[] = { 
-        0.005, NAN, -6.3, NAN, -0.5, 
-        NAN, NAN, 0.2, -1205.4, 8.9 
-    }; 
- 
-    float imag_wnan_data[] = { 
-        NAN, NAN, -9.0, -0.005, -0.3, 
-        0.007, NAN, 0.1, NAN, 4.5 
-    }; 
- 
-    int rows = 5; 
-    int cols = 2; 
-    array real_wnan(rows, cols, real_wnan_data); 
-    array imag_wnan(rows, cols, imag_wnan_data); 
-    array a = af::complex(real_wnan, imag_wnan); 
- 
-    float gold_max_real[] = { -6.3, 8.9 }; 
-    float gold_max_imag[] = { -9.0, 4.5 }; 
-    int gold_max_idx[] = { 2, 4 }; 
-     
-    array max_val; 
-    array max_idx; 
-    af::max(max_val, max_idx, a); 
- 
-    vector< complex<float> > h_max_val(cols); 
-    max_val.host(&h_max_val[0]); 
- 
-    vector<int> h_max_idx(cols); 
-    max_idx.host(&h_max_idx[0]); 
- 
-    for (int i = 0; i < cols; i++) { 
-        ASSERT_FLOAT_EQ(h_max_val[i].real(), gold_max_real[i]); 
-        ASSERT_FLOAT_EQ(h_max_val[i].imag(), gold_max_imag[i]); 
-    } 
- 
-    for (int i = 0; i < cols; i++) { 
-        ASSERT_EQ(h_max_idx[i], gold_max_idx[i]); 
-    } 
-} 
+TEST(IndexedReduce, MaxCplxNaN)
+{
+    float real_wnan_data[] = {
+        0.005f, NAN, -6.3f, NAN, -0.5f,
+        NAN, NAN, 0.2f, -1205.4f, 8.9f
+    };
+
+    float imag_wnan_data[] = {
+        NAN, NAN, -9.0f, -0.005f, -0.3f,
+        0.007f, NAN, 0.1f, NAN, 4.5f
+    };
+
+    int rows = 5;
+    int cols = 2;
+    array real_wnan(rows, cols, real_wnan_data);
+    array imag_wnan(rows, cols, imag_wnan_data);
+    array a = af::complex(real_wnan, imag_wnan);
+
+    float gold_max_real[] = { -6.3f, 8.9f };
+    float gold_max_imag[] = { -9.0f, 4.5f };
+    int gold_max_idx[] = { 2, 4 };
+
+    array max_val;
+    array max_idx;
+    af::max(max_val, max_idx, a);
+
+    vector< complex<float> > h_max_val(cols);
+    max_val.host(&h_max_val[0]);
+
+    vector<int> h_max_idx(cols);
+    max_idx.host(&h_max_idx[0]);
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_FLOAT_EQ(h_max_val[i].real(), gold_max_real[i]);
+        ASSERT_FLOAT_EQ(h_max_val[i].imag(), gold_max_imag[i]);
+    }
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_EQ(h_max_idx[i], gold_max_idx[i]);
+    }
+}
 

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -629,6 +629,15 @@ TEST(MinMax, MaxCplxNaN)
         NAN, NAN, 106.103029, 128.447592, 672.343090
     };
 
+    // 4th element is unusually large to cover the case where
+    //  one part holds the largest value among the array,
+    //  and the other part is NaN.
+    // There's a possibility where the NaN is turned into 0
+    //  (since Binary<>::init() will initialize it to 0 in
+    //  for complex max op) during the comparisons, and so its 
+    //  magnitude will determine that that element is the max, 
+    //  whereas it should have been ignored since its other 
+    //  part is NaN
     float imag_wnan_data[] = {
         NAN, NAN, 728.556795, 7414701.03, 465.926785,
         175.408103, NAN, 464.726170, NAN, 934.297652

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 
 using std::vector;
+using std::complex;
 using std::string;
 using std::cout;
 using std::endl;
@@ -532,88 +533,30 @@ TEST(MinMax, MinMaxNaN)
     freeHost(h_A);
 }
 
-TEST(MinMax, MinLocNaN)
-{
-    float test_data[] = { 1, NAN, 5, 0.1, NAN, -0.5, NAN, 0 };
-    int rows = 4;
-    int cols = 2;
-    af::array a(rows, cols, test_data);
-
-    float gold_min_val[] = { 0.1, -0.5 };
-    int gold_min_idx[] = { 3, 1 };
-    
-    af::array min_val;
-    af::array min_idx;
-    af::min(min_val, min_idx, a);
-
-    std::vector<float> h_min_val(cols);
-    min_val.host(&h_min_val[0]);
-
-    std::vector<int> h_min_idx(cols);
-    min_idx.host(&h_min_idx[0]);
-
-    for (int i = 0; i < cols; i++) {
-        ASSERT_FLOAT_EQ(h_min_val[i], gold_min_val[i]);
-    }
-
-    for (int i = 0; i < cols; i++) {
-        ASSERT_FLOAT_EQ(h_min_idx[i], gold_min_idx[i]);
-    }
-}
-
-TEST(MinMax, MaxLocNaN)
-{
-    float test_data[] = { 1, NAN, 5, 0.1, NAN, -0.5, NAN, 0 };
-    int rows = 4;
-    int cols = 2;
-    af::array a(rows, cols, test_data);
-
-    float gold_max_val[] = { 5.0, 0.0 };
-    int gold_max_idx[] = { 2, 3 };
-    
-    af::array max_val;
-    af::array max_idx;
-    af::max(max_val, max_idx, a);
-
-    std::vector<float> h_max_val(cols);
-    max_val.host(&h_max_val[0]);
-
-    std::vector<int> h_max_idx(cols);
-    max_idx.host(&h_max_idx[0]);
-
-    for (int i = 0; i < cols; i++) {
-        ASSERT_FLOAT_EQ(h_max_val[i], gold_max_val[i]);
-    }
-
-    for (int i = 0; i < cols; i++) {
-        ASSERT_FLOAT_EQ(h_max_idx[i], gold_max_idx[i]);
-    }
-}
-
 TEST(MinMax, MinCplxNaN)
 {
     float real_wnan_data[] = {
-        849.088836, NAN, 889.189274, NAN, 506.472337,
-        NAN, NAN, 106.103029, 128.447592, 672.343090
+        0.005, NAN, -6.3, NAN, -0.5,
+        NAN, NAN, 0.2, -1205.4, 8.9
     };
 
     float imag_wnan_data[] = {
-        NAN, NAN, 728.556795, 741.470103, 465.926785,
-        175.408103, NAN, 464.726170, NAN, 934.297652
+        NAN, NAN, -9.0, -0.005, -0.3,
+        0.007, NAN, 0.1, NAN, 4.5
     };
 
     int rows = 5;
     int cols = 2;
-    af::array real_wnan(rows, cols, real_wnan_data);
-    af::array imag_wnan(rows, cols, imag_wnan_data);
-    af::array a = af::complex(real_wnan, imag_wnan);
+    array real_wnan(rows, cols, real_wnan_data);
+    array imag_wnan(rows, cols, imag_wnan_data);
+    array a = af::complex(real_wnan, imag_wnan);
 
-    float gold_min_real[] = { 506.472337, 106.103029 };
-    float gold_min_imag[] = { 465.926785, 464.726170 };
+    float gold_min_real[] = { -0.5, 0.2 };
+    float gold_min_imag[] = { -0.3, 0.1 };
     
-    af::array min_val = af::min(a);
+    array min_val = af::min(a);
 
-    std::vector< std::complex<float> > h_min_val(cols);
+    vector< complex<float> > h_min_val(cols);
     min_val.host(&h_min_val[0]);
 
     for (int i = 0; i < cols; i++) {
@@ -624,11 +567,6 @@ TEST(MinMax, MinCplxNaN)
 
 TEST(MinMax, MaxCplxNaN)
 {
-    float real_wnan_data[] = {
-        849.088836, NAN, 889.189274, NAN, 506.472337,
-        NAN, NAN, 106.103029, 128.447592, 672.343090
-    };
-
     // 4th element is unusually large to cover the case where
     //  one part holds the largest value among the array,
     //  and the other part is NaN.
@@ -638,112 +576,33 @@ TEST(MinMax, MaxCplxNaN)
     //  magnitude will determine that that element is the max, 
     //  whereas it should have been ignored since its other 
     //  part is NaN
+    float real_wnan_data[] = {
+        0.005, NAN, -6.3, NAN, -0.5,
+        NAN, NAN, 0.2, -1205.4, 8.9
+    };
+
     float imag_wnan_data[] = {
-        NAN, NAN, 728.556795, 7414701.03, 465.926785,
-        175.408103, NAN, 464.726170, NAN, 934.297652
+        NAN, NAN, -9.0, -0.005, -0.3,
+        0.007, NAN, 0.1, NAN, 4.5
     };
 
     int rows = 5;
     int cols = 2;
-    af::array real_wnan(rows, cols, real_wnan_data);
-    af::array imag_wnan(rows, cols, imag_wnan_data);
-    af::array a = af::complex(real_wnan, imag_wnan);
+    array real_wnan(rows, cols, real_wnan_data);
+    array imag_wnan(rows, cols, imag_wnan_data);
+    array a = af::complex(real_wnan, imag_wnan);
 
-    float gold_max_real[] = { 889.189274, 672.343090 };
-    float gold_max_imag[] = { 728.556795, 934.297652 };
+    float gold_max_real[] = { -6.3, 8.9 };
+    float gold_max_imag[] = { -9.0, 4.5 };
     
-    af::array max_val = af::max(a);
+    array max_val = af::max(a);
 
-    std::vector< std::complex<float> > h_max_val(cols);
+    vector< complex<float> > h_max_val(cols);
     max_val.host(&h_max_val[0]);
 
     for (int i = 0; i < cols; i++) {
         ASSERT_FLOAT_EQ(h_max_val[i].real(), gold_max_real[i]);
         ASSERT_FLOAT_EQ(h_max_val[i].imag(), gold_max_imag[i]);
-    }
-}
-
-TEST(MinMax, MinLocCplxNaN)
-{
-    float real_wnan_data[] = {
-        849.088836, NAN, 889.189274, NAN, 506.472337,
-        NAN, NAN, 106.103029, 128.447592, 672.343090
-    };
-
-    float imag_wnan_data[] = {
-        NAN, NAN, 728.556795, 741.470103, 465.926785,
-        175.408103, NAN, 464.726170, NAN, 934.297652
-    };
-
-    int rows = 5;
-    int cols = 2;
-    af::array real_wnan(rows, cols, real_wnan_data);
-    af::array imag_wnan(rows, cols, imag_wnan_data);
-    af::array a = af::complex(real_wnan, imag_wnan);
-
-    float gold_min_real[] = { 506.472337, 106.103029 };
-    float gold_min_imag[] = { 465.926785, 464.726170 };
-    int gold_min_idx[] = { 4, 2 };
-    
-    af::array min_val;
-    af::array min_idx;
-    af::min(min_val, min_idx, a);
-
-    std::vector< std::complex<float> > h_min_val(cols);
-    min_val.host(&h_min_val[0]);
-
-    std::vector<int> h_min_idx(cols);
-    min_idx.host(&h_min_idx[0]);
-
-    for (int i = 0; i < cols; i++) {
-        ASSERT_FLOAT_EQ(h_min_val[i].real(), gold_min_real[i]);
-        ASSERT_FLOAT_EQ(h_min_val[i].imag(), gold_min_imag[i]);
-    }
-
-    for (int i = 0; i < cols; i++) {
-        ASSERT_FLOAT_EQ(h_min_idx[i], gold_min_idx[i]);
-    }
-}
-
-TEST(MinMax, MaxLocCplxNaN)
-{
-    float real_wnan_data[] = {
-        849.088836, NAN, 889.189274, NAN, 506.472337,
-        NAN, NAN, 106.103029, 128.447592, 672.343090
-    };
-
-    float imag_wnan_data[] = {
-        NAN, NAN, 728.556795, 741.470103, 465.926785,
-        175.408103, NAN, 464.726170, NAN, 934.297652
-    };
-
-    int rows = 5;
-    int cols = 2;
-    af::array real_wnan(rows, cols, real_wnan_data);
-    af::array imag_wnan(rows, cols, imag_wnan_data);
-    af::array a = af::complex(real_wnan, imag_wnan);
-
-    float gold_max_real[] = { 889.189274, 672.343090 };
-    float gold_max_imag[] = { 728.556795, 934.297652 };
-    int gold_max_idx[] = { 2, 4 };
-    
-    af::array max_val;
-    af::array max_idx;
-    af::max(max_val, max_idx, a);
-
-    std::vector< std::complex<float> > h_max_val(cols);
-    max_val.host(&h_max_val[0]);
-
-    std::vector<int> h_max_idx(cols);
-    max_idx.host(&h_max_idx[0]);
-
-    for (int i = 0; i < cols; i++) {
-        ASSERT_FLOAT_EQ(h_max_val[i].real(), gold_max_real[i]);
-        ASSERT_FLOAT_EQ(h_max_val[i].imag(), gold_max_imag[i]);
-    }
-
-    for (int i = 0; i < cols; i++) {
-        ASSERT_FLOAT_EQ(h_max_idx[i], gold_max_idx[i]);
     }
 }
 

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -508,7 +508,7 @@ TYPED_TEST(Reduce, Test_Any_Global)
     }
 }
 
-TEST(MinMax, NaN)
+TEST(MinMax, MinMaxNaN)
 {
     const int num = 10000;
     array A = randu(num);
@@ -530,6 +530,212 @@ TEST(MinMax, NaN)
     }
 
     freeHost(h_A);
+}
+
+TEST(MinMax, MinLocNaN)
+{
+    float test_data[] = { 1, NAN, 5, 0.1, NAN, -0.5, NAN, 0 };
+    int rows = 4;
+    int cols = 2;
+    af::array a(rows, cols, test_data);
+
+    float gold_min_val[] = { 0.1, -0.5 };
+    int gold_min_idx[] = { 3, 1 };
+    
+    af::array min_val;
+    af::array min_idx;
+    af::min(min_val, min_idx, a);
+
+    std::vector<float> h_min_val(cols);
+    min_val.host(&h_min_val[0]);
+
+    std::vector<int> h_min_idx(cols);
+    min_idx.host(&h_min_idx[0]);
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_FLOAT_EQ(h_min_val[i], gold_min_val[i]);
+    }
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_FLOAT_EQ(h_min_idx[i], gold_min_idx[i]);
+    }
+}
+
+TEST(MinMax, MaxLocNaN)
+{
+    float test_data[] = { 1, NAN, 5, 0.1, NAN, -0.5, NAN, 0 };
+    int rows = 4;
+    int cols = 2;
+    af::array a(rows, cols, test_data);
+
+    float gold_max_val[] = { 5.0, 0.0 };
+    int gold_max_idx[] = { 2, 3 };
+    
+    af::array max_val;
+    af::array max_idx;
+    af::max(max_val, max_idx, a);
+
+    std::vector<float> h_max_val(cols);
+    max_val.host(&h_max_val[0]);
+
+    std::vector<int> h_max_idx(cols);
+    max_idx.host(&h_max_idx[0]);
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_FLOAT_EQ(h_max_val[i], gold_max_val[i]);
+    }
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_FLOAT_EQ(h_max_idx[i], gold_max_idx[i]);
+    }
+}
+
+TEST(MinMax, MinCplxNaN)
+{
+    float real_wnan_data[] = {
+        849.088836, NAN, 889.189274, NAN, 506.472337,
+        NAN, NAN, 106.103029, 128.447592, 672.343090
+    };
+
+    float imag_wnan_data[] = {
+        NAN, NAN, 728.556795, 741.470103, 465.926785,
+        175.408103, NAN, 464.726170, NAN, 934.297652
+    };
+
+    int rows = 5;
+    int cols = 2;
+    af::array real_wnan(rows, cols, real_wnan_data);
+    af::array imag_wnan(rows, cols, imag_wnan_data);
+    af::array a = af::complex(real_wnan, imag_wnan);
+
+    float gold_min_real[] = { 506.472337, 106.103029 };
+    float gold_min_imag[] = { 465.926785, 464.726170 };
+    
+    af::array min_val = af::min(a);
+
+    std::vector< std::complex<float> > h_min_val(cols);
+    min_val.host(&h_min_val[0]);
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_FLOAT_EQ(h_min_val[i].real(), gold_min_real[i]);
+        ASSERT_FLOAT_EQ(h_min_val[i].imag(), gold_min_imag[i]);
+    }
+}
+
+TEST(MinMax, MaxCplxNaN)
+{
+    float real_wnan_data[] = {
+        849.088836, NAN, 889.189274, NAN, 506.472337,
+        NAN, NAN, 106.103029, 128.447592, 672.343090
+    };
+
+    float imag_wnan_data[] = {
+        NAN, NAN, 728.556795, 7414701.03, 465.926785,
+        175.408103, NAN, 464.726170, NAN, 934.297652
+    };
+
+    int rows = 5;
+    int cols = 2;
+    af::array real_wnan(rows, cols, real_wnan_data);
+    af::array imag_wnan(rows, cols, imag_wnan_data);
+    af::array a = af::complex(real_wnan, imag_wnan);
+
+    float gold_max_real[] = { 889.189274, 672.343090 };
+    float gold_max_imag[] = { 728.556795, 934.297652 };
+    
+    af::array max_val = af::max(a);
+
+    std::vector< std::complex<float> > h_max_val(cols);
+    max_val.host(&h_max_val[0]);
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_FLOAT_EQ(h_max_val[i].real(), gold_max_real[i]);
+        ASSERT_FLOAT_EQ(h_max_val[i].imag(), gold_max_imag[i]);
+    }
+}
+
+TEST(MinMax, MinLocCplxNaN)
+{
+    float real_wnan_data[] = {
+        849.088836, NAN, 889.189274, NAN, 506.472337,
+        NAN, NAN, 106.103029, 128.447592, 672.343090
+    };
+
+    float imag_wnan_data[] = {
+        NAN, NAN, 728.556795, 741.470103, 465.926785,
+        175.408103, NAN, 464.726170, NAN, 934.297652
+    };
+
+    int rows = 5;
+    int cols = 2;
+    af::array real_wnan(rows, cols, real_wnan_data);
+    af::array imag_wnan(rows, cols, imag_wnan_data);
+    af::array a = af::complex(real_wnan, imag_wnan);
+
+    float gold_min_real[] = { 506.472337, 106.103029 };
+    float gold_min_imag[] = { 465.926785, 464.726170 };
+    int gold_min_idx[] = { 4, 2 };
+    
+    af::array min_val;
+    af::array min_idx;
+    af::min(min_val, min_idx, a);
+
+    std::vector< std::complex<float> > h_min_val(cols);
+    min_val.host(&h_min_val[0]);
+
+    std::vector<int> h_min_idx(cols);
+    min_idx.host(&h_min_idx[0]);
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_FLOAT_EQ(h_min_val[i].real(), gold_min_real[i]);
+        ASSERT_FLOAT_EQ(h_min_val[i].imag(), gold_min_imag[i]);
+    }
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_FLOAT_EQ(h_min_idx[i], gold_min_idx[i]);
+    }
+}
+
+TEST(MinMax, MaxLocCplxNaN)
+{
+    float real_wnan_data[] = {
+        849.088836, NAN, 889.189274, NAN, 506.472337,
+        NAN, NAN, 106.103029, 128.447592, 672.343090
+    };
+
+    float imag_wnan_data[] = {
+        NAN, NAN, 728.556795, 741.470103, 465.926785,
+        175.408103, NAN, 464.726170, NAN, 934.297652
+    };
+
+    int rows = 5;
+    int cols = 2;
+    af::array real_wnan(rows, cols, real_wnan_data);
+    af::array imag_wnan(rows, cols, imag_wnan_data);
+    af::array a = af::complex(real_wnan, imag_wnan);
+
+    float gold_max_real[] = { 889.189274, 672.343090 };
+    float gold_max_imag[] = { 728.556795, 934.297652 };
+    int gold_max_idx[] = { 2, 4 };
+    
+    af::array max_val;
+    af::array max_idx;
+    af::max(max_val, max_idx, a);
+
+    std::vector< std::complex<float> > h_max_val(cols);
+    max_val.host(&h_max_val[0]);
+
+    std::vector<int> h_max_idx(cols);
+    max_idx.host(&h_max_idx[0]);
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_FLOAT_EQ(h_max_val[i].real(), gold_max_real[i]);
+        ASSERT_FLOAT_EQ(h_max_val[i].imag(), gold_max_imag[i]);
+    }
+
+    for (int i = 0; i < cols; i++) {
+        ASSERT_FLOAT_EQ(h_max_idx[i], gold_max_idx[i]);
+    }
 }
 
 TEST(Count, NaN)

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -536,13 +536,13 @@ TEST(MinMax, MinMaxNaN)
 TEST(MinMax, MinCplxNaN)
 {
     float real_wnan_data[] = {
-        0.005, NAN, -6.3, NAN, -0.5,
-        NAN, NAN, 0.2, -1205.4, 8.9
+        0.005f, NAN, -6.3f, NAN, -0.5f,
+        NAN, NAN, 0.2f, -1205.4f, 8.9f
     };
 
     float imag_wnan_data[] = {
-        NAN, NAN, -9.0, -0.005, -0.3,
-        0.007, NAN, 0.1, NAN, 4.5
+        NAN, NAN, -9.0f, -0.005f, -0.3f,
+        0.007f, NAN, 0.1f, NAN, 4.5f
     };
 
     int rows = 5;
@@ -551,9 +551,9 @@ TEST(MinMax, MinCplxNaN)
     array imag_wnan(rows, cols, imag_wnan_data);
     array a = af::complex(real_wnan, imag_wnan);
 
-    float gold_min_real[] = { -0.5, 0.2 };
-    float gold_min_imag[] = { -0.3, 0.1 };
-    
+    float gold_min_real[] = { -0.5f, 0.2f };
+    float gold_min_imag[] = { -0.3f, 0.1f };
+
     array min_val = af::min(a);
 
     vector< complex<float> > h_min_val(cols);
@@ -572,18 +572,18 @@ TEST(MinMax, MaxCplxNaN)
     //  and the other part is NaN.
     // There's a possibility where the NaN is turned into 0
     //  (since Binary<>::init() will initialize it to 0 in
-    //  for complex max op) during the comparisons, and so its 
-    //  magnitude will determine that that element is the max, 
-    //  whereas it should have been ignored since its other 
+    //  for complex max op) during the comparisons, and so its
+    //  magnitude will determine that that element is the max,
+    //  whereas it should have been ignored since its other
     //  part is NaN
     float real_wnan_data[] = {
-        0.005, NAN, -6.3, NAN, -0.5,
-        NAN, NAN, 0.2, -1205.4, 8.9
+        0.005f, NAN, -6.3f, NAN, -0.5f,
+        NAN, NAN, 0.2f, -1205.4f, 8.9f
     };
 
     float imag_wnan_data[] = {
-        NAN, NAN, -9.0, -0.005, -0.3,
-        0.007, NAN, 0.1, NAN, 4.5
+        NAN, NAN, -9.0f, -0.005f, -0.3f,
+        0.007f, NAN, 0.1f, NAN, 4.5f
     };
 
     int rows = 5;
@@ -592,9 +592,9 @@ TEST(MinMax, MaxCplxNaN)
     array imag_wnan(rows, cols, imag_wnan_data);
     array a = af::complex(real_wnan, imag_wnan);
 
-    float gold_max_real[] = { -6.3, 8.9 };
-    float gold_max_imag[] = { -9.0, 4.5 };
-    
+    float gold_max_real[] = { -6.3f, 8.9f };
+    float gold_max_imag[] = { -9.0f, 4.5f };
+
     array max_val = af::max(a);
 
     vector< complex<float> > h_max_val(cols);

--- a/test/scan_by_key.cpp
+++ b/test/scan_by_key.cpp
@@ -96,7 +96,7 @@ void verify(af::dim4 dims,
 
     for (int start = 0; start < stride; ++start) {
         Tk keyval = key[start];
-        To gold = binOp.init();
+        To gold = Binary<To, op>::init();
         for (int index = start + (!inclusive_scan)*stride, i = (!inclusive_scan);
                 index < elemCount;
                 index += stride, i = (i+1)%dims[scanDim]) {
@@ -106,7 +106,7 @@ void verify(af::dim4 dims,
                     gold = (To)in[index];
                     ASSERT_NEAR(gold, out[index], eps);
                 } else {
-                    gold = binOp.init();
+                    gold = Binary<To, op>::init();
                 }
             } else {
                 To dataval = (To)in[index - (!inclusive_scan)*stride];

--- a/test/scan_by_key.cpp
+++ b/test/scan_by_key.cpp
@@ -96,7 +96,7 @@ void verify(af::dim4 dims,
 
     for (int start = 0; start < stride; ++start) {
         Tk keyval = key[start];
-        To gold = Binary<To, op>::init();
+        To gold = binOp.init();
         for (int index = start + (!inclusive_scan)*stride, i = (!inclusive_scan);
                 index < elemCount;
                 index += stride, i = (i+1)%dims[scanDim]) {
@@ -106,7 +106,7 @@ void verify(af::dim4 dims,
                     gold = (To)in[index];
                     ASSERT_NEAR(gold, out[index], eps);
                 } else {
-                    gold = Binary<To, op>::init();
+                    gold = binOp.init();
                 }
             } else {
                 To dataval = (To)in[index - (!inclusive_scan)*stride];


### PR DESCRIPTION
Resolves #2130 and also tries to cover the case for complex types as well. Currently, CUDA backend is still being worked on for the complex types.

The essence of the fixes are:
- Guard against the next examined value being a NaN (all backends)
- If the initial min/max value is a NaN (first element of array in CPU, first element that a thread picks up in CUDA and OpenCL) , set it instead to `Binary<T, op>::init()`
- Element index order checks are removed from CUDA backend, since they only make sense to use in a serial reduction (CPU), not in parallel
- The issue only concerns indexed min/max, but OpenCL's non-indexed min/max also had incorrect results also for complex types. Adding the guard fixes it