### PR TITLE
Add libdl when building with FreeImage

### DIFF
--- a/src/api/c/CMakeLists.txt
+++ b/src/api/c/CMakeLists.txt
@@ -165,6 +165,7 @@ if(FreeImage_FOUND AND AF_WITH_IMAGEIO)
     target_link_libraries(c_api_interface INTERFACE FreeImage::FreeImage_STATIC)
   else ()
     target_include_directories(c_api_interface INTERFACE $<TARGET_PROPERTY:FreeImage::FreeImage,INTERFACE_INCLUDE_DIRECTORIES>)
+    target_link_libraries(c_api_interface INTERFACE ${CMAKE_DL_LIBS})
     if (WIN32 AND AF_INSTALL_STANDALONE)
       install(FILES $<TARGET_FILE:FreeImage::FreeImage>
         DESTINATION ${AF_INSTALL_BIN_DIR}


### PR DESCRIPTION
We are now loading FreeImage at runtime. Because of this we need
to link with the libdl library so that we can call dlopen and dlsym.
This was working on the CI builders because we were linking with
MKL which also requires libdl.