### PR TITLE
Fix feature detection functions' 2D to 1D indexing

### DIFF
--- a/examples/computer_vision/fast.cpp
+++ b/examples/computer_vision/fast.cpp
@@ -36,15 +36,15 @@ static void fast_demo(bool console)
     for (size_t f = 0; f < feat.getNumFeatures(); f++) {
         int x = h_x[f];
         int y = h_y[f];
-        img_color(y, seq(x-draw_len, x+draw_len), 0) = 0.f;
-        img_color(y, seq(x-draw_len, x+draw_len), 1) = 1.f;
-        img_color(y, seq(x-draw_len, x+draw_len), 2) = 0.f;
+        img_color(x, seq(y-draw_len, y+draw_len), 0) = 0.f;
+        img_color(x, seq(y-draw_len, y+draw_len), 1) = 1.f;
+        img_color(x, seq(y-draw_len, y+draw_len), 2) = 0.f;
 
         // Draw vertical line of (draw_len * 2 + 1) pixels centered on  the corner
         // Set only the first channel to 1 (green lines)
-        img_color(seq(y-draw_len, y+draw_len), x, 0) = 0.f;
-        img_color(seq(y-draw_len, y+draw_len), x, 1) = 1.f;
-        img_color(seq(y-draw_len, y+draw_len), x, 2) = 0.f;
+        img_color(seq(x-draw_len, x+draw_len), y, 0) = 0.f;
+        img_color(seq(x-draw_len, x+draw_len), y, 1) = 1.f;
+        img_color(seq(x-draw_len, x+draw_len), y, 2) = 0.f;
     }
 
     freeHost(h_x);

--- a/examples/computer_vision/harris.cpp
+++ b/examples/computer_vision/harris.cpp
@@ -15,8 +15,6 @@ using namespace af;
 
 static void harris_demo(bool console)
 {
-    af::Window wnd("Harris Corner Detector");
-
     // Load image
     array img_color;
     if (console)
@@ -28,93 +26,46 @@ static void harris_demo(bool console)
     // For visualization in ArrayFire, color images must be in the [0.0f-1.0f] interval
     img_color /= 255.f;
 
-    // Calculate image gradients
-    array ix, iy;
-    grad(ix, iy, img);
+    features feat = harris(img);
 
-    // Compute second-order derivatives
-    array ixx = ix * ix;
-    array ixy = ix * iy;
-    array iyy = iy * iy;
+    if (!(feat.getNumFeatures() > 0)) {
+        printf("No features found, exiting\n");
+        return;
+    }
 
-    // Compute a Gaussian kernel with standard deviation of 1.0 and length of 5 pixels
-    // These values can be changed to use a smaller or larger window
-    array gauss_filt = gaussianKernel(5, 5, 1.0, 1.0);
-
-    // Filter second-order derivatives with Gaussian kernel computed previously
-    ixx = convolve(ixx, gauss_filt);
-    ixy = convolve(ixy, gauss_filt);
-    iyy = convolve(iyy, gauss_filt);
-
-    // Calculate trace
-    array itr = ixx + iyy;
-    // Calculate determinant
-    array idet = ixx * iyy - ixy * ixy;
-
-    // Calculate Harris response
-    array response = idet - 0.04f * (itr * itr);
-
-    // Gets maximum response for each 3x3 neighborhood
-    //array max_resp = maxfilt(response, 3, 3);
-    array mask = constant(1,3,3);
-    array max_resp = dilate(response, mask);
-
-    // Discard responses that are not greater than threshold
-    array corners = response > 1e5f;
-    corners = corners * response;
-
-    // Discard responses that are not equal to maximum neighborhood response,
-    // scale them to original response value
-    corners = (corners == max_resp) * corners;
-
-    // Gets host pointer to response data
-    float* h_corners = corners.host<float>();
-
-    unsigned good_corners = 0;
+    float* h_x = feat.getX().host<float>();
+    float* h_y = feat.getY().host<float>();
 
     // Draw draw_len x draw_len crosshairs where the corners are
     const int draw_len = 3;
-    for (int y = draw_len; y < img_color.dims(0) - draw_len; y++) {
-        for (int x = draw_len; x < img_color.dims(1) - draw_len; x++) {
-            // Only draws crosshair if is a corner
-            if (h_corners[x * corners.dims(0) + y] > 1e5f) {
-                // Draw horizontal line of (draw_len * 2 + 1) pixels centered on the corner
-                // Set only the first channel to 1 (green lines)
-                img_color(y, seq(x-draw_len, x+draw_len), 0) = 0.f;
-                img_color(y, seq(x-draw_len, x+draw_len), 1) = 1.f;
-                img_color(y, seq(x-draw_len, x+draw_len), 2) = 0.f;
+    for (size_t f = 0; f < feat.getNumFeatures(); f++) {
+        int x = h_x[f];
+        int y = h_y[f];
+        img_color(x, seq(y-draw_len, y+draw_len), 0) = 0.f;
+        img_color(x, seq(y-draw_len, y+draw_len), 1) = 1.f;
+        img_color(x, seq(y-draw_len, y+draw_len), 2) = 0.f;
 
-                // Draw vertical line of (draw_len * 2 + 1) pixels centered on  the corner
-                // Set only the first channel to 1 (green lines)
-                img_color(seq(y-draw_len, y+draw_len), x, 0) = 0.f;
-                img_color(seq(y-draw_len, y+draw_len), x, 1) = 1.f;
-                img_color(seq(y-draw_len, y+draw_len), x, 2) = 0.f;
-
-                good_corners++;
-            }
-        }
+        // Draw vertical line of (draw_len * 2 + 1) pixels centered on  the corner
+        // Set only the first channel to 1 (green lines)
+        img_color(seq(x-draw_len, x+draw_len), y, 0) = 0.f;
+        img_color(seq(x-draw_len, x+draw_len), y, 1) = 1.f;
+        img_color(seq(x-draw_len, x+draw_len), y, 2) = 0.f;
     }
-    freeHost(h_corners);
+    freeHost(h_x);
+    freeHost(h_y);
 
-    printf("Corners found: %u\n", good_corners);
+    printf("Features found: %lu\n", feat.getNumFeatures());
 
     if (!console) {
+        af::Window wnd("Harris Feature Detector");
+
         // Previews color image with green crosshairs
         while(!wnd.close())
             wnd.image(img_color);
     } else {
-        // Find corner indexes in the image as 1D indexes
-        array idx = where(corners);
-
-        // Calculate 2D corner indexes
-        array corners_x = idx / corners.dims()[0];
-        array corners_y = idx % corners.dims()[0];
-
-        const int good_corners = corners_x.dims()[0];
-        printf("Corners found: %d\n\n", good_corners);
-
-        af_print(corners_x);
-        af_print(corners_y);
+        af_print(feat.getX());
+        af_print(feat.getY());
+        af_print(feat.getScore());
     }
 }
 

--- a/examples/computer_vision/susan.cpp
+++ b/examples/computer_vision/susan.cpp
@@ -57,7 +57,7 @@ static void susan_demo(bool console)
     printf("Features found: %lu\n", feat.getNumFeatures());
 
     if (!console) {
-        af::Window wnd("FAST Feature Detector");
+        af::Window wnd("SUSAN Feature Detector");
 
         // Previews color image with green crosshairs
         while(!wnd.close())

--- a/src/backend/cpu/kernel/fast.hpp
+++ b/src/backend/cpu/kernel/fast.hpp
@@ -190,13 +190,13 @@ void non_maximal(CParam<float> score, CParam<float> x_in, CParam<float> y_in,
 
         float v = score_ptr[y * score_dims[0] + x];
         float max_v;
-        max_v = max(score_ptr[(y-1) * score_dims[0] + x-1], score_ptr[(y-1) * score_dims[0] + x]);
-        max_v = max(max_v, score_ptr[(y-1) * score_dims[0] + x+1]);
-        max_v = max(max_v, score_ptr[y     * score_dims[0] + x-1]);
-        max_v = max(max_v, score_ptr[y     * score_dims[0] + x+1]);
-        max_v = max(max_v, score_ptr[(y+1) * score_dims[0] + x-1]);
-        max_v = max(max_v, score_ptr[(y+1) * score_dims[0] + x  ]);
-        max_v = max(max_v, score_ptr[(y+1) * score_dims[0] + x+1]);
+        max_v = max(score_ptr[x-1 + score_dims[0] * (y-1)], score_ptr[x-1 + score_dims[0] * y]);
+        max_v = max(max_v, score_ptr[x-1 + score_dims[0] * (y+1)]);
+        max_v = max(max_v, score_ptr[x   + score_dims[0] * (y-1)]);
+        max_v = max(max_v, score_ptr[x   + score_dims[0] * (y+1)]);
+        max_v = max(max_v, score_ptr[x+1 + score_dims[0] * (y-1)]);
+        max_v = max(max_v, score_ptr[x+1 + score_dims[0] * (y)  ]);
+        max_v = max(max_v, score_ptr[x+1 + score_dims[0] * (y+1)]);
 
         if (y >= score_dims[1] - edge - 1 || y <= edge + 1 ||
             x >= score_dims[0] - edge - 1 || x <= edge + 1)

--- a/src/backend/cpu/kernel/fast.hpp
+++ b/src/backend/cpu/kernel/fast.hpp
@@ -198,8 +198,8 @@ void non_maximal(CParam<float> score, CParam<float> x_in, CParam<float> y_in,
         max_v = std::max(max_v, score_ptr[y+1 + score_dims[0] * (x)  ]);
         max_v = std::max(max_v, score_ptr[y+1 + score_dims[0] * (x+1)]);
 
-        if (y >= score_dims[1] - edge - 1 || y <= edge + 1 ||
-            x >= score_dims[0] - edge - 1 || x <= edge + 1)
+        if (y >= score_dims[0] - edge - 1 || y <= edge + 1 ||
+            x >= score_dims[1] - edge - 1 || x <= edge + 1)
             continue;
 
         // Stores keypoint to feat_out if it's response is maximum compared to

--- a/src/backend/cpu/kernel/fast.hpp
+++ b/src/backend/cpu/kernel/fast.hpp
@@ -16,7 +16,7 @@ namespace cpu
 namespace kernel
 {
 
-inline int idx_y(int i)
+inline int idx_x(int i)
 {
     if (i >= 8)
         return clamp(-(i-8-4), -3, 3);
@@ -24,17 +24,17 @@ inline int idx_y(int i)
     return clamp(i-4, -3, 3);
 }
 
-inline int idx_x(int i)
+inline int idx_y(int i)
 {
     if (i < 12)
-        return idx_y(i+4);
+        return idx_x(i+4);
 
-    return idx_y(i-12);
+    return idx_x(i-12);
 }
 
 inline int idx(int y, int x, unsigned idim0)
 {
-    return x * idim0 + y;
+    return y * idim0 + x;
 }
 
 // test_greater()
@@ -90,8 +90,8 @@ void locate_features(CParam<T> in, Param<float> score,
     af::dim4 in_dims = in.dims();
     T const * in_ptr = in.get();
 
-    for (int y = edge; y < (int)(in_dims[0] - edge); y++) {
-        for (int x = edge; x < (int)(in_dims[1] - edge); x++) {
+    for (int y = edge; y < (int)(in_dims[1] - edge); y++) {
+        for (int x = edge; x < (int)(in_dims[0] - edge); x++) {
             float p = in_ptr[idx(y, x, in_dims[0])];
 
             // Start by testing opposite pixels of the circle that will result in
@@ -188,15 +188,15 @@ void non_maximal(CParam<float> score, CParam<float> x_in, CParam<float> y_in,
         unsigned x = static_cast<unsigned>(round(x_in_ptr[k]));
         unsigned y = static_cast<unsigned>(round(y_in_ptr[k]));
 
-        float v = score_ptr[y + score_dims[0] * x];
+        float v = score_ptr[y * score_dims[0] + x];
         float max_v;
-        max_v = std::max(score_ptr[y-1 + score_dims[0] * (x-1)], score_ptr[y-1 + score_dims[0] * x]);
-        max_v = std::max(max_v, score_ptr[y-1 + score_dims[0] * (x+1)]);
-        max_v = std::max(max_v, score_ptr[y   + score_dims[0] * (x-1)]);
-        max_v = std::max(max_v, score_ptr[y   + score_dims[0] * (x+1)]);
-        max_v = std::max(max_v, score_ptr[y+1 + score_dims[0] * (x-1)]);
-        max_v = std::max(max_v, score_ptr[y+1 + score_dims[0] * (x)  ]);
-        max_v = std::max(max_v, score_ptr[y+1 + score_dims[0] * (x+1)]);
+        max_v = max(score_ptr[(y-1) * score_dims[0] + x-1], score_ptr[(y-1) * score_dims[0] + x]);
+        max_v = max(max_v, score_ptr[(y-1) * score_dims[0] + x+1]);
+        max_v = max(max_v, score_ptr[y     * score_dims[0] + x-1]);
+        max_v = max(max_v, score_ptr[y     * score_dims[0] + x+1]);
+        max_v = max(max_v, score_ptr[(y+1) * score_dims[0] + x-1]);
+        max_v = max(max_v, score_ptr[(y+1) * score_dims[0] + x  ]);
+        max_v = max(max_v, score_ptr[(y+1) * score_dims[0] + x+1]);
 
         if (y >= score_dims[0] - edge - 1 || y <= edge + 1 ||
             x >= score_dims[1] - edge - 1 || x <= edge + 1)

--- a/src/backend/cpu/kernel/fast.hpp
+++ b/src/backend/cpu/kernel/fast.hpp
@@ -190,13 +190,13 @@ void non_maximal(CParam<float> score, CParam<float> x_in, CParam<float> y_in,
 
         float v = score_ptr[y * score_dims[0] + x];
         float max_v;
-        max_v = max(score_ptr[x-1 + score_dims[0] * (y-1)], score_ptr[x-1 + score_dims[0] * y]);
-        max_v = max(max_v, score_ptr[x-1 + score_dims[0] * (y+1)]);
-        max_v = max(max_v, score_ptr[x   + score_dims[0] * (y-1)]);
-        max_v = max(max_v, score_ptr[x   + score_dims[0] * (y+1)]);
-        max_v = max(max_v, score_ptr[x+1 + score_dims[0] * (y-1)]);
-        max_v = max(max_v, score_ptr[x+1 + score_dims[0] * (y)  ]);
-        max_v = max(max_v, score_ptr[x+1 + score_dims[0] * (y+1)]);
+        max_v = max(score_ptr[(y-1) * score_dims[0] + x-1], score_ptr[y * score_dims[0] + x-1]);
+        max_v = max(max_v, score_ptr[(y+1) * score_dims[0] + x-1]);
+        max_v = max(max_v, score_ptr[(y-1) * score_dims[0] + x  ]);
+        max_v = max(max_v, score_ptr[(y+1) * score_dims[0] + x  ]);
+        max_v = max(max_v, score_ptr[(y-1) * score_dims[0] + x+1]);
+        max_v = max(max_v, score_ptr[(y)   * score_dims[0] + x+1]);
+        max_v = max(max_v, score_ptr[(y+1) * score_dims[0] + x+1]);
 
         if (y >= score_dims[1] - edge - 1 || y <= edge + 1 ||
             x >= score_dims[0] - edge - 1 || x <= edge + 1)

--- a/src/backend/cpu/kernel/fast.hpp
+++ b/src/backend/cpu/kernel/fast.hpp
@@ -198,8 +198,8 @@ void non_maximal(CParam<float> score, CParam<float> x_in, CParam<float> y_in,
         max_v = max(max_v, score_ptr[(y+1) * score_dims[0] + x  ]);
         max_v = max(max_v, score_ptr[(y+1) * score_dims[0] + x+1]);
 
-        if (y >= score_dims[0] - edge - 1 || y <= edge + 1 ||
-            x >= score_dims[1] - edge - 1 || x <= edge + 1)
+        if (y >= score_dims[1] - edge - 1 || y <= edge + 1 ||
+            x >= score_dims[0] - edge - 1 || x <= edge + 1)
             continue;
 
         // Stores keypoint to feat_out if it's response is maximum compared to

--- a/src/backend/cpu/kernel/harris.hpp
+++ b/src/backend/cpu/kernel/harris.hpp
@@ -43,9 +43,9 @@ void harris_responses(Param<T> resp, const unsigned idim0, const unsigned idim1,
     const T* iyy_in  = iyy.get();
     const unsigned r = border_len;
 
-    for (unsigned x = r; x < idim1 - r; x++) {
-        for (unsigned y = r; y < idim0 - r; y++) {
-            const unsigned idx = x * idim0 + y;
+    for (unsigned y = r; y < idim1 - r; y++) {
+        for (unsigned x = r; x < idim0 - r; x++) {
+            const unsigned idx = y * idim0 + x;
 
             // Calculates matrix trace and determinant
             T tr = ixx_in[idx] + iyy_in[idx];
@@ -69,19 +69,26 @@ void non_maximal(Param<float> xOut, Param<float> yOut, Param<float> respOut, uns
     // Responses on the border don't have 8-neighbors to compare, discard them
     const unsigned r = border_len + 1;
 
-    for (unsigned x = r; x < idim1 - r; x++) {
-        for (unsigned y = r; y < idim0 - r; y++) {
-            const T v = resp_in[x * idim0 + y];
+    for (unsigned y = r; y < idim1 - r; y++) {
+        for (unsigned x = r; x < idim0 - r; x++) {
+            const T v = resp_in[y * idim0 + x];
 
             // Find maximum neighborhood response
             T max_v;
-            max_v = max(resp_in[(x-1) * idim0 + y-1], resp_in[x * idim0 + y-1]);
-            max_v = max(max_v, resp_in[(x+1) * idim0 + y-1]);
-            max_v = max(max_v, resp_in[(x-1) * idim0 + y  ]);
-            max_v = max(max_v, resp_in[(x+1) * idim0 + y  ]);
-            max_v = max(max_v, resp_in[(x-1) * idim0 + y+1]);
-            max_v = max(max_v, resp_in[(x)   * idim0 + y+1]);
-            max_v = max(max_v, resp_in[(x+1) * idim0 + y+1]);
+            // max_v = max(resp_in[(x-1) * idim0 + y-1], resp_in[x * idim0 + y-1]);
+            // max_v = max(max_v, resp_in[(x+1) * idim0 + y-1]);
+            // max_v = max(max_v, resp_in[(x-1) * idim0 + y  ]);
+            // max_v = max(max_v, resp_in[(x+1) * idim0 + y  ]);
+            // max_v = max(max_v, resp_in[(x-1) * idim0 + y+1]);
+            // max_v = max(max_v, resp_in[(x)   * idim0 + y+1]);
+            // max_v = max(max_v, resp_in[(x+1) * idim0 + y+1]);
+            max_v = max(resp_in[x-1 + idim0 * (y-1)], resp_in[x-1 + idim0 * y]);
+            max_v = max(max_v, resp_in[x-1 + idim0 * (y+1)]);
+            max_v = max(max_v, resp_in[x   + idim0 * (y-1)]);
+            max_v = max(max_v, resp_in[x   + idim0 * (y+1)]);
+            max_v = max(max_v, resp_in[x+1 + idim0 * (y-1)]);
+            max_v = max(max_v, resp_in[x+1 + idim0 * (y)  ]);
+            max_v = max(max_v, resp_in[x+1 + idim0 * (y+1)]);
 
             // Stores corner to {x,y,resp}_out if it's response is maximum compared
             // to its 8-neighborhood and greater or equal minimum response

--- a/src/backend/cpu/kernel/harris.hpp
+++ b/src/backend/cpu/kernel/harris.hpp
@@ -75,13 +75,6 @@ void non_maximal(Param<float> xOut, Param<float> yOut, Param<float> respOut, uns
 
             // Find maximum neighborhood response
             T max_v;
-            // max_v = max(resp_in[(x-1) * idim0 + y-1], resp_in[x * idim0 + y-1]);
-            // max_v = max(max_v, resp_in[(x+1) * idim0 + y-1]);
-            // max_v = max(max_v, resp_in[(x-1) * idim0 + y  ]);
-            // max_v = max(max_v, resp_in[(x+1) * idim0 + y  ]);
-            // max_v = max(max_v, resp_in[(x-1) * idim0 + y+1]);
-            // max_v = max(max_v, resp_in[(x)   * idim0 + y+1]);
-            // max_v = max(max_v, resp_in[(x+1) * idim0 + y+1]);
             max_v = max(resp_in[x-1 + idim0 * (y-1)], resp_in[x-1 + idim0 * y]);
             max_v = max(max_v, resp_in[x-1 + idim0 * (y+1)]);
             max_v = max(max_v, resp_in[x   + idim0 * (y-1)]);

--- a/src/backend/cpu/kernel/harris.hpp
+++ b/src/backend/cpu/kernel/harris.hpp
@@ -75,13 +75,13 @@ void non_maximal(Param<float> xOut, Param<float> yOut, Param<float> respOut, uns
 
             // Find maximum neighborhood response
             T max_v;
-            max_v = max(resp_in[x-1 + idim0 * (y-1)], resp_in[x-1 + idim0 * y]);
-            max_v = max(max_v, resp_in[x-1 + idim0 * (y+1)]);
-            max_v = max(max_v, resp_in[x   + idim0 * (y-1)]);
-            max_v = max(max_v, resp_in[x   + idim0 * (y+1)]);
-            max_v = max(max_v, resp_in[x+1 + idim0 * (y-1)]);
-            max_v = max(max_v, resp_in[x+1 + idim0 * (y)  ]);
-            max_v = max(max_v, resp_in[x+1 + idim0 * (y+1)]);
+            max_v = max(resp_in[(y-1) * idim0 + x-1], resp_in[y * idim0 + x-1]);
+            max_v = max(max_v, resp_in[(y+1) * idim0 + x-1]);
+            max_v = max(max_v, resp_in[(y-1) * idim0 + x  ]);
+            max_v = max(max_v, resp_in[(y+1) * idim0 + x  ]);
+            max_v = max(max_v, resp_in[(y-1) * idim0 + x+1]);
+            max_v = max(max_v, resp_in[(y)   * idim0 + x+1]);
+            max_v = max(max_v, resp_in[(y+1) * idim0 + x+1]);
 
             // Stores corner to {x,y,resp}_out if it's response is maximum compared
             // to its 8-neighborhood and greater or equal minimum response

--- a/src/backend/cpu/kernel/orb.hpp
+++ b/src/backend/cpu/kernel/orb.hpp
@@ -347,7 +347,7 @@ void harris_response(
         // the image, sqrt(2.f) is the radius when angle is 45 degrees and
         // represents widest case possible
         unsigned patch_r = ceil(size * sqrt(2.f) / 2.f);
-        if (x < patch_r || y < patch_r || x >= idims[1] - patch_r || y >= idims[0] - patch_r)
+        if (x < patch_r || y < patch_r || x >= idims[0] - patch_r || y >= idims[1] - patch_r)
             continue;
 
         unsigned r = block_size / 2;
@@ -405,7 +405,7 @@ void centroid_angle(
         unsigned y = (unsigned)round(y_in[f]);
 
         unsigned r = patch_size / 2;
-        if (x < r || y < r || x > idims[1] - r || y > idims[0] - r)
+        if (x < r || y < r || x > idims[0] - r || y > idims[1] - r)
             continue;
 
         T m01 = (T)0, m10 = (T)0;
@@ -415,7 +415,7 @@ void centroid_angle(
             int j = k % patch_size - r;
 
             // Calculate first order moments
-            T p = image_ptr[(x+i) * idims[0] + y+j];
+            T p = image_ptr[(y+j) * idims[0] + (x+i)];
             m01 += j * p;
             m10 += i * p;
         }
@@ -446,7 +446,7 @@ inline T get_pixel(
     x += round(dist_x * patch_scl * ori_cos - dist_y * patch_scl * ori_sin);
     y += round(dist_x * patch_scl * ori_sin + dist_y * patch_scl * ori_cos);
 
-    return image_ptr[x * idims[0] + y];
+    return image_ptr[y * idims[0] + x];
 }
 
 template<typename T>
@@ -469,7 +469,7 @@ void extract_orb(
         unsigned size = patch_size;
 
         unsigned r = ceil(patch_size * sqrt(2.f) / 2.f);
-        if (x < r || y < r || x >= idims[1] - r || y >= idims[0] - r)
+        if (x < r || y < r || x >= idims[0] - r || y >= idims[1] - r)
             continue;
 
         // Descriptor fixed at 256 bits for now

--- a/src/backend/cpu/kernel/orb.hpp
+++ b/src/backend/cpu/kernel/orb.hpp
@@ -347,7 +347,7 @@ void harris_response(
         // the image, sqrt(2.f) is the radius when angle is 45 degrees and
         // represents widest case possible
         unsigned patch_r = ceil(size * sqrt(2.f) / 2.f);
-        if (x < patch_r || y < patch_r || x >= idims[0] - patch_r || y >= idims[1] - patch_r)
+        if (x < patch_r || y < patch_r || x >= idims[1] - patch_r || y >= idims[0] - patch_r)
             continue;
 
         unsigned r = block_size / 2;
@@ -405,7 +405,7 @@ void centroid_angle(
         unsigned y = (unsigned)round(y_in[f]);
 
         unsigned r = patch_size / 2;
-        if (x < r || y < r || x > idims[0] - r || y > idims[1] - r)
+        if (x < r || y < r || x > idims[1] - r || y > idims[0] - r)
             continue;
 
         T m01 = (T)0, m10 = (T)0;
@@ -415,7 +415,7 @@ void centroid_angle(
             int j = k % patch_size - r;
 
             // Calculate first order moments
-            T p = image_ptr[(y+j) * idims[0] + (x+i)];
+            T p = image_ptr[(x+i) * idims[0] + y+j];
             m01 += j * p;
             m10 += i * p;
         }
@@ -446,7 +446,7 @@ inline T get_pixel(
     x += round(dist_x * patch_scl * ori_cos - dist_y * patch_scl * ori_sin);
     y += round(dist_x * patch_scl * ori_sin + dist_y * patch_scl * ori_cos);
 
-    return image_ptr[y * idims[0] + x];
+    return image_ptr[x * idims[0] + y];
 }
 
 template<typename T>
@@ -469,7 +469,7 @@ void extract_orb(
         unsigned size = patch_size;
 
         unsigned r = ceil(patch_size * sqrt(2.f) / 2.f);
-        if (x < r || y < r || x >= idims[0] - r || y >= idims[1] - r)
+        if (x < r || y < r || x >= idims[1] - r || y >= idims[0] - r)
             continue;
 
         // Descriptor fixed at 256 bits for now

--- a/src/backend/cpu/kernel/orb.hpp
+++ b/src/backend/cpu/kernel/orb.hpp
@@ -347,7 +347,7 @@ void harris_response(
         // the image, sqrt(2.f) is the radius when angle is 45 degrees and
         // represents widest case possible
         unsigned patch_r = ceil(size * sqrt(2.f) / 2.f);
-        if (x < patch_r || y < patch_r || x >= idims[1] - patch_r || y >= idims[0] - patch_r)
+        if (x < patch_r || y < patch_r || x >= idims[0] - patch_r || y >= idims[1] - patch_r)
             continue;
 
         unsigned r = block_size / 2;
@@ -359,8 +359,8 @@ void harris_response(
             int j = k % block_size - r;
 
             // Calculate local x and y derivatives
-            float ix = image_ptr[(x+i+1) * idims[0] + y+j] - image_ptr[(x+i-1) * idims[0] + y+j];
-            float iy = image_ptr[(x+i) * idims[0] + y+j+1] - image_ptr[(x+i) * idims[0] + y+j-1];
+            float ix = image_ptr[(y+j) * image.dims()[0] + (x+i+1)] - image_ptr[(y+j) * image.dims()[0] + (x+i-1)];
+            float iy = image_ptr[(y+j+1) * image.dims()[0] + (x+i)] - image_ptr[(y+j-1) * image.dims()[0] + (x+i)];
 
             // Accumulate second order derivatives
             ixx += ix*ix;
@@ -405,7 +405,7 @@ void centroid_angle(
         unsigned y = (unsigned)round(y_in[f]);
 
         unsigned r = patch_size / 2;
-        if (x < r || y < r || x > idims[1] - r || y > idims[0] - r)
+        if (x < r || y < r || x > idims[0] - r || y > idims[1] - r)
             continue;
 
         T m01 = (T)0, m10 = (T)0;
@@ -415,7 +415,7 @@ void centroid_angle(
             int j = k % patch_size - r;
 
             // Calculate first order moments
-            T p = image_ptr[(x+i) * idims[0] + y+j];
+            T p = image_ptr[(y+j) * image.dims()[0] + (x+i)];
             m01 += j * p;
             m10 += i * p;
         }
@@ -446,7 +446,7 @@ inline T get_pixel(
     x += round(dist_x * patch_scl * ori_cos - dist_y * patch_scl * ori_sin);
     y += round(dist_x * patch_scl * ori_sin + dist_y * patch_scl * ori_cos);
 
-    return image_ptr[x * idims[0] + y];
+    return image_ptr[y * image.dims()[0] + x];
 }
 
 template<typename T>
@@ -469,7 +469,7 @@ void extract_orb(
         unsigned size = patch_size;
 
         unsigned r = ceil(patch_size * sqrt(2.f) / 2.f);
-        if (x < r || y < r || x >= idims[1] - r || y >= idims[0] - r)
+        if (x < r || y < r || x >= idims[0] - r || y >= idims[1] - r)
             continue;
 
         // Descriptor fixed at 256 bits for now

--- a/src/backend/cpu/kernel/orb.hpp
+++ b/src/backend/cpu/kernel/orb.hpp
@@ -355,12 +355,12 @@ void harris_response(
         float ixx = 0.f, iyy = 0.f, ixy = 0.f;
         unsigned block_size_sq = block_size * block_size;
         for (unsigned k = 0; k < block_size_sq; k++) {
-            int i = k / block_size - r;
-            int j = k % block_size - r;
+            int i = k % block_size - r;
+            int j = k / block_size - r;
 
             // Calculate local x and y derivatives
-            float ix = image_ptr[(y+j) * image.dims()[0] + (x+i+1)] - image_ptr[(y+j) * image.dims()[0] + (x+i-1)];
-            float iy = image_ptr[(y+j+1) * image.dims()[0] + (x+i)] - image_ptr[(y+j-1) * image.dims()[0] + (x+i)];
+            float ix = image_ptr[(y+j) * idims[0] + (x+i+1)] - image_ptr[(y+j) * idims[0] + (x+i-1)];
+            float iy = image_ptr[(y+j+1) * idims[0] + (x+i)] - image_ptr[(y+j-1) * idims[0] + (x+i)];
 
             // Accumulate second order derivatives
             ixx += ix*ix;
@@ -411,13 +411,13 @@ void centroid_angle(
         T m01 = (T)0, m10 = (T)0;
         unsigned patch_size_sq = patch_size * patch_size;
         for (unsigned k = 0; k < patch_size_sq; k++) {
-            int i = k / patch_size - r;
-            int j = k % patch_size - r;
+            int i = k % patch_size - r;
+            int j = k / patch_size - r;
 
             // Calculate first order moments
-            T p = image_ptr[(y+j) * image.dims()[0] + (x+i)];
-            m01 += j * p;
+            T p = image_ptr[(y+j) * idims[0] + (x+i)];
             m10 += i * p;
+            m01 += j * p;
         }
 
         float angle = atan2(m01, m10);
@@ -446,7 +446,7 @@ inline T get_pixel(
     x += round(dist_x * patch_scl * ori_cos - dist_y * patch_scl * ori_sin);
     y += round(dist_x * patch_scl * ori_sin + dist_y * patch_scl * ori_cos);
 
-    return image_ptr[y * image.dims()[0] + x];
+    return image_ptr[y * idims[0] + x];
 }
 
 template<typename T>

--- a/src/backend/cpu/kernel/susan.hpp
+++ b/src/backend/cpu/kernel/susan.hpp
@@ -27,9 +27,9 @@ void susan_responses(Param<T> output, CParam<T> input,
     const unsigned r = border_len;
     const int rSqrd = radius*radius;
 
-    for (unsigned y = r; y < idim1 - r; ++y) {
-        for (unsigned x = r; x < idim0 - r; ++x) {
-            const unsigned idx = y * idim0 + x;
+    for (unsigned x = r; x < idim1 - r; ++x) {
+        for (unsigned y = r; y < idim0 - r; ++y) {
+            const unsigned idx = x * idim0 + y;
             T m_0 = in[idx];
             float nM = 0.0f;
 
@@ -38,7 +38,7 @@ void susan_responses(Param<T> output, CParam<T> input,
                     if (i*i + j*j < rSqrd) {
                         int p = x + i;
                         int q = y + j;
-                        T m = in[p + idim0 * q];
+                        T m = in[p * idim0 + q];
                         float exp_pow = std::pow((m - m_0)/t, 6.0);
                         float cM = std::exp(-exp_pow);
                         nM += cM;
@@ -65,19 +65,19 @@ void non_maximal(Param<float> xcoords, Param<float> ycoords, Param<float> respon
     // Responses on the border don't have 8-neighbors to compare, discard them
     const unsigned r = border_len + 1;
 
-    for (unsigned y = r; y < idim1 - r; y++) {
-        for (unsigned x = r; x < idim0 - r; x++) {
-            const T v = resp_in[y * idim0 + x];
+    for (unsigned x = r; x < idim1 - r; x++) {
+        for (unsigned y = r; y < idim0 - r; y++) {
+            const T v = resp_in[x * idim0 + y];
 
             // Find maximum neighborhood response
             T max_v;
-            max_v = max(resp_in[(y-1) * idim0 + x-1], resp_in[y * idim0 + x-1]);
-            max_v = max(max_v, resp_in[(y+1) * idim0 + x-1]);
-            max_v = max(max_v, resp_in[(y-1) * idim0 + x  ]);
-            max_v = max(max_v, resp_in[(y+1) * idim0 + x  ]);
-            max_v = max(max_v, resp_in[(y-1) * idim0 + x+1]);
-            max_v = max(max_v, resp_in[(y)   * idim0 + x+1]);
-            max_v = max(max_v, resp_in[(y+1) * idim0 + x+1]);
+            max_v = max(resp_in[(x-1) * idim0 + y-1], resp_in[(x-1) * idim0 + y]);
+            max_v = max(max_v, resp_in[(x-1) * idim0 + y+1]);
+            max_v = max(max_v, resp_in[x     * idim0 + y-1]);
+            max_v = max(max_v, resp_in[x     * idim0 + y+1]);
+            max_v = max(max_v, resp_in[(x+1) * idim0 + y-1]);
+            max_v = max(max_v, resp_in[(x+1) * idim0 + y  ]);
+            max_v = max(max_v, resp_in[(x+1) * idim0 + y+1]);
 
             // Stores corner to {x,y,resp}_out if it's response is maximum compared
             // to its 8-neighborhood and greater or equal minimum response

--- a/src/backend/cpu/kernel/susan.hpp
+++ b/src/backend/cpu/kernel/susan.hpp
@@ -27,9 +27,9 @@ void susan_responses(Param<T> output, CParam<T> input,
     const unsigned r = border_len;
     const int rSqrd = radius*radius;
 
-    for (unsigned x = r; x < idim1 - r; ++x) {
-        for (unsigned y = r; y < idim0 - r; ++y) {
-            const unsigned idx = x * idim0 + y;
+    for (unsigned y = r; y < idim1 - r; ++y) {
+        for (unsigned x = r; x < idim0 - r; ++x) {
+            const unsigned idx = y * idim0 + x;
             T m_0 = in[idx];
             float nM = 0.0f;
 
@@ -38,7 +38,7 @@ void susan_responses(Param<T> output, CParam<T> input,
                     if (i*i + j*j < rSqrd) {
                         int p = x + i;
                         int q = y + j;
-                        T m = in[p * idim0 + q];
+                        T m = in[p + idim0 * q];
                         float exp_pow = std::pow((m - m_0)/t, 6.0);
                         float cM = std::exp(-exp_pow);
                         nM += cM;
@@ -65,19 +65,19 @@ void non_maximal(Param<float> xcoords, Param<float> ycoords, Param<float> respon
     // Responses on the border don't have 8-neighbors to compare, discard them
     const unsigned r = border_len + 1;
 
-    for (unsigned x = r; x < idim1 - r; x++) {
-        for (unsigned y = r; y < idim0 - r; y++) {
-            const T v = resp_in[x * idim0 + y];
+    for (unsigned y = r; y < idim1 - r; y++) {
+        for (unsigned x = r; x < idim0 - r; x++) {
+            const T v = resp_in[y * idim0 + x];
 
             // Find maximum neighborhood response
             T max_v;
-            max_v = max(resp_in[(x-1) * idim0 + y-1], resp_in[(x-1) * idim0 + y]);
-            max_v = max(max_v, resp_in[(x-1) * idim0 + y+1]);
-            max_v = max(max_v, resp_in[x     * idim0 + y-1]);
-            max_v = max(max_v, resp_in[x     * idim0 + y+1]);
-            max_v = max(max_v, resp_in[(x+1) * idim0 + y-1]);
-            max_v = max(max_v, resp_in[(x+1) * idim0 + y  ]);
-            max_v = max(max_v, resp_in[(x+1) * idim0 + y+1]);
+            max_v = max(resp_in[(y-1) * idim0 + x-1], resp_in[y * idim0 + x-1]);
+            max_v = max(max_v, resp_in[(y+1) * idim0 + x-1]);
+            max_v = max(max_v, resp_in[(y-1) * idim0 + x  ]);
+            max_v = max(max_v, resp_in[(y+1) * idim0 + x  ]);
+            max_v = max(max_v, resp_in[(y-1) * idim0 + x+1]);
+            max_v = max(max_v, resp_in[(y)   * idim0 + x+1]);
+            max_v = max(max_v, resp_in[(y+1) * idim0 + x+1]);
 
             // Stores corner to {x,y,resp}_out if it's response is maximum compared
             // to its 8-neighborhood and greater or equal minimum response

--- a/src/backend/cuda/kernel/fast.hpp
+++ b/src/backend/cuda/kernel/fast.hpp
@@ -355,8 +355,8 @@ void get_features(
 
             unsigned id = atomicAdd(&s_idx, 1u);
             if (id >= total) return;
-            y_out[id] = x;
-            x_out[id] = y;
+            x_out[id] = x;
+            y_out[id] = y;
             score_out[id] = v;
         }
     }

--- a/src/backend/cuda/kernel/fast.hpp
+++ b/src/backend/cuda/kernel/fast.hpp
@@ -282,13 +282,13 @@ void non_max_counts(
 
             if (nonmax) {
                 float max_v = v;
-                max_v = max_val(score[x-1 + idim0 * (y-1)], score[x-1 + idim0 * y]);
-                max_v = max_val(max_v, score[x-1 + idim0 * (y+1)]);
-                max_v = max_val(max_v, score[x   + idim0 * (y-1)]);
-                max_v = max_val(max_v, score[x   + idim0 * (y+1)]);
-                max_v = max_val(max_v, score[x+1 + idim0 * (y-1)]);
-                max_v = max_val(max_v, score[x+1 + idim0 * (y)  ]);
-                max_v = max_val(max_v, score[x+1 + idim0 * (y+1)]);
+                max_v = max_val(score[(y-1) * idim0 + x-1], score[y * idim0 + x-1]);
+                max_v = max_val(max_v, score[(y+1) * idim0 + x-1]);
+                max_v = max_val(max_v, score[(y-1) * idim0 + x  ]);
+                max_v = max_val(max_v, score[(y+1) * idim0 + x  ]);
+                max_v = max_val(max_v, score[(y-1) * idim0 + x+1]);
+                max_v = max_val(max_v, score[(y)   * idim0 + x+1]);
+                max_v = max_val(max_v, score[(y+1) * idim0 + x+1]);
 
                 v = (v > max_v) ? v : 0;
                 flags[y * idim0 + x] = v;

--- a/src/backend/cuda/kernel/harris.hpp
+++ b/src/backend/cuda/kernel/harris.hpp
@@ -134,13 +134,13 @@ __global__ void non_maximal(
 
         // Find maximum neighborhood response
         T max_v;
-        max_v = max(resp_in[x-1 + idim0 * (y-1)], resp_in[x-1 + idim0 * y]);
-        max_v = max(max_v, resp_in[x-1 + idim0 * (y+1)]);
-        max_v = max(max_v, resp_in[x   + idim0 * (y-1)]);
-        max_v = max(max_v, resp_in[x   + idim0 * (y+1)]);
-        max_v = max(max_v, resp_in[x+1 + idim0 * (y-1)]);
-        max_v = max(max_v, resp_in[x+1 + idim0 * (y)  ]);
-        max_v = max(max_v, resp_in[x+1 + idim0 * (y+1)]);
+        max_v = max(resp_in[(y-1) * idim0 + x-1], resp_in[y * idim0 + x-1]);
+        max_v = max(max_v, resp_in[(y+1) * idim0 + x-1]);
+        max_v = max(max_v, resp_in[(y-1) * idim0 + x  ]);
+        max_v = max(max_v, resp_in[(y+1) * idim0 + x  ]);
+        max_v = max(max_v, resp_in[(y-1) * idim0 + x+1]);
+        max_v = max(max_v, resp_in[(y)   * idim0 + x+1]);
+        max_v = max(max_v, resp_in[(y+1) * idim0 + x+1]);
 
         // Stores corner to {x,y,resp}_out if it's response is maximum compared
         // to its 8-neighborhood and greater or equal minimum response

--- a/src/backend/cuda/kernel/harris.hpp
+++ b/src/backend/cuda/kernel/harris.hpp
@@ -98,8 +98,8 @@ __global__ void harris_responses(
     const unsigned x = blockDim.x * blockIdx.x + threadIdx.x + r;
     const unsigned y = blockDim.y * blockIdx.y + threadIdx.y + r;
 
-    if (x < idim1 - r && y < idim0 - r) {
-        const unsigned idx = x * idim0 + y;
+    if (x < idim0 - r && y < idim1 - r) {
+        const unsigned idx = y * idim0 + x;
 
         // Calculates matrix trace and determinant
         T tr = ixx_in[idx] + iyy_in[idx];
@@ -129,18 +129,18 @@ __global__ void non_maximal(
     const unsigned x = blockDim.x * blockIdx.x + threadIdx.x + r;
     const unsigned y = blockDim.y * blockIdx.y + threadIdx.y + r;
 
-    if (x < idim1 - r && y < idim0 - r) {
-        const T v = resp_in[x * idim0 + y];
+    if (x < idim0 - r && y < idim1 - r) {
+        const T v = resp_in[y * idim0 + x];
 
         // Find maximum neighborhood response
         T max_v;
-        max_v = max_val(resp_in[(x-1) * idim0 + y-1], resp_in[x * idim0 + y-1]);
-        max_v = max_val(max_v, resp_in[(x+1) * idim0 + y-1]);
-        max_v = max_val(max_v, resp_in[(x-1) * idim0 + y  ]);
-        max_v = max_val(max_v, resp_in[(x+1) * idim0 + y  ]);
-        max_v = max_val(max_v, resp_in[(x-1) * idim0 + y+1]);
-        max_v = max_val(max_v, resp_in[(x)   * idim0 + y+1]);
-        max_v = max_val(max_v, resp_in[(x+1) * idim0 + y+1]);
+        max_v = max(resp_in[x-1 + idim0 * (y-1)], resp_in[x-1 + idim0 * y]);
+        max_v = max(max_v, resp_in[x-1 + idim0 * (y+1)]);
+        max_v = max(max_v, resp_in[x   + idim0 * (y-1)]);
+        max_v = max(max_v, resp_in[x   + idim0 * (y+1)]);
+        max_v = max(max_v, resp_in[x+1 + idim0 * (y-1)]);
+        max_v = max(max_v, resp_in[x+1 + idim0 * (y)  ]);
+        max_v = max(max_v, resp_in[x+1 + idim0 * (y+1)]);
 
         // Stores corner to {x,y,resp}_out if it's response is maximum compared
         // to its 8-neighborhood and greater or equal minimum response
@@ -289,8 +289,8 @@ void harris(unsigned* corners_out,
 
     // Calculate Harris responses for all pixels
     threads = dim3(BLOCK_SIZE, BLOCK_SIZE);
-    blocks = dim3(divup(in.dims[1] - border_len*2, threads.x),
-                  divup(in.dims[0] - border_len*2, threads.y));
+    blocks = dim3(divup(in.dims[0] - border_len*2, threads.x),
+                  divup(in.dims[1] - border_len*2, threads.y));
     CUDA_LAUNCH((harris_responses<T>), blocks, threads,
             d_responses.get(), in.dims[0], in.dims[1],
             ixx.ptr, ixy.ptr, iyy.ptr, k_thr, border_len);

--- a/src/backend/opencl/kernel/fast.cl
+++ b/src/backend/opencl/kernel/fast.cl
@@ -293,8 +293,8 @@ __kernel void get_features(
 
             unsigned id = atomic_inc(&s_idx);
             if (id < total) {
-                y_out[id] = x;
-                x_out[id] = y;
+                x_out[id] = x;
+                y_out[id] = y;
                 score_out[id] = v;
             }
         }

--- a/src/backend/opencl/kernel/fast.cl
+++ b/src/backend/opencl/kernel/fast.cl
@@ -210,13 +210,13 @@ void non_max_counts(
 
 #if NONMAX
                 float max_v = v;
-                max_v = MAX_VAL(score[x-1 + iInfo.dims[0] * (y-1)], score[x-1 + iInfo.dims[0] * y]);
-                max_v = MAX_VAL(max_v, score[x-1 + iInfo.dims[0] * (y+1)]);
-                max_v = MAX_VAL(max_v, score[x   + iInfo.dims[0] * (y-1)]);
-                max_v = MAX_VAL(max_v, score[x   + iInfo.dims[0] * (y+1)]);
-                max_v = MAX_VAL(max_v, score[x+1 + iInfo.dims[0] * (y-1)]);
-                max_v = MAX_VAL(max_v, score[x+1 + iInfo.dims[0] * (y)  ]);
-                max_v = MAX_VAL(max_v, score[x+1 + iInfo.dims[0] * (y+1)]);
+                max_v = MAX_VAL(score[(y-1) * iInfo.dims[0] + x-1], score[y * iInfo.dims[0] + x-1]);
+                max_v = MAX_VAL(max_v, score[(y+1) * iInfo.dims[0] + x-1]);
+                max_v = MAX_VAL(max_v, score[(y-1) * iInfo.dims[0] + x  ]);
+                max_v = MAX_VAL(max_v, score[(y+1) * iInfo.dims[0] + x  ]);
+                max_v = MAX_VAL(max_v, score[(y-1) * iInfo.dims[0] + x+1]);
+                max_v = MAX_VAL(max_v, score[(y)   * iInfo.dims[0] + x+1]);
+                max_v = MAX_VAL(max_v, score[(y+1) * iInfo.dims[0] + x+1]);
 
                 v = (v > max_v) ? v : 0;
                 flags[y * iInfo.dims[0] + x] = v;

--- a/src/backend/opencl/kernel/harris.cl
+++ b/src/backend/opencl/kernel/harris.cl
@@ -76,13 +76,13 @@ __kernel void non_maximal(
 
         // Find maximum neighborhood response
         T max_v;
-        max_v = MAX_VAL(resp_in[x-1 + idim0 * (y-1)], resp_in[x-1 + idim0 * y]);
-        max_v = MAX_VAL(max_v, resp_in[x-1 + idim0 * (y+1)]);
-        max_v = MAX_VAL(max_v, resp_in[x   + idim0 * (y-1)]);
-        max_v = MAX_VAL(max_v, resp_in[x   + idim0 * (y+1)]);
-        max_v = MAX_VAL(max_v, resp_in[x+1 + idim0 * (y-1)]);
-        max_v = MAX_VAL(max_v, resp_in[x+1 + idim0 * (y)  ]);
-        max_v = MAX_VAL(max_v, resp_in[x+1 + idim0 * (y+1)]);
+        max_v = MAX_VAL(resp_in[(y-1) * idim0 + x-1], resp_in[y * idim0 + x-1]);
+        max_v = MAX_VAL(max_v, resp_in[(y+1) * idim0 + x-1]);
+        max_v = MAX_VAL(max_v, resp_in[(y-1) * idim0 + x  ]);
+        max_v = MAX_VAL(max_v, resp_in[(y+1) * idim0 + x  ]);
+        max_v = MAX_VAL(max_v, resp_in[(y-1) * idim0 + x+1]);
+        max_v = MAX_VAL(max_v, resp_in[(y)   * idim0 + x+1]);
+        max_v = MAX_VAL(max_v, resp_in[(y+1) * idim0 + x+1]);
 
         // Stores corner to {x,y,resp}_out if it's response is maximum compared
         // to its 8-neighborhood and greater or equal minimum response

--- a/src/backend/opencl/kernel/harris.cl
+++ b/src/backend/opencl/kernel/harris.cl
@@ -41,8 +41,8 @@ __kernel void harris_responses(
     const unsigned x = get_global_id(0) + r;
     const unsigned y = get_global_id(1) + r;
 
-    if (x < idim1 - r && y < idim0 - r) {
-        const unsigned idx = x * idim0 + y;
+    if (x < idim0 - r && y < idim1 - r) {
+        const unsigned idx = y * idim0 + x;
 
         // Calculates matrix trace and determinant
         T tr = ixx_in[idx] + iyy_in[idx];
@@ -71,18 +71,18 @@ __kernel void non_maximal(
     const unsigned x = get_global_id(0) + r;
     const unsigned y = get_global_id(1) + r;
 
-    if (x < idim1 - r && y < idim0 - r) {
-        const T v = resp_in[x * idim0 + y];
+    if (x < idim0 - r && y < idim1 - r) {
+        const T v = resp_in[y * idim0 + x];
 
         // Find maximum neighborhood response
         T max_v;
-        max_v = MAX_VAL(resp_in[(x-1) * idim0 + y-1], resp_in[x * idim0 + y-1]);
-        max_v = MAX_VAL(max_v, resp_in[(x+1) * idim0 + y-1]);
-        max_v = MAX_VAL(max_v, resp_in[(x-1) * idim0 + y  ]);
-        max_v = MAX_VAL(max_v, resp_in[(x+1) * idim0 + y  ]);
-        max_v = MAX_VAL(max_v, resp_in[(x-1) * idim0 + y+1]);
-        max_v = MAX_VAL(max_v, resp_in[(x)   * idim0 + y+1]);
-        max_v = MAX_VAL(max_v, resp_in[(x+1) * idim0 + y+1]);
+        max_v = MAX_VAL(resp_in[x-1 + idim0 * (y-1)], resp_in[x-1 + idim0 * y]);
+        max_v = MAX_VAL(max_v, resp_in[x-1 + idim0 * (y+1)]);
+        max_v = MAX_VAL(max_v, resp_in[x   + idim0 * (y-1)]);
+        max_v = MAX_VAL(max_v, resp_in[x   + idim0 * (y+1)]);
+        max_v = MAX_VAL(max_v, resp_in[x+1 + idim0 * (y-1)]);
+        max_v = MAX_VAL(max_v, resp_in[x+1 + idim0 * (y)  ]);
+        max_v = MAX_VAL(max_v, resp_in[x+1 + idim0 * (y+1)]);
 
         // Stores corner to {x,y,resp}_out if it's response is maximum compared
         // to its 8-neighborhood and greater or equal minimum response

--- a/src/backend/opencl/kernel/orb.cl
+++ b/src/backend/opencl/kernel/orb.cl
@@ -348,7 +348,7 @@ __kernel void harris_response(
         // represents widest case possible
         unsigned patch_r = ceil(size * sqrt(2.f) / 2.f);
 
-        if (x >= patch_r && y >= patch_r && x < iInfo.dims[1] - patch_r && y < iInfo.dims[0] - patch_r) {
+        if (x >= patch_r && y >= patch_r && x < iInfo.dims[0] - patch_r && y < iInfo.dims[1] - patch_r) {
             unsigned r = block_size / 2;
 
             unsigned block_size_sq = block_size * block_size;
@@ -357,8 +357,8 @@ __kernel void harris_response(
                 int j = k % block_size - r;
 
                 // Calculate local x and y derivatives
-                float ix = image[(x+i+1) * iInfo.dims[0] + y+j] - image[(x+i-1) * iInfo.dims[0] + y+j];
-                float iy = image[(x+i) * iInfo.dims[0] + y+j+1] - image[(x+i) * iInfo.dims[0] + y+j-1];
+                float ix = image[(y+j) * iInfo.dims[0] + (x+i+1)] - image[(y+j) * iInfo.dims[0] + (x+i-1)];
+                float iy = image[(y+j+1) * iInfo.dims[0] + (x+i)] - image[(y+j-1) * iInfo.dims[0] + (x+i)];
 
                 // Accumulate second order derivatives
                 ixx += ix*ix;
@@ -414,14 +414,14 @@ __kernel void centroid_angle(
 
         unsigned r = patch_size / 2;
 
-        if (x >= r && y >= r && x <= iInfo.dims[1] - r && y <= iInfo.dims[0] - r) {
+        if (x >= r && y >= r && x <= iInfo.dims[0] - r && y <= iInfo.dims[1] - r) {
             unsigned patch_size_sq = patch_size * patch_size;
             for (unsigned k = get_local_id(1); k < patch_size_sq; k += get_local_size(1)) {
                 int i = k / patch_size - r;
                 int j = k % patch_size - r;
 
                 // Calculate first order moments
-                T p = image[(x+i) * iInfo.dims[0] + y+j];
+                T p = image[(y+j) * iInfo.dims[0] + (x+i)];
                 m01 += j * p;
                 m10 += i * p;
             }
@@ -456,7 +456,7 @@ inline T get_pixel(
     x += round(dist_x * patch_scl * ori_cos - dist_y * patch_scl * ori_sin);
     y += round(dist_x * patch_scl * ori_sin + dist_y * patch_scl * ori_cos);
 
-    return image[x * iInfo.dims[0] + y];
+    return image[y * iInfo.dims[0] + x];
 }
 
 __kernel void extract_orb(
@@ -483,7 +483,7 @@ __kernel void extract_orb(
 
         unsigned r = ceil(patch_size * sqrt(2.f) / 2.f);
 
-        if (x >= r && y >= r && x < iInfo.dims[1] - r && y < iInfo.dims[0] - r) {
+        if (x >= r && y >= r && x < iInfo.dims[0] - r && y < iInfo.dims[1] - r) {
            // Descriptor fixed at 256 bits for now
             for (unsigned i = get_local_id(1); i < 16; i += get_local_size(1)) {
                 unsigned v = 0;

--- a/test/fast.cpp
+++ b/test/fast.cpp
@@ -231,13 +231,13 @@ TEST(FloatFAST, WideImages) {
     img = colorSpace(img, AF_GRAY, AF_RGB);
     features feats = fast(img);
     // Remember that the image is transposed after loadImage()
-    float* featsY = feats.getY().host<float>();
+    float* featsDim1 = feats.getY().host<float>();
     unsigned int numFeats = feats.getNumFeatures();
-    unsigned int numRows = img.dims()[0];
+    unsigned int idim0 = img.dims()[0];
     bool featsFoundBeyondNumRows = false;
 
     for (unsigned int i = 0; i < numFeats; ++i) {
-        if (featsY[i] > numRows) {
+        if (featsDim1[i] > idim0) {
             featsFoundBeyondNumRows = true;
             break;
         }
@@ -251,13 +251,13 @@ TEST(FloatFAST, TallImages) {
     img = colorSpace(img, AF_GRAY, AF_RGB);
     features feats = fast(img);
     // Remember that the image is transposed after loadImage()
-    float* featsX = feats.getX().host<float>();
+    float* featsDim0 = feats.getX().host<float>();
     unsigned int numFeats = feats.getNumFeatures();
-    unsigned int numCols = img.dims()[1];
+    unsigned int idim1 = img.dims()[1];
     bool featsFoundBeyondNumCols = false;
 
     for (unsigned int i = 0; i < numFeats; ++i) {
-        if (featsX[i] > numCols) {
+        if (featsDim0[i] > idim1) {
             featsFoundBeyondNumCols = true;
             break;
         }

--- a/test/fast.cpp
+++ b/test/fast.cpp
@@ -225,3 +225,39 @@ TEST(FloatFAST, CPP)
     delete[] outOrientation;
     delete[] outSize;
 }
+
+TEST(FloatFAST, WideImages) {
+    array img = loadImage(TEST_DIR"/fast/squares_horiz.jpg", true);
+    img = colorSpace(img, AF_GRAY, AF_RGB);
+    features feats = fast(img);
+    float* featsX = feats.getX().host<float>();
+    unsigned int numFeats = feats.getNumFeatures();
+    unsigned int numRows = img.dims()[0];
+    bool featsFoundBeyondNumRows = false;
+
+    for (unsigned int i = 0; i < numFeats; ++i) {
+        if (featsX[i] > numRows) {
+            featsFoundBeyondNumRows = true;
+        }
+    }
+
+    ASSERT_TRUE(featsFoundBeyondNumRows);
+}
+
+TEST(FloatFAST, TallImages) {
+    array img = loadImage(TEST_DIR"/fast/squares_vert.jpg", true);
+    img = colorSpace(img, AF_GRAY, AF_RGB);
+    features feats = fast(img);
+    float* featsY = feats.getY().host<float>();
+    unsigned int numFeats = feats.getNumFeatures();
+    unsigned int numCols = img.dims()[1];
+    bool featsFoundBeyondNumCols = false;
+
+    for (unsigned int i = 0; i < numFeats; ++i) {
+        if (featsY[i] > numCols) {
+            featsFoundBeyondNumCols = true;
+        }
+    }
+
+    ASSERT_TRUE(featsFoundBeyondNumCols);
+}

--- a/test/fast.cpp
+++ b/test/fast.cpp
@@ -230,14 +230,16 @@ TEST(FloatFAST, WideImages) {
     array img = loadImage(TEST_DIR"/fast/squares_horiz.jpg", true);
     img = colorSpace(img, AF_GRAY, AF_RGB);
     features feats = fast(img);
-    float* featsX = feats.getX().host<float>();
+    // Remember that the image is transposed after loadImage()
+    float* featsY = feats.getY().host<float>();
     unsigned int numFeats = feats.getNumFeatures();
     unsigned int numRows = img.dims()[0];
     bool featsFoundBeyondNumRows = false;
 
     for (unsigned int i = 0; i < numFeats; ++i) {
-        if (featsX[i] > numRows) {
+        if (featsY[i] > numRows) {
             featsFoundBeyondNumRows = true;
+            break;
         }
     }
 
@@ -248,14 +250,16 @@ TEST(FloatFAST, TallImages) {
     array img = loadImage(TEST_DIR"/fast/squares_vert.jpg", true);
     img = colorSpace(img, AF_GRAY, AF_RGB);
     features feats = fast(img);
-    float* featsY = feats.getY().host<float>();
+    // Remember that the image is transposed after loadImage()
+    float* featsX = feats.getX().host<float>();
     unsigned int numFeats = feats.getNumFeatures();
     unsigned int numCols = img.dims()[1];
     bool featsFoundBeyondNumCols = false;
 
     for (unsigned int i = 0; i < numFeats; ++i) {
-        if (featsY[i] > numCols) {
+        if (featsX[i] > numCols) {
             featsFoundBeyondNumCols = true;
+            break;
         }
     }
 

--- a/test/harris.cpp
+++ b/test/harris.cpp
@@ -214,14 +214,16 @@ TEST(FloatHarris, WideImages) {
     array img = loadImage(TEST_DIR"/harris/squares_horiz.jpg", true);
     img = colorSpace(img, AF_GRAY, AF_RGB);
     features feats = harris(img);
-    float* featsX = feats.getX().host<float>();
+    // Remember that the image is transposed after loadImage()
+    float* featsDim1 = feats.getY().host<float>();
     unsigned int numFeats = feats.getNumFeatures();
-    unsigned int numRows = img.dims()[0];
+    unsigned int idim0 = img.dims()[0];
     bool featsFoundBeyondNumRows = false;
 
     for (unsigned int i = 0; i < numFeats; ++i) {
-        if (featsX[i] > numRows) {
+        if (featsDim1[i] > idim0) {
             featsFoundBeyondNumRows = true;
+            break;
         }
     }
 
@@ -232,14 +234,16 @@ TEST(FloatHarris, TallImages) {
     array img = loadImage(TEST_DIR"/harris/squares_vert.jpg", true);
     img = colorSpace(img, AF_GRAY, AF_RGB);
     features feats = harris(img);
-    float* featsY = feats.getY().host<float>();
+    // Remember that the image is transposed after loadImage()
+    float* featsDim0 = feats.getX().host<float>();
     unsigned int numFeats = feats.getNumFeatures();
-    unsigned int numCols = img.dims()[1];
+    unsigned int idim1 = img.dims()[1];
     bool featsFoundBeyondNumCols = false;
 
     for (unsigned int i = 0; i < numFeats; ++i) {
-        if (featsY[i] > numCols) {
+        if (featsDim0[i] > idim1) {
             featsFoundBeyondNumCols = true;
+            break;
         }
     }
 

--- a/test/harris.cpp
+++ b/test/harris.cpp
@@ -209,3 +209,39 @@ TEST(FloatHarris, CPP)
         ASSERT_EQ(out_feat[elIter].f[4], gold_feat[elIter].f[4]) << "at: " << elIter << endl;
     }
 }
+
+TEST(FloatHarris, WideImages) {
+    array img = loadImage(TEST_DIR"/harris/squares_horiz.jpg", true);
+    img = colorSpace(img, AF_GRAY, AF_RGB);
+    features feats = harris(img);
+    float* featsX = feats.getX().host<float>();
+    unsigned int numFeats = feats.getNumFeatures();
+    unsigned int numRows = img.dims()[0];
+    bool featsFoundBeyondNumRows = false;
+
+    for (unsigned int i = 0; i < numFeats; ++i) {
+        if (featsX[i] > numRows) {
+            featsFoundBeyondNumRows = true;
+        }
+    }
+
+    ASSERT_TRUE(featsFoundBeyondNumRows);
+}
+
+TEST(FloatHarris, TallImages) {
+    array img = loadImage(TEST_DIR"/harris/squares_vert.jpg", true);
+    img = colorSpace(img, AF_GRAY, AF_RGB);
+    features feats = harris(img);
+    float* featsY = feats.getY().host<float>();
+    unsigned int numFeats = feats.getNumFeatures();
+    unsigned int numCols = img.dims()[1];
+    bool featsFoundBeyondNumCols = false;
+
+    for (unsigned int i = 0; i < numFeats; ++i) {
+        if (featsY[i] > numCols) {
+            featsFoundBeyondNumCols = true;
+        }
+    }
+
+    ASSERT_TRUE(featsFoundBeyondNumCols);
+}

--- a/test/orb.cpp
+++ b/test/orb.cpp
@@ -151,6 +151,7 @@ void orbTest(string pTestFile)
 
     for (size_t testId=0; testId<testCount; ++testId) {
         af_array inArray_f32  = 0;
+        af_array inArray_f32_T= 0;
         af_array inArray      = 0;
         af_array desc         = 0;
         af_features feat;
@@ -158,7 +159,8 @@ void orbTest(string pTestFile)
         inFiles[testId].insert(0,string(TEST_DIR"/orb/"));
 
         ASSERT_EQ(AF_SUCCESS, af_load_image(&inArray_f32, inFiles[testId].c_str(), false));
-        ASSERT_EQ(AF_SUCCESS, conv_image<T>(&inArray, inArray_f32));
+        ASSERT_EQ(AF_SUCCESS, af_transpose(&inArray_f32_T, inArray_f32, false));
+        ASSERT_EQ(AF_SUCCESS, conv_image<T>(&inArray, inArray_f32_T));
 
         ASSERT_EQ(AF_SUCCESS, af_orb(&feat, &desc, inArray, 20.0f, 400, 1.2f, 8, true));
 
@@ -255,7 +257,7 @@ TEST(ORB, CPP)
     readImageFeaturesDescriptors<unsigned>(string(TEST_DIR"/orb/square.test"), inDims, inFiles, goldFeat, goldDesc);
     inFiles[0].insert(0,string(TEST_DIR"/orb/"));
 
-    array in = loadImage(inFiles[0].c_str(), false);
+    array in = loadImage(inFiles[0].c_str(), false).T();
 
     features feat;
     array desc;

--- a/test/orb.cpp
+++ b/test/orb.cpp
@@ -309,3 +309,43 @@ TEST(ORB, CPP)
     delete[] outSize;
     delete[] outDesc;
 }
+
+TEST(ORB, WideImages) {
+    array img = loadImage(TEST_DIR"/orb/squares_horiz.jpg", true);
+    img = colorSpace(img, AF_GRAY, AF_RGB);
+    features feats;
+    array descs;
+    orb(feats, descs, img);
+    float* featsX = feats.getX().host<float>();
+    unsigned int numFeats = feats.getNumFeatures();
+    unsigned int numRows = img.dims()[0];
+    bool featsFoundBeyondNumRows = false;
+
+    for (unsigned int i = 0; i < numFeats; ++i) {
+        if (featsX[i] > numRows) {
+            featsFoundBeyondNumRows = true;
+        }
+    }
+
+    ASSERT_TRUE(featsFoundBeyondNumRows);
+}
+
+TEST(ORB, TallImages) {
+    array img = loadImage(TEST_DIR"/orb/squares_vert.jpg", true);
+    img = colorSpace(img, AF_GRAY, AF_RGB);
+    features feats;
+    array descs;
+    orb(feats, descs, img);
+    float* featsY = feats.getY().host<float>();
+    unsigned int numFeats = feats.getNumFeatures();
+    unsigned int numCols = img.dims()[1];
+    bool featsFoundBeyondNumCols = false;
+
+    for (unsigned int i = 0; i < numFeats; ++i) {
+        if (featsY[i] > numCols) {
+            featsFoundBeyondNumCols = true;
+        }
+    }
+
+    ASSERT_TRUE(featsFoundBeyondNumCols);
+}

--- a/test/orb.cpp
+++ b/test/orb.cpp
@@ -316,14 +316,15 @@ TEST(ORB, WideImages) {
     features feats;
     array descs;
     orb(feats, descs, img);
-    float* featsX = feats.getX().host<float>();
+    float* featsDim1 = feats.getY().host<float>();
     unsigned int numFeats = feats.getNumFeatures();
-    unsigned int numRows = img.dims()[0];
+    unsigned int idim0 = img.dims()[0];
     bool featsFoundBeyondNumRows = false;
 
     for (unsigned int i = 0; i < numFeats; ++i) {
-        if (featsX[i] > numRows) {
+        if (featsDim1[i] > idim0) {
             featsFoundBeyondNumRows = true;
+            break;
         }
     }
 
@@ -336,14 +337,15 @@ TEST(ORB, TallImages) {
     features feats;
     array descs;
     orb(feats, descs, img);
-    float* featsY = feats.getY().host<float>();
+    float* featsDim0 = feats.getX().host<float>();
     unsigned int numFeats = feats.getNumFeatures();
-    unsigned int numCols = img.dims()[1];
+    unsigned int idim1 = img.dims()[1];
     bool featsFoundBeyondNumCols = false;
 
     for (unsigned int i = 0; i < numFeats; ++i) {
-        if (featsY[i] > numCols) {
+        if (featsDim0[i] > idim1) {
             featsFoundBeyondNumCols = true;
+            break;
         }
     }
 

--- a/test/susan.cpp
+++ b/test/susan.cpp
@@ -187,14 +187,16 @@ TEST(Susan, WideImages) {
     array img = loadImage(TEST_DIR"/susan/squares_horiz.jpg", true);
     img = colorSpace(img, AF_GRAY, AF_RGB);
     features feats = susan(img);
-    float* featsX = feats.getX().host<float>();
+    // Remember that the image is transposed after loadImage()
+    float* featsDim1 = feats.getY().host<float>();
     unsigned int numFeats = feats.getNumFeatures();
-    unsigned int numRows = img.dims()[0];
+    unsigned int idim0 = img.dims()[0];
     bool featsFoundBeyondNumRows = false;
 
     for (unsigned int i = 0; i < numFeats; ++i) {
-        if (featsX[i] > numRows) {
+        if (featsDim1[i] > idim0) {
             featsFoundBeyondNumRows = true;
+            break;
         }
     }
 
@@ -205,14 +207,16 @@ TEST(Susan, TallImages) {
     array img = loadImage(TEST_DIR"/susan/squares_vert.jpg", true);
     img = colorSpace(img, AF_GRAY, AF_RGB);
     features feats = susan(img);
-    float* featsY = feats.getY().host<float>();
+    // Remember that the image is transposed after loadImage()
+    float* featsDim0 = feats.getX().host<float>();
     unsigned int numFeats = feats.getNumFeatures();
-    unsigned int numCols = img.dims()[1];
+    unsigned int idim1 = img.dims()[1];
     bool featsFoundBeyondNumCols = false;
 
     for (unsigned int i = 0; i < numFeats; ++i) {
-        if (featsY[i] > numCols) {
+        if (featsDim0[i] > idim1) {
             featsFoundBeyondNumCols = true;
+            break;
         }
     }
 

--- a/test/susan.cpp
+++ b/test/susan.cpp
@@ -182,3 +182,39 @@ TEST(Susan, InvalidEdge)
         EXPECT_TRUE(true);
     }
 }
+
+TEST(Susan, WideImages) {
+    array img = loadImage(TEST_DIR"/susan/squares_horiz.jpg", true);
+    img = colorSpace(img, AF_GRAY, AF_RGB);
+    features feats = susan(img);
+    float* featsX = feats.getX().host<float>();
+    unsigned int numFeats = feats.getNumFeatures();
+    unsigned int numRows = img.dims()[0];
+    bool featsFoundBeyondNumRows = false;
+
+    for (unsigned int i = 0; i < numFeats; ++i) {
+        if (featsX[i] > numRows) {
+            featsFoundBeyondNumRows = true;
+        }
+    }
+
+    ASSERT_TRUE(featsFoundBeyondNumRows);
+}
+
+TEST(Susan, TallImages) {
+    array img = loadImage(TEST_DIR"/susan/squares_vert.jpg", true);
+    img = colorSpace(img, AF_GRAY, AF_RGB);
+    features feats = susan(img);
+    float* featsY = feats.getY().host<float>();
+    unsigned int numFeats = feats.getNumFeatures();
+    unsigned int numCols = img.dims()[1];
+    bool featsFoundBeyondNumCols = false;
+
+    for (unsigned int i = 0; i < numFeats; ++i) {
+        if (featsY[i] > numCols) {
+            featsFoundBeyondNumCols = true;
+        }
+    }
+
+    ASSERT_TRUE(featsFoundBeyondNumCols);
+}


### PR DESCRIPTION
Some feature detection functions have switched the first and second dimensions when linearizing the 2D indexing of the image data. Issues #2212, #2213, and #2214 all suffer from this problem. I think that this dimension switching is due to the fact that arrayfire is column-major. I also think this was issue hasn't been detected before because the tests use a square image, in which case switching dimensions on the linear array index calculation shouldn't be a problem.