### PR TITLE
Fix host leak when assigning indexed array to another indexed array

### DIFF
--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -562,13 +562,11 @@ namespace af
 #if __cplusplus > 199711L
     af::array::array_proxy::array_proxy(array_proxy &&other) {
         impl = other.impl;
-        other.impl = nullptr;
     }
 
     array::array_proxy&
     af::array::array_proxy::operator=(array_proxy &&other) {
         array out = other;
-        other.impl = nullptr;
         return *this = out;
     }
 #endif


### PR DESCRIPTION
Fixes a memory leak caused by assigning from one indexed array to
another indexed array. This was happening because the move constructor
was setting the array_proxy_impl ptr to null and therefore the object
was not getting released. This would have caused a leak in host memory
but the device memory would have been correctly deallocated.