### PR TITLE
Check for unsupported cards on a given cuda runtime

### DIFF
--- a/test/info.cpp
+++ b/test/info.cpp
@@ -37,13 +37,14 @@ void testFunction()
 
 void infoTest()
 {
+    int nDevices = 0;
+    ASSERT_EQ(AF_SUCCESS, af_get_device_count(&nDevices));
+    ASSERT_EQ(true, nDevices>0);
+
     const char* ENV = getenv("AF_MULTI_GPU_TESTS");
     if(ENV && ENV[0] == '0') {
         testFunction<float>();
     } else {
-        int nDevices = 0;
-        ASSERT_EQ(AF_SUCCESS, af_get_device_count(&nDevices));
-
         int oldDevice = af::getDevice();
         for(int d = 0; d < nDevices; d++) {
             af::setDevice(d);

--- a/test/solve_dense.cpp
+++ b/test/solve_dense.cpp
@@ -165,8 +165,9 @@ TEST(Solve, Threading)
 
     vector<std::thread> tests;
 
-    int numDevices = 1;
+    int numDevices = 0;
     ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
+    ASSERT_EQ(true, numDevices>0);
 
     SOLVE_LU_TESTS_THREADING(float, 0.01);
     SOLVE_LU_TESTS_THREADING(cfloat, 0.01);

--- a/test/threading.cpp
+++ b/test/threading.cpp
@@ -344,8 +344,9 @@ TEST(Threading, FFT_R2C)
 
     vector<std::thread> tests;
 
-    int numDevices = 1;
+    int numDevices = 0;
     ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
+    ASSERT_EQ(true, numDevices>0);
 
     // Real to complex transforms
     INSTANTIATE_TEST(fft ,  R2C_Float, false,  float,  cfloat, string(TEST_DIR"/signal/fft_r2c.test") );
@@ -388,8 +389,9 @@ TEST(Threading, FFT_C2C)
 
     vector<std::thread> tests;
 
-    int numDevices = 1;
+    int numDevices = 0;
     ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
+    ASSERT_EQ(true, numDevices>0);
 
     // complex to complex transforms
     INSTANTIATE_TEST(fft ,  C2C_Float, false,  cfloat,  cfloat, string(TEST_DIR"/signal/fft_c2c.test") );
@@ -437,8 +439,9 @@ TEST(Threading, FFT_ALL)
 
     vector<std::thread> tests;
 
-    int numDevices = 1;
+    int numDevices = 0;
     ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
+    ASSERT_EQ(true, numDevices>0);
 
     // Real to complex transforms
     INSTANTIATE_TEST(fft ,  R2C_Float, false,  float,  cfloat, string(TEST_DIR"/signal/fft_r2c.test") );
@@ -576,8 +579,9 @@ TEST(Threading, BLAS)
 
     vector<std::thread> tests;
 
-    int numDevices = 1;
+    int numDevices = 0;
     ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
+    ASSERT_EQ(true, numDevices>0);
 
     TEST_BLAS_FOR_TYPE(      float);
     TEST_BLAS_FOR_TYPE( af::cfloat);
@@ -606,8 +610,9 @@ TEST(Threading, Sparse)
 
     vector<std::thread> tests;
 
-    int numDevices = 1;
+    int numDevices = 0;
     ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
+    ASSERT_EQ(true, numDevices>0);
 
     SPARSE_TESTS(  float, 1E-3);
     SPARSE_TESTS( cfloat, 1E-3);


### PR DESCRIPTION
Fixes #2181 

CUDA 9.* drops support for all Fermi(NVIDIA) GPUs. This adds
a check when the user wants to run ArrayFire built with CUDA 9.*
on a card with compute version <=2.*