### PR TITLE
Address address sanitizer warnings/errors in tests

### DIFF
--- a/test/jit.cpp
+++ b/test/jit.cpp
@@ -47,7 +47,7 @@ TEST(JIT, CPP_JIT_HASH)
             ASSERT_EQ(hF1[i], valF1);
         }
 
-        delete[] hF1;
+        freeHost(hF1);
     }
 
     // Making sure a different kernel is generated
@@ -61,7 +61,7 @@ TEST(JIT, CPP_JIT_HASH)
             ASSERT_EQ(hF2[i], valF2);
         }
 
-        delete[] hF2;
+        freeHost(hF2);
     }
 }
 

--- a/test/moddims.cpp
+++ b/test/moddims.cpp
@@ -131,15 +131,17 @@ void moddimsArgsTest(string pTestFile)
 
     af_array inArray   = 0;
     af_array outArray  = 0;
+    af_array outArray2  = 0;
     ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<T>::af_type));
 
     af::dim4 newDims(1);
     newDims[0] = dims[1];
     newDims[1] = dims[0]*dims[2];
     ASSERT_EQ(AF_SUCCESS, af_moddims(&outArray,inArray,0,newDims.get()));
-    ASSERT_EQ(AF_ERR_ARG, af_moddims(&outArray,inArray,newDims.ndims(),NULL));
+    ASSERT_EQ(AF_ERR_ARG, af_moddims(&outArray2,inArray,newDims.ndims(),NULL));
 
     ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
 }
 
 TYPED_TEST(Moddims,InvalidArgs)

--- a/test/morph.cpp
+++ b/test/morph.cpp
@@ -493,7 +493,10 @@ TEST(Morph, UnsupportedKernel2D)
 
 #if defined(AF_CPU)
     ASSERT_EQ(AF_SUCCESS, af_dilate(&out, in, mask));
+    ASSERT_EQ(AF_SUCCESS, af_release_array(out));
 #else
     ASSERT_EQ(AF_ERR_NOT_SUPPORTED, af_dilate(&out, in, mask));
 #endif
+    ASSERT_EQ(AF_SUCCESS, af_release_array(in));
+    ASSERT_EQ(AF_SUCCESS, af_release_array(mask));
 }

--- a/test/orb.cpp
+++ b/test/orb.cpp
@@ -213,11 +213,7 @@ void orbTest(string pTestFile)
         ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
         ASSERT_EQ(AF_SUCCESS, af_release_array(inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(x));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(y));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(score));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(orientation));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(size));
+        ASSERT_EQ(AF_SUCCESS, af_release_features(feat));
         ASSERT_EQ(AF_SUCCESS, af_release_array(desc));
 
         delete[] outX;

--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -244,6 +244,7 @@ TYPED_TEST(Sparse, Empty) {
     bool sparse = false;
     EXPECT_EQ(AF_SUCCESS, af_is_sparse(&sparse, ret));
     EXPECT_EQ(true, sparse);
+    EXPECT_EQ(AF_SUCCESS, af_release_array(ret));
 }
 
 TYPED_TEST(Sparse, EmptyDeepCopy) {

--- a/test/topk.cpp
+++ b/test/topk.cpp
@@ -191,6 +191,7 @@ TEST(TopK, ValidationCheck_DimN)
     af_array out, idx, in;
     ASSERT_EQ(AF_SUCCESS, af_randu(&in, 2, dims, f32));
     ASSERT_EQ(AF_ERR_NOT_SUPPORTED, af_topk(&out, &idx, in, 10, 1, AF_TOPK_MAX));
+    ASSERT_EQ(AF_SUCCESS, af_release_array(in));
 }
 
 TEST(TopK, ValidationCheck_DefaultDim)
@@ -199,6 +200,9 @@ TEST(TopK, ValidationCheck_DefaultDim)
     af_array out, idx, in;
     ASSERT_EQ(AF_SUCCESS, af_randu(&in, 4, dims, f32));
     ASSERT_EQ(AF_SUCCESS, af_topk(&out, &idx, in, 10, -1, AF_TOPK_MAX));
+    ASSERT_EQ(AF_SUCCESS, af_release_array(in));
+    ASSERT_EQ(AF_SUCCESS, af_release_array(out));
+    ASSERT_EQ(AF_SUCCESS, af_release_array(idx));
 }
 
 

--- a/test/transform_coordinates.cpp
+++ b/test/transform_coordinates.cpp
@@ -61,6 +61,7 @@ void transformCoordinatesTest(string pTestFile)
         vector<T> outData(outEl);
         ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData.front(), outArray));
 
+        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
         const float thr = 1.f;
 
         for (dim_t elIter = 0; elIter < outEl; elIter++) {
@@ -69,7 +70,6 @@ void transformCoordinatesTest(string pTestFile)
     }
 
     if(tfArray  != 0) af_release_array(tfArray);
-    if(outArray != 0) af_release_array(outArray);
 }
 
 TYPED_TEST(TransformCoordinates, RotateMatrix)

--- a/test/triangle.cpp
+++ b/test/triangle.cpp
@@ -24,9 +24,11 @@ using std::string;
 using std::cout;
 using std::endl;
 using std::abs;
+
 using af::cfloat;
 using af::cdouble;
 using af::dim4;
+using af::freeHost;
 
 template<typename T>
 class Triangle : public ::testing::Test { };
@@ -69,8 +71,8 @@ void triangleTester(const dim4 dims, bool is_upper, bool is_unit_diag=false)
         }
     }
 
-    delete[] h_in;
-    delete[] h_out;
+    freeHost(h_in);
+    freeHost(h_out);
 }
 
 TYPED_TEST(Triangle, Lower2DRect0)

--- a/test/write.cpp
+++ b/test/write.cpp
@@ -22,6 +22,7 @@ using std::cout;
 using std::endl;
 using af::cfloat;
 using af::cdouble;
+using af::freeHost;
 
 template<typename T>
 class Write : public ::testing::Test
@@ -65,9 +66,9 @@ void writeTest(af::dim4 dims)
         ASSERT_EQ(h_check2[i], 0) << "at: " << i << std::endl;
     }
 
-    delete [] a_host;
-    delete [] h_check1;
-    delete [] h_check2;
+    freeHost(a_host);
+    freeHost(h_check1);
+    freeHost(h_check2);
 }
 
 TYPED_TEST(Write, Vector0)


### PR DESCRIPTION
All tests pass using clang-6 + asan. On gcc there are several false positives stack-use-after-scope errors. We should either use clang or create a suppression file for gcc.