### PR TITLE
Add test utility functions to compare af::arrays

### DIFF
--- a/test/anisotropic_diffusion.cpp
+++ b/test/anisotropic_diffusion.cpp
@@ -86,58 +86,58 @@ void imageTest(string pTestFile, const float dt, const float K, const uint iters
         af_array _goldArray  = 0;
         dim_t nElems         = 0;
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&_inArray, inFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, conv_image<T>(&inArray, _inArray));
+        ASSERT_SUCCESS(af_load_image(&_inArray, inFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(conv_image<T>(&inArray, _inArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&_goldArray, outFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(af_load_image(&_goldArray, outFiles[testId].c_str(), isColor));
         // af_load_image always returns float array, so convert to output type
-        ASSERT_EQ(AF_SUCCESS, conv_image<OutType>(&goldArray, _goldArray));
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems, goldArray));
+        ASSERT_SUCCESS(conv_image<OutType>(&goldArray, _goldArray));
+        ASSERT_SUCCESS(af_get_elements(&nElems, goldArray));
 
         if (isCurvatureDiffusion) {
-            ASSERT_EQ(AF_SUCCESS, af_anisotropic_diffusion(&_outArray, inArray, dt, K, iters,
+            ASSERT_SUCCESS(af_anisotropic_diffusion(&_outArray, inArray, dt, K, iters,
                                                            fluxKind, AF_DIFFUSION_MCDE));
         } else {
-            ASSERT_EQ(AF_SUCCESS, af_anisotropic_diffusion(&_outArray, inArray, dt, K, iters,
+            ASSERT_SUCCESS(af_anisotropic_diffusion(&_outArray, inArray, dt, K, iters,
                                                            fluxKind, AF_DIFFUSION_GRAD));
         }
 
         double maxima, minima, imag;
-        ASSERT_EQ(AF_SUCCESS, af_min_all(&minima, &imag, _outArray));
-        ASSERT_EQ(AF_SUCCESS, af_max_all(&maxima, &imag, _outArray));
+        ASSERT_SUCCESS(af_min_all(&minima, &imag, _outArray));
+        ASSERT_SUCCESS(af_max_all(&maxima, &imag, _outArray));
 
         unsigned ndims;
         dim_t dims[4];
-        ASSERT_EQ(AF_SUCCESS, af_get_numdims(&ndims, _outArray));
-        ASSERT_EQ(AF_SUCCESS, af_get_dims(dims, dims+1, dims+2, dims+3, _outArray));
+        ASSERT_SUCCESS(af_get_numdims(&ndims, _outArray));
+        ASSERT_SUCCESS(af_get_dims(dims, dims+1, dims+2, dims+3, _outArray));
 
         af_dtype otype = (af_dtype)af::dtype_traits<OutType>::af_type;
-        ASSERT_EQ(AF_SUCCESS, af_constant(&cstArray, 255.0, ndims, dims, otype));
-        ASSERT_EQ(AF_SUCCESS, af_constant(&denArray, (maxima-minima), ndims, dims, otype));
-        ASSERT_EQ(AF_SUCCESS, af_constant(&minArray, minima, ndims, dims, otype));
-        ASSERT_EQ(AF_SUCCESS, af_sub(&numArray, _outArray, minArray, false));
-        ASSERT_EQ(AF_SUCCESS, af_div(&divArray, numArray, denArray, false));
-        ASSERT_EQ(AF_SUCCESS, af_mul(&outArray, divArray, cstArray, false));
+        ASSERT_SUCCESS(af_constant(&cstArray, 255.0, ndims, dims, otype));
+        ASSERT_SUCCESS(af_constant(&denArray, (maxima-minima), ndims, dims, otype));
+        ASSERT_SUCCESS(af_constant(&minArray, minima, ndims, dims, otype));
+        ASSERT_SUCCESS(af_sub(&numArray, _outArray, minArray, false));
+        ASSERT_SUCCESS(af_div(&divArray, numArray, denArray, false));
+        ASSERT_SUCCESS(af_mul(&outArray, divArray, cstArray, false));
 
         vector<OutType> outData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
         vector<OutType> goldData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)goldData.data(), goldArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
 
         ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(), outData.data(), 0.025f));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(_inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(_outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(cstArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(minArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(denArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(numArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(divArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(_goldArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(goldArray));
+        ASSERT_SUCCESS(af_release_array(_inArray));
+        ASSERT_SUCCESS(af_release_array(_outArray));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(cstArray));
+        ASSERT_SUCCESS(af_release_array(minArray));
+        ASSERT_SUCCESS(af_release_array(denArray));
+        ASSERT_SUCCESS(af_release_array(numArray));
+        ASSERT_SUCCESS(af_release_array(divArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(_goldArray));
+        ASSERT_SUCCESS(af_release_array(goldArray));
     }
 }
 

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -78,20 +78,20 @@ void approx1Test(string pTestFile, const unsigned resultIdx, const af_interp_typ
     vector<T> input(in[0].begin(), in[0].end());
 
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&posArray, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<BT>::af_type));
+    ASSERT_SUCCESS(af_create_array(&posArray, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<BT>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_approx1(&outArray, inArray, posArray, method, 0));
+    ASSERT_SUCCESS(af_approx1(&outArray, inArray, posArray, method, 0));
 
     // Get result
     T* outData = new T[tests[resultIdx].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     // Compare result
     size_t nElems = tests[resultIdx].size();
@@ -143,18 +143,18 @@ void approx1CubicTest(string pTestFile, const unsigned resultIdx, const af_inter
     vector<T> input(in[0].begin(), in[0].end());
 
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&posArray, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<BT>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_approx1(&outArray, inArray, posArray, method, 0));
+    ASSERT_SUCCESS(af_create_array(&posArray, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<BT>::af_type));
+    ASSERT_SUCCESS(af_approx1(&outArray, inArray, posArray, method, 0));
 
     // Get result
     T* outData = new T[tests[resultIdx].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     // Compare result
     size_t nElems = tests[resultIdx].size();
@@ -217,9 +217,9 @@ void approx1ArgsTest(string pTestFile, const unsigned resultIdx, const af_interp
 
     vector<T> input(in[0].begin(), in[0].end());
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&posArray, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<BT>::af_type));
+    ASSERT_SUCCESS(af_create_array(&posArray, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<BT>::af_type));
 
     ASSERT_EQ(err, af_approx1(&outArray, inArray, posArray, method, 0));
 
@@ -259,15 +259,15 @@ void approx1ArgsTestPrecision(string pTestFile, const unsigned resultIdx, const 
 
     vector<T> input(in[0].begin(), in[0].end());
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&posArray, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&posArray, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     if((af_dtype) dtype_traits<T>::af_type == c32 ||
        (af_dtype) dtype_traits<T>::af_type == c64) {
         ASSERT_EQ(AF_ERR_ARG, af_approx1(&outArray, inArray, posArray, method, 0));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_approx1(&outArray, inArray, posArray, method, 0));
+        ASSERT_SUCCESS(af_approx1(&outArray, inArray, posArray, method, 0));
     }
 
     if(inArray   != 0) af_release_array(inArray);

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -76,21 +76,21 @@ void approx2Test(string pTestFile, const unsigned resultIdx, const af_interp_typ
     vector<T> input(in[0].begin(), in[0].end());
 
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&pos0Array, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<BT>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&pos1Array, &(in[2].front()), qdims.ndims(), qdims.get(), (af_dtype) dtype_traits<BT>::af_type));
+    ASSERT_SUCCESS(af_create_array(&pos0Array, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<BT>::af_type));
+    ASSERT_SUCCESS(af_create_array(&pos1Array, &(in[2].front()), qdims.ndims(), qdims.get(), (af_dtype) dtype_traits<BT>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_approx2(&outArray, inArray, pos0Array, pos1Array, method, 0));
+    ASSERT_SUCCESS(af_approx2(&outArray, inArray, pos0Array, pos1Array, method, 0));
 
     // Get result
     T* outData = new T[tests[resultIdx].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     // Compare result
     size_t nElems = tests[resultIdx].size();
@@ -152,10 +152,10 @@ void approx2ArgsTest(string pTestFile, const unsigned resultIdx, const af_interp
 
     vector<T> input(in[0].begin(), in[0].end());
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&pos0Array, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<BT>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&pos1Array, &(in[2].front()), qdims.ndims(), qdims.get(), (af_dtype) dtype_traits<BT>::af_type));
+    ASSERT_SUCCESS(af_create_array(&pos0Array, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<BT>::af_type));
+    ASSERT_SUCCESS(af_create_array(&pos1Array, &(in[2].front()), qdims.ndims(), qdims.get(), (af_dtype) dtype_traits<BT>::af_type));
 
     ASSERT_EQ(err, af_approx2(&outArray, inArray, pos0Array, pos1Array, method, 0));
 
@@ -200,17 +200,17 @@ void approx2ArgsTestPrecision(string pTestFile, const unsigned resultIdx, const 
 
     vector<T> input(in[0].begin(), in[0].end());
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&inArray, &(input.front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&pos0Array, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<T>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&pos1Array, &(in[2].front()), qdims.ndims(), qdims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&pos0Array, &(in[1].front()), pdims.ndims(), pdims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&pos1Array, &(in[2].front()), qdims.ndims(), qdims.get(), (af_dtype) dtype_traits<T>::af_type));
 
 
     if((af_dtype) dtype_traits<T>::af_type == c32 ||
        (af_dtype) dtype_traits<T>::af_type == c64) {
         ASSERT_EQ(AF_ERR_ARG, af_approx2(&outArray, inArray, pos0Array, pos1Array, method, 0));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_approx2(&outArray, inArray, pos0Array, pos1Array, method, 0));
+        ASSERT_SUCCESS(af_approx2(&outArray, inArray, pos0Array, pos1Array, method, 0));
     }
 
     if(inArray   != 0) af_release_array(inArray);

--- a/test/arrayio.cpp
+++ b/test/arrayio.cpp
@@ -118,6 +118,6 @@ TEST(ArrayIO, Save) {
     array aread = readArray("arr.af", "a");
     array bread = readArray("arr.af", "b");
 
-    ASSERT_TRUE(allTrue<bool>(aread == a));
-    ASSERT_TRUE(allTrue<bool>(bread == b));
+    ASSERT_ARRAYS_EQ(a, aread);
+    ASSERT_ARRAYS_EQ(b, bread);
 }

--- a/test/assign.cpp
+++ b/test/assign.cpp
@@ -116,17 +116,17 @@ void assignTest(string pTestFile, const vector<af_seq> *seqv)
     af_array rhsArray  = 0;
     af_array outArray  = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&rhsArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&rhsArray, &(in[0].front()),
                 dims0.ndims(), dims0.get(), (af_dtype)dtype_traits<inType>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&lhsArray, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&lhsArray, &(in[1].front()),
                 dims1.ndims(), dims1.get(), (af_dtype)dtype_traits<outType>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_assign_seq(&outArray, lhsArray, seqv->size(), &seqv->front(), rhsArray));
+    ASSERT_SUCCESS(af_assign_seq(&outArray, lhsArray, seqv->size(), &seqv->front(), rhsArray));
 
     outType *outData = new outType[dims1.elements()];
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     vector<outType> currGoldBar = tests[0];
     size_t nElems        = currGoldBar.size();
@@ -135,9 +135,9 @@ void assignTest(string pTestFile, const vector<af_seq> *seqv)
     }
 
     delete[] outData;
-    ASSERT_EQ(AF_SUCCESS, af_release_array(rhsArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(lhsArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(rhsArray));
+    ASSERT_SUCCESS(af_release_array(lhsArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 template<typename T>
@@ -500,13 +500,13 @@ TEST(ArrayAssign, InvalidArgs)
     ASSERT_EQ(AF_ERR_ARG, af_assign_seq(&outArray,
                                     lhsArray, seqv.size(), &seqv.front(), rhsArray));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&rhsArray, &(in.front()),
+    ASSERT_SUCCESS(af_create_array(&rhsArray, &(in.front()),
                 dims0.ndims(), dims0.get(), (af_dtype)dtype_traits<cfloat>::af_type));
 
     ASSERT_EQ(AF_ERR_ARG, af_assign_seq(&outArray,
                                     lhsArray, seqv.size(), &seqv.front(), rhsArray));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&lhsArray, &(in.front()),
+    ASSERT_SUCCESS(af_create_array(&lhsArray, &(in.front()),
                 dims1.ndims(), dims1.get(), (af_dtype)dtype_traits<float>::af_type));
 
     ASSERT_EQ(AF_ERR_ARG, af_assign_seq(&outArray, lhsArray, 0, &seqv.front(), rhsArray));
@@ -514,8 +514,8 @@ TEST(ArrayAssign, InvalidArgs)
     ASSERT_EQ(AF_ERR_TYPE, af_assign_seq(&outArray,
                                          lhsArray, seqv.size(), &seqv.front(), rhsArray));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(rhsArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(lhsArray));
+    ASSERT_SUCCESS(af_release_array(rhsArray));
+    ASSERT_SUCCESS(af_release_array(lhsArray));
 }
 
 TEST(ArrayAssign, CPP_ASSIGN_TO_INDEXED)
@@ -891,7 +891,7 @@ TEST(Asssign, LinearAssignSeq)
     af_array rhs_arr = rhs.get();
     af_array out_arr;
 
-    ASSERT_EQ(AF_SUCCESS,
+    ASSERT_SUCCESS(
               af_assign_seq(&out_arr, in_arr, 1, &ii.idx.seq, rhs_arr));
 
     array out(out_arr);
@@ -931,7 +931,7 @@ TEST(Asssign, LinearAssignGenSeq)
     af_array rhs_arr = rhs.get();
     af_array out_arr;
 
-    ASSERT_EQ(AF_SUCCESS,
+    ASSERT_SUCCESS(
               af_assign_gen(&out_arr, in_arr, 1, &ii, rhs_arr));
 
     array out(out_arr);
@@ -971,7 +971,7 @@ TEST(Asssign, LinearAssignGenArr)
     af_array rhs_arr = rhs.get();
     af_array out_arr;
 
-    ASSERT_EQ(AF_SUCCESS,
+    ASSERT_SUCCESS(
               af_assign_gen(&out_arr, in_arr, 1, &ii, rhs_arr));
 
     array out(out_arr);

--- a/test/backend.cpp
+++ b/test/backend.cpp
@@ -55,7 +55,7 @@ void testFunction()
 
     // cleanup
     if(outArray != 0) {
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
     }
 }
 

--- a/test/basic.cpp
+++ b/test/basic.cpp
@@ -28,17 +28,17 @@ TEST(BasicTests, constant1000x1000)
 
     double valA = 3.9;
     af_array a;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&a, valA, ndims, d, f32));
+    ASSERT_SUCCESS(af_constant(&a, valA, ndims, d, f32));
 
     vector<float> h_a(dim_size * dim_size, 100);
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void **)&h_a[0], a));
+    ASSERT_SUCCESS(af_get_data_ptr((void **)&h_a[0], a));
 
     size_t elements = dim_size * dim_size;
     for(size_t i = 0; i < elements; i++) {
         ASSERT_FLOAT_EQ(valA, h_a[i]);
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(a));
+    ASSERT_SUCCESS(af_release_array(a));
 }
 
 TEST(BasicTests, constant10x10)
@@ -51,17 +51,17 @@ TEST(BasicTests, constant10x10)
 
     double valA = 3.9;
     af_array a;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&a, valA, ndims, d, f32));
+    ASSERT_SUCCESS(af_constant(&a, valA, ndims, d, f32));
 
     vector<float> h_a(dim_size * dim_size, 0);
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void **)&h_a[0], a));
+    ASSERT_SUCCESS(af_get_data_ptr((void **)&h_a[0], a));
 
     size_t elements = dim_size * dim_size;
     for(size_t i = 0; i < elements; i++) {
         ASSERT_FLOAT_EQ(valA, h_a[i]);
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(a));
+    ASSERT_SUCCESS(af_release_array(a));
 }
 
 TEST(BasicTests, constant100x100)
@@ -74,17 +74,17 @@ TEST(BasicTests, constant100x100)
 
     double valA = 4.9;
     af_array a;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&a, valA, ndims, d, f32));
+    ASSERT_SUCCESS(af_constant(&a, valA, ndims, d, f32));
 
     vector<float> h_a(dim_size * dim_size, 0);
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void **)&h_a[0], a));
+    ASSERT_SUCCESS(af_get_data_ptr((void **)&h_a[0], a));
 
     size_t elements = dim_size * dim_size;
     for(size_t i = 0; i < elements; i++) {
         ASSERT_FLOAT_EQ(valA, h_a[i]);
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(a));
+    ASSERT_SUCCESS(af_release_array(a));
 }
 
 //TODO: Test All The Types \o/
@@ -104,19 +104,19 @@ TEST(BasicTests, AdditionSameType)
     af_array af32, bf32, cf32;
     af_array af64, bf64, cf64;
 
-    ASSERT_EQ(AF_SUCCESS, af_constant(&af32, valA, ndims, d, f32));
-    ASSERT_EQ(AF_SUCCESS, af_constant(&af64, valA, ndims, d, f64));
+    ASSERT_SUCCESS(af_constant(&af32, valA, ndims, d, f32));
+    ASSERT_SUCCESS(af_constant(&af64, valA, ndims, d, f64));
 
-    ASSERT_EQ(AF_SUCCESS, af_constant(&bf32, valB, ndims, d, f32));
-    ASSERT_EQ(AF_SUCCESS, af_constant(&bf64, valB, ndims, d, f64));
+    ASSERT_SUCCESS(af_constant(&bf32, valB, ndims, d, f32));
+    ASSERT_SUCCESS(af_constant(&bf64, valB, ndims, d, f64));
 
-    ASSERT_EQ(AF_SUCCESS, af_add(&cf32, af32, bf32, false));
-    ASSERT_EQ(AF_SUCCESS, af_add(&cf64, af64, bf64, false));
+    ASSERT_SUCCESS(af_add(&cf32, af32, bf32, false));
+    ASSERT_SUCCESS(af_add(&cf64, af64, bf64, false));
 
     vector<float>  h_cf32 (dim_size * dim_size);
     vector<double> h_cf64 (dim_size * dim_size);
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void **)&h_cf32[0], cf32));
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void **)&h_cf64[0], cf64));
+    ASSERT_SUCCESS(af_get_data_ptr((void **)&h_cf32[0], cf32));
+    ASSERT_SUCCESS(af_get_data_ptr((void **)&h_cf64[0], cf64));
 
     double err = 0;
 
@@ -129,12 +129,12 @@ TEST(BasicTests, AdditionSameType)
     }
     ASSERT_NEAR(0.0f, err, 1e-8);
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(af32));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(af64));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(bf32));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(bf64));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(cf32));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(cf64));
+    ASSERT_SUCCESS(af_release_array(af32));
+    ASSERT_SUCCESS(af_release_array(af64));
+    ASSERT_SUCCESS(af_release_array(bf32));
+    ASSERT_SUCCESS(af_release_array(bf64));
+    ASSERT_SUCCESS(af_release_array(cf32));
+    ASSERT_SUCCESS(af_release_array(cf64));
 }
 
 TEST(BasicTests, Additionf64f64)
@@ -151,12 +151,12 @@ TEST(BasicTests, Additionf64f64)
 
     af_array a, b, c;
 
-    ASSERT_EQ(AF_SUCCESS, af_constant(&a, valA, ndims, d, f64));
-    ASSERT_EQ(AF_SUCCESS, af_constant(&b, valB, ndims, d, f64));
-    ASSERT_EQ(AF_SUCCESS, af_add(&c, a, b, false));
+    ASSERT_SUCCESS(af_constant(&a, valA, ndims, d, f64));
+    ASSERT_SUCCESS(af_constant(&b, valB, ndims, d, f64));
+    ASSERT_SUCCESS(af_add(&c, a, b, false));
 
     vector<double> h_c(dim_size * dim_size, 0);
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void **)&h_c[0], c));
+    ASSERT_SUCCESS(af_get_data_ptr((void **)&h_c[0], c));
 
     double err = 0;
 
@@ -168,9 +168,9 @@ TEST(BasicTests, Additionf64f64)
     }
     ASSERT_NEAR(0.0f, err, 1e-8);
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(a));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(b));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(c));
+    ASSERT_SUCCESS(af_release_array(a));
+    ASSERT_SUCCESS(af_release_array(b));
+    ASSERT_SUCCESS(af_release_array(c));
 
 }
 
@@ -189,12 +189,12 @@ TEST(BasicTests, Additionf32f64)
 
     af_array a, b, c;
 
-    ASSERT_EQ(AF_SUCCESS, af_constant(&a, valA, ndims, d, f32));
-    ASSERT_EQ(AF_SUCCESS, af_constant(&b, valB, ndims, d, f64));
-    ASSERT_EQ(AF_SUCCESS, af_add(&c, a, b, false));
+    ASSERT_SUCCESS(af_constant(&a, valA, ndims, d, f32));
+    ASSERT_SUCCESS(af_constant(&b, valB, ndims, d, f64));
+    ASSERT_SUCCESS(af_add(&c, a, b, false));
 
     vector<double> h_c(dim_size * dim_size);
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void **)&h_c[0], c));
+    ASSERT_SUCCESS(af_get_data_ptr((void **)&h_c[0], c));
 
     double err = 0;
 
@@ -206,9 +206,9 @@ TEST(BasicTests, Additionf32f64)
     }
     ASSERT_NEAR(0.0f, err, 1e-8);
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(a));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(b));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(c));
+    ASSERT_SUCCESS(af_release_array(a));
+    ASSERT_SUCCESS(af_release_array(b));
+    ASSERT_SUCCESS(af_release_array(c));
 }
 
 TEST(BasicArrayTests, constant10x10)
@@ -365,7 +365,6 @@ TEST(Assert, TestEqualsDiffSizes) {
 }
 
 TEST(Assert, TestEqualsDiffValue) {
-    // array A = af::randu(3, 3, 3);
     array gold = constant(1, 3, 3);
     array out = gold;
     out(2, 2) = 2;
@@ -376,7 +375,6 @@ TEST(Assert, TestEqualsDiffValue) {
 }
 
 TEST(Assert, TestEqualsDiffComplexValue) {
-    // array A = af::randu(3, 3, 3);
     array gold = constant(af::cfloat(3.1f, 3.1f), 3, 3, c32);
     array out = gold;
     out(2, 2) = 2.2;
@@ -412,10 +410,10 @@ TEST(Assert, TestVectorDiffVecType) {
                               gold, goldDims, out));
 }
 
-TEST(Assert, TestVectorDiffDim4) {
+TEST(Assert, TestVectorDiffGoldSizeDims) {
     array out = constant(3.1f, 3, 3);
 
-    vector<float> gold(out.elements());
+    vector<float> gold(3 * 3);
     dim4 goldDims(3, 2);
     fill(gold.begin(), gold.end(), 3.1f);
 
@@ -425,15 +423,37 @@ TEST(Assert, TestVectorDiffDim4) {
                                gold, goldDims, out));
 }
 
-TEST(Assert, TestVectorDiffVecSize) {
+TEST(Assert, TestVectorDiffOutSizeGoldSize) {
     array out = constant(3.1f, 3, 3);
 
-    vector<float> gold(out.elements() - 1);
-    dim4 goldDims(3, 3);
+    vector<float> gold(3 * 2);
+    dim4 goldDims(3, 2);
     fill(gold.begin(), gold.end(), 3.1f);
 
     // Testing this macro
     // ASSERT_VEC_ARRAY_EQ(gold, goldDims, out);
     ASSERT_FALSE(assertArrayEq("gold", "goldDims", "out",
                                gold, goldDims, out));
+}
+
+TEST(Assert, TestVectorDiffDim4) {
+    array A = constant(3.1f, 3, 3);
+    vector<float> hA(A.elements());
+    dim4 adims(3, 2);
+    fill(hA.begin(), hA.end(), 3.1f);
+
+    // Testing this macro
+    // ASSERT_ARRAYS_EQ(A, B);
+    ASSERT_FALSE(assertArrayEq("hA", "adims", "A", hA, adims, A));
+}
+
+TEST(Assert, TestVectorDiffVecSize) {
+    array A = constant(3.1f, 3, 3);
+    vector<float> hA(A.elements()-1);
+    dim4 adims(3, 3);
+    fill(hA.begin(), hA.end(), 3.1f);
+
+    // Testing this macro
+    // ASSERT_ARRAYS_EQ(A, B);
+    ASSERT_FALSE(assertArrayEq("hA", "adims", "A", hA, adims, A));
 }

--- a/test/basic.cpp
+++ b/test/basic.cpp
@@ -10,8 +10,9 @@
 #include <gtest/gtest.h>
 #include <arrayfire.h>
 #include <af/data.h>
-#include <vector>
 #include <testHelpers.hpp>
+
+#include <vector>
 
 using std::vector;
 using af::array;
@@ -319,4 +320,65 @@ TEST(BasicTests, Additionf32f64_CPP)
         err = err + df * df;
     }
     ASSERT_NEAR(0.0f, err, 1e-8);
+}
+
+TEST(Assert, TestEqualsCpp) {
+    array A = constant(1, 10, 10);
+    array B = constant(1, 10, 10);
+
+    // Testing this macro
+    // ASSERT_ARRAY_EQ(A, B);
+    ASSERT_TRUE(assertArrayEq("A", "B", A, B));
+}
+
+TEST(Assert, TestEqualsC) {
+    af_array A = 0;
+    af_array B = 0;
+    dim_t dims[] = {10, 10, 1, 1};
+    af_constant(&A, 1.0, 4, dims, f32);
+    af_constant(&B, 1.0, 4, dims, f32);
+
+    // Testing this macro
+    //ASSERT_ARRAY_EQ(a, b);
+    ASSERT_TRUE(assertArrayEq("A", "B", A, B));
+}
+
+TEST(Assert, TestEqualsDiffTypes) {
+    array A = constant(1, 10, 10, f64);
+    array B = constant(1, 10, 10);
+
+    // Testing this macro
+    // ASSERT_ARRAY_EQ(A, B);
+    ASSERT_FALSE(assertArrayEq("A", "B", A, B));
+}
+
+TEST(Assert, TestEqualsDiffSizes) {
+    array A = constant(1, 10, 9);
+    array B = constant(1, 10, 10);
+
+    // Testing this macro
+    // ASSERT_ARRAY_EQ(A, B);
+    ASSERT_FALSE(assertArrayEq("A", "B", A, B));
+}
+
+TEST(Assert, TestEqualsDiffValue) {
+    // array A = af::randu(3, 3, 3);
+    array A = constant(1, 3, 3);
+    array B = A;
+    B(2, 2) = 2;
+
+    // Testing this macro
+    //ASSERT_ARRAY_EQ(A, B);
+    ASSERT_FALSE(assertArrayEq("A", "B", A, B));
+}
+
+TEST(Assert, TestEqualsDiffComplexValue) {
+    // array A = af::randu(3, 3, 3);
+    array A = constant(af::cfloat(3.1f, 3.1f), 3, 3, c32);
+    array B = A;
+    B(2, 2) = 2.2;
+
+    // Testing this macro
+    // ASSERT_ARRAY_EQ(A, B);
+    ASSERT_FALSE(assertArrayEq("A", "B", A, B));
 }

--- a/test/basic.cpp
+++ b/test/basic.cpp
@@ -323,62 +323,117 @@ TEST(BasicTests, Additionf32f64_CPP)
 }
 
 TEST(Assert, TestEqualsCpp) {
-    array A = constant(1, 10, 10);
-    array B = constant(1, 10, 10);
+    array gold = constant(1, 10, 10);
+    array out = constant(1, 10, 10);
 
     // Testing this macro
-    // ASSERT_ARRAY_EQ(A, B);
-    ASSERT_TRUE(assertArrayEq("A", "B", A, B));
+    // ASSERT_ARRAYS_EQ(gold, out);
+    ASSERT_TRUE(assertArrayEq("gold", "out", gold, out));
 }
 
 TEST(Assert, TestEqualsC) {
-    af_array A = 0;
-    af_array B = 0;
+    af_array gold = 0;
+    af_array out = 0;
     dim_t dims[] = {10, 10, 1, 1};
-    af_constant(&A, 1.0, 4, dims, f32);
-    af_constant(&B, 1.0, 4, dims, f32);
+    af_constant(&gold, 1.0, 4, dims, f32);
+    af_constant(&out, 1.0, 4, dims, f32);
 
     // Testing this macro
-    //ASSERT_ARRAY_EQ(a, b);
-    ASSERT_TRUE(assertArrayEq("A", "B", A, B));
+    // ASSERT_ARRAYS_EQ(gold, out);
+    ASSERT_TRUE(assertArrayEq("gold", "out", gold, out));
+
+    ASSERT_SUCCESS(af_release_array(out));
+    ASSERT_SUCCESS(af_release_array(gold));
 }
 
 TEST(Assert, TestEqualsDiffTypes) {
-    array A = constant(1, 10, 10, f64);
-    array B = constant(1, 10, 10);
+    array gold = constant(1, 10, 10, f64);
+    array out = constant(1, 10, 10);
 
     // Testing this macro
-    // ASSERT_ARRAY_EQ(A, B);
-    ASSERT_FALSE(assertArrayEq("A", "B", A, B));
+    // ASSERT_ARRAYS_EQ(gold, out);
+    ASSERT_FALSE(assertArrayEq("gold", "out", gold, out));
 }
 
 TEST(Assert, TestEqualsDiffSizes) {
-    array A = constant(1, 10, 9);
-    array B = constant(1, 10, 10);
+    array gold = constant(1, 10, 9);
+    array out = constant(1, 10, 10);
 
     // Testing this macro
-    // ASSERT_ARRAY_EQ(A, B);
-    ASSERT_FALSE(assertArrayEq("A", "B", A, B));
+    // ASSERT_ARRAYS_EQ(gold, out);
+    ASSERT_FALSE(assertArrayEq("gold", "out", gold, out));
 }
 
 TEST(Assert, TestEqualsDiffValue) {
     // array A = af::randu(3, 3, 3);
-    array A = constant(1, 3, 3);
-    array B = A;
-    B(2, 2) = 2;
+    array gold = constant(1, 3, 3);
+    array out = gold;
+    out(2, 2) = 2;
 
     // Testing this macro
-    //ASSERT_ARRAY_EQ(A, B);
-    ASSERT_FALSE(assertArrayEq("A", "B", A, B));
+    // ASSERT_ARRAYS_EQ(gold, out);
+    ASSERT_FALSE(assertArrayEq("gold", "out", gold, out));
 }
 
 TEST(Assert, TestEqualsDiffComplexValue) {
     // array A = af::randu(3, 3, 3);
-    array A = constant(af::cfloat(3.1f, 3.1f), 3, 3, c32);
-    array B = A;
-    B(2, 2) = 2.2;
+    array gold = constant(af::cfloat(3.1f, 3.1f), 3, 3, c32);
+    array out = gold;
+    out(2, 2) = 2.2;
 
     // Testing this macro
-    // ASSERT_ARRAY_EQ(A, B);
-    ASSERT_FALSE(assertArrayEq("A", "B", A, B));
+    // ASSERT_ARRAYS_EQ(gold, out);
+    ASSERT_FALSE(assertArrayEq("gold", "out", gold, out));
+}
+
+TEST(Assert, TestVectorEquals) {
+    array out = constant(3.1f, 3, 3);
+
+    vector<float> gold(out.elements());
+    dim4 goldDims(3, 3);
+    fill(gold.begin(), gold.end(), 3.1f);
+
+    // Testing this macro
+    // ASSERT_VEC_ARRAY_EQ(gold, goldDims, out);
+    ASSERT_TRUE(assertArrayEq("gold", "goldDims", "out",
+                              gold, goldDims, out));
+}
+
+TEST(Assert, TestVectorDiffVecType) {
+    array out = constant(3.1f, 3, 3);
+
+    vector<int> gold(out.elements());
+    dim4 goldDims(3, 3);
+    fill(gold.begin(), gold.end(), 3.1f);
+
+    // Testing this macro
+    // ASSERT_VEC_ARRAY_EQ(gold, goldDims, out);
+    ASSERT_FALSE(assertArrayEq("gold", "goldDims", "out",
+                              gold, goldDims, out));
+}
+
+TEST(Assert, TestVectorDiffDim4) {
+    array out = constant(3.1f, 3, 3);
+
+    vector<float> gold(out.elements());
+    dim4 goldDims(3, 2);
+    fill(gold.begin(), gold.end(), 3.1f);
+
+    // Testing this macro
+    // ASSERT_VEC_ARRAY_EQ(gold, goldDims, out);
+    ASSERT_FALSE(assertArrayEq("gold", "goldDims", "out",
+                               gold, goldDims, out));
+}
+
+TEST(Assert, TestVectorDiffVecSize) {
+    array out = constant(3.1f, 3, 3);
+
+    vector<float> gold(out.elements() - 1);
+    dim4 goldDims(3, 3);
+    fill(gold.begin(), gold.end(), 3.1f);
+
+    // Testing this macro
+    // ASSERT_VEC_ARRAY_EQ(gold, goldDims, out);
+    ASSERT_FALSE(assertArrayEq("gold", "goldDims", "out",
+                               gold, goldDims, out));
 }

--- a/test/bilateral.cpp
+++ b/test/bilateral.cpp
@@ -47,23 +47,23 @@ void bilateralTest(string pTestFile)
         inFiles[testId].insert(0,string(TEST_DIR"/bilateral/"));
         outFiles[testId].insert(0,string(TEST_DIR"/bilateral/"));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&inArray, inFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&goldArray, outFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems, goldArray));
+        ASSERT_SUCCESS(af_load_image(&inArray, inFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(af_load_image(&goldArray, outFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(af_get_elements(&nElems, goldArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_bilateral(&outArray, inArray, 2.25f, 25.56f, isColor));
+        ASSERT_SUCCESS(af_bilateral(&outArray, inArray, 2.25f, 25.56f, isColor));
 
         vector<T> outData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
         vector<T> goldData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)goldData.data(), goldArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
 
         ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(), outData.data(), 0.02f));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(goldArray));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(goldArray));
     }
 }
 
@@ -105,14 +105,14 @@ void bilateralDataTest(string pTestFile)
     af_array outArray  = 0;
     af_array inArray   = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()),
                 dims.ndims(), dims.get(), (af_dtype)dtype_traits<inType>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_bilateral(&outArray, inArray, 2.25f, 25.56f, false));
+    ASSERT_SUCCESS(af_bilateral(&outArray, inArray, 2.25f, 25.56f, false));
 
     vector<outType> outData(dims.elements());
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
     for (size_t testIter=0; testIter<tests.size(); ++testIter) {
         vector<outType> currGoldBar = tests[testIter];
@@ -121,8 +121,8 @@ void bilateralDataTest(string pTestFile)
     }
 
     // cleanup
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TYPED_TEST(BilateralOnData, Rectangle)
@@ -146,10 +146,10 @@ TYPED_TEST(BilateralOnData, InvalidArgs)
 
     // check for color image bilateral
     dim4 dims = dim4(100,1,1,1);
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<TypeParam>::af_type));
     ASSERT_EQ(AF_ERR_SIZE, af_bilateral(&outArray, inArray, 0.12f, 0.34f, true));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 // C++ unit tests

--- a/test/blas.cpp
+++ b/test/blas.cpp
@@ -56,7 +56,7 @@ void MatMulCheck(string TestFile)
     readTests<T,T,int>(TestFile, numDims, hData, tests);
 
     af_array a, aT, b, bT;
-    ASSERT_EQ(AF_SUCCESS,
+    ASSERT_SUCCESS(
             af_create_array(&a, &hData[0].front(), numDims[0].ndims(), numDims[0].get(), (af_dtype) dtype_traits<T>::af_type));
     dim4 atdims = numDims[0];
     {
@@ -64,9 +64,9 @@ void MatMulCheck(string TestFile)
         atdims[0]   =    atdims[1];
         atdims[1]   =    f;
     }
-    ASSERT_EQ(AF_SUCCESS,
+    ASSERT_SUCCESS(
             af_moddims(&aT, a, atdims.ndims(), atdims.get()));
-    ASSERT_EQ(AF_SUCCESS,
+    ASSERT_SUCCESS(
             af_create_array(&b, &hData[1].front(), numDims[1].ndims(), numDims[1].get(), (af_dtype) dtype_traits<T>::af_type));
     dim4 btdims = numDims[1];
     {
@@ -74,29 +74,29 @@ void MatMulCheck(string TestFile)
         btdims[0] = btdims[1];
         btdims[1] = f;
     }
-    ASSERT_EQ(AF_SUCCESS,
+    ASSERT_SUCCESS(
             af_moddims(&bT, b, btdims.ndims(), btdims.get()));
 
     vector<af_array> out(tests.size(), 0);
     if(isBVector) {
-        ASSERT_EQ(AF_SUCCESS, af_matmul( &out[0] , aT, b,    AF_MAT_NONE,    AF_MAT_NONE));
-        ASSERT_EQ(AF_SUCCESS, af_matmul( &out[1] , bT, a,   AF_MAT_NONE,    AF_MAT_NONE));
-        ASSERT_EQ(AF_SUCCESS, af_matmul( &out[2] , b, a,    AF_MAT_TRANS,       AF_MAT_NONE));
-        ASSERT_EQ(AF_SUCCESS, af_matmul( &out[3] , bT, aT,   AF_MAT_NONE,    AF_MAT_TRANS));
-        ASSERT_EQ(AF_SUCCESS, af_matmul( &out[4] , b, aT,    AF_MAT_TRANS,       AF_MAT_TRANS));
+        ASSERT_SUCCESS(af_matmul( &out[0] , aT, b,    AF_MAT_NONE,    AF_MAT_NONE));
+        ASSERT_SUCCESS(af_matmul( &out[1] , bT, a,   AF_MAT_NONE,    AF_MAT_NONE));
+        ASSERT_SUCCESS(af_matmul( &out[2] , b, a,    AF_MAT_TRANS,       AF_MAT_NONE));
+        ASSERT_SUCCESS(af_matmul( &out[3] , bT, aT,   AF_MAT_NONE,    AF_MAT_TRANS));
+        ASSERT_SUCCESS(af_matmul( &out[4] , b, aT,    AF_MAT_TRANS,       AF_MAT_TRANS));
     }
     else {
-        ASSERT_EQ(AF_SUCCESS, af_matmul( &out[0] , a, b, AF_MAT_NONE,   AF_MAT_NONE));
-        ASSERT_EQ(AF_SUCCESS, af_matmul( &out[1] , a, bT, AF_MAT_NONE,   AF_MAT_TRANS));
-        ASSERT_EQ(AF_SUCCESS, af_matmul( &out[2] , a, bT, AF_MAT_TRANS,      AF_MAT_NONE));
-        ASSERT_EQ(AF_SUCCESS, af_matmul( &out[3] , aT, bT, AF_MAT_TRANS,      AF_MAT_TRANS));
+        ASSERT_SUCCESS(af_matmul( &out[0] , a, b, AF_MAT_NONE,   AF_MAT_NONE));
+        ASSERT_SUCCESS(af_matmul( &out[1] , a, bT, AF_MAT_NONE,   AF_MAT_TRANS));
+        ASSERT_SUCCESS(af_matmul( &out[2] , a, bT, AF_MAT_TRANS,      AF_MAT_NONE));
+        ASSERT_SUCCESS(af_matmul( &out[3] , aT, bT, AF_MAT_TRANS,      AF_MAT_TRANS));
     }
 
     for(size_t i = 0; i < tests.size(); i++) {
         dim_t elems;
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&elems, out[i]));
+        ASSERT_SUCCESS(af_get_elements(&elems, out[i]));
         vector<T> h_out(elems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void *)&h_out.front(), out[i]));
+        ASSERT_SUCCESS(af_get_data_ptr((void *)&h_out.front(), out[i]));
 
         if( false == equal(h_out.begin(), h_out.end(), tests[i].begin()) ) {
 
@@ -108,13 +108,13 @@ void MatMulCheck(string TestFile)
         }
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(a));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(aT));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(b));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(bT));
+    ASSERT_SUCCESS(af_release_array(a));
+    ASSERT_SUCCESS(af_release_array(aT));
+    ASSERT_SUCCESS(af_release_array(b));
+    ASSERT_SUCCESS(af_release_array(bT));
 
     for (size_t i = 0; i <  out.size(); i++) {
-        ASSERT_EQ(AF_SUCCESS, af_release_array(out[i]));
+        ASSERT_SUCCESS(af_release_array(out[i]));
     }
 }
 

--- a/test/canny.cpp
+++ b/test/canny.cpp
@@ -49,14 +49,14 @@ void cannyTest(string pTestFile)
     af_array outArray = 0;
     af_array sArray   = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&sArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&sArray, &(in[0].front()),
                 sDims.ndims(), sDims.get(), (af_dtype)dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_canny(&outArray, sArray, AF_CANNY_THRESHOLD_MANUAL, 0.4147f, 0.8454f, 3, true));
+    ASSERT_SUCCESS(af_canny(&outArray, sArray, AF_CANNY_THRESHOLD_MANUAL, 0.4147f, 0.8454f, 3, true));
 
     vector<char> outData(sDims.elements());
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
     vector<char> currGoldBar = tests[0];
     size_t nElems        = currGoldBar.size();
@@ -65,8 +65,8 @@ void cannyTest(string pTestFile)
     }
 
     // cleanup
-    ASSERT_EQ(AF_SUCCESS, af_release_array(sArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(sArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TYPED_TEST(CannyEdgeDetector, ArraySizeLessThanBlockSize10x10)
@@ -112,42 +112,42 @@ void cannyImageOtsuTest(string pTestFile, bool isColor)
 
         af_dtype type = (af_dtype)dtype_traits<T>::af_type;
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&_inArray, inFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(af_load_image(&_inArray, inFiles[testId].c_str(), isColor));
 
-        ASSERT_EQ(AF_SUCCESS, af_cast(&inArray, _inArray, type));
+        ASSERT_SUCCESS(af_cast(&inArray, _inArray, type));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image_native(&goldArray, outFiles[testId].c_str()));
+        ASSERT_SUCCESS(af_load_image_native(&goldArray, outFiles[testId].c_str()));
 
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems, goldArray));
+        ASSERT_SUCCESS(af_get_elements(&nElems, goldArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_canny(&_outArray, inArray, AF_CANNY_THRESHOLD_AUTO_OTSU, 0.08, 0.32, 3, false));
+        ASSERT_SUCCESS(af_canny(&_outArray, inArray, AF_CANNY_THRESHOLD_AUTO_OTSU, 0.08, 0.32, 3, false));
 
         unsigned ndims = 0;
         dim_t dims[4];
 
-        ASSERT_EQ(AF_SUCCESS, af_get_numdims(&ndims, _outArray));
-        ASSERT_EQ(AF_SUCCESS, af_get_dims(dims, dims+1, dims+2, dims+3, _outArray));
+        ASSERT_SUCCESS(af_get_numdims(&ndims, _outArray));
+        ASSERT_SUCCESS(af_get_dims(dims, dims+1, dims+2, dims+3, _outArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_constant(&cstArray, 255.0, ndims, dims, f32));
+        ASSERT_SUCCESS(af_constant(&cstArray, 255.0, ndims, dims, f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_mul(&mulArray, cstArray, _outArray, false));
-        ASSERT_EQ(AF_SUCCESS, af_cast(&outArray, mulArray, u8));
+        ASSERT_SUCCESS(af_mul(&mulArray, cstArray, _outArray, false));
+        ASSERT_SUCCESS(af_cast(&outArray, mulArray, u8));
 
         vector<unsigned char> outData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
         vector<unsigned char> goldData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)goldData.data(), goldArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
 
         ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(), outData.data(), 1.0e-3));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(_inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(cstArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(mulArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(_outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(goldArray));
+        ASSERT_SUCCESS(af_release_array(_inArray));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(cstArray));
+        ASSERT_SUCCESS(af_release_array(mulArray));
+        ASSERT_SUCCESS(af_release_array(_outArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(goldArray));
     }
 }
 
@@ -165,12 +165,12 @@ TEST(CannyEdgeDetector, InvalidSizeArray)
 
     dim4 sDims(100, 1, 1, 1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 sDims.ndims(), sDims.get(), (af_dtype) dtype_traits<float>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_canny(&outArray, inArray, AF_CANNY_THRESHOLD_MANUAL, 0.24, 0.72, 3, true));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TEST(CannyEdgeDetector, Array4x4_Invalid)
@@ -182,12 +182,12 @@ TEST(CannyEdgeDetector, Array4x4_Invalid)
 
     dim4 sDims(4, 4, 1, 1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 sDims.ndims(), sDims.get(), (af_dtype) dtype_traits<float>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_canny(&outArray, inArray, AF_CANNY_THRESHOLD_MANUAL, 0.24, 0.72, 3, true));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TEST(CannyEdgeDetector, Sobel5x5_Invalid)
@@ -199,10 +199,10 @@ TEST(CannyEdgeDetector, Sobel5x5_Invalid)
 
     dim4 sDims(5, 5, 1, 1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 sDims.ndims(), sDims.get(), (af_dtype) dtype_traits<float>::af_type));
 
     ASSERT_EQ(AF_ERR_ARG, af_canny(&outArray, inArray, AF_CANNY_THRESHOLD_MANUAL, 0.24, 0.72, 5, true));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }

--- a/test/cast.cpp
+++ b/test/cast.cpp
@@ -34,7 +34,7 @@ void cast_test()
     af_err err = af_cast(&b, a, tb);
     af_release_array(a);
     af_release_array(b);
-    ASSERT_EQ(err, AF_SUCCESS);
+    ASSERT_SUCCESS(err);
 }
 
 #define REAL_TO_TESTS(Ti, To)                   \
@@ -91,7 +91,7 @@ void cast_test_complex_real()
     af_randu(&a, dims.ndims(), dims.get(), ta);
     af_err err = af_cast(&b, a, tb);
     ASSERT_EQ(err, AF_ERR_TYPE);
-    ASSERT_EQ(AF_SUCCESS, af_release_array(a));
+    ASSERT_SUCCESS(af_release_array(a));
 }
 
 #define COMPLEX_REAL_TESTS(Ti, To)                      \

--- a/test/constant.cpp
+++ b/test/constant.cpp
@@ -57,7 +57,7 @@ void ConstantCCheck(T value) {
     dtype dty = (dtype) dtype_traits<T>::af_type;
     af_array out;
     dim_t dim[] = {(dim_t)num};
-    ASSERT_EQ(AF_SUCCESS, af_constant(&out, val, 1, dim, dty));
+    ASSERT_SUCCESS(af_constant(&out, val, 1, dim, dty));
 
     vector<T> h_in(num);
     af_get_data_ptr(&h_in.front(), out);
@@ -65,7 +65,7 @@ void ConstantCCheck(T value) {
     for (int i = 0; i < num; i++) {
         ASSERT_EQ(::real(h_in[i]), val);
     }
-    ASSERT_EQ(AF_SUCCESS, af_release_array(out));
+    ASSERT_SUCCESS(af_release_array(out));
 }
 
 template<typename T>
@@ -134,7 +134,7 @@ void IdentityCCheck() {
     dtype dty = (dtype) dtype_traits<T>::af_type;
     af_array out;
     dim_t dim[] = {(dim_t)num, (dim_t)num};
-    ASSERT_EQ(AF_SUCCESS, af_identity(&out, 2, dim, dty));
+    ASSERT_SUCCESS(af_identity(&out, 2, dim, dty));
 
     vector<T> h_in(num*num);
     af_get_data_ptr(&h_in.front(), out);
@@ -147,7 +147,7 @@ void IdentityCCheck() {
                 ASSERT_EQ(h_in[i * num + j], T(0));
         }
     }
-    ASSERT_EQ(AF_SUCCESS, af_release_array(out));
+    ASSERT_SUCCESS(af_release_array(out));
 }
 
 template<typename T>

--- a/test/convolve.cpp
+++ b/test/convolve.cpp
@@ -56,31 +56,31 @@ void convolveTest(string pTestFile, int baseDim, bool expand)
     af_array filter   = 0;
     af_array outArray = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&signal, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&signal, &(in[0].front()),
                 sDims.ndims(), sDims.get(), (af_dtype)dtype_traits<T>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&filter, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&filter, &(in[1].front()),
                 fDims.ndims(), fDims.get(), (af_dtype)dtype_traits<T>::af_type));
 
     af_conv_mode mode = expand ? AF_CONV_EXPAND : AF_CONV_DEFAULT;
     switch(baseDim) {
-    case 1: ASSERT_EQ(AF_SUCCESS, af_convolve1(&outArray, signal, filter, mode, AF_CONV_AUTO)); break;
-    case 2: ASSERT_EQ(AF_SUCCESS, af_convolve2(&outArray, signal, filter, mode, AF_CONV_AUTO)); break;
-    case 3: ASSERT_EQ(AF_SUCCESS, af_convolve3(&outArray, signal, filter, mode, AF_CONV_AUTO)); break;
+    case 1: ASSERT_SUCCESS(af_convolve1(&outArray, signal, filter, mode, AF_CONV_AUTO)); break;
+    case 2: ASSERT_SUCCESS(af_convolve2(&outArray, signal, filter, mode, AF_CONV_AUTO)); break;
+    case 3: ASSERT_SUCCESS(af_convolve3(&outArray, signal, filter, mode, AF_CONV_AUTO)); break;
     }
 
     vector<T> currGoldBar = tests[0];
     size_t nElems         = currGoldBar.size();
     vector<T> outData(nElems);
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData.front(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)&outData.front(), outArray));
 
     for (size_t elIter=0; elIter<nElems; ++elIter) {
         ASSERT_EQ(currGoldBar[elIter], outData[elIter])<< "at: " << elIter<< endl;
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(signal));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(filter));
+    ASSERT_SUCCESS(af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(signal));
+    ASSERT_SUCCESS(af_release_array(filter));
 }
 
 TYPED_TEST(Convolve, Vector)
@@ -222,30 +222,30 @@ void sepConvolveTest(string pTestFile, bool expand)
     af_array r_filter = 0;
     af_array outArray = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&signal, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&signal, &(in[0].front()),
                 sDims.ndims(), sDims.get(), (af_dtype)dtype_traits<T>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&c_filter, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&c_filter, &(in[1].front()),
                 cfDims.ndims(), cfDims.get(), (af_dtype)dtype_traits<T>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&r_filter, &(in[2].front()),
+    ASSERT_SUCCESS(af_create_array(&r_filter, &(in[2].front()),
                 rfDims.ndims(), rfDims.get(), (af_dtype)dtype_traits<T>::af_type));
 
     af_conv_mode  mode = expand ? AF_CONV_EXPAND : AF_CONV_DEFAULT;
-    ASSERT_EQ(AF_SUCCESS, af_convolve2_sep(&outArray, c_filter, r_filter, signal, mode));
+    ASSERT_SUCCESS(af_convolve2_sep(&outArray, c_filter, r_filter, signal, mode));
 
     vector<T> currGoldBar = tests[0];
     size_t nElems         = currGoldBar.size();
     vector<T> outData(nElems);
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData.front(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)&outData.front(), outArray));
 
     for (size_t elIter=0; elIter<nElems; ++elIter) {
         ASSERT_EQ(currGoldBar[elIter], outData[elIter])<< "at: " << elIter<< endl;
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(signal));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(c_filter));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(r_filter));
+    ASSERT_SUCCESS(af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(signal));
+    ASSERT_SUCCESS(af_release_array(c_filter));
+    ASSERT_SUCCESS(af_release_array(r_filter));
 }
 
 TYPED_TEST(Convolve, Separable2D_Full)
@@ -304,18 +304,18 @@ TEST(Convolve, Separable_TypeCheck)
     af_array r_filter = 0;
     af_array outArray = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&signal, &(in.front()),
+    ASSERT_SUCCESS(af_create_array(&signal, &(in.front()),
                 sDims.ndims(), sDims.get(), (af_dtype)dtype_traits<float>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&c_filter, &(filt.front()),
+    ASSERT_SUCCESS(af_create_array(&c_filter, &(filt.front()),
                 fDims.ndims(), fDims.get(), (af_dtype)dtype_traits<int>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&r_filter, &(filt.front()),
+    ASSERT_SUCCESS(af_create_array(&r_filter, &(filt.front()),
                 fDims.ndims(), fDims.get(), (af_dtype)dtype_traits<int>::af_type));
 
     ASSERT_EQ(AF_ERR_ARG, af_convolve2_sep(&outArray, c_filter, r_filter, signal, AF_CONV_EXPAND));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(signal));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(c_filter));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(r_filter));
+    ASSERT_SUCCESS(af_release_array(signal));
+    ASSERT_SUCCESS(af_release_array(c_filter));
+    ASSERT_SUCCESS(af_release_array(r_filter));
 }
 
 TEST(Convolve, Separable_DimCheck)
@@ -334,18 +334,18 @@ TEST(Convolve, Separable_DimCheck)
     af_array r_filter = 0;
     af_array outArray = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&signal, &(in.front()),
+    ASSERT_SUCCESS(af_create_array(&signal, &(in.front()),
                 sDims.ndims(), sDims.get(), (af_dtype)dtype_traits<float>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&c_filter, &(filt.front()),
+    ASSERT_SUCCESS(af_create_array(&c_filter, &(filt.front()),
                 fDims.ndims(), fDims.get(), (af_dtype)dtype_traits<int>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&r_filter, &(filt.front()),
+    ASSERT_SUCCESS(af_create_array(&r_filter, &(filt.front()),
                 fDims.ndims(), fDims.get(), (af_dtype)dtype_traits<int>::af_type));
 
     ASSERT_EQ(AF_ERR_ARG, af_convolve2_sep(&outArray, c_filter, r_filter, signal, AF_CONV_EXPAND));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(c_filter));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(r_filter));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(signal));
+    ASSERT_SUCCESS(af_release_array(c_filter));
+    ASSERT_SUCCESS(af_release_array(r_filter));
+    ASSERT_SUCCESS(af_release_array(signal));
 }
 
 ///////////////////////////////////// CPP ////////////////////////////////

--- a/test/dot.cpp
+++ b/test/dot.cpp
@@ -68,26 +68,26 @@ void dotTest(string pTestFile, const int resultIdx,
     af_array b = 0;
     af_array out = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&a, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&a, &(in[0].front()),
                 aDims.ndims(), aDims.get(), (af_dtype)dtype_traits<T>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&b, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&b, &(in[1].front()),
                 bDims.ndims(), bDims.get(), (af_dtype)dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_dot(&out, a, b, optLhs, optRhs));
+    ASSERT_SUCCESS(af_dot(&out, a, b, optLhs, optRhs));
 
     vector<T> goldData = tests[resultIdx];
     size_t nElems      = goldData.size();
     vector<T> outData(nElems);
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData.front(), out));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)&outData.front(), out));
 
     for (size_t elIter=0; elIter<nElems; ++elIter) {
         ASSERT_NEAR(abs(goldData[elIter]), abs(outData[elIter]), 0.03)<< "at: " << elIter<< endl;
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(a));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(b));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(out));
+    ASSERT_SUCCESS(af_release_array(a));
+    ASSERT_SUCCESS(af_release_array(b));
+    ASSERT_SUCCESS(af_release_array(out));
 }
 
 template<typename T>
@@ -128,20 +128,20 @@ void dotAllTest(string pTestFile, const int resultIdx,
     af_array a = 0;
     af_array b = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&a, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&a, &(in[0].front()),
                 aDims.ndims(), aDims.get(), (af_dtype)dtype_traits<T>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&b, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&b, &(in[1].front()),
                 bDims.ndims(), bDims.get(), (af_dtype)dtype_traits<T>::af_type));
 
     double rval = 0, ival = 0;
-    ASSERT_EQ(AF_SUCCESS, af_dot_all(&rval, &ival, a, b, optLhs, optRhs));
+    ASSERT_SUCCESS(af_dot_all(&rval, &ival, a, b, optLhs, optRhs));
 
     vector<T> goldData = tests[resultIdx];
 
     compare<T>(rval, ival, goldData[0]);
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(a));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(b));
+    ASSERT_SUCCESS(af_release_array(a));
+    ASSERT_SUCCESS(af_release_array(b));
 }
 
 
@@ -202,14 +202,8 @@ TEST(DotF, CPP)
     array out = dot(a, b, AF_MAT_CONJ, AF_MAT_NONE);
 
     vector<float> goldData = tests[0];
-    size_t nElems = goldData.size();
-    vector<float> outData(nElems);
-
-    out.host(&outData.front());
-
-    for (size_t elIter=0; elIter<nElems; ++elIter) {
-        ASSERT_EQ(goldData[elIter], outData[elIter]) << "at: " << elIter<< endl;
-    }
+    dim4 goldDims(1);
+    ASSERT_VEC_ARRAY_EQ(goldData, goldDims, out);
 }
 
 TEST(DotCCU, CPP)
@@ -229,14 +223,8 @@ TEST(DotCCU, CPP)
     array out = dot(a, b, AF_MAT_CONJ, AF_MAT_NONE);
 
     vector<cfloat> goldData = tests[2];
-    size_t nElems         = goldData.size();
-    vector<cfloat> outData(nElems);
-
-    out.host(&outData.front());
-
-    for (size_t elIter=0; elIter<nElems; ++elIter) {
-        ASSERT_EQ(goldData[elIter], outData[elIter]) << "at: " << elIter<< endl;
-    }
+    dim4 goldDims(1);
+    ASSERT_VEC_ARRAY_EQ(goldData, goldDims, out);
 }
 
 TEST(DotAllF, CPP)

--- a/test/empty.cpp
+++ b/test/empty.cpp
@@ -8,6 +8,8 @@
  ********************************************************/
 
 #include <gtest/gtest.h>
+#include <testHelpers.hpp>
+
 #include <arrayfire.h>
 #include <cstdio>
 #include <cstdlib>
@@ -283,7 +285,7 @@ TEST(Array, TestEmptyImage) {
     ASSERT_EQ(nd, 0u);
     af_get_numdims(&nd, hout);
     ASSERT_EQ(nd, 0u);
-    ASSERT_EQ(AF_SUCCESS, af_release_array(h));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(hout));
+    ASSERT_SUCCESS(af_release_array(h));
+    ASSERT_SUCCESS(af_release_array(hout));
 }
 

--- a/test/fast.cpp
+++ b/test/fast.cpp
@@ -92,35 +92,35 @@ void fastTest(string pTestFile, bool nonmax)
 
         inFiles[testId].insert(0,string(TEST_DIR"/fast/"));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&inArray_f32, inFiles[testId].c_str(), false));
+        ASSERT_SUCCESS(af_load_image(&inArray_f32, inFiles[testId].c_str(), false));
 
-        ASSERT_EQ(AF_SUCCESS, conv_image<T>(&inArray, inArray_f32));
+        ASSERT_SUCCESS(conv_image<T>(&inArray, inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_fast(&out, inArray, 20.0f, 9, nonmax, 0.05f, 3));
+        ASSERT_SUCCESS(af_fast(&out, inArray, 20.0f, 9, nonmax, 0.05f, 3));
 
         dim_t n = 0;
         af_array x, y, score, orientation, size;
 
-        ASSERT_EQ(AF_SUCCESS, af_get_features_num(&n, out));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_xpos(&x, out));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_ypos(&y, out));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_score(&score, out));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_orientation(&orientation, out));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_size(&size, out));
+        ASSERT_SUCCESS(af_get_features_num(&n, out));
+        ASSERT_SUCCESS(af_get_features_xpos(&x, out));
+        ASSERT_SUCCESS(af_get_features_ypos(&y, out));
+        ASSERT_SUCCESS(af_get_features_score(&score, out));
+        ASSERT_SUCCESS(af_get_features_orientation(&orientation, out));
+        ASSERT_SUCCESS(af_get_features_size(&size, out));
 
 
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems, x));
+        ASSERT_SUCCESS(af_get_elements(&nElems, x));
 
         float * outX           = new float[gold[0].size()];
         float * outY           = new float[gold[1].size()];
         float * outScore       = new float[gold[2].size()];
         float * outOrientation = new float[gold[3].size()];
         float * outSize        = new float[gold[4].size()];
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outX, x));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outY, y));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outScore, score));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outOrientation, orientation));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outSize, size));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outX, x));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outY, y));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outScore, score));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outOrientation, orientation));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outSize, size));
 
         vector<feat_t> out_feat;
         array_to_feat(out_feat, outX, outY, outScore, outOrientation, outSize, n);
@@ -139,10 +139,10 @@ void fastTest(string pTestFile, bool nonmax)
             ASSERT_EQ(out_feat[elIter].f[4], gold_feat[elIter].f[4]) << "at: " << elIter << endl;
         }
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray_f32));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_features(out));
+        ASSERT_SUCCESS(af_release_features(out));
 
         delete [] outX;
         delete [] outY;

--- a/test/fft.cpp
+++ b/test/fft.cpp
@@ -51,11 +51,11 @@ TEST(fft, Invalid_Type)
     af_array outArray  = 0;
 
     dim4 dims(5 * 5 * 2 * 2);
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in.front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in.front()),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<char>::af_type));
 
     ASSERT_EQ(AF_ERR_TYPE, af_fft(&outArray, inArray, 1.0, 0));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TEST(fft2, Invalid_Array)
@@ -68,11 +68,11 @@ TEST(fft2, Invalid_Array)
     af_array outArray  = 0;
 
     dim4 dims(5 * 5 * 2 * 2);
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in.front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in.front()),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<float>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_fft2(&outArray, inArray, 1.0, 0, 0));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TEST(fft3, Invalid_Array)
@@ -85,11 +85,11 @@ TEST(fft3, Invalid_Array)
     af_array outArray  = 0;
 
     dim4 dims(10,10,1,1);
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in.front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in.front()),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<float>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_fft3(&outArray, inArray, 1.0, 0, 0, 0));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TEST(ifft2, Invalid_Array)
@@ -102,11 +102,11 @@ TEST(ifft2, Invalid_Array)
     af_array outArray  = 0;
 
     dim4 dims(100,1,1,1);
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in.front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in.front()),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<float>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_ifft2(&outArray, inArray, 0.01, 0, 0));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TEST(ifft3, Invalid_Array)
@@ -119,11 +119,11 @@ TEST(ifft3, Invalid_Array)
     af_array outArray  = 0;
 
     dim4 dims(10,10,1,1);
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in.front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in.front()),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<float>::af_type));
 
     ASSERT_EQ(AF_ERR_SIZE, af_ifft3(&outArray, inArray, 0.01, 0, 0, 0));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 template<typename inType, typename outType, bool isInverse>
@@ -142,28 +142,28 @@ void fftTest(string pTestFile, dim_t pad0=0, dim_t pad1=0, dim_t pad2=0)
     af_array outArray   = 0;
     af_array inArray    = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()),
                 dims.ndims(), dims.get(), (af_dtype)dtype_traits<inType>::af_type));
 
     if (isInverse){
         switch (dims.ndims()) {
-            case 1 : ASSERT_EQ(AF_SUCCESS, af_ifft (&outArray, inArray, 1.0, pad0));              break;
-            case 2 : ASSERT_EQ(AF_SUCCESS, af_ifft2(&outArray, inArray, 1.0, pad0, pad1));        break;
-            case 3 : ASSERT_EQ(AF_SUCCESS, af_ifft3(&outArray, inArray, 1.0, pad0, pad1, pad2));  break;
+            case 1 : ASSERT_SUCCESS(af_ifft (&outArray, inArray, 1.0, pad0));              break;
+            case 2 : ASSERT_SUCCESS(af_ifft2(&outArray, inArray, 1.0, pad0, pad1));        break;
+            case 3 : ASSERT_SUCCESS(af_ifft3(&outArray, inArray, 1.0, pad0, pad1, pad2));  break;
             default: throw std::runtime_error("This error shouldn't happen, pls check");
         }
     } else {
         switch(dims.ndims()) {
-            case 1 : ASSERT_EQ(AF_SUCCESS, af_fft (&outArray, inArray, 1.0, pad0));               break;
-            case 2 : ASSERT_EQ(AF_SUCCESS, af_fft2(&outArray, inArray, 1.0, pad0, pad1));         break;
-            case 3 : ASSERT_EQ(AF_SUCCESS, af_fft3(&outArray, inArray, 1.0, pad0, pad1, pad2));   break;
+            case 1 : ASSERT_SUCCESS(af_fft (&outArray, inArray, 1.0, pad0));               break;
+            case 2 : ASSERT_SUCCESS(af_fft2(&outArray, inArray, 1.0, pad0, pad1));         break;
+            case 3 : ASSERT_SUCCESS(af_fft3(&outArray, inArray, 1.0, pad0, pad1, pad2));   break;
             default: throw std::runtime_error("This error shouldn't happen, pls check");
         }
     }
 
     size_t out_size = tests[0].size();
     outType *outData= new outType[out_size];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     vector<outType> goldBar(tests[0].begin(), tests[0].end());
 
@@ -184,8 +184,8 @@ void fftTest(string pTestFile, dim_t pad0=0, dim_t pad1=0, dim_t pad2=0)
 
     // cleanup
     delete[] outData;
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 #define INSTANTIATE_TEST(func, name, is_inverse, in_t, out_t, ...)  \
@@ -258,28 +258,28 @@ void fftBatchTest(string pTestFile, dim_t pad0=0, dim_t pad1=0, dim_t pad2=0)
     af_array outArray   = 0;
     af_array inArray    = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()),
                 dims.ndims(), dims.get(), (af_dtype)dtype_traits<inType>::af_type));
 
     if(isInverse) {
         switch(rank) {
-            case 1 : ASSERT_EQ(AF_SUCCESS, af_ifft (&outArray, inArray, 1.0, pad0));              break;
-            case 2 : ASSERT_EQ(AF_SUCCESS, af_ifft2(&outArray, inArray, 1.0, pad0, pad1));        break;
-            case 3 : ASSERT_EQ(AF_SUCCESS, af_ifft3(&outArray, inArray, 1.0, pad0, pad1, pad2));  break;
+            case 1 : ASSERT_SUCCESS(af_ifft (&outArray, inArray, 1.0, pad0));              break;
+            case 2 : ASSERT_SUCCESS(af_ifft2(&outArray, inArray, 1.0, pad0, pad1));        break;
+            case 3 : ASSERT_SUCCESS(af_ifft3(&outArray, inArray, 1.0, pad0, pad1, pad2));  break;
             default: throw std::runtime_error("This error shouldn't happen, pls check");
         }
     } else {
         switch(rank) {
-            case 1 : ASSERT_EQ(AF_SUCCESS, af_fft (&outArray, inArray, 1.0, pad0));               break;
-            case 2 : ASSERT_EQ(AF_SUCCESS, af_fft2(&outArray, inArray, 1.0, pad0, pad1));         break;
-            case 3 : ASSERT_EQ(AF_SUCCESS, af_fft3(&outArray, inArray, 1.0, pad0, pad1, pad2));   break;
+            case 1 : ASSERT_SUCCESS(af_fft (&outArray, inArray, 1.0, pad0));               break;
+            case 2 : ASSERT_SUCCESS(af_fft2(&outArray, inArray, 1.0, pad0, pad1));         break;
+            case 3 : ASSERT_SUCCESS(af_fft3(&outArray, inArray, 1.0, pad0, pad1, pad2));   break;
             default: throw std::runtime_error("This error shouldn't happen, pls check");
         }
     }
 
     size_t out_size = tests[0].size();
     outType *outData= new outType[out_size];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     vector<outType> goldBar(tests[0].begin(), tests[0].end());
 
@@ -308,8 +308,8 @@ void fftBatchTest(string pTestFile, dim_t pad0=0, dim_t pad1=0, dim_t pad2=0)
 
     // cleanup
     delete[] outData;
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 #define INSTANTIATE_BATCH_TEST(func, name, rank, is_inverse, in_t, out_t, ...) \
@@ -624,15 +624,7 @@ TEST(fft, InPlace)
     array b = fft(a);
     fftInPlace(a);
 
-    vector<cfloat> ha(a.elements());
-    vector<cfloat> hb(b.elements());
-
-    a.host(&ha[0]);
-    b.host(&hb[0]);
-
-    for (int i = 0; i < (int)a.elements(); i++) {
-        ASSERT_EQ(ha[i], hb[i]);
-    }
+    ASSERT_ARRAYS_EQ(a, b);
 }
 
 TEST(ifft, InPlace)
@@ -644,12 +636,7 @@ TEST(ifft, InPlace)
     vector<cfloat> ha(a.elements());
     vector<cfloat> hb(b.elements());
 
-    a.host(&ha[0]);
-    b.host(&hb[0]);
-
-    for (int i = 0; i < (int)a.elements(); i++) {
-        ASSERT_EQ(ha[i], hb[i]);
-    }
+    ASSERT_ARRAYS_EQ(a, b);
 }
 
 TEST(fft2, InPlace)
@@ -658,15 +645,7 @@ TEST(fft2, InPlace)
     array b = fft2(a);
     fft2InPlace(a);
 
-    vector<cfloat> ha(a.elements());
-    vector<cfloat> hb(b.elements());
-
-    a.host(&ha[0]);
-    b.host(&hb[0]);
-
-    for (int i = 0; i < (int)a.elements(); i++) {
-        ASSERT_EQ(ha[i], hb[i]);
-    }
+    ASSERT_ARRAYS_EQ(a, b);
 }
 
 TEST(ifft2, InPlace)
@@ -675,15 +654,7 @@ TEST(ifft2, InPlace)
     array b = ifft2(a);
     ifft2InPlace(a);
 
-    vector<cfloat> ha(a.elements());
-    vector<cfloat> hb(b.elements());
-
-    a.host(&ha[0]);
-    b.host(&hb[0]);
-
-    for (int i = 0; i < (int)a.elements(); i++) {
-        ASSERT_EQ(ha[i], hb[i]);
-    }
+    ASSERT_ARRAYS_EQ(a, b);
 }
 
 TEST(fft3, InPlace)
@@ -692,15 +663,7 @@ TEST(fft3, InPlace)
     array b = fft3(a);
     fft3InPlace(a);
 
-    vector<cfloat> ha(a.elements());
-    vector<cfloat> hb(b.elements());
-
-    a.host(&ha[0]);
-    b.host(&hb[0]);
-
-    for (int i = 0; i < (int)a.elements(); i++) {
-        ASSERT_EQ(ha[i], hb[i]);
-    }
+    ASSERT_ARRAYS_EQ(a, b);
 }
 
 TEST(ifft3, InPlace)
@@ -709,15 +672,7 @@ TEST(ifft3, InPlace)
     array b = ifft3(a);
     ifft3InPlace(a);
 
-    vector<cfloat> ha(a.elements());
-    vector<cfloat> hb(b.elements());
-
-    a.host(&ha[0]);
-    b.host(&hb[0]);
-
-    for (int i = 0; i < (int)a.elements(); i++) {
-        ASSERT_EQ(ha[i], hb[i]);
-    }
+    ASSERT_ARRAYS_EQ(a, b);
 }
 
 void fft2InPlaceFunc()
@@ -726,15 +681,7 @@ void fft2InPlaceFunc()
     array b = fft2(a);
     fft2InPlace(a);
 
-    vector<cfloat> ha(a.elements());
-    vector<cfloat> hb(b.elements());
-
-    a.host(&ha[0]);
-    b.host(&hb[0]);
-
-    for (int i = 0; i < (int)a.elements(); i++) {
-        ASSERT_EQ(ha[i], hb[i]);
-    }
+    ASSERT_ARRAYS_EQ(a, b);
 }
 
 using af::setDevice;

--- a/test/fftconvolve.cpp
+++ b/test/fftconvolve.cpp
@@ -66,28 +66,28 @@ void fftconvolveTest(string pTestFile, bool expand)
     af_array outArray = 0;
     af_dtype in_type =(af_dtype)dtype_traits<T>::af_type;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&signal, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&signal, &(in[0].front()),
                                           sDims.ndims(), sDims.get(), in_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&filter, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&filter, &(in[1].front()),
                                           fDims.ndims(), fDims.get(), in_type));
 
     af_conv_mode mode = expand ? AF_CONV_EXPAND : AF_CONV_DEFAULT;
     switch(baseDim) {
-        case 1: ASSERT_EQ(AF_SUCCESS, af_fft_convolve1(&outArray, signal, filter, mode)); break;
-        case 2: ASSERT_EQ(AF_SUCCESS, af_fft_convolve2(&outArray, signal, filter, mode)); break;
-        case 3: ASSERT_EQ(AF_SUCCESS, af_fft_convolve3(&outArray, signal, filter, mode)); break;
+        case 1: ASSERT_SUCCESS(af_fft_convolve1(&outArray, signal, filter, mode)); break;
+        case 2: ASSERT_SUCCESS(af_fft_convolve2(&outArray, signal, filter, mode)); break;
+        case 3: ASSERT_SUCCESS(af_fft_convolve3(&outArray, signal, filter, mode)); break;
     }
 
     vector<T> currGoldBar = tests[0];
     size_t nElems         = currGoldBar.size();
 
     dim_t out_elems = 0;
-    ASSERT_EQ(AF_SUCCESS, af_get_elements(&out_elems, outArray));
+    ASSERT_SUCCESS(af_get_elements(&out_elems, outArray));
     ASSERT_EQ(nElems, (size_t)out_elems);
 
     vector<T> outData(nElems);
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData.front(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)&outData.front(), outArray));
 
     for (size_t elIter=0; elIter<nElems; ++elIter) {
         ASSERT_NEAR(
@@ -96,9 +96,9 @@ void fftconvolveTest(string pTestFile, bool expand)
             , 1e-2)<< "at: " << elIter<< endl;
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(signal));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(filter));
+    ASSERT_SUCCESS(af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(signal));
+    ASSERT_SUCCESS(af_release_array(filter));
 }
 
 template<typename T, int baseDim>

--- a/test/flat.cpp
+++ b/test/flat.cpp
@@ -13,12 +13,17 @@
 #include <af/data.h>
 #include <testHelpers.hpp>
 
+#include <vector>
+
 using af::array;
+using af::dim4;
 using af::flat;
 using af::freeHost;
 using af::randu;
 using af::seq;
 using af::span;
+
+using std::vector;
 
 TEST(FlatTests, Test_flat_1D)
 {
@@ -26,15 +31,7 @@ TEST(FlatTests, Test_flat_1D)
     array in = randu(num);
     array out = flat(in);
 
-    float *h_in = in.host<float>();
-    float *h_out = out.host<float>();
-
-    for (int i = 0; i < num; i++) {
-        ASSERT_EQ(h_in[i], h_out[i]);
-    }
-
-    freeHost(h_in);
-    freeHost(h_out);
+    ASSERT_ARRAYS_EQ(in, out);
 }
 
 TEST(FlatTests, Test_flat_2D)
@@ -46,15 +43,10 @@ TEST(FlatTests, Test_flat_2D)
     array in = randu(nx, ny);
     array out = flat(in);
 
-    float *h_in = in.host<float>();
-    float *h_out = out.host<float>();
-
-    for (int i = 0; i < num; i++) {
-        ASSERT_EQ(h_in[i], h_out[i]);
-    }
-
-    freeHost(h_in);
-    freeHost(h_out);
+    vector<float> h_in_flat(in.elements());
+    in.host(h_in_flat.data());
+    dim4 h_in_flat_dims = dim4(nx*ny);
+    ASSERT_VEC_ARRAY_EQ(h_in_flat, h_in_flat_dims, out);
 }
 
 TEST(FlatTests, Test_flat_1D_index)
@@ -70,6 +62,7 @@ TEST(FlatTests, Test_flat_1D_index)
     float *h_in = in.host<float>();
     float *h_out = out.host<float>();
 
+    // TODO: Use ASSERT_ARRAYS_EQUAL
     for (int i = st; i <= en; i++) {
         ASSERT_EQ(h_in[i], h_out[i - st]);
     }
@@ -93,6 +86,7 @@ TEST(FlatTests, Test_flat_2D_index0)
     float *h_in = in.host<float>();
     float *h_out = out.host<float>();
 
+    // TODO: Use ASSERT_ARRAYS_EQUAL
     for (int j = 0; j < ny; j++) {
         const int in_off = j * nx;
         const int out_off =j * nxo;
@@ -120,6 +114,7 @@ TEST(FlatTests, Test_flat_2D_index1)
     float *h_in = in.host<float>();
     float *h_out = out.host<float>();
 
+    // TODO: Use ASSERT_ARRAYS_EQUAL
     for (int j = st; j <= en; j++) {
 
         const int in_off = j * nx;

--- a/test/gaussiankernel.cpp
+++ b/test/gaussiankernel.cpp
@@ -48,13 +48,13 @@ void gaussianKernelTest(string pFileName, double sigma)
 
     vector<int> input(in[0].begin(), in[0].end());
 
-    ASSERT_EQ(AF_SUCCESS, af_gaussian_kernel(&outArray, input[0], input[1], sigma, sigma));
+    ASSERT_SUCCESS(af_gaussian_kernel(&outArray, input[0], input[1], sigma, sigma));
 
     dim_t outElems = 0;
-    ASSERT_EQ(AF_SUCCESS, af_get_elements(&outElems, outArray));
+    ASSERT_SUCCESS(af_get_elements(&outElems, outArray));
     T *outData = new T[outElems];
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     vector<T> currGoldBar(tests[0].begin(), tests[0].end());
     size_t nElems = currGoldBar.size();
@@ -66,7 +66,7 @@ void gaussianKernelTest(string pFileName, double sigma)
     }
 
     delete[] outData;
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TYPED_TEST(GaussianKernel, Small1D)

--- a/test/gen_assign.cpp
+++ b/test/gen_assign.cpp
@@ -51,32 +51,32 @@ void testGeneralAssignOneArray(string pTestFile, const dim_t ndims, af_index_t* 
     af_array lhsArray  = 0;
     af_array idxArray  = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&lhsArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&lhsArray, &(in[0].front()),
                 dims0.ndims(), dims0.get(), (af_dtype)dtype_traits<float>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&rhsArray, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&rhsArray, &(in[1].front()),
                 dims1.ndims(), dims1.get(), (af_dtype)dtype_traits<float>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&idxArray, &(in[2].front()),
+    ASSERT_SUCCESS(af_create_array(&idxArray, &(in[2].front()),
                 dims2.ndims(), dims2.get(), (af_dtype)dtype_traits<float>::af_type));
     indexs[arrayDim].idx.arr = idxArray;
 
-    ASSERT_EQ(AF_SUCCESS, af_assign_gen(&outArray, lhsArray, ndims, indexs, rhsArray));
+    ASSERT_SUCCESS(af_assign_gen(&outArray, lhsArray, ndims, indexs, rhsArray));
 
     vector<float> currGoldBar = tests[0];
     size_t nElems = currGoldBar.size();
     vector<float> outData(nElems);
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
     for (size_t elIter=0; elIter<nElems; ++elIter) {
         ASSERT_EQ(currGoldBar[elIter], outData[elIter])<< "at: " << elIter<< endl;
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(rhsArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(lhsArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idxArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(rhsArray));
+    ASSERT_SUCCESS(af_release_array(lhsArray));
+    ASSERT_SUCCESS(af_release_array(idxArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TEST(GeneralAssign, ASSS)
@@ -119,27 +119,27 @@ TEST(GeneralAssign, SSSS)
     indexs[0].isSeq = true;
     indexs[1].isSeq = true;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&lhsArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&lhsArray, &(in[0].front()),
                 dims0.ndims(), dims0.get(), (af_dtype)dtype_traits<float>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&rhsArray, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&rhsArray, &(in[1].front()),
                 dims1.ndims(), dims1.get(), (af_dtype)dtype_traits<float>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_assign_gen(&outArray, lhsArray, 2, indexs, rhsArray));
+    ASSERT_SUCCESS(af_assign_gen(&outArray, lhsArray, 2, indexs, rhsArray));
 
     vector<float> currGoldBar = tests[0];
     size_t nElems = currGoldBar.size();
     vector<float> outData(nElems);
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
     for (size_t elIter=0; elIter<nElems; ++elIter) {
         ASSERT_EQ(currGoldBar[elIter], outData[elIter])<< "at: " << elIter<< endl;
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(rhsArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(lhsArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(rhsArray));
+    ASSERT_SUCCESS(af_release_array(lhsArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TEST(GeneralAssign, AAAA)
@@ -170,47 +170,47 @@ TEST(GeneralAssign, AAAA)
     indexs[2].isSeq = false;
     indexs[3].isSeq = false;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&lhsArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&lhsArray, &(in[0].front()),
                 dims0.ndims(), dims0.get(), (af_dtype)dtype_traits<float>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&rhsArray, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&rhsArray, &(in[1].front()),
                 dims1.ndims(), dims1.get(), (af_dtype)dtype_traits<float>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&idxArray0, &(in[2].front()),
+    ASSERT_SUCCESS(af_create_array(&idxArray0, &(in[2].front()),
                 dims2.ndims(), dims2.get(), (af_dtype)dtype_traits<float>::af_type));
     indexs[0].idx.arr = idxArray0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&idxArray1, &(in[3].front()),
+    ASSERT_SUCCESS(af_create_array(&idxArray1, &(in[3].front()),
                 dims3.ndims(), dims3.get(), (af_dtype)dtype_traits<float>::af_type));
     indexs[1].idx.arr = idxArray1;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&idxArray2, &(in[4].front()),
+    ASSERT_SUCCESS(af_create_array(&idxArray2, &(in[4].front()),
                 dims4.ndims(), dims4.get(), (af_dtype)dtype_traits<float>::af_type));
     indexs[2].idx.arr = idxArray2;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&idxArray3, &(in[5].front()),
+    ASSERT_SUCCESS(af_create_array(&idxArray3, &(in[5].front()),
                 dims5.ndims(), dims5.get(), (af_dtype)dtype_traits<float>::af_type));
     indexs[3].idx.arr = idxArray3;
 
-    ASSERT_EQ(AF_SUCCESS, af_assign_gen(&outArray, lhsArray, 4, indexs, rhsArray));
+    ASSERT_SUCCESS(af_assign_gen(&outArray, lhsArray, 4, indexs, rhsArray));
 
     vector<float> currGoldBar = tests[0];
     size_t nElems = currGoldBar.size();
     vector<float> outData(nElems);
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
     for (size_t elIter=0; elIter<nElems; ++elIter) {
         ASSERT_EQ(currGoldBar[elIter], outData[elIter])<< "at: " << elIter<< endl;
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(rhsArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(lhsArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idxArray0));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idxArray1));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idxArray2));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idxArray3));
+    ASSERT_SUCCESS(af_release_array(rhsArray));
+    ASSERT_SUCCESS(af_release_array(lhsArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(idxArray0));
+    ASSERT_SUCCESS(af_release_array(idxArray1));
+    ASSERT_SUCCESS(af_release_array(idxArray2));
+    ASSERT_SUCCESS(af_release_array(idxArray3));
 }
 
 

--- a/test/gen_index.cpp
+++ b/test/gen_index.cpp
@@ -42,28 +42,28 @@ void testGeneralIndexOneArray(string pTestFile, const dim_t ndims, af_index_t* i
     af_array inArray   = 0;
     af_array idxArray  = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()),
                 dims0.ndims(), dims0.get(), (af_dtype)dtype_traits<float>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&idxArray, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&idxArray, &(in[1].front()),
                 dims1.ndims(), dims1.get(), (af_dtype)dtype_traits<float>::af_type));
     indexs[arrayDim].idx.arr = idxArray;
 
-    ASSERT_EQ(AF_SUCCESS, af_index_gen(&outArray, inArray, ndims, indexs));
+    ASSERT_SUCCESS(af_index_gen(&outArray, inArray, ndims, indexs));
 
     vector<float> currGoldBar = tests[0];
     size_t nElems = currGoldBar.size();
     vector<float> outData(nElems);
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
     for (size_t elIter=0; elIter<nElems; ++elIter) {
         ASSERT_EQ(currGoldBar[elIter], outData[elIter])<< "at: " << elIter<< endl;
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idxArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(idxArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TEST(GeneralIndex, SSSA)
@@ -122,35 +122,35 @@ TEST(GeneralIndex, AASS)
 
     af_index_t indexs[2];
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()),
                 dims0.ndims(), dims0.get(), (af_dtype)dtype_traits<float>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&idxArray0, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&idxArray0, &(in[1].front()),
                 dims1.ndims(), dims1.get(), (af_dtype)dtype_traits<float>::af_type));
     indexs[0].isSeq = false;
     indexs[0].idx.arr = idxArray0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&idxArray1, &(in[2].front()),
+    ASSERT_SUCCESS(af_create_array(&idxArray1, &(in[2].front()),
                 dims2.ndims(), dims2.get(), (af_dtype)dtype_traits<float>::af_type));
     indexs[1].isSeq = false;
     indexs[1].idx.arr = idxArray1;
 
-    ASSERT_EQ(AF_SUCCESS, af_index_gen(&outArray, inArray, 2, indexs));
+    ASSERT_SUCCESS(af_index_gen(&outArray, inArray, 2, indexs));
 
     vector<float> currGoldBar = tests[0];
     size_t nElems = currGoldBar.size();
     vector<float> outData(nElems);
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
     for (size_t elIter=0; elIter<nElems; ++elIter) {
         ASSERT_EQ(currGoldBar[elIter], outData[elIter])<< "at: " << elIter<< endl;
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idxArray0));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idxArray1));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(idxArray0));
+    ASSERT_SUCCESS(af_release_array(idxArray1));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 using af::array;

--- a/test/gfor.cpp
+++ b/test/gfor.cpp
@@ -523,13 +523,5 @@ TEST(ASSIGN, ISSUE_1127)
     out1(seq(0,rows-1,2), seq(1,cols-1,2), span) = horiz;
     out1(seq(1,rows-1,2), seq(1,cols-1,2), span) = diag;
 
-    vector<float> hout0(out0.elements());
-    vector<float> hout1(out1.elements());
-
-    out0.host(&hout0[0]);
-    out1.host(&hout1[0]);
-
-    for (int i = 0; i < out0.elements(); i++) {
-        ASSERT_EQ(hout0[i], hout1[i]);
-    }
+    ASSERT_ARRAYS_EQ(out0, out1);
 }

--- a/test/gloh_nonfree.cpp
+++ b/test/gloh_nonfree.cpp
@@ -164,20 +164,20 @@ void glohTest(string pTestFile)
 
         inFiles[testId].insert(0,string(TEST_DIR"/gloh/"));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&inArray_f32, inFiles[testId].c_str(), false));
-        ASSERT_EQ(AF_SUCCESS, conv_image<T>(&inArray, inArray_f32));
+        ASSERT_SUCCESS(af_load_image(&inArray_f32, inFiles[testId].c_str(), false));
+        ASSERT_SUCCESS(conv_image<T>(&inArray, inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_gloh(&feat, &desc, inArray, 3, 0.04f, 10.0f, 1.6f, true, 1.f/256.f, 0.05f));
+        ASSERT_SUCCESS(af_gloh(&feat, &desc, inArray, 3, 0.04f, 10.0f, 1.6f, true, 1.f/256.f, 0.05f));
 
         dim_t n = 0;
         af_array x, y, score, orientation, size;
 
-        ASSERT_EQ(AF_SUCCESS, af_get_features_num(&n, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_xpos(&x, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_ypos(&y, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_score(&score, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_orientation(&orientation, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_size(&size, feat));
+        ASSERT_SUCCESS(af_get_features_num(&n, feat));
+        ASSERT_SUCCESS(af_get_features_xpos(&x, feat));
+        ASSERT_SUCCESS(af_get_features_ypos(&y, feat));
+        ASSERT_SUCCESS(af_get_features_score(&score, feat));
+        ASSERT_SUCCESS(af_get_features_orientation(&orientation, feat));
+        ASSERT_SUCCESS(af_get_features_size(&size, feat));
 
         float * outX           = new float[n];
         float * outY           = new float[n];
@@ -186,15 +186,15 @@ void glohTest(string pTestFile)
         float * outSize        = new float[n];
         dim_t descSize;
         dim_t descDims[4];
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&descSize, desc));
-        ASSERT_EQ(AF_SUCCESS, af_get_dims(&descDims[0], &descDims[1], &descDims[2], &descDims[3], desc));
+        ASSERT_SUCCESS(af_get_elements(&descSize, desc));
+        ASSERT_SUCCESS(af_get_dims(&descDims[0], &descDims[1], &descDims[2], &descDims[3], desc));
         float * outDesc     = new float[descSize];
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outX, x));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outY, y));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outScore, score));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outOrientation, orientation));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outSize, size));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outDesc, desc));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outX, x));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outY, y));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outScore, score));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outOrientation, orientation));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outSize, size));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outDesc, desc));
 
         vector<feat_desc_t> out_feat_desc;
         array_to_feat_desc(out_feat_desc, outX, outY, outScore, outOrientation, outSize, outDesc, n);
@@ -223,15 +223,15 @@ void glohTest(string pTestFile)
 
         EXPECT_TRUE(compareEuclidean(descDims[0], descDims[1], (float*)&v_out_desc[0], (float*)&v_gold_desc[0], 2.f, 5.5f));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray_f32));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(x));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(y));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(score));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(orientation));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(size));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(desc));
+        ASSERT_SUCCESS(af_release_array(x));
+        ASSERT_SUCCESS(af_release_array(y));
+        ASSERT_SUCCESS(af_release_array(score));
+        ASSERT_SUCCESS(af_release_array(orientation));
+        ASSERT_SUCCESS(af_release_array(size));
+        ASSERT_SUCCESS(af_release_array(desc));
 
         delete[] outX;
         delete[] outY;

--- a/test/gradient.cpp
+++ b/test/gradient.cpp
@@ -62,19 +62,19 @@ void gradTest(string pTestFile, const unsigned resultIdx0, const unsigned result
     af_array g1Array = 0;
 
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_gradient(&g0Array, &g1Array, inArray));
+    ASSERT_SUCCESS(af_gradient(&g0Array, &g1Array, inArray));
 
     size_t nElems = tests[resultIdx0].size();
     // Get result
     T* grad0Data = new T[tests[resultIdx0].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)grad0Data, g0Array));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)grad0Data, g0Array));
 
     // Compare result
     for (size_t elIter = 0; elIter < nElems; ++elIter) {
@@ -83,7 +83,7 @@ void gradTest(string pTestFile, const unsigned resultIdx0, const unsigned result
 
     // Get result
     T* grad1Data = new T[tests[resultIdx1].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)grad1Data, g1Array));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)grad1Data, g1Array));
 
     // Compare result
     for (size_t elIter = 0; elIter < nElems; ++elIter) {

--- a/test/hamming.cpp
+++ b/test/hamming.cpp
@@ -68,12 +68,12 @@ void hammingMatcherTest(string pTestFile, int feat_dim)
     af_array idx   = 0;
     af_array dist  = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&query, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&query, &(in[0].front()),
                 qDims.ndims(), qDims.get(), (af_dtype)dtype_traits<T>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&train, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&train, &(in[1].front()),
                 tDims.ndims(), tDims.get(), (af_dtype)dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_hamming_matcher(&idx, &dist, query, train, feat_dim, 1));
+    ASSERT_SUCCESS(af_hamming_matcher(&idx, &dist, query, train, feat_dim, 1));
 
     vector<uint> goldIdx  = tests[0];
     vector<uint> goldDist = tests[1];
@@ -81,8 +81,8 @@ void hammingMatcherTest(string pTestFile, int feat_dim)
     uint *outIdx          = new uint[nElems];
     uint *outDist         = new uint[nElems];
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outIdx,  idx));
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outDist, dist));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outIdx,  idx));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outDist, dist));
 
     for (size_t elIter=0; elIter<nElems; ++elIter) {
         ASSERT_EQ(goldDist[elIter], outDist[elIter])<< "at: " << elIter<< endl;
@@ -90,10 +90,10 @@ void hammingMatcherTest(string pTestFile, int feat_dim)
 
     delete[] outIdx;
     delete[] outDist;
-    ASSERT_EQ(AF_SUCCESS, af_release_array(query));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(train));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idx));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(dist));
+    ASSERT_SUCCESS(af_release_array(query));
+    ASSERT_SUCCESS(af_release_array(train));
+    ASSERT_SUCCESS(af_release_array(idx));
+    ASSERT_SUCCESS(af_release_array(dist));
 }
 
 TYPED_TEST(HammingMatcher8, Hamming_500_5000_Dim0)

--- a/test/harris.cpp
+++ b/test/harris.cpp
@@ -83,35 +83,35 @@ void harrisTest(string pTestFile, float sigma, unsigned block_size)
 
         inFiles[testId].insert(0,string(TEST_DIR"/harris/"));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&inArray_f32, inFiles[testId].c_str(), false));
+        ASSERT_SUCCESS(af_load_image(&inArray_f32, inFiles[testId].c_str(), false));
 
-        ASSERT_EQ(AF_SUCCESS, conv_image<T>(&inArray, inArray_f32));
+        ASSERT_SUCCESS(conv_image<T>(&inArray, inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_harris(&out, inArray, 500, 1e5f, sigma, block_size, 0.04f));
+        ASSERT_SUCCESS(af_harris(&out, inArray, 500, 1e5f, sigma, block_size, 0.04f));
 
         dim_t n = 0;
         af_array x, y, score, orientation, size;
 
-        ASSERT_EQ(AF_SUCCESS, af_get_features_num(&n, out));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_xpos(&x, out));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_ypos(&y, out));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_score(&score, out));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_orientation(&orientation, out));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_size(&size, out));
+        ASSERT_SUCCESS(af_get_features_num(&n, out));
+        ASSERT_SUCCESS(af_get_features_xpos(&x, out));
+        ASSERT_SUCCESS(af_get_features_ypos(&y, out));
+        ASSERT_SUCCESS(af_get_features_score(&score, out));
+        ASSERT_SUCCESS(af_get_features_orientation(&orientation, out));
+        ASSERT_SUCCESS(af_get_features_size(&size, out));
 
 
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems, x));
+        ASSERT_SUCCESS(af_get_elements(&nElems, x));
 
         vector<float> outX           (gold[0].size());
         vector<float> outY           (gold[1].size());
         vector<float> outScore       (gold[2].size());
         vector<float> outOrientation (gold[3].size());
         vector<float> outSize        (gold[4].size());
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outX.front(), x));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outY.front(), y));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outScore.front(), score));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outOrientation.front(), orientation));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outSize.front(), size));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)&outX.front(), x));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)&outY.front(), y));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)&outScore.front(), score));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)&outOrientation.front(), orientation));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)&outSize.front(), size));
 
         vector<feat_t> out_feat;
         array_to_feat(out_feat, &outX.front(), &outY.front(),
@@ -132,10 +132,10 @@ void harrisTest(string pTestFile, float sigma, unsigned block_size)
             ASSERT_EQ(out_feat[elIter].f[4], gold_feat[elIter].f[4]) << "at: " << elIter << endl;
         }
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray_f32));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_features(out));
+        ASSERT_SUCCESS(af_release_features(out));
     }
 }
 

--- a/test/histogram.cpp
+++ b/test/histogram.cpp
@@ -54,25 +54,24 @@ void histTest(string pTestFile, unsigned nbins, double minval, double maxval)
     af_array outArray   = 0;
     af_array inArray    = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<inType>::af_type));
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<inType>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS,af_histogram(&outArray,inArray,nbins,minval,maxval));
+    ASSERT_SUCCESS(af_histogram(&outArray,inArray,nbins,minval,maxval));
 
     vector<outType> outData(dims.elements());
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
     for (size_t testIter=0; testIter<tests.size(); ++testIter) {
         vector<outType> currGoldBar = tests[testIter];
-        size_t nElems        = currGoldBar.size();
-        for (size_t elIter=0; elIter<nElems; ++elIter) {
-            ASSERT_EQ(currGoldBar[elIter],outData[elIter])<< "at: " << elIter<< endl;
-        }
+
+        dim4 goldDims(nbins, 1, dims[2], dims[3]);
+        ASSERT_VEC_ARRAY_EQ(currGoldBar, goldDims, outArray);
     }
 
     // cleanup
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TYPED_TEST(Histogram,256Bins0min255max_ones)
@@ -137,10 +136,11 @@ TEST(Histogram, CPP)
 
     for (size_t testIter=0; testIter<tests.size(); ++testIter) {
         vector<uint> currGoldBar = tests[testIter];
-        size_t nElems        = currGoldBar.size();
-        for (size_t elIter=0; elIter<nElems; ++elIter) {
-            ASSERT_EQ(currGoldBar[elIter],outData[elIter])<< "at: " << elIter<< endl;
-        }
+
+        dim4 goldDims = numDims[0];
+        goldDims[0] = nbins;
+        goldDims[1] = 1;
+        ASSERT_VEC_ARRAY_EQ(currGoldBar, goldDims, output);
     }
 }
 

--- a/test/homography.cpp
+++ b/test/homography.cpp
@@ -69,13 +69,13 @@ void homographyTest(string pTestFile, const af_homography_type htype,
     af_array train_feat_y     = 0;
     af_features train_feat;
 
-    ASSERT_EQ(AF_SUCCESS, af_load_image(&trainArray_f32, inFiles[0].c_str(), false));
-    ASSERT_EQ(AF_SUCCESS, conv_image<T>(&trainArray, trainArray_f32));
+    ASSERT_SUCCESS(af_load_image(&trainArray_f32, inFiles[0].c_str(), false));
+    ASSERT_SUCCESS(conv_image<T>(&trainArray, trainArray_f32));
 
-    ASSERT_EQ(AF_SUCCESS, af_orb(&train_feat, &train_desc, trainArray, 20.0f, 2000, 1.2f, 8, true));
+    ASSERT_SUCCESS(af_orb(&train_feat, &train_desc, trainArray, 20.0f, 2000, 1.2f, 8, true));
 
-    ASSERT_EQ(AF_SUCCESS, af_get_features_xpos(&train_feat_x, train_feat));
-    ASSERT_EQ(AF_SUCCESS, af_get_features_ypos(&train_feat_y, train_feat));
+    ASSERT_SUCCESS(af_get_features_xpos(&train_feat_x, train_feat));
+    ASSERT_SUCCESS(af_get_features_ypos(&train_feat_y, train_feat));
 
     af_array queryArray       = 0;
     af_array query_desc       = 0;
@@ -99,46 +99,46 @@ void homographyTest(string pTestFile, const af_homography_type htype,
     const dim_t test_d1 = inDims[0][1] * size_ratio;
     const dim_t tDims[] = {test_d0, test_d1};
     if (rotate)
-        ASSERT_EQ(AF_SUCCESS, af_rotate(&queryArray, trainArray, theta, false, AF_INTERP_NEAREST));
+        ASSERT_SUCCESS(af_rotate(&queryArray, trainArray, theta, false, AF_INTERP_NEAREST));
     else
-        ASSERT_EQ(AF_SUCCESS, af_resize(&queryArray, trainArray, test_d0, test_d1, AF_INTERP_BILINEAR));
+        ASSERT_SUCCESS(af_resize(&queryArray, trainArray, test_d0, test_d1, AF_INTERP_BILINEAR));
 
-    ASSERT_EQ(AF_SUCCESS, af_orb(&query_feat, &query_desc, queryArray, 20.0f, 2000, 1.2f, 8, true));
+    ASSERT_SUCCESS(af_orb(&query_feat, &query_desc, queryArray, 20.0f, 2000, 1.2f, 8, true));
 
-    ASSERT_EQ(AF_SUCCESS, af_hamming_matcher(&idx, &dist, train_desc, query_desc, 0, 1));
+    ASSERT_SUCCESS(af_hamming_matcher(&idx, &dist, train_desc, query_desc, 0, 1));
 
     dim_t distDims[4];
-    ASSERT_EQ(AF_SUCCESS, af_get_dims(&distDims[0], &distDims[1], &distDims[2], &distDims[3], dist));
+    ASSERT_SUCCESS(af_get_dims(&distDims[0], &distDims[1], &distDims[2], &distDims[3], dist));
 
-    ASSERT_EQ(AF_SUCCESS, af_constant(&const_50, 50, 2, distDims, u32));
-    ASSERT_EQ(AF_SUCCESS, af_lt(&dist_thr, dist, const_50, false));
-    ASSERT_EQ(AF_SUCCESS, af_where(&train_idx, dist_thr));
+    ASSERT_SUCCESS(af_constant(&const_50, 50, 2, distDims, u32));
+    ASSERT_SUCCESS(af_lt(&dist_thr, dist, const_50, false));
+    ASSERT_SUCCESS(af_where(&train_idx, dist_thr));
 
     dim_t tidxDims[4];
-    ASSERT_EQ(AF_SUCCESS, af_get_dims(&tidxDims[0], &tidxDims[1], &tidxDims[2], &tidxDims[3], train_idx));
+    ASSERT_SUCCESS(af_get_dims(&tidxDims[0], &tidxDims[1], &tidxDims[2], &tidxDims[3], train_idx));
     af_index_t tindexs;
     tindexs.isSeq = false;
     tindexs.idx.seq = af_make_seq(0, tidxDims[0]-1, 1);
     tindexs.idx.arr = train_idx;
-    ASSERT_EQ(AF_SUCCESS, af_index_gen(&query_idx, idx, 1, &tindexs));
+    ASSERT_SUCCESS(af_index_gen(&query_idx, idx, 1, &tindexs));
 
-    ASSERT_EQ(AF_SUCCESS, af_get_features_xpos(&query_feat_x, query_feat));
-    ASSERT_EQ(AF_SUCCESS, af_get_features_ypos(&query_feat_y, query_feat));
+    ASSERT_SUCCESS(af_get_features_xpos(&query_feat_x, query_feat));
+    ASSERT_SUCCESS(af_get_features_ypos(&query_feat_y, query_feat));
 
     dim_t qidxDims[4];
-    ASSERT_EQ(AF_SUCCESS, af_get_dims(&qidxDims[0], &qidxDims[1], &qidxDims[2], &qidxDims[3], query_idx));
+    ASSERT_SUCCESS(af_get_dims(&qidxDims[0], &qidxDims[1], &qidxDims[2], &qidxDims[3], query_idx));
     af_index_t qindexs;
     qindexs.isSeq = false;
     qindexs.idx.seq = af_make_seq(0, qidxDims[0]-1, 1);
     qindexs.idx.arr = query_idx;
 
-    ASSERT_EQ(AF_SUCCESS, af_index_gen(&train_feat_x_idx, train_feat_x, 1, &tindexs));
-    ASSERT_EQ(AF_SUCCESS, af_index_gen(&train_feat_y_idx, train_feat_y, 1, &tindexs));
-    ASSERT_EQ(AF_SUCCESS, af_index_gen(&query_feat_x_idx, query_feat_x, 1, &qindexs));
-    ASSERT_EQ(AF_SUCCESS, af_index_gen(&query_feat_y_idx, query_feat_y, 1, &qindexs));
+    ASSERT_SUCCESS(af_index_gen(&train_feat_x_idx, train_feat_x, 1, &tindexs));
+    ASSERT_SUCCESS(af_index_gen(&train_feat_y_idx, train_feat_y, 1, &tindexs));
+    ASSERT_SUCCESS(af_index_gen(&query_feat_x_idx, query_feat_x, 1, &qindexs));
+    ASSERT_SUCCESS(af_index_gen(&query_feat_y_idx, query_feat_y, 1, &qindexs));
 
     int inliers = 0;
-    ASSERT_EQ(AF_SUCCESS, af_homography(&H, &inliers, train_feat_x_idx, train_feat_y_idx,
+    ASSERT_SUCCESS(af_homography(&H, &inliers, train_feat_x_idx, train_feat_y_idx,
                                         query_feat_x_idx, query_feat_y_idx, htype,
                                         3.0f, 1000, (af_dtype) dtype_traits<T>::af_type));
 
@@ -172,25 +172,25 @@ void homographyTest(string pTestFile, const af_homography_type htype,
     delete[] gold_t;
     delete[] out_t;
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(queryArray));
+    ASSERT_SUCCESS(af_release_array(queryArray));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(query_desc));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idx));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(dist));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(const_50));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(dist_thr));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(train_idx));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(query_idx));
-    ASSERT_EQ(AF_SUCCESS, af_release_features(query_feat));
-    ASSERT_EQ(AF_SUCCESS, af_release_features(train_feat));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(train_feat_x_idx));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(train_feat_y_idx));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(query_feat_x_idx));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(query_feat_y_idx));
+    ASSERT_SUCCESS(af_release_array(query_desc));
+    ASSERT_SUCCESS(af_release_array(idx));
+    ASSERT_SUCCESS(af_release_array(dist));
+    ASSERT_SUCCESS(af_release_array(const_50));
+    ASSERT_SUCCESS(af_release_array(dist_thr));
+    ASSERT_SUCCESS(af_release_array(train_idx));
+    ASSERT_SUCCESS(af_release_array(query_idx));
+    ASSERT_SUCCESS(af_release_features(query_feat));
+    ASSERT_SUCCESS(af_release_features(train_feat));
+    ASSERT_SUCCESS(af_release_array(train_feat_x_idx));
+    ASSERT_SUCCESS(af_release_array(train_feat_y_idx));
+    ASSERT_SUCCESS(af_release_array(query_feat_x_idx));
+    ASSERT_SUCCESS(af_release_array(query_feat_y_idx));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(trainArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(trainArray_f32));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(train_desc));
+    ASSERT_SUCCESS(af_release_array(trainArray));
+    ASSERT_SUCCESS(af_release_array(trainArray_f32));
+    ASSERT_SUCCESS(af_release_array(train_desc));
 }
 
 #define HOMOGRAPHY_INIT(desc, image, htype, rotate, size_ratio)                 \

--- a/test/imageio.cpp
+++ b/test/imageio.cpp
@@ -50,11 +50,11 @@ void loadImageTest(string pTestFile, string pImageFile, const bool isColor)
     dim4 dims       = numDims[0];
 
     af_array imgArray = 0;
-    ASSERT_EQ(AF_SUCCESS, af_load_image(&imgArray, pImageFile.c_str(), isColor));
+    ASSERT_SUCCESS(af_load_image(&imgArray, pImageFile.c_str(), isColor));
 
     // Get result
     float *imgData = new float[dims.elements()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*) imgData, imgArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*) imgData, imgArray));
 
     bool isJPEG = false;
     if(pImageFile.find(".jpg") != string::npos) {

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -54,11 +54,11 @@ DimCheck(const vector<af_seq> &seqs) {
     for(int i = 0; i < (int)dims; i++) { hData[i] = i; }
 
     af_array a = 0;
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&a, &hData.front(), ndims, d, (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&a, &hData.front(), ndims, d, (af_dtype) dtype_traits<T>::af_type));
 
     vector<af_array> indexed_array(seqs.size(), 0);
     for(size_t i = 0; i < seqs.size(); i++) {
-        ASSERT_EQ(AF_SUCCESS, af_index(&(indexed_array[i]), a, ndims, &seqs[i]))
+        ASSERT_SUCCESS(af_index(&(indexed_array[i]), a, ndims, &seqs[i]))
             << "where seqs[i].begin == "    << seqs[i].begin
             << " seqs[i].step == "          << seqs[i].step
             << " seqs[i].end == "           << seqs[i].end;
@@ -67,9 +67,9 @@ DimCheck(const vector<af_seq> &seqs) {
     vector<T*> h_indexed(seqs.size());
     for(size_t i = 0; i < seqs.size(); i++) {
         dim_t elems;
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&elems, indexed_array[i]));
+        ASSERT_SUCCESS(af_get_elements(&elems, indexed_array[i]));
         h_indexed[i] = new T[elems];
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void *)(h_indexed[i]), indexed_array[i]));
+        ASSERT_SUCCESS(af_get_data_ptr((void *)(h_indexed[i]), indexed_array[i]));
     }
 
     for(size_t k = 0; k < seqs.size(); k++) {
@@ -86,9 +86,9 @@ DimCheck(const vector<af_seq> &seqs) {
         delete[] h_indexed[k];
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(a));
+    ASSERT_SUCCESS(af_release_array(a));
     for (size_t i = 0; i < indexed_array.size(); i++) {
-        ASSERT_EQ(AF_SUCCESS, af_release_array(indexed_array[i]));
+        ASSERT_SUCCESS(af_release_array(indexed_array[i]));
     }
 }
 
@@ -267,19 +267,19 @@ DimCheck2D(const vector<vector<af_seq> > &seqs,string TestFile, size_t NDims)
     dim4 dimensions = numDims[0];
 
     af_array a = 0;
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&a, &(hData[0].front()), NDims, dimensions.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&a, &(hData[0].front()), NDims, dimensions.get(), (af_dtype) dtype_traits<T>::af_type));
 
     vector<af_array> indexed_arrays(seqs.size(), 0);
     for(size_t i = 0; i < seqs.size(); i++) {
-        ASSERT_EQ(AF_SUCCESS, af_index(&(indexed_arrays[i]), a, NDims, seqs[i].data()));
+        ASSERT_SUCCESS(af_index(&(indexed_arrays[i]), a, NDims, seqs[i].data()));
     }
 
     vector<T*> h_indexed(seqs.size(), NULL);
     for(size_t i = 0; i < seqs.size(); i++) {
         dim_t elems;
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&elems, indexed_arrays[i]));
+        ASSERT_SUCCESS(af_get_elements(&elems, indexed_arrays[i]));
         h_indexed[i] = new T[elems];
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void *)h_indexed[i], indexed_arrays[i]));
+        ASSERT_SUCCESS(af_get_data_ptr((void *)h_indexed[i], indexed_arrays[i]));
 
         T* ptr = h_indexed[i];
         if(false == equal(ptr, ptr + tests[i].size(), tests[i].begin())) {
@@ -292,9 +292,9 @@ DimCheck2D(const vector<vector<af_seq> > &seqs,string TestFile, size_t NDims)
         delete[] h_indexed[i];
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(a));
+    ASSERT_SUCCESS(af_release_array(a));
     for (size_t i = 0; i < indexed_arrays.size(); i++) {
-        ASSERT_EQ(AF_SUCCESS, af_release_array(indexed_arrays[i]));
+        ASSERT_SUCCESS(af_release_array(indexed_arrays[i]));
     }
 }
 
@@ -640,28 +640,23 @@ void arrayIndexTest(string pTestFile, int dim)
     af_array inArray   = 0;
     af_array idxArray  = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()),
                 dims0.ndims(), dims0.get(), (af_dtype)dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&idxArray, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&idxArray, &(in[1].front()),
                 dims1.ndims(), dims1.get(), (af_dtype)dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_lookup(&outArray, inArray, idxArray, dim));
+    ASSERT_SUCCESS(af_lookup(&outArray, inArray, idxArray, dim));
 
     vector<T> currGoldBar = tests[0];
-    size_t nElems = currGoldBar.size();
-    T *outData = new T[nElems];
+    dim4 goldDims = dims0;
+    goldDims[dim] = dims1[0];
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_VEC_ARRAY_EQ(currGoldBar, goldDims, outArray);
 
-    for (size_t elIter=0; elIter<nElems; ++elIter) {
-        ASSERT_EQ(currGoldBar[elIter], outData[elIter])<< "at: " << elIter<< endl;
-    }
-
-    delete[] outData;
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idxArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(idxArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TYPED_TEST(lookup, Dim0)
@@ -700,16 +695,10 @@ TEST(lookup, CPP)
     array output = af::lookup(input, indices, 0);
 
     vector<float> currGoldBar = tests[0];
-    size_t nElems = currGoldBar.size();
-    float *outData = new float[nElems];
+    dim4 goldDims = dims0;
+    goldDims[0] = dims1[0];
 
-    output.host((void*)outData);
-
-    for (size_t elIter=0; elIter<nElems; ++elIter) {
-        ASSERT_EQ(currGoldBar[elIter], outData[elIter])<< "at: " << elIter<< endl;
-    }
-
-    delete[] outData;
+    ASSERT_VEC_ARRAY_EQ(currGoldBar, goldDims, output);
 }
 
 TEST(lookup, largeDim)
@@ -729,7 +718,7 @@ TEST(lookup, Issue2009)
     array idx = constant(0, 1, u32);
     array b   = af::lookup(a, idx, 1);
 
-    ASSERT_EQ(true, allTrue<bool>(a==b));
+    ASSERT_ARRAYS_EQ(a, b);
 }
 
 TEST(SeqIndex, CPP_END)
@@ -835,16 +824,10 @@ TEST(SeqIndex, CPPLarge)
     array output = af::lookup(input, indices, 0);
 
     vector<float> currGoldBar = tests[0];
-    size_t nElems = currGoldBar.size();
-    float *outData = new float[nElems];
+    dim4 goldDims = dims0;
+    goldDims[0] = dims1[0];
 
-    output.host((void*)outData);
-
-    for (size_t elIter=0; elIter<nElems; ++elIter) {
-        ASSERT_EQ(currGoldBar[elIter], outData[elIter])<< "at: " << elIter<< endl;
-    }
-
-    delete[] outData;
+    ASSERT_VEC_ARRAY_EQ(currGoldBar, goldDims, output);
 }
 
 TEST(SeqIndex, Cascade00)
@@ -1334,7 +1317,7 @@ TEST(Assign, LinearIndexSeq)
     af_index_t ii = idx.get();
     af_array out_arr;
 
-    ASSERT_EQ(AF_SUCCESS,
+    ASSERT_SUCCESS(
               af_index(&out_arr, in_arr, 1, &ii.idx.seq));
 
     array out(out_arr);
@@ -1369,7 +1352,7 @@ TEST(Assign, LinearIndexGenSeq)
     af_index_t ii = idx.get();
     af_array out_arr;
 
-    ASSERT_EQ(AF_SUCCESS,
+    ASSERT_SUCCESS(
               af_index_gen(&out_arr, in_arr, 1, &ii));
 
     array out(out_arr);
@@ -1404,7 +1387,7 @@ TEST(Assign, LinearIndexGenArr)
     af_index_t ii = idx.get();
     af_array out_arr;
 
-    ASSERT_EQ(AF_SUCCESS,
+    ASSERT_SUCCESS(
               af_index_gen(&out_arr, in_arr, 1, &ii));
 
     array out(out_arr);
@@ -1442,8 +1425,6 @@ TEST(Index, ISSUE_1101_FULL)
 {
     deviceGC();
     array a = randu(5,5);
-    vector<float> ha(a.elements());
-    a.host(&ha[0]);
 
     size_t aby, abu, lby, lbu;
     deviceMemInfo(&aby, &abu, &lby, &lbu);
@@ -1458,11 +1439,7 @@ TEST(Index, ISSUE_1101_FULL)
     ASSERT_EQ(lby, lby1);
     ASSERT_EQ(lbu, lbu1);
 
-    vector<float> hb(b.elements());
-    b.host(&hb[0]);
-    for (int i = 0; i < b.elements(); i++) {
-        ASSERT_EQ(ha[i], hb[i]);
-    }
+    ASSERT_ARRAYS_EQ(a, b);
 }
 
 TEST(Index, ISSUE_1101_COL0)
@@ -1470,7 +1447,8 @@ TEST(Index, ISSUE_1101_COL0)
     deviceGC();
     array a = randu(5,5);
     vector<float> ha(a.elements());
-    a.host(&ha[0]);
+    a.host(ha.data());
+    vector<float> gold(ha.begin(), ha.begin()+5);
 
     size_t aby, abu, lby, lbu;
     deviceMemInfo(&aby, &abu, &lby, &lbu);
@@ -1480,17 +1458,12 @@ TEST(Index, ISSUE_1101_COL0)
     size_t aby1, abu1, lby1, lbu1;
     deviceMemInfo(&aby1, &abu1, &lby1, &lbu1);
 
-    ASSERT_EQ(aby, aby1);
-    ASSERT_EQ(abu, abu1);
-    ASSERT_EQ(lby, lby1);
-    ASSERT_EQ(lbu, lbu1);
+    ASSERT_EQ(aby, aby1) << "Number of bytes different";
+    ASSERT_EQ(abu, abu1) << "Number of buffers different";
+    ASSERT_EQ(lby, lby1) << "Number of bytes different";
+    ASSERT_EQ(lbu, lbu1) << "Number of buffers different";
 
-    vector<float> hb(b.elements());
-    b.host(&hb[0]);
-    for (int i = 0; i < b.elements(); i++) {
-        ASSERT_EQ(ha[i], hb[i]);
-    }
-
+    ASSERT_VEC_ARRAY_EQ(gold, dim4(a.dims()[0]), b);
 }
 
 TEST(Index, ISSUE_1101_MODDIMS)

--- a/test/info.cpp
+++ b/test/info.cpp
@@ -33,17 +33,17 @@ void testFunction()
 
     af_array outArray = 0;
     dim4 dims(32, 32, 1, 1);
-    ASSERT_EQ(AF_SUCCESS, af_randu(&outArray, dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_randu(&outArray, dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
     // cleanup
     if(outArray != 0) {
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
     }
 }
 
 void infoTest()
 {
     int nDevices = 0;
-    ASSERT_EQ(AF_SUCCESS, af_get_device_count(&nDevices));
+    ASSERT_SUCCESS(af_get_device_count(&nDevices));
     ASSERT_EQ(true, nDevices>0);
 
     const char* ENV = getenv("AF_MULTI_GPU_TESTS");

--- a/test/inverse_deconv.cpp
+++ b/test/inverse_deconv.cpp
@@ -70,53 +70,53 @@ void invDeconvImageTest(string pTestFile, const float gamma, const af_inverse_de
         af_array _goldArray = 0;
         dim_t nElems        = 0;
 
-        ASSERT_EQ(AF_SUCCESS, af_gaussian_kernel(&kerArray, 13, 13, 2.25, 2.25));
+        ASSERT_SUCCESS(af_gaussian_kernel(&kerArray, 13, 13, 2.25, 2.25));
 
         af_dtype itype = (af_dtype)af::dtype_traits<T>::af_type;
         af_dtype otype = (af_dtype)af::dtype_traits<OutType>::af_type;
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&_inArray, inFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, conv_image<T>(&inArray, _inArray));
+        ASSERT_SUCCESS(af_load_image(&_inArray, inFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(conv_image<T>(&inArray, _inArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&_goldArray, outFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, conv_image<OutType>(&goldArray, _goldArray));
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems, goldArray));
+        ASSERT_SUCCESS(af_load_image(&_goldArray, outFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(conv_image<OutType>(&goldArray, _goldArray));
+        ASSERT_SUCCESS(af_get_elements(&nElems, goldArray));
 
         unsigned ndims;
         dim_t dims[4];
-        ASSERT_EQ(AF_SUCCESS, af_get_numdims(&ndims, goldArray));
-        ASSERT_EQ(AF_SUCCESS, af_get_dims(dims, dims+1, dims+2, dims+3, goldArray));
+        ASSERT_SUCCESS(af_get_numdims(&ndims, goldArray));
+        ASSERT_SUCCESS(af_get_dims(dims, dims+1, dims+2, dims+3, goldArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_inverse_deconv(&_outArray, inArray, kerArray, gamma, algo));
+        ASSERT_SUCCESS(af_inverse_deconv(&_outArray, inArray, kerArray, gamma, algo));
 
         double maxima, minima, imag;
-        ASSERT_EQ(AF_SUCCESS, af_min_all(&minima, &imag, _outArray));
-        ASSERT_EQ(AF_SUCCESS, af_max_all(&maxima, &imag, _outArray));
-        ASSERT_EQ(AF_SUCCESS, af_constant(&cstArray, 255.0, ndims, dims, otype));
-        ASSERT_EQ(AF_SUCCESS, af_constant(&denArray, (maxima-minima), ndims, dims, otype));
-        ASSERT_EQ(AF_SUCCESS, af_constant(&minArray, minima, ndims, dims, otype));
-        ASSERT_EQ(AF_SUCCESS, af_sub(&numArray, _outArray, minArray, false));
-        ASSERT_EQ(AF_SUCCESS, af_div(&divArray, numArray, denArray, false));
-        ASSERT_EQ(AF_SUCCESS, af_mul(&outArray, divArray, cstArray, false));
+        ASSERT_SUCCESS(af_min_all(&minima, &imag, _outArray));
+        ASSERT_SUCCESS(af_max_all(&maxima, &imag, _outArray));
+        ASSERT_SUCCESS(af_constant(&cstArray, 255.0, ndims, dims, otype));
+        ASSERT_SUCCESS(af_constant(&denArray, (maxima-minima), ndims, dims, otype));
+        ASSERT_SUCCESS(af_constant(&minArray, minima, ndims, dims, otype));
+        ASSERT_SUCCESS(af_sub(&numArray, _outArray, minArray, false));
+        ASSERT_SUCCESS(af_div(&divArray, numArray, denArray, false));
+        ASSERT_SUCCESS(af_mul(&outArray, divArray, cstArray, false));
 
         std::vector<OutType> outData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
         std::vector<OutType> goldData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)goldData.data(), goldArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(_inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(kerArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(cstArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(minArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(denArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(numArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(divArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(_outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(_goldArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(goldArray));
+        ASSERT_SUCCESS(af_release_array(_inArray));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(kerArray));
+        ASSERT_SUCCESS(af_release_array(cstArray));
+        ASSERT_SUCCESS(af_release_array(minArray));
+        ASSERT_SUCCESS(af_release_array(denArray));
+        ASSERT_SUCCESS(af_release_array(numArray));
+        ASSERT_SUCCESS(af_release_array(divArray));
+        ASSERT_SUCCESS(af_release_array(_outArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(_goldArray));
+        ASSERT_SUCCESS(af_release_array(goldArray));
 
         ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(), outData.data(), 0.03));
     }

--- a/test/iota.cpp
+++ b/test/iota.cpp
@@ -51,7 +51,7 @@ void iotaTest(const dim4 idims, const dim4 tdims)
 
     af_array outArray = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_iota(&outArray, idims.ndims(), idims.get(),
+    ASSERT_SUCCESS(af_iota(&outArray, idims.ndims(), idims.get(),
                tdims.ndims(), tdims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     af_array temp0 = 0, temp1 = 0, temp2 = 0;
@@ -60,20 +60,11 @@ void iotaTest(const dim4 idims, const dim4 tdims)
     for(unsigned i = 0; i < 4; i++) {
         fulldims[i] = idims[i] * tdims[i];
     }
-    ASSERT_EQ(AF_SUCCESS, af_range(&temp2, tempdims.ndims(), tempdims.get(), 0, (af_dtype) dtype_traits<T>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_moddims(&temp1, temp2, idims.ndims(), idims.get()));
-    ASSERT_EQ(AF_SUCCESS, af_tile(&temp0, temp1, tdims[0], tdims[1], tdims[2], tdims[3]));
+    ASSERT_SUCCESS(af_range(&temp2, tempdims.ndims(), tempdims.get(), 0, (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_moddims(&temp1, temp2, idims.ndims(), idims.get()));
+    ASSERT_SUCCESS(af_tile(&temp0, temp1, tdims[0], tdims[1], tdims[2], tdims[3]));
 
-    // Get result
-    vector<T> outData(fulldims.elements());
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData.front(), outArray));
-
-    vector<T> tileData(fulldims.elements());
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&tileData.front(), temp0));
-
-    // Compare result
-    for(int i = 0; i < (int) fulldims.elements(); i++)
-        ASSERT_EQ(tileData[i], outData[i]) << "at: " << i << endl;
+    ASSERT_ARRAYS_EQ(temp0, outArray);
 
     if(outArray  != 0) af_release_array(outArray);
     if(temp0     != 0) af_release_array(temp0);
@@ -125,14 +116,5 @@ TEST(Iota, CPP)
     array output = iota(idims, tdims);
     array tileArray = tile(moddims(range(dim4(idims.elements()), 0), idims), tdims);
 
-    // Get result
-    vector<float> outData (fulldims.elements());
-    output.host((void*)&outData.front());
-
-    vector<float> tileData (fulldims.elements());
-    tileArray.host((void*)&tileData.front());
-
-    // Compare result
-    for(int i = 0; i < (int)fulldims.elements(); i++)
-        ASSERT_EQ(tileData[i], outData[i]) << "at: " << i << endl;
+    ASSERT_ARRAYS_EQ(tileArray, output);
 }

--- a/test/ireduce.cpp
+++ b/test/ireduce.cpp
@@ -182,7 +182,7 @@ TEST(IndexedReduce, MinReduceDimensionHasSingleValue)
     array mm, indx;
     min(mm, indx, data, 2);
 
-    ASSERT_TRUE(allTrue<bool>(mm == data));
+    ASSERT_ARRAYS_EQ(data, mm);
     ASSERT_TRUE(allTrue<bool>(indx == 0));
 }
 
@@ -193,7 +193,7 @@ TEST(IndexedReduce, MaxReduceDimensionHasSingleValue)
     array mm, indx;
     max(mm, indx, data, 2);
 
-    ASSERT_TRUE(allTrue<bool>(mm == data));
+    ASSERT_ARRAYS_EQ(data, mm);
     ASSERT_TRUE(allTrue<bool>(indx == 0));
 }
 

--- a/test/iterative_deconv.cpp
+++ b/test/iterative_deconv.cpp
@@ -71,53 +71,53 @@ void iterDeconvImageTest(string pTestFile, const unsigned iters, const float rf,
         af_array _goldArray = 0;
         dim_t nElems        = 0;
 
-        ASSERT_EQ(AF_SUCCESS, af_gaussian_kernel(&kerArray, 13, 13, 2.25, 2.25));
+        ASSERT_SUCCESS(af_gaussian_kernel(&kerArray, 13, 13, 2.25, 2.25));
 
         af_dtype itype = (af_dtype)af::dtype_traits<T>::af_type;
         af_dtype otype = (af_dtype)af::dtype_traits<OutType>::af_type;
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&_inArray, inFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, conv_image<T>(&inArray, _inArray));
+        ASSERT_SUCCESS(af_load_image(&_inArray, inFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(conv_image<T>(&inArray, _inArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&_goldArray, outFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, conv_image<OutType>(&goldArray, _goldArray));
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems, goldArray));
+        ASSERT_SUCCESS(af_load_image(&_goldArray, outFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(conv_image<OutType>(&goldArray, _goldArray));
+        ASSERT_SUCCESS(af_get_elements(&nElems, goldArray));
 
         unsigned ndims;
         dim_t dims[4];
-        ASSERT_EQ(AF_SUCCESS, af_get_numdims(&ndims, goldArray));
-        ASSERT_EQ(AF_SUCCESS, af_get_dims(dims, dims+1, dims+2, dims+3, goldArray));
+        ASSERT_SUCCESS(af_get_numdims(&ndims, goldArray));
+        ASSERT_SUCCESS(af_get_dims(dims, dims+1, dims+2, dims+3, goldArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_iterative_deconv(&_outArray, inArray, kerArray, iters, rf, algo));
+        ASSERT_SUCCESS(af_iterative_deconv(&_outArray, inArray, kerArray, iters, rf, algo));
 
         double maxima, minima, imag;
-        ASSERT_EQ(AF_SUCCESS, af_min_all(&minima, &imag, _outArray));
-        ASSERT_EQ(AF_SUCCESS, af_max_all(&maxima, &imag, _outArray));
-        ASSERT_EQ(AF_SUCCESS, af_constant(&cstArray, 255.0, ndims, dims, otype));
-        ASSERT_EQ(AF_SUCCESS, af_constant(&denArray, (maxima-minima), ndims, dims, otype));
-        ASSERT_EQ(AF_SUCCESS, af_constant(&minArray, minima, ndims, dims, otype));
-        ASSERT_EQ(AF_SUCCESS, af_sub(&numArray, _outArray, minArray, false));
-        ASSERT_EQ(AF_SUCCESS, af_div(&divArray, numArray, denArray, false));
-        ASSERT_EQ(AF_SUCCESS, af_mul(&outArray, divArray, cstArray, false));
+        ASSERT_SUCCESS(af_min_all(&minima, &imag, _outArray));
+        ASSERT_SUCCESS(af_max_all(&maxima, &imag, _outArray));
+        ASSERT_SUCCESS(af_constant(&cstArray, 255.0, ndims, dims, otype));
+        ASSERT_SUCCESS(af_constant(&denArray, (maxima-minima), ndims, dims, otype));
+        ASSERT_SUCCESS(af_constant(&minArray, minima, ndims, dims, otype));
+        ASSERT_SUCCESS(af_sub(&numArray, _outArray, minArray, false));
+        ASSERT_SUCCESS(af_div(&divArray, numArray, denArray, false));
+        ASSERT_SUCCESS(af_mul(&outArray, divArray, cstArray, false));
 
         std::vector<OutType> outData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
         std::vector<OutType> goldData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)goldData.data(), goldArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(_inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(kerArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(cstArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(minArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(denArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(numArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(divArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(_outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(_goldArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(goldArray));
+        ASSERT_SUCCESS(af_release_array(_inArray));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(kerArray));
+        ASSERT_SUCCESS(af_release_array(cstArray));
+        ASSERT_SUCCESS(af_release_array(minArray));
+        ASSERT_SUCCESS(af_release_array(denArray));
+        ASSERT_SUCCESS(af_release_array(numArray));
+        ASSERT_SUCCESS(af_release_array(divArray));
+        ASSERT_SUCCESS(af_release_array(_outArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(_goldArray));
+        ASSERT_SUCCESS(af_release_array(goldArray));
 
         ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(), outData.data(), 0.03));
     }

--- a/test/jit.cpp
+++ b/test/jit.cpp
@@ -311,11 +311,11 @@ TEST(JIT, NonLinearLargeX)
     dim_t sdims[] = {1, 1, 1};
     dim_t ndims = 3;
 
-    ASSERT_EQ(AF_SUCCESS, af_randu(&r, ndims, rdims, f32));
-    ASSERT_EQ(AF_SUCCESS, af_constant(&c, 1, ndims, cdims, f32));
-    ASSERT_EQ(AF_SUCCESS, af_eval(c));
-    ASSERT_EQ(AF_SUCCESS, af_sub(&s, r, c, true));
-    ASSERT_EQ(AF_SUCCESS, af_eval(s));
+    ASSERT_SUCCESS(af_randu(&r, ndims, rdims, f32));
+    ASSERT_SUCCESS(af_constant(&c, 1, ndims, cdims, f32));
+    ASSERT_SUCCESS(af_eval(c));
+    ASSERT_SUCCESS(af_sub(&s, r, c, true));
+    ASSERT_SUCCESS(af_eval(s));
 
     dim_t relem = 1;
     dim_t celem = 1;
@@ -331,9 +331,9 @@ TEST(JIT, NonLinearLargeX)
     vector<float> hc(celem);
     vector<float> hs(selem);
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr(hr.data(), r));
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr(hc.data(), c));
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr(hs.data(), s));
+    ASSERT_SUCCESS(af_get_data_ptr(hr.data(), r));
+    ASSERT_SUCCESS(af_get_data_ptr(hc.data(), c));
+    ASSERT_SUCCESS(af_get_data_ptr(hs.data(), s));
 
     for (int k = 0; k < sdims[2]; k++) {
         for (int j = 0; j < sdims[1]; j++) {
@@ -356,9 +356,9 @@ TEST(JIT, NonLinearLargeX)
         }
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(r));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(c));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(s));
+    ASSERT_SUCCESS(af_release_array(r));
+    ASSERT_SUCCESS(af_release_array(c));
+    ASSERT_SUCCESS(af_release_array(s));
 }
 
 TEST(JIT, ISSUE_1894)

--- a/test/join.cpp
+++ b/test/join.cpp
@@ -69,35 +69,27 @@ void joinTest(string pTestFile, const unsigned dim, const unsigned in0, const un
     af_array tempArray = 0;
 
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(in[in0].front()), i0dims.ndims(), i0dims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(in[in0].front()), i0dims.ndims(), i0dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&in0Array, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&in0Array, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&in0Array, &(in[in0].front()), i0dims.ndims(), i0dims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&in0Array, &(in[in0].front()), i0dims.ndims(), i0dims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(in[in1].front()), i1dims.ndims(), i1dims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(in[in1].front()), i1dims.ndims(), i1dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&in1Array, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&in1Array, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&in1Array, &(in[in1].front()), i1dims.ndims(), i1dims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&in1Array, &(in[in1].front()), i1dims.ndims(), i1dims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_join(&outArray, dim, in0Array, in1Array));
+    ASSERT_SUCCESS(af_join(&outArray, dim, in0Array, in1Array));
 
-    // Get result
-    T* outData = new T[tests[resultIdx].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    dim4 goldDims = i0dims;
+    goldDims[dim] = i0dims[dim] + i1dims[dim];
 
-    // Compare result
-    size_t nElems = tests[resultIdx].size();
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx][elIter], outData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] outData;
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx], goldDims, outArray);
 
     if(in0Array  != 0) af_release_array(in0Array);
     if(in1Array  != 0) af_release_array(in1Array);
@@ -170,18 +162,10 @@ TEST(Join, CPP)
 
     array output = join(dim, input0, input1);
 
-    // Get result
-    float* outData = new float[tests[resultIdx].size()];
-    output.host((void*)outData);
+    dim4 goldDims = i0dims;
+    goldDims[dim] = i0dims[dim] + i1dims[dim];
 
-    // Compare result
-    size_t nElems = tests[resultIdx].size();
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx][elIter], outData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] outData;
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx], goldDims, output);
 }
 
 TEST(JoinMany0, CPP)

--- a/test/match_template.cpp
+++ b/test/match_template.cpp
@@ -55,17 +55,17 @@ void matchTemplateTest(string pTestFile, af_match_type pMatchType)
     af_array sArray   = 0;
     af_array tArray   = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&sArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&sArray, &(in[0].front()),
                 sDims.ndims(), sDims.get(), (af_dtype)dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&tArray, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&tArray, &(in[1].front()),
                 tDims.ndims(), tDims.get(), (af_dtype)dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_match_template(&outArray, sArray, tArray, pMatchType));
+    ASSERT_SUCCESS(af_match_template(&outArray, sArray, tArray, pMatchType));
 
     vector<outType> outData(sDims.elements());
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
     vector<outType> currGoldBar = tests[0];
     size_t nElems        = currGoldBar.size();
@@ -74,9 +74,9 @@ void matchTemplateTest(string pTestFile, af_match_type pMatchType)
     }
 
     // cleanup
-    ASSERT_EQ(AF_SUCCESS, af_release_array(sArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(tArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(sArray));
+    ASSERT_SUCCESS(af_release_array(tArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TYPED_TEST(MatchTemplate, Matrix_SAD)
@@ -105,16 +105,16 @@ TEST(MatchTemplate, InvalidMatchType)
     dim4 sDims(10, 10, 1, 1);
     dim4 tDims(4, 4, 1, 1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 sDims.ndims(), sDims.get(), (af_dtype) dtype_traits<float>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&tArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&tArray, &in.front(),
                 tDims.ndims(), tDims.get(), (af_dtype) dtype_traits<float>::af_type));
 
     ASSERT_EQ(AF_ERR_ARG, af_match_template(&outArray, inArray, tArray, (af_match_type)-1));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(tArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(tArray));
 }
 
 ///////////////////////////////// CPP TESTS /////////////////////////////

--- a/test/meanshift.cpp
+++ b/test/meanshift.cpp
@@ -43,10 +43,10 @@ TYPED_TEST(Meanshift, InvalidArgs)
     af_array outArray  = 0;
 
     dim4 dims = dim4(100,1,1,1);
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<TypeParam>::af_type));
     ASSERT_EQ(AF_ERR_SIZE, af_mean_shift(&outArray, inArray, 0.12f, 0.34f, 5, true));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 template<typename T, bool isColor>
@@ -76,28 +76,28 @@ void meanshiftTest(string pTestFile, const float ss)
         inFiles[testId].insert(0,string(TEST_DIR"/meanshift/"));
         outFiles[testId].insert(0,string(TEST_DIR"/meanshift/"));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&inArray_f32, inFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, conv_image<T>(&inArray, inArray_f32));
+        ASSERT_SUCCESS(af_load_image(&inArray_f32, inFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(conv_image<T>(&inArray, inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&goldArray_f32, outFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, conv_image<T>(&goldArray, goldArray_f32)); // af_load_image always returns float array
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems, goldArray));
+        ASSERT_SUCCESS(af_load_image(&goldArray_f32, outFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(conv_image<T>(&goldArray, goldArray_f32)); // af_load_image always returns float array
+        ASSERT_SUCCESS(af_get_elements(&nElems, goldArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_mean_shift(&outArray, inArray, ss, 30.f, 5, isColor));
+        ASSERT_SUCCESS(af_mean_shift(&outArray, inArray, ss, 30.f, 5, isColor));
 
         vector<T> outData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
         vector<T> goldData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)goldData.data(), goldArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
 
         ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(), outData.data(), 0.02f));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray_f32));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(goldArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(goldArray_f32));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(inArray_f32));
+        ASSERT_SUCCESS(af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(goldArray));
+        ASSERT_SUCCESS(af_release_array(goldArray_f32));
     }
 }
 

--- a/test/medfilt.cpp
+++ b/test/medfilt.cpp
@@ -58,14 +58,14 @@ void medfiltTest(string pTestFile, dim_t w_len, dim_t w_wid, af_border_type pad)
     af_array outArray  = 0;
     af_array inArray   = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()),
                 dims.ndims(), dims.get(), (af_dtype)dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_medfilt2(&outArray, inArray, w_len, w_wid, pad));
+    ASSERT_SUCCESS(af_medfilt2(&outArray, inArray, w_len, w_wid, pad));
 
     vector<T> outData(dims.elements());
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
     vector<T> currGoldBar = tests[0];
     size_t nElems        = currGoldBar.size();
@@ -74,8 +74,8 @@ void medfiltTest(string pTestFile, dim_t w_len, dim_t w_wid, af_border_type pad)
     }
 
     // cleanup
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TYPED_TEST(MedianFilter, ZERO_PAD_3x3)
@@ -114,14 +114,14 @@ void medfilt1_Test(string pTestFile, dim_t w_wid, af_border_type pad)
     af_array outArray  = 0;
     af_array inArray   = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()),
                 dims.ndims(), dims.get(), (af_dtype)dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_medfilt1(&outArray, inArray, w_wid, pad));
+    ASSERT_SUCCESS(af_medfilt1(&outArray, inArray, w_wid, pad));
 
     vector<T> outData(dims.elements());
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
     vector<T> currGoldBar = tests[0];
     size_t nElems        = currGoldBar.size();
@@ -130,8 +130,8 @@ void medfilt1_Test(string pTestFile, dim_t w_wid, af_border_type pad)
     }
 
     // cleanup
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TYPED_TEST(MedianFilter1d, ZERO_PAD_3)
@@ -179,23 +179,23 @@ void medfiltImageTest(string pTestFile, dim_t w_len, dim_t w_wid)
         inFiles[testId].insert(0,string(TEST_DIR"/medianfilter/"));
         outFiles[testId].insert(0,string(TEST_DIR"/medianfilter/"));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&inArray, inFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&goldArray, outFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems, goldArray));
+        ASSERT_SUCCESS(af_load_image(&inArray, inFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(af_load_image(&goldArray, outFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(af_get_elements(&nElems, goldArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_medfilt2(&outArray, inArray, w_len, w_wid, AF_PAD_ZERO));
+        ASSERT_SUCCESS(af_medfilt2(&outArray, inArray, w_len, w_wid, AF_PAD_ZERO));
 
         vector<T> outData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
         vector<T> goldData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)goldData.data(), goldArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
 
         ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(), outData.data(), 0.018f));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(goldArray));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(goldArray));
     }
 }
 
@@ -212,18 +212,18 @@ void medfiltInputTest(void)
     // Check for 1D inputs -> medfilt1
     dim4 dims = dim4(100, 1, 1, 1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_medfilt2(&outArray, inArray, 1, 1, AF_PAD_ZERO));
+    ASSERT_SUCCESS(af_medfilt2(&outArray, inArray, 1, 1, AF_PAD_ZERO));
 
     bool medfilt1;
-    ASSERT_EQ(AF_SUCCESS, af_is_vector(&medfilt1, outArray));
+    ASSERT_SUCCESS(af_is_vector(&medfilt1, outArray));
 
     ASSERT_EQ(true, medfilt1);
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TYPED_TEST(MedianFilter, InvalidArray)
@@ -244,12 +244,12 @@ void medfiltWindowTest(void)
     // Check for 4D inputs
     dim4 dims(10, 10, 1, 1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     ASSERT_EQ(AF_ERR_ARG, af_medfilt2(&outArray, inArray, 3, 5, AF_PAD_ZERO));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TYPED_TEST(MedianFilter, InvalidWindow)
@@ -271,12 +271,12 @@ void medfilt1d_WindowTest(void)
     // Check for 4D inputs
     dim4 dims(10, 10, 1, 1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     ASSERT_EQ(AF_ERR_ARG, af_medfilt1(&outArray, inArray, -1, AF_PAD_ZERO));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TYPED_TEST(MedianFilter1d, InvalidWindow)
@@ -297,14 +297,14 @@ void medfiltPadTest(void)
     // Check for 4D inputs
     dim4 dims(10, 10, 1, 1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     ASSERT_EQ(AF_ERR_ARG, af_medfilt2(&outArray, inArray, 3, 3, af_border_type(3)));
 
     ASSERT_EQ(AF_ERR_ARG, af_medfilt2(&outArray, inArray, 3, 3, af_border_type(-1)));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TYPED_TEST(MedianFilter, InvalidPadType)
@@ -325,14 +325,14 @@ void medfilt1d_PadTest(void)
     // Check for 4D inputs
     dim4 dims(10, 10, 1, 1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     ASSERT_EQ(AF_ERR_ARG, af_medfilt1(&outArray, inArray, 3, af_border_type(3)));
 
     ASSERT_EQ(AF_ERR_ARG, af_medfilt1(&outArray, inArray, 3, af_border_type(-1)));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TYPED_TEST(MedianFilter1d, InvalidPadType)

--- a/test/memory.cpp
+++ b/test/memory.cpp
@@ -608,7 +608,7 @@ TEST(Memory, unlock)
     vector<float> in(num);
 
     af_array arr = 0;
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&arr, &in[0], 1, &num, f32));
+    ASSERT_SUCCESS(af_create_array(&arr, &in[0], 1, &num, f32));
 
     deviceMemInfo(&alloc_bytes, &alloc_buffers,
                   &lock_bytes, &lock_buffers);

--- a/test/memory_lock.cpp
+++ b/test/memory_lock.cpp
@@ -40,7 +40,7 @@ TEST(Memory, lock)
     vector<float> in(num);
 
     af_array arr = 0;
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&arr, &in[0], 1, &num, f32));
+    ASSERT_SUCCESS(af_create_array(&arr, &in[0], 1, &num, f32));
 
     deviceMemInfo(&alloc_bytes, &alloc_buffers,
                       &lock_bytes, &lock_buffers);

--- a/test/moddims.cpp
+++ b/test/moddims.cpp
@@ -61,40 +61,40 @@ void moddimsTest(string pTestFile, bool isSubRef=false, const vector<af_seq> *se
         af_array subArray  = 0;
         af_array outArray  = 0;
 
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&subArray,inArray,seqv->size(),&seqv->front()));
+        ASSERT_SUCCESS(af_index(&subArray,inArray,seqv->size(),&seqv->front()));
 
         dim4 newDims(1);
         newDims[0] = 2;
         newDims[1] = 3;
-        ASSERT_EQ(AF_SUCCESS, af_moddims(&outArray,subArray,newDims.ndims(),newDims.get()));
+        ASSERT_SUCCESS(af_moddims(&outArray,subArray,newDims.ndims(),newDims.get()));
 
         dim_t nElems;
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems,outArray));
+        ASSERT_SUCCESS(af_get_elements(&nElems,outArray));
 
         outData          = new T[nElems];
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(subArray));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(subArray));
     } else {
         af_array inArray   = 0;
         af_array outArray  = 0;
 
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
         dim4 newDims(1);
         newDims[0] = dims[1];
         newDims[1] = dims[0]*dims[2];
-        ASSERT_EQ(AF_SUCCESS, af_moddims(&outArray,inArray,newDims.ndims(),newDims.get()));
+        ASSERT_SUCCESS(af_moddims(&outArray,inArray,newDims.ndims(),newDims.get()));
 
         outData          = new T[dims.elements()];
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
     }
 
     for (size_t testIter=0; testIter<tests.size(); ++testIter) {
@@ -133,16 +133,16 @@ void moddimsArgsTest(string pTestFile)
     af_array inArray   = 0;
     af_array outArray  = 0;
     af_array outArray2  = 0;
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     dim4 newDims(1);
     newDims[0] = dims[1];
     newDims[1] = dims[0]*dims[2];
-    ASSERT_EQ(AF_SUCCESS, af_moddims(&outArray,inArray,0,newDims.get()));
+    ASSERT_SUCCESS(af_moddims(&outArray,inArray,0,newDims.get()));
     ASSERT_EQ(AF_ERR_ARG, af_moddims(&outArray2,inArray,newDims.ndims(),NULL));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TYPED_TEST(Moddims,InvalidArgs)
@@ -164,14 +164,14 @@ void moddimsMismatchTest(string pTestFile)
 
     af_array inArray   = 0;
     af_array outArray  = 0;
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     dim4 newDims(1);
     newDims[0] = dims[1]-1;
     newDims[1] = (dims[0]-1)*dims[2];
     ASSERT_EQ(AF_ERR_SIZE, af_moddims(&outArray,inArray,newDims.ndims(),newDims.get()));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TYPED_TEST(Moddims,Mismatch)

--- a/test/morph.cpp
+++ b/test/morph.cpp
@@ -53,40 +53,33 @@ void morphTest(string pTestFile)
     af_array inArray   = 0;
     af_array maskArray = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()),
                 dims.ndims(), dims.get(), (af_dtype)dtype_traits<inType>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&maskArray, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&maskArray, &(in[1].front()),
                 maskDims.ndims(), maskDims.get(), (af_dtype)dtype_traits<inType>::af_type));
 
     if (isDilation) {
         if (isVolume)
-            ASSERT_EQ(AF_SUCCESS, af_dilate3(&outArray, inArray, maskArray));
+            ASSERT_SUCCESS(af_dilate3(&outArray, inArray, maskArray));
         else
-            ASSERT_EQ(AF_SUCCESS, af_dilate(&outArray, inArray, maskArray));
+            ASSERT_SUCCESS(af_dilate(&outArray, inArray, maskArray));
     }
     else {
         if (isVolume)
-            ASSERT_EQ(AF_SUCCESS, af_erode3(&outArray, inArray, maskArray));
+            ASSERT_SUCCESS(af_erode3(&outArray, inArray, maskArray));
         else
-            ASSERT_EQ(AF_SUCCESS, af_erode(&outArray, inArray, maskArray));
+            ASSERT_SUCCESS(af_erode(&outArray, inArray, maskArray));
     }
-
-    vector<inType> outData(dims.elements());
-
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
 
     for (size_t testIter=0; testIter<tests.size(); ++testIter) {
         vector<inType> currGoldBar = tests[testIter];
-        size_t nElems        = currGoldBar.size();
-        for (size_t elIter=0; elIter<nElems; ++elIter) {
-            ASSERT_EQ(currGoldBar[elIter], outData[elIter])<< "at: " << elIter<< endl;
-        }
+        ASSERT_VEC_ARRAY_EQ(currGoldBar, dims, outArray);
     }
 
     // cleanup
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(maskArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(maskArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TYPED_TEST(Morph, Dilate3x3)
@@ -171,30 +164,30 @@ void morphImageTest(string pTestFile)
         outFiles[testId].insert(0,string(TEST_DIR"/morph/"));
 
         dim4 mdims(3,3,1,1);
-        ASSERT_EQ(AF_SUCCESS, af_constant(&maskArray, 1.0,
+        ASSERT_SUCCESS(af_constant(&maskArray, 1.0,
                     mdims.ndims(), mdims.get(), (af_dtype)dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&inArray, inFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&goldArray, outFiles[testId].c_str(), isColor));
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems, goldArray));
+        ASSERT_SUCCESS(af_load_image(&inArray, inFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(af_load_image(&goldArray, outFiles[testId].c_str(), isColor));
+        ASSERT_SUCCESS(af_get_elements(&nElems, goldArray));
 
         if (isDilation)
-            ASSERT_EQ(AF_SUCCESS, af_dilate(&outArray, inArray, maskArray));
+            ASSERT_SUCCESS(af_dilate(&outArray, inArray, maskArray));
         else
-            ASSERT_EQ(AF_SUCCESS, af_erode(&outArray, inArray, maskArray));
+            ASSERT_SUCCESS(af_erode(&outArray, inArray, maskArray));
 
         vector<T> outData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData.data(), outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
 
         vector<T> goldData(nElems);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)goldData.data(), goldArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
 
         ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(), outData.data(), 0.018f));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(maskArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(goldArray));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(maskArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(goldArray));
     }
 }
 
@@ -224,10 +217,10 @@ void morphInputTest(void)
     dim4 dims = dim4(100,1,1,1);
     dim4 mdims(3,3,1,1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&maskArray, &mask.front(),
+    ASSERT_SUCCESS(af_create_array(&maskArray, &mask.front(),
                 mdims.ndims(), mdims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     if (isDilation)
@@ -235,9 +228,9 @@ void morphInputTest(void)
     else
         ASSERT_EQ(AF_ERR_SIZE, af_erode(&outArray, inArray, maskArray));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(maskArray));
+    ASSERT_SUCCESS(af_release_array(maskArray));
 }
 
 TYPED_TEST(Morph, DilateInvalidInput)
@@ -266,10 +259,10 @@ void morphMaskTest(void)
     dim4 dims(10,10,1,1);
     dim4 mdims(2,2,2,2);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&maskArray, &mask.front(),
+    ASSERT_SUCCESS(af_create_array(&maskArray, &mask.front(),
                 mdims.ndims(), mdims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     if (isDilation)
@@ -277,12 +270,12 @@ void morphMaskTest(void)
     else
         ASSERT_EQ(AF_ERR_SIZE, af_erode(&outArray, inArray, maskArray));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(maskArray));
+    ASSERT_SUCCESS(af_release_array(maskArray));
 
     // Check for 1D mask
     mdims = dim4(16,1,1,1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&maskArray, &mask.front(),
+    ASSERT_SUCCESS(af_create_array(&maskArray, &mask.front(),
                 mdims.ndims(), mdims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     if (isDilation)
@@ -290,9 +283,9 @@ void morphMaskTest(void)
     else
         ASSERT_EQ(AF_ERR_SIZE, af_erode(&outArray, inArray, maskArray));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(maskArray));
+    ASSERT_SUCCESS(af_release_array(maskArray));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TYPED_TEST(Morph, DilateInvalidMask)
@@ -321,10 +314,10 @@ void morph3DMaskTest(void)
     dim4 dims(10,10,10,1);
     dim4 mdims(9,9,1,1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(),
                 dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&maskArray, &mask.front(),
+    ASSERT_SUCCESS(af_create_array(&maskArray, &mask.front(),
                 mdims.ndims(), mdims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     if (isDilation)
@@ -332,12 +325,12 @@ void morph3DMaskTest(void)
     else
         ASSERT_EQ(AF_ERR_SIZE, af_erode3(&outArray, inArray, maskArray));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(maskArray));
+    ASSERT_SUCCESS(af_release_array(maskArray));
 
     // Check for 4D mask
     mdims = dim4(3,3,3,3);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&maskArray, &mask.front(),
+    ASSERT_SUCCESS(af_create_array(&maskArray, &mask.front(),
                 mdims.ndims(), mdims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     if (isDilation)
@@ -345,9 +338,9 @@ void morph3DMaskTest(void)
     else
         ASSERT_EQ(AF_ERR_SIZE, af_erode3(&outArray, inArray, maskArray));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(maskArray));
+    ASSERT_SUCCESS(af_release_array(maskArray));
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 TYPED_TEST(Morph, DilateVolumeInvalidMask)
@@ -497,15 +490,15 @@ TEST(Morph, UnsupportedKernel2D)
 
     af_array in, mask, out;
 
-    ASSERT_EQ(AF_SUCCESS, af_constant(&mask, 1.0, ndims, kdims, f32));
-    ASSERT_EQ(AF_SUCCESS, af_randu(&in, ndims, dims, f32));
+    ASSERT_SUCCESS(af_constant(&mask, 1.0, ndims, kdims, f32));
+    ASSERT_SUCCESS(af_randu(&in, ndims, dims, f32));
 
 #if defined(AF_CPU)
-    ASSERT_EQ(AF_SUCCESS, af_dilate(&out, in, mask));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(out));
+    ASSERT_SUCCESS(af_dilate(&out, in, mask));
+    ASSERT_SUCCESS(af_release_array(out));
 #else
     ASSERT_EQ(AF_ERR_NOT_SUPPORTED, af_dilate(&out, in, mask));
 #endif
-    ASSERT_EQ(AF_SUCCESS, af_release_array(in));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(mask));
+    ASSERT_SUCCESS(af_release_array(in));
+    ASSERT_SUCCESS(af_release_array(mask));
 }

--- a/test/nearest_neighbour.cpp
+++ b/test/nearest_neighbour.cpp
@@ -81,12 +81,12 @@ void nearestNeighbourTest(string pTestFile, int feat_dim, const af_match_type ty
     af_array idx   = 0;
     af_array dist  = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&query, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&query, &(in[0].front()),
                 qDims.ndims(), qDims.get(), (af_dtype)dtype_traits<T>::af_type));
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&train, &(in[1].front()),
+    ASSERT_SUCCESS(af_create_array(&train, &(in[1].front()),
                 tDims.ndims(), tDims.get(), (af_dtype)dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_nearest_neighbour(&idx, &dist, query, train, feat_dim, 1, type));
+    ASSERT_SUCCESS(af_nearest_neighbour(&idx, &dist, query, train, feat_dim, 1, type));
 
     vector<uint> goldIdx  = tests[0];
     vector<uint> goldDist = tests[1];
@@ -94,8 +94,8 @@ void nearestNeighbourTest(string pTestFile, int feat_dim, const af_match_type ty
     uint *outIdx          = new uint[nElems];
     To *outDist           = new To[nElems];
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outIdx,  idx));
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outDist, dist));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outIdx,  idx));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outDist, dist));
 
     for (size_t elIter=0; elIter<nElems; ++elIter) {
         ASSERT_EQ((To)goldDist[elIter], outDist[elIter])<< "at: " << elIter<< endl;
@@ -103,10 +103,10 @@ void nearestNeighbourTest(string pTestFile, int feat_dim, const af_match_type ty
 
     delete[] outIdx;
     delete[] outDist;
-    ASSERT_EQ(AF_SUCCESS, af_release_array(query));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(train));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idx));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(dist));
+    ASSERT_SUCCESS(af_release_array(query));
+    ASSERT_SUCCESS(af_release_array(train));
+    ASSERT_SUCCESS(af_release_array(idx));
+    ASSERT_SUCCESS(af_release_array(dist));
 }
 
 /////////////////////////////////////////////////

--- a/test/orb.cpp
+++ b/test/orb.cpp
@@ -157,20 +157,20 @@ void orbTest(string pTestFile)
 
         inFiles[testId].insert(0,string(TEST_DIR"/orb/"));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&inArray_f32, inFiles[testId].c_str(), false));
-        ASSERT_EQ(AF_SUCCESS, conv_image<T>(&inArray, inArray_f32));
+        ASSERT_SUCCESS(af_load_image(&inArray_f32, inFiles[testId].c_str(), false));
+        ASSERT_SUCCESS(conv_image<T>(&inArray, inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_orb(&feat, &desc, inArray, 20.0f, 400, 1.2f, 8, true));
+        ASSERT_SUCCESS(af_orb(&feat, &desc, inArray, 20.0f, 400, 1.2f, 8, true));
 
         dim_t n = 0;
         af_array x, y, score, orientation, size;
 
-        ASSERT_EQ(AF_SUCCESS, af_get_features_num(&n, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_xpos(&x, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_ypos(&y, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_score(&score, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_orientation(&orientation, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_size(&size, feat));
+        ASSERT_SUCCESS(af_get_features_num(&n, feat));
+        ASSERT_SUCCESS(af_get_features_xpos(&x, feat));
+        ASSERT_SUCCESS(af_get_features_ypos(&y, feat));
+        ASSERT_SUCCESS(af_get_features_score(&score, feat));
+        ASSERT_SUCCESS(af_get_features_orientation(&orientation, feat));
+        ASSERT_SUCCESS(af_get_features_size(&size, feat));
 
         float * outX           = new float[n];
         float * outY           = new float[n];
@@ -178,14 +178,14 @@ void orbTest(string pTestFile)
         float * outOrientation = new float[n];
         float * outSize        = new float[n];
         dim_t descSize;
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&descSize, desc));
+        ASSERT_SUCCESS(af_get_elements(&descSize, desc));
         unsigned * outDesc     = new unsigned[descSize];
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outX, x));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outY, y));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outScore, score));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outOrientation, orientation));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outSize, size));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outDesc, desc));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outX, x));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outY, y));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outScore, score));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outOrientation, orientation));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outSize, size));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outDesc, desc));
 
         vector<feat_desc_t> out_feat_desc;
         array_to_feat_desc(out_feat_desc, outX, outY, outScore, outOrientation, outSize, outDesc, n);
@@ -215,11 +215,11 @@ void orbTest(string pTestFile)
         // TODO: improve distance for single/double-precision interchangeability
         EXPECT_TRUE(compareHamming(descSize, (unsigned*)&v_out_desc[0], (unsigned*)&v_gold_desc[0], 3));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray_f32));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_features(feat));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(desc));
+        ASSERT_SUCCESS(af_release_features(feat));
+        ASSERT_SUCCESS(af_release_array(desc));
 
         delete[] outX;
         delete[] outY;

--- a/test/random.cpp
+++ b/test/random.cpp
@@ -99,7 +99,7 @@ void randuTest(dim4 & dims)
     if (noDoubleTests<T>()) return;
 
     af_array outArray = 0;
-    ASSERT_EQ(AF_SUCCESS, af_randu(&outArray, dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_randu(&outArray, dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
     ASSERT_EQ(af_sync(-1), AF_SUCCESS);
     if(outArray != 0) af_release_array(outArray);
 }
@@ -110,7 +110,7 @@ void randnTest(dim4 &dims)
     if (noDoubleTests<T>()) return;
 
     af_array outArray = 0;
-    ASSERT_EQ(AF_SUCCESS, af_randn(&outArray, dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_randn(&outArray, dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
     ASSERT_EQ(af_sync(-1), AF_SUCCESS);
     if(outArray != 0) af_release_array(outArray);
 }

--- a/test/range.cpp
+++ b/test/range.cpp
@@ -56,11 +56,11 @@ void rangeTest(const uint x, const uint y, const uint z, const uint w, const uin
 
     af_array outArray = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_range(&outArray, idims.ndims(), idims.get(), dim, (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_range(&outArray, idims.ndims(), idims.get(), dim, (af_dtype) dtype_traits<T>::af_type));
 
     // Get result
     T* outData = new T[idims.elements()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     // Compare result
     for(int w = 0; w < (int)idims[3]; w++) {

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -60,11 +60,11 @@ void reduceTest(string pTestFile, int off = 0, bool isSubRef=false, const vector
 
     // Get input array
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<Ti>::af_type));
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv.size(), &seqv.front()));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(tempArray));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<Ti>::af_type));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv.size(), &seqv.front()));
+        ASSERT_SUCCESS(af_release_array(tempArray));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<Ti>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) af::dtype_traits<Ti>::af_type));
     }
 
     // Compare result
@@ -73,14 +73,14 @@ void reduceTest(string pTestFile, int off = 0, bool isSubRef=false, const vector
         vector<To> currGoldBar(tests[d].begin(), tests[d].end());
 
         // Run sum
-        ASSERT_EQ(AF_SUCCESS, af_reduce(&outArray, inArray, d + off));
+        ASSERT_SUCCESS(af_reduce(&outArray, inArray, d + off));
 
         af_dtype t;
         af_get_type(&t, outArray);
 
         // Get result
         vector<To> outData(dims.elements());
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData.front(), outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)&outData.front(), outArray));
 
         size_t nElems = currGoldBar.size();
         if(std::equal(currGoldBar.begin(), currGoldBar.end(), outData.begin()) == false)
@@ -102,10 +102,10 @@ void reduceTest(string pTestFile, int off = 0, bool isSubRef=false, const vector
             FAIL();
         }
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 template<typename T,reduceFunc OP>

--- a/test/regions.cpp
+++ b/test/regions.cpp
@@ -59,18 +59,18 @@ void regionsTest(string pTestFile, af_connectivity connectivity, bool isSubRef =
     af_array outArray = 0;
 
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<char>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<char>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<char>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<char>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_regions(&outArray, inArray, connectivity, (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_regions(&outArray, inArray, connectivity, (af_dtype) dtype_traits<T>::af_type));
 
     // Get result
     T* outData = new T[idims.elements()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     // Compare result
     for (size_t testIter = 0; testIter < tests.size(); ++testIter) {

--- a/test/reorder.cpp
+++ b/test/reorder.cpp
@@ -69,27 +69,17 @@ void reorderTest(string pTestFile, const unsigned resultIdx,
     af_array tempArray = 0;
 
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_reorder(&outArray, inArray, x, y, z, w));
+    ASSERT_SUCCESS(af_reorder(&outArray, inArray, x, y, z, w));
 
-    // Get result
-    T* outData = new T[tests[resultIdx].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
-
-    // Compare result
-    size_t nElems = tests[resultIdx].size();
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx][elIter], outData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] outData;
+    dim4 goldDims(idims[x], idims[y], idims[z], idims[w]);
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx], goldDims, outArray);
 
     if(inArray   != 0) af_release_array(inArray);
     if(outArray  != 0) af_release_array(outArray);
@@ -157,18 +147,8 @@ TEST(Reorder, CPP)
     array input(idims, &(in[0].front()));
     array output = reorder(input, x, y, z, w);
 
-    // Get result
-    float* outData = new float[tests[resultIdx].size()];
-    output.host((void*)outData);
-
-    // Compare result
-    size_t nElems = tests[resultIdx].size();
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx][elIter], outData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] outData;
+    dim4 goldDims(idims[x], idims[y], idims[z], idims[w]);
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx], goldDims, output);
 }
 
 TEST(Reorder, ISSUE_1777)
@@ -208,5 +188,5 @@ TEST(Reorder, MaxDim)
 
     array gold = range(dim4(2, largeDim, 2));
 
-    ASSERT_TRUE(allTrue<bool>(output == gold));
+    ASSERT_ARRAYS_EQ(gold, output);
 }

--- a/test/resize.cpp
+++ b/test/resize.cpp
@@ -74,10 +74,10 @@ TYPED_TEST(Resize, InvalidDims)
 
     dim4 dims = dim4(8,8,1,1);
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(), dims.ndims(), dims.get(),
+    ASSERT_SUCCESS(af_create_array(&inArray, &in.front(), dims.ndims(), dims.get(),
                                           (af_dtype) dtype_traits<TypeParam>::af_type));
     ASSERT_EQ(AF_ERR_SIZE, af_resize(&outArray, inArray, 0, 0, AF_INTERP_NEAREST));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 template<typename T>
@@ -129,19 +129,19 @@ void resizeTest(string pTestFile, const unsigned resultIdx, const dim_t odim0, c
     af_array tempArray = 0;
     if (isSubRef) {
 
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_resize(&outArray, inArray, odim0, odim1, method));
+    ASSERT_SUCCESS(af_resize(&outArray, inArray, odim0, odim1, method));
 
     // Get result
     dim4 odims(odim0, odim1, dims[2], dims[3]);
     T* outData = new T[odims.elements()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     // Compare result
     size_t nElems = tests[resultIdx].size();
@@ -331,7 +331,7 @@ void resizeArgsTest(af_err err, string pTestFile, const dim4 odims, const af_int
 
     af_array inArray = 0;
     af_array outArray = 0;
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     ASSERT_EQ(err, af_resize(&outArray, inArray, odims[0], odims[1], method));
 

--- a/test/rotate.cpp
+++ b/test/rotate.cpp
@@ -61,13 +61,13 @@ void rotateTest(string pTestFile, const unsigned resultIdx, const float angle, c
 
     float theta = angle * PI / 180.0f;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_rotate(&outArray, inArray, theta, crop, AF_INTERP_NEAREST));
+    ASSERT_SUCCESS(af_rotate(&outArray, inArray, theta, crop, AF_INTERP_NEAREST));
 
     // Get result
     T* outData = new T[tests[resultIdx].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     // Compare result
     size_t nElems = tests[resultIdx].size();

--- a/test/rotate_linear.cpp
+++ b/test/rotate_linear.cpp
@@ -67,18 +67,18 @@ void rotateTest(string pTestFile, const unsigned resultIdx, const float angle, c
 
     if (isSubRef) {
 
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_rotate(&outArray, inArray, theta, crop, AF_INTERP_BILINEAR));
+    ASSERT_SUCCESS(af_rotate(&outArray, inArray, theta, crop, AF_INTERP_BILINEAR));
 
     // Get result
     T* outData = new T[tests[resultIdx].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     // Compare result
     size_t nElems = tests[resultIdx].size();

--- a/test/scan.cpp
+++ b/test/scan.cpp
@@ -56,12 +56,12 @@ void scanTest(string pTestFile, int off = 0, bool isSubRef=false, const vector<a
 
     // Get input array
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) dtype_traits<Ti>::af_type));
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv.size(), &seqv.front()));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(tempArray));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) dtype_traits<Ti>::af_type));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv.size(), &seqv.front()));
+        ASSERT_SUCCESS(af_release_array(tempArray));
     } else {
 
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) dtype_traits<Ti>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) dtype_traits<Ti>::af_type));
     }
 
     // Compare result
@@ -69,12 +69,12 @@ void scanTest(string pTestFile, int off = 0, bool isSubRef=false, const vector<a
         vector<To> currGoldBar(tests[d].begin(), tests[d].end());
 
         // Run sum
-        ASSERT_EQ(AF_SUCCESS, af_scan(&outArray, inArray, d + off));
+        ASSERT_SUCCESS(af_scan(&outArray, inArray, d + off));
 
         // Get result
         To *outData;
         outData = new To[dims.elements()];
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
         size_t nElems = currGoldBar.size();
         for (size_t elIter = 0; elIter < nElems; ++elIter) {
@@ -85,10 +85,10 @@ void scanTest(string pTestFile, int off = 0, bool isSubRef=false, const vector<a
 
         // Delete
         delete[] outData;
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
 }
 
 #define SCAN_TESTS(FN, TAG, Ti, To)             \
@@ -179,7 +179,7 @@ TEST(Accum, MaxDim)
     gold_first(span, seq(0, 9999), span, span) = range(2, 10000, 2, 2) + 1;
 
     array output_first = accum(input, 0);
-    ASSERT_TRUE(allTrue<bool>(output_first == gold_first));
+    ASSERT_ARRAYS_EQ(gold_first, output_first);
 
 
     input = constant(0, 2, 2, 2, largeDim);
@@ -189,7 +189,7 @@ TEST(Accum, MaxDim)
     gold_first(span, span, span, seq(0, 9999)) = range(2, 2, 2, 10000) + 1;
 
     output_first = accum(input, 0);
-    ASSERT_TRUE(allTrue<bool>(output_first == gold_first));
+    ASSERT_ARRAYS_EQ(gold_first, output_first);
 
 
     //other dimension kernel tests
@@ -200,7 +200,7 @@ TEST(Accum, MaxDim)
     gold_dim(span, seq(0, 9999), span, span) = range(dim4(2, 10000, 2, 2), 1) + 1;
 
     array output_dim = accum(input, 1);
-    ASSERT_TRUE(allTrue<bool>(output_dim == gold_dim));
+    ASSERT_ARRAYS_EQ(gold_dim, output_dim);
 
 
     input = constant(0, 2, 2, 2, largeDim);
@@ -210,6 +210,6 @@ TEST(Accum, MaxDim)
     gold_dim(span, span, span, seq(0, 9999)) = range(dim4(2, 2, 2, 10000), 1) + 1;
 
     output_dim = accum(input, 1);
-    ASSERT_TRUE(allTrue<bool>(output_dim == gold_dim));
+    ASSERT_ARRAYS_EQ(gold_dim, output_dim);
 
 }

--- a/test/select.cpp
+++ b/test/select.cpp
@@ -488,13 +488,13 @@ TEST(Select, InvalidSizeOfAB) {
 
     double val = 0;
     dim_t dims = 10;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&a, val, 1, &dims, f32));
+    ASSERT_SUCCESS(af_constant(&a, val, 1, &dims, f32));
 
     dims = 9;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&b, val, 1, &dims, f32));
+    ASSERT_SUCCESS(af_constant(&b, val, 1, &dims, f32));
 
     dims = 10;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&cond, val, 1, &dims, b8));
+    ASSERT_SUCCESS(af_constant(&cond, val, 1, &dims, b8));
 
     ASSERT_EQ(AF_ERR_SIZE, af_select(&out, cond, a, b));
 
@@ -515,13 +515,13 @@ TEST(Select, InvalidSizeOfCond) {
 
     double val = 0;
     dim_t dims = 10;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&a, val, 1, &dims, f32));
+    ASSERT_SUCCESS(af_constant(&a, val, 1, &dims, f32));
 
     dims = 10;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&b, val, 1, &dims, f32));
+    ASSERT_SUCCESS(af_constant(&b, val, 1, &dims, f32));
 
     dims = 9;
-    ASSERT_EQ(AF_SUCCESS, af_constant(&cond, val, 1, &dims, b8));
+    ASSERT_SUCCESS(af_constant(&cond, val, 1, &dims, b8));
 
     ASSERT_EQ(AF_ERR_SIZE, af_select(&out, cond, a, b));
 

--- a/test/set.cpp
+++ b/test/set.cpp
@@ -48,18 +48,18 @@ void uniqueTest(string pTestFile)
         af_array outArray  = 0;
 
         // Get input array
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(), dims.ndims(),
+        ASSERT_SUCCESS(af_create_array(&inArray, &in.front(), dims.ndims(),
                                               dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
 
         vector<T> currGoldBar(tests[d].begin(), tests[d].end());
 
         // Run sum
-        ASSERT_EQ(AF_SUCCESS, af_set_unique(&outArray, inArray, d == 0 ? false : true));
+        ASSERT_SUCCESS(af_set_unique(&outArray, inArray, d == 0 ? false : true));
 
         // Get result
         vector<T >outData (currGoldBar.size());
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData.front(), outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)&outData.front(), outArray));
 
         size_t nElems = currGoldBar.size();
         for (size_t elIter = 0; elIter < nElems; ++elIter) {
@@ -115,20 +115,20 @@ void setTest(string pTestFile)
         af_array inArray1   = 0;
         af_array outArray  = 0;
 
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray0, &in0.front(), dims0.ndims(),
+        ASSERT_SUCCESS(af_create_array(&inArray0, &in0.front(), dims0.ndims(),
                                               dims0.get(), (af_dtype) dtype_traits<T>::af_type));
 
 
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray1, &in1.front(), dims1.ndims(),
+        ASSERT_SUCCESS(af_create_array(&inArray1, &in1.front(), dims1.ndims(),
                                               dims1.get(), (af_dtype) dtype_traits<T>::af_type));
         vector<T> currGoldBar(tests[d].begin(), tests[d].end());
 
         // Run sum
-        ASSERT_EQ(AF_SUCCESS, af_set_func(&outArray, inArray0, inArray1, d == 0 ? false : true));
+        ASSERT_SUCCESS(af_set_func(&outArray, inArray0, inArray1, d == 0 ? false : true));
 
         // Get result
         vector<T> outData(currGoldBar.size());
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData.front(), outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)&outData.front(), outArray));
 
         size_t nElems = currGoldBar.size();
         for (size_t elIter = 0; elIter < nElems; ++elIter) {

--- a/test/shift.cpp
+++ b/test/shift.cpp
@@ -65,27 +65,16 @@ void shiftTest(string pTestFile, const unsigned resultIdx,
     af_array tempArray = 0;
 
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_shift(&outArray, inArray, x, y, z, w));
+    ASSERT_SUCCESS(af_shift(&outArray, inArray, x, y, z, w));
 
-    // Get result
-    T* outData = new T[tests[resultIdx].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
-
-    // Compare result
-    size_t nElems = tests[resultIdx].size();
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx][elIter], outData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] outData;
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx], idims, outArray);
 
     if(inArray   != 0) af_release_array(inArray);
     if(outArray  != 0) af_release_array(outArray);
@@ -136,18 +125,7 @@ TEST(Shift, CPP)
     array input(idims, &(in[0].front()));
     array output = shift(input, x, y, z, w);
 
-    // Get result
-    float* outData = new float[tests[resultIdx].size()];
-    output.host((void*)outData);
-
-    // Compare result
-    size_t nElems = tests[resultIdx].size();
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx][elIter], outData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] outData;
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx], idims, output);
 }
 
 TEST(Shift, MaxDim)

--- a/test/sift_nonfree.cpp
+++ b/test/sift_nonfree.cpp
@@ -163,20 +163,20 @@ void siftTest(string pTestFile, unsigned nLayers, float contrastThr, float edgeT
 
         inFiles[testId].insert(0,string(TEST_DIR"/sift/"));
 
-        ASSERT_EQ(AF_SUCCESS, af_load_image(&inArray_f32, inFiles[testId].c_str(), false));
-        ASSERT_EQ(AF_SUCCESS, conv_image<T>(&inArray, inArray_f32));
+        ASSERT_SUCCESS(af_load_image(&inArray_f32, inFiles[testId].c_str(), false));
+        ASSERT_SUCCESS(conv_image<T>(&inArray, inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_sift(&feat, &desc, inArray, nLayers, contrastThr, edgeThr, initSigma, doubleInput, 1.f/256.f, 0.05f));
+        ASSERT_SUCCESS(af_sift(&feat, &desc, inArray, nLayers, contrastThr, edgeThr, initSigma, doubleInput, 1.f/256.f, 0.05f));
 
         dim_t n = 0;
         af_array x, y, score, orientation, size;
 
-        ASSERT_EQ(AF_SUCCESS, af_get_features_num(&n, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_xpos(&x, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_ypos(&y, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_score(&score, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_orientation(&orientation, feat));
-        ASSERT_EQ(AF_SUCCESS, af_get_features_size(&size, feat));
+        ASSERT_SUCCESS(af_get_features_num(&n, feat));
+        ASSERT_SUCCESS(af_get_features_xpos(&x, feat));
+        ASSERT_SUCCESS(af_get_features_ypos(&y, feat));
+        ASSERT_SUCCESS(af_get_features_score(&score, feat));
+        ASSERT_SUCCESS(af_get_features_orientation(&orientation, feat));
+        ASSERT_SUCCESS(af_get_features_size(&size, feat));
 
         float * outX           = new float[n];
         float * outY           = new float[n];
@@ -185,15 +185,15 @@ void siftTest(string pTestFile, unsigned nLayers, float contrastThr, float edgeT
         float * outSize        = new float[n];
         dim_t descSize;
         dim_t descDims[4];
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&descSize, desc));
-        ASSERT_EQ(AF_SUCCESS, af_get_dims(&descDims[0], &descDims[1], &descDims[2], &descDims[3], desc));
+        ASSERT_SUCCESS(af_get_elements(&descSize, desc));
+        ASSERT_SUCCESS(af_get_dims(&descDims[0], &descDims[1], &descDims[2], &descDims[3], desc));
         float * outDesc     = new float[descSize];
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outX, x));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outY, y));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outScore, score));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outOrientation, orientation));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outSize, size));
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outDesc, desc));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outX, x));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outY, y));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outScore, score));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outOrientation, orientation));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outSize, size));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)outDesc, desc));
 
         vector<feat_desc_t> out_feat_desc;
         array_to_feat_desc(out_feat_desc, outX, outY, outScore, outOrientation, outSize, outDesc, n);
@@ -222,15 +222,15 @@ void siftTest(string pTestFile, unsigned nLayers, float contrastThr, float edgeT
 
         EXPECT_TRUE(compareEuclidean(descDims[0], descDims[1], (float*)&v_out_desc[0], (float*)&v_gold_desc[0], 2.f, 4.5f));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(inArray_f32));
+        ASSERT_SUCCESS(af_release_array(inArray));
+        ASSERT_SUCCESS(af_release_array(inArray_f32));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(x));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(y));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(score));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(orientation));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(size));
-        ASSERT_EQ(AF_SUCCESS, af_release_array(desc));
+        ASSERT_SUCCESS(af_release_array(x));
+        ASSERT_SUCCESS(af_release_array(y));
+        ASSERT_SUCCESS(af_release_array(score));
+        ASSERT_SUCCESS(af_release_array(orientation));
+        ASSERT_SUCCESS(af_release_array(size));
+        ASSERT_SUCCESS(af_release_array(desc));
 
         delete[] outX;
         delete[] outY;

--- a/test/sobel.cpp
+++ b/test/sobel.cpp
@@ -59,32 +59,24 @@ void testSobelDerivatives(string pTestFile)
     af_array dyArray = 0;
     af_array inArray = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()),
                 dims.ndims(), dims.get(), (af_dtype)dtype_traits<Ti>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_sobel_operator(&dxArray, &dyArray, inArray, 3));
-
-    vector<To> dxData(dims.elements());
-    vector<To> dyData(dims.elements());
-
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)dxData.data(), dxArray));
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)dyData.data(), dyArray));
+    ASSERT_SUCCESS(af_sobel_operator(&dxArray, &dyArray, inArray, 3));
 
     vector<To> currDXGoldBar = tests[0];
     vector<To> currDYGoldBar = tests[1];
+
     size_t nElems = currDXGoldBar.size();
-    for (size_t elIter=0; elIter<nElems; ++elIter) {
-        ASSERT_EQ(currDXGoldBar[elIter], dxData[elIter])<< "at: " << elIter<< endl;
-    }
+    ASSERT_VEC_ARRAY_EQ(currDXGoldBar, dims, dxArray);
+
     nElems = currDYGoldBar.size();
-    for (size_t elIter=0; elIter<nElems; ++elIter) {
-        ASSERT_EQ(currDYGoldBar[elIter], dyData[elIter])<< "at: " << elIter<< endl;
-    }
+    ASSERT_VEC_ARRAY_EQ(currDYGoldBar, dims, dyArray);
 
     // cleanup
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(dxArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(dyArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(dxArray));
+    ASSERT_SUCCESS(af_release_array(dyArray));
 }
 
 TYPED_TEST(Sobel, Rectangle)

--- a/test/solve_dense.cpp
+++ b/test/solve_dense.cpp
@@ -166,7 +166,7 @@ TEST(Solve, Threading)
     vector<std::thread> tests;
 
     int numDevices = 0;
-    ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
+    ASSERT_SUCCESS(af_get_device_count(&numDevices));
     ASSERT_EQ(true, numDevices>0);
 
     SOLVE_LU_TESTS_THREADING(float, 0.01);

--- a/test/sort.cpp
+++ b/test/sort.cpp
@@ -63,20 +63,20 @@ void sortTest(string pTestFile, const bool dir, const unsigned resultIdx0, bool 
     af_array sxArray = 0;
 
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_sort(&sxArray, inArray, 0, dir));
+    ASSERT_SUCCESS(af_sort(&sxArray, inArray, 0, dir));
 
     size_t nElems = tests[resultIdx0].size();
 
     // Get result
     T* sxData = new T[tests[resultIdx0].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)sxData, sxArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)sxData, sxArray));
 
     // Compare result
     for (size_t elIter = 0; elIter < nElems; ++elIter) {

--- a/test/sort_by_key.cpp
+++ b/test/sort_by_key.cpp
@@ -53,8 +53,8 @@ void sortTest(string pTestFile, const bool dir, const unsigned resultIdx0, const
 
     vector<dim4> numDims;
     vector<vector<T> > in;
-    vector<vector<float> > tests;
-    readTests<T, float, int>(pTestFile,numDims,in,tests);
+    vector<vector<T> > tests;
+    readTests<T, T, int>(pTestFile,numDims,in,tests);
 
     dim4 idims = numDims[0];
 
@@ -65,40 +65,25 @@ void sortTest(string pTestFile, const bool dir, const unsigned resultIdx0, const
     af_array ovalArray = 0;
 
     if (isSubRef) {
-        //ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        //ASSERT_SUCCESS(af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        //ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        //ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&ikeyArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&ivalArray, &(in[1].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&ikeyArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&ivalArray, &(in[1].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_sort_by_key(&okeyArray, &ovalArray, ikeyArray, ivalArray, 0, dir));
+    ASSERT_SUCCESS(af_sort_by_key(&okeyArray, &ovalArray, ikeyArray, ivalArray, 0, dir));
 
     size_t nElems = tests[resultIdx0].size();
 
-    // Get result
-    T* keyData = new T[tests[resultIdx0].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)keyData, okeyArray));
-
     // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx0][elIter], keyData[elIter]) << "at: " << elIter << endl;
-    }
-
-    T* valData = new T[tests[resultIdx1].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)valData, ovalArray));
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx0], idims, okeyArray);
 
 #ifndef AF_OPENCL
     // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx1][elIter], valData[elIter]) << "at: " << elIter << endl;
-    }
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx1], idims, ovalArray);
 #endif
-
-    // Delete
-    delete[] keyData;
-    delete[] valData;
 
     if(ikeyArray != 0) af_release_array(ikeyArray);
     if(ivalArray != 0) af_release_array(ivalArray);
@@ -149,27 +134,8 @@ TEST(SortByKey, CPPDim0)
     array out_keys, out_vals;
     sort(out_keys, out_vals, keys, vals, 0, dir);
 
-    size_t nElems = tests[resultIdx0].size();
-    // Get result
-    float* keyData = new float[tests[resultIdx0].size()];
-    out_keys.host((void*)keyData);
-
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx0][elIter], keyData[elIter]) << "at: " << elIter << endl;
-    }
-
-    float* valData = new float[tests[resultIdx1].size()];
-    out_vals.host((void*)valData);
-
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx1][elIter], valData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] keyData;
-    delete[] valData;
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx0], idims, out_keys);
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx1], idims, out_vals);
 }
 
 TEST(SortByKey, CPPDim1)
@@ -198,27 +164,8 @@ TEST(SortByKey, CPPDim1)
     out_keys = reorder(out_keys, 1, 0, 2, 3);
     out_vals = reorder(out_vals, 1, 0, 2, 3);
 
-    size_t nElems = tests[resultIdx0].size();
-    // Get result
-    float* keyData = new float[tests[resultIdx0].size()];
-    out_keys.host((void*)keyData);
-
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx0][elIter], keyData[elIter]) << "at: " << elIter << endl;
-    }
-
-    float* valData = new float[tests[resultIdx1].size()];
-    out_vals.host((void*)valData);
-
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx1][elIter], valData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] keyData;
-    delete[] valData;
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx0], idims, out_keys);
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx1], idims, out_vals);
 }
 
 TEST(SortByKey, CPPDim2)
@@ -247,25 +194,6 @@ TEST(SortByKey, CPPDim2)
     out_keys = reorder(out_keys, 2, 0, 1, 3);
     out_vals = reorder(out_vals, 2, 0, 1, 3);
 
-    size_t nElems = tests[resultIdx0].size();
-    // Get result
-    float* keyData = new float[tests[resultIdx0].size()];
-    out_keys.host((void*)keyData);
-
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx0][elIter], keyData[elIter]) << "at: " << elIter << endl;
-    }
-
-    float* valData = new float[tests[resultIdx1].size()];
-    out_vals.host((void*)valData);
-
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx1][elIter], valData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] keyData;
-    delete[] valData;
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx0], idims, out_keys);
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx1], idims, out_vals);
 }

--- a/test/sort_index.cpp
+++ b/test/sort_index.cpp
@@ -64,40 +64,22 @@ void sortTest(string pTestFile, const bool dir, const unsigned resultIdx0, const
     af_array ixArray = 0;
 
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_sort_index(&sxArray, &ixArray, inArray, 0, dir));
+    ASSERT_SUCCESS(af_sort_index(&sxArray, &ixArray, inArray, 0, dir));
 
-    size_t nElems = tests[resultIdx0].size();
-
-    // Get result
-    T* sxData = new T[tests[resultIdx0].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)sxData, sxArray));
-
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx0][elIter], sxData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Get result
-    unsigned* ixData = new unsigned[tests[resultIdx1].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)ixData, ixArray));
+    vector<T> sxTest(tests[resultIdx0].begin(), tests[resultIdx0].end());
+    ASSERT_VEC_ARRAY_EQ(sxTest, idims, sxArray);
 
 #ifndef AF_OPENCL
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx1][elIter], ixData[elIter]) << "at: " << elIter << endl;
-    }
+    vector<unsigned> ixTest(tests[resultIdx1].begin(), tests[resultIdx1].end());
+    ASSERT_VEC_ARRAY_EQ(ixTest, idims, ixArray);
 #endif
-
-    // Delete
-    delete[] sxData;
-    delete[] ixData;
 
     if(inArray   != 0) af_release_array(inArray);
     if(sxArray   != 0) af_release_array(sxArray);
@@ -151,27 +133,10 @@ TEST(SortIndex, CPPDim0)
 
     size_t nElems = tests[resultIdx0].size();
 
-    // Get result
-    float* sxData = new float[tests[resultIdx0].size()];
-    outValues.host((void*)sxData);
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx0], idims, outValues);
 
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx0][elIter], sxData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Get result
-    unsigned* ixData = new unsigned[tests[resultIdx1].size()];
-    outIndices.host((void*)ixData);
-
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx1][elIter], ixData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] sxData;
-    delete[] ixData;
+    vector<unsigned> ixTest(tests[resultIdx1].begin(), tests[resultIdx1].end());
+    ASSERT_VEC_ARRAY_EQ(ixTest, idims, outIndices);
 }
 
 TEST(SortIndex, CPPDim1)
@@ -199,27 +164,10 @@ TEST(SortIndex, CPPDim1)
 
     size_t nElems = tests[resultIdx0].size();
 
-    // Get result
-    float* sxData = new float[tests[resultIdx0].size()];
-    outValues.host((void*)sxData);
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx0], idims, outValues);
 
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx0][elIter], sxData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Get result
-    unsigned* ixData = new unsigned[tests[resultIdx1].size()];
-    outIndices.host((void*)ixData);
-
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx1][elIter], ixData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] sxData;
-    delete[] ixData;
+    vector<unsigned> ixTest(tests[resultIdx1].begin(), tests[resultIdx1].end());
+    ASSERT_VEC_ARRAY_EQ(ixTest, idims, outIndices);
 }
 
 TEST(SortIndex, CPPDim2)
@@ -246,25 +194,8 @@ TEST(SortIndex, CPPDim2)
     outIndices = reorder(outIndices, 2, 0, 1, 3);
     size_t nElems = tests[resultIdx0].size();
 
-    // Get result
-    float* sxData = new float[tests[resultIdx0].size()];
-    outValues.host((void*)sxData);
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx0], idims, outValues);
 
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx0][elIter], sxData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Get result
-    unsigned* ixData = new unsigned[tests[resultIdx1].size()];
-    outIndices.host((void*)ixData);
-
-    // Compare result
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx1][elIter], ixData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] sxData;
-    delete[] ixData;
+    vector<unsigned> ixTest(tests[resultIdx1].begin(), tests[resultIdx1].end());
+    ASSERT_VEC_ARRAY_EQ(ixTest, idims, outIndices);
 }

--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -236,7 +236,7 @@ TYPED_TEST(Sparse, DeepCopy) {
                                   "copy do not match the original array";
         array d = dense(s);
         array d2 = dense(s2);
-        ASSERT_TRUE(allTrue<bool>(d == d2));
+        ASSERT_ARRAYS_EQ(d, d2);
     }
 }
 

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -509,6 +509,8 @@ std::ostream& operator<<(std::ostream& os, af::dtype type) {
     return os << name;
 }
 
+// Calculate a linearized index's multi-dimensonal coordinates in an af::array,
+//  given its dimension sizes and strides
 af::dim4 unravelIdx(uint idx, af::dim4 dims, af::dim4 strides) {
     af::dim4 coords;
     coords[3] = idx / (strides[3]);
@@ -531,20 +533,18 @@ af::dim4 unravelIdx(uint idx, af::array arr) {
 #define ASSERT_SUCCESS(CALL)                    \
     ASSERT_EQ(AF_SUCCESS, CALL)
 
-/// Compares two af::array or af_arrays for their type, dims, and values.
+/// Compares two af::array or af_arrays for their types, dims, and values.
 ///
-/// \param[in] EXPECTED This is the expected value of the assertion
-/// \param[in] ACTUAL This is the actual value of the calculation
-///
-/// \NOTE: This macro will deallocate the af_arrays after the call
+/// \param[in] EXPECTED The expected array of the assertion
+/// \param[in] ACTUAL The actual resulting array from the calculation
 #define ASSERT_ARRAYS_EQ(EXPECTED, ACTUAL) \
     EXPECT_PRED_FORMAT2(assertArrayEq, EXPECTED, ACTUAL)
 
-/// Compares a std::vector with an af::array for their dims and values.
+/// Compares a std::vector with an af::/af_array for their types, dims, and values.
 ///
 /// \param[in] EXPECTED_VEC The vector that represents the expected array
 /// \param[in] EXPECTED_ARR_DIMS The dimensions of the expected array
-/// \param[in] ACTUAL_ARR The actual array from the calculation
+/// \param[in] ACTUAL_ARR The actual resulting array from the calculation
 #define ASSERT_VEC_ARRAY_EQ(EXPECTED_VEC, EXPECTED_ARR_DIMS, ACTUAL_ARR) \
     EXPECT_PRED_FORMAT3(assertArrayEq, EXPECTED_VEC, EXPECTED_ARR_DIMS, ACTUAL_ARR)
 
@@ -754,15 +754,15 @@ template<typename T>
     const uint ndimIds = 4;
     if(aDims != b.dims()) {
         return ::testing::AssertionFailure() << "SIZE MISMATCH: "
-                                             << hA_name << "[" << aDims << "], "
-                                             << bName << "[" << b.dims() << "]";
+                                             << aDimsName << "([" << aDims << "]), "
+                                             << bName << "([" << b.dims() << "])";
     }
 
     // In case vector<T> a.size() != aDims.elements()
     if (hA.size() != aDims.elements())
-        return ::testing::AssertionFailure() << "Gold af::array and std::vector SIZE MISMATCH: "
+        return ::testing::AssertionFailure() << "SIZE MISMATCH: "
                                              << hA_name << ".size()(" << hA.size() << "), "
-                                             << bName << "([" << aDims << "] = "
+                                             << aDimsName << "([" << aDims << "] = "
                                              << aDims.elements() << ")";
 
     return elemWiseEq<T>(hA_name, bName, hA, aDims, b);

--- a/test/threading.cpp
+++ b/test/threading.cpp
@@ -279,30 +279,30 @@ void fftTest(int targetDevice, string pTestFile, dim_t pad0=0, dim_t pad1=0, dim
     af_array outArray   = 0;
     af_array inArray    = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_set_device(targetDevice));
+    ASSERT_SUCCESS(af_set_device(targetDevice));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()),
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()),
                 dims.ndims(), dims.get(), (af_dtype)dtype_traits<inType>::af_type));
 
     if (isInverse){
         switch (dims.ndims()) {
-            case 1 : ASSERT_EQ(AF_SUCCESS, af_ifft (&outArray, inArray, 1.0, pad0));              break;
-            case 2 : ASSERT_EQ(AF_SUCCESS, af_ifft2(&outArray, inArray, 1.0, pad0, pad1));        break;
-            case 3 : ASSERT_EQ(AF_SUCCESS, af_ifft3(&outArray, inArray, 1.0, pad0, pad1, pad2));  break;
+            case 1 : ASSERT_SUCCESS(af_ifft (&outArray, inArray, 1.0, pad0));              break;
+            case 2 : ASSERT_SUCCESS(af_ifft2(&outArray, inArray, 1.0, pad0, pad1));        break;
+            case 3 : ASSERT_SUCCESS(af_ifft3(&outArray, inArray, 1.0, pad0, pad1, pad2));  break;
             default: throw std::runtime_error("This error shouldn't happen, pls check");
         }
     } else {
         switch(dims.ndims()) {
-            case 1 : ASSERT_EQ(AF_SUCCESS, af_fft (&outArray, inArray, 1.0, pad0));               break;
-            case 2 : ASSERT_EQ(AF_SUCCESS, af_fft2(&outArray, inArray, 1.0, pad0, pad1));         break;
-            case 3 : ASSERT_EQ(AF_SUCCESS, af_fft3(&outArray, inArray, 1.0, pad0, pad1, pad2));   break;
+            case 1 : ASSERT_SUCCESS(af_fft (&outArray, inArray, 1.0, pad0));               break;
+            case 2 : ASSERT_SUCCESS(af_fft2(&outArray, inArray, 1.0, pad0, pad1));         break;
+            case 3 : ASSERT_SUCCESS(af_fft3(&outArray, inArray, 1.0, pad0, pad1, pad2));   break;
             default: throw std::runtime_error("This error shouldn't happen, pls check");
         }
     }
 
     size_t out_size = tests[0].size();
     outType *outData= new outType[out_size];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     vector<outType> goldBar(tests[0].begin(), tests[0].end());
 
@@ -324,8 +324,8 @@ void fftTest(int targetDevice, string pTestFile, dim_t pad0=0, dim_t pad1=0, dim
 
     // cleanup
     delete[] outData;
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 #define INSTANTIATE_TEST(func, name, is_inverse, in_t, out_t, file)                         \
@@ -347,7 +347,7 @@ TEST(Threading, FFT_R2C)
     vector<std::thread> tests;
 
     int numDevices = 0;
-    ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
+    ASSERT_SUCCESS(af_get_device_count(&numDevices));
     ASSERT_EQ(true, numDevices>0);
 
     // Real to complex transforms
@@ -392,7 +392,7 @@ TEST(Threading, FFT_C2C)
     vector<std::thread> tests;
 
     int numDevices = 0;
-    ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
+    ASSERT_SUCCESS(af_get_device_count(&numDevices));
     ASSERT_EQ(true, numDevices>0);
 
     // complex to complex transforms
@@ -442,7 +442,7 @@ TEST(Threading, FFT_ALL)
     vector<std::thread> tests;
 
     int numDevices = 0;
-    ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
+    ASSERT_SUCCESS(af_get_device_count(&numDevices));
     ASSERT_EQ(true, numDevices>0);
 
     // Real to complex transforms
@@ -582,7 +582,7 @@ TEST(Threading, BLAS)
     vector<std::thread> tests;
 
     int numDevices = 0;
-    ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
+    ASSERT_SUCCESS(af_get_device_count(&numDevices));
     ASSERT_EQ(true, numDevices>0);
 
     TEST_BLAS_FOR_TYPE(      float);
@@ -613,7 +613,7 @@ TEST(Threading, Sparse)
     vector<std::thread> tests;
 
     int numDevices = 0;
-    ASSERT_EQ(AF_SUCCESS, af_get_device_count(&numDevices));
+    ASSERT_SUCCESS(af_get_device_count(&numDevices));
     ASSERT_EQ(true, numDevices>0);
 
     SPARSE_TESTS(  float, 1E-3);
@@ -667,7 +667,7 @@ TEST(Threading, DISABLED_Sort)
 
     vector<std::thread> tests;
 
-    ASSERT_EQ(AF_SUCCESS, af_set_device(0));
+    ASSERT_SUCCESS(af_set_device(0));
 
     for (int i=0; i<THREAD_COUNT; ++i) {
         tests.emplace_back([] {

--- a/test/tile.cpp
+++ b/test/tile.cpp
@@ -65,27 +65,20 @@ void tileTest(string pTestFile, const unsigned resultIdx, const uint x, const ui
     af_array tempArray = 0;
 
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv->size(), &seqv->front()));
     } else {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_tile(&outArray, inArray, x, y, z, w));
+    ASSERT_SUCCESS(af_tile(&outArray, inArray, x, y, z, w));
 
-    // Get result
-    T* outData = new T[tests[resultIdx].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
-
-    // Compare result
-    size_t nElems = tests[resultIdx].size();
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx][elIter], outData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] outData;
+    dim4 goldDims(idims[0] * x,
+                  idims[1] * y,
+                  idims[2] * z,
+                  idims[3] * w);
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx], goldDims, outArray);
 
     if(inArray   != 0) af_release_array(inArray);
     if(outArray  != 0) af_release_array(outArray);
@@ -138,18 +131,11 @@ TEST(Tile, CPP)
     array input(idims, &(in[0].front()));
     array output = tile(input, x, y, z, w);
 
-    // Get result
-    float* outData = new float[tests[resultIdx].size()];
-    output.host((void*)outData);
-
-    // Compare result
-    size_t nElems = tests[resultIdx].size();
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(tests[resultIdx][elIter], outData[elIter]) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] outData;
+    dim4 goldDims(idims[0] * x,
+                  idims[1] * y,
+                  idims[2] * z,
+                  idims[3] * w);
+    ASSERT_VEC_ARRAY_EQ(tests[resultIdx], goldDims, output);
 }
 
 TEST(Tile, MaxDim)

--- a/test/topk.cpp
+++ b/test/topk.cpp
@@ -110,14 +110,14 @@ void topkTest(const unsigned ndims, const dim_t* dims,
         }
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&input, inData.data(), ndims, dims, dtype));
-    ASSERT_EQ(AF_SUCCESS, af_topk(&output, &outindex, input, k, dim, order));
+    ASSERT_SUCCESS(af_create_array(&input, inData.data(), ndims, dims, dtype));
+    ASSERT_SUCCESS(af_topk(&output, &outindex, input, k, dim, order));
 
     vector<T> hovals(oelems);
     vector<uint> hoidxs(oelems);
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)hovals.data(), output));
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)hoidxs.data(), outindex));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)hovals.data(), output));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)hoidxs.data(), outindex));
 
     for (int i=0; i<oelems; ++i)
     {
@@ -130,9 +130,9 @@ void topkTest(const unsigned ndims, const dim_t* dims,
         ASSERT_EQ(outIdxs[i], hoidxs[i]) << "at: " << i;
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_release_array(input    ));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(output   ));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outindex ));
+    ASSERT_SUCCESS(af_release_array(input    ));
+    ASSERT_SUCCESS(af_release_array(output   ));
+    ASSERT_SUCCESS(af_release_array(outindex ));
 }
 
 TYPED_TEST(TopK, Max1D0)
@@ -187,20 +187,20 @@ TEST(TopK, ValidationCheck_DimN)
 {
     dim_t dims[4] = {10, 10, 1, 1};
     af_array out, idx, in;
-    ASSERT_EQ(AF_SUCCESS, af_randu(&in, 2, dims, f32));
+    ASSERT_SUCCESS(af_randu(&in, 2, dims, f32));
     ASSERT_EQ(AF_ERR_NOT_SUPPORTED, af_topk(&out, &idx, in, 10, 1, AF_TOPK_MAX));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(in));
+    ASSERT_SUCCESS(af_release_array(in));
 }
 
 TEST(TopK, ValidationCheck_DefaultDim)
 {
     dim_t dims[4] = {10, 10, 1, 1};
     af_array out, idx, in;
-    ASSERT_EQ(AF_SUCCESS, af_randu(&in, 4, dims, f32));
-    ASSERT_EQ(AF_SUCCESS, af_topk(&out, &idx, in, 10, -1, AF_TOPK_MAX));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(in));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(out));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(idx));
+    ASSERT_SUCCESS(af_randu(&in, 4, dims, f32));
+    ASSERT_SUCCESS(af_topk(&out, &idx, in, 10, -1, AF_TOPK_MAX));
+    ASSERT_SUCCESS(af_release_array(in));
+    ASSERT_SUCCESS(af_release_array(out));
+    ASSERT_SUCCESS(af_release_array(idx));
 }
 
 

--- a/test/transform.cpp
+++ b/test/transform.cpp
@@ -79,27 +79,27 @@ void transformTest(string pTestFile, string pHomographyFile, const af_interp_typ
     af_array outArray = 0;
     af_array HArray = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_load_image(&sceneArray_f32, inFiles[1].c_str(), false));
-    ASSERT_EQ(AF_SUCCESS, af_load_image(&goldArray_f32, goldFiles[0].c_str(), false));
+    ASSERT_SUCCESS(af_load_image(&sceneArray_f32, inFiles[1].c_str(), false));
+    ASSERT_SUCCESS(af_load_image(&goldArray_f32, goldFiles[0].c_str(), false));
 
-    ASSERT_EQ(AF_SUCCESS, conv_image<T>(&sceneArray, sceneArray_f32));
-    ASSERT_EQ(AF_SUCCESS, conv_image<T>(&goldArray, goldArray_f32));
+    ASSERT_SUCCESS(conv_image<T>(&sceneArray, sceneArray_f32));
+    ASSERT_SUCCESS(conv_image<T>(&goldArray, goldArray_f32));
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&HArray, &(HIn[0].front()), HDims.ndims(), HDims.get(), f32));
+    ASSERT_SUCCESS(af_create_array(&HArray, &(HIn[0].front()), HDims.ndims(), HDims.get(), f32));
 
-    ASSERT_EQ(AF_SUCCESS, af_transform(&outArray, sceneArray, HArray, objDims[0], objDims[1], method, invert));
+    ASSERT_SUCCESS(af_transform(&outArray, sceneArray, HArray, objDims[0], objDims[1], method, invert));
 
     // Get gold data
     dim_t goldEl = 0;
-    ASSERT_EQ(AF_SUCCESS, af_get_elements(&goldEl, goldArray));
+    ASSERT_SUCCESS(af_get_elements(&goldEl, goldArray));
     vector<T> goldData(goldEl);
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&goldData.front(), goldArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)&goldData.front(), goldArray));
 
     // Get result
     dim_t outEl = 0;
-    ASSERT_EQ(AF_SUCCESS, af_get_elements(&outEl, outArray));
+    ASSERT_SUCCESS(af_get_elements(&outEl, outArray));
     vector<T> outData(outEl);
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData.front(), outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)&outData.front(), outArray));
 
     const float thr = 1.1f;
 

--- a/test/transform_coordinates.cpp
+++ b/test/transform_coordinates.cpp
@@ -47,7 +47,7 @@ void transformCoordinatesTest(string pTestFile)
 
     af_array tfArray = 0;
     af_array outArray = 0;
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&tfArray, &(in[0].front()), inDims[0].ndims(), inDims[0].get(), (af_dtype)dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&tfArray, &(in[0].front()), inDims[0].ndims(), inDims[0].get(), (af_dtype)dtype_traits<T>::af_type));
 
     int nTests = in.size();
 
@@ -55,15 +55,15 @@ void transformCoordinatesTest(string pTestFile)
         dim_t d0 = (dim_t)in[test][0];
         dim_t d1 = (dim_t)in[test][1];
 
-        ASSERT_EQ(AF_SUCCESS, af_transform_coordinates(&outArray, tfArray, d0, d1));
+        ASSERT_SUCCESS(af_transform_coordinates(&outArray, tfArray, d0, d1));
 
         // Get result
         dim_t outEl = 0;
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&outEl, outArray));
+        ASSERT_SUCCESS(af_get_elements(&outEl, outArray));
         vector<T> outData(outEl);
-        ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData.front(), outArray));
+        ASSERT_SUCCESS(af_get_data_ptr((void*)&outData.front(), outArray));
 
-        ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+        ASSERT_SUCCESS(af_release_array(outArray));
         const float thr = 1.f;
 
         for (dim_t elIter = 0; elIter < outEl; elIter++) {

--- a/test/translate.cpp
+++ b/test/translate.cpp
@@ -64,13 +64,13 @@ void translateTest(string pTestFile, const unsigned resultIdx, dim4 odims, const
 
     dim4 dims = numDims[0];
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_translate(&outArray, inArray, tx, ty, odims[0], odims[1], method));
+    ASSERT_SUCCESS(af_translate(&outArray, inArray, tx, ty, odims[0], odims[1], method));
 
     // Get result
     T* outData = new T[tests[resultIdx].size()];
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     // Compare result
     size_t nElems = tests[resultIdx].size();

--- a/test/transpose.cpp
+++ b/test/transpose.cpp
@@ -64,26 +64,26 @@ void trsTest(string pTestFile, bool isSubRef=false, const vector<af_seq> *seqv=N
     af_array outArray   = 0;
     af_array inArray    = 0;
     T *outData;
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
     // check if the test is for indexed Array
     if (isSubRef) {
         dim4 newDims(dims[1]-4,dims[0]-4,dims[2],dims[3]);
         af_array subArray = 0;
-        ASSERT_EQ(AF_SUCCESS, af_index(&subArray,inArray,seqv->size(),&seqv->front()));
-        ASSERT_EQ(AF_SUCCESS, af_transpose(&outArray,subArray, false));
+        ASSERT_SUCCESS(af_index(&subArray,inArray,seqv->size(),&seqv->front()));
+        ASSERT_SUCCESS(af_transpose(&outArray,subArray, false));
         // destroy the temporary indexed Array
-        ASSERT_EQ(AF_SUCCESS, af_release_array(subArray));
+        ASSERT_SUCCESS(af_release_array(subArray));
 
         dim_t nElems;
-        ASSERT_EQ(AF_SUCCESS, af_get_elements(&nElems,outArray));
+        ASSERT_SUCCESS(af_get_elements(&nElems,outArray));
         outData = new T[nElems];
     } else {
-        ASSERT_EQ(AF_SUCCESS,af_transpose(&outArray,inArray, false));
+        ASSERT_SUCCESS(af_transpose(&outArray,inArray, false));
         outData = new T[dims.elements()];
     }
 
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)outData, outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)outData, outArray));
 
     for (size_t testIter=0; testIter<tests.size(); ++testIter) {
         vector<T> currGoldBar   = tests[testIter];
@@ -95,8 +95,8 @@ void trsTest(string pTestFile, bool isSubRef=false, const vector<af_seq> *seqv=N
 
     // cleanup
     delete[] outData;
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 TYPED_TEST(Transpose,Vector)
@@ -251,13 +251,13 @@ TEST(Transpose, MaxDim)
 
     ASSERT_EQ(output.dims(0), (int)largeDim);
     ASSERT_EQ(output.dims(1), 2);
-    ASSERT_TRUE(allTrue<bool>(output == gold));
+    ASSERT_ARRAYS_EQ(gold, output);
 
     input  = range(dim4(2, 5, 1, largeDim));
     gold   = range(dim4(5, 2, 1, largeDim), 1);
     output = transpose(input);
 
-    ASSERT_TRUE(allTrue<bool>(output == gold));
+    ASSERT_ARRAYS_EQ(gold, output);
 }
 
 

--- a/test/transpose_inplace.cpp
+++ b/test/transpose_inplace.cpp
@@ -46,25 +46,16 @@ void transposeip_test(dim4 dims)
     af_array inArray  = 0;
     af_array outArray = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_randu(&inArray, dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_randu(&inArray, dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_transpose(&outArray, inArray, false));
-    ASSERT_EQ(AF_SUCCESS, af_transpose_inplace(inArray, false));
+    ASSERT_SUCCESS(af_transpose(&outArray, inArray, false));
+    ASSERT_SUCCESS(af_transpose_inplace(inArray, false));
 
-    vector<T> outData(dims.elements());
-    vector<T> trsData(dims.elements());
-
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData.front(), outArray));
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&trsData.front(), inArray));
-
-    dim_t nElems = dims.elements();
-    for (int elIter = 0; elIter < (int)nElems; ++elIter) {
-        ASSERT_EQ(trsData[elIter] , outData[elIter])<< "at: " << elIter << endl;
-    }
+    ASSERT_ARRAYS_EQ(inArray, outArray);
 
     // cleanup
-    ASSERT_EQ(AF_SUCCESS, af_release_array(inArray));
-    ASSERT_EQ(AF_SUCCESS, af_release_array(outArray));
+    ASSERT_SUCCESS(af_release_array(inArray));
+    ASSERT_SUCCESS(af_release_array(outArray));
 }
 
 #define INIT_TEST(Side, D3, D4)                                                     \
@@ -92,14 +83,5 @@ void transposeInPlaceCPPTest()
     array output = transpose(input);
     transposeInPlace(input);
 
-    vector<float> outData(dims.elements());
-    vector<float> trsData(dims.elements());
-
-    output.host((void*)&outData.front());
-    input.host((void*)&trsData.front());
-
-    dim_t nElems = dims.elements();
-    for (int elIter = 0; elIter < (int)nElems; ++elIter) {
-        ASSERT_EQ(trsData[elIter], outData[elIter])<< "at: " << elIter << endl;
-    }
+    ASSERT_ARRAYS_EQ(input, output);
 }

--- a/test/unwrap.cpp
+++ b/test/unwrap.cpp
@@ -61,23 +61,24 @@ void unwrapTest(string pTestFile, const unsigned resultIdx,
     af_array outArrayT = 0;
     af_array outArray2 = 0;
 
-    ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&inArray, &(in[0].front()), idims.ndims(), idims.get(), (af_dtype) dtype_traits<T>::af_type));
 
-    ASSERT_EQ(AF_SUCCESS, af_unwrap(&outArray , inArray, wx, wy, sx, sy, px, py, true ));
-    ASSERT_EQ(AF_SUCCESS, af_unwrap(&outArrayT, inArray, wx, wy, sx, sy, px, py, false));
-    ASSERT_EQ(AF_SUCCESS, af_transpose(&outArray2, outArrayT, false));
+    ASSERT_SUCCESS(af_unwrap(&outArray , inArray, wx, wy, sx, sy, px, py, true ));
+    ASSERT_SUCCESS(af_unwrap(&outArrayT, inArray, wx, wy, sx, sy, px, py, false));
+    ASSERT_SUCCESS(af_transpose(&outArray2, outArrayT, false));
 
     size_t nElems = tests[resultIdx].size();
     vector<T> outData(nElems);
 
+    // TODO: Change to ASSERT_VEC_ARRAY_EQ
     // Compare is_column == true results
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData[0], outArray));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)&outData[0], outArray));
     for (size_t elIter = 0; elIter < nElems; ++elIter) {
         ASSERT_EQ(tests[resultIdx][elIter], outData[elIter]) << "at: " << elIter << endl;
     }
 
     // Compare is_column == false results
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr((void*)&outData[0], outArray2));
+    ASSERT_SUCCESS(af_get_data_ptr((void*)&outData[0], outArray2));
     for (size_t elIter = 0; elIter < nElems; ++elIter) {
         ASSERT_EQ(tests[resultIdx][elIter], outData[elIter]) << "at: " << elIter << endl;
     }
@@ -198,5 +199,5 @@ TEST(Unwrap, MaxDim)
     array gold = range(dim4(5, 5, 1, largeDim));
     gold = moddims(gold, dim4(25, 1, largeDim));
 
-    ASSERT_TRUE(allTrue<bool>(output == gold));
+    ASSERT_ARRAYS_EQ(gold, output);
 }

--- a/test/where.cpp
+++ b/test/where.cpp
@@ -56,28 +56,20 @@ void whereTest(string pTestFile, bool isSubRef=false, const vector<af_seq> seqv=
 
     // Get input array
     if (isSubRef) {
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&tempArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
-        ASSERT_EQ(AF_SUCCESS, af_index(&inArray, tempArray, seqv.size(), &seqv.front()));
+        ASSERT_SUCCESS(af_create_array(&tempArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_index(&inArray, tempArray, seqv.size(), &seqv.front()));
     } else {
 
-        ASSERT_EQ(AF_SUCCESS, af_create_array(&inArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
+        ASSERT_SUCCESS(af_create_array(&inArray, &in.front(), dims.ndims(), dims.get(), (af_dtype) dtype_traits<T>::af_type));
     }
 
     // Compare result
     vector<uint> currGoldBar(tests[0].begin(), tests[0].end());
 
     // Run sum
-    ASSERT_EQ(AF_SUCCESS, af_where(&outArray, inArray));
+    ASSERT_SUCCESS(af_where(&outArray, inArray));
 
-    // Get result
-    size_t nElems = currGoldBar.size();
-    vector<uint> outData(nElems);
-    ASSERT_EQ(AF_SUCCESS, af_get_data_ptr(&outData.front(), outArray));
-
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(currGoldBar[elIter], outData[elIter]) << "at: " << elIter
-                                                        << endl;
-    }
+    ASSERT_VEC_ARRAY_EQ(currGoldBar, dim4(tests[0].size()), outArray);
 
     if(inArray   != 0) af_release_array(inArray);
     if(outArray  != 0) af_release_array(outArray);
@@ -117,15 +109,7 @@ TYPED_TEST(Where, CPP)
     // Compare result
     vector<uint> currGoldBar(tests[0].begin(), tests[0].end());
 
-    // Get result
-    size_t nElems = currGoldBar.size();
-    vector<uint> outData(nElems);
-    output.host((void*)&(outData.front()));
-
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_EQ(currGoldBar[elIter], outData[elIter]) << "at: " << elIter
-                                                        << endl;
-    }
+    ASSERT_VEC_ARRAY_EQ(currGoldBar, dim4(tests[0].size()), output);
 }
 
 TEST(Where, MaxDim)
@@ -135,11 +119,11 @@ TEST(Where, MaxDim)
     array input = range(dim4(1, largeDim), 1);
     array output = where(input % 2 == 0);
     array gold = 2 * range(largeDim/2);
-    ASSERT_TRUE(allTrue<bool>(output == gold));
+    ASSERT_ARRAYS_EQ(gold.as(u32), output);
 
     input = range(dim4(1, 1, 1, largeDim), 3);
     output = where(input % 2 == 0);
-    ASSERT_TRUE(allTrue<bool>(output == gold));
+    ASSERT_ARRAYS_EQ(gold.as(u32), output);
 }
 
 TEST(Where, ISSUE_1259)

--- a/test/wrap.cpp
+++ b/test/wrap.cpp
@@ -200,5 +200,5 @@ TEST(Wrap, MaxDim)
     array unwrapped = unwrap(input, wx, wy, sx, sy, px, py);
     array output = wrap(unwrapped, 5, 5, wx, wy, sx, sy, px, py);
 
-    ASSERT_TRUE(allTrue<bool>(output == input));
+    ASSERT_ARRAYS_EQ(output, input);
 }


### PR DESCRIPTION
A lot of tests have common code for gtest asserts. One of those common code is comparing two arrays for equality. The usual method is to get the raw data from the backend to the host and then iterate over the two host arrays for element-wise comparison. A new utility function would simplify that so that we could just pass in the af::arrays directly. It will:

- compare types _(done)_
- compare dimension sizes _(done)_
- compare elements for equality _(done, but float types are compared using simple equality for now)_
- display the difference in any of the above _(done)_
- ~~for comparing elements, display an n-dimensional window around the mismatched elements~~
- ~~for floating-point types, use a threshold of machine error to the equality operator or let the test-writer to define that threshold~~
- ~~for images, provide an option to save/display the difference between the reference and output images~~

(Strikethroughed items will be done in a separate PR)

Another utility function would be to simplify the assert for error code-returning C arrayfire calls. Instead of displaying the error code in its raw numeric form, the utility function would display the enum name for that error code, thereby making the error message more human-readable. _(done)_

p.s. I modified `test/basic.cpp` for now to try out how the error messages come out. ~~The tests will fail~~The tests should pass in the CI since we use `ASSERT_FALSE()` on the utility function within the test cases, but when one uses the actual new macro, it should fail and give back an easy-to-read error message.