### PR TITLE
Added logging support for memory operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ option(AF_BUILD_EXAMPLES "Build Examples"                            ON)
 
 option(AF_WITH_GRAPHICS "Build ArrayFire with Forge Graphics"  $<AND:${OPENGL_FOUND},${Forge_FOUND},${glbinding_FOUND}>)
 option(AF_WITH_NONFREE  "Build ArrayFire nonfree algorithms"   OFF)
+option(AF_WITH_LOGGING  "Build ArrayFire with logging support" ${spdlog_FOUND})
 
 option(AF_INSTALL_STANDALONE "Build installers that include all dependencies" OFF)
 
@@ -61,8 +62,6 @@ cmake_dependent_option(AF_WITH_IMAGEIO "Build ArrayFire with Image IO support" $
                        "FreeImage_FOUND" OFF)
 cmake_dependent_option(AF_BUILD_FRAMEWORK "Build an ArrayFire framework for Apple platforms.(Experimental)" OFF
                        "APPLE" OFF)
-cmake_dependent_option(AF_WITH_LOGGING "Build ArrayFire with support for logging functionallity." ON
-                       "TARGET spdlog::spdlog" OFF)
 
 option(AF_WITH_STATIC_FREEIMAGE "Use Static FreeImage Lib" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ find_package(CBLAS)
 find_package(LAPACKE)
 find_package(Doxygen)
 find_package(MKL)
+find_package(spdlog QUIET)
 
 # Graphics dependencies
 find_package(glbinding QUIET)
@@ -60,6 +61,9 @@ cmake_dependent_option(AF_WITH_IMAGEIO "Build ArrayFire with Image IO support" $
                        "FreeImage_FOUND" OFF)
 cmake_dependent_option(AF_BUILD_FRAMEWORK "Build an ArrayFire framework for Apple platforms.(Experimental)" OFF
                        "APPLE" OFF)
+cmake_dependent_option(AF_WITH_LOGGING "Build ArrayFire with support for logging functionallity." ON
+                       "TARGET spdlog::spdlog" OFF)
+
 option(AF_WITH_STATIC_FREEIMAGE "Use Static FreeImage Lib" OFF)
 
 set(AF_WITH_CPUID ON CACHE BOOL "Build with CPUID integration")

--- a/docs/pages/configuring_arrayfire_environment.md
+++ b/docs/pages/configuring_arrayfire_environment.md
@@ -145,8 +145,9 @@ paths, then those paths are shown in full.
 AF_MEM_DEBUG {#af_mem_debug}
 -------------------------------------------------------------------------------
 
-When AF_MEM_DEBUG is set to 1 (or anything not equal to 0), the caching mechanism in the memory manager is disabled.
-The device buffers are allocated using native functions as needed and freed when going out of scope.
+When AF_MEM_DEBUG is set to 1 (or anything not equal to 0), the caching
+mechanism in the memory manager is disabled. The device buffers are allocated
+using native functions as needed and freed when going out of scope.
 
 When the environment variable is not set, it is treated to be zero.
 
@@ -154,33 +155,58 @@ When the environment variable is not set, it is treated to be zero.
 AF_MEM_DEBUG=1 ./myprogram
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+AF_TRACE {#af_trace}
+-------------------------------------------------------------------------------
+
+If ArrayFire was built with logging support, this enviornment variable will
+enable tracing of various modules within ArrayFire. This is a comma separated
+list of modules to trace. If enabled, ArrayFire will print relevant information
+to stdout. Currently the following modules are supported:
+
+- mem: Memory management allocation, free and garbage collection information
+
+Tracing displays the information that could be useful when debugging or
+optimizing your application. Here is how you would use this variable:
+
+    AF_TRACE=mem ./myprogram
+
+This will print information about memory operations such as allocations,
+deallocations, and garbage collection.
+
 
 AF_MAX_BUFFERS {#af_max_buffers}
 -------------------------------------------------------------------------
 
-When AF_MAX_BUFFERS is set, this environment variable specifies the maximum number of buffers allocated before garbage collection kicks in.
+When AF_MAX_BUFFERS is set, this environment variable specifies the maximum
+number of buffers allocated before garbage collection kicks in.
 
-Please note that the total number of buffers that can exist simultaneously can be higher than this number. This variable tells the garbage collector that it should free any available buffers immediately if the treshold is reached.
+Please note that the total number of buffers that can exist simultaneously can
+be higher than this number. This variable tells the garbage collector that it
+should free any available buffers immediately if the treshold is reached.
 
 When not set, the default value is 1000.
 
 AF_OPENCL_MAX_JIT_LEN {#af_opencl_max_jit_len}
 -------------------------------------------------------------------------------
 
-When set, this environment variable specifies the maximum height of the OpenCL JIT tree after which evaluation is forced.
+When set, this environment variable specifies the maximum height of the OpenCL
+JIT tree after which evaluation is forced.
 
-The default value, as of v3.4, is 50 on OSX, 100 everywhere else. This value was 20 for older versions.
+The default value, as of v3.4, is 50 on OSX, 100 everywhere else. This value was
+20 for older versions.
 
 AF_CUDA_MAX_JIT_LEN {#af_cuda_max_jit_len}
 -------------------------------------------------------------------------------
 
-When set, this environment variable specifies the maximum height of the CUDA JIT tree after which evaluation is forced.
+When set, this environment variable specifies the maximum height of the CUDA JIT
+tree after which evaluation is forced.
 
 The default value, as of v3.4, 100. This value was 20 for older versions.
 
 AF_CPU_MAX_JIT_LEN {#af_cpu_max_jit_len}
 -------------------------------------------------------------------------------
 
-When set, this environment variable specifies the maximum length of the CPU JIT tree after which evaluation is forced.
+When set, this environment variable specifies the maximum length of the CPU JIT
+tree after which evaluation is forced.
 
 The default value, as of v3.4, 100. This value was 20 for older versions.

--- a/src/backend/common/CMakeLists.txt
+++ b/src/backend/common/CMakeLists.txt
@@ -55,6 +55,7 @@ add_library(afcommon_lapack_interface INTERFACE)
 
 
 if(AF_WITH_LOGGING)
+  dependency_check(spdlog_FOUND "spdlog not found.")
   target_compile_definitions(afcommon_interface
     INTERFACE AF_WITH_LOGGING)
   target_link_libraries(afcommon_interface

--- a/src/backend/common/CMakeLists.txt
+++ b/src/backend/common/CMakeLists.txt
@@ -14,10 +14,11 @@ target_sources(afcommon_interface
     ${CMAKE_CURRENT_SOURCE_DIR}/DependencyModule.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/DependencyModule.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/FFTPlanCache.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Logger.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Logger.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/MatrixAlgebraHandle.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/MemoryManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/MersenneTwister.hpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/module_loading.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SparseArray.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SparseArray.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/blas_headers.hpp
@@ -31,6 +32,7 @@ target_sources(afcommon_interface
     ${CMAKE_CURRENT_SOURCE_DIR}/err_common.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/host_memory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/host_memory.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/module_loading.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sparse_helpers.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/util.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/util.hpp
@@ -50,6 +52,15 @@ target_include_directories(afcommon_interface
   )
 
 add_library(afcommon_lapack_interface INTERFACE)
+
+
+if(AF_WITH_LOGGING)
+  target_compile_definitions(afcommon_interface
+    INTERFACE AF_WITH_LOGGING)
+  target_link_libraries(afcommon_interface
+    INTERFACE
+      spdlog::spdlog)
+endif()
 
 if(AF_WITH_GRAPHICS)
   dependency_check(glbinding_FOUND "glbinding not found.")

--- a/src/backend/common/Logger.cpp
+++ b/src/backend/common/Logger.cpp
@@ -1,0 +1,55 @@
+
+#include <common/Logger.hpp>
+#include <common/util.hpp>
+
+#include <array>
+#include <cstdlib>
+#include <string>
+#include <memory>
+
+using std::array;
+using std::make_shared;
+using std::string;
+using std::shared_ptr;
+using std::to_string;
+
+using spdlog::level::trace;
+using spdlog::logger;
+using spdlog::stdout_logger_mt;
+
+namespace common {
+
+#ifdef AF_WITH_LOGGING
+shared_ptr<logger>
+logger_factory(string name) {
+    auto logger = stdout_logger_mt(name);
+    logger->set_pattern("[%n][%t] %v");
+
+    // Log mode
+    string env_var = getEnvVar("AF_TRACE");
+    if(env_var.find_first_of("all") != string::npos ||
+       env_var.find_first_of(name) != string::npos)
+        logger->set_level(trace);
+    return logger;
+}
+
+string bytes_to_string(size_t bytes) {
+  static array<const char *, 5> units{"B", "KB", "MB", "GB", "TB"};
+  int count = 0;
+  double fbytes = static_cast<double>(bytes);
+  for(count = 0; count < units.size() && fbytes > 1000.0; count++) {
+    fbytes *= (1.0 / 1024.0);
+  }
+  return fmt::format("{:.3g} {}", fbytes, units[count]);
+}
+#else
+  shared_ptr<logger>
+  logger_factory(string name) {
+    return make_shared<logger>();
+  }
+
+  string bytes_to_string(size_t bytes) {
+    return "";
+  }
+#endif
+}

--- a/src/backend/common/Logger.cpp
+++ b/src/backend/common/Logger.cpp
@@ -13,6 +13,7 @@ using std::string;
 using std::shared_ptr;
 using std::to_string;
 
+using spdlog::get;
 using spdlog::level::trace;
 using spdlog::logger;
 using spdlog::stdout_logger_mt;
@@ -22,25 +23,28 @@ namespace common {
 #ifdef AF_WITH_LOGGING
 shared_ptr<logger>
 loggerFactory(string name) {
-    auto logger = stdout_logger_mt(name);
-    logger->set_pattern("[%n][%t] %v");
+    shared_ptr<logger> logger;
+    if(!(logger = get(name))) {
+        logger = stdout_logger_mt(name);
+        logger->set_pattern("[%n][%t] %v");
 
-    // Log mode
-    string env_var = getEnvVar("AF_TRACE");
-    if(env_var.find_first_of("all") != string::npos ||
-       env_var.find_first_of(name) != string::npos)
-        logger->set_level(trace);
+        // Log mode
+        string env_var = getEnvVar("AF_TRACE");
+        if(env_var.find_first_of("all") != string::npos ||
+          env_var.find_first_of(name) != string::npos)
+              logger->set_level(trace);
+    }
     return logger;
 }
 
 string bytesToString(size_t bytes) {
-  static array<const char *, 5> units{"B", "KB", "MB", "GB", "TB"};
-  int count = 0;
-  double fbytes = static_cast<double>(bytes);
-  for(count = 0; count < units.size() && fbytes > 1000.0; count++) {
-    fbytes *= (1.0 / 1024.0);
-  }
-  return fmt::format("{:.3g} {}", fbytes, units[count]);
+    static array<const char *, 5> units{"B", "KB", "MB", "GB", "TB"};
+    int count = 0;
+    double fbytes = static_cast<double>(bytes);
+    for(count = 0; count < units.size() && fbytes > 1000.0; count++) {
+        fbytes *= (1.0 / 1024.0);
+    }
+    return fmt::format("{:.3g} {}", fbytes, units[count]);
 }
 #else
   shared_ptr<logger>

--- a/src/backend/common/Logger.cpp
+++ b/src/backend/common/Logger.cpp
@@ -1,3 +1,11 @@
+/*******************************************************
+ * Copyright (c) 2018, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
 
 #include <common/Logger.hpp>
 #include <common/util.hpp>

--- a/src/backend/common/Logger.cpp
+++ b/src/backend/common/Logger.cpp
@@ -21,7 +21,7 @@ namespace common {
 
 #ifdef AF_WITH_LOGGING
 shared_ptr<logger>
-logger_factory(string name) {
+loggerFactory(string name) {
     auto logger = stdout_logger_mt(name);
     logger->set_pattern("[%n][%t] %v");
 
@@ -33,7 +33,7 @@ logger_factory(string name) {
     return logger;
 }
 
-string bytes_to_string(size_t bytes) {
+string bytesToString(size_t bytes) {
   static array<const char *, 5> units{"B", "KB", "MB", "GB", "TB"};
   int count = 0;
   double fbytes = static_cast<double>(bytes);
@@ -44,11 +44,11 @@ string bytes_to_string(size_t bytes) {
 }
 #else
   shared_ptr<logger>
-  logger_factory(string name) {
+  loggerFactory(string name) {
     return make_shared<logger>();
   }
 
-  string bytes_to_string(size_t bytes) {
+  string bytesToString(size_t bytes) {
     return "";
   }
 #endif

--- a/src/backend/common/Logger.hpp
+++ b/src/backend/common/Logger.hpp
@@ -20,10 +20,9 @@
 /// the users system. Only the functions we used are implemented here. Other
 /// functions will need to be implemented later.
 namespace spdlog {
+    class logger { public: logger() {} };
     std::shared_ptr<spdlog::logger> get(std::string &name);
-    class logger{ public: logger() {} };
-    std::shared_ptr<spdlog::logger>
-    stdout_logger_mt(std::string&);
+    std::shared_ptr<spdlog::logger> stdout_logger_mt(std::string&);
     namespace level {
         enum enum_level { trace };
     }

--- a/src/backend/common/Logger.hpp
+++ b/src/backend/common/Logger.hpp
@@ -1,0 +1,44 @@
+/*******************************************************
+ * Copyright (c) 2018, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#ifdef AF_WITH_LOGGING
+#include <spdlog/spdlog.h>
+#else
+
+namespace spdlog {
+  class logger{ public: logger() {} };
+  std::shared_ptr<logger>
+  stdout_logger_mt(std::string&);
+  namespace level {
+    enum enum_level { trace };
+  }
+}
+#endif
+
+namespace common {
+    std::shared_ptr<spdlog::logger> logger_factory(std::string name);
+    std::string bytes_to_string(size_t bytes);
+}
+
+#ifdef AF_WITH_LOGGING
+#define AF_STR_H(x) #x
+#define AF_STR_HELPER(x) AF_STR_H(x)
+#ifdef _MSC_VER
+#define AF_TRACE(...) getLogger()->trace("[ " __FILE__ "(" AF_STR_HELPER(__LINE__) ") ] " __VA_ARGS__)
+#else
+#define AF_TRACE(...) getLogger()->trace("[ " __FILE__ ":" AF_STR_HELPER(__LINE__) " ] " __VA_ARGS__)
+#endif
+#else
+#define AF_TRACE(logger, ...) (void)0
+#endif

--- a/src/backend/common/Logger.hpp
+++ b/src/backend/common/Logger.hpp
@@ -20,8 +20,9 @@
 /// the users system. Only the functions we used are implemented here. Other
 /// functions will need to be implemented later.
 namespace spdlog {
+  std::shared_ptr<spdlog::logger> get(std::string &name);
   class logger{ public: logger() {} };
-  std::shared_ptr<logger>
+  std::shared_ptr<spdlog::logger>
   stdout_logger_mt(std::string&);
   namespace level {
     enum enum_level { trace };

--- a/src/backend/common/Logger.hpp
+++ b/src/backend/common/Logger.hpp
@@ -20,13 +20,13 @@
 /// the users system. Only the functions we used are implemented here. Other
 /// functions will need to be implemented later.
 namespace spdlog {
-  std::shared_ptr<spdlog::logger> get(std::string &name);
-  class logger{ public: logger() {} };
-  std::shared_ptr<spdlog::logger>
-  stdout_logger_mt(std::string&);
-  namespace level {
-    enum enum_level { trace };
-  }
+    std::shared_ptr<spdlog::logger> get(std::string &name);
+    class logger{ public: logger() {} };
+    std::shared_ptr<spdlog::logger>
+    stdout_logger_mt(std::string&);
+    namespace level {
+        enum enum_level { trace };
+    }
 }
 #endif
 

--- a/src/backend/common/Logger.hpp
+++ b/src/backend/common/Logger.hpp
@@ -16,6 +16,9 @@
 #include <spdlog/spdlog.h>
 #else
 
+/// This is a stub class to match the spdlog API in case it is not installed on
+/// the users system. Only the functions we used are implemented here. Other
+/// functions will need to be implemented later.
 namespace spdlog {
   class logger{ public: logger() {} };
   std::shared_ptr<logger>
@@ -27,8 +30,8 @@ namespace spdlog {
 #endif
 
 namespace common {
-    std::shared_ptr<spdlog::logger> logger_factory(std::string name);
-    std::string bytes_to_string(size_t bytes);
+    std::shared_ptr<spdlog::logger> loggerFactory(std::string name);
+    std::string bytesToString(size_t bytes);
 }
 
 #ifdef AF_WITH_LOGGING

--- a/src/backend/common/MemoryManager.hpp
+++ b/src/backend/common/MemoryManager.hpp
@@ -77,10 +77,10 @@ class MemoryManager
     size_t mem_step_size;
     unsigned max_buffers;
     std::vector<memory_info> memory;
+    std::shared_ptr<spdlog::logger> logger;
     bool debug_mode;
 
     memory_info& getCurrentMemoryInfo();
-    std::shared_ptr<spdlog::logger> logger;
 
     inline int getActiveDeviceId();
     inline size_t getMaxMemorySize(int id);

--- a/src/backend/common/MemoryManager.hpp
+++ b/src/backend/common/MemoryManager.hpp
@@ -22,6 +22,9 @@
 #include <unordered_map>
 #include <vector>
 
+namespace spdlog {
+  class logger;
+}
 namespace common
 {
 using mutex_t      = std::mutex;
@@ -77,13 +80,14 @@ class MemoryManager
     bool debug_mode;
 
     memory_info& getCurrentMemoryInfo();
+    std::shared_ptr<spdlog::logger> logger;
 
     inline int getActiveDeviceId();
     inline size_t getMaxMemorySize(int id);
     void cleanDeviceMemoryManager(int device);
 
   public:
-     MemoryManager(int num_devices, unsigned max_buffers, bool debug);
+    MemoryManager(int num_devices, unsigned max_buffers, bool debug);
 
     // Intended to be used with OpenCL backend, where
     // users are allowed to add external devices(context, device pair)
@@ -130,6 +134,7 @@ class MemoryManager
     inline void nativeFree(void *ptr);
     bool checkMemoryLimit();
   protected:
+    spdlog::logger* getLogger();
     MemoryManager() = delete;
     ~MemoryManager() = default;
     MemoryManager(const MemoryManager& other) = delete;

--- a/src/backend/common/MemoryManagerImpl.hpp
+++ b/src/backend/common/MemoryManagerImpl.hpp
@@ -60,7 +60,7 @@ void MemoryManager<T>::cleanDeviceMemoryManager(int device) {
         current.free_map.clear();
     }
 
-    AF_TRACE("GC: Clearing {} buffers {}", free_ptrs.size(), bytes_to_string(bytes_freed));
+    AF_TRACE("GC: Clearing {} buffers {}", free_ptrs.size(), bytesToString(bytes_freed));
     // Free memory outside of the lock
     for(auto ptr : free_ptrs) {
         this->nativeFree(ptr);
@@ -75,7 +75,7 @@ MemoryManager<T>::MemoryManager(int num_devices,
       max_buffers(max_buffers),
       memory(num_devices),
       debug_mode(debug),
-      logger (logger_factory("mem")) {
+      logger (loggerFactory("mem")) {
     // Check for environment variables
 
     // Debug mode

--- a/src/backend/common/MemoryManagerImpl.hpp
+++ b/src/backend/common/MemoryManagerImpl.hpp
@@ -1,3 +1,11 @@
+/*******************************************************
+ * Copyright (c) 2018, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
 
 #include <common/MemoryManager.hpp>
 #include <common/Logger.hpp>

--- a/src/backend/cpu/Array.hpp
+++ b/src/backend/cpu/Array.hpp
@@ -26,18 +26,15 @@
 
 namespace cpu
 {
-namespace kernel
-{
-    template<typename T> void evalArray(Param<T> in, TNJ::Node_ptr node);
+    namespace kernel
+    {
+        template<typename T> void evalArray(Param<T> in, TNJ::Node_ptr node);
 
-    template<typename T>
-    void evalMultiple(std::vector<Param<T>> arrays, std::vector<TNJ::Node_ptr> nodes);
+        template<typename T>
+        void evalMultiple(std::vector<Param<T>> arrays, std::vector<TNJ::Node_ptr> nodes);
 
-}
-}
+    }
 
-namespace cpu
-{
     template<typename T> class Array;
 
     using std::shared_ptr;

--- a/src/backend/cpu/memory.cpp
+++ b/src/backend/cpu/memory.cpp
@@ -8,10 +8,12 @@
  ********************************************************/
 
 #include <memory.hpp>
+
+#include <common/Logger.hpp>
 #include <err_cpu.hpp>
-#include <types.hpp>
 #include <platform.hpp>
 #include <queue.hpp>
+#include <types.hpp>
 
 #include <common/MemoryManagerImpl.hpp>
 
@@ -24,6 +26,8 @@ template class common::MemoryManager<cpu::MemoryManager>;
 #ifndef AF_CPU_MEM_DEBUG
 #define AF_CPU_MEM_DEBUG 0
 #endif
+
+using common::bytes_to_string;
 
 using std::unique_ptr;
 using std::function;
@@ -178,12 +182,14 @@ size_t MemoryManager::getMaxMemorySize(int id)
 void *MemoryManager::nativeAlloc(const size_t bytes)
 {
     void *ptr = malloc(bytes);
+    AF_TRACE("{}: {} {}", __func__, bytes_to_string(bytes), ptr);
     if (!ptr) AF_ERROR("Unable to allocate memory", AF_ERR_NO_MEM);
     return ptr;
 }
 
 void MemoryManager::nativeFree(void *ptr)
 {
+    AF_TRACE("nativeFree: {}", ptr);
     // Make sure this pointer is not being used on the queue before freeing the memory.
     getQueue().sync();
     return free((void *)ptr);

--- a/src/backend/cpu/memory.cpp
+++ b/src/backend/cpu/memory.cpp
@@ -27,7 +27,7 @@ template class common::MemoryManager<cpu::MemoryManager>;
 #define AF_CPU_MEM_DEBUG 0
 #endif
 
-using common::bytes_to_string;
+using common::bytesToString;
 
 using std::unique_ptr;
 using std::function;
@@ -182,7 +182,7 @@ size_t MemoryManager::getMaxMemorySize(int id)
 void *MemoryManager::nativeAlloc(const size_t bytes)
 {
     void *ptr = malloc(bytes);
-    AF_TRACE("{}: {} {}", __func__, bytes_to_string(bytes), ptr);
+    AF_TRACE("{}: {} {}", __func__, bytesToString(bytes), ptr);
     if (!ptr) AF_ERROR("Unable to allocate memory", AF_ERR_NO_MEM);
     return ptr;
 }

--- a/src/backend/cpu/memory.cpp
+++ b/src/backend/cpu/memory.cpp
@@ -182,14 +182,14 @@ size_t MemoryManager::getMaxMemorySize(int id)
 void *MemoryManager::nativeAlloc(const size_t bytes)
 {
     void *ptr = malloc(bytes);
-    AF_TRACE("{}: {} {}", __func__, bytesToString(bytes), ptr);
+    AF_TRACE("nativeAlloc: {:>7} {}", bytesToString(bytes), ptr);
     if (!ptr) AF_ERROR("Unable to allocate memory", AF_ERR_NO_MEM);
     return ptr;
 }
 
 void MemoryManager::nativeFree(void *ptr)
 {
-    AF_TRACE("nativeFree: {}", ptr);
+    AF_TRACE("nativeFree: {: >8} {}", " ", ptr);
     // Make sure this pointer is not being used on the queue before freeing the memory.
     getQueue().sync();
     return free((void *)ptr);

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -7,20 +7,21 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include <cuda.h>
-#include <cuda_runtime_api.h>
-#include <cuda_runtime.h>
-#include <platform.hpp>
-#include <err_cuda.hpp>
 #include <memory.hpp>
-#include <common/util.hpp>
-#include <types.hpp>
+
+#include <common/Logger.hpp>
 #include <common/dispatch.hpp>
+#include <common/util.hpp>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_runtime_api.h>
+#include <err_cuda.hpp>
+#include <platform.hpp>
+#include <types.hpp>
 
 #include <mutex>
 
 #include <common/MemoryManagerImpl.hpp>
-
 template class common::MemoryManager<cuda::MemoryManager>;
 template class common::MemoryManager<cuda::MemoryManagerPinned>;
 
@@ -31,6 +32,8 @@ template class common::MemoryManager<cuda::MemoryManagerPinned>;
 #ifndef AF_CUDA_MEM_DEBUG
 #define AF_CUDA_MEM_DEBUG 0
 #endif
+
+using common::bytes_to_string;
 
 using std::lock_guard;
 using std::recursive_mutex;
@@ -185,11 +188,13 @@ void *MemoryManager::nativeAlloc(const size_t bytes)
 {
     void *ptr = NULL;
     CUDA_CHECK(cudaMalloc(&ptr, bytes));
+    AF_TRACE("{}: {} {}", __func__, bytes_to_string(bytes), ptr);
     return ptr;
 }
 
 void MemoryManager::nativeFree(void *ptr)
 {
+    AF_TRACE("{}: {}", __func__, ptr);
     cudaError_t err = cudaFree(ptr);
     if (err != cudaErrorCudartUnloading) {
         CUDA_CHECK(err);
@@ -222,11 +227,13 @@ void *MemoryManagerPinned::nativeAlloc(const size_t bytes)
 {
     void *ptr;
     CUDA_CHECK(cudaMallocHost(&ptr, bytes));
+    AF_TRACE("Pinned::{}: {} {}", __func__, bytes_to_string(bytes), ptr);
     return ptr;
 }
 
 void MemoryManagerPinned::nativeFree(void *ptr)
 {
+    AF_TRACE("Pinned::{}: {}", __func__, ptr);
     cudaError_t err = cudaFreeHost(ptr);
     if (err != cudaErrorCudartUnloading) {
         CUDA_CHECK(err);

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -33,7 +33,7 @@ template class common::MemoryManager<cuda::MemoryManagerPinned>;
 #define AF_CUDA_MEM_DEBUG 0
 #endif
 
-using common::bytes_to_string;
+using common::bytesToString;
 
 using std::lock_guard;
 using std::recursive_mutex;
@@ -188,7 +188,7 @@ void *MemoryManager::nativeAlloc(const size_t bytes)
 {
     void *ptr = NULL;
     CUDA_CHECK(cudaMalloc(&ptr, bytes));
-    AF_TRACE("{}: {} {}", __func__, bytes_to_string(bytes), ptr);
+    AF_TRACE("{}: {} {}", __func__, bytesToString(bytes), ptr);
     return ptr;
 }
 
@@ -227,7 +227,7 @@ void *MemoryManagerPinned::nativeAlloc(const size_t bytes)
 {
     void *ptr;
     CUDA_CHECK(cudaMallocHost(&ptr, bytes));
-    AF_TRACE("Pinned::{}: {} {}", __func__, bytes_to_string(bytes), ptr);
+    AF_TRACE("Pinned::{}: {} {}", __func__, bytesToString(bytes), ptr);
     return ptr;
 }
 

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -188,13 +188,13 @@ void *MemoryManager::nativeAlloc(const size_t bytes)
 {
     void *ptr = NULL;
     CUDA_CHECK(cudaMalloc(&ptr, bytes));
-    AF_TRACE("{}: {} {}", __func__, bytesToString(bytes), ptr);
+    AF_TRACE("nativeAlloc: {:>7} {}", bytesToString(bytes), ptr);
     return ptr;
 }
 
 void MemoryManager::nativeFree(void *ptr)
 {
-    AF_TRACE("{}: {}", __func__, ptr);
+    AF_TRACE("nativeFree:          {}", ptr);
     cudaError_t err = cudaFree(ptr);
     if (err != cudaErrorCudartUnloading) {
         CUDA_CHECK(err);
@@ -227,13 +227,13 @@ void *MemoryManagerPinned::nativeAlloc(const size_t bytes)
 {
     void *ptr;
     CUDA_CHECK(cudaMallocHost(&ptr, bytes));
-    AF_TRACE("Pinned::{}: {} {}", __func__, bytesToString(bytes), ptr);
+    AF_TRACE("Pinned::nativeAlloc: {:>7} {}", bytesToString(bytes), ptr);
     return ptr;
 }
 
 void MemoryManagerPinned::nativeFree(void *ptr)
 {
-    AF_TRACE("Pinned::{}: {}", __func__, ptr);
+    AF_TRACE("Pinned::nativeFree:          {}", ptr);
     cudaError_t err = cudaFreeHost(ptr);
     if (err != cudaErrorCudartUnloading) {
         CUDA_CHECK(err);

--- a/src/backend/cuda/platform.hpp
+++ b/src/backend/cuda/platform.hpp
@@ -18,10 +18,14 @@
 #include <cusolverDn.hpp>
 #include <cusparse.hpp>
 
+
 #include <memory>
 #include <string>
 #include <vector>
 
+namespace spdlog {
+  class logger;
+}
 namespace cuda
 {
 int getBackend();
@@ -54,6 +58,8 @@ cudaStream_t getActiveStream();
 size_t getDeviceMemorySize(int device);
 
 size_t getHostMemorySize();
+
+spdlog::logger* getLogger();
 
 int setDevice(int device);
 

--- a/src/backend/opencl/memory.cpp
+++ b/src/backend/opencl/memory.cpp
@@ -26,7 +26,7 @@ template class common::MemoryManager<opencl::MemoryManagerPinned>;
 #define AF_OPENCL_MEM_DEBUG 0
 #endif
 
-using common::bytes_to_string;
+using common::bytesToString;
 
 using std::unique_ptr;
 using std::function;
@@ -186,7 +186,7 @@ size_t MemoryManager::getMaxMemorySize(int id)
 void *MemoryManager::nativeAlloc(const size_t bytes)
 {
     auto ptr = (void *)(new cl::Buffer(getContext(), CL_MEM_READ_WRITE, bytes));
-    AF_TRACE("{}: {} {}", __func__, bytes_to_string(bytes), ptr);
+    AF_TRACE("{}: {} {}", __func__, bytesToString(bytes), ptr);
     return ptr;
 }
 
@@ -232,7 +232,7 @@ void *MemoryManagerPinned::nativeAlloc(const size_t bytes)
     void *ptr = NULL;
     cl::Buffer* buf = new cl::Buffer(getContext(), CL_MEM_ALLOC_HOST_PTR, bytes);
     ptr = getQueue().enqueueMapBuffer(*buf, true, CL_MAP_READ | CL_MAP_WRITE, 0, bytes);
-    AF_TRACE("Pinned::{}: {} {}", __func__, bytes_to_string(bytes), ptr);
+    AF_TRACE("Pinned::{}: {} {}", __func__, bytesToString(bytes), ptr);
     pinnedMaps[opencl::getActiveDeviceId()].emplace(ptr, buf);
     return ptr;
 }

--- a/src/backend/opencl/memory.cpp
+++ b/src/backend/opencl/memory.cpp
@@ -186,13 +186,13 @@ size_t MemoryManager::getMaxMemorySize(int id)
 void *MemoryManager::nativeAlloc(const size_t bytes)
 {
     auto ptr = (void *)(new cl::Buffer(getContext(), CL_MEM_READ_WRITE, bytes));
-    AF_TRACE("{}: {} {}", __func__, bytesToString(bytes), ptr);
+    AF_TRACE("nativeAlloc: {} {}", bytesToString(bytes), ptr);
     return ptr;
 }
 
 void MemoryManager::nativeFree(void *ptr)
 {
-    AF_TRACE("{}: {}", __func__, ptr);
+    AF_TRACE("nativeFree:          {}", ptr);
     delete (cl::Buffer *)ptr;
 }
 
@@ -232,14 +232,14 @@ void *MemoryManagerPinned::nativeAlloc(const size_t bytes)
     void *ptr = NULL;
     cl::Buffer* buf = new cl::Buffer(getContext(), CL_MEM_ALLOC_HOST_PTR, bytes);
     ptr = getQueue().enqueueMapBuffer(*buf, true, CL_MAP_READ | CL_MAP_WRITE, 0, bytes);
-    AF_TRACE("Pinned::{}: {} {}", __func__, bytesToString(bytes), ptr);
+    AF_TRACE("Pinned::nativeAlloc: {:>7} {}", bytesToString(bytes), ptr);
     pinnedMaps[opencl::getActiveDeviceId()].emplace(ptr, buf);
     return ptr;
 }
 
 void MemoryManagerPinned::nativeFree(void *ptr)
 {
-    AF_TRACE("Pinned::{}: {}", __func__, ptr);
+    AF_TRACE("Pinned::nativeFree:          {}", ptr);
     int n = opencl::getActiveDeviceId();
     auto map = pinnedMaps[n];
     auto iter = map.find(ptr);

--- a/src/backend/opencl/memory.cpp
+++ b/src/backend/opencl/memory.cpp
@@ -12,8 +12,9 @@
 #include <types.hpp>
 #include <err_opencl.hpp>
 
-#include <common/MemoryManagerImpl.hpp>
+#include <common/Logger.hpp>
 
+#include <common/MemoryManagerImpl.hpp>
 template class common::MemoryManager<opencl::MemoryManager>;
 template class common::MemoryManager<opencl::MemoryManagerPinned>;
 
@@ -24,6 +25,8 @@ template class common::MemoryManager<opencl::MemoryManagerPinned>;
 #ifndef AF_OPENCL_MEM_DEBUG
 #define AF_OPENCL_MEM_DEBUG 0
 #endif
+
+using common::bytes_to_string;
 
 using std::unique_ptr;
 using std::function;
@@ -182,11 +185,14 @@ size_t MemoryManager::getMaxMemorySize(int id)
 
 void *MemoryManager::nativeAlloc(const size_t bytes)
 {
-    return (void *)(new cl::Buffer(getContext(), CL_MEM_READ_WRITE, bytes));
+    auto ptr = (void *)(new cl::Buffer(getContext(), CL_MEM_READ_WRITE, bytes));
+    AF_TRACE("{}: {} {}", __func__, bytes_to_string(bytes), ptr);
+    return ptr;
 }
 
 void MemoryManager::nativeFree(void *ptr)
 {
+    AF_TRACE("{}: {}", __func__, ptr);
     delete (cl::Buffer *)ptr;
 }
 
@@ -226,12 +232,14 @@ void *MemoryManagerPinned::nativeAlloc(const size_t bytes)
     void *ptr = NULL;
     cl::Buffer* buf = new cl::Buffer(getContext(), CL_MEM_ALLOC_HOST_PTR, bytes);
     ptr = getQueue().enqueueMapBuffer(*buf, true, CL_MAP_READ | CL_MAP_WRITE, 0, bytes);
+    AF_TRACE("Pinned::{}: {} {}", __func__, bytes_to_string(bytes), ptr);
     pinnedMaps[opencl::getActiveDeviceId()].emplace(ptr, buf);
     return ptr;
 }
 
 void MemoryManagerPinned::nativeFree(void *ptr)
 {
+    AF_TRACE("Pinned::{}: {}", __func__, ptr);
     int n = opencl::getActiveDeviceId();
     auto map = pinnedMaps[n];
     auto iter = map.find(ptr);


### PR DESCRIPTION
Added logging support to memory operations. By default this is
turned off but you can enable them by setting the AF_TRACE
environment variable to 'mem'. Other components can also be
added in a later commit

This is implemented using the spdlog library.