### PR TITLE
Fix leak caused by the use of initArray instead of createEmptyArray

### DIFF
--- a/src/api/c/array.cpp
+++ b/src/api/c/array.cpp
@@ -236,16 +236,6 @@ af_err af_release_array(af_array arr)
     return AF_SUCCESS;
 }
 
-
-template<typename T>
-static af_array retainHandle(const af_array in)
-{
-    detail::Array<T> *A = reinterpret_cast<detail::Array<T> *>(in);
-    detail::Array<T> *out = detail::initArray<T>();
-    *out= *A;
-    return reinterpret_cast<af_array>(out);
-}
-
 af_array retain(const af_array in)
 {
     const ArrayInfo& info = getInfo(in, false, false);

--- a/src/api/c/handle.hpp
+++ b/src/api/c/handle.hpp
@@ -81,6 +81,15 @@ getHandle(const detail::Array<T> &A)
 }
 
 template<typename T>
+static af_array retainHandle(const af_array in)
+{
+    detail::Array<T> *A = reinterpret_cast<detail::Array<T> *>(in);
+    detail::Array<T> *out = detail::initArray<T>();
+    *out= *A;
+    return reinterpret_cast<af_array>(out);
+}
+
+template<typename T>
 static af_array createHandle(af::dim4 d)
 {
     return getHandle(detail::createEmptyArray<T>(d));

--- a/src/backend/cpu/Array.hpp
+++ b/src/backend/cpu/Array.hpp
@@ -58,17 +58,22 @@ namespace cpu
     template<typename T>
     Array<T> createDeviceDataArray(const af::dim4 &size, const void *data);
 
-    // Copies data to an existing Array object from a host pointer
+    /// Copies data to an existing Array object from a host pointer
     template<typename T>
     void writeHostDataArray(Array<T> &arr, const T * const data, const size_t bytes);
 
-    // Copies data to an existing Array object from a device pointer
+    /// Copies data to an existing Array object from a device pointer
     template<typename T>
     void writeDeviceDataArray(Array<T> &arr, const void * const data, const size_t bytes);
 
-    // Create an Array object and do not assign any values to it
+    /// Create an Array object and do not assign any values to it.
+    /// \NOTE: This object should not be used to initalize an array. Use
+    ///       createEmptyArray instead
     template<typename T> Array<T> *initArray();
 
+    /// Creates an empty array of a given size. No data is initialized
+    ///
+    /// \param[in] size The dimension of the output array
     template<typename T>
     Array<T> createEmptyArray(const af::dim4 &size);
 

--- a/src/backend/cuda/Array.hpp
+++ b/src/backend/cuda/Array.hpp
@@ -48,23 +48,32 @@ namespace cuda
     template<typename T>
     Array<T> createDeviceDataArray(const af::dim4 &size, const void *data);
 
-    // Copies data to an existing Array object from a host pointer
+    /// Copies data to an existing Array object from a host pointer
     template<typename T>
     void writeHostDataArray(Array<T> &arr, const T * const data, const size_t bytes);
 
-    // Copies data to an existing Array object from a device pointer
+    /// Copies data to an existing Array object from a device pointer
     template<typename T>
     void writeDeviceDataArray(Array<T> &arr, const void * const data, const size_t bytes);
 
-    // Create an Array object and do not assign any values to it
+    /// Create an Array object and do not assign any values to it.
+    /// \NOTE: This object should not be used to initalize an array. Use
+    ///       createEmptyArray instead
     template<typename T> Array<T> *initArray();
 
+    /// Creates an empty array of a given size. No data is initialized
+    ///
+    /// \param[in] size The dimension of the output array
     template<typename T>
     Array<T> createEmptyArray(const af::dim4 &size);
 
-    // Create an Array object from Param<T>
+    /// Create an Array object from Param<T> object.
+    ///
+    /// \param[in] in    The Param<T> array that is created.
+    /// \param[in] owner If true, the new Array<T> object is the owner of the data. If false
+    ///                  the Array<T> will not delete the object on destruction
     template<typename T>
-    Array<T> createParamArray(Param<T> &tmp, bool owner);
+    Array<T> createParamArray(Param<T> &in, bool owner);
 
     template<typename T>
     Array<T> createSubArray(const Array<T>& parent,

--- a/src/backend/cuda/homography.cu
+++ b/src/backend/cuda/homography.cu
@@ -40,7 +40,7 @@ int homography(Array<T> &bestH,
     const unsigned nsamples = idims[0];
 
     unsigned iter = iterations;
-    Array<float> err = *initArray<float>();
+    Array<float> err = createEmptyArray<float>(dim4());
     if (htype == AF_HOMOGRAPHY_LMEDS) {
         iter = ::std::min(iter, (unsigned)(log(1.f - LMEDSConfidence) / log(1.f - pow(1.f - LMEDSOutlierRatio, 4.f))));
         err = createValueArray<float>(af::dim4(nsamples, iter), FLT_MAX);

--- a/src/backend/cuda/kernel/mean.hpp
+++ b/src/backend/cuda/kernel/mean.hpp
@@ -203,17 +203,17 @@ namespace kernel
 
         blocks_dim[dim] = divup(in.dims[dim], threads_y * REPEAT);
 
-        Array<To> tmpOut = *initArray<To>();
-        Array<Tw> tmpWt  = *initArray<Tw>();
+        Array<To> tmpOut = createEmptyArray<To>(dim4());
+        Array<Tw> tmpWt  = createEmptyArray<Tw>(dim4());
 
         if (blocks_dim[dim] > 1) {
-          dim4 dims(4, out.dims);
-          dims[dim] = blocks_dim[dim];
-          tmpOut = createEmptyArray<To>(dims);
-          tmpWt  = createEmptyArray<Tw>(dims);
+            dim4 dims(4, out.dims);
+            dims[dim] = blocks_dim[dim];
+            tmpOut = createEmptyArray<To>(dims);
+            tmpWt  = createEmptyArray<Tw>(dims);
         }
         else {
-          tmpOut = createParamArray(out, false);
+            tmpOut = createParamArray(out, false);
         }
 
         mean_dim_launcher<Ti, Tw, To, dim>(tmpOut, tmpWt, in, iwt, threads_y, blocks_dim);
@@ -221,7 +221,7 @@ namespace kernel
         if (blocks_dim[dim] > 1) {
             blocks_dim[dim] = 1;
 
-            Array<Tw> owt = *initArray<Tw>();
+            Array<Tw> owt = createEmptyArray<Tw>(dim4());
             mean_dim_launcher<To, Tw, To, dim>(out, owt, tmpOut, tmpWt,
                                                     threads_y, blocks_dim);
 
@@ -382,8 +382,8 @@ namespace kernel
         uint blocks_x = divup(in.dims[0], threads_x * REPEAT);
         uint blocks_y = divup(in.dims[1], threads_y);
 
-        Array<To> tmpOut = *initArray<To>();
-        Array<Tw> tmpWt  = *initArray<Tw>();
+        Array<To> tmpOut = createEmptyArray<To>(dim4());
+        Array<Tw> tmpWt  = createEmptyArray<Tw>(dim4());
         if (blocks_x > 1) {
           tmpOut = createEmptyArray<To>({blocks_x, in.dims[1], in.dims[2], in.dims[3]});
           tmpWt = createEmptyArray<Tw>({blocks_x, in.dims[1], in.dims[2], in.dims[3]});

--- a/src/backend/cuda/kernel/orb.hpp
+++ b/src/backend/cuda/kernel/orb.hpp
@@ -339,7 +339,7 @@ void orb(unsigned* out_feat,
     unsigned total_feat = 0;
 
     // Calculate a separable Gaussian kernel
-    Array<convAccT> gauss_filter = *initArray<convAccT>();
+    Array<convAccT> gauss_filter = createEmptyArray<convAccT>(dim4());
     if (blur_img) {
         unsigned gauss_len = 9;
         vector<convAccT> h_gauss(gauss_len);

--- a/src/backend/cuda/kernel/topk.hpp
+++ b/src/backend/cuda/kernel/topk.hpp
@@ -106,8 +106,8 @@ void topkDim0(Param<T> ovals, Param<uint> oidxs, CParam<T> ivals,
     // before the first iteration and reused for further iterations.
 
     // Temporary storage allocation for iterations
-    Array<T> tvals = *initArray<T>();
-    Array<uint> tidxs = *initArray<uint>();
+    Array<T> tvals = createEmptyArray<T>(dim4());
+    Array<uint> tidxs = createEmptyArray<uint>(dim4());
 
     if (numBlocksX > 1) {
         tvals = createEmptyArray<T>(dim4(k * numBlocksX, ivals.dims[1]));

--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -33,36 +33,45 @@ namespace opencl
     void evalNodes(Param &out, JIT::Node *node);
     void evalNodes(std::vector<Param> &outputs, std::vector<JIT::Node *> nodes);
 
-    // Creates a new Array object on the heap and returns a reference to it.
+    /// Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
     Array<T> createNodeArray(const af::dim4 &size, JIT::Node_ptr node);
 
-    // Creates a new Array object on the heap and returns a reference to it.
+    /// Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
     Array<T> createValueArray(const af::dim4 &size, const T& value);
 
-    // Creates a new Array object on the heap and returns a reference to it.
+    /// Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
     Array<T> createHostDataArray(const af::dim4 &size, const T * const data);
 
     template<typename T>
     Array<T> createDeviceDataArray(const af::dim4 &size, const void *data, bool copy = false);
 
-    // Copies data to an existing Array object from a host pointer
+    /// Copies data to an existing Array object from a host pointer
     template<typename T>
     void writeHostDataArray(Array<T> &arr, const T * const data, const size_t bytes);
 
-    // Copies data to an existing Array object from a device pointer
+    /// Copies data to an existing Array object from a device pointer
     template<typename T>
     void writeDeviceDataArray(Array<T> &arr, const void * const data, const size_t bytes);
 
-    // Create an Array object and do not assign any values to it
+    /// Create an Array object and do not assign any values to it.
+    /// \NOTE: This object should not be used to initalize an array. Use
+    ///       createEmptyArray instead
     template<typename T> Array<T> *initArray();
 
+    /// Creates an empty array of a given size. No data is initialized
+    ///
+    /// \param[in] size The dimension of the output array
     template<typename T>
     Array<T> createEmptyArray(const af::dim4 &size);
 
-    // Create an Array object from Param
+    /// Create an Array object from Param object.
+    ///
+    /// \param[in] in    The Param array that is created.
+    /// \param[in] owner If true, the new Array<T> object is the owner of the data. If false
+    ///                  the Array<T> will not delete the object on destruction
     template<typename T>
     Array<T> createParamArray(Param &tmp, bool owner);
 
@@ -71,7 +80,7 @@ namespace opencl
                             const std::vector<af_seq> &index,
                             bool copy=true);
 
-    // Creates a new Array object on the heap and returns a reference to it.
+    /// Creates a new Array object on the heap and returns a reference to it.
     template<typename T>
     void destroyArray(Array<T> *A);
 


### PR DESCRIPTION
initArray is only used to create Array<T> pointers where a new handle
is created or to increase the internal reference count of the Array<T>
object. They should not be used to initialize an empty Array<T> object
because it would cause a leak.