### PR TITLE
Fix several memory related issues in unit tests.

### DIFF
--- a/test/anisotropic_diffusion.cpp
+++ b/test/anisotropic_diffusion.cpp
@@ -122,6 +122,7 @@ void imageTest(string pTestFile, const float dt, const float K, const uint iters
         ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(), outData.data(), 0.025f));
 
         ASSERT_EQ(AF_SUCCESS, af_release_array(_inArray));
+        ASSERT_EQ(AF_SUCCESS, af_release_array(_outArray));
         ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
         ASSERT_EQ(AF_SUCCESS, af_release_array(cstArray));
         ASSERT_EQ(AF_SUCCESS, af_release_array(minArray));

--- a/test/cast.cpp
+++ b/test/cast.cpp
@@ -30,6 +30,8 @@ void cast_test()
     af_array a, b;
     af_randu(&a, dims.ndims(), dims.get(), ta);
     af_err err = af_cast(&b, a, tb);
+    af_release_array(a);
+    af_release_array(b);
     ASSERT_EQ(err, AF_SUCCESS);
 }
 
@@ -87,6 +89,7 @@ void cast_test_complex_real()
     af_randu(&a, dims.ndims(), dims.get(), ta);
     af_err err = af_cast(&b, a, tb);
     ASSERT_EQ(err, AF_ERR_TYPE);
+    ASSERT_EQ(AF_SUCCESS, af_release_array(a));
 }
 
 #define COMPLEX_REAL_TESTS(Ti, To)                      \

--- a/test/complex.cpp
+++ b/test/complex.cpp
@@ -37,9 +37,9 @@ const int num = 10;
         for (int i = 0; i < num; i++)                                   \
             ASSERT_EQ(h_c[i], CPLX(Tc)(h_a[i], h_b[i])) <<              \
                 "for values: " << h_a[i]  << "," << h_b[i] << std::endl; \
-        delete[] h_a;                                                   \
-        delete[] h_b;                                                   \
-        delete[] h_c;                                                   \
+        freeHost(h_a);                                                  \
+        freeHost(h_b);                                                  \
+        freeHost(h_c);                                                  \
     }                                                                   \
     TEST(ComplexTests, Test_cplx_##Ta##_##Tb##_left)                    \
     {                                                                   \
@@ -55,8 +55,8 @@ const int num = 10;
         for (int i = 0; i < num; i++)                                   \
             ASSERT_EQ(h_c[i], CPLX(Ta)(h_a[i], h_b)) <<                 \
                 "for values: " << h_a[i]  << "," << h_b << std::endl;   \
-        delete[] h_a;                                                   \
-        delete[] h_c;                                                   \
+        freeHost(h_a);                                                  \
+        freeHost(h_c);                                                  \
     }                                                                   \
                                                                         \
     TEST(ComplexTests, Test_cplx_##Ta##_##Tb##_right)                   \
@@ -73,8 +73,8 @@ const int num = 10;
         for (int i = 0; i < num; i++)                                   \
             ASSERT_EQ(h_c[i], CPLX(Tb)(h_a, h_b[i])) <<                 \
                 "for values: " << h_a  << "," << h_b[i] << std::endl;   \
-        delete[] h_b;                                                   \
-        delete[] h_c;                                                   \
+        freeHost(h_b);                                                  \
+        freeHost(h_c);                                                  \
     }                                                                   \
     TEST(ComplexTests, Test_##Ta##_##Tb##_Real)                         \
     {                                                                   \
@@ -92,8 +92,8 @@ const int num = 10;
         Tc *h_d = d.host<Tc>();                                         \
         for (int i = 0; i < num; i++)                                   \
             ASSERT_EQ(h_d[i], h_a[i]) << "at: " << i << std::endl;      \
-        delete[] h_a;                                                   \
-        delete[] h_d;                                                   \
+        freeHost(h_a);                                                  \
+        freeHost(h_d);                                                  \
     }                                                                   \
     TEST(ComplexTests, Test_##Ta##_##Tb##_Imag)                         \
     {                                                                   \
@@ -111,8 +111,8 @@ const int num = 10;
         Tc *h_d = d.host<Tc>();                                         \
         for (int i = 0; i < num; i++)                                   \
             ASSERT_EQ(h_d[i], h_b[i])  << "at: " << i << std::endl;     \
-        delete[] h_b;                                                   \
-        delete[] h_d;                                                   \
+        freeHost(h_b);                                                  \
+        freeHost(h_d);                                                  \
     }                                                                   \
     TEST(ComplexTests, Test_##Ta##_##Tb##_Conj)                         \
     {                                                                   \
@@ -131,8 +131,8 @@ const int num = 10;
         for (int i = 0; i < num; i++)                                   \
             ASSERT_EQ(conj(h_c[i]), h_d[i])                             \
                 << "at: " << i << std::endl;                            \
-        delete[] h_c;                                                   \
-        delete[] h_d;                                                   \
+        freeHost(h_c);                                                  \
+        freeHost(h_d);                                                  \
     }                                                                   \
 
 

--- a/test/constant.cpp
+++ b/test/constant.cpp
@@ -57,6 +57,7 @@ void ConstantCCheck(T value) {
     for (int i = 0; i < num; i++) {
         ASSERT_EQ(::real(h_in[i]), val);
     }
+    ASSERT_EQ(AF_SUCCESS, af_release_array(out));
 }
 
 template<typename T>
@@ -138,6 +139,7 @@ void IdentityCCheck() {
                 ASSERT_EQ(h_in[i * num + j], T(0));
         }
     }
+    ASSERT_EQ(AF_SUCCESS, af_release_array(out));
 }
 
 template<typename T>

--- a/test/empty.cpp
+++ b/test/empty.cpp
@@ -283,5 +283,7 @@ TEST(Array, TestEmptyImage) {
     ASSERT_EQ(nd, 0u);
     af_get_numdims(&nd, hout);
     ASSERT_EQ(nd, 0u);
+    ASSERT_EQ(AF_SUCCESS, af_release_array(h));
+    ASSERT_EQ(AF_SUCCESS, af_release_array(hout));
 }
 

--- a/test/fast.cpp
+++ b/test/fast.cpp
@@ -141,11 +141,7 @@ void fastTest(string pTestFile, bool nonmax)
         ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
         ASSERT_EQ(AF_SUCCESS, af_release_array(inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(x));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(y));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(score));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(orientation));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(size));
+        ASSERT_EQ(AF_SUCCESS, af_release_features(out));
 
         delete [] outX;
         delete [] outY;

--- a/test/fft.cpp
+++ b/test/fft.cpp
@@ -511,8 +511,8 @@ TEST(fft, CPP_4D)
         ASSERT_EQ(h_b[i], h_B[i]) << "at: " << i << std::endl;
     }
 
-    delete[] h_b;
-    delete[] h_B;
+    freeHost(h_b);
+    freeHost(h_B);
 }
 
 TEST(ifft, CPP_4D)
@@ -530,8 +530,8 @@ TEST(ifft, CPP_4D)
         ASSERT_EQ(h_b[i], h_B[i]) << "at: " << i << std::endl;
     }
 
-    delete[] h_b;
-    delete[] h_B;
+    freeHost(h_b);
+    freeHost(h_B);
 }
 
 TEST(fft, GFOR)
@@ -551,8 +551,8 @@ TEST(fft, GFOR)
         ASSERT_EQ(h_b[i], h_c[i]) << "at: " << i << std::endl;
     }
 
-    delete[] h_b;
-    delete[] h_c;
+    freeHost(h_b);
+    freeHost(h_c);
 }
 
 TEST(fft2, GFOR)
@@ -572,8 +572,8 @@ TEST(fft2, GFOR)
         ASSERT_EQ(h_b[i], h_c[i]) << "at: " << i << std::endl;
     }
 
-    delete[] h_b;
-    delete[] h_c;
+    freeHost(h_b);
+    freeHost(h_c);
 }
 
 TEST(fft3, GFOR)
@@ -593,8 +593,8 @@ TEST(fft3, GFOR)
         ASSERT_EQ(h_b[i], h_c[i]) << "at: " << i << std::endl;
     }
 
-    delete[] h_b;
-    delete[] h_c;
+    freeHost(h_b);
+    freeHost(h_c);
 }
 
 TEST(fft, InPlace)

--- a/test/flat.cpp
+++ b/test/flat.cpp
@@ -28,8 +28,8 @@ TEST(FlatTests, Test_flat_1D)
         ASSERT_EQ(h_in[i], h_out[i]);
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }
 
 TEST(FlatTests, Test_flat_2D)
@@ -48,8 +48,8 @@ TEST(FlatTests, Test_flat_2D)
         ASSERT_EQ(h_in[i], h_out[i]);
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }
 
 TEST(FlatTests, Test_flat_1D_index)
@@ -69,8 +69,8 @@ TEST(FlatTests, Test_flat_1D_index)
         ASSERT_EQ(h_in[i], h_out[i - st]);
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }
 
 TEST(FlatTests, Test_flat_2D_index0)
@@ -97,8 +97,8 @@ TEST(FlatTests, Test_flat_2D_index0)
         }
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }
 
 TEST(FlatTests, Test_flat_2D_index1)
@@ -126,6 +126,6 @@ TEST(FlatTests, Test_flat_2D_index1)
         }
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }

--- a/test/flip.cpp
+++ b/test/flip.cpp
@@ -30,8 +30,8 @@ TEST(FlipTests, Test_flip_1D)
             << "at (" << i << ")";
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }
 
 TEST(FlipTests, Test_flip_2D0)
@@ -54,8 +54,8 @@ TEST(FlipTests, Test_flip_2D0)
         }
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }
 
 TEST(FlipTests, Test_flip_2D1)
@@ -78,8 +78,8 @@ TEST(FlipTests, Test_flip_2D1)
         }
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }
 
 
@@ -101,8 +101,8 @@ TEST(FlipTests, Test_flip_1D_index)
             << "at (" << i << ")";
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }
 
 TEST(FlipTests, Test_flip_2D_index00)
@@ -129,8 +129,8 @@ TEST(FlipTests, Test_flip_2D_index00)
         }
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }
 
 TEST(FlipTests, Test_flip_2D_index01)
@@ -157,8 +157,8 @@ TEST(FlipTests, Test_flip_2D_index01)
         }
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }
 
 TEST(FlipTests, Test_flip_2D_index10)
@@ -186,8 +186,8 @@ TEST(FlipTests, Test_flip_2D_index10)
         }
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }
 
 TEST(FlipTests, Test_flip_2D_index11)
@@ -215,6 +215,6 @@ TEST(FlipTests, Test_flip_2D_index11)
         }
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }

--- a/test/gen_assign.cpp
+++ b/test/gen_assign.cpp
@@ -28,6 +28,7 @@ using std::cout;
 using std::endl;
 using std::ostream_iterator;
 using af::dtype_traits;
+using af::freeHost;
 
 void testGeneralAssignOneArray(string pTestFile, const dim_t ndims, af_index_t* indexs, int arrayDim)
 {
@@ -252,11 +253,11 @@ TEST(ArrayAssign, CPP_ASSIGN_INDEX)
         ASSERT_EQ(hAO[i], hAC[i]);
     }
 
-    delete[] hA;
-    delete[] hB;
-    delete[] hAC;
-    delete[] hAO;
-    delete[] hIdx;
+    freeHost(hA);
+    freeHost(hB);
+    freeHost(hAC);
+    freeHost(hAO);
+    freeHost(hIdx);
 }
 
 TEST(ArrayAssign, CPP_ASSIGN_INDEX_LOGICAL)
@@ -304,11 +305,11 @@ TEST(ArrayAssign, CPP_ASSIGN_INDEX_LOGICAL)
             ASSERT_EQ(hAO[i], hAC[i]);
         }
 
-        delete[] hA;
-        delete[] hB;
-        delete[] hAC;
-        delete[] hAO;
-        delete[] hIdx;
+        freeHost(hA);
+        freeHost(hB);
+        freeHost(hAC);
+        freeHost(hAO);
+        freeHost(hIdx);
     } catch(af::exception &ex) {
         FAIL() << ex.what() << std::endl;
     }
@@ -347,9 +348,9 @@ TEST(GeneralAssign, CPP_ASNN)
         }
     }
 
-    delete[] hA;
-    delete[] hB;
-    delete[] hIdx;
+    freeHost(hA);
+    freeHost(hB);
+    freeHost(hIdx);
 }
 
 TEST(GeneralAssign, CPP_SANN)
@@ -384,9 +385,9 @@ TEST(GeneralAssign, CPP_SANN)
         }
     }
 
-    delete[] hA;
-    delete[] hB;
-    delete[] hIdx;
+    freeHost(hA);
+    freeHost(hB);
+    freeHost(hIdx);
 }
 
 TEST(GeneralAssign, CPP_SSAN)
@@ -424,9 +425,9 @@ TEST(GeneralAssign, CPP_SSAN)
         }
     }
 
-    delete[] hA;
-    delete[] hB;
-    delete[] hIdx;
+    freeHost(hA);
+    freeHost(hB);
+    freeHost(hIdx);
 }
 
 TEST(GeneralAssign, CPP_AANN)
@@ -459,8 +460,8 @@ TEST(GeneralAssign, CPP_AANN)
         }
     }
 
-    delete[] hA;
-    delete[] hB;
-    delete[] hIdx0;
-    delete[] hIdx1;
+    freeHost(hA);
+    freeHost(hB);
+    freeHost(hIdx0);
+    freeHost(hIdx1);
 }

--- a/test/gen_index.cpp
+++ b/test/gen_index.cpp
@@ -183,9 +183,9 @@ TEST(GeneralIndex, CPP_ASNN)
         }
     }
 
-    delete[] hA;
-    delete[] hB;
-    delete[] hIdx;
+    freeHost(hA);
+    freeHost(hB);
+    freeHost(hIdx);
 }
 
 TEST(GeneralIndex, CPP_SANN)
@@ -217,9 +217,9 @@ TEST(GeneralIndex, CPP_SANN)
         }
     }
 
-    delete[] hA;
-    delete[] hB;
-    delete[] hIdx;
+    freeHost(hA);
+    freeHost(hB);
+    freeHost(hIdx);
 }
 
 TEST(GeneralIndex, CPP_SSAN)
@@ -255,9 +255,9 @@ TEST(GeneralIndex, CPP_SSAN)
         }
     }
 
-    delete[] hA;
-    delete[] hB;
-    delete[] hIdx;
+    freeHost(hA);
+    freeHost(hB);
+    freeHost(hIdx);
 }
 
 TEST(GeneralIndex, CPP_AANN)
@@ -289,8 +289,8 @@ TEST(GeneralIndex, CPP_AANN)
         }
     }
 
-    delete[] hA;
-    delete[] hB;
-    delete[] hIdx0;
-    delete[] hIdx1;
+    freeHost(hA);
+    freeHost(hB);
+    freeHost(hIdx0);
+    freeHost(hIdx1);
 }

--- a/test/gfor.cpp
+++ b/test/gfor.cpp
@@ -40,7 +40,7 @@ TEST(GFOR, Assign_Scalar_Span)
         ASSERT_EQ(hA[i], val);
     }
 
-    delete[] hA;
+    freeHost(hA);
 }
 
 TEST(GFOR, Assign_Scalar_Seq)
@@ -64,8 +64,8 @@ TEST(GFOR, Assign_Scalar_Seq)
         else ASSERT_EQ(hA[i], hB[i]);
     }
 
-    delete[] hA;
-    delete[] hB;
+    freeHost(hA);
+    freeHost(hB);
 }
 
 TEST(GFOR, Inc_Scalar_Span)
@@ -86,8 +86,8 @@ TEST(GFOR, Inc_Scalar_Span)
         ASSERT_EQ(hA[i], val + hB[i]);
     }
 
-    delete[] hA;
-    delete[] hB;
+    freeHost(hA);
+    freeHost(hB);
 }
 
 TEST(GFOR, Inc_Scalar_Seq)
@@ -111,8 +111,8 @@ TEST(GFOR, Inc_Scalar_Seq)
         else ASSERT_EQ(hA[i], hB[i]);
     }
 
-    delete[] hA;
-    delete[] hB;
+    freeHost(hA);
+    freeHost(hB);
 }
 
 TEST(GFOR, Assign_Array_Span)
@@ -132,7 +132,7 @@ TEST(GFOR, Assign_Array_Span)
         ASSERT_EQ(hA[i], val);
     }
 
-    delete[] hA;
+    freeHost(hA);
 }
 
 TEST(GFOR, Assign_Array_Seq)
@@ -162,9 +162,9 @@ TEST(GFOR, Assign_Array_Seq)
         }
     }
 
-    delete[] hA;
-    delete[] hB;
-    delete[] hC;
+    freeHost(hA);
+    freeHost(hB);
+    freeHost(hC);
 }
 
 TEST(GFOR, Inc_Array_Span)
@@ -186,8 +186,8 @@ TEST(GFOR, Inc_Array_Span)
         ASSERT_EQ(hA[i], val + hB[i]);
     }
 
-    delete[] hA;
-    delete[] hB;
+    freeHost(hA);
+    freeHost(hB);
 }
 
 TEST(GFOR, Inc_Array_Seq)
@@ -217,9 +217,9 @@ TEST(GFOR, Inc_Array_Seq)
         }
     }
 
-    delete[] hA;
-    delete[] hB;
-    delete[] hC;
+    freeHost(hA);
+    freeHost(hB);
+    freeHost(hC);
 }
 
 TEST(BatchFunc, 2D0)

--- a/test/harris.cpp
+++ b/test/harris.cpp
@@ -134,11 +134,7 @@ void harrisTest(string pTestFile, float sigma, unsigned block_size)
         ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
         ASSERT_EQ(AF_SUCCESS, af_release_array(inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(x));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(y));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(score));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(orientation));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(size));
+        ASSERT_EQ(AF_SUCCESS, af_release_features(out));
     }
 }
 

--- a/test/homography.cpp
+++ b/test/homography.cpp
@@ -176,8 +176,8 @@ void homographyTest(string pTestFile, const af_homography_type htype,
     ASSERT_EQ(AF_SUCCESS, af_release_array(dist_thr));
     ASSERT_EQ(AF_SUCCESS, af_release_array(train_idx));
     ASSERT_EQ(AF_SUCCESS, af_release_array(query_idx));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(query_feat_x));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(query_feat_y));
+    ASSERT_EQ(AF_SUCCESS, af_release_features(query_feat));
+    ASSERT_EQ(AF_SUCCESS, af_release_features(train_feat));
     ASSERT_EQ(AF_SUCCESS, af_release_array(train_feat_x_idx));
     ASSERT_EQ(AF_SUCCESS, af_release_array(train_feat_y_idx));
     ASSERT_EQ(AF_SUCCESS, af_release_array(query_feat_x_idx));
@@ -186,8 +186,6 @@ void homographyTest(string pTestFile, const af_homography_type htype,
     ASSERT_EQ(AF_SUCCESS, af_release_array(trainArray));
     ASSERT_EQ(AF_SUCCESS, af_release_array(trainArray_f32));
     ASSERT_EQ(AF_SUCCESS, af_release_array(train_desc));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(train_feat_x));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(train_feat_y));
 }
 
 #define HOMOGRAPHY_INIT(desc, image, htype, rotate, size_ratio)                 \

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -28,6 +28,7 @@ using std::cout;
 using std::endl;
 using std::ostream_iterator;
 using af::dtype_traits;
+using af::freeHost;
 
 template<typename T, typename OP>
 void
@@ -737,8 +738,8 @@ TEST(SeqIndex, CPP_END)
     }
 
 
-    delete[] hA;
-    delete[] hB;
+    freeHost(hA);
+    freeHost(hB);
 }
 
 
@@ -760,8 +761,8 @@ TEST(SeqIndex, CPP_END_SEQ)
         ASSERT_EQ(hA[i + end_begin - 1], hB[i]);
     }
 
-    delete[] hA;
-    delete[] hB;
+    freeHost(hA);
+    freeHost(hB);
 }
 
 af::array cpp_scope_seq_test(const int num, const float val, const af::seq s)
@@ -786,7 +787,7 @@ TEST(SeqIndex, CPP_SCOPE_SEQ)
         ASSERT_EQ(hB[i], val);
     }
 
-    delete[] hB;
+    freeHost(hB);
 }
 
 af::array cpp_scope_arr_test(const int num, const float val)
@@ -810,7 +811,7 @@ TEST(SeqIndex, CPP_SCOPE_ARR)
         ASSERT_EQ(hB[i], val * (val - 1));
     }
 
-    delete[] hB;
+    freeHost(hB);
 }
 
 TEST(SeqIndex, CPPLarge)
@@ -884,9 +885,9 @@ TEST(SeqIndex, Cascade00)
         }
     }
 
-    delete[] h_a;
-    delete[] h_b;
-    delete[] h_c;
+    freeHost(h_a);
+    freeHost(h_b);
+    freeHost(h_c);
 }
 
 TEST(SeqIndex, Cascade01)
@@ -930,9 +931,9 @@ TEST(SeqIndex, Cascade01)
         }
     }
 
-    delete[] h_a;
-    delete[] h_b;
-    delete[] h_c;
+    freeHost(h_a);
+    freeHost(h_b);
+    freeHost(h_c);
 }
 
 TEST(SeqIndex, Cascade10)
@@ -976,9 +977,9 @@ TEST(SeqIndex, Cascade10)
         }
     }
 
-    delete[] h_a;
-    delete[] h_b;
-    delete[] h_c;
+    freeHost(h_a);
+    freeHost(h_b);
+    freeHost(h_c);
 }
 
 TEST(SeqIndex, Cascade11)
@@ -1023,9 +1024,9 @@ TEST(SeqIndex, Cascade11)
         }
     }
 
-    delete[] h_a;
-    delete[] h_b;
-    delete[] h_c;
+    freeHost(h_a);
+    freeHost(h_b);
+    freeHost(h_c);
 }
 
 TEST(ArrayIndex, CPP_INDEX_VECTOR)
@@ -1048,8 +1049,8 @@ TEST(ArrayIndex, CPP_INDEX_VECTOR)
         ASSERT_EQ(h_C[i], h_B[(int)h_inds[i]]);
     }
 
-    delete[] h_B;
-    delete[] h_C;
+    freeHost(h_B);
+    freeHost(h_C);
 }
 
 TEST(SeqIndex, CPP_INDEX_VECTOR)
@@ -1076,8 +1077,8 @@ TEST(SeqIndex, CPP_INDEX_VECTOR)
         ASSERT_EQ(h_C[i], h_B[i + st]);
     }
 
-    delete[] h_B;
-    delete[] h_C;
+    freeHost(h_B);
+    freeHost(h_C);
 }
 
 
@@ -1101,8 +1102,8 @@ TEST(ArrayIndex, CPP_INDEX_VECTOR_2D)
         ASSERT_EQ(h_C[i], h_B[(int)h_inds[i]]);
     }
 
-    delete[] h_B;
-    delete[] h_C;
+    freeHost(h_B);
+    freeHost(h_C);
 }
 
 TEST(SeqIndex, CPP_INDEX_VECTOR_2D)
@@ -1130,8 +1131,8 @@ TEST(SeqIndex, CPP_INDEX_VECTOR_2D)
         ASSERT_EQ(h_C[i], h_B[i + st]);
     }
 
-    delete[] h_B;
-    delete[] h_C;
+    freeHost(h_B);
+    freeHost(h_C);
 }
 
 template<typename T>
@@ -1337,7 +1338,7 @@ TEST(Indexing, SNIPPET_indexing_copy)
   // freed once.
 }
 
-TEST(Asssign, LinearIndexSeq)
+TEST(Assign, LinearIndexSeq)
 {
     using af::array;
     const int nx = 5;
@@ -1373,7 +1374,7 @@ TEST(Asssign, LinearIndexSeq)
     }
 }
 
-TEST(Asssign, LinearIndexGenSeq)
+TEST(Assign, LinearIndexGenSeq)
 {
     using af::array;
     const int nx = 5;
@@ -1409,7 +1410,7 @@ TEST(Asssign, LinearIndexGenSeq)
     }
 }
 
-TEST(Asssign, LinearIndexGenArr)
+TEST(Assign, LinearIndexGenArr)
 {
     using af::array;
     const int nx = 5;

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -52,10 +52,9 @@ void readTests(const std::string &FileName, std::vector<af::dim4> &inputDims,
     if(testFile.good()) {
         unsigned inputCount;
         testFile >> inputCount;
+        inputDims.resize(inputCount);
         for(unsigned i=0; i<inputCount; i++) {
-            af::dim4 temp(1);
-            testFile >> temp;
-            inputDims.push_back(temp);
+            testFile >> inputDims[i];
         }
 
         unsigned testCount;


### PR DESCRIPTION
* Release objects before the test finishs
* Use freeHost instead of delete[]
* Correctly release af_feature objects and arrays
* Use resize in readTests to avoid multiple allocations