### PR TITLE
Implement af::pinverse()

### DIFF
--- a/docs/details/lapack.dox
+++ b/docs/details/lapack.dox
@@ -252,6 +252,31 @@ I [3 3 1 1]
 
 \endcode
 
+=======================================================================
+
+\defgroup lapack_ops_func_pinv pinverse
+
+\ingroup lapack_ops_mat
+
+\brief Pseudo-invert a matrix
+
+This function calculates the Moore-Penrose pseudoinverse of a matrix \f$A\f$,
+using \ref af::svd at its core. If \f$A\f$ is of size \f$M \times N\f$, then its
+pseudoinverse \f$A^+\f$ will be of size \f$N \times M\f$.
+
+This calculation can be batched if the input array is three or four-dimensional
+\f$(M \times N \times P \times Q\f$, with \f$Q=1\f$ for only three dimensions
+\f$)\f$. Each \f$M \times N\f$ slice along the third dimension will have its own
+pseudoinverse, for a total of \f$P \times Q\f$ pseudoinverses in the output array
+\f$(N \times M \times P \times Q)\f$.
+
+Here's an example snippet of its usage. In this example, we have a matrix \f$A\f$
+and we compute its pseudoinverse \f$A^+\f$. This condition must hold:
+\f$AA^+A=A\f$, given that the two matrices are pseudoinverses of each other (in
+fact, this is one of the Moore-Penrose conditions):
+
+\snippet test/pinverse.cpp ex_pinverse
+
 ==================================================================================
 
 \defgroup lapack_ops_func_rank rank

--- a/include/af/lapack.h
+++ b/include/af/lapack.h
@@ -200,6 +200,28 @@ namespace af
     */
     AFAPI array inverse(const array &in, const matProp options = AF_MAT_NONE);
 
+#if AF_API_VERSION >= 37
+    /**
+       C++ Interface for pseudo-inverting (Moore-Penrose) a matrix.
+       Currently uses the SVD-based approach.
+
+       \param[in] in is the input matrix
+       \param[in] tol defines the lower threshold for singular values from SVD
+       \param[in] options must be AF_MAT_NONE (more options might be supported
+                  in the future)
+       \returns the pseudo-inverse of the input matrix
+
+       \note \p tol is not the actual lower threshold, but it is passed in as
+             a parameter to the calculation of the actual threshold relative to
+             the shape and contents of \p in.
+       \note This function is not supported in GFOR
+
+       \ingroup lapack_ops_func_pinv
+    */
+    AFAPI array pinverse(const array &in, const double tol=1E-6,
+                         const matProp options = AF_MAT_NONE);
+#endif
+
     /**
        C++ Interface for finding the rank of a matrix
 
@@ -400,6 +422,30 @@ extern "C" {
        \note currently options needs to be \ref AF_MAT_NONE
     */
     AFAPI af_err af_inverse(af_array *out, const af_array in, const af_mat_prop options);
+
+#if AF_API_VERSION >= 37
+    /**
+       C Interface for pseudo-inverting (Moore-Penrose) a matrix.
+       Currently uses the SVD-based approach.
+
+       \param[out] out will contain the pseudo-inverse of matrix \p in
+       \param[in] in is the input matrix
+       \param[in] tol defines the lower threshold for singular values from SVD
+       \param[in] options must be AF_MAT_NONE (more options might be supported
+       in the future)
+
+       \note \p tol is not the actual lower threshold, but it is passed in as a
+             parameter to the calculation of the actual threshold relative to the
+             shape and contents of \p in.
+       \note At first, try setting \p tol to 1e-6 for single precision and 1e-12
+             for double.
+       \note This function is not supported in GFOR
+
+       \ingroup lapack_ops_func_pinv
+    */
+    AFAPI af_err af_pinverse(af_array *out, const af_array in, const double tol,
+                             const af_mat_prop options);
+#endif
 
     /**
        C Interface for finding the rank of a matrix

--- a/src/api/c/CMakeLists.txt
+++ b/src/api/c/CMakeLists.txt
@@ -113,6 +113,7 @@ target_sources(c_api_interface
     ${CMAKE_CURRENT_SOURCE_DIR}/ops.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/optypes.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/orb.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/pinverse.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/plot.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/print.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/qr.cpp

--- a/src/api/c/pinverse.cpp
+++ b/src/api/c/pinverse.cpp
@@ -1,0 +1,199 @@
+/*******************************************************
+ * Copyright (c) 2018, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <backend.hpp>
+#include <Array.hpp>
+
+#include <af/array.h>
+#include <af/complex.h>
+#include <af/defines.h>
+#include <af/lapack.h>
+#include <arith.hpp>
+#include <blas.hpp>
+#include <cast.hpp>
+#include <common/ArrayInfo.hpp>
+#include <common/err_common.hpp>
+#include <diagonal.hpp>
+#include <handle.hpp>
+#include <logic.hpp>
+#include <math.hpp>
+#include <reduce.hpp>
+#include <select.hpp>
+#include <svd.hpp>
+#include <tile.hpp>
+#include <transpose.hpp>
+
+using af::dim4;
+using af::dtype_traits;
+using std::vector;
+using std::swap;
+
+using namespace detail;
+
+const double dfltTol = 1e-6;
+
+template<typename T>
+Array<T> getSubArray(const Array<T> &in, const bool copy,
+                       uint dim0begin = 0, uint dim0end = 0,
+                       uint dim1begin = 0, uint dim1end = 0,
+                       uint dim2begin = 0, uint dim2end = 0,
+                       uint dim3begin = 0, uint dim3end = 0) {
+    vector<af_seq> seqs = {
+        {static_cast<double>(dim0begin), static_cast<double>(dim0end), 1.},
+        {static_cast<double>(dim1begin), static_cast<double>(dim1end), 1.},
+        {static_cast<double>(dim2begin), static_cast<double>(dim2end), 1.},
+        {static_cast<double>(dim3begin), static_cast<double>(dim3end), 1.}
+    };
+    return createSubArray<T>(in, seqs, copy);
+}
+
+// Moore-Penrose Pseudoinverse
+template<typename T>
+Array<T> pinverseSvd(const Array<T> &in, const double tol)
+{
+    in.eval();
+    int M = in.dims()[0];
+    int N = in.dims()[1];
+    int P = in.dims()[2];
+    int Q = in.dims()[3];
+
+    // Compute SVD
+    typedef typename dtype_traits<T>::base_type Tr;
+    // Ideally, these initializations should use createEmptyArray(), but for some
+    // reason, linux-opencl-k80 will produce wrong results for large arrays
+    Array<T> u = createValueArray<T>(dim4(M, M, P, Q), scalar<T>(0));
+    Array<T> vT = createValueArray<T>(dim4(N, N, P, Q), scalar<T>(0));
+    Array<Tr> sVec = createValueArray<Tr>(dim4(min(M, N), 1, P, Q), scalar<Tr>(0));
+    for (uint j = 0; j < Q; ++j) {
+        for (uint i = 0; i < P; ++i) {
+            Array<T> inSlice = getSubArray(in, false,
+                                           0, M - 1,
+                                           0, N - 1,
+                                           i, i,
+                                           j, j);
+            Array<Tr> sVecSlice = getSubArray(sVec, false,
+                                              0, sVec.dims()[0] - 1,
+                                              0, 0,
+                                              i, i,
+                                              j, j);
+            Array<T> uSlice = getSubArray(u, false,
+                                          0, u.dims()[0] - 1,
+                                          0, u.dims()[1] - 1,
+                                          i, i,
+                                          j, j);
+            Array<T> vTSlice = getSubArray(vT, false,
+                                           0, vT.dims()[0] - 1,
+                                           0, vT.dims()[1] - 1,
+                                           i, i,
+                                           j, j);
+            svd<T, Tr>(sVecSlice, uSlice, vTSlice, inSlice);
+        }
+    }
+
+    // Cast s back to original data type for matmul later
+    // (since svd() makes s' type the base type of T)
+    Array<T> sVecCast = cast<T, Tr>(sVec);
+
+    Array<T> v = transpose(vT, true);
+
+    // Build relative tolerance array
+    Array<Tr> sVecMax = reduce<af_max_t, Tr, Tr>(sVec, 0);
+    Array<T> sVecMaxCast = cast<T, Tr>(sVecMax);
+    double tolMulShape = tol * static_cast<double>(max(M, N));
+    Array<T> tolMulShapeArr = createValueArray<T>(sVecMaxCast.dims(),
+                                                  scalar<T>(tolMulShape));
+    Array<T> relTol = arithOp<T, af_mul_t>(tolMulShapeArr, sVecMaxCast,
+                                           sVecMaxCast.dims());
+    Array<T> relTolArr = tile<T>(relTol, dim4(sVecCast.dims()[0]));
+
+    // Get reciprocal of sVec's non-zero values for s pinverse, except for
+    // very small non-zero values though (< relTol), in order to avoid very
+    // large reciprocals
+    Array<T> ones = createValueArray<T>(sVecCast.dims(), scalar<T>(1.));
+    Array<T> sVecRecip = arithOp<T, af_div_t>(ones, sVecCast, sVecCast.dims());
+    Array<char> cond = logicOp<T, af_ge_t>(sVecCast, relTolArr, sVecCast.dims());
+    Array<T> zeros = createValueArray<T>(sVecCast.dims(), scalar<T>(0.));
+    sVecRecip = createSelectNode<T>(cond, sVecRecip, zeros, sVecRecip.dims());
+
+    // Make s vector into s pinverse array
+    Array<T> sVecRecipMod = modDims<T>(sVecRecip, dim4(sVecRecip.dims()[0],
+                                                       (sVecRecip.dims()[2]
+                                                        * sVecRecip.dims()[3])));
+    Array<T> sPinv = diagCreate<T>(sVecRecipMod, 0);
+    sPinv = modDims<T>(sPinv, dim4(sPinv.dims()[0], sPinv.dims()[1],
+                                   sVecRecip.dims()[2], sVecRecip.dims()[3]));
+
+    Array<T> uT = transpose(u, true);
+
+    // Crop v and u* for final matmul later based on s+'s size, because
+    // sVec produced by svd() has minimal dim length (no extra zeroes).
+    // Thus s+ produced by diagCreate() will have minimal dims as well,
+    // and v could have an extra dim0 or u* could have an extra dim1
+    if (v.dims()[1] > sPinv.dims()[0]) {
+        v = getSubArray(v, false,
+                        0, v.dims()[0] - 1,
+                        0, sPinv.dims()[0] - 1,
+                        0, v.dims()[2] - 1,
+                        0, v.dims()[3] - 1);
+    }
+    if (uT.dims()[0] > sPinv.dims()[1]) {
+        uT = getSubArray(uT, false,
+                         0, sPinv.dims()[1] - 1,
+                         0, uT.dims()[1] - 1,
+                         0, uT.dims()[2] - 1,
+                         0, uT.dims()[3] - 1);
+    }
+
+    Array<T> out = matmul<T>(matmul<T>(v, sPinv, AF_MAT_NONE, AF_MAT_NONE),
+                             uT, AF_MAT_NONE, AF_MAT_NONE);
+
+    return out;
+}
+
+template<typename T>
+static inline af_array pinverse(const af_array in, const double tol)
+{
+    return getHandle(pinverseSvd<T>(getArray<T>(in), tol));
+}
+
+af_err af_pinverse(af_array *out, const af_array in, const double tol,
+                   const af_mat_prop options)
+{
+    try {
+        const ArrayInfo& i_info = getInfo(in);
+
+        af_dtype type = i_info.getType();
+
+        if (options != AF_MAT_NONE) {
+            AF_ERROR("Using this property is not yet supported in inverse", AF_ERR_NOT_SUPPORTED);
+        }
+
+        ARG_ASSERT(1, i_info.isFloating()); // Only floating and complex types
+        ARG_ASSERT(2, tol >= 0.); // Ensure tolerance is not negative
+
+        af_array output;
+
+        if(i_info.ndims() == 0) {
+            return af_retain_array(out, in);
+        }
+
+        switch(type) {
+            case f32: output = pinverse<float  >(in, tol);  break;
+            case f64: output = pinverse<double >(in, tol);  break;
+            case c32: output = pinverse<cfloat >(in, tol);  break;
+            case c64: output = pinverse<cdouble>(in, tol);  break;
+            default:  TYPE_ERROR(1, type);
+        }
+        swap(*out, output);
+    }
+    CATCHALL;
+
+    return AF_SUCCESS;
+}
+

--- a/src/api/cpp/lapack.cpp
+++ b/src/api/cpp/lapack.cpp
@@ -117,6 +117,13 @@ namespace af
         return array(out);
     }
 
+    array pinverse(const array &in, const double tol, const matProp options)
+    {
+        af_array out;
+        AF_THROW(af_pinverse(&out, in.get(), tol, options));
+        return array(out);
+    }
+
     unsigned rank(const array &in, const double tol)
     {
         unsigned r = 0;

--- a/src/api/unified/lapack.cpp
+++ b/src/api/unified/lapack.cpp
@@ -79,6 +79,13 @@ af_err af_inverse(af_array *out, const af_array in, const af_mat_prop options)
     return CALL(out, in, options);
 }
 
+af_err af_pinverse(af_array *out, const af_array in, const double tol,
+                   const af_mat_prop options)
+{
+    CHECK_ARRAYS(in);
+    return CALL(out, in, options);
+}
+
 af_err af_rank(unsigned *rank, const af_array in, const double tol)
 {
     CHECK_ARRAYS(in);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -236,6 +236,7 @@ if(OpenCL_FOUND)
 endif()
 
 make_test(SRC orb.cpp)
+make_test(SRC pinverse.cpp)
 make_test(SRC qr_dense.cpp)
 make_test(SRC random.cpp)
 make_test(SRC range.cpp)

--- a/test/pinverse.cpp
+++ b/test/pinverse.cpp
@@ -1,0 +1,346 @@
+/*******************************************************
+ * Copyright (c) 2018, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <gtest/gtest.h>
+#include <arrayfire.h>
+#include <af/dim4.hpp>
+#include <af/defines.h>
+#include <af/traits.hpp>
+#include <iostream>
+#include <complex>
+#include <testHelpers.hpp>
+#include <limits>
+
+using af::array;
+using af::cdouble;
+using af::cfloat;
+using af::constant;
+using af::dim4;
+using af::dtype;
+using af::dtype_traits;
+using af::exception;
+using af::identity;
+using af::matmul;
+using af::max;
+using af::pinverse;
+using af::randu;
+using af::span;
+using std::abs;
+using std::string;
+using std::vector;
+
+template<typename T>
+array makeComplex(dim4 dims, const vector<T>& real, const vector<T>& imag) {
+    array realArr(dims, &real.front());
+    array imagArr(dims, &imag.front());
+    return af::complex(realArr, imagArr);
+}
+
+template<typename T>
+array readTestInput(string testFilePath) {
+    typedef typename dtype_traits<T>::base_type InBaseType;
+    dtype outAfType = (dtype) dtype_traits<T>::af_type;
+
+    vector<dim4> dimsVec;
+    vector<vector<InBaseType> > inVec;
+    vector<vector<InBaseType> > goldVec;
+    readTestsFromFile<InBaseType, InBaseType>(testFilePath, dimsVec, inVec, goldVec);
+    dim4 inDims = dimsVec[0];
+
+    if (outAfType == c32 || outAfType == c64) {
+        return makeComplex(inDims, inVec[1], inVec[2]);
+    }
+    else {
+        return array(inDims, &inVec[0].front());
+    }
+}
+
+template<typename T>
+array readTestGold(string testFilePath) {
+    typedef typename dtype_traits<T>::base_type InBaseType;
+    dtype outAfType = (dtype) dtype_traits<T>::af_type;
+
+    vector<dim4> dimsVec;
+    vector<vector<InBaseType> > inVec;
+    vector<vector<InBaseType> > goldVec;
+    readTestsFromFile<InBaseType, InBaseType>(testFilePath, dimsVec, inVec, goldVec);
+    dim4 goldDims(dimsVec[0][1], dimsVec[0][0]);
+
+    if (outAfType == c32 || outAfType == c64) {
+        return makeComplex(goldDims, goldVec[1], goldVec[2]);
+    }
+    else {
+        return array(goldDims, &goldVec[0].front());
+    }
+}
+
+template<typename T>
+class Pinverse : public ::testing::Test
+{
+
+};
+
+// Epsilons taken from test/inverse.cpp
+template<typename T>
+double eps();
+
+template<>
+double eps<float>() {
+    return 0.01f;
+}
+
+template<>
+double eps<double>() {
+    return 1e-5;
+}
+
+template<>
+double eps<cfloat>() {
+    return 0.01f;
+}
+
+template<>
+double eps<cdouble>() {
+    return 1e-5;
+}
+
+template<typename T>
+double relEps(array in) {
+    typedef typename af::dtype_traits<T>::base_type InBaseType;
+    return std::numeric_limits<InBaseType>::epsilon()
+        * std::max(in.dims(0), in.dims(1)) * af::max<double>(in);
+}
+
+typedef ::testing::Types<float, cfloat, double, cdouble> TestTypes;
+TYPED_TEST_CASE(Pinverse, TestTypes);
+
+// Test Moore-Penrose conditions in the following first 4 tests
+// See https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Definition
+TYPED_TEST(Pinverse, AApinvA_A) {
+    array in = readTestInput<TypeParam>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
+    array inpinv = pinverse(in);
+    array out = matmul(in, inpinv, in);
+    ASSERT_ARRAYS_NEAR(in, out, eps<TypeParam>());
+}
+
+TYPED_TEST(Pinverse, ApinvAApinv_Apinv) {
+    array in = readTestInput<TypeParam>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
+    array inpinv = pinverse(in);
+    array out = matmul(inpinv, in, inpinv);
+    ASSERT_ARRAYS_NEAR(inpinv, out, eps<TypeParam>());
+}
+
+TYPED_TEST(Pinverse, AApinv_IsHermitian) {
+    array in = readTestInput<TypeParam>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
+    array inpinv = pinverse(in);
+    array aapinv = matmul(in, inpinv);
+    array out = matmul(in, inpinv).H();
+    ASSERT_ARRAYS_NEAR(aapinv, out, eps<TypeParam>());
+}
+
+TYPED_TEST(Pinverse, ApinvA_IsHermitian) {
+    array in = readTestInput<TypeParam>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
+    array inpinv = pinverse(in);
+    array apinva = af::matmul(inpinv, in);
+    array out = af::matmul(inpinv, in).H();
+    ASSERT_ARRAYS_NEAR(apinva, out, eps<TypeParam>());
+}
+
+TYPED_TEST(Pinverse, Large) {
+    array in = readTestInput<TypeParam>(string(TEST_DIR"/pinverse/pinverse640x480.test"));
+    array inpinv = pinverse(in);
+    array out = matmul(in, inpinv, in);
+    ASSERT_ARRAYS_NEAR(in, out, relEps<TypeParam>(in));
+}
+
+TYPED_TEST(Pinverse, LargeTall) {
+    array in = readTestInput<TypeParam>(string(TEST_DIR"/pinverse/pinverse640x480.test")).T();
+    array inpinv = pinverse(in);
+    array out = matmul(in, inpinv, in);
+    ASSERT_ARRAYS_NEAR(in, out, relEps<TypeParam>(in));
+}
+
+TEST(Pinverse, Square) {
+    array in = readTestInput<float>(string(TEST_DIR"/pinverse/pinverse10x10.test"));
+    array inpinv = pinverse(in);
+    array out = matmul(in, inpinv, in);
+    ASSERT_ARRAYS_NEAR(in, out, eps<float>());
+}
+
+TEST(Pinverse, Dim1GtDim0) {
+    array in = readTestInput<float>(string(TEST_DIR"/pinverse/pinverse8x10.test"));
+    array inpinv = pinverse(in);
+    array out = matmul(in, inpinv, in);
+    ASSERT_ARRAYS_NEAR(in, out, eps<float>());
+}
+
+TEST(Pinverse, CompareWithNumpy) {
+    array in = readTestInput<float>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
+    array gold = readTestGold<float>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
+    array out = pinverse(in);
+    ASSERT_ARRAYS_NEAR(gold, out, relEps<float>(gold));
+}
+
+TEST(Pinverse, SmallSigValExistsFloat) {
+    array in = readTestInput<float>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
+    const dim_t dim0 = in.dims(0);
+    const dim_t dim1 = in.dims(1);
+
+    // Generate sigma with small non-zero value
+    af::array u;
+    af::array vT;
+    af::array sVec;
+    af::svd(u, sVec, vT, in);
+    dim_t sSize = sVec.elements();
+
+    sVec(2) = 1e-12;
+    af::array s = af::diag(sVec, 0, false);
+    af::array zeros = af::constant(0,
+                                   dim0 > sSize ? dim0 - sSize : sSize,
+                                   dim1 > sSize ? dim1 - sSize : sSize);
+    s = af::join(dim0 > dim1 ? 0 : 1, s, zeros);
+
+    // Make new input array that has a small non-zero value in its SVD sigma
+    in = af::matmul(u, s, vT);
+    array inpinv = pinverse(in);
+    array out = matmul(in, inpinv, in);
+
+    ASSERT_ARRAYS_NEAR(in, out, eps<float>());
+}
+
+TEST(Pinverse, SmallSigValExistsDouble) {
+    array in = readTestInput<double>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
+    const dim_t dim0 = in.dims(0);
+    const dim_t dim1 = in.dims(1);
+
+    // Generate sigma with small non-zero value
+    array u;
+    array vT;
+    array sVec;
+    svd(u, sVec, vT, in);
+    dim_t sSize = sVec.elements();
+
+    sVec(2) = (double) 1e-16;
+    array s = diag(sVec, 0, false);
+    array zeros = constant(0,
+                           dim0 > sSize ? dim0 - sSize : sSize,
+                           dim1 > sSize ? dim1 - sSize : sSize,
+                           f64);
+    s = join(dim0 > dim1 ? 0 : 1, s, zeros);
+
+    // Make new input array that has a small non-zero value in its SVD sigma
+    in = matmul(u, s, vT);
+    array inpinv = pinverse(in, 1e-15);
+    array out = matmul(in, inpinv, in);
+
+    ASSERT_ARRAYS_NEAR(in, out, eps<double>());
+}
+
+TEST(Pinverse, Batching3D) {
+    array in = readTestInput<float>(string(TEST_DIR"/pinverse/pinverse10x8x2.test"));
+    array inpinv0 = pinverse(in(span, span, 0));
+    array inpinv1 = pinverse(in(span, span, 1));
+
+    array out = pinverse(in);
+    array out0 = out(span, span, 0);
+    array out1 = out(span, span, 1);
+
+    ASSERT_ARRAYS_NEAR(inpinv0, out0, relEps<float>(inpinv0));
+    ASSERT_ARRAYS_NEAR(inpinv1, out1, relEps<float>(inpinv1));
+}
+
+TEST(Pinverse, Batching4D) {
+    array in = readTestInput<float>(string(TEST_DIR"/pinverse/pinverse10x8x2x2.test"));
+    array inpinv00 = pinverse(in(span, span, 0, 0));
+    array inpinv01 = pinverse(in(span, span, 0, 1));
+    array inpinv10 = pinverse(in(span, span, 1, 0));
+    array inpinv11 = pinverse(in(span, span, 1, 1));
+
+    array out = pinverse(in);
+    array out00 = out(span, span, 0, 0);
+    array out01 = out(span, span, 0, 1);
+    array out10 = out(span, span, 1, 0);
+    array out11 = out(span, span, 1, 1);
+
+    ASSERT_ARRAYS_NEAR(inpinv00, out00, relEps<float>(inpinv00));
+    ASSERT_ARRAYS_NEAR(inpinv01, out01, relEps<float>(inpinv01));
+    ASSERT_ARRAYS_NEAR(inpinv10, out10, relEps<float>(inpinv10));
+    ASSERT_ARRAYS_NEAR(inpinv11, out11, relEps<float>(inpinv11));
+}
+
+TEST(Pinverse, CustomTol) {
+    array in = readTestInput<float>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
+    array inpinv = pinverse(in, 1e-12);
+    array out = matmul(in, inpinv, in);
+    ASSERT_ARRAYS_NEAR(in, out, eps<float>());
+}
+
+TEST(Pinverse, C) {
+    array in = readTestInput<float>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
+    af_array inpinv = 0, out = 0;
+    ASSERT_SUCCESS(af_pinverse(&inpinv, in.get(), 1e-6, AF_MAT_NONE));
+    ASSERT_SUCCESS(af_matmul(&out, in.get(), inpinv, AF_MAT_NONE, AF_MAT_NONE));
+    ASSERT_SUCCESS(af_matmul(&out, out, in.get(), AF_MAT_NONE, AF_MAT_NONE));
+
+    ASSERT_ARRAYS_NEAR(in.get(), out, eps<float>());
+
+    ASSERT_SUCCESS(af_release_array(out));
+    ASSERT_SUCCESS(af_release_array(inpinv));
+}
+
+TEST(Pinverse, C_CustomTol) {
+    array in = readTestInput<float>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
+    af_array inpinv = 0, out = 0;
+    ASSERT_SUCCESS(af_pinverse(&inpinv, in.get(), 1e-12, AF_MAT_NONE));
+    ASSERT_SUCCESS(af_matmul(&out, in.get(), inpinv, AF_MAT_NONE, AF_MAT_NONE));
+    ASSERT_SUCCESS(af_matmul(&out, out, in.get(), AF_MAT_NONE, AF_MAT_NONE));
+
+    ASSERT_ARRAYS_NEAR(in.get(), out, eps<float>());
+
+    ASSERT_SUCCESS(af_release_array(out));
+    ASSERT_SUCCESS(af_release_array(inpinv));
+}
+
+TEST(Pinverse, NegativeTol) {
+    array in = readTestInput<float>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
+    array out;
+    ASSERT_THROW(out = pinverse(in, -1.f), exception);
+}
+
+TEST(Pinverse, InvalidType) {
+    array in = constant(0, 10, 8, u8);
+    array out;
+    ASSERT_THROW(out = pinverse(in, -1.f), exception);
+}
+
+TEST(Pinverse, InvalidMatProp) {
+    array in = constant(0.f, 10, 8, f32);
+    array out;
+    ASSERT_THROW(out = pinverse(in, -1.f, AF_MAT_SYM), exception);
+}
+
+TEST(Pinverse, DocSnippet) {
+    //! [ex_pinverse]
+    float hA[] = {0, 1, 2, 3, 4, 5};
+    array A(3, 2, hA);
+    //  0.0000     3.0000
+    //  1.0000     4.0000
+    //  2.0000     5.0000
+
+    array Apinv = pinverse(A);
+    // -0.7778    -0.1111     0.5556
+    //  0.2778     0.1111    -0.0556
+
+    array MustBeA = matmul(A, Apinv, A);
+    //  0.0000     3.0000
+    //  1.0000     4.0000
+    //  2.0000     5.0000
+    //! [ex_pinverse]
+    ASSERT_ARRAYS_NEAR(A, MustBeA, eps<float>());
+}


### PR DESCRIPTION
SVD-based Moore-Penrose pseudoinverse.

This has the same type restrictions as `af::inverse()`, but lifts the dims restriction of requiring the array to be square. The third dimension is also allowed for batching, although this uses naive batching for now (loop through and successively process each slice along the third dimension). No backend-specific code were added, since all the necessary pieces for the SVD-based approach are already implemented in arrayfire (thus all the code is in `src/api/c/pinverse.cpp`). 

The tests include checking if all the Moore-Penrose conditions hold (see https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Definition), for all the the appropriate types (f32, f64, c32, c64).

The CI tests might fail initially until the corresponding [PR on arrayfire-data](https://github.com/arrayfire/arrayfire-data/pull/11) is approved and I update the git submodule reference here. 

This addresses #2074, #2077, and #2143 (this last one indirectly).