### PR TITLE
Implement approx1 and approx2 along specified dimensions.

### DIFF
--- a/docs/details/signal.dox
+++ b/docs/details/signal.dox
@@ -211,30 +211,37 @@ respectively, then the possible batch operations are as follows.
 \defgroup signal_func_approx1 approx1
 \ingroup approx_mat
 
-approx1 interpolates data along the first dimension.
-It supports the following types of interpolation:
-- Nearest neighbor interpolation - \ref AF_INTERP_NEAREST
-- Linear interpolation  - \ref AF_INTERP_LINEAR, \ref AF_INTERP_LINEAR_COSINE
-- Cubic interpolation - \ref AF_INTERP_CUBIC, \ref AF_INTERP_CUBIC_SPLINE
-- Lower interpolation - \ref AF_INTERP_LOWER
+approx1 interpolates data along a single dimension.
 
 Unless specified, interpolation is performed assuming input data is
 equally spaced with indices in the range [0, n). The positions are
 sampled with respect to data at these locations.
 
+The following interpolation types are supported for approx1:
+- Nearest neighbor interpolation - \ref AF_INTERP_NEAREST
+- Linear interpolation  - \ref AF_INTERP_LINEAR, \ref AF_INTERP_LINEAR_COSINE
+- Cubic interpolation - \ref AF_INTERP_CUBIC, \ref AF_INTERP_CUBIC_SPLINE
+- Lower interpolation - \ref AF_INTERP_LOWER
+
 \snippet test/approx1.cpp ex_signal_approx1
+
+\snippet test/approx1.cpp ex_uniform_approx1
 
 \defgroup signal_func_approx2 approx2
 \ingroup approx_mat
 
-approx2 performs interpolation on data along the first and second dimensions.
-It supports all of the interpolation types defined in \ref af_interp_type.
+approx2 interpolates data on two dimensions.
 
 Unless specified, interpolation is performed assuming input data is
 equally spaced with indices in the range [0, n) along each dimension.
 The positions are sampled with respect to data at these locations.
 
+All of the interpolation types defined in \ref af_interp_type are
+supported by approx2.
+
 \snippet test/approx2.cpp ex_signal_approx2
+
+\snippet test/approx2.cpp ex_uniform_approx2
 
 \defgroup signal_func_fir fir
 \ingroup sigfilt_mat

--- a/docs/details/signal.dox
+++ b/docs/details/signal.dox
@@ -214,39 +214,24 @@ respectively, then the possible batch operations are as follows.
 Performs interpolation on data along a single dimension.
 
 Interpolation is the process of computing for unknown values within a
-continuous range described by a discrete set of known values.
+continuous range described by a discrete set of known values. These
+known values (`in`) correspond to a uniformly-spaced range of indices
+determined by start and step values, whose defaults are 0.0 and 1.0,
+respectively.
 
-`in`, the N-D input array, is comprised of known values that will be
-used for interpolation in order to compute for values at unknown
-indices. These known values correspond to a uniformly-spaced range of
-indices determined by `idx_start`, `idx_step`.
-
-`idx_start` (default: 0.0) defines the first index in the range.
-
-`idx_step` (default: 1.0) defines the uniform spacing value used
-between subsequent indices.
-
-`interp_dim` (default: 0) defines the dimension which we'd like to
-perform interpolation across respective to the input array.
-
-`pos`, the positions array, contains indices whose values we want to
-find along corresponding dimension `interp_dim` in the input
-array. Values of **known indices** will be looked up in the input
-array, while values of **unknown indices** will be found via
-interpolation. Indices outside of the index range are not
-extrapolated. Instead, those values are set to `off_grid`, whose
+The positions array (`pos`) contains the interpolating points (indices
+whose values we want to find) along a given dimension. Values of **known indices**
+will be looked up in the input array, while values of **unknown indices**
+will be found via interpolation. Indices outside of the index range
+are not extrapolated. Instead, those values are set `off_grid`, whose
 default value is 0.0.
 
-Using the default start and step values,
+The following image illustrates a simple example (known values
+represented by blue dots, unknown values represented by red dots):
 
 \image html approx1_default_idx.png "approx1() using idx_start=0.0, idx_step=1.0"
 
-If instead, we chose 10 for start and step,
-
-\image html approx1_arbitrary_idx.png "approx1() using idx_start=10.0, idx_step=10.0"
-
-`method` controls the interpolation method to be performed. Several
-interpolation methods are supported by `approx1()`:
+Several interpolation methods are supported by approx1:
 
 - Nearest neighbor interpolation - \ref AF_INTERP_NEAREST
 - Linear interpolation (default) - \ref AF_INTERP_LINEAR, \ref AF_INTERP_LINEAR_COSINE
@@ -257,59 +242,28 @@ Unless specified, linear interpolation is performed by default. Refer
 to \ref af_interp_type for more information about ArrayFire's
 interpolation types.
 
-It is not necessary to specify the `idx_start`, `idx_step`, and
-`interp_dim` as long as desired values match the default ones.
-
-\snippet test/approx1.cpp ex_signal_approx1
-
 \defgroup signal_func_approx2 approx2
 \ingroup approx_mat
 
 Performs interpolation on data along two dimensions.
 
 Interpolation is the process of computing for unknown values within a
-continuous range described by a discrete set of known values. For 2D
-interpolation, two sets of values, indices, and interpolation
-dimensions are necessary.
+continuous range described by a discrete set of known values. These
+known values correspond to a uniformly-spaced range of indices
+determined by start and step values, whose defaults are 0.0 and 1.0,
+respectively.
 
-`in`, the N-D input array, is comprised of known values that will be
-used for interpolation in order to compute for values at unknown
-indices. These known values correspond to a uniformly-spaced range of
-indices determined by:
-
-- `idx_start_dim0` and `idx_step_dim0` along `interp_dim0`
-- `idx_start_dim1` and `idx_step_dim1` along `interp_dim1`
-
-`idx_start_dim0` (default: 0.0) and `idx_start_dim1` (default: 0.0) each
-define the first index value along their respective dimension.
-
-`idx_step_dim0` (default: 1.0) and `idx_step_dim1` (default: 1.0) each
-define the uniform spacing value used between subsequent indices along
-their respective dimension.
-
-`interp_dim0` (default: 0) and `interp_dim1` (default: 1), define the
-dimensions which we'd like to perform interpolation across respective
-to the input array.
-
-`pos0` and `pos1`, the positions arrays, contain indices whose values
-we want to find along corresponding dimensions `interp_dim0` and
-`interp_dim1` in the input array. Values of **known indices** will be
-looked up in the input array, while values of **unknown indices** will
-be found via interpolation. Indices outside of the index range are not
+The positions arrays (`pos0` and `pos1`) contain the interpolating
+points (indices whose values we want to find) along two given
+dimensions. Values of **known indices** will be looked up in the input
+array, while values of **unknown indices** will be found via
+interpolation. Indices outside of the index range are not
 extrapolated. Instead, those values are set to `off_grid`, whose
 default value is 0.0.
 
-`method` controls the interpolation method to be performed. All of the
-interpolation methods defined in \ref af_interp_type are supported by
-approx2(). Unless specified, linear interpolation is performed by
-default.
-
-It is not necessary to specify the start arguments (`idx_start_dim0`,
-`idx_start_dim1`), step arguments (`idx_step_dim0` and
-`idx_step_dim1`), and dimension arguments (`interp_dim0` and
-`interp_dim1`) as long as desired values match the default ones.
-
-\snippet test/approx2.cpp ex_signal_approx2
+All of the interpolation methods defined in \ref af_interp_type are
+supported by approx2. Unless specified, linear interpolation is
+performed by default.
 
 \defgroup signal_func_fir fir
 \ingroup sigfilt_mat

--- a/docs/details/signal.dox
+++ b/docs/details/signal.dox
@@ -211,53 +211,108 @@ respectively, then the possible batch operations are as follows.
 \defgroup signal_func_approx1 approx1
 \ingroup approx_mat
 
-approx1 interpolates data along a single dimension.
+approx1 interpolates data along one dimension. Interpolation computes
+for values of unknown points out of known ones.
 
-Interpolation is performed assuming input data is equally spaced with
-indices in the range [0, n). The positions are sampled with respect to
-data at these locations.
+The multi-dimensional (>=1D) input array, `in`, contains known values
+to be used for interpolation. These known values lie on a 1D
+interpolation grid - a one-dimensional, uniformly-spaced grid of
+points. Interpolation is performed to obtain values for any unknown
+points on the grid. The index values of the grid can be specified with
+the `grid_beg` and `grid_step` arguments.
 
-The dimension of the input to be interpolated may be
-specified. Otherwise, ArrayFire will perform interpolation on the
-first dimension by default.
+The position array (<=1D), `pos`, contains a combination of known and
+unkown positions/indices on the interpolation grid. The position
+array, `pos`, must be one-dimensional and must lead across the
+dimension in which the measurements will be made in the input array.
 
-The beginning and step values of the interpolation grid dimension may
-also be specified. A standard uniform grid with a start value of 0 and
-step value of 1 are assumed otherwise.
+Any unknown position/index values that lie within the interpolation
+grid range will be calculated for using interpolation. Unknown points
+that are outside of the interpolation grid range will be replaced with
+the `off_grid` value. Known points will be replaced with corresponding
+values from the input array.
 
-ArrayFire supports the following interpolation types for approx1():
+The interpolation dimension, `interp_dim`, is the leading dimension
+used to measure across the interpolation grid. Interpolation is thus
+performed along the same dimension of the input array.
+
+The uniformly-spaced one-dimensional interpolation grid on which the
+input values lie on can be adjusted with the corresponding `grid_beg`
+and `grid_step` arguments. A standard uniform interpolation grid with
+equally spaced indices in the range of [0,n) can be achieved with grid
+begin and step values of 0 and 1, respectively. A standard uniform
+grid will be used in the case that the interpolating dimension as well
+as the grid start and step values are not passed in.
+
+The type of interpolation to be performed is controlled with the
+`method` argument. The following are the different interpolation types
+supported by `approx1()`:
+
 - Nearest neighbor interpolation - \ref AF_INTERP_NEAREST
 - Linear interpolation (default) - \ref AF_INTERP_LINEAR, \ref AF_INTERP_LINEAR_COSINE
 - Cubic interpolation - \ref AF_INTERP_CUBIC, \ref AF_INTERP_CUBIC_SPLINE
 - Lower interpolation - \ref AF_INTERP_LOWER
 
-Arrayfire performs linear interpolation by default.
+Unless specified, linear interpolation is performed by default. Refer
+to \ref af_interp_type for more information about ArrayFire's
+interpolation types.
 
-ArrayFire does not perform extrapolation when out of bounds. The value
-is filled with `off_grid`, instead.
+Interpolation positions outside of the interpolation grid range are
+not extrapolated. Instead, those values default to `off_grid`, whose
+default value is 0.
 
 \snippet test/approx1.cpp ex_signal_approx1
 
 \defgroup signal_func_approx2 approx2
 \ingroup approx_mat
 
-approx2 interpolates data along two dimensions.
+approx2 interpolates data along two dimensions. Interpolation computes
+for values of unknown points out of known ones.
 
-Interpolation is performed assuming input data is equally spaced with
-indices in the range [0, n) along each dimension. The positions are
-sampled with respect to data at these locations.
+The multi-dimensional (>=2D) input array, `in`, contains known values
+to be used for interpolation. These known values lie on a 2D
+interpolation grid - a two-dimensional, uniformly-spaced grid of
+points. Interpolation is performed to obtain values for any unknown
+points on the grid. The index values of the grid can be specified with
+the `grid_beg` and `grid_step` arguments.
 
-The two dimensions of the input to be interpolated may be
-specified. Otherwise, ArrayFire will perform interpolation on the
-first and second dimensions by default.
+Two position arrays (<=2D), `pos0` and `pos1`, contain a combination
+of known and unkown positions/indices on the interpolation grid. Each
+of the position arrays must be of at most two dimensions. The index
+values for each of the position arrays is read along the dimensions
+specified by `pos0_interp_dim` and `pos1_interp_dim`, respectively.
 
-The beginning and step values of the interpolation grid dimensions may
-also be specified. A standard uniform grid with a start value of 0 and
-step value of 1 are assumed otherwise.
+Any unknown position/index values that lie within the interpolation
+grid range will be calculated for using interpolation. Unknown points
+that are outside of the interpolation grid range will be replaced with
+the `off_grid` value. Known points will be replaced with corresponding
+values from the input array.
+
+The two interpolation dimensions, `pos0_interp_dim` and
+`pos1_interp_dim`, correspond to the dimensions that the `pos0` and
+`pos1` arrays will be measured across the interpolation
+grid. Interpolation is thus performed along both specified dimensions
+of the input array.
+
+The uniformly-spaced two-dimensional interpolation grid on which the
+input values lie on can be adjusted with the corresponding grid begin
+and step arguments. A standard uniform interpolation grid with equally
+spaced indices in the range of [0,n) can be achieved with grid begin
+and step values of 0 and 1, respectively. A standard uniform grid will
+be used in the case that the interpolating dimension as well as the
+grid start and step values are not passed in.
 
 All of the interpolation types defined in \ref af_interp_type are
 supported by approx2(). ArrayFire performs linear interpolation by
 default.
+
+Unless specified, linear interpolation is performed by default. Refer
+to \ref af_interp_type for more information about ArrayFire's
+interpolation types.
+
+Interpolation positions outside of the interpolation grid range are
+not extrapolated. Instead, those values default to `off_grid`, whose
+default value is 0.
 
 \snippet test/approx2.cpp ex_signal_approx2
 

--- a/docs/details/signal.dox
+++ b/docs/details/signal.dox
@@ -211,16 +211,16 @@ respectively, then the possible batch operations are as follows.
 \defgroup signal_func_approx1 approx1
 \ingroup approx_mat
 
-approx1 interpolates data along the first dimensions.
-It has three options for the type of interpolation to perform:
-- Nearest neighbor  - \ref AF_INTERP_NEAREST
-- Linear interpolation  - \ref AF_INTERP_LINEAR
-- Bilinear interpolation - \ref AF_INTERP_BILINEAR
-- Cubic interpolation - \ref AF_INTERP_CUBIC
+approx1 interpolates data along the first dimension.
+It supports the following types of interpolation:
+- Nearest neighbor interpolation - \ref AF_INTERP_NEAREST
+- Linear interpolation  - \ref AF_INTERP_LINEAR, \ref AF_INTERP_LINEAR_COSINE
+- Cubic interpolation - \ref AF_INTERP_CUBIC, \ref AF_INTERP_CUBIC_SPLINE
+- Lower interpolation - \ref AF_INTERP_LOWER
 
-Interpolation is performed assuming input data is equally spaced with indices
-in the range [0, n). The positions are sampled with respect to data at these
-locations.
+Unless specified, interpolation is performed assuming input data is
+equally spaced with indices in the range [0, n). The positions are
+sampled with respect to data at these locations.
 
 \snippet test/approx1.cpp ex_signal_approx1
 
@@ -228,14 +228,10 @@ locations.
 \ingroup approx_mat
 
 approx2 performs interpolation on data along the first and second dimensions.
-It has three options for the type of interpolation to perform:
-- Nearest neighbor  - \ref AF_INTERP_NEAREST
-- Linear interpolation  - \ref AF_INTERP_LINEAR
-- Bilinear interpolation - \ref AF_INTERP_BILINEAR
-- Cubic interpolation - \ref AF_INTERP_CUBIC
+It supports all of the interpolation types defined in \ref af_interp_type.
 
-Interpolation is performed assuming input data is equally spaced with indices
-in the range [0, n) along each dimension.
+Unless specified, interpolation is performed assuming input data is
+equally spaced with indices in the range [0, n) along each dimension.
 The positions are sampled with respect to data at these locations.
 
 \snippet test/approx2.cpp ex_signal_approx2

--- a/docs/details/signal.dox
+++ b/docs/details/signal.dox
@@ -213,46 +213,53 @@ respectively, then the possible batch operations are as follows.
 
 approx1 interpolates data along a single dimension.
 
-approx1 is responsible for interpolating data `yi` at `xo` points,
-with the interpolated data being returned by the function. The `xdim`
-argument is used to select which dimension to interpolate
-across. Otherwise, the first dimension is interpolated by default.
+Interpolation is performed assuming input data is equally spaced with
+indices in the range [0, n). The positions are sampled with respect to
+data at these locations.
 
-Unless specified, interpolation is performed assuming input data is
-equally spaced with indices in the range [0, n). The positions are
-sampled with respect to data at these locations.
+The dimension of the input to be interpolated may be
+specified. Otherwise, ArrayFire will perform interpolation on the
+first dimension by default.
 
-The following interpolation types are supported for approx1:
+The beginning and step values of the interpolation grid dimension may
+also be specified. A standard uniform grid with a start value of 0 and
+step value of 1 are assumed otherwise.
+
+ArrayFire supports the following interpolation types for approx1():
 - Nearest neighbor interpolation - \ref AF_INTERP_NEAREST
-- Linear interpolation  - \ref AF_INTERP_LINEAR, \ref AF_INTERP_LINEAR_COSINE
+- Linear interpolation (default) - \ref AF_INTERP_LINEAR, \ref AF_INTERP_LINEAR_COSINE
 - Cubic interpolation - \ref AF_INTERP_CUBIC, \ref AF_INTERP_CUBIC_SPLINE
 - Lower interpolation - \ref AF_INTERP_LOWER
 
-\snippet test/approx1.cpp ex_signal_approx1
+Arrayfire performs linear interpolation by default.
 
-\snippet test/approx1.cpp ex_uniform_approx1
+ArrayFire does not perform extrapolation when out of bounds. The value
+is filled with `off_grid`, instead.
+
+\snippet test/approx1.cpp ex_signal_approx1
 
 \defgroup signal_func_approx2 approx2
 \ingroup approx_mat
 
-approx2 interpolates data on two dimensions.
+approx2 interpolates data along two dimensions.
 
-approx2 is responsible for interpolating data `zi` at `xo` and `yo`
-points, with the interpolated data being returned by the function. The
-`xdim` and `ydim` arguments specify which dimensions were measured
-first and second, respectively. Otherwise, the first dimension and
-second dimensions are selected by default.
+Interpolation is performed assuming input data is equally spaced with
+indices in the range [0, n) along each dimension. The positions are
+sampled with respect to data at these locations.
 
-Unless specified, interpolation is performed assuming input data is
-equally spaced with indices in the range [0, n) along each dimension.
-The positions are sampled with respect to data at these locations.
+The two dimensions of the input to be interpolated may be
+specified. Otherwise, ArrayFire will perform interpolation on the
+first and second dimensions by default.
+
+The beginning and step values of the interpolation grid dimensions may
+also be specified. A standard uniform grid with a start value of 0 and
+step value of 1 are assumed otherwise.
 
 All of the interpolation types defined in \ref af_interp_type are
-supported by approx2.
+supported by approx2(). ArrayFire performs linear interpolation by
+default.
 
 \snippet test/approx2.cpp ex_signal_approx2
-
-\snippet test/approx2.cpp ex_uniform_approx2
 
 \defgroup signal_func_fir fir
 \ingroup sigfilt_mat

--- a/docs/details/signal.dox
+++ b/docs/details/signal.dox
@@ -211,42 +211,42 @@ respectively, then the possible batch operations are as follows.
 \defgroup signal_func_approx1 approx1
 \ingroup approx_mat
 
-approx1 interpolates data along one dimension. Interpolation computes
-for values of unknown points out of known ones.
+Performs interpolation on data along a single dimension.
 
-The multi-dimensional (>=1D) input array, `in`, contains known values
-to be used for interpolation. These known values lie on a 1D
-interpolation grid - a one-dimensional, uniformly-spaced grid of
-points. Interpolation is performed to obtain values for any unknown
-points on the grid. The index values of the grid can be specified with
-the `grid_beg` and `grid_step` arguments.
+Interpolation is the process of computing for unknown values within a
+continuous range described by a discrete set of known values.
 
-The position array (<=1D), `pos`, contains a combination of known and
-unkown positions/indices on the interpolation grid. The position
-array, `pos`, must be one-dimensional and must lead across the
-dimension in which the measurements will be made in the input array.
+`in`, the N-D input array, is comprised of known values that will be
+used for interpolation in order to compute for values at unknown
+indices. These known values correspond to a uniformly-spaced range of
+indices determined by `idx_start`, `idx_step`.
 
-Any unknown position/index values that lie within the interpolation
-grid range will be calculated for using interpolation. Unknown points
-that are outside of the interpolation grid range will be replaced with
-the `off_grid` value. Known points will be replaced with corresponding
-values from the input array.
+`idx_start` (default: 0.0) defines the first index in the range.
 
-The interpolation dimension, `interp_dim`, is the leading dimension
-used to measure across the interpolation grid. Interpolation is thus
-performed along the same dimension of the input array.
+`idx_step` (default: 1.0) defines the uniform spacing value used
+between subsequent indices.
 
-The uniformly-spaced one-dimensional interpolation grid on which the
-input values lie on can be adjusted with the corresponding `grid_beg`
-and `grid_step` arguments. A standard uniform interpolation grid with
-equally spaced indices in the range of [0,n) can be achieved with grid
-begin and step values of 0 and 1, respectively. A standard uniform
-grid will be used in the case that the interpolating dimension as well
-as the grid start and step values are not passed in.
+`interp_dim` (default: 0) defines the dimension which we'd like to
+perform interpolation across respective to the input array.
 
-The type of interpolation to be performed is controlled with the
-`method` argument. The following are the different interpolation types
-supported by `approx1()`:
+`pos`, the positions array, contains indices whose values we want to
+find along corresponding dimension `interp_dim` in the input
+array. Values of **known indices** will be looked up in the input
+array, while values of **unknown indices** will be found via
+interpolation. Indices outside of the index range are not
+extrapolated. Instead, those values are set to `off_grid`, whose
+default value is 0.0.
+
+Using the default start and step values,
+
+\image html approx1_default_idx.png "approx1() using idx_start=0.0, idx_step=1.0"
+
+If instead, we chose 10 for start and step,
+
+\image html approx1_arbitrary_idx.png "approx1() using idx_start=10.0, idx_step=10.0"
+
+`method` controls the interpolation method to be performed. Several
+interpolation methods are supported by `approx1()`:
 
 - Nearest neighbor interpolation - \ref AF_INTERP_NEAREST
 - Linear interpolation (default) - \ref AF_INTERP_LINEAR, \ref AF_INTERP_LINEAR_COSINE
@@ -257,62 +257,57 @@ Unless specified, linear interpolation is performed by default. Refer
 to \ref af_interp_type for more information about ArrayFire's
 interpolation types.
 
-Interpolation positions outside of the interpolation grid range are
-not extrapolated. Instead, those values default to `off_grid`, whose
-default value is 0.
+It is not necessary to specify the `idx_start`, `idx_step`, and
+`interp_dim` as long as desired values match the default ones.
 
 \snippet test/approx1.cpp ex_signal_approx1
 
 \defgroup signal_func_approx2 approx2
 \ingroup approx_mat
 
-approx2 interpolates data along two dimensions. Interpolation computes
-for values of unknown points out of known ones.
+Performs interpolation on data along two dimensions.
 
-The multi-dimensional (>=2D) input array, `in`, contains known values
-to be used for interpolation. These known values lie on a 2D
-interpolation grid - a two-dimensional, uniformly-spaced grid of
-points. Interpolation is performed to obtain values for any unknown
-points on the grid. The index values of the grid can be specified with
-the `grid_beg` and `grid_step` arguments.
+Interpolation is the process of computing for unknown values within a
+continuous range described by a discrete set of known values. For 2D
+interpolation, two sets of values, indices, and interpolation
+dimensions are necessary.
 
-Two position arrays (<=2D), `pos0` and `pos1`, contain a combination
-of known and unkown positions/indices on the interpolation grid. Each
-of the position arrays must be of at most two dimensions. The index
-values for each of the position arrays is read along the dimensions
-specified by `pos0_interp_dim` and `pos1_interp_dim`, respectively.
+`in`, the N-D input array, is comprised of known values that will be
+used for interpolation in order to compute for values at unknown
+indices. These known values correspond to a uniformly-spaced range of
+indices determined by:
 
-Any unknown position/index values that lie within the interpolation
-grid range will be calculated for using interpolation. Unknown points
-that are outside of the interpolation grid range will be replaced with
-the `off_grid` value. Known points will be replaced with corresponding
-values from the input array.
+- `idx_start_dim0` and `idx_step_dim0` along `interp_dim0`
+- `idx_start_dim1` and `idx_step_dim1` along `interp_dim1`
 
-The two interpolation dimensions, `pos0_interp_dim` and
-`pos1_interp_dim`, correspond to the dimensions that the `pos0` and
-`pos1` arrays will be measured across the interpolation
-grid. Interpolation is thus performed along both specified dimensions
-of the input array.
+`idx_start_dim0` (default: 0.0) and `idx_start_dim1` (default: 0.0) each
+define the first index value along their respective dimension.
 
-The uniformly-spaced two-dimensional interpolation grid on which the
-input values lie on can be adjusted with the corresponding grid begin
-and step arguments. A standard uniform interpolation grid with equally
-spaced indices in the range of [0,n) can be achieved with grid begin
-and step values of 0 and 1, respectively. A standard uniform grid will
-be used in the case that the interpolating dimension as well as the
-grid start and step values are not passed in.
+`idx_step_dim0` (default: 1.0) and `idx_step_dim1` (default: 1.0) each
+define the uniform spacing value used between subsequent indices along
+their respective dimension.
 
-All of the interpolation types defined in \ref af_interp_type are
-supported by approx2(). ArrayFire performs linear interpolation by
+`interp_dim0` (default: 0) and `interp_dim1` (default: 1), define the
+dimensions which we'd like to perform interpolation across respective
+to the input array.
+
+`pos0` and `pos1`, the positions arrays, contain indices whose values
+we want to find along corresponding dimensions `interp_dim0` and
+`interp_dim1` in the input array. Values of **known indices** will be
+looked up in the input array, while values of **unknown indices** will
+be found via interpolation. Indices outside of the index range are not
+extrapolated. Instead, those values are set to `off_grid`, whose
+default value is 0.0.
+
+`method` controls the interpolation method to be performed. All of the
+interpolation methods defined in \ref af_interp_type are supported by
+approx2(). Unless specified, linear interpolation is performed by
 default.
 
-Unless specified, linear interpolation is performed by default. Refer
-to \ref af_interp_type for more information about ArrayFire's
-interpolation types.
-
-Interpolation positions outside of the interpolation grid range are
-not extrapolated. Instead, those values default to `off_grid`, whose
-default value is 0.
+It is not necessary to specify the start arguments (`idx_start_dim0`,
+`idx_start_dim1`), step arguments (`idx_step_dim0` and
+`idx_step_dim1`), and dimension arguments (`interp_dim0` and
+`interp_dim1`) as long as desired values match the default ones.
 
 \snippet test/approx2.cpp ex_signal_approx2
 

--- a/docs/details/signal.dox
+++ b/docs/details/signal.dox
@@ -213,6 +213,11 @@ respectively, then the possible batch operations are as follows.
 
 approx1 interpolates data along a single dimension.
 
+approx1 is responsible for interpolating data `yi` at `xo` points,
+with the interpolated data being returned by the function. The `xdim`
+argument is used to select which dimension to interpolate
+across. Otherwise, the first dimension is interpolated by default.
+
 Unless specified, interpolation is performed assuming input data is
 equally spaced with indices in the range [0, n). The positions are
 sampled with respect to data at these locations.
@@ -231,6 +236,12 @@ The following interpolation types are supported for approx1:
 \ingroup approx_mat
 
 approx2 interpolates data on two dimensions.
+
+approx2 is responsible for interpolating data `zi` at `xo` and `yo`
+points, with the interpolated data being returned by the function. The
+`xdim` and `ydim` arguments specify which dimensions were measured
+first and second, respectively. Otherwise, the first dimension and
+second dimensions are selected by default.
 
 Unless specified, interpolation is performed assuming input data is
 equally spaced with indices in the range [0, n) along each dimension.

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -21,10 +21,14 @@ class dim4;
    C++ Interface for data interpolation on one-dimensional signals.
 
    \param[in]  in is the multidimensional input array. Values assumed to lie uniformly spaced indices in the range of `[0, n)`, where `n` is the number of elements in the array.
-   \param[in]  pos is the positions array.
+   \param[in]  pos positions of the interpolation points along the first dimension.
    \param[in]  method is the interpolation method to be used. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
    \param[in]  off_grid is the default value for any indices outside the valid range of indices.
    \returns    the interpolated array.
+
+   The code sample below demonstrates approx1()'s usage:
+
+   \snippet test/approx1.cpp ex_signal_approx1
 
    \ingroup signal_func_approx1
  */
@@ -35,11 +39,15 @@ AFAPI array approx1(const array &in, const array &pos,
    C++ Interface for data interpolation on two-dimensional signals.
 
    \param[in]  in is the multidimensional input array. Values assumed to lie uniformly spaced indices in the range of `[0, n)` along both interpolation dimensions. `n` is the number of elements in the array.
-   \param[in]  pos0 is the first positions array.
-   \param[in]  pos1 is the second positions array.
+   \param[in]  pos0 positions of the interpolation points along the first dimension.
+   \param[in]  pos1 positions of the interpolation points along the second dimension.
    \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
    \param[in]  off_grid is the default value for any indices outside the valid range of indices.
    \returns    the interpolated array.
+
+   The code sample below demonstrates approx2()'s usage:
+
+   \snippet test/approx2.cpp ex_signal_approx2
 
    \ingroup signal_func_approx2
  */
@@ -51,14 +59,31 @@ AFAPI array approx2(const array &in, const array &pos0, const array &pos1,
 /**
    C++ Interface for data interpolation on one-dimensional signals.
 
+   The following version of approx1() accepts the dimension to perform
+   the interpolation along the input. It also accepts start and step
+   values which define the uniform range of corresponding indices.
+
+   The following image illustrates what the range of indices
+   corresponding to the input values look like if `idx_start` and
+   `idx_step` are set to an arbitrary value of 10,
+
+   \image html approx1_arbitrary_idx.png "approx1() using idx_start=10.0, idx_step=10.0"
+
+   The blue dots represent indices whose values are known. The red dots
+   represent indices whose values are unknown.
+
    \param[in]  in is the multidimensional input array. Values lie on uniformly spaced indices determined by `idx_start` and `idx_step`.
-   \param[in]  pos is the positions array.
+   \param[in]  pos positions of the interpolation points along `interp_dim`.
    \param[in]  interp_dim is the dimension to perform interpolation across.
    \param[in]  idx_start is the first index value along `interp_dim`.
    \param[in]  idx_step is the uniform spacing value between subsequent indices along `interp_dim`.
    \param[in]  method is the interpolation method to be used. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
    \param[in]  off_grid is the default value for any indices outside the valid range of indices.
    \returns    the interpolated array.
+
+   The code sample below demonstrates usage:
+
+   \snippet test/approx1.cpp ex_signal_approx1_uniform
 
    \ingroup signal_func_approx1
  */
@@ -70,18 +95,27 @@ AFAPI array approx1(const array &in,
 /**
    C++ Interface for data interpolation on two-dimensional signals.
 
+   The following version of the approx2() accepts the two dimensions
+   to perform the interpolation along the input. It also accepts start
+   and step values which define the uniform range of corresponding
+   indices.
+
    \param[in]  in is the multidimensional input array.
-   \param[in]  pos0 is the first positions array.
+   \param[in]  pos0 positions of the interpolation points along `interp_dim0`.
    \param[in]  interp_dim0 is the first dimension to perform interpolation across.
    \param[in]  idx_start_dim0 is the first index value along `interp_dim0`.
    \param[in]  idx_step_dim0 is the uniform spacing value between subsequent indices along `interp_dim0`.
-   \param[in]  pos1 is the second positions array.
+   \param[in]  pos1 positions of the interpolation points along `interp_dim1`.
    \param[in]  interp_dim1 is the second dimension to perform interpolation across.
    \param[in]  idx_start_dim1 is the first index value along `interp_dim1`.
    \param[in]  idx_step_dim1 is the uniform spacing value between subsequent indices along `interp_dim1`.
    \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
    \param[in]  off_grid is the default value for any indices outside the valid range of indices.
    \returns    the interpolated array.
+
+   The code sample below demonstrates usage:
+
+   \snippet test/approx2.cpp ex_signal_approx2_uniform
 
    \ingroup signal_func_approx2
  */
@@ -721,7 +755,7 @@ extern "C" {
 
    \param[out] out the interpolated array.
    \param[in]  in is the multidimensional input array. Values assumed to lie uniformly spaced indices in the range of `[0, n)`, where `n` is the number of elements in the array.
-   \param[in]  pos is the positions array.
+   \param[in]  pos positions of the interpolation points along the first dimension.
    \param[in]  method is the interpolation method to be used. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
    \param[in]  off_grid is the default value for any indices outside the valid range of indices.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
@@ -737,8 +771,8 @@ AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
 
    \param[out] out the interpolated array.
    \param[in]  in is the multidimensional input array. Values assumed to lie uniformly spaced indices in the range of `[0, n)` along both interpolation dimensions. `n` is the number of elements in the array.
-   \param[in]  pos0 is the first positions array.
-   \param[in]  pos1 is the second positions array.
+   \param[in]  pos0 positions of the interpolation points along the first dimension.
+   \param[in]  pos1 positions of the interpolation points along the second dimension.
    \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
    \param[in]  off_grid is the default value for any indices outside the valid range of indices.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
@@ -753,9 +787,22 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
 /**
    C Interface for signals interpolation on one dimensional signals along specified dimension.
 
+   af_approx1_uniform() accepts the dimension to perform the
+   interpolation along the input. It also accepts start and step
+   values which define the uniform range of corresponding indices.
+
+   The following image illustrates what the range of indices
+   corresponding to the input values look like if `idx_start` and
+   `idx_step` are set to an arbitrary value of 10,
+
+   \image html approx1_arbitrary_idx.png "approx1() using idx_start=10.0, idx_step=10.0"
+
+   The blue dots represent indices whose values are known. The red dots
+   represent indices whose values are unknown.
+
    \param[out] out the interpolated array.
    \param[in]  in is the multidimensional input array. Values lie on uniformly spaced indices determined by `idx_start` and `idx_step`.
-   \param[in]  pos is the positions array.
+   \param[in]  pos positions of the interpolation points along `interp_dim`.
    \param[in]  interp_dim is the dimension to perform interpolation across.
    \param[in]  idx_start is the first index value along `interp_dim`.
    \param[in]  idx_step is the uniform spacing value between subsequent indices along `interp_dim`.
@@ -774,13 +821,17 @@ AFAPI af_err af_approx1_uniform(af_array *out, const af_array in,
 /**
    C Interface for signals interpolation on two dimensional signals alog specified dimensions.
 
+   af_approx2_uniform() accepts two dimensions to perform the
+   interpolation along the input. It also accepts start and step
+   values which define the uniform range of corresponding indices.
+
    \param[out] out the interpolated array.
    \param[in]  in is the multidimensional input array.
-   \param[in]  pos0 is the first positions array.
+   \param[in]  pos0 positions of the interpolation points along `interp_dim0`.
    \param[in]  interp_dim0 is the first dimension to perform interpolation across.
    \param[in]  idx_start_dim0 is the first index value along `interp_dim0`.
    \param[in]  idx_step_dim0 is the uniform spacing value between subsequent indices along `interp_dim0`.
-   \param[in]  pos1 is the second positions array.
+   \param[in]  pos1 positions of the interpolation points along `interp_dim1`.
    \param[in]  interp_dim1 is the second dimension to perform interpolation across.
    \param[in]  idx_start_dim1 is the first index value along `interp_dim1`.
    \param[in]  idx_step_dim1 is the uniform spacing value between subsequent indices along `interp_dim1`.

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -20,10 +20,10 @@ class dim4;
 /**
    C++ Interface for data interpolation on one-dimensional signals.
 
-   \param[in]  in is the input array. Data assumed to be equally spaced with indices in the range of [0, n).
-   \param[in]  pos array contains the interpolation positions.
-   \param[in]  method is the interpolation type. The following types (defined in enum \ref af_interp_type) can be used: nearest neighbor, linear, and cubic.
-   \param[in]  off_grid is the value that will be set in the output array for any indices that are out of bounds.
+   \param[in]  in Input array containing known values to perform interpolation on. Interpolation grid assumed to be uniformly spaced with indices in the range of `[0, n)`, where `n` is the number of elements in the array.
+   \param[in]  pos Contains known and unkown positions along the first dimension of the interpolation grid. Unknown values will be calculated for using interpolation.
+   \param[in]  method Interpolation type. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
+   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
    \return     The interpolated array.
 
    \ingroup signal_func_approx1
@@ -34,11 +34,11 @@ AFAPI array approx1(const array &in, const array &pos,
 /**
    C++ Interface for data interpolation on two-dimensional signals.
 
-   \param[in]  in is the input array. Data assumed to be equally spaced with indices in the range of [0, n) along both dimensions to interpolate across..
-   \param[in]  pos0 array contains the interpolation positions for first dimension.
-   \param[in]  pos1 array contains the interpolation positions for second dimension.
-   \param[in]  method is the interpolation type. All interpolation types defined in \ref af_interp_type are supported.
-   \param[in]  off_grid is the value that will be set in the output array for any indices that are out of bounds.
+   \param[in]  in Input array containing known values to perform interpolation on. Must be of at least two dimensions. Interpolation grid assumed to be uniformly spaced with indices in the range of `[0, n)` across both dimension, where `n` is the number of elements in the array.
+   \param[in]  pos0 Contains known and unkown positions along the first dimension of the interpolation grid. Unknown values will be calculated for using interpolation.
+   \param[in]  pos1 Contains known and unkown positions along the second dimension of the interpolation grid. Unknown values will be calculated for using interpolation.
+   \param[in]  method Interpolation type. All interpolation types defined in \ref af_interp_type are supported.
+   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
    \return     The interpolated array.
 
    \ingroup signal_func_approx2
@@ -51,36 +51,36 @@ AFAPI array approx2(const array &in, const array &pos0, const array &pos1,
 /**
    C++ Interface for data interpolation on one-dimensional signals.
 
-   \param[in]  in is the input array.
-   \param[in]  pos array contains the interpolation positions.
+   \param[in]  in Input array containing known values to perform interpolation on. The interpolation grid on which these points lie on are controlled by the `grid_beg` and `grid_step` arguments.
+   \param[in]  pos Contains known and unkown positions from the interpolation grid along the dimension specified by `interp_dim`.
    \param[in]  interp_dim Specifies the dimension along which measurements were made.
-   \param[in]  grid_beg Initial value of the grid on which original values were measured.
-   \param[in]  grid_step Step size of the grid on which original values were measured.
-   \param[in]  method is the interpolation type. The following types (defined in enum \ref af_interp_type) can be used: nearest neighbor, linear, and cubic.
-   \param[in]  off_grid is the value that will be set in the output array for any indices that are out of bounds.
+   \param[in]  interp_grid_beg Initial value of the grid on which original values were measured.
+   \param[in]  interp_grid_step Step size of the grid on which original values were measured.
+   \param[in]  method Interpolation type. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
+   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
    \return     The interpolated array.
 
    \ingroup signal_func_approx1
  */
 AFAPI array approx1(const array &in,
                     const array &pos, const int interp_dim,
-                    const double grid_beg, const double grid_step,
+                    const double interp_grid_beg, const double interp_grid_step,
                     const interpType method = AF_INTERP_LINEAR, const float off_grid = 0.0f);
 
 /**
    C++ Interface for data interpolation on two-dimensional signals.
 
-   \param[in]  in is the input array.
-   \param[in]  pos0 array contains the interpolation positions along the first dimension.
+   \param[in]  in Input array containing known values to perform interpolation on. Must be of at least two dimensions. The interpolation grid on which these points lie on are controlled by the `grid_beg` and `grid_step` arguments.
+   \param[in]  pos0 Contains known and unknown positions along the first dimension of the interpolation grid, specified by `pos0_interp_grid_dim`.
    \param[in]  pos0_interp_dim Specifies the first dimension along which measurements were made.
    \param[in]  pos0_interp_grid_beg Initial value of the grid on which original values were measured for the first dimension.
    \param[in]  pos0_interp_grid_step Step size of the grid on which original values were measured for the first dimension.
-   \param[in]  pos1 array contains the interpolation positions along the second dimension.
+   \param[in]  pos1 Contains known and unknown positions along the second dimension of the interpolation grid, specified by `pos1_interp_grid_dim`.
    \param[in]  pos1_interp_dim Specifies the second dimension along which measurements were made.
    \param[in]  pos1_interp_grid_beg Initial value of the grid on which original values were measured for the second dimension.
    \param[in]  pos1_interp_grid_step Step size of the grid on which original values were measured for the second dimension.
-   \param[in]  method is the interpolation type. All interpolation types defined in \ref af_interp_type are supported.
-   \param[in]  off_grid is the value that will be set in the output array for any indices that are out of bounds.
+   \param[in]  method Interpolation type. All interpolation types defined in \ref af_interp_type are supported.
+   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
    \return     The interpolated array.
 
    \ingroup signal_func_approx2
@@ -719,12 +719,11 @@ extern "C" {
 /**
    C Interface for signals interpolation on one dimensional signals.
 
-   \param[out] out is the array with interpolated values.
-   \param[in]  in is the input array.
-   \param[in]  pos array contains the interpolation positions.
-   \param[in]  method is the interpolation type, it can take one of the values defined by the
-               enum \ref af_interp_type.
-   \param[in]  off_grid is the value that will set in the output array when certain index is out of bounds.
+   \param[out] out The interpolated array.
+   \param[in]  in Input array containing known values to perform interpolation on. Interpolation grid assumed to be uniformly spaced with indices in the range of `[0, n)`, where `n` is the number of elements in the array.
+   \param[in]  pos Contains known and unkown positions along the first dimension of the interpolation grid. Unknown values will be calculated for using interpolation.
+   \param[in]  method method Interpolation type. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
+   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
                otherwise an appropriate error code is returned.
 
@@ -736,13 +735,12 @@ AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
 /**
    C Interface for signals interpolation on two dimensional signals.
 
-   \param[out] out is the array with interpolated values.
-   \param[in]  in is the input array.
-   \param[in]  pos0 array contains the interpolation positions for first dimension.
-   \param[in]  pos1 array contains the interpolation positions for second dimension.
-   \param[in]  method is the interpolation type, it can take one of the values defined by the
-               enum \ref af_interp_type.
-   \param[in]  off_grid is the value that will set in the output array when certain index is out of bounds.
+   \param[out] out The interpolated array.
+   \param[in]  in in Input array containing known values to perform interpolation on. Must be of at least two dimensions. Interpolation grid assumed to be uniformly spaced with indices in the range of `[0, n)` across both dimension, where `n` is the number of elements in the array.
+   \param[in]  pos0 Contains known and unkown positions along the first dimension of the interpolation grid. Unknown values will be calculated for using interpolation.
+   \param[in]  pos1 Contains known and unkown positions along the second dimension of the interpolation grid. Unknown values will be calculated for using interpolation.
+   \param[in]  method Interpolation type. All interpolation types defined in \ref af_interp_type are supported.
+   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
                otherwise an appropriate error code is returned.
 
@@ -755,15 +753,14 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
 /**
    C Interface for signals interpolation on one dimensional signals along specified dimension.
 
-   \param[out] out is the array with interpolated values.
-   \param[in]  in is the array containing the measured / reference values.
-   \param[in]  pos array containining the interpolation positions.
-   \param[in]  interp_dim The dimension along which measurements were made.
-   \param[in]  pos0_interp_grid_beg Initial value of the grid on which the original values were measured.
-   \param[in]  pos0_interp_grid_step Step size of the grid on which the original values were measured.
-   \param[in]  method is the interpolation type, it can take one of the values defined by the
-               enum \ref af_interp_type.
-   \param[in]  off_grid is the value that will set in the output array when certain index is out of bounds.
+   \param[out] out The interpolated array.
+   \param[in]  in Input array containing known values to perform interpolation on. The interpolation grid on which these points lie on are controlled by the `grid_beg` and `grid_step` arguments.
+   \param[in]  pos Contains known and unkown positions from the interpolation grid along the dimension specified by `interp_dim`.
+   \param[in]  interp_dim Specifies the dimension along which measurements were made.
+   \param[in]  interp_grid_beg Initial value of the grid on which the original values were measured.
+   \param[in]  interp_grid_step Step size of the grid on which the original values were measured.
+   \param[in]  method Interpolation type. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
+   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
                otherwise an appropriate error code is returned.
 
@@ -771,25 +768,24 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
  */
 AFAPI af_err af_approx1_uniform(af_array *out, const af_array in,
                                 const af_array pos, const int interp_dim,
-                                const double pos0_interp_grid_beg, const double pos0_interp_grid_step,
+                                const double interp_grid_beg, const double interp_grid_step,
                                 const af_interp_type method, const float off_grid);
 
 /**
    C Interface for signals interpolation on two dimensional signals alog specified dimensions.
 
-   \param[out] out is the array with interpolated values.
-   \param[in]  in is the array containing the measured / reference values.
-   \param[in]  pos0 array containining the interpolation positions.
-   \param[in]  pos0_interp_dim The dimension along which the interpolation needs to occur.
-   \param[in]  pos0_interp_grid_beg Initial value of the grid on which the original values were measured.
-   \param[in]  pos0_interp_grid_step Step size of the grid on which the original values were measured.
-   \param[in]  pos1 array containining the interpolation positions.
-   \param[in]  pos1_interp_dim The dimension along which the interpolation needs to occur.
-   \param[in]  pos1_interp_grid_beg Initial value of the grid on which the original values were measured.
-   \param[in]  pos1_interp_grid_step Step size of the grid on which the original values were measured.
-   \param[in]  method is the interpolation type, it can take one of the values defined by the
-               enum \ref af_interp_type.
-   \param[in]  off_grid is the value that will set in the output array when certain index is out of bounds.
+   \param[out] out The interpolated array.
+   \param[in]  in Input array containing known values to perform interpolation on. Must be of at least two dimensions. The interpolation grid on which these points lie on are controlled by the `grid_beg` and `grid_step` arguments.
+   \param[in]  pos0 Contains known and unknown positions along the first dimension of the interpolation grid, specified by `pos0_interp_dim`.
+   \param[in]  pos0_interp_dim Specifies the second dimension along which measurements were made.
+   \param[in]  pos0_interp_grid_beg Initial value of the grid on which original values were measured for the first dimension.
+   \param[in]  pos0_interp_grid_step Step size of the grid on which original values were measured for the first dimension.
+   \param[in]  pos1 Contains known and unknown positions along the second dimension of the interpolation grid, specified by `pos1_interp_dim`.
+   \param[in]  pos1_interp_dim Specifies the second dimension along which measurements were made.
+   \param[in]  pos1_interp_grid_beg Initial value of the grid on which original values were measured for the second dimension.
+   \param[in]  pos1_interp_grid_step Step size of the grid on which original values were measured for the second dimension.
+   \param[in]  method Interpolation type. All interpolation types defined in \ref af_interp_type are supported.
+   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
                otherwise an appropriate error code is returned.
 

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -20,8 +20,8 @@ class dim4;
 /**
    C++ Interface for data interpolation on one dimensional signals.
 
-   \param[in]  in is the input array
-   \param[in]  pos array contains the interpolation locations
+   \param[in]  yi is the input array
+   \param[in]  xo array contains the interpolation locations
    \param[in]  method is the interpolation type, it can take one of the values defined by the
                enum \ref af_interp_type
    \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
@@ -29,15 +29,15 @@ class dim4;
 
    \ingroup signal_func_approx1
  */
-AFAPI array approx1(const array &in, const array &pos,
+AFAPI array approx1(const array &yi, const array &xo,
                     const interpType method = AF_INTERP_LINEAR, const float offGrid = 0.0f);
 
 /**
    C++ Interface for data interpolation on two dimensional signals.
 
-   \param[in]  in is the input array
-   \param[in]  pos0 array contains the interpolation locations for first dimension
-   \param[in]  pos1 array contains the interpolation locations for second dimension
+   \param[in]  zi is the input array
+   \param[in]  xo array contains the interpolation locations for first dimension
+   \param[in]  yo array contains the interpolation locations for second dimension
    \param[in]  method is the interpolation type, it can take one of the values defined by the
                enum \ref af_interp_type
    \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
@@ -45,8 +45,51 @@ AFAPI array approx1(const array &in, const array &pos,
 
    \ingroup signal_func_approx2
  */
-AFAPI array approx2(const array &in, const array &pos0, const array &pos1,
+AFAPI array approx2(const array &zi, const array &xo, const array &yo,
                     const interpType method = AF_INTERP_LINEAR, const float offGrid = 0.0f);
+
+
+#if AF_API_VERSION >= 36
+/**
+   C++ Interface for data interpolation on one dimensional signals
+
+   \param[in]  yi is the input array
+   \param[in]  xo array contains the interpolation locations
+   \param[in]  xdim Specifies the dimension along with measurements were made.
+   \param[in]  xi_beg Initial value of the grid on which original values were measured.
+   \param[in]  xi_step Step size of the grid on which original values were measured.
+   \param[in]  method is the interpolation type, it can take one of the values defined by the
+               enum \ref af_interp_type
+   \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
+   \return     the array with interpolated values
+
+   \ingroup signal_func_approx1
+ */
+AFAPI array approx1(const array &yi,
+                    const array &xo, const int xdim,
+                    const double xi_beg, const double xi_step,
+                    const interpType method = AF_INTERP_LINEAR, const float offGrid = 0.0f);
+
+/**
+   C++ Interface for data interpolation on two dimensional signals
+
+   \param[in]  zi is the input array
+   \param[in]  xo array contains the interpolation locations for first dimension
+   \param[in]  yo array contains the interpolation locations for second dimension
+   \param[in]  method is the interpolation type, it can take one of the values defined by the
+               enum \ref af_interp_type
+   \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
+   \return     the array with interpolated values
+
+   \ingroup signal_func_approx2
+ */
+AFAPI array approx2(const array &zi,
+                    const array &xo, const int xdim,
+                    const array &yo, const int ydim,
+                    const double xi_beg, const double xi_step,
+                    const double yi_beg, const double yi_step,
+                    const interpType method = AF_INTERP_LINEAR, const float offGrid = 0.0f);
+#endif
 
 /**
    C++ Interface for fast fourier transform on one dimensional signals
@@ -676,9 +719,9 @@ extern "C" {
 /**
    C Interface for signals interpolation on one dimensional signals.
 
-   \param[out] out is the array with interpolated values
-   \param[in]  in is the input array
-   \param[in]  pos array contains the interpolation locations
+   \param[out] yo is the array with interpolated values
+   \param[in]  yi is the input array
+   \param[in]  xo array contains the interpolation locations
    \param[in]  method is the interpolation type, it can take one of the values defined by the
                enum \ref af_interp_type
    \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
@@ -687,16 +730,16 @@ extern "C" {
 
    \ingroup signal_func_approx1
  */
-AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
+AFAPI af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
                         const af_interp_type method, const float offGrid);
 
 /**
    C Interface for signals interpolation on two dimensional signals.
 
-   \param[out] out is the array with interpolated values
-   \param[in]  in is the input array
-   \param[in]  pos0 array contains the interpolation locations for first dimension
-   \param[in]  pos1 array contains the interpolation locations for second dimension
+   \param[out] zo is the array with interpolated values
+   \param[in]  zi is the input array
+   \param[in]  xo array contains the interpolation locations for first dimension
+   \param[in]  yo array contains the interpolation locations for second dimension
    \param[in]  method is the interpolation type, it can take one of the values defined by the
                enum \ref af_interp_type
    \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
@@ -705,8 +748,60 @@ AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
 
    \ingroup signal_func_approx2
  */
-AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, const af_array pos1,
+AFAPI af_err af_approx2(af_array *zo, const af_array zi, const af_array xo, const af_array yo,
                         const af_interp_type method, const float offGrid);
+
+#if AF_API_VERSION >= 36
+/**
+   C Interface for signals interpolation on one dimensional signals along specified dimension.
+
+   \param[out] yo is the array with interpolated values.
+   \param[in]  yi is the array containing the measured / reference values.
+   \param[in]  xo array containining the interpolation locations.
+   \param[in]  dim The dimension along the measurements were made.
+   \param[in]  xi_beg Initial value of the grid on which the original values were measured.
+   \param[in]  xi_step Step size of the grid on which the original values were measured.
+   \param[in]  method is the interpolation type, it can take one of the values defined by the
+               enum \ref af_interp_type
+   \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
+   \return     \ref AF_SUCCESS if the interpolation operation is successful,
+               otherwise an appropriate error code is returned.
+
+   \ingroup signal_func_approx1
+ */
+AFAPI af_err af_approx1_uniform(af_array *yo, const af_array yi,
+                                const af_array xo, const int xdim,
+                                const double xi_beg, const double xi_step,
+                                const af_interp_type method, const float offGrid);
+
+/**
+   C Interface for signals interpolation on two dimensional signals alog specified dimensions.
+
+   \param[out] zo is the array with interpolated values.
+   \param[in]  zi is the array containing the measured / reference values.
+   \param[in]  xo array containining the interpolation locations.
+   \param[in]  yo array containining the interpolation locations.
+   \param[in]  xdim The dimension along which the interpolation needs to occur.
+   \param[in]  ydim The dimension along which the interpolation needs to occur.
+   \param[in]  xi_beg Initial value of the grid on which the original values were measured.
+   \param[in]  xi_step Step size of the grid on which the original values were measured.
+   \param[in]  yi_beg Initial value of the grid on which the original values were measured.
+   \param[in]  yi_step Step size of the grid on which the original values were measured.
+   \param[in]  method is the interpolation type, it can take one of the values defined by the
+               enum \ref af_interp_type
+   \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
+   \return     \ref AF_SUCCESS if the interpolation operation is successful,
+               otherwise an appropriate error code is returned.
+
+   \ingroup signal_func_approx2
+ */
+AFAPI af_err af_approx2_uniform(af_array *zo, const af_array zi,
+                                const af_array xo, const int xdim,
+                                const af_array yo, const int ydim,
+                                const double xi_beg, const double xi_step,
+                                const double yi_beg, const double yi_step,
+                                const af_interp_type method, const float offGrid);
+#endif
 
 /**
    C Interface for fast fourier transform on one dimensional signals

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -72,13 +72,13 @@ AFAPI array approx1(const array &in,
 
    \param[in]  in is the input array.
    \param[in]  pos0 array contains the interpolation positions along the first dimension.
-   \param[in]  interp_dim0 Specifies the first dimension along which measurements were made.
+   \param[in]  pos0_interp_dim Specifies the first dimension along which measurements were made.
+   \param[in]  pos0_interp_grid_beg Initial value of the grid on which original values were measured for the first dimension.
+   \param[in]  pos0_interp_grid_step Step size of the grid on which original values were measured for the first dimension.
    \param[in]  pos1 array contains the interpolation positions along the second dimension.
-   \param[in]  interp_dim1 Specifies the second dimension along which measurements were made.
-   \param[in]  grid0_beg Initial value of the grid on which original values were measured for the first dimension.
-   \param[in]  grid0_step Step size of the grid on which original values were measured for the first dimension.
-   \param[in]  grid1_beg Initial value of the grid on which original values were measured for the second dimension.
-   \param[in]  grid1_step Step size of the grid on which original values were measured for the second dimension.
+   \param[in]  pos1_interp_dim Specifies the second dimension along which measurements were made.
+   \param[in]  pos1_interp_grid_beg Initial value of the grid on which original values were measured for the second dimension.
+   \param[in]  pos1_interp_grid_step Step size of the grid on which original values were measured for the second dimension.
    \param[in]  method is the interpolation type. All interpolation types defined in \ref af_interp_type are supported.
    \param[in]  off_grid is the value that will be set in the output array for any indices that are out of bounds.
    \return     The interpolated array.
@@ -86,10 +86,8 @@ AFAPI array approx1(const array &in,
    \ingroup signal_func_approx2
  */
 AFAPI array approx2(const array &in,
-                    const array &pos0, const int interp_dim0,
-                    const array &pos1, const int interp_dim1,
-                    const double grid0_beg, const double grid0_step,
-                    const double grid1_beg, const double grid1_step,
+                    const array &pos0, const int pos0_interp_dim, const double pos0_interp_grid_beg, const double pos0_interp_grid_step,
+                    const array &pos1, const int pos1_interp_dim, const double pos1_interp_grid_beg, const double pos1_interp_grid_step,
                     const interpType method = AF_INTERP_LINEAR, const float off_grid = 0.0f);
 #endif
 
@@ -761,8 +759,8 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
    \param[in]  in is the array containing the measured / reference values.
    \param[in]  pos array containining the interpolation positions.
    \param[in]  interp_dim The dimension along which measurements were made.
-   \param[in]  grid0_beg Initial value of the grid on which the original values were measured.
-   \param[in]  grid0_step Step size of the grid on which the original values were measured.
+   \param[in]  pos0_interp_grid_beg Initial value of the grid on which the original values were measured.
+   \param[in]  pos0_interp_grid_step Step size of the grid on which the original values were measured.
    \param[in]  method is the interpolation type, it can take one of the values defined by the
                enum \ref af_interp_type.
    \param[in]  off_grid is the value that will set in the output array when certain index is out of bounds.
@@ -773,7 +771,7 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
  */
 AFAPI af_err af_approx1_uniform(af_array *out, const af_array in,
                                 const af_array pos, const int interp_dim,
-                                const double grid0_beg, const double grid0_step,
+                                const double pos0_interp_grid_beg, const double pos0_interp_grid_step,
                                 const af_interp_type method, const float off_grid);
 
 /**
@@ -782,13 +780,13 @@ AFAPI af_err af_approx1_uniform(af_array *out, const af_array in,
    \param[out] out is the array with interpolated values.
    \param[in]  in is the array containing the measured / reference values.
    \param[in]  pos0 array containining the interpolation positions.
+   \param[in]  pos0_interp_dim The dimension along which the interpolation needs to occur.
+   \param[in]  pos0_interp_grid_beg Initial value of the grid on which the original values were measured.
+   \param[in]  pos0_interp_grid_step Step size of the grid on which the original values were measured.
    \param[in]  pos1 array containining the interpolation positions.
-   \param[in]  interp_dim0 The dimension along which the interpolation needs to occur.
-   \param[in]  interp_dim1 The dimension along which the interpolation needs to occur.
-   \param[in]  grid0_beg Initial value of the grid on which the original values were measured.
-   \param[in]  grid0_step Step size of the grid on which the original values were measured.
-   \param[in]  grid1_beg Initial value of the grid on which the original values were measured.
-   \param[in]  grid1_step Step size of the grid on which the original values were measured.
+   \param[in]  pos1_interp_dim The dimension along which the interpolation needs to occur.
+   \param[in]  pos1_interp_grid_beg Initial value of the grid on which the original values were measured.
+   \param[in]  pos1_interp_grid_step Step size of the grid on which the original values were measured.
    \param[in]  method is the interpolation type, it can take one of the values defined by the
                enum \ref af_interp_type.
    \param[in]  off_grid is the value that will set in the output array when certain index is out of bounds.
@@ -798,10 +796,8 @@ AFAPI af_err af_approx1_uniform(af_array *out, const af_array in,
    \ingroup signal_func_approx2
  */
 AFAPI af_err af_approx2_uniform(af_array *out, const af_array in,
-                                const af_array pos0, const int interp_dim0,
-                                const af_array pos1, const int interp_dim1,
-                                const double grid0_beg, const double grid0_step,
-                                const double grid1_beg, const double grid1_step,
+                                const af_array pos0, const int pos0_interp_dim, const double pos0_interp_grid_beg, const double pos0_interp_grid_step,
+                                const af_array pos1, const int pos1_interp_dim, const double pos1_interp_grid_beg, const double pos1_interp_grid_step,
                                 const af_interp_type method, const float off_grid);
 #endif
 

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -20,7 +20,7 @@ class dim4;
 /**
    C++ Interface for data interpolation on one-dimensional signals.
 
-   \param[in]  in is the input array.
+   \param[in]  in is the input array. Data assumed to be equally spaced with indices in the range of [0, n).
    \param[in]  pos array contains the interpolation positions.
    \param[in]  method is the interpolation type. The following types (defined in enum \ref af_interp_type) can be used: nearest neighbor, linear, and cubic.
    \param[in]  off_grid is the value that will be set in the output array for any indices that are out of bounds.
@@ -34,7 +34,7 @@ AFAPI array approx1(const array &in, const array &pos,
 /**
    C++ Interface for data interpolation on two-dimensional signals.
 
-   \param[in]  in is the input array.
+   \param[in]  in is the input array. Data assumed to be equally spaced with indices in the range of [0, n) along both dimensions to interpolate across..
    \param[in]  pos0 array contains the interpolation positions for first dimension.
    \param[in]  pos1 array contains the interpolation positions for second dimension.
    \param[in]  method is the interpolation type. All interpolation types defined in \ref af_interp_type are supported.

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -49,7 +49,7 @@ AFAPI array approx2(const array &zi, const array &xo, const array &yo,
                     const interpType method = AF_INTERP_LINEAR, const float offGrid = 0.0f);
 
 
-#if AF_API_VERSION >= 36
+#if AF_API_VERSION >= 37
 /**
    C++ Interface for data interpolation on one dimensional signals
 
@@ -80,6 +80,12 @@ AFAPI array approx1(const array &yi,
                enum \ref af_interp_type
    \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
    \return     the array with interpolated values
+   \param[in]  xdim Specifies the first dimension along which measurements were made.
+   \param[in]  ydim Specifies the second dimension along which measurements were made.
+   \param[in]  xi_beg Initial value of the grid on which original values were measured for the first dimension.
+   \param[in]  xi_step Step size of the grid on which original values were measured for the first dimension.
+   \param[in]  yi_beg Initial value of the grid on which original values were measured for the second dimension.
+   \param[in]  yi_step Step size of the grid on which original values were measured for the second dimension.
 
    \ingroup signal_func_approx2
  */
@@ -751,14 +757,14 @@ AFAPI af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
 AFAPI af_err af_approx2(af_array *zo, const af_array zi, const af_array xo, const af_array yo,
                         const af_interp_type method, const float offGrid);
 
-#if AF_API_VERSION >= 36
+#if AF_API_VERSION >= 37
 /**
    C Interface for signals interpolation on one dimensional signals along specified dimension.
 
    \param[out] yo is the array with interpolated values.
    \param[in]  yi is the array containing the measured / reference values.
    \param[in]  xo array containining the interpolation locations.
-   \param[in]  dim The dimension along the measurements were made.
+   \param[in]  xdim The dimension along which measurements were made.
    \param[in]  xi_beg Initial value of the grid on which the original values were measured.
    \param[in]  xi_step Step size of the grid on which the original values were measured.
    \param[in]  method is the interpolation type, it can take one of the values defined by the

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -20,11 +20,11 @@ class dim4;
 /**
    C++ Interface for data interpolation on one-dimensional signals.
 
-   \param[in]  in Input array containing known values to perform interpolation on. Interpolation grid assumed to be uniformly spaced with indices in the range of `[0, n)`, where `n` is the number of elements in the array.
-   \param[in]  pos Contains known and unkown positions along the first dimension of the interpolation grid. Unknown values will be calculated for using interpolation.
-   \param[in]  method Interpolation type. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
-   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
-   \return     The interpolated array.
+   \param[in]  in is the multidimensional input array. Values assumed to lie uniformly spaced indices in the range of `[0, n)`, where `n` is the number of elements in the array.
+   \param[in]  pos is the positions array.
+   \param[in]  method is the interpolation method to be used. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
+   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
+   \returns    the interpolated array.
 
    \ingroup signal_func_approx1
  */
@@ -34,12 +34,12 @@ AFAPI array approx1(const array &in, const array &pos,
 /**
    C++ Interface for data interpolation on two-dimensional signals.
 
-   \param[in]  in Input array containing known values to perform interpolation on. Must be of at least two dimensions. Interpolation grid assumed to be uniformly spaced with indices in the range of `[0, n)` across both dimension, where `n` is the number of elements in the array.
-   \param[in]  pos0 Contains known and unkown positions along the first dimension of the interpolation grid. Unknown values will be calculated for using interpolation.
-   \param[in]  pos1 Contains known and unkown positions along the second dimension of the interpolation grid. Unknown values will be calculated for using interpolation.
-   \param[in]  method Interpolation type. All interpolation types defined in \ref af_interp_type are supported.
-   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
-   \return     The interpolated array.
+   \param[in]  in is the multidimensional input array. Values assumed to lie uniformly spaced indices in the range of `[0, n)` along both interpolation dimensions. `n` is the number of elements in the array.
+   \param[in]  pos0 is the first positions array.
+   \param[in]  pos1 is the second positions array.
+   \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
+   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
+   \returns    the interpolated array.
 
    \ingroup signal_func_approx2
  */
@@ -51,43 +51,43 @@ AFAPI array approx2(const array &in, const array &pos0, const array &pos1,
 /**
    C++ Interface for data interpolation on one-dimensional signals.
 
-   \param[in]  in Input array containing known values to perform interpolation on. The interpolation grid on which these points lie on are controlled by the `grid_beg` and `grid_step` arguments.
-   \param[in]  pos Contains known and unkown positions from the interpolation grid along the dimension specified by `interp_dim`.
-   \param[in]  interp_dim Specifies the dimension along which measurements were made.
-   \param[in]  interp_grid_beg Initial value of the grid on which original values were measured.
-   \param[in]  interp_grid_step Step size of the grid on which original values were measured.
-   \param[in]  method Interpolation type. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
-   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
-   \return     The interpolated array.
+   \param[in]  in is the multidimensional input array. Values lie on uniformly spaced indices determined by `idx_start` and `idx_step`.
+   \param[in]  pos is the positions array.
+   \param[in]  interp_dim is the dimension to perform interpolation across.
+   \param[in]  idx_start is the first index value along `interp_dim`.
+   \param[in]  idx_step is the uniform spacing value between subsequent indices along `interp_dim`.
+   \param[in]  method is the interpolation method to be used. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
+   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
+   \returns    the interpolated array.
 
    \ingroup signal_func_approx1
  */
 AFAPI array approx1(const array &in,
                     const array &pos, const int interp_dim,
-                    const double interp_grid_beg, const double interp_grid_step,
+                    const double idx_start, const double idx_step,
                     const interpType method = AF_INTERP_LINEAR, const float off_grid = 0.0f);
 
 /**
    C++ Interface for data interpolation on two-dimensional signals.
 
-   \param[in]  in Input array containing known values to perform interpolation on. Must be of at least two dimensions. The interpolation grid on which these points lie on are controlled by the `grid_beg` and `grid_step` arguments.
-   \param[in]  pos0 Contains known and unknown positions along the first dimension of the interpolation grid, specified by `pos0_interp_grid_dim`.
-   \param[in]  pos0_interp_dim Specifies the first dimension along which measurements were made.
-   \param[in]  pos0_interp_grid_beg Initial value of the grid on which original values were measured for the first dimension.
-   \param[in]  pos0_interp_grid_step Step size of the grid on which original values were measured for the first dimension.
-   \param[in]  pos1 Contains known and unknown positions along the second dimension of the interpolation grid, specified by `pos1_interp_grid_dim`.
-   \param[in]  pos1_interp_dim Specifies the second dimension along which measurements were made.
-   \param[in]  pos1_interp_grid_beg Initial value of the grid on which original values were measured for the second dimension.
-   \param[in]  pos1_interp_grid_step Step size of the grid on which original values were measured for the second dimension.
-   \param[in]  method Interpolation type. All interpolation types defined in \ref af_interp_type are supported.
-   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
-   \return     The interpolated array.
+   \param[in]  in is the multidimensional input array.
+   \param[in]  pos0 is the first positions array.
+   \param[in]  interp_dim0 is the first dimension to perform interpolation across.
+   \param[in]  idx_start_dim0 is the first index value along `interp_dim0`.
+   \param[in]  idx_step_dim0 is the uniform spacing value between subsequent indices along `interp_dim0`.
+   \param[in]  pos1 is the second positions array.
+   \param[in]  interp_dim1 is the second dimension to perform interpolation across.
+   \param[in]  idx_start_dim1 is the first index value along `interp_dim1`.
+   \param[in]  idx_step_dim1 is the uniform spacing value between subsequent indices along `interp_dim1`.
+   \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
+   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
+   \returns    the interpolated array.
 
    \ingroup signal_func_approx2
  */
 AFAPI array approx2(const array &in,
-                    const array &pos0, const int pos0_interp_dim, const double pos0_interp_grid_beg, const double pos0_interp_grid_step,
-                    const array &pos1, const int pos1_interp_dim, const double pos1_interp_grid_beg, const double pos1_interp_grid_step,
+                    const array &pos0, const int interp_dim0, const double idx_start_dim0, const double idx_step_dim0,
+                    const array &pos1, const int interp_dim1, const double idx_start_dim1, const double idx_step_dim1,
                     const interpType method = AF_INTERP_LINEAR, const float off_grid = 0.0f);
 #endif
 
@@ -719,11 +719,11 @@ extern "C" {
 /**
    C Interface for signals interpolation on one dimensional signals.
 
-   \param[out] out The interpolated array.
-   \param[in]  in Input array containing known values to perform interpolation on. Interpolation grid assumed to be uniformly spaced with indices in the range of `[0, n)`, where `n` is the number of elements in the array.
-   \param[in]  pos Contains known and unkown positions along the first dimension of the interpolation grid. Unknown values will be calculated for using interpolation.
-   \param[in]  method method Interpolation type. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
-   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
+   \param[out] out the interpolated array.
+   \param[in]  in is the multidimensional input array. Values assumed to lie uniformly spaced indices in the range of `[0, n)`, where `n` is the number of elements in the array.
+   \param[in]  pos is the positions array.
+   \param[in]  method is the interpolation method to be used. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
+   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
                otherwise an appropriate error code is returned.
 
@@ -735,12 +735,12 @@ AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
 /**
    C Interface for signals interpolation on two dimensional signals.
 
-   \param[out] out The interpolated array.
-   \param[in]  in in Input array containing known values to perform interpolation on. Must be of at least two dimensions. Interpolation grid assumed to be uniformly spaced with indices in the range of `[0, n)` across both dimension, where `n` is the number of elements in the array.
-   \param[in]  pos0 Contains known and unkown positions along the first dimension of the interpolation grid. Unknown values will be calculated for using interpolation.
-   \param[in]  pos1 Contains known and unkown positions along the second dimension of the interpolation grid. Unknown values will be calculated for using interpolation.
-   \param[in]  method Interpolation type. All interpolation types defined in \ref af_interp_type are supported.
-   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
+   \param[out] out the interpolated array.
+   \param[in]  in is the multidimensional input array. Values assumed to lie uniformly spaced indices in the range of `[0, n)` along both interpolation dimensions. `n` is the number of elements in the array.
+   \param[in]  pos0 is the first positions array.
+   \param[in]  pos1 is the second positions array.
+   \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
+   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
                otherwise an appropriate error code is returned.
 
@@ -753,14 +753,14 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
 /**
    C Interface for signals interpolation on one dimensional signals along specified dimension.
 
-   \param[out] out The interpolated array.
-   \param[in]  in Input array containing known values to perform interpolation on. The interpolation grid on which these points lie on are controlled by the `grid_beg` and `grid_step` arguments.
-   \param[in]  pos Contains known and unkown positions from the interpolation grid along the dimension specified by `interp_dim`.
-   \param[in]  interp_dim Specifies the dimension along which measurements were made.
-   \param[in]  interp_grid_beg Initial value of the grid on which the original values were measured.
-   \param[in]  interp_grid_step Step size of the grid on which the original values were measured.
-   \param[in]  method Interpolation type. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
-   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
+   \param[out] out the interpolated array.
+   \param[in]  in is the multidimensional input array. Values lie on uniformly spaced indices determined by `idx_start` and `idx_step`.
+   \param[in]  pos is the positions array.
+   \param[in]  interp_dim is the dimension to perform interpolation across.
+   \param[in]  idx_start is the first index value along `interp_dim`.
+   \param[in]  idx_step is the uniform spacing value between subsequent indices along `interp_dim`.
+   \param[in]  method is the interpolation method to be used. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
+   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
                otherwise an appropriate error code is returned.
 
@@ -768,32 +768,32 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
  */
 AFAPI af_err af_approx1_uniform(af_array *out, const af_array in,
                                 const af_array pos, const int interp_dim,
-                                const double interp_grid_beg, const double interp_grid_step,
+                                const double idx_start, const double idx_step,
                                 const af_interp_type method, const float off_grid);
 
 /**
    C Interface for signals interpolation on two dimensional signals alog specified dimensions.
 
-   \param[out] out The interpolated array.
-   \param[in]  in Input array containing known values to perform interpolation on. Must be of at least two dimensions. The interpolation grid on which these points lie on are controlled by the `grid_beg` and `grid_step` arguments.
-   \param[in]  pos0 Contains known and unknown positions along the first dimension of the interpolation grid, specified by `pos0_interp_dim`.
-   \param[in]  pos0_interp_dim Specifies the second dimension along which measurements were made.
-   \param[in]  pos0_interp_grid_beg Initial value of the grid on which original values were measured for the first dimension.
-   \param[in]  pos0_interp_grid_step Step size of the grid on which original values were measured for the first dimension.
-   \param[in]  pos1 Contains known and unknown positions along the second dimension of the interpolation grid, specified by `pos1_interp_dim`.
-   \param[in]  pos1_interp_dim Specifies the second dimension along which measurements were made.
-   \param[in]  pos1_interp_grid_beg Initial value of the grid on which original values were measured for the second dimension.
-   \param[in]  pos1_interp_grid_step Step size of the grid on which original values were measured for the second dimension.
-   \param[in]  method Interpolation type. All interpolation types defined in \ref af_interp_type are supported.
-   \param[in]  off_grid Default value for any positions/points that lie outside of the interpolation grid.
+   \param[out] out the interpolated array.
+   \param[in]  in is the multidimensional input array.
+   \param[in]  pos0 is the first positions array.
+   \param[in]  interp_dim0 is the first dimension to perform interpolation across.
+   \param[in]  idx_start_dim0 is the first index value along `interp_dim0`.
+   \param[in]  idx_step_dim0 is the uniform spacing value between subsequent indices along `interp_dim0`.
+   \param[in]  pos1 is the second positions array.
+   \param[in]  interp_dim1 is the second dimension to perform interpolation across.
+   \param[in]  idx_start_dim1 is the first index value along `interp_dim1`.
+   \param[in]  idx_step_dim1 is the uniform spacing value between subsequent indices along `interp_dim1`.
+   \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
+   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
                otherwise an appropriate error code is returned.
 
    \ingroup signal_func_approx2
  */
 AFAPI af_err af_approx2_uniform(af_array *out, const af_array in,
-                                const af_array pos0, const int pos0_interp_dim, const double pos0_interp_grid_beg, const double pos0_interp_grid_step,
-                                const af_array pos1, const int pos1_interp_dim, const double pos1_interp_grid_beg, const double pos1_interp_grid_step,
+                                const af_array pos0, const int interp_dim0, const double idx_start_dim0, const double idx_step_dim0,
+                                const af_array pos1, const int interp_dim1, const double idx_start_dim1, const double idx_step_dim1,
                                 const af_interp_type method, const float off_grid);
 #endif
 

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -20,77 +20,77 @@ class dim4;
 /**
    C++ Interface for data interpolation on one-dimensional signals.
 
-   \param[in]  yi is the input array
-   \param[in]  xo array contains the interpolation locations
+   \param[in]  in is the input array.
+   \param[in]  pos array contains the interpolation positions.
    \param[in]  method is the interpolation type. The following types (defined in enum \ref af_interp_type) can be used: nearest neighbor, linear, and cubic.
-   \param[in]  offGrid is the value that will be set in the output array for any indices that are out of bounds.
-   \return     Interpolated array.
+   \param[in]  off_grid is the value that will be set in the output array for any indices that are out of bounds.
+   \return     The interpolated array.
 
    \ingroup signal_func_approx1
  */
-AFAPI array approx1(const array &yi, const array &xo,
-                    const interpType method = AF_INTERP_LINEAR, const float offGrid = 0.0f);
+AFAPI array approx1(const array &in, const array &pos,
+                    const interpType method = AF_INTERP_LINEAR, const float off_grid = 0.0f);
 
 /**
    C++ Interface for data interpolation on two-dimensional signals.
 
-   \param[in]  zi is the input array
-   \param[in]  xo array contains the interpolation locations for first dimension
-   \param[in]  yo array contains the interpolation locations for second dimension
+   \param[in]  in is the input array.
+   \param[in]  pos0 array contains the interpolation positions for first dimension.
+   \param[in]  pos1 array contains the interpolation positions for second dimension.
    \param[in]  method is the interpolation type. All interpolation types defined in \ref af_interp_type are supported.
-   \param[in]  offGrid is the value that will be set in the output array for any indices that are out of bounds.
-   \return     Interpolated array.
+   \param[in]  off_grid is the value that will be set in the output array for any indices that are out of bounds.
+   \return     The interpolated array.
 
    \ingroup signal_func_approx2
  */
-AFAPI array approx2(const array &zi, const array &xo, const array &yo,
-                    const interpType method = AF_INTERP_LINEAR, const float offGrid = 0.0f);
+AFAPI array approx2(const array &in, const array &pos0, const array &pos1,
+                    const interpType method = AF_INTERP_LINEAR, const float off_grid = 0.0f);
 
 
 #if AF_API_VERSION >= 37
 /**
    C++ Interface for data interpolation on one-dimensional signals.
 
-   \param[in]  yi is the input array.
-   \param[in]  xo array contains the interpolation locations.
-   \param[in]  xdim Specifies the dimension along which measurements were made.
-   \param[in]  xi_beg Initial value of the grid on which original values were measured.
-   \param[in]  xi_step Step size of the grid on which original values were measured.
+   \param[in]  in is the input array.
+   \param[in]  pos array contains the interpolation positions.
+   \param[in]  interp_dim Specifies the dimension along which measurements were made.
+   \param[in]  grid_beg Initial value of the grid on which original values were measured.
+   \param[in]  grid_step Step size of the grid on which original values were measured.
    \param[in]  method is the interpolation type. The following types (defined in enum \ref af_interp_type) can be used: nearest neighbor, linear, and cubic.
-   \param[in]  offGrid is the value that will be set in the output array for any indices that are out of bounds.
-   \return     Interpolated array.
+   \param[in]  off_grid is the value that will be set in the output array for any indices that are out of bounds.
+   \return     The interpolated array.
 
    \ingroup signal_func_approx1
  */
-AFAPI array approx1(const array &yi,
-                    const array &xo, const int xdim,
-                    const double xi_beg, const double xi_step,
-                    const interpType method = AF_INTERP_LINEAR, const float offGrid = 0.0f);
+AFAPI array approx1(const array &in,
+                    const array &pos, const int interp_dim,
+                    const double grid_beg, const double grid_step,
+                    const interpType method = AF_INTERP_LINEAR, const float off_grid = 0.0f);
 
 /**
    C++ Interface for data interpolation on two-dimensional signals.
 
-   \param[in]  zi is the input array.
-   \param[in]  xo array contains the interpolation locations along the first dimension.
-   \param[in]  xdim Specifies the first dimension along which measurements were made.
-   \param[in]  yo array contains the interpolation locations along the second dimension.
-   \param[in]  ydim Specifies the second dimension along which measurements were made.
-   \param[in]  xi_beg Initial value of the grid on which original values were measured for the first dimension.
-   \param[in]  xi_step Step size of the grid on which original values were measured for the first dimension.
-   \param[in]  yi_beg Initial value of the grid on which original values were measured for the second dimension.
-   \param[in]  yi_step Step size of the grid on which original values were measured for the second dimension.
+   \param[in]  in is the input array.
+   \param[in]  pos0 array contains the interpolation positions along the first dimension.
+   \param[in]  interp_dim0 Specifies the first dimension along which measurements were made.
+   \param[in]  pos1 array contains the interpolation positions along the second dimension.
+   \param[in]  interp_dim1 Specifies the second dimension along which measurements were made.
+   \param[in]  grid0_beg Initial value of the grid on which original values were measured for the first dimension.
+   \param[in]  grid0_step Step size of the grid on which original values were measured for the first dimension.
+   \param[in]  grid1_beg Initial value of the grid on which original values were measured for the second dimension.
+   \param[in]  grid1_step Step size of the grid on which original values were measured for the second dimension.
    \param[in]  method is the interpolation type. All interpolation types defined in \ref af_interp_type are supported.
-   \param[in]  offGrid is the value that will be set in the output array for any indices that are out of bounds.
-   \return     Interpolated array.
+   \param[in]  off_grid is the value that will be set in the output array for any indices that are out of bounds.
+   \return     The interpolated array.
 
    \ingroup signal_func_approx2
  */
-AFAPI array approx2(const array &zi,
-                    const array &xo, const int xdim,
-                    const array &yo, const int ydim,
-                    const double xi_beg, const double xi_step,
-                    const double yi_beg, const double yi_step,
-                    const interpType method = AF_INTERP_LINEAR, const float offGrid = 0.0f);
+AFAPI array approx2(const array &in,
+                    const array &pos0, const int interp_dim0,
+                    const array &pos1, const int interp_dim1,
+                    const double grid0_beg, const double grid0_step,
+                    const double grid1_beg, const double grid1_step,
+                    const interpType method = AF_INTERP_LINEAR, const float off_grid = 0.0f);
 #endif
 
 /**
@@ -721,88 +721,88 @@ extern "C" {
 /**
    C Interface for signals interpolation on one dimensional signals.
 
-   \param[out] yo is the array with interpolated values
-   \param[in]  yi is the input array
-   \param[in]  xo array contains the interpolation locations
+   \param[out] out is the array with interpolated values.
+   \param[in]  in is the input array.
+   \param[in]  pos array contains the interpolation positions.
    \param[in]  method is the interpolation type, it can take one of the values defined by the
-               enum \ref af_interp_type
-   \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
+               enum \ref af_interp_type.
+   \param[in]  off_grid is the value that will set in the output array when certain index is out of bounds.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
                otherwise an appropriate error code is returned.
 
    \ingroup signal_func_approx1
  */
-AFAPI af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
-                        const af_interp_type method, const float offGrid);
+AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
+                        const af_interp_type method, const float off_grid);
 
 /**
    C Interface for signals interpolation on two dimensional signals.
 
-   \param[out] zo is the array with interpolated values
-   \param[in]  zi is the input array
-   \param[in]  xo array contains the interpolation locations for first dimension
-   \param[in]  yo array contains the interpolation locations for second dimension
+   \param[out] out is the array with interpolated values.
+   \param[in]  in is the input array.
+   \param[in]  pos0 array contains the interpolation positions for first dimension.
+   \param[in]  pos1 array contains the interpolation positions for second dimension.
    \param[in]  method is the interpolation type, it can take one of the values defined by the
-               enum \ref af_interp_type
-   \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
+               enum \ref af_interp_type.
+   \param[in]  off_grid is the value that will set in the output array when certain index is out of bounds.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
                otherwise an appropriate error code is returned.
 
    \ingroup signal_func_approx2
  */
-AFAPI af_err af_approx2(af_array *zo, const af_array zi, const af_array xo, const af_array yo,
-                        const af_interp_type method, const float offGrid);
+AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, const af_array pos1,
+                        const af_interp_type method, const float off_grid);
 
 #if AF_API_VERSION >= 37
 /**
    C Interface for signals interpolation on one dimensional signals along specified dimension.
 
-   \param[out] yo is the array with interpolated values.
-   \param[in]  yi is the array containing the measured / reference values.
-   \param[in]  xo array containining the interpolation locations.
-   \param[in]  xdim The dimension along which measurements were made.
-   \param[in]  xi_beg Initial value of the grid on which the original values were measured.
-   \param[in]  xi_step Step size of the grid on which the original values were measured.
+   \param[out] out is the array with interpolated values.
+   \param[in]  in is the array containing the measured / reference values.
+   \param[in]  pos array containining the interpolation positions.
+   \param[in]  interp_dim The dimension along which measurements were made.
+   \param[in]  grid0_beg Initial value of the grid on which the original values were measured.
+   \param[in]  grid0_step Step size of the grid on which the original values were measured.
    \param[in]  method is the interpolation type, it can take one of the values defined by the
-               enum \ref af_interp_type
-   \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
+               enum \ref af_interp_type.
+   \param[in]  off_grid is the value that will set in the output array when certain index is out of bounds.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
                otherwise an appropriate error code is returned.
 
    \ingroup signal_func_approx1
  */
-AFAPI af_err af_approx1_uniform(af_array *yo, const af_array yi,
-                                const af_array xo, const int xdim,
-                                const double xi_beg, const double xi_step,
-                                const af_interp_type method, const float offGrid);
+AFAPI af_err af_approx1_uniform(af_array *out, const af_array in,
+                                const af_array pos, const int interp_dim,
+                                const double grid0_beg, const double grid0_step,
+                                const af_interp_type method, const float off_grid);
 
 /**
    C Interface for signals interpolation on two dimensional signals alog specified dimensions.
 
-   \param[out] zo is the array with interpolated values.
-   \param[in]  zi is the array containing the measured / reference values.
-   \param[in]  xo array containining the interpolation locations.
-   \param[in]  yo array containining the interpolation locations.
-   \param[in]  xdim The dimension along which the interpolation needs to occur.
-   \param[in]  ydim The dimension along which the interpolation needs to occur.
-   \param[in]  xi_beg Initial value of the grid on which the original values were measured.
-   \param[in]  xi_step Step size of the grid on which the original values were measured.
-   \param[in]  yi_beg Initial value of the grid on which the original values were measured.
-   \param[in]  yi_step Step size of the grid on which the original values were measured.
+   \param[out] out is the array with interpolated values.
+   \param[in]  in is the array containing the measured / reference values.
+   \param[in]  pos0 array containining the interpolation positions.
+   \param[in]  pos1 array containining the interpolation positions.
+   \param[in]  interp_dim0 The dimension along which the interpolation needs to occur.
+   \param[in]  interp_dim1 The dimension along which the interpolation needs to occur.
+   \param[in]  grid0_beg Initial value of the grid on which the original values were measured.
+   \param[in]  grid0_step Step size of the grid on which the original values were measured.
+   \param[in]  grid1_beg Initial value of the grid on which the original values were measured.
+   \param[in]  grid1_step Step size of the grid on which the original values were measured.
    \param[in]  method is the interpolation type, it can take one of the values defined by the
-               enum \ref af_interp_type
-   \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
+               enum \ref af_interp_type.
+   \param[in]  off_grid is the value that will set in the output array when certain index is out of bounds.
    \return     \ref AF_SUCCESS if the interpolation operation is successful,
                otherwise an appropriate error code is returned.
 
    \ingroup signal_func_approx2
  */
-AFAPI af_err af_approx2_uniform(af_array *zo, const af_array zi,
-                                const af_array xo, const int xdim,
-                                const af_array yo, const int ydim,
-                                const double xi_beg, const double xi_step,
-                                const double yi_beg, const double yi_step,
-                                const af_interp_type method, const float offGrid);
+AFAPI af_err af_approx2_uniform(af_array *out, const af_array in,
+                                const af_array pos0, const int interp_dim0,
+                                const af_array pos1, const int interp_dim1,
+                                const double grid0_beg, const double grid0_step,
+                                const double grid1_beg, const double grid1_step,
+                                const af_interp_type method, const float off_grid);
 #endif
 
 /**

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -18,14 +18,13 @@ class array;
 class dim4;
 
 /**
-   C++ Interface for data interpolation on one dimensional signals.
+   C++ Interface for data interpolation on one-dimensional signals.
 
    \param[in]  yi is the input array
    \param[in]  xo array contains the interpolation locations
-   \param[in]  method is the interpolation type, it can take one of the values defined by the
-               enum \ref af_interp_type
-   \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
-   \return     the array with interpolated values
+   \param[in]  method is the interpolation type. The following types (defined in enum \ref af_interp_type) can be used: nearest neighbor, linear, and cubic.
+   \param[in]  offGrid is the value that will be set in the output array for any indices that are out of bounds.
+   \return     Interpolated array.
 
    \ingroup signal_func_approx1
  */
@@ -33,15 +32,14 @@ AFAPI array approx1(const array &yi, const array &xo,
                     const interpType method = AF_INTERP_LINEAR, const float offGrid = 0.0f);
 
 /**
-   C++ Interface for data interpolation on two dimensional signals.
+   C++ Interface for data interpolation on two-dimensional signals.
 
    \param[in]  zi is the input array
    \param[in]  xo array contains the interpolation locations for first dimension
    \param[in]  yo array contains the interpolation locations for second dimension
-   \param[in]  method is the interpolation type, it can take one of the values defined by the
-               enum \ref af_interp_type
-   \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
-   \return     the array with interpolated values
+   \param[in]  method is the interpolation type. All interpolation types defined in \ref af_interp_type are supported.
+   \param[in]  offGrid is the value that will be set in the output array for any indices that are out of bounds.
+   \return     Interpolated array.
 
    \ingroup signal_func_approx2
  */
@@ -51,17 +49,16 @@ AFAPI array approx2(const array &zi, const array &xo, const array &yo,
 
 #if AF_API_VERSION >= 37
 /**
-   C++ Interface for data interpolation on one dimensional signals
+   C++ Interface for data interpolation on one-dimensional signals.
 
-   \param[in]  yi is the input array
-   \param[in]  xo array contains the interpolation locations
-   \param[in]  xdim Specifies the dimension along with measurements were made.
+   \param[in]  yi is the input array.
+   \param[in]  xo array contains the interpolation locations.
+   \param[in]  xdim Specifies the dimension along which measurements were made.
    \param[in]  xi_beg Initial value of the grid on which original values were measured.
    \param[in]  xi_step Step size of the grid on which original values were measured.
-   \param[in]  method is the interpolation type, it can take one of the values defined by the
-               enum \ref af_interp_type
-   \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
-   \return     the array with interpolated values
+   \param[in]  method is the interpolation type. The following types (defined in enum \ref af_interp_type) can be used: nearest neighbor, linear, and cubic.
+   \param[in]  offGrid is the value that will be set in the output array for any indices that are out of bounds.
+   \return     Interpolated array.
 
    \ingroup signal_func_approx1
  */
@@ -71,21 +68,20 @@ AFAPI array approx1(const array &yi,
                     const interpType method = AF_INTERP_LINEAR, const float offGrid = 0.0f);
 
 /**
-   C++ Interface for data interpolation on two dimensional signals
+   C++ Interface for data interpolation on two-dimensional signals.
 
-   \param[in]  zi is the input array
-   \param[in]  xo array contains the interpolation locations for first dimension
-   \param[in]  yo array contains the interpolation locations for second dimension
-   \param[in]  method is the interpolation type, it can take one of the values defined by the
-               enum \ref af_interp_type
-   \param[in]  offGrid is the value that will set in the output array when certain index is out of bounds
-   \return     the array with interpolated values
+   \param[in]  zi is the input array.
+   \param[in]  xo array contains the interpolation locations along the first dimension.
    \param[in]  xdim Specifies the first dimension along which measurements were made.
+   \param[in]  yo array contains the interpolation locations along the second dimension.
    \param[in]  ydim Specifies the second dimension along which measurements were made.
    \param[in]  xi_beg Initial value of the grid on which original values were measured for the first dimension.
    \param[in]  xi_step Step size of the grid on which original values were measured for the first dimension.
    \param[in]  yi_beg Initial value of the grid on which original values were measured for the second dimension.
    \param[in]  yi_step Step size of the grid on which original values were measured for the second dimension.
+   \param[in]  method is the interpolation type. All interpolation types defined in \ref af_interp_type are supported.
+   \param[in]  offGrid is the value that will be set in the output array for any indices that are out of bounds.
+   \return     Interpolated array.
 
    \ingroup signal_func_approx2
  */

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -81,6 +81,7 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi,
             }
         }
 
+        ARG_ASSERT(5, xi_step != 0);
         ARG_ASSERT(6, (method == AF_INTERP_LINEAR  ||
                        method == AF_INTERP_NEAREST ||
                        method == AF_INTERP_CUBIC   ||
@@ -150,6 +151,8 @@ af_err af_approx2_uniform(af_array *zo, const af_array zi,
 
         ARG_ASSERT(3, xdim >= 0 && xdim < 4);
         ARG_ASSERT(5, ydim >= 0 && ydim < 4);
+        ARG_ASSERT(7, xi_step != 0);
+        ARG_ASSERT(9, yi_step != 0);
 
         // POS should either be (x, y, 1, 1) or (x, y, zi_dims[2], zi_dims[3])
         if (xo_dims[xdim] * xo_dims[ydim] != xo_dims.elements()) {

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -33,17 +33,13 @@ static inline af_array approx1(const af_array yi,
 
 template<typename Ty, typename Tp>
 static inline af_array approx2(const af_array zi,
-                               const af_array xo, const int xdim,
-                               const af_array yo, const int ydim,
-                               const Tp &xi_beg, const Tp &xi_step,
-                               const Tp &yi_beg, const Tp &yi_step,
+                               const af_array xo, const int xdim, const Tp &xi_beg, const Tp &xi_step,
+                               const af_array yo, const int ydim, const Tp &yi_beg, const Tp &yi_step,
                                const af_interp_type method, const float offGrid)
 {
     return getHandle(approx2<Ty>(getArray<Ty>(zi),
-                                 getArray<Tp>(xo), xdim,
-                                 getArray<Tp>(yo), ydim,
-                                 xi_beg, xi_step,
-                                 yi_beg, yi_step,
+                                 getArray<Tp>(xo), xdim, xi_beg, xi_step,
+                                 getArray<Tp>(yo), ydim, yi_beg, yi_step,
                                  method, offGrid));
 }
 
@@ -117,14 +113,12 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi,
 af_err af_approx2(af_array *zo, const af_array zi, const af_array xo, const af_array yo,
                   const af_interp_type method, const float offGrid)
 {
-    return af_approx2_uniform(zo, zi, xo, 0, yo, 1, 0.0, 1.0, 0.0, 1.0, method, offGrid);
+    return af_approx2_uniform(zo, zi, xo, 0, 0.0, 1.0, yo, 1, 0.0, 1.0, method, offGrid);
 }
 
 af_err af_approx2_uniform(af_array *zo, const af_array zi,
-                          const af_array xo, const int xdim,
-                          const af_array yo, const int ydim,
-                          const double xi_beg, const double xi_step,
-                          const double yi_beg, const double yi_step,
+                          const af_array xo, const int xdim, const double xi_beg, const double xi_step,
+                          const af_array yo, const int ydim, const double yi_beg, const double yi_step,
                           const af_interp_type method, const float offGrid)
 {
     try {
@@ -163,17 +157,21 @@ af_err af_approx2_uniform(af_array *zo, const af_array zi,
         af_array output;
 
         switch(zi_info.getType()) {
-        case f32: output = approx2<float  , float >(zi, xo, xdim, yo, ydim,
-                                                    xi_beg, xi_step, yi_beg, yi_step,
+        case f32: output = approx2<float  , float >(zi,
+                                                    xo, xdim, xi_beg, xi_step,
+                                                    yo, ydim, yi_beg, yi_step,
                                                     method, offGrid);  break;
-        case f64: output = approx2<double , double>(zi, xo, xdim, yo, ydim,
-                                                    xi_beg, xi_step, yi_beg, yi_step,
+        case f64: output = approx2<double , double>(zi,
+                                                    xo, xdim, xi_beg, xi_step,
+                                                    yo, ydim, yi_beg, yi_step,
                                                     method, offGrid);  break;
-        case c32: output = approx2<cfloat , float >(zi, xo, xdim, yo, ydim,
-                                                    xi_beg, xi_step, yi_beg, yi_step,
+        case c32: output = approx2<cfloat , float >(zi,
+                                                    xo, xdim, xi_beg, xi_step,
+                                                    yo, ydim, yi_beg, yi_step,
                                                     method, offGrid);  break;
-        case c64: output = approx2<cdouble, double>(zi, xo, xdim, yo, ydim,
-                                                    xi_beg, xi_step, yi_beg, yi_step,
+        case c64: output = approx2<cdouble, double>(zi,
+                                                    xo, xdim, xi_beg, xi_step,
+                                                    yo, ydim, yi_beg, yi_step,
                                                     method, offGrid);  break;
         default:  TYPE_ERROR(1, zi_info.getType());
         }

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -65,16 +65,13 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi,
         dim4 yi_dims = yi_info.dims();
         dim4 xo_dims = xo_info.dims();
 
-        af_dtype itype = yi_info.getType();
-
-        ARG_ASSERT(1, yi_info.isFloating());                       // Only floating and complex types
-        ARG_ASSERT(2, xo_info.isRealFloating());                   // Only floating types
+        ARG_ASSERT(1, yi_info.isFloating());                        // Only floating and complex types
+        ARG_ASSERT(2, xo_info.isRealFloating()) ;                   // Only floating types
         ARG_ASSERT(1, yi_info.isSingle() == xo_info.isSingle());    // Must have same precision
         ARG_ASSERT(1, yi_info.isDouble() == xo_info.isDouble());    // Must have same precision
-        // POS should either be (x, 1, 1, 1) or (1, yi_dims[1], yi_dims[2], yi_dims[3])
-
         ARG_ASSERT(3, xdim >= 0 && xdim < 4);
 
+        // POS should either be (x, 1, 1, 1) or (1, yi_dims[1], yi_dims[2], yi_dims[3])
         if (xo_dims[xdim] != xo_dims.elements()) {
             for (int i = 0; i < 4; i++) {
                 if (xdim != i) DIM_ASSERT(2, xo_dims[i] == yi_dims[i]);
@@ -82,20 +79,20 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi,
         }
 
         ARG_ASSERT(5, xi_step != 0);
-        ARG_ASSERT(6, (method == AF_INTERP_LINEAR  ||
-                       method == AF_INTERP_NEAREST ||
-                       method == AF_INTERP_CUBIC   ||
-                       method == AF_INTERP_CUBIC_SPLINE ||
+        ARG_ASSERT(6, (method == AF_INTERP_CUBIC         ||
+                       method == AF_INTERP_CUBIC_SPLINE  ||
+                       method == AF_INTERP_LINEAR        ||
                        method == AF_INTERP_LINEAR_COSINE ||
-                       method == AF_INTERP_LOWER));
+                       method == AF_INTERP_LOWER         ||
+                       method == AF_INTERP_NEAREST));
 
-        if(yi_dims.ndims() == 0 || xo_dims.ndims() ==  0) {
-            return af_create_handle(yo, 0, nullptr, itype);
+        if (yi_dims.ndims() == 0 || xo_dims.ndims() ==  0) {
+            return af_create_handle(yo, 0, nullptr, yi_info.getType());
         }
 
         af_array output;
 
-        switch(itype) {
+        switch(yi_info.getType()) {
         case f32: output = approx1<float  , float >(yi, xo, xdim,
                                                     xi_beg, xi_step,
                                                     method, offGrid);  break;
@@ -108,7 +105,7 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi,
         case c64: output = approx1<cdouble, double>(yi, xo, xdim,
                                                     xi_beg, xi_step,
                                                     method, offGrid);  break;
-        default:  TYPE_ERROR(1, itype);
+        default:  TYPE_ERROR(1, yi_info.getType());
         }
         std::swap(*yo,output);
     }
@@ -139,8 +136,6 @@ af_err af_approx2_uniform(af_array *zo, const af_array zi,
         dim4 xo_dims = xo_info.dims();
         dim4 yo_dims = yo_info.dims();
 
-        af_dtype itype = zi_info.getType();
-
         ARG_ASSERT(1, zi_info.isFloating());                     // Only floating and complex types
         ARG_ASSERT(2, xo_info.isRealFloating());                 // Only floating types
         ARG_ASSERT(4, yo_info.isRealFloating());                 // Only floating types
@@ -161,13 +156,13 @@ af_err af_approx2_uniform(af_array *zo, const af_array zi,
             }
         }
 
-        if(zi_dims.ndims() == 0 || xo_dims.ndims() ==  0 || yo_dims.ndims() == 0) {
-            return af_create_handle(zo, 0, nullptr, itype);
+        if (zi_dims.ndims() == 0 || xo_dims.ndims() ==  0 || yo_dims.ndims() == 0) {
+            return af_create_handle(zo, 0, nullptr, zi_info.getType());
         }
 
         af_array output;
 
-        switch(itype) {
+        switch(zi_info.getType()) {
         case f32: output = approx2<float  , float >(zi, xo, xdim, yo, ydim,
                                                     xi_beg, xi_step, yi_beg, yi_step,
                                                     method, offGrid);  break;
@@ -180,7 +175,7 @@ af_err af_approx2_uniform(af_array *zo, const af_array zi,
         case c64: output = approx2<cdouble, double>(zi, xo, xdim, yo, ydim,
                                                     xi_beg, xi_step, yi_beg, yi_step,
                                                     method, offGrid);  break;
-        default:  TYPE_ERROR(1, itype);
+        default:  TYPE_ERROR(1, zi_info.getType());
         }
         std::swap(*zo, output);
     }

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -20,106 +20,166 @@ using af::dim4;
 using namespace detail;
 
 template<typename Ty, typename Tp>
-static inline af_array approx1(const af_array in, const af_array pos,
+static inline af_array approx1(const af_array yi,
+                               const af_array xo, const int xdim,
+                               const Tp &xi_beg, const Tp &xi_step,
                                const af_interp_type method, const float offGrid)
 {
-    return getHandle(approx1<Ty>(getArray<Ty>(in), getArray<Tp>(pos), method, offGrid));
-}
-
-template<typename Ty, typename Tp>
-static inline af_array approx2(const af_array in, const af_array pos0, const af_array pos1,
-                               const af_interp_type method, const float offGrid)
-{
-    return getHandle(approx2<Ty>(getArray<Ty>(in), getArray<Tp>(pos0), getArray<Tp>(pos1),
+    return getHandle(approx1<Ty>(getArray<Ty>(yi),
+                                 getArray<Tp>(xo), xdim,
+                                 xi_beg, xi_step,
                                  method, offGrid));
 }
 
-af_err af_approx1(af_array *out, const af_array in, const af_array pos,
+template<typename Ty, typename Tp>
+static inline af_array approx2(const af_array zi,
+                               const af_array xo, const int xdim,
+                               const af_array yo, const int ydim,
+                               const Tp &xi_beg, const Tp &xi_step,
+                               const Tp &yi_beg, const Tp &yi_step,
+                               const af_interp_type method, const float offGrid)
+{
+    return getHandle(approx2<Ty>(getArray<Ty>(zi),
+                                 getArray<Tp>(xo), xdim,
+                                 getArray<Tp>(yo), ydim,
+                                 xi_beg, xi_step,
+                                 yi_beg, yi_step,
+                                 method, offGrid));
+}
+
+af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
                   const af_interp_type method, const float offGrid)
 {
+    return af_approx1_uniform(yo, yi, xo, 0, 0.0, 1.0, method, offGrid);
+}
+
+af_err af_approx1_uniform(af_array *yo, const af_array yi,
+                          const af_array xo, const int xdim,
+                          const double xi_beg, const double xi_step,
+                          const af_interp_type method, const float offGrid)
+{
     try {
-        const ArrayInfo& i_info = getInfo(in);
-        const ArrayInfo& p_info = getInfo(pos);
+        const ArrayInfo& yi_info = getInfo(yi);
+        const ArrayInfo& xo_info = getInfo(xo);
 
-        dim4 idims = i_info.dims();
-        dim4 pdims = p_info.dims();
+        dim4 yi_dims = yi_info.dims();
+        dim4 xo_dims = xo_info.dims();
 
-        af_dtype itype = i_info.getType();
+        af_dtype itype = yi_info.getType();
 
-        ARG_ASSERT(1, i_info.isFloating());                       // Only floating and complex types
-        ARG_ASSERT(2, p_info.isRealFloating());                   // Only floating types
-        ARG_ASSERT(1, i_info.isSingle() == p_info.isSingle());    // Must have same precision
-        ARG_ASSERT(1, i_info.isDouble() == p_info.isDouble());    // Must have same precision
-        // POS should either be (x, 1, 1, 1) or (1, idims[1], idims[2], idims[3])
-        DIM_ASSERT(2, p_info.isColumn() ||
-                      (pdims[1] == idims[1] && pdims[2] == idims[2] && pdims[3] == idims[3]));
-        ARG_ASSERT(3, (method == AF_INTERP_LINEAR  ||
+        ARG_ASSERT(1, yi_info.isFloating());                       // Only floating and complex types
+        ARG_ASSERT(2, xo_info.isRealFloating());                   // Only floating types
+        ARG_ASSERT(1, yi_info.isSingle() == xo_info.isSingle());    // Must have same precision
+        ARG_ASSERT(1, yi_info.isDouble() == xo_info.isDouble());    // Must have same precision
+        // POS should either be (x, 1, 1, 1) or (1, yi_dims[1], yi_dims[2], yi_dims[3])
+
+        ARG_ASSERT(3, xdim >= 0 && xdim < 4);
+
+        if (xo_dims[xdim] != xo_dims.elements()) {
+            for (int i = 0; i < 4; i++) {
+                if (xdim != i) DIM_ASSERT(2, xo_dims[i] == yi_dims[i]);
+            }
+        }
+
+        ARG_ASSERT(6, (method == AF_INTERP_LINEAR  ||
                        method == AF_INTERP_NEAREST ||
                        method == AF_INTERP_CUBIC   ||
                        method == AF_INTERP_CUBIC_SPLINE ||
                        method == AF_INTERP_LINEAR_COSINE ||
                        method == AF_INTERP_LOWER));
 
-        if(idims.ndims() == 0 || pdims.ndims() ==  0) {
-            return af_create_handle(out, 0, nullptr, itype);
+        if(yi_dims.ndims() == 0 || xo_dims.ndims() ==  0) {
+            return af_create_handle(yo, 0, nullptr, itype);
         }
 
         af_array output;
 
         switch(itype) {
-            case f32: output = approx1<float  , float >(in, pos, method, offGrid);  break;
-            case f64: output = approx1<double , double>(in, pos, method, offGrid);  break;
-            case c32: output = approx1<cfloat , float >(in, pos, method, offGrid);  break;
-            case c64: output = approx1<cdouble, double>(in, pos, method, offGrid);  break;
-            default:  TYPE_ERROR(1, itype);
+        case f32: output = approx1<float  , float >(yi, xo, xdim,
+                                                    xi_beg, xi_step,
+                                                    method, offGrid);  break;
+        case f64: output = approx1<double , double>(yi, xo, xdim,
+                                                    xi_beg, xi_step,
+                                                    method, offGrid);  break;
+        case c32: output = approx1<cfloat , float >(yi, xo, xdim,
+                                                    xi_beg, xi_step,
+                                                    method, offGrid);  break;
+        case c64: output = approx1<cdouble, double>(yi, xo, xdim,
+                                                    xi_beg, xi_step,
+                                                    method, offGrid);  break;
+        default:  TYPE_ERROR(1, itype);
         }
-        std::swap(*out,output);
+        std::swap(*yo,output);
     }
     CATCHALL;
 
     return AF_SUCCESS;
 }
 
-af_err af_approx2(af_array *out, const af_array in, const af_array pos0, const af_array pos1,
+af_err af_approx2(af_array *zo, const af_array zi, const af_array xo, const af_array yo,
                   const af_interp_type method, const float offGrid)
 {
+    return af_approx2_uniform(zo, zi, xo, 0, yo, 1, 0.0, 1.0, 0.0, 1.0, method, offGrid);
+}
+
+af_err af_approx2_uniform(af_array *zo, const af_array zi,
+                          const af_array xo, const int xdim,
+                          const af_array yo, const int ydim,
+                          const double xi_beg, const double xi_step,
+                          const double yi_beg, const double yi_step,
+                          const af_interp_type method, const float offGrid)
+{
     try {
-        const ArrayInfo& i_info = getInfo(in);
-        const ArrayInfo& p_info = getInfo(pos0);
-        const ArrayInfo& q_info = getInfo(pos1);
+        const ArrayInfo& zi_info = getInfo(zi);
+        const ArrayInfo& xo_info = getInfo(xo);
+        const ArrayInfo& yo_info = getInfo(yo);
 
-        dim4 idims = i_info.dims();
-        dim4 pdims = p_info.dims();
-        dim4 qdims = q_info.dims();
+        dim4 zi_dims = zi_info.dims();
+        dim4 xo_dims = xo_info.dims();
+        dim4 yo_dims = yo_info.dims();
 
-        af_dtype itype = i_info.getType();
+        af_dtype itype = zi_info.getType();
 
-        ARG_ASSERT(1, i_info.isFloating());                     // Only floating and complex types
-        ARG_ASSERT(2, p_info.isRealFloating());                 // Only floating types
-        ARG_ASSERT(3, q_info.isRealFloating());                 // Only floating types
-        ARG_ASSERT(1, p_info.getType() == q_info.getType());    // Must have same type
-        ARG_ASSERT(1, i_info.isSingle() == p_info.isSingle());  // Must have same precision
-        ARG_ASSERT(1, i_info.isDouble() == p_info.isDouble());  // Must have same precision
-        DIM_ASSERT(2, pdims == qdims);                          // POS0 and POS1 must have same dims
+        ARG_ASSERT(1, zi_info.isFloating());                     // Only floating and complex types
+        ARG_ASSERT(2, xo_info.isRealFloating());                 // Only floating types
+        ARG_ASSERT(4, yo_info.isRealFloating());                 // Only floating types
+        ARG_ASSERT(2, xo_info.getType() == yo_info.getType());    // Must have same type
+        ARG_ASSERT(1, zi_info.isSingle() == xo_info.isSingle());  // Must have same precision
+        ARG_ASSERT(1, zi_info.isDouble() == xo_info.isDouble());  // Must have same precision
+        DIM_ASSERT(2, xo_dims == yo_dims);                        // POS0 and POS1 must have same dims
 
-        // POS should either be (x, y, 1, 1) or (x, y, idims[2], idims[3])
-        DIM_ASSERT(2, (pdims[2] == 1        && pdims[3] == 1) ||
-                      (pdims[2] == idims[2] && pdims[3] == idims[3]));
+        ARG_ASSERT(3, xdim >= 0 && xdim < 4);
+        ARG_ASSERT(5, ydim >= 0 && ydim < 4);
 
-        if(idims.ndims() == 0 || pdims.ndims() ==  0 || qdims.ndims() == 0) {
-            return af_create_handle(out, 0, nullptr, itype);
+        // POS should either be (x, y, 1, 1) or (x, y, zi_dims[2], zi_dims[3])
+        if (xo_dims[xdim] * xo_dims[ydim] != xo_dims.elements()) {
+            for (int i = 0; i < 4; i++) {
+                if (xdim != i && ydim != i) DIM_ASSERT(2, xo_dims[i] == zi_dims[i]);
+            }
+        }
+
+        if(zi_dims.ndims() == 0 || xo_dims.ndims() ==  0 || yo_dims.ndims() == 0) {
+            return af_create_handle(zo, 0, nullptr, itype);
         }
 
         af_array output;
 
         switch(itype) {
-            case f32: output = approx2<float  , float >(in, pos0, pos1, method, offGrid);  break;
-            case f64: output = approx2<double , double>(in, pos0, pos1, method, offGrid);  break;
-            case c32: output = approx2<cfloat , float >(in, pos0, pos1, method, offGrid);  break;
-            case c64: output = approx2<cdouble, double>(in, pos0, pos1, method, offGrid);  break;
-            default:  TYPE_ERROR(1, itype);
+        case f32: output = approx2<float  , float >(zi, xo, xdim, yo, ydim,
+                                                    xi_beg, xi_step, yi_beg, yi_step,
+                                                    method, offGrid);  break;
+        case f64: output = approx2<double , double>(zi, xo, xdim, yo, ydim,
+                                                    xi_beg, xi_step, yi_beg, yi_step,
+                                                    method, offGrid);  break;
+        case c32: output = approx2<cfloat , float >(zi, xo, xdim, yo, ydim,
+                                                    xi_beg, xi_step, yi_beg, yi_step,
+                                                    method, offGrid);  break;
+        case c64: output = approx2<cdouble, double>(zi, xo, xdim, yo, ydim,
+                                                    xi_beg, xi_step, yi_beg, yi_step,
+                                                    method, offGrid);  break;
+        default:  TYPE_ERROR(1, itype);
         }
-        std::swap(*out,output);
+        std::swap(*zo, output);
     }
     CATCHALL;
 

--- a/src/api/cpp/approx.cpp
+++ b/src/api/cpp/approx.cpp
@@ -39,18 +39,14 @@ namespace af
      }
 
     array approx2(const array &zi,
-                  const array &xo, const int xdim,
-                  const array &yo, const int ydim,
-                  const double xi_beg, const double xi_step,
-                  const double yi_beg, const double yi_step,
+                  const array &xo, const int xdim, const double xi_beg, const double xi_step,
+                  const array &yo, const int ydim, const double yi_beg, const double yi_step,
                   const interpType method, const float offGrid)
     {
         af_array zo = 0;
         AF_THROW(af_approx2_uniform(&zo, zi.get(),
-                                    xo.get(), xdim,
-                                    yo.get(), ydim,
-                                    xi_beg, xi_step,
-                                    yi_beg, yi_step,
+                                    xo.get(), xdim, xi_beg, xi_step,
+                                    yo.get(), ydim, yi_beg, yi_step,
                                     method, offGrid));
         return array(zo);
     }

--- a/src/api/cpp/approx.cpp
+++ b/src/api/cpp/approx.cpp
@@ -13,18 +13,45 @@
 
 namespace af
 {
-    array approx1(const array& in, const array &pos, const interpType method, const float offGrid)
+    array approx1(const array& yi, const array &xo, const interpType method, const float offGrid)
     {
-        af_array out = 0;
-        AF_THROW(af_approx1(&out, in.get(), pos.get(), method, offGrid));
-        return array(out);
+        af_array yo = 0;
+        AF_THROW(af_approx1(&yo, yi.get(), xo.get(), method, offGrid));
+        return array(yo);
     }
 
-    array approx2(const array& in, const array &pos0, const array &pos1,
+    array approx2(const array& zi, const array &xo, const array &yo,
                   const interpType method, const float offGrid)
     {
-        af_array out = 0;
-        AF_THROW(af_approx2(&out, in.get(), pos0.get(), pos1.get(), method, offGrid));
-        return array(out);
+        af_array zo = 0;
+        AF_THROW(af_approx2(&zo, zi.get(), xo.get(), yo.get(), method, offGrid));
+        return array(zo);
+    }
+
+     array approx1(const array &yi,
+                   const array &xo, const int xdim,
+                   const double xi_beg, const double xi_step,
+                   const interpType method, const float offGrid)
+     {
+        af_array yo = 0;
+        AF_THROW(af_approx1_uniform(&yo, yi.get(), xo.get(), xdim, xi_beg, xi_step, method, offGrid));
+        return array(yo);
+     }
+
+    array approx2(const array &zi,
+                  const array &xo, const int xdim,
+                  const array &yo, const int ydim,
+                  const double xi_beg, const double xi_step,
+                  const double yi_beg, const double yi_step,
+                  const interpType method, const float offGrid)
+    {
+        af_array zo = 0;
+        AF_THROW(af_approx2_uniform(&zo, zi.get(),
+                                    xo.get(), xdim,
+                                    yo.get(), ydim,
+                                    xi_beg, xi_step,
+                                    yi_beg, yi_step,
+                                    method, offGrid));
+        return array(zo);
     }
 }

--- a/src/api/unified/signal.cpp
+++ b/src/api/unified/signal.cpp
@@ -11,16 +11,39 @@
 #include <af/signal.h>
 #include "symbol_manager.hpp"
 
-af_err af_approx1(af_array *out, const af_array in, const af_array pos, const af_interp_type method, const float offGrid)
+af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
+                  const af_interp_type method, const float offGrid)
 {
-    CHECK_ARRAYS(in, pos);
-    return CALL(out, in, pos, method, offGrid);
+    CHECK_ARRAYS(yi, xo);
+    return CALL(yo, yi, xo, method, offGrid);
 }
 
-af_err af_approx2(af_array *out, const af_array in, const af_array pos0, const af_array pos1, const af_interp_type method, const float offGrid)
+af_err af_approx2(af_array *zo, const af_array zi,
+                  const af_array xo, const af_array yo,
+                  const af_interp_type method, const float offGrid)
 {
-    CHECK_ARRAYS(in, pos0, pos1);
-    return CALL(out, in, pos0, pos1, method, offGrid);
+    CHECK_ARRAYS(zi, xo, yo);
+    return CALL(zo, zi, xo, yo, method, offGrid);
+}
+
+af_err af_approx1_uniform(af_array *yo, const af_array yi,
+                          const af_array xo, const int xdim,
+                          const double xi_beg, const double xi_step,
+                          const af_interp_type method, const float offGrid)
+{
+    CHECK_ARRAYS(yi, xo);
+    return CALL(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid);
+}
+
+af_err af_approx2_uniform(af_array *zo, const af_array zi,
+                          const af_array xo, const int xdim,
+                          const af_array yo, const int ydim,
+                          const double xi_beg, const double xi_step,
+                          const double yi_beg, const double yi_step,
+                          const af_interp_type method, const float offGrid)
+{
+    CHECK_ARRAYS(zi, xo, yo);
+    return CALL(zo, zi, xo, xdim, yo, ydim, xi_beg, xi_step, yi_beg, yi_step, method, offGrid);
 }
 
 af_err af_set_fft_plan_cache_size(size_t cache_size)

--- a/src/api/unified/signal.cpp
+++ b/src/api/unified/signal.cpp
@@ -36,14 +36,12 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi,
 }
 
 af_err af_approx2_uniform(af_array *zo, const af_array zi,
-                          const af_array xo, const int xdim,
-                          const af_array yo, const int ydim,
-                          const double xi_beg, const double xi_step,
-                          const double yi_beg, const double yi_step,
+                          const af_array xo, const int xdim, const double xi_beg, const double xi_step,
+                          const af_array yo, const int ydim, const double yi_beg, const double yi_step,
                           const af_interp_type method, const float offGrid)
 {
     CHECK_ARRAYS(zi, xo, yo);
-    return CALL(zo, zi, xo, xdim, yo, ydim, xi_beg, xi_step, yi_beg, yi_step, method, offGrid);
+    return CALL(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg, yi_step, method, offGrid);
 }
 
 af_err af_set_fft_plan_cache_size(size_t cache_size)

--- a/src/backend/cpu/approx.cpp
+++ b/src/backend/cpu/approx.cpp
@@ -20,86 +20,107 @@ namespace cpu
 {
 
 template<typename Ty, typename Tp>
-Array<Ty> approx1(const Array<Ty> &in, const Array<Tp> &pos,
+Array<Ty> approx1(const Array<Ty> &yi,
+                  const Array<Tp> &xo, const int xdim,
+                  const Tp &xi_beg, const Tp &xi_step,
                   const af_interp_type method, const float offGrid)
 {
-    in.eval();
-    pos.eval();
+    yi.eval();
+    xo.eval();
 
-    af::dim4 odims = in.dims();
-    odims[0] = pos.dims()[0];
+    af::dim4 odims = yi.dims();
+    odims[xdim] = xo.dims()[xdim];
 
-    Array<Ty> out = createEmptyArray<Ty>(odims);
+    Array<Ty> yo = createEmptyArray<Ty>(odims);
 
     switch(method) {
     case AF_INTERP_NEAREST:
     case AF_INTERP_LOWER:
         getQueue().enqueue(kernel::approx1<Ty, Tp, 1>,
-                           out, in, pos, offGrid, method);
+                           yo, yi, xo, xdim, xi_beg, xi_step, offGrid, method);
         break;
     case AF_INTERP_LINEAR:
     case AF_INTERP_LINEAR_COSINE:
         getQueue().enqueue(kernel::approx1<Ty, Tp, 2>,
-                           out, in, pos, offGrid, method);
+                           yo, yi, xo, xdim, xi_beg, xi_step, offGrid, method);
         break;
     case AF_INTERP_CUBIC:
     case AF_INTERP_CUBIC_SPLINE:
         getQueue().enqueue(kernel::approx1<Ty, Tp, 3>,
-                           out, in, pos, offGrid, method);
+                           yo, yi, xo, xdim, xi_beg, xi_step, offGrid, method);
         break;
     default:
         break;
     }
-    return out;
+    return yo;
 }
 
-
 template<typename Ty, typename Tp>
-Array<Ty> approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
+Array<Ty> approx2(const Array<Ty> &zi,
+                  const Array<Tp> &xo, const int xdim,
+                  const Array<Tp> &yo, const int ydim,
+                  const Tp &xi_beg, const Tp &xi_step,
+                  const Tp &yi_beg, const Tp &yi_step,
                   const af_interp_type method, const float offGrid)
 {
-    in.eval();
-    pos0.eval();
-    pos1.eval();
+    zi.eval();
+    xo.eval();
+    yo.eval();
 
-    af::dim4 odims = in.dims();
-    odims[0] = pos0.dims()[0];
-    odims[1] = pos0.dims()[1];
+    af::dim4 odims = zi.dims();
+    odims[xdim] = xo.dims()[xdim];
+    odims[ydim] = xo.dims()[ydim];
 
-    Array<Ty> out = createEmptyArray<Ty>(odims);
+    Array<Ty> zo = createEmptyArray<Ty>(odims);
 
     switch(method) {
     case AF_INTERP_NEAREST:
     case AF_INTERP_LOWER:
         getQueue().enqueue(kernel::approx2<Ty, Tp, 1>,
-                           out, in, pos0, pos1, offGrid, method);
+                           zo, zi, xo, xdim, yo, ydim,
+                           xi_beg, xi_step, yi_beg, yi_step, offGrid, method);
         break;
     case AF_INTERP_LINEAR:
     case AF_INTERP_BILINEAR:
     case AF_INTERP_LINEAR_COSINE:
     case AF_INTERP_BILINEAR_COSINE:
         getQueue().enqueue(kernel::approx2<Ty, Tp, 2>,
-                           out, in, pos0, pos1, offGrid, method);
+                           zo, zi, xo, xdim, yo, ydim,
+                           xi_beg, xi_step, yi_beg, yi_step, offGrid, method);
         break;
     case AF_INTERP_CUBIC:
     case AF_INTERP_BICUBIC:
     case AF_INTERP_CUBIC_SPLINE:
     case AF_INTERP_BICUBIC_SPLINE:
         getQueue().enqueue(kernel::approx2<Ty, Tp, 3>,
-                           out, in, pos0, pos1, offGrid, method);
+                           zo, zi, xo, xdim, yo, ydim,
+                           xi_beg, xi_step, yi_beg, yi_step, offGrid, method);
         break;
     default:
         break;
     }
-    return out;
+    return zo;
 }
 
-#define INSTANTIATE(Ty, Tp)                                                                    \
-    template Array<Ty> approx1<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos,              \
-                                       const af_interp_type method, const float offGrid);      \
-    template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos0,             \
-                                       const Array<Tp> &pos1, const af_interp_type method,     \
-                                       const float offGrid);                                   \
+#define INSTANTIATE(Ty, Tp)                                         \
+    template Array<Ty> approx1<Ty, Tp>(const Array<Ty> &yi,         \
+                                       const Array<Tp> &xo,         \
+                                       const int xdim,              \
+                                       const Tp &xi_beg,            \
+                                       const Tp &xi_step,           \
+                                       const af_interp_type method, \
+                                       const float offGrid);        \
+    template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &zi,         \
+                                       const Array<Tp> &xo,         \
+                                       const int xdim,              \
+                                       const Array<Tp> &yo,         \
+                                       const int ydim,              \
+                                       const Tp &xi_beg,            \
+                                       const Tp &xi_step,           \
+                                       const Tp &yi_beg,            \
+                                       const Tp &yi_step,           \
+                                       const af_interp_type method, \
+                                       const float offGrid);        \
 
 INSTANTIATE(float  , float )
 INSTANTIATE(double , double)

--- a/src/backend/cpu/approx.cpp
+++ b/src/backend/cpu/approx.cpp
@@ -8,12 +8,8 @@
  ********************************************************/
 
 #include <approx.hpp>
-
-#include <Array.hpp>
 #include <kernel/approx.hpp>
 #include <platform.hpp>
-
-#include <af/defines.h>
 #include <af/dim4.hpp>
 
 namespace cpu
@@ -28,7 +24,7 @@ Array<Ty> approx1(const Array<Ty> &yi,
     yi.eval();
     xo.eval();
 
-    af::dim4 odims = yi.dims();
+    dim4 odims = yi.dims();
     odims[xdim] = xo.dims()[xdim];
 
     Array<Ty> yo = createEmptyArray<Ty>(odims);
@@ -67,7 +63,7 @@ Array<Ty> approx2(const Array<Ty> &zi,
     xo.eval();
     yo.eval();
 
-    af::dim4 odims = zi.dims();
+    dim4 odims = zi.dims();
     odims[xdim] = xo.dims()[xdim];
     odims[ydim] = xo.dims()[ydim];
 

--- a/src/backend/cpu/approx.cpp
+++ b/src/backend/cpu/approx.cpp
@@ -53,10 +53,8 @@ Array<Ty> approx1(const Array<Ty> &yi,
 
 template<typename Ty, typename Tp>
 Array<Ty> approx2(const Array<Ty> &zi,
-                  const Array<Tp> &xo, const int xdim,
-                  const Array<Tp> &yo, const int ydim,
-                  const Tp &xi_beg, const Tp &xi_step,
-                  const Tp &yi_beg, const Tp &yi_step,
+                  const Array<Tp> &xo, const int xdim, const Tp &xi_beg, const Tp &xi_step,
+                  const Array<Tp> &yo, const int ydim, const Tp &yi_beg, const Tp &yi_step,
                   const af_interp_type method, const float offGrid)
 {
     zi.eval();
@@ -73,24 +71,29 @@ Array<Ty> approx2(const Array<Ty> &zi,
     case AF_INTERP_NEAREST:
     case AF_INTERP_LOWER:
         getQueue().enqueue(kernel::approx2<Ty, Tp, 1>,
-                           zo, zi, xo, xdim, yo, ydim,
-                           xi_beg, xi_step, yi_beg, yi_step, offGrid, method);
+                           zo, zi,
+                           xo, xdim, xi_beg, xi_step,
+                           yo, ydim, yi_beg, yi_step, offGrid, method);
         break;
     case AF_INTERP_LINEAR:
     case AF_INTERP_BILINEAR:
     case AF_INTERP_LINEAR_COSINE:
     case AF_INTERP_BILINEAR_COSINE:
         getQueue().enqueue(kernel::approx2<Ty, Tp, 2>,
-                           zo, zi, xo, xdim, yo, ydim,
-                           xi_beg, xi_step, yi_beg, yi_step, offGrid, method);
+                           zo, zi,
+                           xo, xdim, xi_beg, xi_step,
+                           yo, ydim, yi_beg, yi_step,
+                           offGrid, method);
         break;
     case AF_INTERP_CUBIC:
     case AF_INTERP_BICUBIC:
     case AF_INTERP_CUBIC_SPLINE:
     case AF_INTERP_BICUBIC_SPLINE:
         getQueue().enqueue(kernel::approx2<Ty, Tp, 3>,
-                           zo, zi, xo, xdim, yo, ydim,
-                           xi_beg, xi_step, yi_beg, yi_step, offGrid, method);
+                           zo, zi,
+                           xo, xdim, xi_beg, xi_step,
+                           yo, ydim, yi_beg, yi_step,
+                           offGrid, method);
         break;
     default:
         break;
@@ -109,10 +112,10 @@ Array<Ty> approx2(const Array<Ty> &zi,
     template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &zi,         \
                                        const Array<Tp> &xo,         \
                                        const int xdim,              \
-                                       const Array<Tp> &yo,         \
-                                       const int ydim,              \
                                        const Tp &xi_beg,            \
                                        const Tp &xi_step,           \
+                                       const Array<Tp> &yo,         \
+                                       const int ydim,              \
                                        const Tp &yi_beg,            \
                                        const Tp &yi_step,           \
                                        const af_interp_type method, \

--- a/src/backend/cpu/approx.hpp
+++ b/src/backend/cpu/approx.hpp
@@ -20,9 +20,7 @@ namespace cpu
 
     template<typename Ty, typename Tp>
     Array<Ty> approx2(const Array<Ty> &zi,
-                      const Array<Tp> &xo, const int xdim,
-                      const Array<Tp> &yo, const int ydim,
-                      const Tp &xi_beg, const Tp &xi_step,
-                      const Tp &yi_beg, const Tp &yi_step,
+                      const Array<Tp> &xo, const int xdim, const Tp &xi_beg, const Tp &xi_step,
+                      const Array<Tp> &yo, const int ydim, const Tp &yi_beg, const Tp &yi_step,
                       const af_interp_type method, const float offGrid);
 }

--- a/src/backend/cpu/approx.hpp
+++ b/src/backend/cpu/approx.hpp
@@ -13,10 +13,16 @@
 namespace cpu
 {
     template<typename Ty, typename Tp>
-    Array<Ty> approx1(const Array<Ty> &in, const Array<Tp> &pos,
+    Array<Ty> approx1(const Array<Ty> &yi,
+                      const Array<Tp> &xo, const int xdim,
+                      const Tp &xi_beg, const Tp &xi_step,
                       const af_interp_type method, const float offGrid);
 
     template<typename Ty, typename Tp>
-    Array<Ty> approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
+    Array<Ty> approx2(const Array<Ty> &zi,
+                      const Array<Tp> &xo, const int xdim,
+                      const Array<Tp> &yo, const int ydim,
+                      const Tp &xi_beg, const Tp &xi_step,
+                      const Tp &yi_beg, const Tp &yi_step,
                       const af_interp_type method, const float offGrid);
 }

--- a/src/backend/cpu/kernel/approx.hpp
+++ b/src/backend/cpu/kernel/approx.hpp
@@ -128,7 +128,7 @@ void approx2(Param<InT> zo, CParam<InT> zi,
                         y < 0 || zi_dims[ydim] < y + 1 ) {
                         zo_ptr[zo_off + idx] = scalar<InT>(offGrid);
                     } else {
-                        interp(zo, zo_off + idx, zi, zi_off + zi_idx, x, y, method, 1, clamp);
+                        interp(zo, zo_off + idx, zi, zi_off + zi_idx, x, y, method, 1, clamp, xdim, ydim);
                     }
                 }
             }

--- a/src/backend/cpu/kernel/approx.hpp
+++ b/src/backend/cpu/kernel/approx.hpp
@@ -74,10 +74,8 @@ void approx1(Param<InT> yo, CParam<InT> yi,
 
 template<typename InT, typename LocT, int order>
 void approx2(Param<InT> zo, CParam<InT> zi,
-             CParam<LocT> xo, const int xdim,
-             CParam<LocT> yo, const int ydim,
-             const LocT &xi_beg, const LocT &xi_step,
-             const LocT &yi_beg, const LocT &yi_step,
+             CParam<LocT> xo, const int xdim, const LocT &xi_beg, const LocT &xi_step,
+             CParam<LocT> yo, const int ydim, const LocT &yi_beg, const LocT &yi_step,
              float const offGrid, af_interp_type method)
 {
     InT *zo_ptr = zo.get();

--- a/src/backend/cpu/kernel/approx.hpp
+++ b/src/backend/cpu/kernel/approx.hpp
@@ -18,48 +18,50 @@ namespace kernel
 {
 
 template<typename InT, typename LocT, int order>
-void approx1(Param<InT> output, CParam<InT> input,
-             CParam<LocT> xposition, const float offGrid, af_interp_type method)
+void approx1(Param<InT> yo, CParam<InT> yi,
+             CParam<LocT> xo, const int xdim,
+             const LocT &xi_beg, const LocT &xi_step,
+             const float offGrid, af_interp_type method)
 {
-    InT * out = output.get();
-    const LocT *xpos = xposition.get();
+    InT *yo_ptr = yo.get();
+    const LocT *xo_ptr = xo.get();
 
-    const af::dim4 odims     = output.dims();
-    const af::dim4 idims     = input.dims();
-    const af::dim4 xdims     = xposition.dims();
+    const af::dim4 yo_dims     = yo.dims();
+    const af::dim4 yi_dims     = yi.dims();
+    const af::dim4 xo_dims     = xo.dims();
 
-    const af::dim4 ostrides  = output.strides();
-    const af::dim4 istrides  = input.strides();
-    const af::dim4 xstrides  = xposition.strides();
+    const af::dim4 yo_strides  = yo.strides();
+    const af::dim4 yi_strides  = yi.strides();
+    const af::dim4 xo_strides  = xo.strides();
 
     Interp1<InT, LocT, order> interp;
-    bool batch = !(xdims[1] == 1 && xdims[2] == 1 && xdims[3] == 1);
+    bool batch[] = {xo_dims[0] > 1, xo_dims[1] > 1, xo_dims[2] > 1, xo_dims[3] > 1};
 
-    for(dim_t idw = 0; idw < odims[3]; idw++) {
-        for(dim_t idz = 0; idz < odims[2]; idz++) {
-            dim_t ooffzw = idw * ostrides[3] + idz * ostrides[2];
-            dim_t ioffzw = idw * istrides[3] + idz * istrides[2];
-            dim_t xoffzw = idw * xstrides[3] + idz * xstrides[2];
+    for(dim_t idw = 0; idw < yo_dims[3]; idw++) {
+        for(dim_t idz = 0; idz < yo_dims[2]; idz++) {
+            dim_t ooffzw = idw * yo_strides[3] + idz * yo_strides[2];
+            dim_t ioffzw = idw * yi_strides[3] + idz * yi_strides[2];
+            dim_t xoffzw = idw * xo_strides[3] * batch[3] + idz * xo_strides[2] * batch[2];
 
-            for(dim_t idy = 0; idy < odims[1]; idy++) {
+            for(dim_t idy = 0; idy < yo_dims[1]; idy++) {
 
-                dim_t ooff = ooffzw + idy * ostrides[1];
-                dim_t ioff = ioffzw + idy * istrides[1];
-                dim_t xoff = xoffzw + idy * xstrides[1];
+                dim_t ooff = ooffzw + idy * yo_strides[1];
+                dim_t ioff = ioffzw + idy * yi_strides[1];
+                dim_t xoff = xoffzw + idy * xo_strides[1] * batch[1];
 
-                for(dim_t idx = 0; idx < odims[0]; idx++) {
+                for(dim_t idx = 0; idx < yo_dims[0]; idx++) {
 
-                    const LocT x = xpos[batch * xoff + idx];
+                    const LocT x = (xo_ptr[xoff + idx * batch[0]] - xi_beg) / xi_step;
 
                     // FIXME: Only cubic interpolation is doing clamping
                     // We need to make it consistent across all methods
                     // Not changing the behavior because tests will fail
                     bool clamp = order == 3;
 
-                    if (x < 0 || idims[0] < x + 1) {
-                        out[ooff + idx] = scalar<InT>(offGrid);
+                    if (x < 0 || yi_dims[xdim] < x + 1) {
+                        yo_ptr[ooff + idx] = scalar<InT>(offGrid);
                     } else {
-                        interp(output, ooff + idx, input, ioff, x, method, 1, clamp);
+                        interp(yo, ooff + idx, yi, ioff, x, method, 1, clamp);
                     }
                 }
             }
@@ -68,53 +70,56 @@ void approx1(Param<InT> output, CParam<InT> input,
 }
 
 template<typename InT, typename LocT, int order>
-void approx2(Param<InT> output, CParam<InT> input,
-             CParam<LocT> xposition, CParam<LocT> yposition,
+void approx2(Param<InT> zo, CParam<InT> zi,
+             CParam<LocT> xo, const int xdim,
+             CParam<LocT> yo, const int ydim,
+             const LocT &xi_beg, const LocT &xi_step,
+             const LocT &yi_beg, const LocT &yi_step,
              float const offGrid, af_interp_type method)
 {
-    InT * out = output.get();
-    const LocT *xpos = xposition.get();
-    const LocT *ypos = yposition.get();
+    InT *zo_ptr = zo.get();
+    const LocT *xo_ptr = xo.get();
+    const LocT *yo_ptr = yo.get();
 
-    af::dim4 const odims     = output.dims();
-    af::dim4 const idims     = input.dims();
-    af::dim4 const xdims     = xposition.dims();
-    af::dim4 const ostrides  = output.strides();
-    af::dim4 const istrides  = input.strides();
-    af::dim4 const xstrides  = xposition.strides();
-    af::dim4 const ystrides  = yposition.strides();
+    af::dim4 const zo_dims     = zo.dims();
+    af::dim4 const zi_dims     = zi.dims();
+    af::dim4 const xo_dims     = xo.dims();
+    af::dim4 const zo_strides  = zo.strides();
+    af::dim4 const zi_strides  = zi.strides();
+    af::dim4 const xo_strides  = xo.strides();
+    af::dim4 const yo_strides  = yo.strides();
 
     Interp2<InT, LocT, order> interp;
-    bool batch = !(xdims[2] == 1 && xdims[3] == 1);
+    bool batch[] = {xo_dims[0] > 1, xo_dims[1] > 1, xo_dims[2] > 1, xo_dims[3] > 1};
 
-    for(dim_t idw = 0; idw < odims[3]; idw++) {
-        for(dim_t idz = 0; idz < odims[2]; idz++) {
+    for(dim_t idw = 0; idw < zo_dims[3]; idw++) {
+        for(dim_t idz = 0; idz < zo_dims[2]; idz++) {
 
-            dim_t xoffzw = idw * xstrides[3] + idz * xstrides[2];
-            dim_t yoffzw = idw * ystrides[3] + idz * ystrides[2];
-            dim_t ooffzw = idw * ostrides[3] + idz * ostrides[2];
-            dim_t ioffzw = idw * istrides[3] + idz * istrides[2];
+            dim_t xoffzw = idw * xo_strides[3] * batch[3] + idz * xo_strides[2] * batch[2];
+            dim_t yoffzw = idw * yo_strides[3] * batch[3] + idz * yo_strides[2] * batch[2];
+            dim_t ooffzw = idw * zo_strides[3] + idz * zo_strides[2];
+            dim_t ioffzw = idw * zi_strides[3] + idz * zi_strides[2];
 
-            for(dim_t idy = 0; idy < odims[1]; idy++) {
-                dim_t xoff = xoffzw * batch + idy * xstrides[1];
-                dim_t yoff = yoffzw * batch + idy * ystrides[1];
-                dim_t ooff = ooffzw         + idy * ostrides[1];
+            for(dim_t idy = 0; idy < zo_dims[1]; idy++) {
+                dim_t xoff = xoffzw + idy * xo_strides[1] * batch[1];
+                dim_t yoff = yoffzw + idy * yo_strides[1] * batch[1];
+                dim_t ooff = ooffzw + idy * zo_strides[1];
 
-                for(dim_t idx = 0; idx < odims[0]; idx++) {
+                for(dim_t idx = 0; idx < zo_dims[0]; idx++) {
 
-                    const LocT x = xpos[xoff + idx];
-                    const LocT y = ypos[yoff + idx];
+                    const LocT x = (xo_ptr[xoff + idx] - xi_beg) / xi_step;
+                    const LocT y = (yo_ptr[yoff + idx] - yi_beg) / yi_step;
 
                     // FIXME: Only cubic interpolation is doing clamping
                     // We need to make it consistent across all methods
                     // Not changing the behavior because tests will fail
                     bool clamp = order == 3;
 
-                    if (x < 0 || idims[0] < x + 1 ||
-                        y < 0 || idims[1] < y + 1 ) {
-                        out[ooff + idx] = scalar<InT>(offGrid);
+                    if (x < 0 || zi_dims[0] < x + 1 ||
+                        y < 0 || zi_dims[1] < y + 1 ) {
+                        zo_ptr[ooff + idx] = scalar<InT>(offGrid);
                     } else {
-                        interp(output, ooff + idx, input, ioffzw, x, y, method, 1, clamp);
+                        interp(zo, ooff + idx, zi, ioffzw, x, y, method, 1, clamp);
                     }
                 }
             }

--- a/src/backend/cpu/kernel/approx.hpp
+++ b/src/backend/cpu/kernel/approx.hpp
@@ -35,23 +35,26 @@ void approx1(Param<InT> yo, CParam<InT> yi,
     const af::dim4 xo_strides  = xo.strides();
 
     Interp1<InT, LocT, order> interp;
-    bool batch[] = {xo_dims[0] > 1, xo_dims[1] > 1, xo_dims[2] > 1, xo_dims[3] > 1};
+    bool is_xo_off[] = {xo_dims[0] > 1, xo_dims[1] > 1, xo_dims[2] > 1, xo_dims[3] > 1};
+    bool is_yi_off[] = {true, true, true, true};
+    is_yi_off[xdim] = false;
 
     for(dim_t idw = 0; idw < yo_dims[3]; idw++) {
         for(dim_t idz = 0; idz < yo_dims[2]; idz++) {
-            dim_t ooffzw = idw * yo_strides[3] + idz * yo_strides[2];
-            dim_t ioffzw = idw * yi_strides[3] + idz * yi_strides[2];
-            dim_t xoffzw = idw * xo_strides[3] * batch[3] + idz * xo_strides[2] * batch[2];
+            dim_t yo_off_zw = idw * yo_strides[3] + idz * yo_strides[2];
+            dim_t yi_off_zw = idw * yi_strides[3] * is_yi_off[3] + idz * yi_strides[2] * is_yi_off[2];
+            dim_t xo_off_zw = idw * xo_strides[3] * is_xo_off[3] + idz * xo_strides[2] * is_xo_off[2];
 
             for(dim_t idy = 0; idy < yo_dims[1]; idy++) {
 
-                dim_t ooff = ooffzw + idy * yo_strides[1];
-                dim_t ioff = ioffzw + idy * yi_strides[1];
-                dim_t xoff = xoffzw + idy * xo_strides[1] * batch[1];
+                dim_t yo_off = yo_off_zw + idy * yo_strides[1];
+                dim_t yi_off = yi_off_zw + idy * yi_strides[1] * is_yi_off[1];
+                dim_t xo_off = xo_off_zw + idy * xo_strides[1] * is_xo_off[1];
 
                 for(dim_t idx = 0; idx < yo_dims[0]; idx++) {
 
-                    const LocT x = (xo_ptr[xoff + idx * batch[0]] - xi_beg) / xi_step;
+                    dim_t yi_idx = idx * is_yi_off[0];
+                    const LocT x = (xo_ptr[xo_off + idx * is_xo_off[0]] - xi_beg) / xi_step;
 
                     // FIXME: Only cubic interpolation is doing clamping
                     // We need to make it consistent across all methods
@@ -59,9 +62,9 @@ void approx1(Param<InT> yo, CParam<InT> yi,
                     bool clamp = order == 3;
 
                     if (x < 0 || yi_dims[xdim] < x + 1) {
-                        yo_ptr[ooff + idx] = scalar<InT>(offGrid);
+                        yo_ptr[yo_off + idx] = scalar<InT>(offGrid);
                     } else {
-                        interp(yo, ooff + idx, yi, ioff, x, method, 1, clamp);
+                        interp(yo, yo_off + idx, yi, yi_off + yi_idx, x, method, 1, clamp, xdim);
                     }
                 }
             }
@@ -90,36 +93,42 @@ void approx2(Param<InT> zo, CParam<InT> zi,
     af::dim4 const yo_strides  = yo.strides();
 
     Interp2<InT, LocT, order> interp;
-    bool batch[] = {xo_dims[0] > 1, xo_dims[1] > 1, xo_dims[2] > 1, xo_dims[3] > 1};
+    bool is_xo_off[] = {xo_dims[0] > 1, xo_dims[1] > 1, xo_dims[2] > 1, xo_dims[3] > 1};
+    bool is_zi_off[] = {true, true, true, true};
+    is_zi_off[xdim] = false;
+    is_zi_off[ydim] = false;
 
     for(dim_t idw = 0; idw < zo_dims[3]; idw++) {
         for(dim_t idz = 0; idz < zo_dims[2]; idz++) {
 
-            dim_t xoffzw = idw * xo_strides[3] * batch[3] + idz * xo_strides[2] * batch[2];
-            dim_t yoffzw = idw * yo_strides[3] * batch[3] + idz * yo_strides[2] * batch[2];
-            dim_t ooffzw = idw * zo_strides[3] + idz * zo_strides[2];
-            dim_t ioffzw = idw * zi_strides[3] + idz * zi_strides[2];
+            dim_t zo_off_zw = idw * zo_strides[3] + idz * zo_strides[2];
+            dim_t zi_off_zw = idw * zi_strides[3] * is_zi_off[3] + idz * zi_strides[2] * is_zi_off[2];
+            dim_t xo_off_zw = idw * xo_strides[3] * is_xo_off[3] + idz * xo_strides[2] * is_xo_off[2];
+            dim_t yo_off_zw = idw * yo_strides[3] * is_xo_off[3] + idz * yo_strides[2] * is_xo_off[2];
 
             for(dim_t idy = 0; idy < zo_dims[1]; idy++) {
-                dim_t xoff = xoffzw + idy * xo_strides[1] * batch[1];
-                dim_t yoff = yoffzw + idy * yo_strides[1] * batch[1];
-                dim_t ooff = ooffzw + idy * zo_strides[1];
+                dim_t xo_off = xo_off_zw + idy * xo_strides[1] * is_xo_off[1];
+                dim_t yo_off = yo_off_zw + idy * yo_strides[1] * is_xo_off[1];
+                dim_t zi_off = zi_off_zw + idy * zi_strides[1] * is_zi_off[1];
+                dim_t zo_off = zo_off_zw + idy * zo_strides[1];
 
                 for(dim_t idx = 0; idx < zo_dims[0]; idx++) {
 
-                    const LocT x = (xo_ptr[xoff + idx] - xi_beg) / xi_step;
-                    const LocT y = (yo_ptr[yoff + idx] - yi_beg) / yi_step;
+                    const LocT x = (xo_ptr[xo_off + idx] - xi_beg) / xi_step;
+                    const LocT y = (yo_ptr[yo_off + idx] - yi_beg) / yi_step;
+
+                    dim_t zi_idx = idx * zi_strides[0] * is_zi_off[0];
 
                     // FIXME: Only cubic interpolation is doing clamping
                     // We need to make it consistent across all methods
                     // Not changing the behavior because tests will fail
                     bool clamp = order == 3;
 
-                    if (x < 0 || zi_dims[0] < x + 1 ||
-                        y < 0 || zi_dims[1] < y + 1 ) {
-                        zo_ptr[ooff + idx] = scalar<InT>(offGrid);
+                    if (x < 0 || zi_dims[xdim] < x + 1 ||
+                        y < 0 || zi_dims[ydim] < y + 1 ) {
+                        zo_ptr[zo_off + idx] = scalar<InT>(offGrid);
                     } else {
-                        interp(zo, ooff + idx, zi, ioffzw, x, y, method, 1, clamp);
+                        interp(zo, zo_off + idx, zi, zi_off + zi_idx, x, y, method, 1, clamp);
                     }
                 }
             }

--- a/src/backend/cuda/approx.cu
+++ b/src/backend/cuda/approx.cu
@@ -54,7 +54,7 @@ namespace cuda
                       const Tp &yi_beg, const Tp &yi_step,
                       const af_interp_type method, const float offGrid)
     {
-        af::dim4 odims = zi.dims()
+        af::dim4 odims = zi.dims();
         odims[xdim] = xo.dims()[xdim];
         odims[ydim] = xo.dims()[ydim];
 

--- a/src/backend/cuda/approx.cu
+++ b/src/backend/cuda/approx.cu
@@ -48,10 +48,8 @@ namespace cuda
 
     template<typename Ty, typename Tp>
     Array<Ty> approx2(const Array<Ty> &zi,
-                      const Array<Tp> &xo, const int xdim,
-                      const Array<Tp> &yo, const int ydim,
-                      const Tp &xi_beg, const Tp &xi_step,
-                      const Tp &yi_beg, const Tp &yi_step,
+                      const Array<Tp> &xo, const int xdim, const Tp &xi_beg, const Tp &xi_step,
+                      const Array<Tp> &yo, const int ydim, const Tp &yi_beg, const Tp &yi_step,
                       const af_interp_type method, const float offGrid)
     {
         af::dim4 odims = zi.dims();
@@ -65,10 +63,8 @@ namespace cuda
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
             kernel::approx2<Ty, Tp, 1> (zo, zi,
-                                        xo, xdim,
-                                        yo, ydim,
-                                        xi_beg, xi_step,
-                                        yi_beg, yi_step,
+                                        xo, xdim, xi_beg, xi_step,
+                                        yo, ydim, yi_beg, yi_step,
                                         offGrid, method);
             break;
         case AF_INTERP_LINEAR:
@@ -76,10 +72,8 @@ namespace cuda
         case AF_INTERP_LINEAR_COSINE:
         case AF_INTERP_BILINEAR_COSINE:
             kernel::approx2<Ty, Tp, 2> (zo, zi,
-                                        xo, xdim,
-                                        yo, ydim,
-                                        xi_beg, xi_step,
-                                        yi_beg, yi_step,
+                                        xo, xdim, xi_beg, xi_step,
+                                        yo, ydim, yi_beg, yi_step,
                                         offGrid, method);
             break;
         case AF_INTERP_CUBIC:
@@ -87,10 +81,8 @@ namespace cuda
         case AF_INTERP_CUBIC_SPLINE:
         case AF_INTERP_BICUBIC_SPLINE:
             kernel::approx2<Ty, Tp, 3> (zo, zi,
-                                        xo, xdim,
-                                        yo, ydim,
-                                        xi_beg, xi_step,
-                                        yi_beg, yi_step,
+                                        xo, xdim, xi_beg, xi_step,
+                                        yo, ydim, yi_beg, yi_step,
                                         offGrid, method);
             break;
         default:
@@ -110,10 +102,10 @@ namespace cuda
     template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &zi,         \
                                        const Array<Tp> &xo,         \
                                        const int xdim,              \
-                                       const Array<Tp> &yo,         \
-                                       const int ydim,              \
                                        const Tp &xi_beg,            \
                                        const Tp &xi_step,           \
+                                       const Array<Tp> &yo,         \
+                                       const int ydim,              \
                                        const Tp &yi_beg,            \
                                        const Tp &yi_step,           \
                                        const af_interp_type method, \

--- a/src/backend/cuda/approx.cu
+++ b/src/backend/cuda/approx.cu
@@ -16,79 +16,112 @@
 namespace cuda
 {
     template<typename Ty, typename Tp>
-    Array<Ty> approx1(const Array<Ty> &in, const Array<Tp> &pos,
+    Array<Ty> approx1(const Array<Ty> &yi,
+                      const Array<Tp> &xo, const int xdim,
+                      const Tp &xi_beg, const Tp &xi_step,
                       const af_interp_type method, const float offGrid)
     {
-        af::dim4 idims = in.dims();
-        af::dim4 odims = in.dims();
-        odims[0] = pos.dims()[0];
+        af::dim4 odims = yi.dims();
+        odims[xdim] = xo.dims()[xdim];
 
         // Create output placeholder
-        Array<Ty> out = createEmptyArray<Ty>(odims);
+        Array<Ty> yo = createEmptyArray<Ty>(odims);
 
         switch(method) {
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
-            kernel::approx1<Ty, Tp, 1> (out, in, pos, offGrid, method);
+            kernel::approx1<Ty, Tp, 1> (yo, yi, xo, xdim, xi_beg, xi_step, offGrid, method);
             break;
         case AF_INTERP_LINEAR:
         case AF_INTERP_LINEAR_COSINE:
-            kernel::approx1<Ty, Tp, 2> (out, in, pos, offGrid, method);
+            kernel::approx1<Ty, Tp, 2> (yo, yi, xo, xdim, xi_beg, xi_step, offGrid, method);
             break;
         case AF_INTERP_CUBIC:
         case AF_INTERP_CUBIC_SPLINE:
-            kernel::approx1<Ty, Tp, 3> (out, in, pos, offGrid, method);
+            kernel::approx1<Ty, Tp, 3> (yo, yi, xo, xdim, xi_beg, xi_step, offGrid, method);
             break;
         default:
             break;
         }
-        return out;
+        return yo;
     }
 
     template<typename Ty, typename Tp>
-    Array<Ty> approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
+    Array<Ty> approx2(const Array<Ty> &zi,
+                      const Array<Tp> &xo, const int xdim,
+                      const Array<Tp> &yo, const int ydim,
+                      const Tp &xi_beg, const Tp &xi_step,
+                      const Tp &yi_beg, const Tp &yi_step,
                       const af_interp_type method, const float offGrid)
     {
-        af::dim4 idims = in.dims();
-        af::dim4 odims = pos0.dims();
-        odims[2] = in.dims()[2];
-        odims[3] = in.dims()[3];
+        af::dim4 odims = zi.dims()
+        odims[xdim] = xo.dims()[xdim];
+        odims[ydim] = xo.dims()[ydim];
 
         // Create output placeholder
-        Array<Ty> out = createEmptyArray<Ty>(odims);
+        Array<Ty> zo = createEmptyArray<Ty>(odims);
 
         switch(method) {
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
-            kernel::approx2<Ty, Tp, 1> (out, in, pos0, pos1, offGrid, method);
+            kernel::approx2<Ty, Tp, 1> (zo, zi,
+                                        xo, xdim,
+                                        yo, ydim,
+                                        xi_beg, xi_step,
+                                        yi_beg, yi_step,
+                                        offGrid, method);
             break;
         case AF_INTERP_LINEAR:
         case AF_INTERP_BILINEAR:
         case AF_INTERP_LINEAR_COSINE:
         case AF_INTERP_BILINEAR_COSINE:
-            kernel::approx2<Ty, Tp, 2> (out, in, pos0, pos1, offGrid, method);
+            kernel::approx2<Ty, Tp, 2> (zo, zi,
+                                        xo, xdim,
+                                        yo, ydim,
+                                        xi_beg, xi_step,
+                                        yi_beg, yi_step,
+                                        offGrid, method);
             break;
         case AF_INTERP_CUBIC:
         case AF_INTERP_BICUBIC:
         case AF_INTERP_CUBIC_SPLINE:
         case AF_INTERP_BICUBIC_SPLINE:
-            kernel::approx2<Ty, Tp, 3> (out, in, pos0, pos1, offGrid, method);
+            kernel::approx2<Ty, Tp, 3> (zo, zi,
+                                        xo, xdim,
+                                        yo, ydim,
+                                        xi_beg, xi_step,
+                                        yi_beg, yi_step,
+                                        offGrid, method);
             break;
         default:
             break;
         }
-        return out;
+        return zo;
     }
 
-#define INSTANTIATE(Ty, Tp)                                             \
-    template Array<Ty> approx1<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos, \
-                                       const af_interp_type method, const float offGrid); \
-    template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos0, \
-                                       const Array<Tp> &pos1, const af_interp_type method, \
-                                       const float offGrid);            \
+#define INSTANTIATE(Ty, Tp)                                         \
+    template Array<Ty> approx1<Ty, Tp>(const Array<Ty> &yi,         \
+                                       const Array<Tp> &xo,         \
+                                       const int xdim,              \
+                                       const Tp &xi_beg,            \
+                                       const Tp &xi_step,           \
+                                       const af_interp_type method, \
+                                       const float offGrid);        \
+    template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &zi,         \
+                                       const Array<Tp> &xo,         \
+                                       const int xdim,              \
+                                       const Array<Tp> &yo,         \
+                                       const int ydim,              \
+                                       const Tp &xi_beg,            \
+                                       const Tp &xi_step,           \
+                                       const Tp &yi_beg,            \
+                                       const Tp &yi_step,           \
+                                       const af_interp_type method, \
+                                       const float offGrid);        \
 
     INSTANTIATE(float  , float )
     INSTANTIATE(double , double)
     INSTANTIATE(cfloat , float )
     INSTANTIATE(cdouble, double)
+
 }

--- a/src/backend/cuda/approx.hpp
+++ b/src/backend/cuda/approx.hpp
@@ -19,9 +19,7 @@ namespace cuda
 
     template<typename Ty, typename Tp>
     Array<Ty> approx2(const Array<Ty> &zi,
-                      const Array<Tp> &xo, const int xdim,
-                      const Array<Tp> &yo, const int ydim,
-                      const Tp &xi_beg, const Tp &xi_step,
-                      const Tp &yi_beg, const Tp &yi_step,
+                      const Array<Tp> &xo, const int xdim, const Tp &xi_beg, const Tp &xi_step,
+                      const Array<Tp> &yo, const int ydim, const Tp &yi_beg, const Tp &yi_step,
                       const af_interp_type method, const float offGrid);
 }

--- a/src/backend/cuda/approx.hpp
+++ b/src/backend/cuda/approx.hpp
@@ -12,10 +12,16 @@
 namespace cuda
 {
     template<typename Ty, typename Tp>
-    Array<Ty> approx1(const Array<Ty> &in, const Array<Tp> &pos,
+    Array<Ty> approx1(const Array<Ty> &yi,
+                      const Array<Tp> &xo, const int xdim,
+                      const Tp &xi_beg, const Tp &xi_step,
                       const af_interp_type method, const float offGrid);
 
     template<typename Ty, typename Tp>
-    Array<Ty> approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
+    Array<Ty> approx2(const Array<Ty> &zi,
+                      const Array<Tp> &xo, const int xdim,
+                      const Array<Tp> &yo, const int ydim,
+                      const Tp &xi_beg, const Tp &xi_step,
+                      const Tp &yi_beg, const Tp &yi_step,
                       const af_interp_type method, const float offGrid);
 }

--- a/src/backend/cuda/kernel/approx.hpp
+++ b/src/backend/cuda/kernel/approx.hpp
@@ -75,10 +75,8 @@ namespace cuda
         template<typename Ty, typename Tp, int order>
         __global__
         void approx2_kernel(Param<Ty> zo, CParam<Ty> zi,
-                            CParam<Tp> xo, const int xdim,
-                            CParam<Tp> yo, const int ydim,
-                            const Tp xi_beg, const Tp xi_step,
-                            const Tp yi_beg, const Tp yi_step,
+                            CParam<Tp> xo, const int xdim, const Tp xi_beg, const Tp xi_step,
+                            CParam<Tp> yo, const int ydim, const Tp yi_beg, const Tp yi_step,
                             const float offGrid,
                             const int blocksMatX, const int blocksMatY, const bool batch,
                             af_interp_type method)
@@ -152,10 +150,8 @@ namespace cuda
 
         template <typename Ty, typename Tp, int order>
         void approx2(Param<Ty> zo, CParam<Ty> zi,
-                     CParam<Tp> xo, const int xdim,
-                     CParam<Tp> yo, const int ydim,
-                     const Tp &xi_beg, const Tp &xi_step,
-                     const Tp &yi_beg, const Tp &yi_step,
+                     CParam<Tp> xo, const int xdim, const Tp &xi_beg, const Tp &xi_step,
+                     CParam<Tp> yo, const int ydim, const Tp &yi_beg, const Tp &yi_step,
                      const float offGrid,
                      af_interp_type method)
         {
@@ -171,7 +167,7 @@ namespace cuda
             blocks.y = divup(blocks.y, blocks.z);
 
             CUDA_LAUNCH((approx2_kernel<Ty, Tp, order>), blocks, threads,
-                        zo, zi, xo, xdim, yo, ydim, xi_beg, xi_step, yi_beg, yi_step,
+                        zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg, yi_step,
                         offGrid, blocksPerMatX, blocksPerMatY, batch, method);
             POST_LAUNCH_CHECK();
         }

--- a/src/backend/cuda/kernel/interp.hpp
+++ b/src/backend/cuda/kernel/interp.hpp
@@ -227,7 +227,7 @@ struct Interp2<Ty, Tp, 1>
 };
 
 template<typename Ty, typename Tp>
-struct Interp2<Ty, Tp, 2>
+struct Interp2<Ty, Tpxo, 2>
 {
     __device__ void operator()(Param<Ty> out, int ooff,
                                CParam<Ty> in, int ioff, Tp x, Tp y,

--- a/src/backend/opencl/approx.cpp
+++ b/src/backend/opencl/approx.cpp
@@ -47,10 +47,8 @@ namespace opencl
 
     template<typename Ty, typename Tp>
     Array<Ty> approx2(const Array<Ty> &zi,
-                      const Array<Tp> &xo, const int xdim,
-                      const Array<Tp> &yo, const int ydim,
-                      const Tp &xi_beg, const Tp &xi_step,
-                      const Tp &yi_beg, const Tp &yi_step,
+                      const Array<Tp> &xo, const int xdim, const Tp &xi_beg, const Tp &xi_step,
+                      const Array<Tp> &yo, const int ydim, const Tp &yi_beg, const Tp &yi_step,
                       const af_interp_type method, const float offGrid)
     {
         af::dim4 odims = zi.dims();
@@ -63,24 +61,27 @@ namespace opencl
         switch(method) {
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
-            kernel::approx2<Ty, Tp, 1> (zo, zi, xo, xdim, yo, ydim,
-                                        xi_beg, xi_step, yi_beg, yi_step,
+            kernel::approx2<Ty, Tp, 1> (zo, zi,
+                                        xo, xdim, xi_beg, xi_step,
+                                        yo, ydim, yi_beg, yi_step,
                                         offGrid, method);
             break;
         case AF_INTERP_LINEAR:
         case AF_INTERP_BILINEAR:
         case AF_INTERP_LINEAR_COSINE:
         case AF_INTERP_BILINEAR_COSINE:
-            kernel::approx2<Ty, Tp, 2> (zo, zi, xo, xdim, yo, ydim,
-                                        xi_beg, xi_step, yi_beg, yi_step,
+            kernel::approx2<Ty, Tp, 2> (zo, zi,
+                                        xo, xdim, xi_beg, xi_step,
+                                        yo, ydim, yi_beg, yi_step,
                                         offGrid, method);
             break;
         case AF_INTERP_CUBIC:
         case AF_INTERP_BICUBIC:
         case AF_INTERP_CUBIC_SPLINE:
         case AF_INTERP_BICUBIC_SPLINE:
-            kernel::approx2<Ty, Tp, 3> (zo, zi, xo, xdim, yo, ydim,
-                                        xi_beg, xi_step, yi_beg, yi_step,
+            kernel::approx2<Ty, Tp, 3> (zo, zi,
+                                        xo, xdim, xi_beg, xi_step,
+                                        yo, ydim, yi_beg, yi_step,
                                         offGrid, method);
             break;
         default:
@@ -101,10 +102,10 @@ namespace opencl
     template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &zi,         \
                                        const Array<Tp> &xo,         \
                                        const int xdim,              \
-                                       const Array<Tp> &yo,         \
-                                       const int ydim,              \
                                        const Tp &xi_beg,            \
                                        const Tp &xi_step,           \
+                                       const Array<Tp> &yo,         \
+                                       const int ydim,              \
                                        const Tp &yi_beg,            \
                                        const Tp &yi_step,           \
                                        const af_interp_type method, \

--- a/src/backend/opencl/approx.cpp
+++ b/src/backend/opencl/approx.cpp
@@ -16,77 +16,103 @@
 namespace opencl
 {
     template<typename Ty, typename Tp>
-    Array<Ty> approx1(const Array<Ty> &in, const Array<Tp> &pos,
+    Array<Ty> approx1(const Array<Ty> &yi,
+                      const Array<Tp> &xo, const int xdim,
+                      const Tp &xi_beg, const Tp &xi_step,
                       const af_interp_type method, const float offGrid)
     {
-        af::dim4 odims = in.dims();
-        odims[0] = pos.dims()[0];
+        af::dim4 odims = yi.dims();
+        odims[xdim] = xo.dims()[xdim];
 
         // Create output placeholder
-        Array<Ty> out = createEmptyArray<Ty>(odims);
+        Array<Ty> yo = createEmptyArray<Ty>(odims);
         switch(method) {
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
-            kernel::approx1<Ty, Tp, 1> (out, in, pos, offGrid, method);
+            kernel::approx1<Ty, Tp, 1> (yo, yi, xo, xdim, xi_beg, xi_step, offGrid, method);
             break;
         case AF_INTERP_LINEAR:
         case AF_INTERP_LINEAR_COSINE:
-            kernel::approx1<Ty, Tp, 2> (out, in, pos, offGrid, method);
+            kernel::approx1<Ty, Tp, 2> (yo, yi, xo, xdim, xi_beg, xi_step, offGrid, method);
             break;
         case AF_INTERP_CUBIC:
         case AF_INTERP_CUBIC_SPLINE:
-            kernel::approx1<Ty, Tp, 3> (out, in, pos, offGrid, method);
+            kernel::approx1<Ty, Tp, 3> (yo, yi, xo, xdim, xi_beg, xi_step, offGrid, method);
             break;
         default:
             break;
         }
-        return out;
+        return yo;
     }
 
     template<typename Ty, typename Tp>
-    Array<Ty> approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
+    Array<Ty> approx2(const Array<Ty> &zi,
+                      const Array<Tp> &xo, const int xdim,
+                      const Array<Tp> &yo, const int ydim,
+                      const Tp &xi_beg, const Tp &xi_step,
+                      const Tp &yi_beg, const Tp &yi_step,
                       const af_interp_type method, const float offGrid)
     {
-        af::dim4 odims = pos0.dims();
-        odims[2] = in.dims()[2];
-        odims[3] = in.dims()[3];
+        af::dim4 odims = zi.dims();
+        odims[xdim] = xo.dims()[xdim];
+        odims[ydim] = xo.dims()[ydim];
 
         // Create output placeholder
-        Array<Ty> out = createEmptyArray<Ty>(odims);
+        Array<Ty> zo = createEmptyArray<Ty>(odims);
 
         switch(method) {
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
-            kernel::approx2<Ty, Tp, 1> (out, in, pos0, pos1, offGrid, method);
+            kernel::approx2<Ty, Tp, 1> (zo, zi, xo, xdim, yo, ydim,
+                                        xi_beg, xi_step, yi_beg, yi_step,
+                                        offGrid, method);
             break;
         case AF_INTERP_LINEAR:
         case AF_INTERP_BILINEAR:
         case AF_INTERP_LINEAR_COSINE:
         case AF_INTERP_BILINEAR_COSINE:
-            kernel::approx2<Ty, Tp, 2> (out, in, pos0, pos1, offGrid, method);
+            kernel::approx2<Ty, Tp, 2> (zo, zi, xo, xdim, yo, ydim,
+                                        xi_beg, xi_step, yi_beg, yi_step,
+                                        offGrid, method);
             break;
         case AF_INTERP_CUBIC:
         case AF_INTERP_BICUBIC:
         case AF_INTERP_CUBIC_SPLINE:
         case AF_INTERP_BICUBIC_SPLINE:
-            kernel::approx2<Ty, Tp, 3> (out, in, pos0, pos1, offGrid, method);
+            kernel::approx2<Ty, Tp, 3> (zo, zi, xo, xdim, yo, ydim,
+                                        xi_beg, xi_step, yi_beg, yi_step,
+                                        offGrid, method);
             break;
         default:
             break;
         }
 
-        return out;
+        return zo;
     }
 
-#define INSTANTIATE(Ty, Tp)                                             \
-    template Array<Ty> approx1<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos, \
-                                       const af_interp_type method, const float offGrid); \
-    template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &in, const Array<Tp> &pos0, \
-                                       const Array<Tp> &pos1, const af_interp_type method, \
-                                       const float offGrid);            \
+#define INSTANTIATE(Ty, Tp)                                         \
+    template Array<Ty> approx1<Ty, Tp>(const Array<Ty> &yi,         \
+                                       const Array<Tp> &xo,         \
+                                       const int xdim,              \
+                                       const Tp &xi_beg,            \
+                                       const Tp &xi_step,           \
+                                       const af_interp_type method, \
+                                       const float offGrid);        \
+    template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &zi,         \
+                                       const Array<Tp> &xo,         \
+                                       const int xdim,              \
+                                       const Array<Tp> &yo,         \
+                                       const int ydim,              \
+                                       const Tp &xi_beg,            \
+                                       const Tp &xi_step,           \
+                                       const Tp &yi_beg,            \
+                                       const Tp &yi_step,           \
+                                       const af_interp_type method, \
+                                       const float offGrid);        \
 
     INSTANTIATE(float  , float )
     INSTANTIATE(double , double)
     INSTANTIATE(cfloat , float )
     INSTANTIATE(cdouble, double)
+
 }

--- a/src/backend/opencl/approx.hpp
+++ b/src/backend/opencl/approx.hpp
@@ -19,9 +19,7 @@ namespace opencl
 
     template<typename Ty, typename Tp>
     Array<Ty> approx2(const Array<Ty> &zi,
-                      const Array<Tp> &xo, const int xdim,
-                      const Array<Tp> &yo, const int ydim,
-                      const Tp &xi_beg, const Tp &xi_step,
-                      const Tp &yi_beg, const Tp &yi_step,
+                      const Array<Tp> &xo, const int xdim, const Tp &xi_beg, const Tp &xi_step,
+                      const Array<Tp> &yo, const int ydim, const Tp &yi_beg, const Tp &yi_step,
                       const af_interp_type method, const float offGrid);
 }

--- a/src/backend/opencl/approx.hpp
+++ b/src/backend/opencl/approx.hpp
@@ -12,10 +12,16 @@
 namespace opencl
 {
     template<typename Ty, typename Tp>
-    Array<Ty> approx1(const Array<Ty> &in, const Array<Tp> &pos,
+    Array<Ty> approx1(const Array<Ty> &yi,
+                      const Array<Tp> &xo, const int xdim,
+                      const Tp &xi_beg, const Tp &xi_step,
                       const af_interp_type method, const float offGrid);
 
     template<typename Ty, typename Tp>
-    Array<Ty> approx2(const Array<Ty> &in, const Array<Tp> &pos0, const Array<Tp> &pos1,
+    Array<Ty> approx2(const Array<Ty> &zi,
+                      const Array<Tp> &xo, const int xdim,
+                      const Array<Tp> &yo, const int ydim,
+                      const Tp &xi_beg, const Tp &xi_step,
+                      const Tp &yi_beg, const Tp &yi_step,
                       const af_interp_type method, const float offGrid);
 }

--- a/src/backend/opencl/kernel/approx.hpp
+++ b/src/backend/opencl/kernel/approx.hpp
@@ -73,7 +73,8 @@ std::string generateOptionsString()
 // Wrapper functions
 ///////////////////////////////////////////////////////////////////////////
 template <typename Ty, typename Tp, int order>
-void approx1(Param out, const Param in, const Param xpos, const float offGrid,
+void approx1(Param yo, const Param yi, const Param xo, const int xdim,
+             const Tp xi_beg, const Tp xi_step, const float offGrid,
              af_interp_type method)
 {
     std::string refName = std::string("approx1_kernel_") +
@@ -98,27 +99,33 @@ void approx1(Param out, const Param in, const Param xpos, const float offGrid,
     }
 
     auto approx1Op = KernelFunctor< Buffer, const KParam, const Buffer, const KParam,
-                                    const Buffer, const KParam, const Ty,
+                                    const Buffer, const KParam, const int,
+                                    const Tp, const Tp, const Ty,
                                     const int, const int, const int >(*entry.ker);
 
     NDRange local(THREADS, 1, 1);
-    dim_t blocksPerMat = divup(out.info.dims[0], local[0]);
-    NDRange global(blocksPerMat * local[0] * out.info.dims[1],
-                   out.info.dims[2] * out.info.dims[3] * local[1], 1);
+    dim_t blocksPerMat = divup(yo.info.dims[0], local[0]);
+    NDRange global(blocksPerMat * local[0] * yo.info.dims[1],
+                   yo.info.dims[2] * yo.info.dims[3] * local[0], 1);
 
     // Passing bools to opencl kernels is not allowed
-    bool batch = !(xpos.info.dims[1] == 1 && xpos.info.dims[2] == 1 && xpos.info.dims[3] == 1);
+    bool batch = !(xo.info.dims[1] == 1 && xo.info.dims[2] == 1 && xo.info.dims[3] == 1);
 
     approx1Op(EnqueueArgs(getQueue(), global, local),
-              *out.data, out.info, *in.data, in.info,
-              *xpos.data, xpos.info, scalar<Ty>(offGrid),
+              *yo.data, yo.info, *yi.data, yi.info,
+              *xo.data, xo.info, xdim, xi_beg, xi_step,
+              scalar<Ty>(offGrid),
               blocksPerMat, (int)batch, (int)method);
 
     CL_DEBUG_FINISH(getQueue());
 }
 
 template <typename Ty, typename Tp, int order>
-void approx2(Param out, const Param in, const Param xpos, const Param ypos,
+void approx2(Param zo, const Param zi,
+             const Param xo, const int xdim,
+             const Param yo, const int ydim,
+             const Tp &xi_beg, const Tp &xi_step,
+             const Tp &yi_beg, const Tp &yi_step,
              const float offGrid, af_interp_type method)
 {
     std::string refName = std::string("approx2_kernel_") +
@@ -142,22 +149,27 @@ void approx2(Param out, const Param in, const Param xpos, const Param ypos,
         addKernelToCache(device, refName, entry);
     }
 
-    auto approx2Op = KernelFunctor< Buffer, const KParam, const Buffer, const KParam,
-                                    const Buffer, const KParam, const Buffer, const KParam,
+    auto approx2Op = KernelFunctor< Buffer, const KParam,
+                                    const Buffer, const KParam,
+                                    const Buffer, const KParam, const int,
+                                    const Buffer, const KParam, const int,
+                                    const Tp, const Tp, const Tp, const Tp,
                                     const Ty, const int, const int, const int, const int >(*entry.ker);
 
     NDRange local(TX, TY, 1);
-    dim_t blocksPerMatX = divup(out.info.dims[0], local[0]);
-    dim_t blocksPerMatY = divup(out.info.dims[1], local[1]);
-    NDRange global(blocksPerMatX * local[0] * out.info.dims[2],
-                   blocksPerMatY * local[1] * out.info.dims[3], 1);
+    dim_t blocksPerMatX = divup(zo.info.dims[0], local[0]);
+    dim_t blocksPerMatY = divup(zo.info.dims[1], local[1]);
+    NDRange global(blocksPerMatX * local[0] * zo.info.dims[2],
+                   blocksPerMatY * local[1] * zo.info.dims[3], 1);
 
     // Passing bools to opencl kernels is not allowed
-    bool batch = !(xpos.info.dims[2] == 1 && xpos.info.dims[3] == 1);
+    bool batch = !(xo.info.dims[2] == 1 && xo.info.dims[3] == 1);
 
     approx2Op(EnqueueArgs(getQueue(), global, local),
-              *out.data, out.info, *in.data, in.info,
-              *xpos.data, xpos.info, *ypos.data, ypos.info,
+              *zo.data, zo.info, *zi.data, zi.info,
+              *xo.data, xo.info, xdim,
+              *yo.data, yo.info, ydim,
+              xi_beg, xi_step, yi_beg, yi_step,
               scalar<Ty>(offGrid), blocksPerMatX, blocksPerMatY, (int)batch, (int)method);
 
     CL_DEBUG_FINISH(getQueue());

--- a/src/backend/opencl/kernel/approx.hpp
+++ b/src/backend/opencl/kernel/approx.hpp
@@ -122,10 +122,8 @@ void approx1(Param yo, const Param yi, const Param xo, const int xdim,
 
 template <typename Ty, typename Tp, int order>
 void approx2(Param zo, const Param zi,
-             const Param xo, const int xdim,
-             const Param yo, const int ydim,
-             const Tp &xi_beg, const Tp &xi_step,
-             const Tp &yi_beg, const Tp &yi_step,
+             const Param xo, const int xdim, const Tp &xi_beg, const Tp &xi_step,
+             const Param yo, const int ydim, const Tp &yi_beg, const Tp &yi_step,
              const float offGrid, af_interp_type method)
 {
     std::string refName = std::string("approx2_kernel_") +

--- a/src/backend/opencl/kernel/approx.hpp
+++ b/src/backend/opencl/kernel/approx.hpp
@@ -106,7 +106,7 @@ void approx1(Param yo, const Param yi, const Param xo, const int xdim,
     NDRange local(THREADS, 1, 1);
     dim_t blocksPerMat = divup(yo.info.dims[0], local[0]);
     NDRange global(blocksPerMat * local[0] * yo.info.dims[1],
-                   yo.info.dims[2] * yo.info.dims[3] * local[0], 1);
+                   yo.info.dims[2] * yo.info.dims[3] * local[1]);
 
     // Passing bools to opencl kernels is not allowed
     bool batch = !(xo.info.dims[1] == 1 && xo.info.dims[2] == 1 && xo.info.dims[3] == 1);

--- a/src/backend/opencl/kernel/approx1.cl
+++ b/src/backend/opencl/kernel/approx1.cl
@@ -8,43 +8,44 @@
  ********************************************************/
 
 __kernel
-void approx1_kernel(__global       Ty *d_out, const KParam out,
-                    __global const Ty *d_in,  const KParam in,
-                    __global const Tp *d_xpos, const KParam xpos,
+void approx1_kernel(__global       Ty *d_yo, const KParam yo,
+                    __global const Ty *d_yi,  const KParam yi,
+                    __global const Tp *d_xo, const KParam xo, const int xdim,
+                    const Tp xi_beg, const Tp xi_step,
                     const Ty offGrid, const int blocksMatX, const int batch, const int method)
 {
-    const int idw = get_group_id(1) / out.dims[2];
-    const int idz = get_group_id(1)  - idw * out.dims[2];
+    const int idw = get_group_id(1) / yo.dims[2];
+    const int idz = get_group_id(1)  - idw * yo.dims[2];
 
     const int idy = get_group_id(0) / blocksMatX;
     const int blockIdx_x = get_group_id(0) - idy * blocksMatX;
     const int idx = get_local_id(0) + blockIdx_x * get_local_size(0);
 
-    if(idx >= out.dims[0] ||
-       idy >= out.dims[1] ||
-       idz >= out.dims[2] ||
-       idw >= out.dims[3])
+    if(idx >= yo.dims[0] ||
+       idy >= yo.dims[1] ||
+       idz >= yo.dims[2] ||
+       idw >= yo.dims[3])
         return;
 
-    const int omId = idw * out.strides[3] + idz * out.strides[2]
-        + idy * out.strides[1] + idx + out.offset;
-    int xmid = idx + xpos.offset;
-    if(batch) xmid += idw * xpos.strides[3] + idz * xpos.strides[2] + idy * xpos.strides[1];
+    const int omId = idw * yo.strides[3] + idz * yo.strides[2]
+        + idy * yo.strides[1] + idx + yo.offset;
+    int xmid = idx + xo.offset;
+    if(batch) xmid += idw * xo.strides[3] + idz * xo.strides[2] + idy * xo.strides[1];
 
-    const Tp x = d_xpos[xmid];
-    if (x < 0 || in.dims[0] < x+1) {
-        d_out[omId] = offGrid;
+    const Tp x = (d_xo[xmid] - xi_beg) / xi_step;
+    if (x < 0 || yi.dims[0] < x+1) {
+        d_yo[omId] = offGrid;
         return;
     }
 
-    int ioff = idw * in.strides[3] + idz * in.strides[2] + idy * in.strides[1] + in.offset;
+    int ioff = idw * yi.strides[3] + idz * yi.strides[2] + idy * yi.strides[1] + yi.offset;
 
     // FIXME: Only cubic interpolation is doing clamping
     // We need to make it consistent across all methods
     // Not changing the behavior because tests will fail
     bool clamp = INTERP_ORDER == 3;
 
-    interp1(d_out, out, omId,
-             d_in,  in, ioff,
+    interp1(d_yo, yo, omId,
+            d_yi,  yi, ioff,
             x, method, 1, clamp);
 }

--- a/src/backend/opencl/kernel/approx1.cl
+++ b/src/backend/opencl/kernel/approx1.cl
@@ -27,25 +27,34 @@ void approx1_kernel(__global       Ty *d_yo, const KParam yo,
        idw >= yo.dims[3])
         return;
 
-    const int omId = idw * yo.strides[3] + idz * yo.strides[2]
-        + idy * yo.strides[1] + idx + yo.offset;
-    int xmid = idx + xo.offset;
-    if(batch) xmid += idw * xo.strides[3] + idz * xo.strides[2] + idy * xo.strides[1];
+    bool is_xo_off[] = {xo.dims[0] > 1, xo.dims[1] > 1, xo.dims[2] > 1, xo.dims[3] > 1};
+    bool is_yi_off[] = {true, true, true, true};
+    is_yi_off[xdim] = false;
 
-    const Tp x = (d_xo[xmid] - xi_beg) / xi_step;
-    if (x < 0 || yi.dims[0] < x+1) {
-        d_yo[omId] = offGrid;
+    const int yo_idx = idw * yo.strides[3] + idz * yo.strides[2] + idy * yo.strides[1] + idx + yo.offset;
+
+    int xo_idx = idx * is_xo_off[0] + xo.offset;
+    xo_idx += idw * xo.strides[3] * is_xo_off[3];
+    xo_idx += idz * xo.strides[2] * is_xo_off[2];
+    xo_idx += idy * xo.strides[1] * is_xo_off[1];
+
+    const Tp x = (d_xo[xo_idx] - xi_beg) / xi_step;
+    if (x < 0 || yi.dims[xdim] < x+1) {
+        d_yo[yo_idx] = offGrid;
         return;
     }
 
-    int ioff = idw * yi.strides[3] + idz * yi.strides[2] + idy * yi.strides[1] + yi.offset;
+    int yi_idx = idx * is_yi_off[0] + yi.offset;
+    yi_idx += idw * yi.strides[3] * is_yi_off[3];
+    yi_idx += idz * yi.strides[2] * is_yi_off[2];
+    yi_idx += idy * yi.strides[1] * is_yi_off[1];
 
     // FIXME: Only cubic interpolation is doing clamping
     // We need to make it consistent across all methods
     // Not changing the behavior because tests will fail
     bool clamp = INTERP_ORDER == 3;
 
-    interp1(d_yo, yo, omId,
-            d_yi,  yi, ioff,
-            x, method, 1, clamp);
+    interp1_dim(d_yo, yo, yo_idx,
+                d_yi, yi, yi_idx,
+                x, method, 1, clamp, xdim);
 }

--- a/src/backend/opencl/kernel/approx2.cl
+++ b/src/backend/opencl/kernel/approx2.cl
@@ -32,30 +32,34 @@ void approx2_kernel(__global       Ty *d_zo, const KParam zo,
        idw >= zo.dims[3])
         return;
 
-    const int omId = idw * zo.strides[3] + idz * zo.strides[2]
-        + idy * zo.strides[1] + idx + zo.offset;
-    int xmid = idy * xo.strides[1] + idx + xo.offset;
-    int ymid = idy * yo.strides[1] + idx + yo.offset;
-    if(batch) {
-        xmid += idw * xo.strides[3] + idz * xo.strides[2];
-        ymid += idw * yo.strides[3] + idz * yo.strides[2];
-    }
+    bool is_xo_off[] = {xo.dims[0] > 1, xo.dims[1] > 1, xo.dims[2] > 1, xo.dims[3] > 1};
+    bool is_zi_off[] = {true, true, true, true};
+    is_zi_off[xdim] = false;
+    is_zi_off[ydim] = false;
 
-    const Tp x = (d_xo[xmid] - xi_beg) / xi_step;
-    const Tp y = (d_yo[ymid] - yi_beg) / yi_step;
-    if (x < 0 || y < 0 || zi.dims[0] < x+1 || zi.dims[1] < y+1) {
-        d_zo[omId] = offGrid;
+    const int zo_idx = idw * zo.strides[3] + idz * zo.strides[2] + idy * zo.strides[1] + idx + zo.offset;
+    int xo_idx = idy * xo.strides[1] * is_xo_off[1] + idx * is_xo_off[0] + xo.offset;
+    int yo_idx = idy * yo.strides[1] * is_xo_off[1] + idx * is_xo_off[0] + yo.offset;
+    xo_idx += idw * xo.strides[3] * is_xo_off[3] + idz * xo.strides[2]  * is_xo_off[2];
+    yo_idx += idw * yo.strides[3] * is_xo_off[3] + idz * yo.strides[2]  * is_xo_off[2];
+
+    const Tp x = (d_xo[xo_idx] - xi_beg) / xi_step;
+    const Tp y = (d_yo[yo_idx] - yi_beg) / yi_step;
+    if (x < 0 || y < 0 || zi.dims[xdim] < x+1 || zi.dims[ydim] < y+1) {
+        d_zo[zo_idx] = offGrid;
         return;
     }
 
-    int ioff = idw * zi.strides[3] + idz * zi.strides[2] + zi.offset;
+    int zi_idx = idy * zi.strides[1] * is_zi_off[1] + idx * is_zi_off[0] + zi.offset;
+    zi_idx += idw * zi.strides[3] * is_zi_off[3] + idz * zi.strides[2] * is_zi_off[2];
 
     // FIXME: Only cubic interpolation is doing clamping
     // We need to make it consistent across all methods
     // Not changing the behavior because tests will fail
     bool clamp = INTERP_ORDER == 3;
 
-    interp2(d_zo, zo, omId,
-            d_zi,  zi, ioff,
-            x, y, method, 1, clamp);
+    interp2_dim(d_zo, zo, zo_idx,
+                d_zi,  zi, zi_idx,
+                x, y, method, 1, clamp,
+                xdim, ydim);
 }

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -517,6 +517,45 @@ TEST(Approx1, CPPUsage)
     //! [ex_signal_approx1]
 
     // Input data array.
+    float input_vals[3] = {10.0, 20.0, 30.0};
+    array in(dim4(3, 1), input_vals);
+    // [3 1 1 1]
+    //     10.0000
+    //     20.0000
+    //     30.0000
+
+    // Array of positions to be found along the first dimension.
+    float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
+    array pos(dim4(5,1), pv);
+    // [5 1 1 1]
+    //     0.0000
+    //     0.5000
+    //     1.0000
+    //     1.5000
+    //     2.0000
+
+    // Perform interpolation across dimension 0.
+    array interp = approx1(in, pos);
+    // [5 1 1 1]
+    //     10.0000
+    //     15.0000
+    //     20.0000
+    //     25.0000
+    //     30.0000
+
+    //! [ex_signal_approx1]
+
+    float civ[5] = {10.0, 15.0, 20.0, 25.0, 30.0};
+    array interp_gold(dim4(5,1), civ);
+    ASSERT_ARRAYS_EQ(interp, interp_gold);
+
+}
+
+
+TEST(Approx1, CPPUniformUsage)
+{
+    //! [ex_signal_approx1_uniform]
+
     float input_vals[9] = {10.0, 20.0, 30.0,
                            40.0, 50.0, 60.0,
                            70.0, 80.0, 90.0};
@@ -525,8 +564,6 @@ TEST(Approx1, CPPUsage)
     //     10.0000    40.0000    70.0000
     //     20.0000    50.0000    80.0000
     //     30.0000    60.0000    90.0000
-
-
 
     // Array of positions to be found along the interpolation
     // dimension, `interp_dim`.
@@ -538,8 +575,6 @@ TEST(Approx1, CPPUsage)
     //     1.0000
     //     1.5000
     //     2.0000
-
-
 
     // Define range of indices with which the input values will
     // correspond along the interpolation dimension.
@@ -564,7 +599,7 @@ TEST(Approx1, CPPUsage)
     //     20.0000    35.0000    50.0000    65.0000    80.0000
     //     30.0000    45.0000    60.0000    75.0000    90.0000
 
-    //! [ex_signal_approx1]
+    //! [ex_signal_approx1_uniform]
 
     float civ[15] = {10.0, 15.0, 20.0, 25.0, 30.0,
                      40.0, 45.0, 50.0, 55.0, 60.0,
@@ -580,7 +615,6 @@ TEST(Approx1, CPPUsage)
                      70.0, 80.0, 90.0};
     array interp_gold_row(dim4(3,5), riv);
     ASSERT_ARRAYS_EQ(row_major_interp, interp_gold_row);
-
 }
 
 TEST(Approx1, CPPDecimalStepRescaleGrid)

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -717,8 +717,8 @@ TEST(Approx1, CPPUniformInterpDim0)
                     40.0, 50.0, 60.0,
                     70.0, 80.0, 90.0};
     array in(dim4(3,3), inv);
-    float pv[3] = {0, 1, 2};
-    array pos(dim4(3,1), pv);
+    float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
+    array pos(dim4(5,1), pv);
 
     const int start = 0;
     const double step = 1;
@@ -726,10 +726,11 @@ TEST(Approx1, CPPUniformInterpDim0)
     array interpolated = approx1(in,
                                  pos, dim0,
                                  start, step);
-    float iv[9] = {10.0, 20.0, 30.0,
-                   40.0, 50.0, 60.0,
-                   70.0, 80.0, 90.0};
-    array interp_gold(dim4(3,3), iv);
+    float iv[15] = {10.0, 15.0, 20.0, 25.0, 30.0,
+                    40.0, 45.0, 50.0, 55.0, 60.0,
+                    70.0, 75.0, 80.0, 85.0, 90.0};
+
+    array interp_gold(dim4(5,3), iv);
     ASSERT_ARRAYS_EQ(interpolated, interp_gold);
 }
 
@@ -739,8 +740,8 @@ TEST(Approx1, CPPUniformInterpDim1)
                     40.0, 50.0, 60.0,
                     70.0, 80.0, 90.0};
     array in(dim4(3,3), inv);
-    float pv[3] = {0, 1, 2};
-    array pos(dim4(1,3), pv);
+    float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
+    array pos(dim4(1,5), pv);
 
     const int start = 0;
     const double step = 1;
@@ -748,10 +749,12 @@ TEST(Approx1, CPPUniformInterpDim1)
     array interpolated = approx1(in,
                                  pos, dim1,
                                  start, step);
-    float iv[9] = {10.0, 20.0, 30.0,
-                   40.0, 50.0, 60.0,
-                   70.0, 80.0, 90.0};
-    array interp_gold(dim4(3,3), iv);
+    float iv[15] = {10.0, 20.0, 30.0,
+                    25.0, 35.0, 45.0,
+                    40.0, 50.0, 60.0,
+                    55.0, 65.0, 75.0,
+                    70.0, 80.0, 90.0};
+    array interp_gold(dim4(3,5), iv);
     ASSERT_ARRAYS_EQ(interpolated, interp_gold);
 }
 

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -534,6 +534,25 @@ TEST(Approx1, CPPUniformUsage)
     ASSERT_ARRAYS_NEAR(interpolated, interp_gold, 1e-5);
 }
 
+// \TODO(miguel) double check
+TEST(Approx1, CPPNonMonotonicPos)
+{
+    float inv[3] = {10, 20, 30};
+    array in(dim4(3,1), inv);
+    float pv[3] = {0.0, 1.0, 0.5};
+    array pos(dim4(3,1), pv);
+
+    const int start = 0;
+    const double step = 0.5;
+    const int dim0 = 0;
+    array interpolated = approx1(in,
+                                 pos, dim0,
+                                 start, step);
+    float iv[3] = {10, 30, 20};
+    array interp_gold(dim4(3,1), iv);
+    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+}
+
 TEST(Approx1, CPPUniformDecimalStep)
 {
     float inv[3] = {10, 20, 30};
@@ -697,3 +716,57 @@ TEST(Approx1, OtherDimCubic)
         ASSERT_NEAR(0, af::max<float>(af::abs(res - yo)), 1E-3);
     }
 }
+
+// Unless the sampling grid specifications - begin, step - are
+// specified by the user, ArrayFire will assume a regular grid with a
+// starting index of 0 and a step value of 1.
+TEST(Approx1, InfCheck)
+{
+    array sampled(seq(0.0, 5.0, 0.5));
+    sampled(0) = -af::Inf;
+    seq xo(0.0, 2.0, 0.25);
+    int dim0 = 0;
+    array interp = approx1(sampled, xo); // fail
+    array interp_augmented = join(1, xo, interp);
+
+    float goldv[9] = {-af::Inf, -af::Inf, -af::Inf, -af::Inf, 0.5, 0.625, 0.75, 0.875, 1.0};
+    array gold(dim4(9,1), goldv);
+
+    // \TODO(miguel) handle infs
+    // ASSERT_ARRAYS_EQ(interp, gold);
+}
+
+
+// \TODO(miguel)
+// TEST(Approx1, UniformInfCheck)
+// {
+//     // float sampledv[8] = {-af::Inf, 0, 0.5, 1, 1.5, 2, 2.5, 3};
+//     // array sampled(dim4(8,1), sampledv);
+
+//     // float xov[6] = {0., 0.25, 0.5, 0.75, 1.0, 1.5};
+//     // array xo(dim4(6,1), xov);
+
+//     const float measured_start = 0.0;
+//     const float measured_step = 0.5;
+//     array sampled(seq(measured_start, 5.0, measured_step));
+
+//     sampled(0) = -af::Inf;
+//     seq xo(0.0, 5.0, 0.5);
+
+//     int dim0 = 0;
+//     array interp = approx1(sampled,
+//                            xo, dim0,
+//                            measured_start, measured_step);
+//     // array interp = approx1(sampled, xo); // fail
+//     // array interp_augmented = join(1, xo, interp);
+//     // af_print(interp_augmented);
+//     // getchar();
+
+//     // float goldv[9] = {-af::Inf, -af::Inf, 0.5, 0.625, 0.75, 0.875, 1.0};
+//     // array gold(dim4(9,1), goldv);
+
+//     float goldv[9] = {-af::Inf, -af::Inf, -af::Inf, 0.5, 0.625, 0.75, 0.875, 1.0};
+//     array gold(dim4(9,1), goldv);
+
+//     ASSERT_ARRAYS_NEAR(interp, gold, 1e-5);
+// }

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -517,16 +517,17 @@ TEST(Approx1, CPPUsage)
     //! [ex_signal_approx1]
 
     // Input data.
-    float inv[9] = {10.0, 20.0, 30.0,
-                    40.0, 50.0, 60.0,
-                    70.0, 80.0, 90.0};
-    array in(dim4(3, 3), inv);
+    float input_vals[9] = {10.0, 20.0, 30.0,
+                           40.0, 50.0, 60.0,
+                           70.0, 80.0, 90.0};
+    array in(dim4(3, 3), input_vals);
     // [3 3 1 1]
     //     10.0000    40.0000    70.0000
     //     20.0000    50.0000    80.0000
     //     30.0000    60.0000    90.0000
 
-    // Array of positions to perform interpolation on.
+    // Array of known and unknown positions to measure and perform
+    // interpolation along a specified dimension.
     float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
     array pos(dim4(5,1), pv);
     // [5 1 1 1]
@@ -536,6 +537,8 @@ TEST(Approx1, CPPUsage)
     //     1.5000
     //     2.0000
 
+    // Specify a standard uniform grid with start and step values of 0
+    // and 1, respectively.
     const int interp_grid_start = 0;
     const double interp_grid_step = 1.0;
 
@@ -589,12 +592,12 @@ TEST(Approx1, CPPDecimalStepRescaleGrid)
     const int interp_grid_start = 0;
     const double interp_grid_step = 0.5;
     const int interp_dim = 0;
-    array interpolated = approx1(in,
-                                 pos, interp_dim,
-                                 interp_grid_start, interp_grid_step);
+    array interp = approx1(in,
+                           pos, interp_dim, interp_grid_start, interp_grid_step);
+
     float iv[5] = {10.0, 15.0, 20.0, 25.0, 30.0};
     array interp_gold(dim4(5,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+    ASSERT_ARRAYS_EQ(interp, interp_gold);
 }
 
 TEST(Approx1, CPPRepeatPos)
@@ -603,22 +606,20 @@ TEST(Approx1, CPPRepeatPos)
                     40.0, 50.0, 60.0,
                     70.0, 80.0, 90.0};
     array in(dim4(3, 3), inv);
-
     float pv[5] = {0.0, 0.5, 0.5, 1.5, 1.5};
     array pos(dim4(5,1), pv);
 
     const int interp_grid_start = 0;
     const double interp_grid_step = 1.0;
     const int interp_dim = 0;
-    array interpolated = approx1(in,
-                                 pos, interp_dim,
-                                 interp_grid_start, interp_grid_step);
+    array interp = approx1(in,
+                           pos, interp_dim, interp_grid_start, interp_grid_step);
 
     float iv[15] = {10.0, 15.0, 15.0, 25.0, 25.0,
                     40.0, 45.0, 45.0, 55.0, 55.0,
                     70.0, 75.0, 75.0, 85.0, 85.0};
     array interp_gold(dim4(5,3), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+    ASSERT_ARRAYS_EQ(interp, interp_gold);
 }
 
 
@@ -626,19 +627,18 @@ TEST(Approx1, CPPNonMonotonicPos)
 {
     float inv[3] = {10.0, 20.0, 30.0};
     array in(dim4(3,1), inv);
-
     float pv[5] = {0.5, 1.0, 1.5, 0.0, 2.0};
     array pos(dim4(5,1), pv);
 
     const int interp_grid_start = 0;
     const double interp_grid_step = 1.0;
     const int interp_dim = 0;
-    array interpolated = approx1(in,
-                                 pos, interp_dim,
-                                 interp_grid_start, interp_grid_step);
+    array interp = approx1(in,
+                           pos, interp_dim, interp_grid_start, interp_grid_step);
+
     float iv[5] = {15.0, 20.0, 25.0, 10.0, 30.0};
     array interp_gold(dim4(5,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+    ASSERT_ARRAYS_EQ(interp, interp_gold);
 }
 
 TEST(Approx1, CPPMismatchingIndexingDim)
@@ -652,16 +652,16 @@ TEST(Approx1, CPPMismatchingIndexingDim)
     const double interp_grid_step = 1.0;
     const int interp_dim = 1;
     const float off_grid = -1.0;
-    array interpolated = approx1(in,
-                                 pos, interp_dim,
-                                 interp_grid_start, interp_grid_step,
-                                 AF_INTERP_LINEAR, off_grid);
+    array interp = approx1(in,
+                           pos, interp_dim, interp_grid_start, interp_grid_step,
+                           AF_INTERP_LINEAR, off_grid);
+
     float iv[12] = {10.0, 20.0, 30.0,
                    -1.0, -1.0, -1.0,
                    -1.0, -1.0, -1.0,
                    -1.0, -1.0, -1.0};
     array interp_gold(dim4(3,4), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+    ASSERT_ARRAYS_EQ(interp, interp_gold);
 }
 
 TEST(Approx1, CPPNegativeGridStart)
@@ -674,12 +674,12 @@ TEST(Approx1, CPPNegativeGridStart)
     const int interp_grid_start = -1;
     const double interp_grid_step = 1;
     const int interp_dim = 0;
-    array interpolated = approx1(in,
-                                 pos, interp_dim,
-                                 interp_grid_start, interp_grid_step);
+    array interp = approx1(in,
+                           pos, interp_dim, interp_grid_start, interp_grid_step);
+
     float iv[5] = {20.0, 25.0, 30.0, 0.0, 0.0};
     array interp_gold(dim4(5,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+    ASSERT_ARRAYS_EQ(interp, interp_gold);
 
 }
 
@@ -693,12 +693,12 @@ TEST(Approx1, CPPInterpolateBackwards)
     const int interp_grid_start = in.elements()-1;
     const double interp_grid_step = -1;
     const int interp_dim = 0;
-    array interpolated = approx1(in,
-                                 pos, interp_dim,
-                                 interp_grid_start, interp_grid_step);
+    array interp = approx1(in,
+                           pos, interp_dim, interp_grid_start, interp_grid_step);
+
     float iv[5] = {30.0, 25.0, 20.0, 15.0, 10.0};
     array interp_gold(dim4(3,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+    ASSERT_ARRAYS_EQ(interp, interp_gold);
 }
 
 
@@ -712,12 +712,12 @@ TEST(Approx1, CPPStartOffGridAndNegativeStep)
     const int interp_grid_start = -1;
     const double interp_grid_step = -1;
     const int interp_dim = 0;
-    array interpolated = approx1(in,
-                                 pos, interp_dim,
-                                 interp_grid_start, interp_grid_step);
+    array interp = approx1(in,
+                           pos, interp_dim, interp_grid_start, interp_grid_step);
+
     float iv[5] = {0.0, 0.0, 10.0, 15.0, 20.0};
     array interp_gold(dim4(5,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+    ASSERT_ARRAYS_EQ(interp, interp_gold);
 }
 
 TEST(Approx1, CPPUniformInvalidStepSize)
@@ -732,9 +732,8 @@ TEST(Approx1, CPPUniformInvalidStepSize)
         const int interp_grid_start = 0;
         const double interp_grid_step = 0;
         const int interp_dim = 0;
-        array interpolated = approx1(in,
-                                     pos, interp_dim,
-                                     interp_grid_start, interp_grid_step);
+        array interp = approx1(in,
+                               pos, interp_dim, interp_grid_start, interp_grid_step);
         FAIL() << "Expected af::exception\n";
     } catch (af::exception &ex) {
         SUCCEED();
@@ -781,9 +780,9 @@ TEST(Approx1, CPPEmptyPos)
     float inv[3] = {10.0, 20.0, 30.0};
     array in(dim4(3,1), inv);
     array pos;
-    array interpolated = approx1(in, pos);
+    array interp = approx1(in, pos);
     ASSERT_TRUE(pos.isempty());
-    ASSERT_TRUE(interpolated.isempty());
+    ASSERT_TRUE(interp.isempty());
 }
 
 TEST(Approx1, CPPEmptyInput)
@@ -792,17 +791,17 @@ TEST(Approx1, CPPEmptyInput)
     float pv[3] = {0.0, 1.0, 2.0};
     array pos(dim4(3,1), pv);
 
-    array interpolated = approx1(in, pos);
+    array interp = approx1(in, pos);
     ASSERT_TRUE(in.isempty());
-    ASSERT_TRUE(interpolated.isempty());
+    ASSERT_TRUE(interp.isempty());
 }
 
 TEST(Approx1, CPPEmptyPosAndInput)
 {
     array in;
     array pos;
-    array interpolated = approx1(in, pos);
+    array interp = approx1(in, pos);
     ASSERT_TRUE(in.isempty());
     ASSERT_TRUE(pos.isempty());
-    ASSERT_TRUE(interpolated.isempty());
+    ASSERT_TRUE(interp.isempty());
 }

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -509,6 +509,8 @@ TEST(Approx1, CPP2DInput)
 
 TEST(Approx1, CPPUniformUsage)
 {
+    //! [ex_uniform_approx1]
+
     // input data
     float inv[3] = {10, 20, 30};
     array in(dim4(3,1), inv);
@@ -524,6 +526,9 @@ TEST(Approx1, CPPUniformUsage)
     array interpolated = approx1(in,
                                  pos, dim0,
                                  start, step);
+    // interpolated == {10, 15, 20, 25, 30};
+    //! [ex_uniform_approx1]
+
     float iv[5] = {10, 15, 20, 25, 30};
     array interp_gold(dim4(5,1), iv);
     ASSERT_ARRAYS_NEAR(interpolated, interp_gold, 1e-5);

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -516,7 +516,7 @@ TEST(Approx1, CPPUsage)
 {
     //! [ex_signal_approx1]
 
-    // Input data.
+    // Input data array.
     float input_vals[9] = {10.0, 20.0, 30.0,
                            40.0, 50.0, 60.0,
                            70.0, 80.0, 90.0};
@@ -526,8 +526,10 @@ TEST(Approx1, CPPUsage)
     //     20.0000    50.0000    80.0000
     //     30.0000    60.0000    90.0000
 
-    // Array of known and unknown positions to measure and perform
-    // interpolation along a specified dimension.
+
+
+    // Array of positions to be found along the interpolation
+    // dimension, `interp_dim`.
     float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
     array pos(dim4(5,1), pv);
     // [5 1 1 1]
@@ -537,15 +539,16 @@ TEST(Approx1, CPPUsage)
     //     1.5000
     //     2.0000
 
-    // Specify a standard uniform grid with start and step values of 0
-    // and 1, respectively.
-    const int interp_grid_start = 0;
-    const double interp_grid_step = 1.0;
 
-    // Perform column major interpolation on the 2-dimensional input
-    // array.
+
+    // Define range of indices with which the input values will
+    // correspond along the interpolation dimension.
+    const double idx_start = 0.0;
+    const double idx_step = 1.0;
+
+    // Perform interpolation across dimension 0.
     int interp_dim = 0;
-    array col_major_interp = approx1(in, pos, interp_dim, interp_grid_start, interp_grid_step);
+    array col_major_interp = approx1(in, pos, interp_dim, idx_start, idx_step);
     // [5 3 1 1]
     //     10.0000    40.0000    70.0000
     //     15.0000    45.0000    75.0000
@@ -553,11 +556,9 @@ TEST(Approx1, CPPUsage)
     //     25.0000    55.0000    85.0000
     //     30.0000    60.0000    90.0000
 
-    // Perform row major interpolation on the 2-dimensional input
-    // array.
-    pos = transpose(pos);
+    // Perform interpolation across dimension 1.
     interp_dim = 1;
-    array row_major_interp = approx1(in, pos, interp_dim, interp_grid_start, interp_grid_step);
+    array row_major_interp = approx1(in, transpose(pos), interp_dim, idx_start, idx_step);
     // [3 5 1 1]
     //     10.0000    25.0000    40.0000    55.0000    70.0000
     //     20.0000    35.0000    50.0000    65.0000    80.0000

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -464,300 +464,6 @@ TEST(Approx1, CPPCubicMaxDims)
     SUCCEED();
 }
 
-TEST(Approx1, CPPUsage)
-{
-    //! [ex_signal_approx1]
-
-    // Input data.
-    float inv[3] = {10.0, 20.0, 30.0};
-    array in(dim4(3, 1), inv);
-
-    // Positions of interpolated values.
-    float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
-    array pos(dim4(5,1), pv);
-
-    // Interpolate data across the first dimension, with a start grid
-    // index of 0 and a grid step size of 1.
-    array interp_uniform = approx1(in,
-                                   pos, 0,
-                                   0, 1);
-    // interp_uniform == { 10, 15, 20, 25, 30 };
-
-    // Interpolate data across the first dimension. Grid start point
-    // is 0 and grid step is 1 by default.
-    array interp         = approx1(in, pos);
-    // interp == interp_uniform == { 10, 15, 20, 25, 30 };
-
-    //! [ex_signal_approx1]
-
-    float iv[5] = {10.0, 15.0, 20.0, 25.0, 30.0};
-    array interp_gold(dim4(5,1), iv);
-    ASSERT_ARRAYS_EQ(interp, interp_gold);
-    ASSERT_ARRAYS_EQ(interp, interp_uniform);
-}
-
-TEST(Approx1, CPP2DInput)
-{
-    float inv[9] = {10.0, 20.0, 30.0,
-                    40.0, 50.0, 60.0,
-                    70.0, 80.0, 90.0};
-    array in(dim4(3,3), inv);
-    float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
-    array pos(dim4(5,1), pv);
-
-    array interpolated = approx1(in, pos);
-    float iv[15] = {10.0, 15.0, 20.0, 25.0, 30.0,
-                    40.0, 45.0, 50.0, 55.0, 60.0,
-                    70.0, 75.0, 80.0, 85.0, 90.0};
-    array interp_gold(dim4(5,3), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-}
-
-TEST(Approx1, CPPUniformUsage)
-{
-    //! [ex_uniform_approx1]
-
-    // Input data.
-    float inv[3] = {10.0, 20.0, 30.0};
-    array in(dim4(3,1), inv);
-
-    // Positions of interpolated values.
-    float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
-    array pos(dim4(5,1), pv);
-
-    const int    dim0 = 0;  // Dimension to interpolate across.
-    const int   start = 0;  // Starting index value of grid on which measurements were made.
-    const double step = 1;  // Step size of grid on which measurements were made.
-    array interpolated = approx1(in,
-                                 pos, dim0,
-                                 start, step);
-    // interpolated == {10, 15, 20, 25, 30};
-    //! [ex_uniform_approx1]
-
-    float iv[5] = {10.0, 15.0, 20.0, 25.0, 30.0};
-    array interp_gold(dim4(5,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-}
-
-TEST(Approx1, CPPUniformNonMonotonicPos)
-{
-    float inv[10] = {10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0};
-    array in(dim4(10,1), inv);
-
-    float pv[10] = {1.0, 0.0, 2.0, 9.0, 7.0, 4.0, 3.0, 5.0, 6.0, 8.0};
-    array pos(dim4(10,1), pv);
-
-    const int start = 0;
-    const double step = 1.0;
-    const int dim0 = 0;
-    array interpolated = approx1(in,
-                                 pos, dim0,
-                                 start, step);
-    float iv[10] = {20.0, 10.0, 30.0, 100.0, 80.0, 50.0, 40.0, 60.0, 70.0, 90.0};
-    array interp_gold(dim4(10,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-}
-
-TEST(Approx1, CPPUniformSamePos)
-{
-    float inv[10] = {10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0};
-    array in(dim4(10,1), inv);
-
-    float pv[10] = {0.0, 0.0, 0.0, 9.0, 9.0, 9.0, 2.0, 2.0, 2.0, 8.0};
-    array pos(dim4(10,1), pv);
-
-    const int start = 0;
-    const double step = 1.0;
-    const int dim0 = 0;
-    array interpolated = approx1(in,
-                                 pos, dim0,
-                                 start, step);
-    float iv[10] = {10.0, 10.0, 10.0, 100.0, 100.0, 100.0, 30.0, 30.0, 30.0, 90.0};
-    array interp_gold(dim4(10,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-}
-
-TEST(Approx1, CPPUniformDecimalStep)
-{
-    float inv[3] = {10.0, 20.0, 30.0};
-    array in(dim4(3,1), inv);
-    float pv[3] = {0, 0.5, 1.0};
-    array pos(dim4(3,1), pv);
-
-    const int start = 0;
-    const double step = 0.5;
-    const int dim0 = 0;
-    array interpolated = approx1(in,
-                                 pos, dim0,
-                                 start, step);
-    float iv[3] = {10.0, 20.0, 30.0};
-    array interp_gold(dim4(3,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-}
-
-TEST(Approx1, CPPUniformMismatchingIndexingDim)
-{
-    float inv[3] = {10.0, 20.0, 30.0};
-    array in(dim4(3,1), inv);
-    float pv[3] = {0.0, 1.0, 2.0};
-    array pos(dim4(3,1), pv);
-
-    const int start = 0;
-    const double step = 1.0;
-    const int dim1 = 1;
-    array interpolated = approx1(in,
-                                 pos, dim1,
-                                 start, step);
-    float iv[3] = {10.0, 0.0, 0.0};
-    array interp_gold(dim4(3,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-}
-
-TEST(Approx1, CPPUniformPositiveStartAndStep)
-{
-    float inv[3] = {10.0, 20.0, 30.0};
-    array in(dim4(3,1), inv);
-    float pv[3] = {0.0, 1.0, 2.0};
-    array pos(dim4(3,1), pv);
-
-    const int start = 1;
-    const double step = 1;
-    const int dim0 = 0;
-    array interpolated = approx1(in,
-                                 pos, dim0,
-                                 start, step);
-    float iv[3] = {0.0, 10.0, 20.0};
-    array interp_gold(dim4(3,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-}
-
-TEST(Approx1, CPPUniformNegativeStart)
-{
-    float inv[3] = {10.0, 20.0, 30.0};
-    array in(dim4(3,1), inv);
-    float pv[3] = {0.0, 1.0, 2.0};
-    array pos(dim4(3,1), pv);
-
-    const int start = -1;
-    const double step = 1;
-    const int dim0 = 0;
-    array interpolated = approx1(in,
-                                 pos, dim0,
-                                 start, step);
-    float iv[3] = {20.0, 30.0, 0.0};
-    array interp_gold(dim4(3,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-}
-
-TEST(Approx1, CPPUniformInterpolateBackwards)
-{
-    float inv[3] = {10.0, 20.0, 30.0};
-    array in(dim4(3,1), inv);
-    float pv[3] = {0.0, 1.0, 2.0};
-    array pos(dim4(3,1), pv);
-
-    const int start = 2;
-    const double step = -1;
-    const int dim0 = 0;
-    array interpolated = approx1(in,
-                                 pos, dim0,
-                                 start, step);
-    float iv[3] = {30.0, 20.0, 10.0};
-    array interp_gold(dim4(3,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-}
-
-TEST(Approx1, CPPUniformOffGridAndNegativeStep)
-{
-    float inv[3] = {10.0, 20.0, 30.0};
-    array in(dim4(3,1), inv);
-    float pv[3] = {0.0, -1.0, -2.0};
-    array pos(dim4(3,1), pv);
-
-    const int start = -1;
-    const double step = -1;
-    const int dim0 = 0;
-    array interpolated = approx1(in,
-                                 pos, dim0,
-                                 start, step);
-    float iv[3] = {0.0, 10.0, 20.0};
-    array interp_gold(dim4(3,1), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-}
-
-TEST(Approx1, CPPUniformInvalidStepSize)
-{
-    try
-    {
-        float inv[3] = {10.0, 20.0, 30.0};
-        array in(dim4(3,1), inv);
-        float pv[3] = {0.0, -1.0, -2.0};
-        array pos(dim4(3,1), pv);
-
-        const int start = -1;
-        const double step = 0;
-        const int dim0 = 0;
-        array interpolated = approx1(in,
-                                     pos, dim0,
-                                     start, step);
-        FAIL() << "Expected af::exception\n";
-        float iv[3] = {0.0, 10.0, 20.0};
-        array interp_gold(dim4(3,1), iv);
-        ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-    } catch (af::exception &ex) {
-        SUCCEED();
-    } catch(...) {
-        FAIL() << "Expected af::exception\n";
-    }
-}
-
-TEST(Approx1, CPPUniformInterpDim0)
-{
-    float inv[9] = {10.0, 20.0, 30.0,
-                    40.0, 50.0, 60.0,
-                    70.0, 80.0, 90.0};
-    array in(dim4(3,3), inv);
-    float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
-    array pos(dim4(5,1), pv);
-
-    const int start = 0;
-    const double step = 1;
-    const int dim0 = 0;
-    array interpolated = approx1(in,
-                                 pos, dim0,
-                                 start, step);
-    float iv[15] = {10.0, 15.0, 20.0, 25.0, 30.0,
-                    40.0, 45.0, 50.0, 55.0, 60.0,
-                    70.0, 75.0, 80.0, 85.0, 90.0};
-
-    array interp_gold(dim4(5,3), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-}
-
-TEST(Approx1, CPPUniformInterpDim1)
-{
-    float inv[9] = {10.0, 20.0, 30.0,
-                    40.0, 50.0, 60.0,
-                    70.0, 80.0, 90.0};
-    array in(dim4(3,3), inv);
-    float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
-    array pos(dim4(1,5), pv);
-
-    const int start = 0;
-    const double step = 1;
-    const int dim1 = 1;
-    array interpolated = approx1(in,
-                                 pos, dim1,
-                                 start, step);
-    float iv[15] = {10.0, 20.0, 30.0,
-                    25.0, 35.0, 45.0,
-                    40.0, 50.0, 60.0,
-                    55.0, 65.0, 75.0,
-                    70.0, 80.0, 90.0};
-    array interp_gold(dim4(3,5), iv);
-    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-}
-
 TEST(Approx1, OtherDimLinear)
 {
     int start = 0;
@@ -803,6 +509,237 @@ TEST(Approx1, OtherDimCubic)
                                      d, start, step, AF_INTERP_CUBIC);
         array res = reorder(yo_reordered, rdims[0], rdims[1], rdims[2], rdims[3]);
         ASSERT_NEAR(0, af::max<float>(af::abs(res - yo)), 1E-3);
+    }
+}
+
+TEST(Approx1, CPPUsage)
+{
+    //! [ex_signal_approx1]
+
+    // Input data.
+    float inv[9] = {10.0, 20.0, 30.0,
+                    40.0, 50.0, 60.0,
+                    70.0, 80.0, 90.0};
+    array in(dim4(3, 3), inv);
+    // [3 3 1 1]
+    //     10.0000    40.0000    70.0000
+    //     20.0000    50.0000    80.0000
+    //     30.0000    60.0000    90.0000
+
+    // Array of positions to perform interpolation on.
+    float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
+    array pos(dim4(5,1), pv);
+    // [5 1 1 1]
+    //     0.0000
+    //     0.5000
+    //     1.0000
+    //     1.5000
+    //     2.0000
+
+    const int interp_grid_start = 0;
+    const double interp_grid_step = 1.0;
+
+    // Perform column major interpolation on the 2-dimensional input
+    // array.
+    int interp_dim = 0;
+    array col_major_interp = approx1(in, pos, interp_dim, interp_grid_start, interp_grid_step);
+    // [5 3 1 1]
+    //     10.0000    40.0000    70.0000
+    //     15.0000    45.0000    75.0000
+    //     20.0000    50.0000    80.0000
+    //     25.0000    55.0000    85.0000
+    //     30.0000    60.0000    90.0000
+
+    // Perform row major interpolation on the 2-dimensional input
+    // array.
+    pos = transpose(pos);
+    interp_dim = 1;
+    array row_major_interp = approx1(in, pos, interp_dim, interp_grid_start, interp_grid_step);
+    // [3 5 1 1]
+    //     10.0000    25.0000    40.0000    55.0000    70.0000
+    //     20.0000    35.0000    50.0000    65.0000    80.0000
+    //     30.0000    45.0000    60.0000    75.0000    90.0000
+
+    //! [ex_signal_approx1]
+
+    float civ[15] = {10.0, 15.0, 20.0, 25.0, 30.0,
+                     40.0, 45.0, 50.0, 55.0, 60.0,
+                     70.0, 75.0, 80.0, 85.0, 90.0};
+    array interp_gold_col(dim4(5,3), civ);
+    ASSERT_ARRAYS_EQ(col_major_interp, interp_gold_col);
+
+
+    float riv[15] = {10.0, 20.0, 30.0,
+                     25.0, 35.0, 45.0,
+                     40.0, 50.0, 60.0,
+                     55.0, 65.0, 75.0,
+                     70.0, 80.0, 90.0};
+    array interp_gold_row(dim4(3,5), riv);
+    ASSERT_ARRAYS_EQ(row_major_interp, interp_gold_row);
+
+}
+
+TEST(Approx1, CPPDecimalStepRescaleGrid)
+{
+    float inv[3] = {10.0, 20.0, 30.0};
+    array in(dim4(3,1), inv);
+    float pv[5] = {0, 0.25, 0.5, 0.75, 1.0};
+    array pos(dim4(5,1), pv);
+
+    const int interp_grid_start = 0;
+    const double interp_grid_step = 0.5;
+    const int interp_dim = 0;
+    array interpolated = approx1(in,
+                                 pos, interp_dim,
+                                 interp_grid_start, interp_grid_step);
+    float iv[5] = {10.0, 15.0, 20.0, 25.0, 30.0};
+    array interp_gold(dim4(5,1), iv);
+    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+}
+
+TEST(Approx1, CPPRepeatPos)
+{
+    float inv[9] = {10.0, 20.0, 30.0,
+                    40.0, 50.0, 60.0,
+                    70.0, 80.0, 90.0};
+    array in(dim4(3, 3), inv);
+
+    float pv[5] = {0.0, 0.5, 0.5, 1.5, 1.5};
+    array pos(dim4(5,1), pv);
+
+    const int interp_grid_start = 0;
+    const double interp_grid_step = 1.0;
+    const int interp_dim = 0;
+    array interpolated = approx1(in,
+                                 pos, interp_dim,
+                                 interp_grid_start, interp_grid_step);
+
+    float iv[15] = {10.0, 15.0, 15.0, 25.0, 25.0,
+                    40.0, 45.0, 45.0, 55.0, 55.0,
+                    70.0, 75.0, 75.0, 85.0, 85.0};
+    array interp_gold(dim4(5,3), iv);
+    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+}
+
+
+TEST(Approx1, CPPNonMonotonicPos)
+{
+    float inv[3] = {10.0, 20.0, 30.0};
+    array in(dim4(3,1), inv);
+
+    float pv[5] = {0.5, 1.0, 1.5, 0.0, 2.0};
+    array pos(dim4(5,1), pv);
+
+    const int interp_grid_start = 0;
+    const double interp_grid_step = 1.0;
+    const int interp_dim = 0;
+    array interpolated = approx1(in,
+                                 pos, interp_dim,
+                                 interp_grid_start, interp_grid_step);
+    float iv[5] = {15.0, 20.0, 25.0, 10.0, 30.0};
+    array interp_gold(dim4(5,1), iv);
+    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+}
+
+TEST(Approx1, CPPMismatchingIndexingDim)
+{
+    float inv[3] = {10.0, 20.0, 30.0};
+    array in(dim4(3,1), inv);
+    float pv[4] = {0.0, 0.5, 1.0, 2.0};
+    array pos(dim4(1,4), pv);
+
+    const int interp_grid_start = 0;
+    const double interp_grid_step = 1.0;
+    const int interp_dim = 1;
+    const float off_grid = -1.0;
+    array interpolated = approx1(in,
+                                 pos, interp_dim,
+                                 interp_grid_start, interp_grid_step,
+                                 AF_INTERP_LINEAR, off_grid);
+    float iv[12] = {10.0, 20.0, 30.0,
+                   -1.0, -1.0, -1.0,
+                   -1.0, -1.0, -1.0,
+                   -1.0, -1.0, -1.0};
+    array interp_gold(dim4(3,4), iv);
+    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+}
+
+TEST(Approx1, CPPNegativeGridStart)
+{
+    float inv[3] = {10.0, 20.0, 30.0};
+    array in(dim4(3,1), inv);
+    float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
+    array pos(dim4(5,1), pv);
+
+    const int interp_grid_start = -1;
+    const double interp_grid_step = 1;
+    const int interp_dim = 0;
+    array interpolated = approx1(in,
+                                 pos, interp_dim,
+                                 interp_grid_start, interp_grid_step);
+    float iv[5] = {20.0, 25.0, 30.0, 0.0, 0.0};
+    array interp_gold(dim4(5,1), iv);
+    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+
+}
+
+TEST(Approx1, CPPInterpolateBackwards)
+{
+    float inv[3] = {10.0, 20.0, 30.0};
+    array in(dim4(3,1), inv);
+    float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
+    array pos(dim4(3,1), pv);
+
+    const int interp_grid_start = in.elements()-1;
+    const double interp_grid_step = -1;
+    const int interp_dim = 0;
+    array interpolated = approx1(in,
+                                 pos, interp_dim,
+                                 interp_grid_start, interp_grid_step);
+    float iv[5] = {30.0, 25.0, 20.0, 15.0, 10.0};
+    array interp_gold(dim4(3,1), iv);
+    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+}
+
+
+TEST(Approx1, CPPStartOffGridAndNegativeStep)
+{
+    float inv[3] = {10.0, 20.0, 30.0};
+    array in(dim4(3,1), inv);
+    float pv[5] = {0.0, -0.5, -1.0, -1.5, -2.0};
+    array pos(dim4(5,1), pv);
+
+    const int interp_grid_start = -1;
+    const double interp_grid_step = -1;
+    const int interp_dim = 0;
+    array interpolated = approx1(in,
+                                 pos, interp_dim,
+                                 interp_grid_start, interp_grid_step);
+    float iv[5] = {0.0, 0.0, 10.0, 15.0, 20.0};
+    array interp_gold(dim4(5,1), iv);
+    ASSERT_ARRAYS_EQ(interpolated, interp_gold);
+}
+
+TEST(Approx1, CPPUniformInvalidStepSize)
+{
+    try
+    {
+        float inv[3] = {10.0, 20.0, 30.0};
+        array in(dim4(3,1), inv);
+        float pv[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
+        array pos(dim4(5,1), pv);
+
+        const int interp_grid_start = 0;
+        const double interp_grid_step = 0;
+        const int interp_dim = 0;
+        array interpolated = approx1(in,
+                                     pos, interp_dim,
+                                     interp_grid_start, interp_grid_step);
+        FAIL() << "Expected af::exception\n";
+    } catch (af::exception &ex) {
+        SUCCEED();
+    } catch(...) {
+        FAIL() << "Expected af::exception\n";
     }
 }
 
@@ -869,4 +806,3 @@ TEST(Approx1, CPPEmptyPosAndInput)
     ASSERT_TRUE(pos.isempty());
     ASSERT_TRUE(interpolated.isempty());
 }
-

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -457,9 +457,8 @@ TEST(Approx2, OtherDimLinear)
         array xo_reordered = reorder(xo, rdims[0], rdims[1], rdims[2], rdims[3]);
         array yo_reordered = reorder(yo, rdims[0], rdims[1], rdims[2], rdims[3]);
         array zo_reordered = approx2(zi_reordered,
-                                     xo_reordered, d,
-                                     yo_reordered, d + 1,
-                                     start, step, start, step,
+                                     xo_reordered, d, start, step,
+                                     yo_reordered, d + 1, start, step,
                                      AF_INTERP_LINEAR);
         rdims[d] = 0;
         rdims[0] = d;
@@ -489,9 +488,8 @@ TEST(Approx2, OtherDimCubic)
         array xo_reordered = reorder(xo, rdims[0], rdims[1], rdims[2], rdims[3]);
         array yo_reordered = reorder(yo, rdims[0], rdims[1], rdims[2], rdims[3]);
         array zo_reordered = approx2(zi_reordered,
-                                     xo_reordered, d,
-                                     yo_reordered, d + 1,
-                                     start, step, start, step,
+                                     xo_reordered, d, start, step,
+                                     yo_reordered, d + 1, start, step,
                                      AF_INTERP_CUBIC);
         rdims[d] = 0;
         rdims[0] = d;
@@ -531,10 +529,8 @@ TEST(Approx2, CPPUsage)
     const int pos0_interp_dim = 0;
     const int pos1_interp_dim = 1;
     array interp = approx2(input,
-                           pos0, pos0_interp_dim,
-                           pos1, pos1_interp_dim,
-                           pos0_interp_grid_start, pos0_interp_grid_step,
-                           pos0_interp_grid_start, pos0_interp_grid_step);
+                           pos0, pos0_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step,
+                           pos1, pos1_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step);
     // [2 2 1 1]
     //     1.5000     2.5000
     //     1.5000     2.5000
@@ -563,10 +559,8 @@ TEST(Approx2, CPPUniformOneDimIndices)
     const int pos0_interp_grid_start = 0;
     const double pos0_interp_grid_step = 1;
     array interpolated = approx2(input,
-                                 pos0, 0,
-                                 pos1, 1,
-                                 pos0_interp_grid_start, pos0_interp_grid_step,
-                                 pos0_interp_grid_start, pos0_interp_grid_step);
+                                 pos0, 0, pos0_interp_grid_start, pos0_interp_grid_step,
+                                 pos1, 1, pos0_interp_grid_start, pos0_interp_grid_step);
 
     float expected_interp[3] = {10.0, 50.0, 90.0};
 
@@ -592,10 +586,8 @@ TEST(Approx2, CPPUniformTwoDimIndices)
     const int pos1_interp_dim = 1;
 
     array interpolated = approx2(input,
-                                 pos0, pos0_interp_dim,
-                                 pos1, pos1_interp_dim,
-                                 pos0_interp_grid_start, pos0_interp_grid_step,
-                                 pos0_interp_grid_start, pos0_interp_grid_step);
+                                 pos0, pos0_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step,
+                                 pos1, pos1_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step);
 
     float expected_interp[4] = {10.0, 30.0, 70.0, 90.0};
     array interpolated_gold(dim4(2,2), expected_interp);
@@ -618,10 +610,8 @@ TEST(Approx2, CPPUniformInvalidStepSize)
         const int pos1_interp_dim = 1;
 
         array interpolated = approx2(in,
-                                     pos, pos0_interp_dim,
-                                     pos, pos1_interp_dim,
-                                     pos0_interp_grid_start, pos0_interp_grid_step,
-                                     pos0_interp_grid_start, pos0_interp_grid_step);
+                                     pos, pos0_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step,
+                                     pos, pos1_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step);
         FAIL() << "Expected af::exception\n";
 
     } catch (af::exception &ex) {
@@ -648,16 +638,12 @@ TEST(Approx2, CPPUniformColumnMajorInterpolation)
     const double pos0_interp_grid_step = 1;
 
     array first = approx2(input,
-                          pos0, pos0_interp_dim,
-                          pos1, pos1_interp_dim,
-                          pos0_interp_grid_start, pos0_interp_grid_step,
-                          pos0_interp_grid_start, pos0_interp_grid_step);
+                          pos0, pos0_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step,
+                          pos1, pos1_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step);
 
     array second = approx2(input,
-                           pos1, pos1_interp_dim,
-                           pos0, pos0_interp_dim,
-                           pos0_interp_grid_start, pos0_interp_grid_step,
-                           pos0_interp_grid_start, pos0_interp_grid_step);
+                           pos1, pos1_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step,
+                           pos0, pos0_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step);
 
     // Verify.
     float expected_interp[4] = {10.0, 30.0, 70.0, 90.0};
@@ -681,16 +667,12 @@ TEST(Approx2, CPPUniformRowMajorInterpolation)
     const double pos0_interp_grid_step = 1;
 
     array first = approx2(input,
-                          pos0, 1,
-                          pos1, 0,
-                          pos0_interp_grid_start, pos0_interp_grid_step,
-                          pos0_interp_grid_start, pos0_interp_grid_step);
+                          pos0, 1, pos0_interp_grid_start, pos0_interp_grid_step,
+                          pos1, 0, pos0_interp_grid_start, pos0_interp_grid_step);
 
     array second = approx2(input,
-                           pos1, 0,
-                           pos0, 1,
-                           pos0_interp_grid_start, pos0_interp_grid_step,
-                           pos0_interp_grid_start, pos0_interp_grid_step);
+                           pos1, 0, pos0_interp_grid_start, pos0_interp_grid_step,
+                           pos0, 1, pos0_interp_grid_start, pos0_interp_grid_step);
 
     // Verify.
     float expected_interp[4] = {10.0, 70.0, 30.0, 90.0};

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -512,18 +512,24 @@ TEST(Approx2, CPPUsage)
     //     1.0000     2.0000     3.0000
     //     1.0000     2.0000     3.0000
 
+    // First array of known and unknown positions to measure and perform
+    // interpolation along a specified dimension.
     float p0[4] = {0.5, 1.5, 0.5, 1.5};
     array pos0(2, 2, p0);
     // [2 2 1 1]
     //     0.5000     0.5000
     //     1.5000     1.5000
 
+    // Second array of known and unknown positions to measure and perform
+    // interpolation along a specified dimension.
     float p1[4] = {0.5, 0.5, 1.5, 1.5};
     array pos1(2, 2, p1);
     // [2 2 1 1]
     //     0.5000     1.5000
     //     0.5000     1.5000
 
+    // Specify a standard uniform grid with start and step values of 0
+    // and 1 along each of the interpolation grid dimensions.
     const int pos0_interp_grid_start = 0;
     const double pos0_interp_grid_step = 1;
     const int pos0_interp_dim = 0;
@@ -613,7 +619,6 @@ TEST(Approx2, CPPUniformInvalidStepSize)
                                      pos, pos0_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step,
                                      pos, pos1_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step);
         FAIL() << "Expected af::exception\n";
-
     } catch (af::exception &ex) {
         SUCCEED();
     } catch(...) {

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -512,7 +512,48 @@ TEST(Approx2, CPPUsage)
     //     1.0000     2.0000     3.0000
     //     1.0000     2.0000     3.0000
 
+    // First array of positions to be found along the first dimension.
+    float pv0[4] = {0.5, 1.5, 0.5, 1.5};
+    array pos0(2, 2, pv0);
+    // [2 2 1 1]
+    //     0.5000     0.5000
+    //     1.5000     1.5000
 
+    // Second array of positions to be found along the second
+    // dimension.
+    float pv1[4] = {0.5, 0.5, 1.5, 1.5};
+    array pos1(2, 2, pv1);
+    // [2 2 1 1]
+    //     0.5000     1.5000
+    //     0.5000     1.5000
+
+    array interp = approx2(input, pos0, pos1);
+    // [2 2 1 1]
+    //     1.5000     2.5000
+    //     1.5000     2.5000
+
+    //! [ex_signal_approx2]
+
+    float expected_interp[4] = {1.5, 1.5,
+                                2.5, 2.5};
+
+    array interp_gold(2, 2, expected_interp);
+    ASSERT_ARRAYS_EQ(interp, interp_gold);
+}
+
+TEST(Approx2, CPPUniformUsage)
+{
+    //! [ex_signal_approx2_uniform]
+
+    // Input data array.
+    float input_vals[9] = {1.0, 1.0, 1.0,
+                           2.0, 2.0, 2.0,
+                           3.0, 3.0, 3.0};
+    array input(3, 3, input_vals);
+    // [3 3 1 1]
+    //     1.0000     2.0000     3.0000
+    //     1.0000     2.0000     3.0000
+    //     1.0000     2.0000     3.0000
 
     // First array of positions to be found along the interpolation
     // dimension, `interp_dim0`.
@@ -530,8 +571,6 @@ TEST(Approx2, CPPUsage)
     //     0.5000     1.5000
     //     0.5000     1.5000
 
-
-
     // Define range of indices with which the input values will
     // correspond along both dimensions to be interpolated.
     const double idx_start_dim0 = 0.0;
@@ -545,7 +584,7 @@ TEST(Approx2, CPPUsage)
     //     1.5000     2.5000
     //     1.5000     2.5000
 
-    //! [ex_signal_approx2]
+    //! [ex_signal_approx2_uniform]
 
     float expected_interp[4] = {1.5, 1.5,
                                 2.5, 2.5};

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -471,6 +471,7 @@ TEST(Approx2, SNIPPET_approx2)
 
     array interpolated_gold(2, 2, expected_interp);
     ASSERT_ARRAYS_NEAR(interpolated, interpolated_gold, 1e-5);
+}
 
 TEST(Approx2, OtherDimLinear)
 {

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -436,7 +436,8 @@ TEST(Approx2, CPPCubicMaxDims)
     SUCCEED();
 }
 
-TEST(Approx2, SNIPPET_approx2) {
+TEST(Approx2, SNIPPET_approx2)
+{
 
     //! [ex_signal_approx2]
 
@@ -471,4 +472,66 @@ TEST(Approx2, SNIPPET_approx2) {
     array interpolated_gold(2, 2, expected_interp);
     ASSERT_ARRAYS_NEAR(interpolated, interpolated_gold, 1e-5);
 
+TEST(Approx2, OtherDimLinear)
+{
+    int start = 0;
+    int stop = 10000;
+    int step = 100;
+    int num = 1000;
+    af::array xi = af::tile(af::seq(start, stop, step), 1, 2, 2, 2);
+    af::array yi = af::tile(af::seq(start, stop, step), 1, 2, 2, 2);
+    af::array zi = 4 * xi * yi - 3 * xi;
+    af::array xo = af::round(step * af::randu(num, 2, 2, 2));
+    af::array yo = af::round(step * af::randu(num, 2, 2, 2));
+    af::array zo = 4 * xo * yo - 3 * xo;
+    for (int d = 1; d < 3; d++) {
+        af::dim4 rdims(0,1,2,3);
+        rdims[0] = d;
+        rdims[d] = 0;
+
+        af::array zi_reordered = af::reorder(zi, rdims[0], rdims[1], rdims[2], rdims[3]);
+        af::array xo_reordered = af::reorder(xo, rdims[0], rdims[1], rdims[2], rdims[3]);
+        af::array yo_reordered = af::reorder(yo, rdims[0], rdims[1], rdims[2], rdims[3]);
+        af::array zo_reordered = af::approx2(zi_reordered,
+                                             xo_reordered, d,
+                                             yo_reordered, d + 1,
+                                             start, step, start, step,
+                                             AF_INTERP_LINEAR);
+        rdims[d] = 0;
+        rdims[0] = d;
+        af::array res = af::reorder(yo_reordered, rdims[0], rdims[1], rdims[2], rdims[3]);
+        ASSERT_NEAR(0, af::max<float>(af::abs(res - yo)), 1E-3);
+    }
+}
+
+TEST(Approx2, OtherDimCubic)
+{
+    float start = 0;
+    float stop = 100;
+    float step = 0.01;
+    int num = 1000;
+    af::array xi = af::tile(af::seq(start, stop, step), 1, 2, 2, 2);
+    af::array yi = af::tile(af::seq(start, stop, step), 1, 2, 2, 2);
+    af::array zi = 4 * sin(xi) * cos(yi);
+    af::array xo = af::round(step * af::randu(num, 2, 2, 2));
+    af::array yo = af::round(step * af::randu(num, 2, 2, 2));
+    af::array zo = 4 * sin(xo) * cos(yo);
+    for (int d = 1; d < 3; d++) {
+        af::dim4 rdims(0,1,2,3);
+        rdims[0] = d;
+        rdims[d] = 0;
+
+        af::array zi_reordered = af::reorder(zi, rdims[0], rdims[1], rdims[2], rdims[3]);
+        af::array xo_reordered = af::reorder(xo, rdims[0], rdims[1], rdims[2], rdims[3]);
+        af::array yo_reordered = af::reorder(yo, rdims[0], rdims[1], rdims[2], rdims[3]);
+        af::array zo_reordered = af::approx2(zi_reordered,
+                                             xo_reordered, d,
+                                             yo_reordered, d + 1,
+                                             start, step, start, step,
+                                             AF_INTERP_CUBIC);
+        rdims[d] = 0;
+        rdims[0] = d;
+        af::array res = af::reorder(yo_reordered, rdims[0], rdims[1], rdims[2], rdims[3]);
+        ASSERT_NEAR(0, af::max<float>(af::abs(res - yo)), 1E-3);
+    }
 }

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -474,6 +474,8 @@ TEST(Approx2, CPPUsage)
 
 TEST(Approx2, CPPUniformUsage)
 {
+    //! [ex_uniform_approx2]
+
     // constant input data
     // {{1 2 3},
     //  {1 2 3},
@@ -503,6 +505,8 @@ TEST(Approx2, CPPUniformUsage)
                                  start, step);
     // interpolated == {{1.5 2.5},
     //                  {1.5 2.5}};
+    //! [ex_uniform_approx2]
+
     float expected_interp[4] = {1.5, 1.5,
                                 2.5, 2.5};
 

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -165,20 +165,20 @@ void approx2ArgsTest(string pTestFile, const unsigned resultIdx, const af_interp
     if(outArray  != 0) af_release_array(outArray);
 }
 
-    TYPED_TEST(Approx2, Approx2NearestArgsPos3D)
-    {
-        approx2ArgsTest<TypeParam>(string(TEST_DIR"/approx/approx2_pos3d.test"), 0, AF_INTERP_NEAREST, AF_ERR_SIZE);
-    }
+TYPED_TEST(Approx2, Approx2NearestArgsPos3D)
+{
+    approx2ArgsTest<TypeParam>(string(TEST_DIR"/approx/approx2_pos3d.test"), 0, AF_INTERP_NEAREST, AF_ERR_SIZE);
+}
 
-    TYPED_TEST(Approx2, Approx2LinearArgsPos3D)
-    {
-        approx2ArgsTest<TypeParam>(string(TEST_DIR"/approx/approx2_pos3d.test"), 1, AF_INTERP_LINEAR, AF_ERR_SIZE);
-    }
+TYPED_TEST(Approx2, Approx2LinearArgsPos3D)
+{
+    approx2ArgsTest<TypeParam>(string(TEST_DIR"/approx/approx2_pos3d.test"), 1, AF_INTERP_LINEAR, AF_ERR_SIZE);
+}
 
-    TYPED_TEST(Approx2, Approx2NearestArgsPosUnequal)
-    {
-        approx2ArgsTest<TypeParam>(string(TEST_DIR"/approx/approx2_unequal.test"), 0, AF_INTERP_NEAREST, AF_ERR_SIZE);
-    }
+TYPED_TEST(Approx2, Approx2NearestArgsPosUnequal)
+{
+    approx2ArgsTest<TypeParam>(string(TEST_DIR"/approx/approx2_unequal.test"), 0, AF_INTERP_NEAREST, AF_ERR_SIZE);
+}
 
 template<typename T>
 void approx2ArgsTestPrecision(string pTestFile, const unsigned resultIdx, const af_interp_type method)
@@ -436,9 +436,8 @@ TEST(Approx2, CPPCubicMaxDims)
     SUCCEED();
 }
 
-TEST(Approx2, SNIPPET_approx2)
+TEST(Approx2, CPPUsage)
 {
-
     //! [ex_signal_approx2]
 
     // constant input data
@@ -473,34 +472,155 @@ TEST(Approx2, SNIPPET_approx2)
     ASSERT_ARRAYS_NEAR(interpolated, interpolated_gold, 1e-5);
 }
 
+TEST(Approx2, CPPUniformUsage)
+{
+    // constant input data
+    // {{1 2 3},
+    //  {1 2 3},
+    //  {1 2 3}},
+    float input_vals[9] = {1, 1, 1,
+                           2, 2, 2,
+                           3, 3, 3};
+    array input(3, 3, input_vals);
+
+    // generate grid of interpolation locations
+    // interpolation locations along dim0
+    float p0[4] = {0.5, 1.5,
+                   0.5, 1.5};
+    array pos0(2, 2, p0);
+    // interpolation locations along dim1
+    float p1[4] = {0.5, 0.5,
+                   1.5, 1.5};
+    array pos1(2, 2, p1);
+
+    const int start = 0;
+    const double step = 1;
+    const int dim0 = 0;
+    array interpolated = approx2(input,
+                                 pos0, dim0,
+                                 pos1, dim0 + 1,
+                                 start, step,
+                                 start, step);
+    // interpolated == {{1.5 2.5},
+    //                  {1.5 2.5}};
+    float expected_interp[4] = {1.5, 1.5,
+                                2.5, 2.5};
+
+    array interpolated_gold(2, 2, expected_interp);
+    ASSERT_ARRAYS_NEAR(interpolated, interpolated_gold, 1e-5);
+}
+
+TEST(Approx2, CPPUniformOneDimIndices)
+{
+    float inv[9] = {10, 20, 30,
+                    40, 50, 60,
+                    70, 80, 90};
+    array input(dim4(3,3), inv);
+
+    // generate grid of interpolation locations
+    float p0[3] = {0, 1, 2};
+    float p1[3] = {0, 1, 2};
+    array pos0(dim4(3,1), p0);
+    array pos1(dim4(3,1), p1);
+
+    const int start = 0;
+    const double step = 1;
+    const int d0 = 0;
+    array interpolated = approx2(input,
+                                 pos0, d0,
+                                 pos1, d0 + 1,
+                                 start, step,
+                                 start, step);
+
+    const float expected_interp[3] = {10, 50, 90};
+
+
+    array interpolated_gold(dim4(3,1), expected_interp);
+    ASSERT_ARRAYS_NEAR(interpolated, interpolated_gold, 1e-5);
+}
+
+TEST(Approx2, CPPUniformTwoDimIndices)
+{
+    float inv[9] = {10, 20, 30,
+                    40, 50, 60,
+                    70, 80, 90};
+    array input(dim4(3,3), inv);
+
+    // generate grid of interpolation locations
+    float p0[4] = {0, 2, 0, 2};
+    float p1[4] = {0, 0, 2, 2};
+    array pos0(dim4(2,2), p0);
+    array pos1(dim4(2,2), p1);
+
+    const int start = 0;
+    const double step = 1;
+    const int d0 = 0;
+    array interpolated = approx2(input,
+                                 pos0, d0,
+                                 pos1, d0 + 1,
+                                 start, step,
+                                 start, step);
+
+    const float expected_interp[4] = {10, 30, 70, 90};
+    array interpolated_gold(dim4(2,2), expected_interp);
+    ASSERT_ARRAYS_NEAR(interpolated, interpolated_gold, 1e-5);
+}
+
+TEST(Approx2, CPPUniformFlippedDims)
+{
+    float inv[9] = {10, 20, 30,
+                    40, 50, 60,
+                    70, 80, 90};
+    array input(dim4(3,3), inv);
+
+    // generate grid of interpolation locations
+    float p0[4] = {0, 2, 0, 2};
+    float p1[4] = {0, 0, 2, 2};
+    array pos0(dim4(2,2), p0);
+    array pos1(dim4(2,2), p1);
+
+    const int start = 0;
+    const double step = 1;
+    const int d1 = 1;
+    array interpolated = approx2(input,
+                                 pos1, d1,
+                                 pos0, d1 - 1,
+                                 start, step,
+                                 start, step);
+
+    const float expected_interp[4] = {10, 70, 30, 90};
+    array interpolated_gold(dim4(2,2), expected_interp);
+    ASSERT_ARRAYS_NEAR(interpolated, interpolated_gold, 1e-5);
+}
+
 TEST(Approx2, OtherDimLinear)
 {
     int start = 0;
     int stop = 10000;
     int step = 100;
     int num = 1000;
-    af::array xi = af::tile(af::seq(start, stop, step), 1, 2, 2, 2);
-    af::array yi = af::tile(af::seq(start, stop, step), 1, 2, 2, 2);
-    af::array zi = 4 * xi * yi - 3 * xi;
-    af::array xo = af::round(step * af::randu(num, 2, 2, 2));
-    af::array yo = af::round(step * af::randu(num, 2, 2, 2));
-    af::array zo = 4 * xo * yo - 3 * xo;
+    array xi = af::tile(seq(start, stop, step), 1, 2, 2, 2);
+    array yi = af::tile(seq(start, stop, step), 1, 2, 2, 2);
+    array zi = 4 * xi * yi - 3 * xi;
+    array xo = af::round(step * randu(num, 2, 2, 2));
+    array yo = af::round(step * randu(num, 2, 2, 2));
+    array zo = 4 * xo * yo - 3 * xo;
     for (int d = 1; d < 3; d++) {
-        af::dim4 rdims(0,1,2,3);
+        dim4 rdims(0,1,2,3);
         rdims[0] = d;
         rdims[d] = 0;
 
-        af::array zi_reordered = af::reorder(zi, rdims[0], rdims[1], rdims[2], rdims[3]);
-        af::array xo_reordered = af::reorder(xo, rdims[0], rdims[1], rdims[2], rdims[3]);
-        af::array yo_reordered = af::reorder(yo, rdims[0], rdims[1], rdims[2], rdims[3]);
-        af::array zo_reordered = af::approx2(zi_reordered,
-                                             xo_reordered, d,
-                                             yo_reordered, d + 1,
-                                             start, step, start, step,
-                                             AF_INTERP_LINEAR);
+        array zi_reordered = reorder(zi, rdims[0], rdims[1], rdims[2], rdims[3]);
+        array xo_reordered = reorder(xo, rdims[0], rdims[1], rdims[2], rdims[3]);
+        array yo_reordered = reorder(yo, rdims[0], rdims[1], rdims[2], rdims[3]);
+        array zo_reordered = approx2(zi_reordered,
+                                     xo_reordered, d,
+                                     yo_reordered, d + 1,
+                                     start, step, start, step,
+                                     AF_INTERP_LINEAR);
         rdims[d] = 0;
         rdims[0] = d;
-        af::array res = af::reorder(yo_reordered, rdims[0], rdims[1], rdims[2], rdims[3]);
+        array res = af::reorder(yo_reordered, rdims[0], rdims[1], rdims[2], rdims[3]);
         ASSERT_NEAR(0, af::max<float>(af::abs(res - yo)), 1E-3);
     }
 }
@@ -511,28 +631,28 @@ TEST(Approx2, OtherDimCubic)
     float stop = 100;
     float step = 0.01;
     int num = 1000;
-    af::array xi = af::tile(af::seq(start, stop, step), 1, 2, 2, 2);
-    af::array yi = af::tile(af::seq(start, stop, step), 1, 2, 2, 2);
-    af::array zi = 4 * sin(xi) * cos(yi);
-    af::array xo = af::round(step * af::randu(num, 2, 2, 2));
-    af::array yo = af::round(step * af::randu(num, 2, 2, 2));
-    af::array zo = 4 * sin(xo) * cos(yo);
+    array xi = af::tile(seq(start, stop, step), 1, 2, 2, 2);
+    array yi = af::tile(seq(start, stop, step), 1, 2, 2, 2);
+    array zi = 4 * sin(xi) * cos(yi);
+    array xo = af::round(step * randu(num, 2, 2, 2));
+    array yo = af::round(step * randu(num, 2, 2, 2));
+    array zo = 4 * sin(xo) * cos(yo);
     for (int d = 1; d < 3; d++) {
-        af::dim4 rdims(0,1,2,3);
+        dim4 rdims(0,1,2,3);
         rdims[0] = d;
         rdims[d] = 0;
 
-        af::array zi_reordered = af::reorder(zi, rdims[0], rdims[1], rdims[2], rdims[3]);
-        af::array xo_reordered = af::reorder(xo, rdims[0], rdims[1], rdims[2], rdims[3]);
-        af::array yo_reordered = af::reorder(yo, rdims[0], rdims[1], rdims[2], rdims[3]);
-        af::array zo_reordered = af::approx2(zi_reordered,
-                                             xo_reordered, d,
-                                             yo_reordered, d + 1,
-                                             start, step, start, step,
-                                             AF_INTERP_CUBIC);
+        array zi_reordered = reorder(zi, rdims[0], rdims[1], rdims[2], rdims[3]);
+        array xo_reordered = reorder(xo, rdims[0], rdims[1], rdims[2], rdims[3]);
+        array yo_reordered = reorder(yo, rdims[0], rdims[1], rdims[2], rdims[3]);
+        array zo_reordered = approx2(zi_reordered,
+                                     xo_reordered, d,
+                                     yo_reordered, d + 1,
+                                     start, step, start, step,
+                                     AF_INTERP_CUBIC);
         rdims[d] = 0;
         rdims[0] = d;
-        af::array res = af::reorder(yo_reordered, rdims[0], rdims[1], rdims[2], rdims[3]);
+        array res = reorder(yo_reordered, rdims[0], rdims[1], rdims[2], rdims[3]);
         ASSERT_NEAR(0, af::max<float>(af::abs(res - yo)), 1E-3);
     }
 }

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -444,9 +444,9 @@ TEST(Approx2, CPPUsage)
     // {{1 2 3},
     //  {1 2 3},
     //  {1 2 3}},
-    float input_vals[9] = {1, 1, 1,
-                           2, 2, 2,
-                           3, 3, 3};
+    float input_vals[9] = {1.0, 1.0, 1.0,
+                           2.0, 2.0, 2.0,
+                           3.0, 3.0, 3.0};
     array input(3, 3, input_vals);
 
     // generate grid of interpolation locations
@@ -478,8 +478,8 @@ TEST(Approx2, CPPUsage)
                                 2.5, 2.5};
 
     array interp_gold(2, 2, expected_interp);
-    ASSERT_ARRAYS_NEAR(interp, interp_gold, 1e-5);
-    ASSERT_ARRAYS_NEAR(interp, interp_gold, 1e-5);
+    ASSERT_ARRAYS_EQ(interp, interp_gold);
+    ASSERT_ARRAYS_EQ(interp, interp_gold);
 }
 
 TEST(Approx2, CPPUniformUsage)
@@ -490,9 +490,9 @@ TEST(Approx2, CPPUniformUsage)
     // {{1 2 3},
     //  {1 2 3},
     //  {1 2 3}},
-    float input_vals[9] = {1, 1, 1,
-                           2, 2, 2,
-                           3, 3, 3};
+    float input_vals[9] = {1.0, 1.0, 1.0,
+                           2.0, 2.0, 2.0,
+                           3.0, 3.0, 3.0};
     array input(3, 3, input_vals);
 
     // generate grid of interpolation locations
@@ -521,43 +521,42 @@ TEST(Approx2, CPPUniformUsage)
                                 2.5, 2.5};
 
     array interpolated_gold(2, 2, expected_interp);
-    ASSERT_ARRAYS_NEAR(interpolated, interpolated_gold, 1e-5);
+    ASSERT_ARRAYS_EQ(interpolated, interpolated_gold);
 }
 
 TEST(Approx2, CPPUniformOneDimIndices)
 {
-    float inv[9] = {10, 20, 30,
-                    40, 50, 60,
-                    70, 80, 90};
+    float inv[9] = {10.0, 20.0, 30.0,
+                    40.0, 50.0, 60.0,
+                    70.0, 80.0, 90.0};
     array input(dim4(3,3), inv);
 
     // generate grid of interpolation locations
-    float p0[3] = {0, 1, 2};
-    float p1[3] = {0, 1, 2};
+    float p0[3] = {0.0, 1.0, 2.0};
+    float p1[3] = {0.0, 1.0, 2.0};
     array pos0(dim4(3,1), p0);
     array pos1(dim4(3,1), p1);
 
     const int start = 0;
     const double step = 1;
-    const int d0 = 0;
     array interpolated = approx2(input,
-                                 pos0, d0,
-                                 pos1, d0 + 1,
+                                 pos0, 0,
+                                 pos1, 1,
                                  start, step,
                                  start, step);
 
-    const float expected_interp[3] = {10, 50, 90};
+    float expected_interp[3] = {10.0, 50.0, 90.0};
 
 
     array interpolated_gold(dim4(3,1), expected_interp);
-    ASSERT_ARRAYS_NEAR(interpolated, interpolated_gold, 1e-5);
+    ASSERT_ARRAYS_EQ(interpolated, interpolated_gold);
 }
 
 TEST(Approx2, CPPUniformTwoDimIndices)
 {
-    float inv[9] = {10, 20, 30,
-                    40, 50, 60,
-                    70, 80, 90};
+    float inv[9] = {10.0, 20.0, 30.0,
+                    40.0, 50.0, 60.0,
+                    70.0, 80.0, 90.0};
     array input(dim4(3,3), inv);
 
     // generate grid of interpolation locations
@@ -575,18 +574,18 @@ TEST(Approx2, CPPUniformTwoDimIndices)
                                  start, step,
                                  start, step);
 
-    const float expected_interp[4] = {10, 30, 70, 90};
+    float expected_interp[4] = {10.0, 30.0, 70.0, 90.0};
     array interpolated_gold(dim4(2,2), expected_interp);
-    ASSERT_ARRAYS_NEAR(interpolated, interpolated_gold, 1e-5);
+    ASSERT_ARRAYS_EQ(interpolated, interpolated_gold);
 }
 
 TEST(Approx2, CPPUniformInvalidStepSize)
 {
     try
     {
-        float inv[9] = {10, 20, 30,
-                        40, 50, 60,
-                        70, 80, 90};
+        float inv[9] = {10.0, 20.0, 30.0,
+                        40.0, 50.0, 60.0,
+                        70.0, 80.0, 90.0};
         array in(dim4(3,3), inv);
         float pv[3] = {0.0, -1.0, -2.0};
         array pos(dim4(3,1), pv);
@@ -610,31 +609,75 @@ TEST(Approx2, CPPUniformInvalidStepSize)
     }
 }
 
-TEST(Approx2, CPPUniformRowMajorInterpolation)
+TEST(Approx2, CPPUniformColumnMajorInterpolation)
 {
-    float inv[9] = {10, 20, 30,
-                    40, 50, 60,
-                    70, 80, 90};
+    float inv[9] = {10.0, 20.0, 30.0,
+                    40.0, 50.0, 60.0,
+                    70.0, 80.0, 90.0};
     array input(dim4(3,3), inv);
 
-    // generate grid of interpolation locations
+    // Generate grid of interpolation locations
     float p0[4] = {0, 2, 0, 2};
     float p1[4] = {0, 0, 2, 2};
     array pos0(dim4(2,2), p0);
     array pos1(dim4(2,2), p1);
 
+    // Grid metadata.
     const int start = 0;
     const double step = 1;
-    const int d1 = 1;
-    array interpolated = approx2(input,
-                                 pos1, d1,
-                                 pos0, d1-1,
-                                 start, step,
-                                 start, step);
 
-    const float expected_interp[4] = {10, 70, 30, 90};
+    array first = approx2(input,
+                          pos0, 0,
+                          pos1, 1,
+                          start, step,
+                          start, step);
+
+    array second = approx2(input,
+                           pos1, 1,
+                           pos0, 0,
+                           start, step,
+                           start, step);
+
+    // Verify.
+    float expected_interp[4] = {10.0, 30.0, 70.0, 90.0};
     array interpolated_gold(dim4(2,2), expected_interp);
-    ASSERT_ARRAYS_NEAR(interpolated, interpolated_gold, 1e-5);
+    ASSERT_ARRAYS_EQ(first, interpolated_gold);
+    ASSERT_ARRAYS_EQ(first, second);
+}
+
+TEST(Approx2, CPPUniformRowMajorInterpolation)
+{
+    float inv[9] = {10.0, 20.0, 30.0,
+                    40.0, 50.0, 60.0,
+                    70.0, 80.0, 90.0};
+    array input(dim4(3,3), inv);
+
+    // Generate grid of interpolation locations.
+    float p0[4] = {0, 2, 0, 2};
+    float p1[4] = {0, 0, 2, 2};
+    array pos0(dim4(2,2), p0);
+    array pos1(dim4(2,2), p1);
+
+    // Grid metadata.
+    const int start = 0;
+    const double step = 1;
+    array first = approx2(input,
+                          pos0, 1,
+                          pos1, 0,
+                          start, step,
+                          start, step);
+
+    array second = approx2(input,
+                           pos1, 0,
+                           pos0, 1,
+                           start, step,
+                           start, step);
+
+    // Verify.
+    float expected_interp[4] = {10.0, 70.0, 30.0, 90.0};
+    array interpolated_gold(dim4(2,2), expected_interp);
+    ASSERT_ARRAYS_EQ(first, interpolated_gold);
+    ASSERT_ARRAYS_EQ(first, second);
 }
 
 TEST(Approx2, OtherDimLinear)

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -436,250 +436,6 @@ TEST(Approx2, CPPCubicMaxDims)
     SUCCEED();
 }
 
-TEST(Approx2, CPPUsage)
-{
-    //! [ex_signal_approx2]
-
-    // constant input data
-    // {{1 2 3},
-    //  {1 2 3},
-    //  {1 2 3}},
-    float input_vals[9] = {1.0, 1.0, 1.0,
-                           2.0, 2.0, 2.0,
-                           3.0, 3.0, 3.0};
-    array input(3, 3, input_vals);
-
-    // generate grid of interpolation locations
-    // interpolation locations along dim0
-    float p0[4] = {0.5, 1.5,
-                   0.5, 1.5};
-    array pos0(2, 2, p0);
-    // interpolation locations along dim1
-    float p1[4] = {0.5, 0.5,
-                   1.5, 1.5};
-    array pos1(2, 2, p1);
-
-    const int start = 0;
-    const double step = 1;
-    const int dim0 = 0;
-    array interp_uniform = approx2(input,
-                                   pos0, dim0,
-                                   pos1, dim0 + 1,
-                                   start, step,
-                                   start, step);
-
-    array interp = approx2(input, pos0, pos1);
-    // interp == interp_uniform == {{1.5 2.5},
-    //                              {1.5 2.5}};;
-
-    //! [ex_signal_approx2]
-
-    float expected_interp[4] = {1.5, 1.5,
-                                2.5, 2.5};
-
-    array interp_gold(2, 2, expected_interp);
-    ASSERT_ARRAYS_EQ(interp, interp_gold);
-    ASSERT_ARRAYS_EQ(interp, interp_gold);
-}
-
-TEST(Approx2, CPPUniformUsage)
-{
-    //! [ex_uniform_approx2]
-
-    // constant input data
-    // {{1 2 3},
-    //  {1 2 3},
-    //  {1 2 3}},
-    float input_vals[9] = {1.0, 1.0, 1.0,
-                           2.0, 2.0, 2.0,
-                           3.0, 3.0, 3.0};
-    array input(3, 3, input_vals);
-
-    // generate grid of interpolation locations
-    // interpolation locations along dim0
-    float p0[4] = {0.5, 1.5,
-                   0.5, 1.5};
-    array pos0(2, 2, p0);
-    // interpolation locations along dim1
-    float p1[4] = {0.5, 0.5,
-                   1.5, 1.5};
-    array pos1(2, 2, p1);
-
-    const int start = 0;
-    const double step = 1;
-    const int dim0 = 0;
-    array interpolated = approx2(input,
-                                 pos0, dim0,
-                                 pos1, dim0 + 1,
-                                 start, step,
-                                 start, step);
-    // interpolated == {{1.5 2.5},
-    //                  {1.5 2.5}};
-    //! [ex_uniform_approx2]
-
-    float expected_interp[4] = {1.5, 1.5,
-                                2.5, 2.5};
-
-    array interpolated_gold(2, 2, expected_interp);
-    ASSERT_ARRAYS_EQ(interpolated, interpolated_gold);
-}
-
-TEST(Approx2, CPPUniformOneDimIndices)
-{
-    float inv[9] = {10.0, 20.0, 30.0,
-                    40.0, 50.0, 60.0,
-                    70.0, 80.0, 90.0};
-    array input(dim4(3,3), inv);
-
-    // generate grid of interpolation locations
-    float p0[3] = {0.0, 1.0, 2.0};
-    float p1[3] = {0.0, 1.0, 2.0};
-    array pos0(dim4(3,1), p0);
-    array pos1(dim4(3,1), p1);
-
-    const int start = 0;
-    const double step = 1;
-    array interpolated = approx2(input,
-                                 pos0, 0,
-                                 pos1, 1,
-                                 start, step,
-                                 start, step);
-
-    float expected_interp[3] = {10.0, 50.0, 90.0};
-
-
-    array interpolated_gold(dim4(3,1), expected_interp);
-    ASSERT_ARRAYS_EQ(interpolated, interpolated_gold);
-}
-
-TEST(Approx2, CPPUniformTwoDimIndices)
-{
-    float inv[9] = {10.0, 20.0, 30.0,
-                    40.0, 50.0, 60.0,
-                    70.0, 80.0, 90.0};
-    array input(dim4(3,3), inv);
-
-    // generate grid of interpolation locations
-    float p0[4] = {0, 2, 0, 2};
-    float p1[4] = {0, 0, 2, 2};
-    array pos0(dim4(2,2), p0);
-    array pos1(dim4(2,2), p1);
-
-    const int start = 0;
-    const double step = 1;
-    const int d0 = 0;
-    array interpolated = approx2(input,
-                                 pos0, d0,
-                                 pos1, d0 + 1,
-                                 start, step,
-                                 start, step);
-
-    float expected_interp[4] = {10.0, 30.0, 70.0, 90.0};
-    array interpolated_gold(dim4(2,2), expected_interp);
-    ASSERT_ARRAYS_EQ(interpolated, interpolated_gold);
-}
-
-TEST(Approx2, CPPUniformInvalidStepSize)
-{
-    try
-    {
-        float inv[9] = {10.0, 20.0, 30.0,
-                        40.0, 50.0, 60.0,
-                        70.0, 80.0, 90.0};
-        array in(dim4(3,3), inv);
-        float pv[3] = {0.0, -1.0, -2.0};
-        array pos(dim4(3,1), pv);
-
-        const int start = -1;
-        const double step = 0;
-        const int dim0 = 0;
-        array interpolated = approx2(in,
-                                     pos, dim0,
-                                     pos, dim0+1,
-                                     start, step,
-                                     start, step);
-        FAIL() << "Expected af::exception\n";
-        float iv[3] = {0.0, 10.0, 20.0};
-        array interp_gold(dim4(3,1), iv);
-        ASSERT_ARRAYS_EQ(interpolated, interp_gold);
-    } catch (af::exception &ex) {
-        SUCCEED();
-    } catch(...) {
-        FAIL() << "Expected af::exception\n";
-    }
-}
-
-TEST(Approx2, CPPUniformColumnMajorInterpolation)
-{
-    float inv[9] = {10.0, 20.0, 30.0,
-                    40.0, 50.0, 60.0,
-                    70.0, 80.0, 90.0};
-    array input(dim4(3,3), inv);
-
-    // Generate grid of interpolation locations
-    float p0[4] = {0, 2, 0, 2};
-    float p1[4] = {0, 0, 2, 2};
-    array pos0(dim4(2,2), p0);
-    array pos1(dim4(2,2), p1);
-
-    // Grid metadata.
-    const int start = 0;
-    const double step = 1;
-
-    array first = approx2(input,
-                          pos0, 0,
-                          pos1, 1,
-                          start, step,
-                          start, step);
-
-    array second = approx2(input,
-                           pos1, 1,
-                           pos0, 0,
-                           start, step,
-                           start, step);
-
-    // Verify.
-    float expected_interp[4] = {10.0, 30.0, 70.0, 90.0};
-    array interpolated_gold(dim4(2,2), expected_interp);
-    ASSERT_ARRAYS_EQ(first, interpolated_gold);
-    ASSERT_ARRAYS_EQ(first, second);
-}
-
-TEST(Approx2, CPPUniformRowMajorInterpolation)
-{
-    float inv[9] = {10.0, 20.0, 30.0,
-                    40.0, 50.0, 60.0,
-                    70.0, 80.0, 90.0};
-    array input(dim4(3,3), inv);
-
-    // Generate grid of interpolation locations.
-    float p0[4] = {0, 2, 0, 2};
-    float p1[4] = {0, 0, 2, 2};
-    array pos0(dim4(2,2), p0);
-    array pos1(dim4(2,2), p1);
-
-    // Grid metadata.
-    const int start = 0;
-    const double step = 1;
-    array first = approx2(input,
-                          pos0, 1,
-                          pos1, 0,
-                          start, step,
-                          start, step);
-
-    array second = approx2(input,
-                           pos1, 0,
-                           pos0, 1,
-                           start, step,
-                           start, step);
-
-    // Verify.
-    float expected_interp[4] = {10.0, 70.0, 30.0, 90.0};
-    array interpolated_gold(dim4(2,2), expected_interp);
-    ASSERT_ARRAYS_EQ(first, interpolated_gold);
-    ASSERT_ARRAYS_EQ(first, second);
-}
-
 TEST(Approx2, OtherDimLinear)
 {
     int start = 0;
@@ -742,6 +498,205 @@ TEST(Approx2, OtherDimCubic)
         array res = reorder(yo_reordered, rdims[0], rdims[1], rdims[2], rdims[3]);
         ASSERT_NEAR(0, af::max<float>(af::abs(res - yo)), 1E-3);
     }
+}
+
+TEST(Approx2, CPPUsage)
+{
+    //! [ex_signal_approx2]
+
+    // Input data.
+    float input_vals[9] = {1.0, 1.0, 1.0,
+                           2.0, 2.0, 2.0,
+                           3.0, 3.0, 3.0};
+    array input(3, 3, input_vals);
+    // [3 3 1 1]
+    //     1.0000     2.0000     3.0000
+    //     1.0000     2.0000     3.0000
+    //     1.0000     2.0000     3.0000
+
+    float p0[4] = {0.5, 1.5, 0.5, 1.5};
+    array pos0(2, 2, p0);
+    // [2 2 1 1]
+    //     0.5000     0.5000
+    //     1.5000     1.5000
+
+    float p1[4] = {0.5, 0.5, 1.5, 1.5};
+    array pos1(2, 2, p1);
+    // [2 2 1 1]
+    //     0.5000     1.5000
+    //     0.5000     1.5000
+
+    const int pos0_interp_grid_start = 0;
+    const double pos0_interp_grid_step = 1;
+    const int pos0_interp_dim = 0;
+    const int pos1_interp_dim = 1;
+    array interp = approx2(input,
+                           pos0, pos0_interp_dim,
+                           pos1, pos1_interp_dim,
+                           pos0_interp_grid_start, pos0_interp_grid_step,
+                           pos0_interp_grid_start, pos0_interp_grid_step);
+    // [2 2 1 1]
+    //     1.5000     2.5000
+    //     1.5000     2.5000
+
+    //! [ex_signal_approx2]
+
+    float expected_interp[4] = {1.5, 1.5,
+                                2.5, 2.5};
+
+    array interp_gold(2, 2, expected_interp);
+    ASSERT_ARRAYS_EQ(interp, interp_gold);
+}
+
+TEST(Approx2, CPPUniformOneDimIndices)
+{
+    float inv[9] = {10.0, 20.0, 30.0,
+                    40.0, 50.0, 60.0,
+                    70.0, 80.0, 90.0};
+    array input(dim4(3,3), inv);
+
+    float p0[3] = {0.0, 1.0, 2.0};
+    float p1[3] = {0.0, 1.0, 2.0};
+    array pos0(dim4(3,1), p0);
+    array pos1(dim4(3,1), p1);
+
+    const int pos0_interp_grid_start = 0;
+    const double pos0_interp_grid_step = 1;
+    array interpolated = approx2(input,
+                                 pos0, 0,
+                                 pos1, 1,
+                                 pos0_interp_grid_start, pos0_interp_grid_step,
+                                 pos0_interp_grid_start, pos0_interp_grid_step);
+
+    float expected_interp[3] = {10.0, 50.0, 90.0};
+
+
+    array interpolated_gold(dim4(3,1), expected_interp);
+    ASSERT_ARRAYS_EQ(interpolated, interpolated_gold);
+}
+
+TEST(Approx2, CPPUniformTwoDimIndices)
+{
+    float inv[9] = {10.0, 20.0, 30.0,
+                    40.0, 50.0, 60.0,
+                    70.0, 80.0, 90.0};
+    array input(dim4(3,3), inv);
+
+    float p0[4] = {0, 2, 0, 2};
+    float p1[4] = {0, 0, 2, 2};
+    array pos0(dim4(2,2), p0);
+    array pos1(dim4(2,2), p1);
+    const int pos0_interp_grid_start = 0;
+    const double pos0_interp_grid_step = 1;
+    const int pos0_interp_dim = 0;
+    const int pos1_interp_dim = 1;
+
+    array interpolated = approx2(input,
+                                 pos0, pos0_interp_dim,
+                                 pos1, pos1_interp_dim,
+                                 pos0_interp_grid_start, pos0_interp_grid_step,
+                                 pos0_interp_grid_start, pos0_interp_grid_step);
+
+    float expected_interp[4] = {10.0, 30.0, 70.0, 90.0};
+    array interpolated_gold(dim4(2,2), expected_interp);
+    ASSERT_ARRAYS_EQ(interpolated, interpolated_gold);
+}
+
+TEST(Approx2, CPPUniformInvalidStepSize)
+{
+    try
+    {
+        float inv[9] = {10.0, 20.0, 30.0,
+                        40.0, 50.0, 60.0,
+                        70.0, 80.0, 90.0};
+        array in(dim4(3,3), inv);
+        float pv[3] = {0.0, -1.0, -2.0};
+        array pos(dim4(3,1), pv);
+        const int pos0_interp_grid_start = -1;
+        const double pos0_interp_grid_step = 0;
+        const int pos0_interp_dim = 0;
+        const int pos1_interp_dim = 1;
+
+        array interpolated = approx2(in,
+                                     pos, pos0_interp_dim,
+                                     pos, pos1_interp_dim,
+                                     pos0_interp_grid_start, pos0_interp_grid_step,
+                                     pos0_interp_grid_start, pos0_interp_grid_step);
+        FAIL() << "Expected af::exception\n";
+
+    } catch (af::exception &ex) {
+        SUCCEED();
+    } catch(...) {
+        FAIL() << "Expected af::exception\n";
+    }
+}
+
+TEST(Approx2, CPPUniformColumnMajorInterpolation)
+{
+    float inv[9] = {10.0, 20.0, 30.0,
+                    40.0, 50.0, 60.0,
+                    70.0, 80.0, 90.0};
+    array input(dim4(3,3), inv);
+
+    float p0[4] = {0, 2, 0, 2};
+    float p1[4] = {0, 0, 2, 2};
+    array pos0(dim4(2,2), p0);
+    array pos1(dim4(2,2), p1);
+    const int pos0_interp_dim = 0;
+    const int pos1_interp_dim = 1;
+    const int pos0_interp_grid_start = 0;
+    const double pos0_interp_grid_step = 1;
+
+    array first = approx2(input,
+                          pos0, pos0_interp_dim,
+                          pos1, pos1_interp_dim,
+                          pos0_interp_grid_start, pos0_interp_grid_step,
+                          pos0_interp_grid_start, pos0_interp_grid_step);
+
+    array second = approx2(input,
+                           pos1, pos1_interp_dim,
+                           pos0, pos0_interp_dim,
+                           pos0_interp_grid_start, pos0_interp_grid_step,
+                           pos0_interp_grid_start, pos0_interp_grid_step);
+
+    // Verify.
+    float expected_interp[4] = {10.0, 30.0, 70.0, 90.0};
+    array interpolated_gold(dim4(2,2), expected_interp);
+    ASSERT_ARRAYS_EQ(first, interpolated_gold);
+    ASSERT_ARRAYS_EQ(first, second);
+}
+
+TEST(Approx2, CPPUniformRowMajorInterpolation)
+{
+    float inv[9] = {10.0, 20.0, 30.0,
+                    40.0, 50.0, 60.0,
+                    70.0, 80.0, 90.0};
+    array input(dim4(3,3), inv);
+
+    float p0[4] = {0, 2, 0, 2};
+    float p1[4] = {0, 0, 2, 2};
+    array pos0(dim4(2,2), p0);
+    array pos1(dim4(2,2), p1);
+    const int pos0_interp_grid_start = 0;
+    const double pos0_interp_grid_step = 1;
+
+    array first = approx2(input,
+                          pos0, 1,
+                          pos1, 0,
+                          pos0_interp_grid_start, pos0_interp_grid_step,
+                          pos0_interp_grid_start, pos0_interp_grid_step);
+
+    array second = approx2(input,
+                           pos1, 0,
+                           pos0, 1,
+                           pos0_interp_grid_start, pos0_interp_grid_step,
+                           pos0_interp_grid_start, pos0_interp_grid_step);
+
+    // Verify.
+    float expected_interp[4] = {10.0, 70.0, 30.0, 90.0};
+    array interpolated_gold(dim4(2,2), expected_interp);
+    ASSERT_ARRAYS_EQ(first, interpolated_gold);
+    ASSERT_ARRAYS_EQ(first, second);
 }
 
 TEST(Approx2, CPPEmptyPos)

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -502,7 +502,7 @@ TEST(Approx2, CPPUsage)
 {
     //! [ex_signal_approx2]
 
-    // Input data.
+    // Input data array.
     float input_vals[9] = {1.0, 1.0, 1.0,
                            2.0, 2.0, 2.0,
                            3.0, 3.0, 3.0};
@@ -512,31 +512,35 @@ TEST(Approx2, CPPUsage)
     //     1.0000     2.0000     3.0000
     //     1.0000     2.0000     3.0000
 
-    // First array of known and unknown positions to measure and perform
-    // interpolation along a specified dimension.
-    float p0[4] = {0.5, 1.5, 0.5, 1.5};
-    array pos0(2, 2, p0);
+
+
+    // First array of positions to be found along the interpolation
+    // dimension, `interp_dim0`.
+    float pv0[4] = {0.5, 1.5, 0.5, 1.5};
+    array pos0(2, 2, pv0);
     // [2 2 1 1]
     //     0.5000     0.5000
     //     1.5000     1.5000
 
-    // Second array of known and unknown positions to measure and perform
-    // interpolation along a specified dimension.
-    float p1[4] = {0.5, 0.5, 1.5, 1.5};
-    array pos1(2, 2, p1);
+    // Second array of positions to be found along the interpolation
+    // dimension, `interp_dim1`.
+    float pv1[4] = {0.5, 0.5, 1.5, 1.5};
+    array pos1(2, 2, pv1);
     // [2 2 1 1]
     //     0.5000     1.5000
     //     0.5000     1.5000
 
-    // Specify a standard uniform grid with start and step values of 0
-    // and 1 along each of the interpolation grid dimensions.
-    const int pos0_interp_grid_start = 0;
-    const double pos0_interp_grid_step = 1;
-    const int pos0_interp_dim = 0;
-    const int pos1_interp_dim = 1;
+
+
+    // Define range of indices with which the input values will
+    // correspond along both dimensions to be interpolated.
+    const double idx_start_dim0 = 0.0;
+    const double idx_step_dim0 = 1.0;
+    const int interp_dim0 = 0;
+    const int interp_dim1 = 1;
     array interp = approx2(input,
-                           pos0, pos0_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step,
-                           pos1, pos1_interp_dim, pos0_interp_grid_start, pos0_interp_grid_step);
+                           pos0, interp_dim0, idx_start_dim0, idx_step_dim0,
+                           pos1, interp_dim1, idx_start_dim0, idx_step_dim0);
     // [2 2 1 1]
     //     1.5000     2.5000
     //     1.5000     2.5000

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -696,8 +696,6 @@ template<typename T>
 ::testing::AssertionResult elemWiseEq(std::string aName, std::string bName,
                                       const std::vector<T>& a, af::dim4 aDims,
                                       const std::vector<T>& b, af::dim4 bDims,
-
-
                                       float maxAbsDiff, IntegerTag) {
     typedef typename std::vector<T>::const_iterator iter;
     std::pair<iter, iter> mismatches = std::mismatch(a.begin(), a.end(), b.begin());


### PR DESCRIPTION
New approx1/2 functions which allow the user to select which dimension(s) to interpolate across.

Documentation has been updated and new tests have been added to @pavanky's original #1990 PR.