### PR TITLE
Move memory manager definition to impl file.

### DIFF
--- a/src/backend/common/MemoryManager.hpp
+++ b/src/backend/common/MemoryManager.hpp
@@ -76,364 +76,60 @@ class MemoryManager
     std::vector<memory_info> memory;
     bool debug_mode;
 
-    memory_info& getCurrentMemoryInfo()
-    {
-        return memory[this->getActiveDeviceId()];
-    }
+    memory_info& getCurrentMemoryInfo();
 
-    inline int getActiveDeviceId()
-    {
-        return static_cast<T*>(this)->getActiveDeviceId();
-    }
+    inline int getActiveDeviceId();
+    inline size_t getMaxMemorySize(int id);
+    void cleanDeviceMemoryManager(int device);
 
-    inline size_t getMaxMemorySize(int id)
-    {
-        return static_cast<T*>(this)->getMaxMemorySize(id);
-    }
-
-    void cleanDeviceMemoryManager(int device)
-    {
-        if (this->debug_mode) return;
-
-        // This vector is used to store the pointers which will be deleted by
-        // the memory manager. We are using this to avoid calling free while
-        // the lock is being held becasue the CPU backend calls sync.
-        std::vector<void*> free_ptrs;
-        memory_info& current = memory[device];
-        {
-            lock_guard_t lock(this->memory_mutex);
-            // Return if all buffers are locked
-            if (current.total_buffers == current.lock_buffers) return;
-            free_ptrs.reserve(32);
-
-            for (auto &kv : current.free_map) {
-                size_t num_ptrs = kv.second.size();
-                // Free memory by pushing the last element into the free_ptrs
-                // vector which will be freed once outside of the lock
-                for(auto p : kv.second) {
-                    free_ptrs.push_back(p);
-                }
-                current.total_bytes -= num_ptrs * kv.first;
-                current.total_buffers -= num_ptrs;
-            }
-            current.free_map.clear();
-        }
-        // Free memory outside of the lock
-        for(auto ptr : free_ptrs) {
-            this->nativeFree(ptr);
-        }
-    }
-
-    public:
-    MemoryManager(int num_devices, unsigned max_buffers, bool debug)
-        : mem_step_size(1024), max_buffers(max_buffers), memory(num_devices), debug_mode(debug)
-    {
-        // Check for environment variables
-
-        // Debug mode
-        std::string env_var = getEnvVar("AF_MEM_DEBUG");
-        if (!env_var.empty()) this->debug_mode = env_var[0] != '0';
-        if (this->debug_mode) mem_step_size = 1;
-
-        // Max Buffer count
-        env_var = getEnvVar("AF_MAX_BUFFERS");
-        if (!env_var.empty()) this->max_buffers = std::max(1, std::stoi(env_var));
-    }
+  public:
+     MemoryManager(int num_devices, unsigned max_buffers, bool debug);
 
     // Intended to be used with OpenCL backend, where
     // users are allowed to add external devices(context, device pair)
     // to the list of devices automatically detected by the library
-    void addMemoryManagement(int device)
-    {
-        // If there is a memory manager allocated for
-        // this device id, we might as well use it and the
-        // buffers allocated for it
-        if (static_cast<size_t>(device) < memory.size())
-            return;
-
-        // Assuming, device need not be always the next device
-        // Lets resize to current_size + device + 1
-        // +1 is to account for device being 0-based index of devices
-        memory.resize(memory.size()+device+1);
-    }
+    void addMemoryManagement(int device);
 
     // Intended to be used with OpenCL backend, where
     // users are allowed to add external devices(context, device pair)
     // to the list of devices automatically detected by the library
-    void removeMemoryManagement(int device)
-    {
-        if ((size_t)device>=memory.size())
-            AF_ERROR("No matching device found", AF_ERR_ARG);
+    void removeMemoryManagement(int device);
 
-        // Do garbage collection for the device and leave
-        // the memory_info struct from the memory vector intact
-        cleanDeviceMemoryManager(device);
-    }
+    void setMaxMemorySize();
 
-    void setMaxMemorySize()
-    {
-        for (unsigned n = 0; n < memory.size(); n++) {
-            // Calls garbage collection when:
-            // total_bytes > memsize * 0.75 when memsize <  4GB
-            // total_bytes > memsize - 1 GB when memsize >= 4GB
-            // If memsize returned 0, then use 1GB
-            size_t memsize = this->getMaxMemorySize(n);
-            memory[n].max_bytes = memsize == 0 ? ONE_GB :
-                std::max(memsize * 0.75, (double)(memsize - ONE_GB));
-        }
-    }
+    /// Returns a pointer of size at least long
+    ///
+    /// This funciton will return a memory location of at least \p size
+    /// bytes. If there is already a free buffer available, it will use
+    /// that buffer. Otherwise, it will allocate a new buffer using the
+    /// nativeAlloc function.
+    void *alloc(const size_t size, bool user_lock);
 
-    void *alloc(const size_t bytes, bool user_lock)
-    {
-        void *ptr = nullptr;
-        size_t alloc_bytes =
-          this->debug_mode ? bytes :
-                             (divup(bytes, mem_step_size) * mem_step_size);
+    /// returns the size of the buffer at the pointer allocated by the memory
+    /// manager.
+    size_t allocated(void *ptr);
 
-        if (bytes > 0) {
-            memory_info& current = this->getCurrentMemoryInfo();
-            locked_info info = {!user_lock, user_lock, alloc_bytes};
+    /// Frees or marks the pointer for deletion during the nex garbage collection
+    /// event
+    void unlock(void *ptr, bool user_unlock);
 
-            // There is no memory cache in debug mode
-            if (!this->debug_mode) {
+    /// Frees all buffers which are not locked by the user or not being used.
+    void garbageCollect();
 
-                // FIXME: Add better checks for garbage collection
-                // Perhaps look at total memory available as a metric
-                if (this->checkMemoryLimit()) {
-                    this->garbageCollect();
-                }
-
-                lock_guard_t lock(this->memory_mutex);
-                free_iter iter = current.free_map.find(alloc_bytes);
-
-                if (iter != current.free_map.end() && !iter->second.empty()) {
-                    ptr = iter->second.back();
-                    iter->second.pop_back();
-                    current.locked_map[ptr] = info;
-                    current.lock_bytes += alloc_bytes;
-                    current.lock_buffers++;
-                }
-            }
-
-            // Only comes here if buffer size not found or in debug mode
-            if (ptr == nullptr) {
-                // Perform garbage collection if memory can not be allocated
-                try {
-                    ptr = this->nativeAlloc(alloc_bytes);
-                } catch (const AfError &ex) {
-                    // If out of memory, run garbage collect and try again
-                    if (ex.getError() != AF_ERR_NO_MEM) throw;
-                    this->garbageCollect();
-                    ptr = this->nativeAlloc(alloc_bytes);
-                }
-
-                lock_guard_t lock(this->memory_mutex);
-                // Increment these two only when it succeeds to come here.
-                current.total_bytes += alloc_bytes;
-                current.total_buffers += 1;
-                current.locked_map[ptr] = info;
-                current.lock_bytes += alloc_bytes;
-                current.lock_buffers++;
-            }
-        }
-        return ptr;
-    }
-
-    size_t allocated(void *ptr)
-    {
-        if (!ptr) return 0;
-        memory_info& current = this->getCurrentMemoryInfo();
-        locked_iter iter = current.locked_map.find((void *)ptr);
-        if (iter == current.locked_map.end()) return 0;
-        return (iter->second).bytes;
-    }
-
-    void unlock(void *ptr, bool user_unlock)
-    {
-        // Shortcut for empty arrays
-        if (!ptr) return;
-
-        // Frees the pointer outside the lock.
-        uptr_t freed_ptr(nullptr, [this](void* p) { this->nativeFree(p); });
-        {
-            lock_guard_t lock(this->memory_mutex);
-            memory_info& current = this->getCurrentMemoryInfo();
-
-            locked_iter iter = current.locked_map.find((void *)ptr);
-
-            // Pointer not found in locked map
-            if (iter == current.locked_map.end()) {
-                // Probably came from user, just free it
-                freed_ptr.reset(ptr);
-                return;
-            }
-
-            if (user_unlock) {
-                (iter->second).user_lock = false;
-            } else {
-                (iter->second).manager_lock = false;
-            }
-
-            // Return early if either one is locked
-            if ((iter->second).user_lock || (iter->second).manager_lock) return;
-
-            size_t bytes = iter->second.bytes;
-            current.lock_bytes -= iter->second.bytes;
-            current.lock_buffers--;
-
-            if (this->debug_mode) {
-                // Just free memory in debug mode
-                if ((iter->second).bytes > 0) {
-                    freed_ptr.reset(iter->first);
-                    current.total_buffers--;
-                    current.total_bytes -= iter->second.bytes;
-                }
-            } else {
-                current.free_map[bytes].push_back(ptr);
-            }
-            current.locked_map.erase(iter);
-        }
-    }
-
-    void garbageCollect()
-    {
-        cleanDeviceMemoryManager(this->getActiveDeviceId());
-    }
-
-    void printInfo(const char *msg, const int device)
-    {
-        const memory_info& current = this->getCurrentMemoryInfo();
-
-        printf("%s\n", msg);
-        printf("---------------------------------------------------------\n"
-               "|     POINTER      |    SIZE    |  AF LOCK  | USER LOCK |\n"
-               "---------------------------------------------------------\n");
-
-        lock_guard_t lock(this->memory_mutex);
-        for(auto& kv : current.locked_map) {
-            const char* status_mngr = "Yes";
-            const char* status_user = "Unknown";
-            if(kv.second.user_lock)     status_user = "Yes";
-            else                        status_user = " No";
-
-            const char* unit = "KB";
-            double size = (double)(kv.second.bytes) / 1024;
-            if(size >= 1024) {
-                size = size / 1024;
-                unit = "MB";
-            }
-
-            printf("|  %14p  |  %6.f %s | %9s | %9s |\n",
-                   kv.first, size, unit, status_mngr, status_user);
-        }
-
-        for(auto &kv : current.free_map) {
-
-            const char* status_mngr = "No";
-            const char* status_user = "No";
-
-            const char* unit = "KB";
-            double size = (double)(kv.first) / 1024;
-            if(size >= 1024) {
-                size = size / 1024;
-                unit = "MB";
-            }
-
-            for (auto &ptr : kv.second) {
-              printf("|  %14p  |  %6.f %s | %9s | %9s |\n",
-                     ptr, size, unit, status_mngr, status_user);
-            }
-        }
-
-        printf("---------------------------------------------------------\n");
-    }
-
+    void printInfo(const char *msg, const int device);
     void bufferInfo(size_t *alloc_bytes, size_t *alloc_buffers,
-                    size_t *lock_bytes,  size_t *lock_buffers)
-    {
-        const memory_info& current = this->getCurrentMemoryInfo();
-        lock_guard_t lock(this->memory_mutex);
-        if (alloc_bytes   ) *alloc_bytes   = current.total_bytes;
-        if (alloc_buffers ) *alloc_buffers = current.total_buffers;
-        if (lock_bytes    ) *lock_bytes    = current.lock_bytes;
-        if (lock_buffers  ) *lock_buffers  = current.lock_buffers;
-    }
-
-    void userLock(const void *ptr)
-    {
-        memory_info& current = this->getCurrentMemoryInfo();
-
-        lock_guard_t lock(this->memory_mutex);
-
-        locked_iter iter = current.locked_map.find(const_cast<void *>(ptr));
-        if (iter != current.locked_map.end()) {
-            iter->second.user_lock = true;
-        } else {
-            locked_info info = {false,
-                true,
-                100}; //This number is not relevant
-
-            current.locked_map[(void *)ptr] = info;
-        }
-    }
-
-    void userUnlock(const void *ptr)
-    {
-        this->unlock(const_cast<void *>(ptr), true);
-    }
-
-    bool isUserLocked(const void *ptr)
-    {
-        memory_info& current = this->getCurrentMemoryInfo();
-        lock_guard_t lock(this->memory_mutex);
-        locked_iter iter = current.locked_map.find(const_cast<void *>(ptr));
-        if (iter != current.locked_map.end()) {
-            return iter->second.user_lock;
-        } else {
-            return false;
-        }
-    }
-
-    size_t getMemStepSize()
-    {
-        lock_guard_t lock(this->memory_mutex);
-        return this->mem_step_size;
-    }
-
-    size_t getMaxBytes()
-    {
-        lock_guard_t lock(this->memory_mutex);
-        return this->getCurrentMemoryInfo().max_bytes;
-    }
-
-    unsigned getMaxBuffers()
-    {
-        return this->max_buffers;
-    }
-
-    void setMemStepSize(size_t new_step_size)
-    {
-        lock_guard_t lock(this->memory_mutex);
-        this->mem_step_size = new_step_size;
-    }
-
-    inline void *nativeAlloc(const size_t bytes)
-    {
-        return static_cast<T*>(this)->nativeAlloc(bytes);
-    }
-
-    inline void nativeFree(void *ptr)
-    {
-        static_cast<T*>(this)->nativeFree(ptr);
-    }
-
-    bool checkMemoryLimit()
-    {
-        const memory_info& current = this->getCurrentMemoryInfo();
-        return current.lock_bytes >= current.max_bytes || current.total_buffers >= this->max_buffers;
-    }
-
-    protected:
+                    size_t *lock_bytes,  size_t *lock_buffers);
+    void userLock(const void *ptr);
+    void userUnlock(const void *ptr);
+    bool isUserLocked(const void *ptr);
+    size_t getMemStepSize();
+    size_t getMaxBytes();
+    unsigned getMaxBuffers();
+    void setMemStepSize(size_t new_step_size);
+    inline void *nativeAlloc(const size_t bytes);
+    inline void nativeFree(void *ptr);
+    bool checkMemoryLimit();
+  protected:
     MemoryManager() = delete;
     ~MemoryManager() = default;
     MemoryManager(const MemoryManager& other) = delete;

--- a/src/backend/common/MemoryManagerImpl.hpp
+++ b/src/backend/common/MemoryManagerImpl.hpp
@@ -1,0 +1,362 @@
+
+#include <common/MemoryManager.hpp>
+
+namespace common
+{
+template<typename T>
+typename MemoryManager<T>::memory_info&
+MemoryManager<T>::getCurrentMemoryInfo() {
+    return memory[this->getActiveDeviceId()];
+}
+
+template<typename T>
+inline int MemoryManager<T>::getActiveDeviceId() {
+    return static_cast<T*>(this)->getActiveDeviceId();
+}
+
+template<typename T>
+inline size_t MemoryManager<T>::getMaxMemorySize(int id) {
+    return static_cast<T*>(this)->getMaxMemorySize(id);
+}
+
+template<typename T>
+void MemoryManager<T>::cleanDeviceMemoryManager(int device) {
+    if (this->debug_mode) return;
+
+    // This vector is used to store the pointers which will be deleted by
+    // the memory manager. We are using this to avoid calling free while
+    // the lock is being held becasue the CPU backend calls sync.
+    std::vector<void*> free_ptrs;
+    memory_info& current = memory[device];
+    {
+        lock_guard_t lock(this->memory_mutex);
+        // Return if all buffers are locked
+        if (current.total_buffers == current.lock_buffers) return;
+        free_ptrs.reserve(32);
+
+        for (auto &kv : current.free_map) {
+            size_t num_ptrs = kv.second.size();
+            // Free memory by pushing the last element into the free_ptrs
+            // vector which will be freed once outside of the lock
+            for(auto p : kv.second) {
+                free_ptrs.push_back(p);
+            }
+            current.total_bytes -= num_ptrs * kv.first;
+            current.total_buffers -= num_ptrs;
+        }
+        current.free_map.clear();
+    }
+    // Free memory outside of the lock
+    for(auto ptr : free_ptrs) {
+        this->nativeFree(ptr);
+    }
+}
+
+template<typename T>
+MemoryManager<T>::MemoryManager(int num_devices,
+                              unsigned max_buffers,
+                              bool debug)
+    : mem_step_size(1024),
+      max_buffers(max_buffers),
+      memory(num_devices),
+      debug_mode(debug) {
+    // Check for environment variables
+
+    // Debug mode
+    std::string env_var = getEnvVar("AF_MEM_DEBUG");
+    if (!env_var.empty()) this->debug_mode = env_var[0] != '0';
+    if (this->debug_mode) mem_step_size = 1;
+
+    // Max Buffer count
+    env_var = getEnvVar("AF_MAX_BUFFERS");
+    if (!env_var.empty())
+      this->max_buffers = std::max(1, std::stoi(env_var));
+}
+
+template<typename T>
+void MemoryManager<T>::addMemoryManagement(int device) {
+    // If there is a memory manager allocated for this device id, we might
+    // as well use it and the buffers allocated for it
+    if (static_cast<size_t>(device) < memory.size())
+        return;
+
+    // Assuming, device need not be always the next device Lets resize to
+    // current_size + device + 1 +1 is to account for device being 0-based
+    // index of devices
+    memory.resize(memory.size()+device+1);
+}
+
+template<typename T>
+void MemoryManager<T>::removeMemoryManagement(int device) {
+    if ((size_t)device>=memory.size())
+        AF_ERROR("No matching device found", AF_ERR_ARG);
+
+    // Do garbage collection for the device and leave the memory_info struct
+    // from the memory vector intact
+    cleanDeviceMemoryManager(device);
+}
+
+template<typename T>
+void MemoryManager<T>::setMaxMemorySize() {
+    for (unsigned n = 0; n < memory.size(); n++) {
+
+        // Calls garbage collection when: total_bytes > memsize * 0.75 when
+        // memsize < 4GB total_bytes > memsize - 1 GB when memsize >= 4GB If
+        // memsize returned 0, then use 1GB
+        size_t memsize = this->getMaxMemorySize(n);
+        memory[n].max_bytes = memsize == 0 ? ONE_GB :
+            std::max(memsize * 0.75, (double)(memsize - ONE_GB));
+    }
+}
+
+template<typename T>
+void *MemoryManager<T>::alloc(const size_t bytes, bool user_lock) {
+    void *ptr = nullptr;
+    size_t alloc_bytes =
+      this->debug_mode ? bytes :
+                          (divup(bytes, mem_step_size) * mem_step_size);
+
+    if (bytes > 0) {
+        memory_info& current = this->getCurrentMemoryInfo();
+        locked_info info = {!user_lock, user_lock, alloc_bytes};
+
+        // There is no memory cache in debug mode
+        if (!this->debug_mode) {
+
+            // FIXME: Add better checks for garbage collection
+            // Perhaps look at total memory available as a metric
+            if (this->checkMemoryLimit()) {
+                this->garbageCollect();
+            }
+
+            lock_guard_t lock(this->memory_mutex);
+            free_iter iter = current.free_map.find(alloc_bytes);
+
+            if (iter != current.free_map.end() && !iter->second.empty()) {
+                ptr = iter->second.back();
+                iter->second.pop_back();
+                current.locked_map[ptr] = info;
+                current.lock_bytes += alloc_bytes;
+                current.lock_buffers++;
+            }
+        }
+
+        // Only comes here if buffer size not found or in debug mode
+        if (ptr == nullptr) {
+            // Perform garbage collection if memory can not be allocated
+            try {
+                ptr = this->nativeAlloc(alloc_bytes);
+            } catch (const AfError &ex) {
+                // If out of memory, run garbage collect and try again
+                if (ex.getError() != AF_ERR_NO_MEM) throw;
+                this->garbageCollect();
+                ptr = this->nativeAlloc(alloc_bytes);
+            }
+
+            lock_guard_t lock(this->memory_mutex);
+            // Increment these two only when it succeeds to come here.
+            current.total_bytes += alloc_bytes;
+            current.total_buffers += 1;
+            current.locked_map[ptr] = info;
+            current.lock_bytes += alloc_bytes;
+            current.lock_buffers++;
+        }
+    }
+    return ptr;
+}
+
+template<typename T>
+size_t MemoryManager<T>::allocated(void *ptr) {
+    if (!ptr) return 0;
+    memory_info& current = this->getCurrentMemoryInfo();
+    locked_iter iter = current.locked_map.find((void *)ptr);
+    if (iter == current.locked_map.end()) return 0;
+    return (iter->second).bytes;
+}
+
+template<typename T>
+void MemoryManager<T>::unlock(void *ptr, bool user_unlock) {
+    // Shortcut for empty arrays
+    if (!ptr) return;
+
+    // Frees the pointer outside the lock.
+    uptr_t freed_ptr(nullptr, [this](void* p) { this->nativeFree(p); });
+    {
+        lock_guard_t lock(this->memory_mutex);
+        memory_info& current = this->getCurrentMemoryInfo();
+
+        locked_iter iter = current.locked_map.find((void *)ptr);
+
+        // Pointer not found in locked map
+        if (iter == current.locked_map.end()) {
+            // Probably came from user, just free it
+            freed_ptr.reset(ptr);
+            return;
+        }
+
+        if (user_unlock) {
+            (iter->second).user_lock = false;
+        } else {
+            (iter->second).manager_lock = false;
+        }
+
+        // Return early if either one is locked
+        if ((iter->second).user_lock || (iter->second).manager_lock) return;
+
+        size_t bytes = iter->second.bytes;
+        current.lock_bytes -= iter->second.bytes;
+        current.lock_buffers--;
+
+        if (this->debug_mode) {
+            // Just free memory in debug mode
+            if ((iter->second).bytes > 0) {
+                freed_ptr.reset(iter->first);
+                current.total_buffers--;
+                current.total_bytes -= iter->second.bytes;
+            }
+        } else {
+            current.free_map[bytes].push_back(ptr);
+        }
+        current.locked_map.erase(iter);
+    }
+}
+
+template<typename T>
+void MemoryManager<T>::garbageCollect() {
+    cleanDeviceMemoryManager(this->getActiveDeviceId());
+}
+
+template<typename T>
+void MemoryManager<T>::printInfo(const char *msg, const int device) {
+    const memory_info& current = this->getCurrentMemoryInfo();
+
+    printf("%s\n", msg);
+    printf("---------------------------------------------------------\n"
+            "|     POINTER      |    SIZE    |  AF LOCK  | USER LOCK |\n"
+            "---------------------------------------------------------\n");
+
+    lock_guard_t lock(this->memory_mutex);
+    for(auto& kv : current.locked_map) {
+        const char* status_mngr = "Yes";
+        const char* status_user = "Unknown";
+        if(kv.second.user_lock)     status_user = "Yes";
+        else                        status_user = " No";
+
+        const char* unit = "KB";
+        double size = (double)(kv.second.bytes) / 1024;
+        if(size >= 1024) {
+            size = size / 1024;
+            unit = "MB";
+        }
+
+        printf("|  %14p  |  %6.f %s | %9s | %9s |\n",
+                kv.first, size, unit, status_mngr, status_user);
+    }
+
+    for(auto &kv : current.free_map) {
+
+        const char* status_mngr = "No";
+        const char* status_user = "No";
+
+        const char* unit = "KB";
+        double size = (double)(kv.first) / 1024;
+        if(size >= 1024) {
+            size = size / 1024;
+            unit = "MB";
+        }
+
+        for (auto &ptr : kv.second) {
+          printf("|  %14p  |  %6.f %s | %9s | %9s |\n",
+                  ptr, size, unit, status_mngr, status_user);
+        }
+    }
+
+    printf("---------------------------------------------------------\n");
+}
+
+template<typename T>
+void MemoryManager<T>::bufferInfo(size_t *alloc_bytes, size_t *alloc_buffers,
+                                  size_t *lock_bytes,  size_t *lock_buffers) {
+    const memory_info& current = this->getCurrentMemoryInfo();
+    lock_guard_t lock(this->memory_mutex);
+    if (alloc_bytes   ) *alloc_bytes   = current.total_bytes;
+    if (alloc_buffers ) *alloc_buffers = current.total_buffers;
+    if (lock_bytes    ) *lock_bytes    = current.lock_bytes;
+    if (lock_buffers  ) *lock_buffers  = current.lock_buffers;
+}
+
+template<typename T>
+void MemoryManager<T>::userLock(const void *ptr) {
+    memory_info& current = this->getCurrentMemoryInfo();
+
+    lock_guard_t lock(this->memory_mutex);
+
+    locked_iter iter = current.locked_map.find(const_cast<void *>(ptr));
+    if (iter != current.locked_map.end()) {
+        iter->second.user_lock = true;
+    } else {
+        locked_info info = {false,
+            true,
+            100}; //This number is not relevant
+
+        current.locked_map[(void *)ptr] = info;
+    }
+}
+
+template<typename T>
+void MemoryManager<T>::userUnlock(const void *ptr) {
+    this->unlock(const_cast<void *>(ptr), true);
+}
+
+template<typename T>
+bool MemoryManager<T>::isUserLocked(const void *ptr) {
+    memory_info& current = this->getCurrentMemoryInfo();
+    lock_guard_t lock(this->memory_mutex);
+    locked_iter iter = current.locked_map.find(const_cast<void *>(ptr));
+    if (iter != current.locked_map.end()) {
+        return iter->second.user_lock;
+    } else {
+        return false;
+    }
+}
+
+template<typename T>
+size_t MemoryManager<T>::getMemStepSize() {
+    lock_guard_t lock(this->memory_mutex);
+    return this->mem_step_size;
+}
+
+template<typename T>
+size_t MemoryManager<T>::getMaxBytes() {
+    lock_guard_t lock(this->memory_mutex);
+    return this->getCurrentMemoryInfo().max_bytes;
+}
+
+template<typename T>
+unsigned MemoryManager<T>::getMaxBuffers() {
+    return this->max_buffers;
+}
+
+template<typename T>
+void MemoryManager<T>::setMemStepSize(size_t new_step_size) {
+    lock_guard_t lock(this->memory_mutex);
+    this->mem_step_size = new_step_size;
+}
+
+template<typename T>
+inline void *MemoryManager<T>::nativeAlloc(const size_t bytes) {
+    return static_cast<T*>(this)->nativeAlloc(bytes);
+}
+
+template<typename T>
+inline void MemoryManager<T>::nativeFree(void *ptr) {
+    static_cast<T*>(this)->nativeFree(ptr);
+}
+
+template<typename T>
+bool MemoryManager<T>::checkMemoryLimit() {
+    const memory_info& current = this->getCurrentMemoryInfo();
+    return current.lock_bytes >= current.max_bytes ||
+            current.total_buffers >= this->max_buffers;
+}
+}

--- a/src/backend/cpu/memory.cpp
+++ b/src/backend/cpu/memory.cpp
@@ -13,6 +13,10 @@
 #include <platform.hpp>
 #include <queue.hpp>
 
+#include <common/MemoryManagerImpl.hpp>
+
+template class common::MemoryManager<cpu::MemoryManager>;
+
 #ifndef AF_MEM_DEBUG
 #define AF_MEM_DEBUG 0
 #endif

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -19,6 +19,11 @@
 
 #include <mutex>
 
+#include <common/MemoryManagerImpl.hpp>
+
+template class common::MemoryManager<cuda::MemoryManager>;
+template class common::MemoryManager<cuda::MemoryManagerPinned>;
+
 #ifndef AF_MEM_DEBUG
 #define AF_MEM_DEBUG 0
 #endif

--- a/src/backend/opencl/memory.cpp
+++ b/src/backend/opencl/memory.cpp
@@ -12,6 +12,11 @@
 #include <types.hpp>
 #include <err_opencl.hpp>
 
+#include <common/MemoryManagerImpl.hpp>
+
+template class common::MemoryManager<opencl::MemoryManager>;
+template class common::MemoryManager<opencl::MemoryManagerPinned>;
+
 #ifndef AF_MEM_DEBUG
 #define AF_MEM_DEBUG 0
 #endif


### PR DESCRIPTION
Move the definition of the memory manager to a MemoryManagerImpl.hpp
file so that the definition is not compiled multiple times. Should
improve compilation times. No source code changes were made in this
commit