### PR TITLE
Make FreeImage a run-time instead of a link-time dependency

### DIFF
--- a/src/api/c/CMakeLists.txt
+++ b/src/api/c/CMakeLists.txt
@@ -58,6 +58,7 @@ target_sources(c_api_interface
     ${CMAKE_CURRENT_SOURCE_DIR}/corrcoef.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/covariance.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/DependencyModule.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/det.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/diff.cpp
@@ -155,9 +156,10 @@ target_sources(c_api_interface
 if(FreeImage_FOUND AND AF_WITH_IMAGEIO)
   target_compile_definitions(c_api_interface INTERFACE WITH_FREEIMAGE)
   if (AF_WITH_STATIC_FREEIMAGE)
+    target_compile_definitions(c_api_interface INTERFACE FREEIMAGE_STATIC)
     target_link_libraries(c_api_interface INTERFACE FreeImage::FreeImage_STATIC)
   else ()
-    target_link_libraries(c_api_interface INTERFACE FreeImage::FreeImage)
+    target_include_directories(c_api_interface INTERFACE $<TARGET_PROPERTY:FreeImage::FreeImage,INTERFACE_INCLUDE_DIRECTORIES>)
     if (WIN32 AND AF_INSTALL_STANDALONE)
       install(FILES $<TARGET_FILE:FreeImage::FreeImage>
         DESTINATION ${AF_INSTALL_BIN_DIR}

--- a/src/api/c/DependencyModule.cpp
+++ b/src/api/c/DependencyModule.cpp
@@ -1,0 +1,101 @@
+
+#include <DependencyModule.hpp>
+#include <algorithm>
+#include <string>
+
+using std::string;
+namespace {
+
+#if(OS_WIN)
+    static const char* librarySuffix = ".dll";
+    static const char* libraryPrefix = "";
+
+    LibHandle loadLibrary(const char* library_name) {
+        return LoadLibrary(library_name);
+    }
+
+    void unloadLibrary(LibHandle handle) {
+        FreeLibrary(handle);
+    }
+
+    string getErrorMessage() {
+        LPVOID lpMsgBuf;
+        LPVOID lpDisplayBuf;
+        DWORD dw = GetLastError();
+
+        size_t characters_in_message;
+        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                      FORMAT_MESSAGE_FROM_SYSTEM |
+                      FORMAT_MESSAGE_IGNORE_INSERTS,
+                      NULL,
+                      dw,
+                      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                      (LPTSTR) &lpMsgBuf,
+                      0, NULL );
+        string error_message(lpMsgBuf);
+        return error_message;
+    }
+
+#else
+#if(OS_MAC)
+    static const char* librarySuffix = ".dylib";
+#else
+    static const char* librarySuffix = ".so";
+#endif
+
+    static const char* libraryPrefix = "lib";
+
+    LibHandle loadLibrary(const char* library_name) {
+        return dlopen(library_name, RTLD_LAZY);
+    }
+    void unloadLibrary(LibHandle handle) {
+        dlclose(handle);
+    }
+
+    string getErrorMessage() {
+        string error_message(dlerror());
+        return error_message;
+    }
+
+#endif
+
+    std::string libName(std::string name) {
+        return libraryPrefix + name + librarySuffix;
+    }
+}
+
+#if(OS_WIN)
+void* DependencyModule::getFunctionPointer(LibHandle handle, const char* name) {
+    return GetProcAddress(handle, symbolName);
+}
+#else
+void* DependencyModule::getFunctionPointer(LibHandle handle, const char* name) {
+    return dlsym(handle, name);
+}
+#endif
+
+DependencyModule::DependencyModule(const char* plugin_file_name, const char** paths)
+    : handle(nullptr) {
+    // TODO(umar): Implement handling of non-standard paths
+    if(plugin_file_name) {
+        handle = loadLibrary(libName(plugin_file_name).c_str());
+    }
+}
+
+DependencyModule::~DependencyModule() {
+    if(handle) {
+        unloadLibrary(handle);
+    }
+}
+
+bool DependencyModule::isLoaded() {
+    return (bool)handle;
+}
+
+bool DependencyModule::symbolsLoaded() {
+    return all_of(begin(functions), end(functions), [](void* ptr){ return ptr != nullptr; });
+}
+
+string DependencyModule::getErrorMessage() {
+    return ::getErrorMessage();
+}

--- a/src/api/c/DependencyModule.hpp
+++ b/src/api/c/DependencyModule.hpp
@@ -1,0 +1,55 @@
+#pragma once
+#include <dlfcn.h>
+#include <utility>
+#include <type_traits>
+#include <vector>
+#include <string>
+
+#if(OS_WIN)
+#include <Windows.h>
+using LibHandle = HMODULE;
+#else
+using LibHandle = void*;
+#endif
+
+/// Allows you to create classes which dynamically load dependencies at runtime
+///
+/// Creates a dependency module which will dynamically load a library
+/// at runtime instead of at link time. This class will be a component of a
+/// module class which will have member functions for each of the functions
+/// we use in ArrayFire
+class DependencyModule {
+  LibHandle handle;
+  std::vector<void*> functions;
+  void* getFunctionPointer(LibHandle handle, const char* name);
+
+public:
+  DependencyModule(const char* plugin_file_name, const char** paths = nullptr);
+
+  ~DependencyModule();
+
+  /// Returns a function pointer to the function with the name symbol_name
+  template<typename T>
+  T getSymbol(const char* symbol_name) {
+      functions.push_back(getFunctionPointer(handle, symbol_name));
+      return (T)functions.back();
+  }
+
+  /// Returns true if the module was successfully loaded
+  bool isLoaded();
+
+  /// Returns true if the module was successfully loaded
+  bool symbolsLoaded();
+
+  /// Returns the last error message that occurred because of loading the
+  /// library
+  std::string getErrorMessage();
+};
+
+/// Creates a function pointer
+#define MODULE_MEMBER(NAME)                     \
+  decltype(&::NAME) NAME
+
+/// Dynamically loads the function pointer at runtime
+#define MODULE_FUNCTION_INIT(NAME)                \
+  NAME = module.getSymbol<decltype(&::NAME)>(#NAME)

--- a/src/api/c/imageio.cpp
+++ b/src/api/c/imageio.cpp
@@ -26,13 +26,19 @@
 #include <common/err_common.hpp>
 #include <handle.hpp>
 
+#include <DependencyModule.hpp>
+
 #include <string>
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
+#include <memory>
 
 using af::dim4;
 using namespace detail;
+using std::unique_ptr;
+using std::string;
+using std::swap;
 
 template<typename T, FI_CHANNELS fi_color, FI_CHANNELS fo_color>
 static af_err readImage(af_array *rImage, const uchar* pSrcLine, const int nSrcPitch,
@@ -78,6 +84,85 @@ static af_err readImage(af_array *rImage, const uchar* pSrcLine, const int nSrcP
     af_err err = af_create_array(rImage, pDst, dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<float>::af_type);
     pinnedFree(pDst);
     return err;
+}
+
+#ifdef FREEIMAGE_STATIC
+    // NOTE: Redefine the MODULE_FUNCTION_INIT macro to call the static functions
+    // instead of dynamically loaded symbols in case we are building with a static
+    // FreeImage library
+    #define MODULE_FUNCTION_INIT(NAME)                  \
+      NAME = &::NAME
+
+FreeImage_Module::FreeImage_Module()
+  : module(nullptr, nullptr) {
+    // We don't care if the module loaded if we are staticly linking against
+    // FreeImage
+    ::FreeImage_Initialise(false);
+#else
+FreeImage_Module::FreeImage_Module()
+  : module("freeimage", nullptr) {
+    printf(__FILE__"%d\n", __LINE__);
+    if(!module.isLoaded()) {
+        printf(__FILE__"%d\n", __LINE__);
+        string error_message = "Error loading FreeImage: " + module.getErrorMessage()
+            + "\nFreeImage or one of it's dependencies failed to "
+              "load. Try installing FreeImage or check if FreeImage is in the "
+              "search path.";
+        printf(__FILE__"%d\n", __LINE__);
+        AF_ERROR(error_message.c_str(), AF_ERR_LOAD_LIB);
+    }
+#endif
+    MODULE_FUNCTION_INIT(FreeImage_Allocate);
+    MODULE_FUNCTION_INIT(FreeImage_AllocateT);
+    MODULE_FUNCTION_INIT(FreeImage_CloseMemory);
+    MODULE_FUNCTION_INIT(FreeImage_DeInitialise);
+    MODULE_FUNCTION_INIT(FreeImage_FIFSupportsReading);
+    MODULE_FUNCTION_INIT(FreeImage_GetBPP);
+    MODULE_FUNCTION_INIT(FreeImage_GetBits);
+    MODULE_FUNCTION_INIT(FreeImage_GetColorType);
+    MODULE_FUNCTION_INIT(FreeImage_GetFIFFromFilename);
+    MODULE_FUNCTION_INIT(FreeImage_GetFileType);
+    MODULE_FUNCTION_INIT(FreeImage_GetFileTypeFromMemory);
+    MODULE_FUNCTION_INIT(FreeImage_GetHeight);
+    MODULE_FUNCTION_INIT(FreeImage_GetImageType);
+    MODULE_FUNCTION_INIT(FreeImage_GetPitch);
+    MODULE_FUNCTION_INIT(FreeImage_GetWidth);
+    MODULE_FUNCTION_INIT(FreeImage_Initialise);
+    MODULE_FUNCTION_INIT(FreeImage_Load);
+    MODULE_FUNCTION_INIT(FreeImage_LoadFromMemory);
+    MODULE_FUNCTION_INIT(FreeImage_OpenMemory);
+    MODULE_FUNCTION_INIT(FreeImage_Save);
+    MODULE_FUNCTION_INIT(FreeImage_SaveToMemory);
+    MODULE_FUNCTION_INIT(FreeImage_SeekMemory);
+    MODULE_FUNCTION_INIT(FreeImage_SetOutputMessage);
+    MODULE_FUNCTION_INIT(FreeImage_Unload);
+
+#ifndef FREEIMAGE_STATIC
+    if(!module.symbolsLoaded()) {
+        printf(__FILE__"%d\n", __LINE__);
+        string error_message = "Error loading FreeImage: "
+          + module.getErrorMessage()
+          + "\nThe installed version of FreeImage is not compatible with "
+            "ArrayFire. Please create an issue on which this error message";
+        printf(__FILE__"%d\n", __LINE__);
+        AF_ERROR(error_message.c_str(), AF_ERR_LOAD_LIB);
+    }
+#endif
+}
+
+FreeImage_Module::~FreeImage_Module() {
+#ifdef FREEIMAGE_STATIC
+    getFreeImagePlugin().FreeImage_DeInitialise();
+#endif
+}
+
+FreeImage_Module& getFreeImagePlugin() {
+    static FreeImage_Module *plugin = new FreeImage_Module();
+    return *plugin;
+}
+
+bitmap_ptr make_bitmap_ptr(FIBITMAP* ptr) {
+  return bitmap_ptr(ptr, getFreeImagePlugin().FreeImage_Unload);
 }
 
 template<typename T, FI_CHANNELS fo_color>
@@ -129,16 +214,15 @@ af_err af_load_image(af_array *out, const char* filename, const bool isColor)
     try {
         ARG_ASSERT(1, filename != NULL);
 
-        // for statically linked FI
-        FI_Init();
+        FreeImage_Module& _ = getFreeImagePlugin();
 
         // set your own FreeImage error handler
-        FreeImage_SetOutputMessage(FreeImageErrorHandler);
+        _.FreeImage_SetOutputMessage(FreeImageErrorHandler);
 
         // try to guess the file format from the file extension
-        FREE_IMAGE_FORMAT fif = FreeImage_GetFileType(filename);
+        FREE_IMAGE_FORMAT fif = _.FreeImage_GetFileType(filename, 0);
         if (fif == FIF_UNKNOWN) {
-            fif = FreeImage_GetFIFFromFilename(filename);
+            fif = _.FreeImage_GetFIFFromFilename(filename);
         }
 
         if(fif == FIF_UNKNOWN) {
@@ -152,21 +236,18 @@ af_err af_load_image(af_array *out, const char* filename, const bool isColor)
 #endif
 
         // check that the plugin has reading capabilities ...
-        FIBITMAP* pBitmap = NULL;
-        if (FreeImage_FIFSupportsReading(fif)) {
-            pBitmap = FreeImage_Load(fif, filename, flags);
+        bitmap_ptr pBitmap = make_bitmap_ptr(NULL);
+        if (_.FreeImage_FIFSupportsReading(fif)) {
+            pBitmap.reset(_.FreeImage_Load(fif, filename, flags));
         }
 
         if(pBitmap == NULL) {
             AF_ERROR("FreeImage Error: Error reading image or file does not exist", AF_ERR_RUNTIME);
         }
 
-        // make sure pBitmap is unleaded automatically, no matter how we exit this function
-        FI_BitmapResource bitmapUnloader(pBitmap);
-
         // check image color type
-        uint color_type = FreeImage_GetColorType(pBitmap);
-        const uint fi_bpp = FreeImage_GetBPP(pBitmap);
+        uint color_type = _.FreeImage_GetColorType(pBitmap.get());
+        const uint fi_bpp = _.FreeImage_GetBPP(pBitmap.get());
         //int fi_color = (int)((fi_bpp / 8.0) + 0.5);        //ceil
         int fi_color;
         switch(color_type) {
@@ -189,15 +270,15 @@ af_err af_load_image(af_array *out, const char* filename, const bool isColor)
         }
 
         // data type
-        FREE_IMAGE_TYPE image_type = FreeImage_GetImageType(pBitmap);
+        FREE_IMAGE_TYPE image_type = _.FreeImage_GetImageType(pBitmap.get());
 
         // sizes
-        uint fi_w = FreeImage_GetWidth(pBitmap);
-        uint fi_h = FreeImage_GetHeight(pBitmap);
+        uint fi_w = _.FreeImage_GetWidth(pBitmap.get());
+        uint fi_h = _.FreeImage_GetHeight(pBitmap.get());
 
         // FI = row major | AF = column major
-        uint nSrcPitch = FreeImage_GetPitch(pBitmap);
-        const uchar* pSrcLine = FreeImage_GetBits(pBitmap) + nSrcPitch * (fi_h - 1);
+        uint nSrcPitch = _.FreeImage_GetPitch(pBitmap.get());
+        const uchar* pSrcLine = _.FreeImage_GetBits(pBitmap.get()) + nSrcPitch * (fi_h - 1);
 
         // result image
         af_array rImage;
@@ -267,7 +348,7 @@ af_err af_load_image(af_array *out, const char* filename, const bool isColor)
             }
         }
 
-        std::swap(*out,rImage);
+        swap(*out,rImage);
     } CATCHALL;
 
     return AF_SUCCESS;
@@ -280,15 +361,15 @@ af_err af_save_image(const char* filename, const af_array in_)
 
         ARG_ASSERT(0, filename != NULL);
 
-        FI_Init();
+        FreeImage_Module& _ = getFreeImagePlugin();
 
         // set your own FreeImage error handler
-        FreeImage_SetOutputMessage(FreeImageErrorHandler);
+        _.FreeImage_SetOutputMessage(FreeImageErrorHandler);
 
         // try to guess the file format from the file extension
-        FREE_IMAGE_FORMAT fif = FreeImage_GetFileType(filename);
+        FREE_IMAGE_FORMAT fif = _.FreeImage_GetFileType(filename, 0);
         if (fif == FIF_UNKNOWN) {
-            fif = FreeImage_GetFIFFromFilename(filename);
+            fif = _.FreeImage_GetFIFFromFilename(filename);
         }
 
         if(fif == FIF_UNKNOWN) {
@@ -308,13 +389,10 @@ af_err af_save_image(const char* filename, const af_array in_)
         uint fi_h = info.dims()[0];
 
         // create the result image storage using FreeImage
-        FIBITMAP* pResultBitmap = FreeImage_Allocate(fi_w, fi_h, fi_bpp);
+        bitmap_ptr pResultBitmap = make_bitmap_ptr(_.FreeImage_Allocate(fi_w, fi_h, fi_bpp, 0, 0, 0));
         if(pResultBitmap == NULL) {
             AF_ERROR("FreeImage Error: Error creating image or file", AF_ERR_RUNTIME);
         }
-
-        // make sure pResultBitmap is unleaded automatically, no matter how we exit this function
-        FI_BitmapResource resultBitmapUnloader(pResultBitmap);
 
         // FI assumes [0-255]
         // If array is in 0-1 range, multiply by 255
@@ -341,8 +419,8 @@ af_err af_save_image(const char* filename, const af_array in_)
         }
 
         // FI = row major | AF = column major
-        uint nDstPitch = FreeImage_GetPitch(pResultBitmap);
-        uchar* pDstLine = FreeImage_GetBits(pResultBitmap) + nDstPitch * (fi_h - 1);
+        uint nDstPitch = _.FreeImage_GetPitch(pResultBitmap.get());
+        uchar* pDstLine = _.FreeImage_GetBits(pResultBitmap.get()) + nDstPitch * (fi_h - 1);
         af_array rr = 0, gg = 0, bb = 0, aa = 0;
         AF_CHECK(channel_split(in, info.dims(), &rr, &gg, &bb, &aa)); // convert array to 3 channels if needed
 
@@ -430,7 +508,7 @@ af_err af_save_image(const char* filename, const af_array in_)
         if(fif == FIF_JPEG) flags = flags | JPEG_QUALITYSUPERB;
 
         // now save the result image
-        if (!(FreeImage_Save(fif, pResultBitmap, filename, flags) == TRUE)) {
+        if (!(_.FreeImage_Save(fif, pResultBitmap.get(), filename, flags) == TRUE)) {
             AF_ERROR("FreeImage Error: Failed to save image", AF_ERR_RUNTIME);
         }
 
@@ -458,17 +536,16 @@ af_err af_load_image_memory(af_array *out, const void* ptr)
     try {
         ARG_ASSERT(1, ptr != NULL);
 
-        // for statically linked FI
-        FI_Init();
+        FreeImage_Module& _ = getFreeImagePlugin();
 
         // set your own FreeImage error handler
-        FreeImage_SetOutputMessage(FreeImageErrorHandler);
+        _.FreeImage_SetOutputMessage(FreeImageErrorHandler);
 
         FIMEMORY *stream = (FIMEMORY*)ptr;
-        FreeImage_SeekMemory(stream, 0L, SEEK_SET);
+        _.FreeImage_SeekMemory(stream, 0L, SEEK_SET);
 
         // try to guess the file format from the file extension
-        FREE_IMAGE_FORMAT fif = FreeImage_GetFileTypeFromMemory(stream, 0);
+        FREE_IMAGE_FORMAT fif = _.FreeImage_GetFileTypeFromMemory(stream, 0);
         //if (fif == FIF_UNKNOWN) {
         //    fif = FreeImage_GetFIFFromFilenameFromMemory(filename);
         //}
@@ -481,21 +558,18 @@ af_err af_load_image_memory(af_array *out, const void* ptr)
         if(fif == FIF_JPEG) flags = flags | JPEG_ACCURATE;
 
         // check that the plugin has reading capabilities ...
-        FIBITMAP* pBitmap = NULL;
-        if (FreeImage_FIFSupportsReading(fif)) {
-            pBitmap = FreeImage_LoadFromMemory(fif, stream, flags);
+        bitmap_ptr pBitmap = make_bitmap_ptr(NULL);
+        if (_.FreeImage_FIFSupportsReading(fif)) {
+            pBitmap.reset(_.FreeImage_LoadFromMemory(fif, stream, flags));
         }
 
         if(pBitmap == NULL) {
             AF_ERROR("FreeImage Error: Error reading image or file does not exist", AF_ERR_RUNTIME);
         }
 
-        // make sure pBitmap is unleaded automatically, no matter how we exit this function
-        FI_BitmapResource bitmapUnloader(pBitmap);
-
         // check image color type
-        uint color_type = FreeImage_GetColorType(pBitmap);
-        const uint fi_bpp = FreeImage_GetBPP(pBitmap);
+        uint color_type = _.FreeImage_GetColorType(pBitmap.get());
+        const uint fi_bpp = _.FreeImage_GetBPP(pBitmap.get());
         //int fi_color = (int)((fi_bpp / 8.0) + 0.5);        //ceil
         int fi_color;
         switch(color_type) {
@@ -517,12 +591,12 @@ af_err af_load_image_memory(af_array *out, const void* ptr)
         }
 
         // sizes
-        uint fi_w = FreeImage_GetWidth(pBitmap);
-        uint fi_h = FreeImage_GetHeight(pBitmap);
+        uint fi_w = _.FreeImage_GetWidth(pBitmap.get());
+        uint fi_h = _.FreeImage_GetHeight(pBitmap.get());
 
         // FI = row major | AF = column major
-        uint nSrcPitch = FreeImage_GetPitch(pBitmap);
-        const uchar* pSrcLine = FreeImage_GetBits(pBitmap) + nSrcPitch * (fi_h - 1);
+        uint nSrcPitch = _.FreeImage_GetPitch(pBitmap.get());
+        const uchar* pSrcLine = _.FreeImage_GetBits(pBitmap.get()) + nSrcPitch * (fi_h - 1);
 
         // result image
         af_array rImage;
@@ -549,7 +623,7 @@ af_err af_load_image_memory(af_array *out, const void* ptr)
                 AF_CHECK((readImage<float,  AFFI_RGB, AFFI_RGB>)(&rImage, pSrcLine, nSrcPitch, fi_w, fi_h));
         }
 
-        std::swap(*out,rImage);
+        swap(*out,rImage);
     } CATCHALL;
 
     return AF_SUCCESS;
@@ -559,11 +633,10 @@ af_err af_load_image_memory(af_array *out, const void* ptr)
 af_err af_save_image_memory(void **ptr, const af_array in_, const af_image_format format)
 {
     try {
+        FreeImage_Module& _ = getFreeImagePlugin();
 
-        FI_Init();
-
-        // set your own FreeImage error handler
-        FreeImage_SetOutputMessage(FreeImageErrorHandler);
+        // set our own FreeImage error handler
+        _.FreeImage_SetOutputMessage(FreeImageErrorHandler);
 
         // try to guess the file format from the file extension
         FREE_IMAGE_FORMAT fif = (FREE_IMAGE_FORMAT)format;
@@ -585,13 +658,10 @@ af_err af_save_image_memory(void **ptr, const af_array in_, const af_image_forma
         uint fi_h = info.dims()[0];
 
         // create the result image storage using FreeImage
-        FIBITMAP* pResultBitmap = FreeImage_Allocate(fi_w, fi_h, fi_bpp);
+        bitmap_ptr pResultBitmap = make_bitmap_ptr(_.FreeImage_Allocate(fi_w, fi_h, fi_bpp, 0, 0, 0));
         if(pResultBitmap == NULL) {
             AF_ERROR("FreeImage Error: Error creating image or file", AF_ERR_RUNTIME);
         }
-
-        // make sure pResultBitmap is unleaded automatically, no matter how we exit this function
-        FI_BitmapResource resultBitmapUnloader(pResultBitmap);
 
         // FI assumes [0-255]
         // If array is in 0-1 range, multiply by 255
@@ -610,8 +680,8 @@ af_err af_save_image_memory(void **ptr, const af_array in_, const af_image_forma
         }
 
         // FI = row major | AF = column major
-        uint nDstPitch = FreeImage_GetPitch(pResultBitmap);
-        uchar* pDstLine = FreeImage_GetBits(pResultBitmap) + nDstPitch * (fi_h - 1);
+        uint nDstPitch = _.FreeImage_GetPitch(pResultBitmap.get());
+        uchar* pDstLine = _.FreeImage_GetBits(pResultBitmap.get()) + nDstPitch * (fi_h - 1);
         af_array rr = 0, gg = 0, bb = 0, aa = 0;
         AF_CHECK(channel_split(in, info.dims(), &rr, &gg, &bb, &aa)); // convert array to 3 channels if needed
 
@@ -695,13 +765,15 @@ af_err af_save_image_memory(void **ptr, const af_array in_, const af_image_forma
             pinnedFree(pSrc0);
         }
 
-        FIMEMORY *stream = FreeImage_OpenMemory();
+        uint8_t* data = nullptr;
+        uint32_t size_in_bytes = 0;
+        FIMEMORY *stream = _.FreeImage_OpenMemory(data, size_in_bytes);
 
         int flags = 0;
         if(fif == FIF_JPEG) flags = flags | JPEG_QUALITYSUPERB;
 
         // now save the result image
-        if (!(FreeImage_SaveToMemory(fif, pResultBitmap, stream, flags) == TRUE)) {
+        if (!(_.FreeImage_SaveToMemory(fif, pResultBitmap.get(), stream, flags) == TRUE)) {
             AF_ERROR("FreeImage Error: Failed to save image", AF_ERR_RUNTIME);
         }
 
@@ -728,21 +800,21 @@ af_err af_delete_image_memory(void *ptr)
 
         ARG_ASSERT(0, ptr != NULL);
 
-        FI_Init();
+        FreeImage_Module& _ = getFreeImagePlugin();
 
         // set your own FreeImage error handler
-        FreeImage_SetOutputMessage(FreeImageErrorHandler);
+        _.FreeImage_SetOutputMessage(FreeImageErrorHandler);
 
         FIMEMORY *stream = (FIMEMORY*)ptr;
-        FreeImage_SeekMemory(stream, 0L, SEEK_SET);
+        _.FreeImage_SeekMemory(stream, 0L, SEEK_SET);
 
         // Ensure data is freeimage compatible
-        FREE_IMAGE_FORMAT fif = FreeImage_GetFileTypeFromMemory((FIMEMORY*)ptr, 0);
+        FREE_IMAGE_FORMAT fif = _.FreeImage_GetFileTypeFromMemory((FIMEMORY*)ptr, 0);
         if(fif == FIF_UNKNOWN) {
             AF_ERROR("FreeImage Error: Unknown Filetype", AF_ERR_NOT_SUPPORTED);
         }
 
-        FreeImage_CloseMemory((FIMEMORY *)ptr);
+        _.FreeImage_CloseMemory((FIMEMORY *)ptr);
 
     } CATCHALL
 

--- a/src/api/c/imageio_helper.h
+++ b/src/api/c/imageio_helper.h
@@ -10,51 +10,54 @@
 #ifndef IMAGEIO_HELPER_H
 #define IMAGEIO_HELPER_H
 
-#include <FreeImage.h>
-
+#include <DependencyModule.hpp>
 #include <af/array.h>
-#include <af/index.h>
 #include <af/dim4.hpp>
+#include <af/index.h>
 #include <common/err_common.hpp>
 
-class FI_Manager
-{
-    public:
-    FI_Manager()
-    {
-#ifdef FREEIMAGE_LIB
-        FreeImage_Initialise();
-#endif
-    }
+#include <FreeImage.h>
 
-    ~FI_Manager()
-    {
-#ifdef FREEIMAGE_LIB
-        FreeImage_DeInitialise();
-#endif
-    }
-};
+#include <memory>
+#include <functional>
 
-static void FI_Init()
-{
-    static FI_Manager manager = FI_Manager();
-}
+class FreeImage_Module {
+    DependencyModule module;
 
-class FI_BitmapResource
-{
 public:
-    explicit FI_BitmapResource(FIBITMAP * p) :
-        pBitmap(p)
-    {
-    }
+    MODULE_MEMBER(FreeImage_Allocate);
+    MODULE_MEMBER(FreeImage_AllocateT);
+    MODULE_MEMBER(FreeImage_CloseMemory);
+    MODULE_MEMBER(FreeImage_DeInitialise);
+    MODULE_MEMBER(FreeImage_FIFSupportsReading);
+    MODULE_MEMBER(FreeImage_GetBPP);
+    MODULE_MEMBER(FreeImage_GetBits);
+    MODULE_MEMBER(FreeImage_GetColorType);
+    MODULE_MEMBER(FreeImage_GetFIFFromFilename);
+    MODULE_MEMBER(FreeImage_GetFileType);
+    MODULE_MEMBER(FreeImage_GetFileTypeFromMemory);
+    MODULE_MEMBER(FreeImage_GetHeight);
+    MODULE_MEMBER(FreeImage_GetImageType);
+    MODULE_MEMBER(FreeImage_GetPitch);
+    MODULE_MEMBER(FreeImage_GetWidth);
+    MODULE_MEMBER(FreeImage_Initialise);
+    MODULE_MEMBER(FreeImage_Load);
+    MODULE_MEMBER(FreeImage_LoadFromMemory);
+    MODULE_MEMBER(FreeImage_OpenMemory);
+    MODULE_MEMBER(FreeImage_Save);
+    MODULE_MEMBER(FreeImage_SaveToMemory);
+    MODULE_MEMBER(FreeImage_SeekMemory);
+    MODULE_MEMBER(FreeImage_SetOutputMessage);
+    MODULE_MEMBER(FreeImage_Unload);
 
-    ~FI_BitmapResource()
-    {
-        FreeImage_Unload(pBitmap);
-    }
-private:
-    FIBITMAP * pBitmap;
+    FreeImage_Module();
+    ~FreeImage_Module();
 };
+
+FreeImage_Module& getFreeImagePlugin();
+
+using bitmap_ptr = std::unique_ptr<FIBITMAP, std::function<void(FIBITMAP*)>>;
+bitmap_ptr make_bitmap_ptr(FIBITMAP*);
 
 typedef enum {
     AFFI_GRAY = 1,

--- a/src/backend/cpu/platform.cpp
+++ b/src/backend/cpu/platform.cpp
@@ -86,7 +86,7 @@ CPUInfo::CPUInfo()
             mNumCores = mNumLogCpus = 1;
         }
     } else {
-        mVendorId = "Unkown";
+        mVendorId = "Unknown";
     }
     // Get processor brand string
     // This seems to be working for both Intel & AMD vendors


### PR DESCRIPTION
This commit will make the FreeImage library a runtime dependency
instead of a link time dependency. This means that the user does
not need to have FreeImage installed on their system if they are
not using the image input and output functions. The FreeImage
library will be loaded at runtime only when the image io functions
are used.

Also includes the DependencyModule class which will make it easier
for other classes to be loaded in a similar way.