### PR TITLE
Fix valgrind errors by replacing malloc with calloc

### DIFF
--- a/src/backend/cpu/memory.cpp
+++ b/src/backend/cpu/memory.cpp
@@ -136,7 +136,7 @@ bool checkMemoryLimit()
     template void memFree(T* ptr);                                                            \
     template T* pinnedAlloc(const size_t &elements);                                          \
     template void pinnedFree(T* ptr);                                                         \
- 
+
 INSTANTIATE(float)
 INSTANTIATE(cfloat)
 INSTANTIATE(double)
@@ -181,7 +181,7 @@ size_t MemoryManager::getMaxMemorySize(int id)
 
 void *MemoryManager::nativeAlloc(const size_t bytes)
 {
-    void *ptr = malloc(bytes);
+    void *ptr = calloc(bytes, 1);
     AF_TRACE("nativeAlloc: {:>7} {}", bytesToString(bytes), ptr);
     if (!ptr) AF_ERROR("Unable to allocate memory", AF_ERR_NO_MEM);
     return ptr;

--- a/src/backend/cuda/cufft.cpp
+++ b/src/backend/cuda/cufft.cpp
@@ -117,7 +117,7 @@ SharedPlan findPlan(int rank, int *n,
     if (retVal)
         return retVal;
 
-    PlanType* temp = (PlanType*)malloc(sizeof(PlanType));
+    PlanType* temp = (PlanType*)calloc(1, sizeof(PlanType));
     cufftResult res = cufftPlanMany(temp, rank, n,
                                     inembed, istride, idist, onembed, ostride, odist,
                                     type, batch);

--- a/src/backend/cuda/driver.cpp
+++ b/src/backend/cuda/driver.cpp
@@ -31,7 +31,7 @@ int nvDriverVersion(char *result, int len)
     dwLen = GetFileVersionInfoSize(lptstrFilename, &dwHandle);
     if (dwLen == 0) return 0;
 
-    lpData = malloc(dwLen);
+    lpData = calloc(1, dwLen);
     if (!lpData) return 0;
 
     rv = GetFileVersionInfo(lptstrFilename, 0, dwLen, lpData);

--- a/src/backend/opencl/clfft.cpp
+++ b/src/backend/opencl/clfft.cpp
@@ -128,7 +128,7 @@ SharedPlan findPlan(clfftLayout iLayout, clfftLayout oLayout,
     if (retVal)
         return retVal;
 
-    PlanType* temp = (PlanType*)malloc(sizeof(PlanType));
+    PlanType* temp = (PlanType*)calloc(1, sizeof(PlanType));
 
     // getContext() returns object of type Context
     // Context() returns the actual cl_context handle


### PR DESCRIPTION
The difference in exeuction time for calloc and malloc is barely
noticeable. I have timed their execution times using af::timeit.