### PR TITLE
Add missing AF_WITH_LOGGING definiton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,10 @@ endif()
 
 foreach(backend ${built_backends})
   target_compile_definitions(${backend} PRIVATE AFDLL)
+  if(AF_WITH_LOGGING)
+    target_compile_definitions(${backend}
+      PRIVATE AF_WITH_LOGGING)
+  endif()
 endforeach()
 
 if(AF_BUILD_FRAMEWORK)

--- a/src/api/unified/symbol_manager.cpp
+++ b/src/api/unified/symbol_manager.cpp
@@ -8,14 +8,17 @@
  ********************************************************/
 
 #include "symbol_manager.hpp"
+
 #include <af/version.h>
+
+#include <common/Logger.hpp>
 #include <common/module_loading.hpp>
+#include <spdlog/spdlog.h>
 
 #include <cmath>
 #include <functional>
 #include <string>
 #include <type_traits>
-#include <spdlog/spdlog.h>
 
 
 #ifdef OS_WIN

--- a/src/api/unified/symbol_manager.hpp
+++ b/src/api/unified/symbol_manager.hpp
@@ -18,6 +18,7 @@
 #include <cstdlib>
 #include <string>
 #include <unordered_map>
+#include <spdlog/spdlog.h>
 
 namespace unified
 {

--- a/src/backend/cpu/memory.cpp
+++ b/src/backend/cpu/memory.cpp
@@ -10,12 +10,12 @@
 #include <memory.hpp>
 
 #include <common/Logger.hpp>
+#include <common/MemoryManagerImpl.hpp>
 #include <err_cpu.hpp>
 #include <platform.hpp>
 #include <queue.hpp>
+#include <spdlog/spdlog.h>
 #include <types.hpp>
-
-#include <common/MemoryManagerImpl.hpp>
 
 template class common::MemoryManager<cpu::MemoryManager>;
 

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -10,6 +10,7 @@
 #include <memory.hpp>
 
 #include <common/Logger.hpp>
+#include <common/MemoryManagerImpl.hpp>
 #include <common/dispatch.hpp>
 #include <common/util.hpp>
 #include <cuda.h>
@@ -17,11 +18,11 @@
 #include <cuda_runtime_api.h>
 #include <err_cuda.hpp>
 #include <platform.hpp>
+#include <spdlog/spdlog.h>
 #include <types.hpp>
 
 #include <mutex>
 
-#include <common/MemoryManagerImpl.hpp>
 template class common::MemoryManager<cuda::MemoryManager>;
 template class common::MemoryManager<cuda::MemoryManagerPinned>;
 

--- a/src/backend/opencl/memory.cpp
+++ b/src/backend/opencl/memory.cpp
@@ -13,6 +13,7 @@
 #include <err_opencl.hpp>
 
 #include <common/Logger.hpp>
+#include <spdlog/spdlog.h>
 
 #include <common/MemoryManagerImpl.hpp>
 template class common::MemoryManager<opencl::MemoryManager>;


### PR DESCRIPTION
The AF_WITH_LOGGING definition was removed in #2264. This disabled the logging mechanism even if AF_WITH_LOGGING was enabled in the configuration.