### PR TITLE
Add batching support for cond argument in select; Batching Tests

### DIFF
--- a/src/api/c/select.cpp
+++ b/src/api/c/select.cpp
@@ -33,26 +33,24 @@ af_err af_select(af_array *out, const af_array cond, const af_array a, const af_
     try {
         const ArrayInfo& ainfo = getInfo(a);
         const ArrayInfo& binfo = getInfo(b);
-        const ArrayInfo& cinfo = getInfo(cond);
+        const ArrayInfo& cond_info = getInfo(cond);
 
-        if(cinfo.ndims() == 0) {
+        if(cond_info.ndims() == 0) {
             return af_retain_array(out, cond);
         }
 
         ARG_ASSERT(2, ainfo.getType() == binfo.getType());
-        ARG_ASSERT(1, cinfo.getType() == b8);
-
-        DIM_ASSERT(1, cinfo.ndims() == std::min(ainfo.ndims(), binfo.ndims()));
+        ARG_ASSERT(1, cond_info.getType() == b8);
 
         dim4 adims = ainfo.dims();
         dim4 bdims = binfo.dims();
-        dim4 cdims = cinfo.dims();
+        dim4 cond_dims = cond_info.dims();
         dim4 odims(1, 1, 1, 1);
 
         for (int i = 0; i < 4; i++) {
-            DIM_ASSERT(1, cdims[i] == std::min(adims[i], bdims[i]));
-            DIM_ASSERT(2, adims[i] == bdims[i] || adims[i] == 1 || bdims[i] == 1);
-            odims[i] = std::max(adims[i], bdims[i]);
+            DIM_ASSERT(2, (adims[i] == bdims[i] && adims[i] == cond_dims[i])
+                        || adims[i] == 1 || bdims[i] == 1 || cond_dims[i] == 1);
+            odims[i] = std::max(std::max(adims[i], bdims[i]), cond_dims[i]);
         }
 
         af_array res;
@@ -92,30 +90,31 @@ af_err af_select_scalar_r(af_array *out, const af_array cond, const af_array a, 
         const ArrayInfo& cinfo = getInfo(cond);
 
         ARG_ASSERT(1, cinfo.getType() == b8);
-        DIM_ASSERT(1, cinfo.ndims() == ainfo.ndims());
 
         dim4 adims = ainfo.dims();
-        dim4 cdims = cinfo.dims();
+        dim4 cond_dims = cinfo.dims();
+        dim4 odims(1);
 
         for (int i = 0; i < 4; i++) {
-            DIM_ASSERT(1, cdims[i] == adims[i]);
+            DIM_ASSERT(1, cond_dims[i] == adims[i] | cond_dims[i] == 1 | adims[i] == 1);
+            odims[i] = std::max(cond_dims[i], adims[i]);
         }
 
         af_array res;
 
         switch (ainfo.getType()) {
-        case f32: res = select_scalar<float  , false>(cond, a, b, adims); break;
-        case f64: res = select_scalar<double , false>(cond, a, b, adims); break;
-        case c32: res = select_scalar<cfloat , false>(cond, a, b, adims); break;
-        case c64: res = select_scalar<cdouble, false>(cond, a, b, adims); break;
-        case s32: res = select_scalar<int    , false>(cond, a, b, adims); break;
-        case u32: res = select_scalar<uint   , false>(cond, a, b, adims); break;
-        case s16: res = select_scalar<short  , false>(cond, a, b, adims); break;
-        case u16: res = select_scalar<ushort , false>(cond, a, b, adims); break;
-        case s64: res = select_scalar<intl   , false>(cond, a, b, adims); break;
-        case u64: res = select_scalar<uintl  , false>(cond, a, b, adims); break;
-        case u8:  res = select_scalar<uchar  , false>(cond, a, b, adims); break;
-        case b8:  res = select_scalar<char   , false>(cond, a, b, adims); break;
+        case f32: res = select_scalar<float  , false>(cond, a, b, odims); break;
+        case f64: res = select_scalar<double , false>(cond, a, b, odims); break;
+        case c32: res = select_scalar<cfloat , false>(cond, a, b, odims); break;
+        case c64: res = select_scalar<cdouble, false>(cond, a, b, odims); break;
+        case s32: res = select_scalar<int    , false>(cond, a, b, odims); break;
+        case u32: res = select_scalar<uint   , false>(cond, a, b, odims); break;
+        case s16: res = select_scalar<short  , false>(cond, a, b, odims); break;
+        case u16: res = select_scalar<ushort , false>(cond, a, b, odims); break;
+        case s64: res = select_scalar<intl   , false>(cond, a, b, odims); break;
+        case u64: res = select_scalar<uintl  , false>(cond, a, b, odims); break;
+        case u8:  res = select_scalar<uchar  , false>(cond, a, b, odims); break;
+        case b8:  res = select_scalar<char   , false>(cond, a, b, odims); break;
         default:  TYPE_ERROR(2, ainfo.getType());
         }
 
@@ -131,30 +130,31 @@ af_err af_select_scalar_l(af_array *out, const af_array cond, const double a, co
         const ArrayInfo& cinfo = getInfo(cond);
 
         ARG_ASSERT(1, cinfo.getType() == b8);
-        DIM_ASSERT(1, cinfo.ndims() == binfo.ndims());
 
         dim4 bdims = binfo.dims();
-        dim4 cdims = cinfo.dims();
+        dim4 cond_dims = cinfo.dims();
+        dim4 odims(1);
 
         for (int i = 0; i < 4; i++) {
-            DIM_ASSERT(1, cdims[i] == bdims[i]);
+            DIM_ASSERT(1, cond_dims[i] == bdims[i] || cond_dims[i] == 1 || bdims[i] == 1);
+            odims[i] = std::max(cond_dims[i], bdims[i]);
         }
 
         af_array res;
 
         switch (binfo.getType()) {
-        case f32: res = select_scalar<float  , true >(cond, b, a, bdims); break;
-        case f64: res = select_scalar<double , true >(cond, b, a, bdims); break;
-        case c32: res = select_scalar<cfloat , true >(cond, b, a, bdims); break;
-        case c64: res = select_scalar<cdouble, true >(cond, b, a, bdims); break;
-        case s32: res = select_scalar<int    , true >(cond, b, a, bdims); break;
-        case u32: res = select_scalar<uint   , true >(cond, b, a, bdims); break;
-        case s16: res = select_scalar<short  , true >(cond, b, a, bdims); break;
-        case u16: res = select_scalar<ushort , true >(cond, b, a, bdims); break;
-        case s64: res = select_scalar<intl   , true >(cond, b, a, bdims); break;
-        case u64: res = select_scalar<uintl  , true >(cond, b, a, bdims); break;
-        case u8:  res = select_scalar<uchar  , true >(cond, b, a, bdims); break;
-        case b8:  res = select_scalar<char   , true >(cond, b, a, bdims); break;
+        case f32: res = select_scalar<float  , true >(cond, b, a, odims); break;
+        case f64: res = select_scalar<double , true >(cond, b, a, odims); break;
+        case c32: res = select_scalar<cfloat , true >(cond, b, a, odims); break;
+        case c64: res = select_scalar<cdouble, true >(cond, b, a, odims); break;
+        case s32: res = select_scalar<int    , true >(cond, b, a, odims); break;
+        case u32: res = select_scalar<uint   , true >(cond, b, a, odims); break;
+        case s16: res = select_scalar<short  , true >(cond, b, a, odims); break;
+        case u16: res = select_scalar<ushort , true >(cond, b, a, odims); break;
+        case s64: res = select_scalar<intl   , true >(cond, b, a, odims); break;
+        case u64: res = select_scalar<uintl  , true >(cond, b, a, odims); break;
+        case u8:  res = select_scalar<uchar  , true >(cond, b, a, odims); break;
+        case b8:  res = select_scalar<char   , true >(cond, b, a, odims); break;
         default:  TYPE_ERROR(2, binfo.getType());
         }
 

--- a/test/select.cpp
+++ b/test/select.cpp
@@ -7,14 +7,18 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include <gtest/gtest.h>
+#define GTEST_LINKED_AS_SHARED_LIBRARY 1
 #include <arrayfire.h>
+#include <gtest/gtest.h>
+#include <testHelpers.hpp>
+
 #include <af/dim4.hpp>
 #include <af/traits.hpp>
-#include <vector>
+
+#include <cstdio>
 #include <iostream>
 #include <string>
-#include <testHelpers.hpp>
+#include <vector>
 
 using af::NaN;
 using af::array;
@@ -32,7 +36,6 @@ using af::span;
 using af::sum;
 using std::string;
 using std::stringstream;
-using std::to_string;
 using std::vector;
 
 
@@ -305,13 +308,19 @@ struct select_params {
     dim4 cond;
     dim4 a;
     dim4 b;
+  select_params(dim4 out_, dim4 cond_, dim4 a_, dim4 b_)
+    : out(out_), cond(cond_), a(a_), b(b_)
+  {}
 };
 
 class Select_ : public ::testing::TestWithParam<select_params> {};
 
 string pd4(dim4 dims) {
-    return to_string(dims[0]) + "_" + to_string(dims[1]) + "_"
-         + to_string(dims[2]) + "_" + to_string(dims[3]) + "_";
+    string out(32, '\0');
+    int len = snprintf(const_cast<char*>(out.data()), 32,
+                       "%d_%d_%d_%d", dims[0], dims[1], dims[2], dims[3]);
+    out.resize(len);
+    return out;
 }
 
 string testNameGenerator(const ::testing::TestParamInfo<Select_::ParamType> info) {
@@ -324,16 +333,17 @@ string testNameGenerator(const ::testing::TestParamInfo<Select_::ParamType> info
 }
 
 vector<select_params> getSelectTestParams(int M, int N) {
-  return {select_params{dim4(M), dim4(M), dim4(M), dim4(M)},
-          select_params{dim4(M, N), dim4(M, N), dim4(M, N), dim4(M, N)},
-          select_params{dim4(M, N, N), dim4(M, N, N), dim4(M, N, N), dim4(M, N, N)},
-          select_params{dim4(M, N, N, N), dim4(M, N, N, N), dim4(M, N, N, N), dim4(M, N, N, N)},
-          select_params{dim4(M, N), dim4(M, 1), dim4(M, 1), dim4(M, N)},
-          select_params{dim4(M, N), dim4(M, 1), dim4(M, N), dim4(M, 1)},
-          select_params{dim4(M, N), dim4(M, 1), dim4(M, N), dim4(M, N)},
-          select_params{dim4(M, N), dim4(M, N), dim4(M, 1), dim4(M, N)},
-          select_params{dim4(M, N), dim4(M, N), dim4(M, N), dim4(M, 1)},
-          select_params{dim4(M, N), dim4(M, N), dim4(M, 1), dim4(M, 1)}};
+  const select_params _[] = {select_params(dim4(M), dim4(M), dim4(M), dim4(M)),
+          select_params(dim4(M, N), dim4(M, N), dim4(M, N), dim4(M, N)),
+          select_params(dim4(M, N, N), dim4(M, N, N), dim4(M, N, N), dim4(M, N, N)),
+          select_params(dim4(M, N, N, N), dim4(M, N, N, N), dim4(M, N, N, N), dim4(M, N, N, N)),
+          select_params(dim4(M, N), dim4(M, 1), dim4(M, 1), dim4(M, N)),
+          select_params(dim4(M, N), dim4(M, 1), dim4(M, N), dim4(M, 1)),
+          select_params(dim4(M, N), dim4(M, 1), dim4(M, N), dim4(M, N)),
+          select_params(dim4(M, N), dim4(M, N), dim4(M, 1), dim4(M, N)),
+          select_params(dim4(M, N), dim4(M, N), dim4(M, N), dim4(M, 1)),
+          select_params(dim4(M, N), dim4(M, N), dim4(M, 1), dim4(M, 1))};
+  return vector<select_params>(_, _ + sizeof(_) / sizeof(_[0]));
 }
 
 INSTANTIATE_TEST_CASE_P(
@@ -381,17 +391,22 @@ struct selectlr_params {
   dim4 out;
   dim4 cond;
   dim4 ab;
+  selectlr_params(dim4 out_, dim4 cond_, dim4 ab_)
+    : out(out_), cond(cond_), ab(ab_) {}
 };
 
 class SelectLR_ : public ::testing::TestWithParam<selectlr_params> {};
 
 vector<selectlr_params> getSelectLRTestParams(int M, int N) {
-  return {selectlr_params{dim4(M), dim4(M), dim4(M)},
-          selectlr_params{dim4(M, N), dim4(M, N), dim4(M, N)},
-          selectlr_params{dim4(M, N, N), dim4(M, N, N), dim4(M, N, N)},
-          selectlr_params{dim4(M, N, N, N), dim4(M, N, N, N), dim4(M, N, N, N)},
-          selectlr_params{dim4(M, N), dim4(M, 1), dim4(M, N)},
-          selectlr_params{dim4(M, N), dim4(M, N), dim4(M, 1)}};
+  const selectlr_params _[] = {
+              selectlr_params(dim4(M), dim4(M), dim4(M)),
+              selectlr_params(dim4(M, N), dim4(M, N), dim4(M, N)),
+              selectlr_params(dim4(M, N, N), dim4(M, N, N), dim4(M, N, N)),
+              selectlr_params(dim4(M, N, N, N), dim4(M, N, N, N), dim4(M, N, N, N)),
+              selectlr_params(dim4(M, N), dim4(M, 1), dim4(M, N)),
+              selectlr_params(dim4(M, N), dim4(M, N), dim4(M, 1))};
+
+  return vector<selectlr_params> (_, _+sizeof(_)/sizeof(_[0]));
 }
 
 string testNameGeneratorLR(const ::testing::TestParamInfo<SelectLR_::ParamType> info) {
@@ -472,18 +487,18 @@ TEST(Select, InvalidSizeOfAB) {
     af_array out = 0;
 
     double val = 0;
-    std::array<dim_t, 1> dims = {10};
-    ASSERT_EQ(AF_SUCCESS, af_constant(&a, val, 1, dims.data(), f32));
+    dim_t dims = 10;
+    ASSERT_EQ(AF_SUCCESS, af_constant(&a, val, 1, &dims, f32));
 
-    dims[0] = 9;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&b, val, 1, dims.data(), f32));
+    dims = 9;
+    ASSERT_EQ(AF_SUCCESS, af_constant(&b, val, 1, &dims, f32));
 
-    dims[0] = 10;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&cond, val, 1, dims.data(), b8));
+    dims = 10;
+    ASSERT_EQ(AF_SUCCESS, af_constant(&cond, val, 1, &dims, b8));
 
     ASSERT_EQ(AF_ERR_SIZE, af_select(&out, cond, a, b));
 
-    char* msg = nullptr;
+    char* msg = NULL;
     dim_t len = 0;
     af_get_last_error(&msg, &len);
     af_free_host(msg);
@@ -499,18 +514,18 @@ TEST(Select, InvalidSizeOfCond) {
     af_array out = 0;
 
     double val = 0;
-    std::array<dim_t, 1> dims = {10};
-    ASSERT_EQ(AF_SUCCESS, af_constant(&a, val, 1, dims.data(), f32));
+    dim_t dims = 10;
+    ASSERT_EQ(AF_SUCCESS, af_constant(&a, val, 1, &dims, f32));
 
-    dims[0] = 10;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&b, val, 1, dims.data(), f32));
+    dims = 10;
+    ASSERT_EQ(AF_SUCCESS, af_constant(&b, val, 1, &dims, f32));
 
-    dims[0] = 9;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&cond, val, 1, dims.data(), b8));
+    dims = 9;
+    ASSERT_EQ(AF_SUCCESS, af_constant(&cond, val, 1, &dims, b8));
 
     ASSERT_EQ(AF_ERR_SIZE, af_select(&out, cond, a, b));
 
-    char* msg = nullptr;
+    char* msg = NULL;
     dim_t len = 0;
     af_get_last_error(&msg, &len);
     af_free_host(msg);


### PR DESCRIPTION
Addresses: #2236 

Select now supports the following combinations:
```
 |------------+------------+------------+------------|
 | Out Dim    | Cond Dim   | A Dim      | B Dim      |
 |------------+------------+------------+------------|
 | M          | M          | M          | M          |
 | M, N       | M, N       | M, N       | M, N       |
 | M, N, N    | M, N, N    | M, N, N    | M, N, N    |
 | M, N, N, N | M, N, N, N | M, N, N, N | M, N, N, N |
 | M, N       | M, 1       | M, 1       | M, N       |
 | M, N       | M, 1       | M, N       | M, 1       |
 | M, N       | M, 1       | M, N       | M, N       |
 | M, N       | M, N       | M, 1       | M, N       |
 | M, N       | M, N       | M, N       | M, 1       |
 | M, N       | M, N       | M, 1       | M, 1       |
 |------------+------------+------------+------------|
```
 Added tests for all combinations of batches above.