### PR TITLE
Set the symbol visibility to hidden

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,10 @@ configure_package_config_file(
 # TODO(umar): Disable for now. Causing issues with builds on windows.
 #export(PACKAGE ArrayFire)
 
+# Unset the visibility to avoid setting policy commands for older versions of
+# CMake for examples and tests.
+unset(CMAKE_CXX_VISIBILITY_PRESET)
+
 include(CTest)
 
 # Handle depricated BUILD_TEST variable if found.

--- a/CMakeModules/InternalUtils.cmake
+++ b/CMakeModules/InternalUtils.cmake
@@ -68,6 +68,7 @@ macro(arrayfire_set_cmake_default_variables)
 
   set(CMAKE_CXX_STANDARD 11)
   set(CMAKE_CXX_EXTENSIONS OFF)
+  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
   # Set a default build type if none was specified
   if(NOT CMAKE_BUILD_TYPE)

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -115,7 +115,7 @@ endfunction()
 
 arrayfire_get_cuda_cxx_flags(cuda_cxx_flags)
 if(NOT MSVC)
-  set(cuda_cxx_flags "${cuda_cxx_flags} -Xcompiler -fPIC")
+  set(cuda_cxx_flags "${cuda_cxx_flags} -Xcompiler -fPIC  -Xcompiler=${CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY}hidden")
 endif()
 
 if(AF_WITH_NONFREE AND CMAKE_VERSION VERSION_LESS "3.7")


### PR DESCRIPTION
Setting the visibility to hidden to improve link times and reduce the
binary size. This reduced the libafcpu.so size from 41MB to 36MB