### PR TITLE
Revert "Use CLBlast as default blas upstream for OpenCL backend"

### DIFF
--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 include(InternalUtils)
 
-set(AF_OPENCL_BLAS_LIBRARY CLBlast CACHE STRING "Select OpenCL BLAS back-end")
+set(AF_OPENCL_BLAS_LIBRARY clBLAS CACHE STRING "Select OpenCL BLAS back-end")
 set_property(CACHE AF_OPENCL_BLAS_LIBRARY PROPERTY STRINGS "clBLAS" "CLBlast")
 
 af_deprecate(OPENCL_BLAS_LIBRARY AF_OPENCL_BLAS_LIBRARY)


### PR DESCRIPTION
This reverts commit 98e6d5e220babd52769541e87f7479526e71cebc.