### PR TITLE
Fix and improve af::accum documentation

### DIFF
--- a/docs/details/algorithm.dox
+++ b/docs/details/algorithm.dox
@@ -107,15 +107,21 @@ Return type is u32 for all input types
 
 \ingroup scan_mat
 
-Compute the cumulative sum (inclusive) along the specified dimension
+Calculate the cumulative sum (inclusive) along the specified dimension
 
-Here is a simple example for 1D arrays:
+For a 1D array \f$X\f$, the inclusive cumulative sum calculates \f$x_i =
+\sum_{p=0}^{i}x_p\f$ for every \f$x \in X\f$. Here is a simple example for the
+1D case:
 
 \snippet test/scan.cpp ex_accum_1D
 
 For 2D arrays (and higher dimensions), you can specify the dimension along which
-the cumulative sum will be performed. If none is specified, it will be performed
-along the first dimension (0):
+the cumulative sum will be calculated. Thus, the formula above will be
+calculated for all array slices along the specified dimension (in the 2D case
+for example, this looks like \f$x_{i,j} = \sum_{p=0}^{j}x_{i,p}\f$ if the second
+dimension (dim1) was chosen). If no dimension is specified, then the first
+dimension (dim0) is used by default (only in the C++ API; the dimension is
+required to be specified in the C API):
 
 \snippet test/scan.cpp ex_accum_2D
 

--- a/docs/details/algorithm.dox
+++ b/docs/details/algorithm.dox
@@ -107,9 +107,20 @@ Return type is u32 for all input types
 
 \ingroup scan_mat
 
-Perform inclusive sum along specified dimension
+Compute the cumulative sum (inclusive) along the specified dimension
 
-This table defines the return value types for the corresponding input types
+Here is a simple example for 1D arrays:
+
+\snippet test/scan.cpp ex_accum_1D
+
+For 2D arrays (and higher dimensions), you can specify the dimension along which
+the cumulative sum will be performed. If none is specified, it will be performed
+along the first dimension (0):
+
+\snippet test/scan.cpp ex_accum_2D
+
+The output array type may be different from the input array type. The following
+table defines the corresponding output types for each input type:
 
 Input Type          | Output Type
 --------------------|---------------------

--- a/include/af/algorithm.h
+++ b/include/af/algorithm.h
@@ -309,7 +309,7 @@ namespace af
        C++ Interface for computing the cumulative sum (inclusive) of an array
 
        \param[in] in is the input array
-       \param[in] dim is the dimension along which inclusive sum is performed
+       \param[in] dim is the dimension along which the inclusive sum is calculated
        \return the output containing inclusive sums of the input
 
        \ingroup scan_func_accum
@@ -765,7 +765,7 @@ extern "C" {
 
        \param[out] out will contain inclusive sums of the input
        \param[in] in is the input array
-       \param[in] dim is the dimension along which inclusive sum is performed
+       \param[in] dim is the dimension along which the inclusive sum is calculated
        \return \ref AF_SUCCESS if the execution completes properly
 
        \ingroup scan_func_accum

--- a/include/af/algorithm.h
+++ b/include/af/algorithm.h
@@ -306,11 +306,11 @@ namespace af
     template<typename T> void max(T *val, unsigned *idx, const array &in);
 
     /**
-       C++ Interface inclusive sum (cumulative sum) of an array
+       C++ Interface for computing the cumulative sum (inclusive) of an array
 
        \param[in] in is the input array
-       \param[in] dim The dimension along which exclusive sum is performed
-       \return the output containing exclusive sums of the input
+       \param[in] dim is the dimension along which inclusive sum is performed
+       \return the output containing inclusive sums of the input
 
        \ingroup scan_func_accum
     */
@@ -761,11 +761,11 @@ extern "C" {
     AFAPI af_err af_imax_all(double *real, double *imag, unsigned *idx, const af_array in);
 
     /**
-       C Interface inclusive sum (cumulative sum) of an array
+       C Interface for computing the cumulative sum (inclusive) of an array
 
-       \param[out] out will contain exclusive sums of the input
+       \param[out] out will contain inclusive sums of the input
        \param[in] in is the input array
-       \param[in] dim The dimension along which exclusive sum is performed
+       \param[in] dim is the dimension along which inclusive sum is performed
        \return \ref AF_SUCCESS if the execution completes properly
 
        \ingroup scan_func_accum

--- a/test/scan.cpp
+++ b/test/scan.cpp
@@ -213,3 +213,52 @@ TEST(Accum, MaxDim)
     ASSERT_ARRAYS_EQ(gold_dim, output_dim);
 
 }
+
+TEST(Accum, DocSnippet) {
+    //! [ex_accum_1D]
+    float hA[] = {0, 1, 2, 3, 4};
+    array A(5, hA);
+    //  0.
+    //  1.
+    //  2.
+    //  3.
+    //  4.
+
+    array accumA = accum(A);
+    //  0.
+    //  1.
+    //  3.
+    //  6.
+    //  10.
+    //! [ex_accum_1D]
+
+    float h_gold_accumA[] = {0, 1, 3, 6, 10};
+    array gold_accumA(5, h_gold_accumA);
+    ASSERT_ARRAYS_EQ(gold_accumA, accumA);
+
+    //! [ex_accum_2D]
+    float hB[] = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+    array B(3, 3, hB);
+    //  0.     3.     6.
+    //  1.     4.     7.
+    //  2.     5.     8.
+
+    array accumB_dim0 = accum(B);
+    //  0.     3.     6.
+    //  1.     7.     13.
+    //  3.     12.    21.
+
+    array accumB_dim1 = accum(B, 1);
+    //  0.     3.     9.
+    //  1.     5.     12.
+    //  2.     7.     15.
+    //! [ex_accum_2D]
+
+    float h_gold_accumB_dim0[] = {0, 1, 3, 3, 7, 12, 6, 13, 21};
+    array gold_accumB_dim0(3, 3, h_gold_accumB_dim0);
+    ASSERT_ARRAYS_EQ(gold_accumB_dim0, accumB_dim0);
+
+    float h_gold_accumB_dim1[] = {0, 1, 2, 3, 5, 7, 9, 12, 15};
+    array gold_accumB_dim1(3, 3, h_gold_accumB_dim1);
+    ASSERT_ARRAYS_EQ(gold_accumB_dim1, accumB_dim1);
+}


### PR DESCRIPTION
The accum docs has some typos, such as saying "exclusive sum" on the function docs while it is really an inclusive sum scan. Also I think the brief description needs to say "cumulative" somewhere - "inclusive sum (scan)" didn't really ring a bell to me until I started learning parallel programming (a Google search on "inclusive sum" also doesn't immediately get clear results that it means inclusive sum scan). I added an example too just so it's clearer what it does.

Here are some snapshots of the docs after the change:
![image](https://user-images.githubusercontent.com/19368448/45910678-1a347b00-bdd9-11e8-867c-6b881f81da71.png)
![image](https://user-images.githubusercontent.com/19368448/45910683-2d474b00-bdd9-11e8-8eab-15faeb79ce5e.png)
![image](https://user-images.githubusercontent.com/19368448/45910688-389a7680-bdd9-11e8-8d63-44d9c75c1bcc.png)
