### PR TITLE
Add floating point "near" comparison for new arrayfire assert utility functions

### DIFF
--- a/test/basic.cpp
+++ b/test/basic.cpp
@@ -457,3 +457,19 @@ TEST(Assert, TestVectorDiffVecSize) {
     // ASSERT_ARRAYS_EQ(A, B);
     ASSERT_FALSE(assertArrayEq("hA", "adims", "A", hA, adims, A));
 }
+
+TEST(Assert, TestArraysNear) {
+    array gold = constant(1, 3, 3);
+    array out = constant(1, 3, 3);
+    gold(2, 2) = 2.2345;
+    out(2, 2) = 2.2445;
+    float maxDiff = 0.001;
+
+    // Testing this macro
+    // ASSERT_ARRAYS_NEAR(gold, out, maxDiff);
+    ASSERT_FALSE(assertArrayEq("gold", "out", gold, out, maxDiff));
+}
+
+TEST(Assert, TestVecArrayNear) {
+    ASSERT_TRUE(true);
+}

--- a/test/blas.cpp
+++ b/test/blas.cpp
@@ -295,15 +295,5 @@ TEST(MatrixMultiply, ISSUE_1882)
     array res1 = matmul(A.T(), B.T());
     array res2 = matmulTT(A, B);
 
-    vector<float> hres1(res1.elements());
-    vector<float> hres2(res2.elements());
-
-    res1.host(&hres1.front());
-    res2.host(&hres2.front());
-
-    ASSERT_EQ(hres1.size(), hres2.size());
-
-    for (size_t i = 0; i < hres1.size(); i++) {
-        ASSERT_NEAR(hres1[i], hres2[i], 1E-5);
-    }
+    ASSERT_ARRAYS_NEAR(res1, res2, 1E-5);
 }

--- a/test/fftconvolve.cpp
+++ b/test/fftconvolve.cpp
@@ -172,20 +172,7 @@ void fftconvolveTestLarge(int sDim, int fDim, int sBatch, int fBatch, bool expan
         break;
     }
 
-    size_t outElems  = out.elements();
-    size_t goldElems = gold.elements();
-
-    ASSERT_EQ(goldElems, outElems);
-
-    vector<T> goldData(goldElems);
-    gold.host(&goldData.front());
-
-    vector<T> outData(outElems);
-    out.host(&outData.front());
-
-    for (size_t elIter=0; elIter<outElems; ++elIter) {
-        ASSERT_NEAR(goldData[elIter], outData[elIter], 5e-2) << "at: " << elIter << endl;
-    }
+    ASSERT_ARRAYS_NEAR(gold, out, 5e-2);
 }
 
 TYPED_TEST(FFTConvolveLarge, VectorLargeSignalSmallFilter)

--- a/test/hsv_rgb.cpp
+++ b/test/hsv_rgb.cpp
@@ -50,14 +50,8 @@ TEST(hsv2rgb, CPP)
     array input(dims, &(in[0].front()));
     array output = hsv2rgb(input);
 
-    vector<float> outData(dims.elements());
-    output.host((void*)outData.data());
-
     vector<float> currGoldBar = tests[0];
-    size_t nElems = currGoldBar.size();
-    for (size_t elIter=0; elIter<nElems; ++elIter) {
-        ASSERT_NEAR(currGoldBar[elIter], outData[elIter], 1.0e-3)<< "at: " << elIter<< endl;
-    }
+    ASSERT_VEC_ARRAY_NEAR(currGoldBar, dims, output, 1.0e-3);
 }
 
 TEST(rgb2hsv, CPP)
@@ -72,14 +66,8 @@ TEST(rgb2hsv, CPP)
     array input(dims, &(in[0].front()));
     array output = rgb2hsv(input);
 
-    vector<float> outData(dims.elements());
-    output.host((void*)outData.data());
-
     vector<float> currGoldBar = tests[0];
-    size_t nElems = currGoldBar.size();
-    for (size_t elIter=0; elIter<nElems; ++elIter) {
-        ASSERT_NEAR(currGoldBar[elIter], outData[elIter], 1.0e-3)<< "at: " << elIter<< endl;
-    }
+    ASSERT_VEC_ARRAY_NEAR(currGoldBar, dims, output, 1.0e-3);
 }
 
 TEST(rgb2hsv, MaxDim)

--- a/test/resize.cpp
+++ b/test/resize.cpp
@@ -373,19 +373,8 @@ TEST(Resize, CPP)
     array input(dims, &(in[0].front()));
     array output = resize(input, 16, 16);
 
-    // Get result
-    dim4 odims(16, 16, dims[2], dims[3]);
-    float* outData = new float[odims.elements()];
-    output.host((void*)outData);
-
-    // Compare result
-    size_t nElems = tests[0].size();
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_NEAR(tests[0][elIter], outData[elIter], 0.0001) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] outData;
+    dim4 goldDims(16, 16, dims[2], dims[3]);
+    ASSERT_VEC_ARRAY_NEAR(tests[0], goldDims, output, 0.0001);
 }
 
 TEST(ResizeScale1, CPP)
@@ -401,19 +390,8 @@ TEST(ResizeScale1, CPP)
     array input(dims, &(in[0].front()));
     array output = resize(2.f, input);
 
-    // Get result
-    dim4 odims(16, 16, dims[2], dims[3]);
-    float* outData = new float[odims.elements()];
-    output.host((void*)outData);
-
-    // Compare result
-    size_t nElems = tests[0].size();
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_NEAR(tests[0][elIter], outData[elIter], 0.0001) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] outData;
+    dim4 goldDims(16, 16, dims[2], dims[3]);
+    ASSERT_VEC_ARRAY_NEAR(tests[0], goldDims, output, 0.0001);
 }
 
 TEST(ResizeScale2, CPP)
@@ -429,19 +407,8 @@ TEST(ResizeScale2, CPP)
     array input(dims, &(in[0].front()));
     array output = resize(2.f, 2.f, input);
 
-    // Get result
-    dim4 odims(16, 16, dims[2], dims[3]);
-    float* outData = new float[odims.elements()];
-    output.host((void*)outData);
-
-    // Compare result
-    size_t nElems = tests[0].size();
-    for (size_t elIter = 0; elIter < nElems; ++elIter) {
-        ASSERT_NEAR(tests[0][elIter], outData[elIter], 0.0001) << "at: " << elIter << endl;
-    }
-
-    // Delete
-    delete[] outData;
+    dim4 goldDims(16, 16, dims[2], dims[3]);
+    ASSERT_VEC_ARRAY_NEAR(tests[0], goldDims, output, 0.0001);
 }
 
 TEST(Resize, ExtractGFOR)


### PR DESCRIPTION
Continuing from #2249, this adds "near" element-wise comparison for floating point types (similar to googletest's `ASSERT_NEAR()`), This PR also tries to use this new ASSERT for some existing arrayfire tests.