### PR TITLE
Refactor sign macro internally

### DIFF
--- a/src/api/c/optypes.hpp
+++ b/src/api/c/optypes.hpp
@@ -75,7 +75,7 @@ typedef enum {
     af_ceil_t,
     af_round_t,
     af_trunc_t,
-    af_sign_t,
+    af_signbit_t,
 
     af_rem_t,
     af_mod_t,

--- a/src/api/c/unary.cpp
+++ b/src/api/c/unary.cpp
@@ -108,11 +108,13 @@ static af_err af_unary_complex(af_array *out, const af_array in)
     return AF_SUCCESS;
 }
 
-#define UNARY(fn)                                       \
-    af_err af_##fn(af_array *out, const af_array in)    \
+#define UNARY_FN(name, opcode)                          \
+    af_err af_##name(af_array *out, const af_array in)  \
     {                                                   \
-        return af_unary<af_##fn##_t>(out, in);          \
+        return af_unary<af_##opcode##_t>(out, in);          \
     }
+
+#define UNARY(fn) UNARY_FN(fn, fn)
 
 #define UNARY_COMPLEX(fn)                               \
     af_err af_##fn(af_array *out, const af_array in)    \
@@ -121,7 +123,7 @@ static af_err af_unary_complex(af_array *out, const af_array in)
     }
 
 UNARY(trunc)
-UNARY(sign)
+UNARY_FN(sign, signbit)
 UNARY(round)
 UNARY(floor)
 UNARY(ceil)

--- a/src/backend/cpu/unary.hpp
+++ b/src/backend/cpu/unary.hpp
@@ -17,12 +17,6 @@ namespace cpu
 {
 
 template<typename T>
-T sign(T in)
-{
-    return T(std::signbit(in));
-}
-
-template<typename T>
 T sigmoid(T in)
 {
     return (1.0) / (1 + std::exp(-in));
@@ -61,7 +55,7 @@ UNARY_OP(atanh)
 
 UNARY_OP(round)
 UNARY_OP(trunc)
-UNARY_OP_FN(sign, sign)
+UNARY_OP(signbit)
 UNARY_OP(floor)
 UNARY_OP(ceil)
 
@@ -83,7 +77,7 @@ UNARY_OP(tgamma)
 UNARY_OP(lgamma)
 
 #undef UNARY_OP
-#undef sign
+#undef UNARY_OP_FN
 
     template<typename T, af_op_t op>
     Array<T> unaryOp(const Array<T> &in)

--- a/src/backend/cuda/kernel/jit.cuh
+++ b/src/backend/cuda/kernel/jit.cuh
@@ -24,7 +24,6 @@ typedef cuDoubleComplex cdouble;
 // ----------------------------------------------
 // REAL NUMBER OPERATIONS
 // ----------------------------------------------
-#define sign(in) signbit((in))
 #define __noop(a) (a)
 #define __add(lhs, rhs) (lhs) + (rhs)
 #define __sub(lhs, rhs) (lhs) - (rhs)

--- a/src/backend/cuda/unary.hpp
+++ b/src/backend/cuda/unary.hpp
@@ -62,13 +62,16 @@ UNARY_FN(cbrt)
 
 UNARY_FN(trunc)
 UNARY_FN(round)
-UNARY_FN(sign)
+UNARY_FN(signbit)
 UNARY_FN(ceil)
 UNARY_FN(floor)
 
 UNARY_FN(isinf)
 UNARY_FN(isnan)
 UNARY_FN(iszero)
+
+#undef UNARY_DECL
+#undef UNARY_FN
 
 template<typename T, af_op_t op>
 Array<T> unaryOp(const Array<T> &in)

--- a/src/backend/opencl/kernel/jit.cl
+++ b/src/backend/opencl/kernel/jit.cl
@@ -11,7 +11,6 @@
 #define __not_select(cond, a, b) (cond) ? (b) : (a)
 #define __circular_mod(a, b) ((a) < (b)) ? (a) : (a - b)
 
-#define sign(in) signbit((in))
 #define __noop(a) (a)
 #define __add(lhs, rhs) (lhs) + (rhs)
 #define __sub(lhs, rhs) (lhs) - (rhs)

--- a/src/backend/opencl/unary.hpp
+++ b/src/backend/opencl/unary.hpp
@@ -62,13 +62,15 @@ UNARY_FN(cbrt)
 
 UNARY_FN(trunc)
 UNARY_FN(round)
-UNARY_FN(sign)
+UNARY_FN(signbit)
 UNARY_FN(ceil)
 UNARY_FN(floor)
 
 UNARY_FN(isinf)
 UNARY_FN(isnan)
 UNARY_FN(iszero)
+
+#undef UNARY_FN
 
 template<typename T, af_op_t op>
 Array<T> unaryOp(const Array<T> &in)


### PR DESCRIPTION
The have made the internal refactoring into a separate commit so that it can be pushed to next fix release which resolves #2200 

I have deprecated `sign`/`af_sign` in favor of `signbit`/`af_signbit` to be consistent with C++ standard. This change doesn't need to be pushed any time soon and can be done for the next major release.