### PR TITLE
WIP: Change canny test threshold

### DIFF
--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -322,8 +322,10 @@ bool compareArraysRMSD(dim_t data_size, T *gold, T *data, double tolerance)
     accum /= data_size;
     double NRMSD = std::sqrt(accum)/(maxion-minion);
 
-    if (std::isnan(NRMSD) || NRMSD > tolerance)
+    if (std::isnan(NRMSD) || NRMSD > tolerance) {
+        printf("NRMSD is %lf\n", NRMSD);
         return false;
+    }
 
     return true;
 }


### PR DESCRIPTION
I have tested the canny_cpu and canny_cuda tests on the ci machines manually and the pass the Trying to see how ci tests differ and whats the RMSD value when run via ci. Manually, I get an error of 0.00039.

Related to #2001 