### PR TITLE
Improve unwrap documentation

### DIFF
--- a/docs/details/image.dox
+++ b/docs/details/image.dox
@@ -770,96 +770,73 @@ The output array of this function will have \f$ S(x, y) \f$ values at their corr
 \defgroup image_func_unwrap unwrap
 \ingroup image_mod_mat
 
-Generate an array with image windows as columns
+\brief Rearrange windowed sections of an array into columns (or rows)
 
-unwrap takes in an input image along with the window sizes \p wx and \p
-wy, strides \p sx and \p sy, and padding \p px and \p py. This function then
-generates a matrix where each windows is an independent column.
+The figure below illustrates how unwrap works. A moving window (marked by
+orange boxes in the figure) of size `wx` \f$\times \f$ `wy` captures sections of
+the input array, and flattens them into columns (or rows if `is_column` is false)
+of the output array (illustrated in the right image). It starts at the top-left
+section of the input array and moves in column-major order, each time moving in
+strides of `sx` units along the column and `sy` units along the row, whenever it
+exhausts a column (stride size illustrated as the white arrows in the left image,
+and window movement illustrated as the progression of the small yellow numbers on
+the corner of each window). When the remainder of the column or row is not big
+enough to accomodate the window, that remainder is skipped and the window moves
+on (in the figure, the last row is not captured in any of the windows).
 
-The number of columns (rows if is_column is true) in the output array are govenered by the number of
-windows that can be fit along x and y directions. Padding is applied along all
-4 sides of the matrix with \p px defining the height of the padding along dim
-0 and \p py defining the width of the padding along dim 1.
+Optionally, one can specify that the input image's border be padded (with zeros,
+represented as the gray boxes in the figure) before the moving window starts
+capturing sections. The width of the padding is defined by `px` for the top and
+bottom and `py` for the left and right sides, with maximum values of `wx`-1 and
+`wy`-1, respectively. The moving window then captures sections as if the padding
+is part of the input image, and thus the padding also becomes part of the output
+array's columns (illustrated in the bottom of the right image).
 
-The first column window is always at the top left corner of the input including
-padding. If a window cannot fit before the end of the matrix + padding, it is
-skipped from the generated matrix.
+\image html unwrap_640.png "Unwrap on a 3x4 input array, using a 2x2 window, 2x2 stride, 1x1 padding"
 
-Padding can take a maximum value of window - 1 repectively for x and y.
+In the figure, the stride is set to be equally large as the window size (both
+2x2), and thus the sections that the window captures are distinct. However, when
+the stride is set to the minimum (1x1) and is smaller than the window size, the
+sections overlap (which in turn makes the output's columns overlap as well). The
+window then acts as a perfect "sliding window" in this case (see the first code
+example below). In general, there will be some overlap as long as the stride is
+smaller than the window size (though the overlap decreases as the stride
+approaches the window size), and when the stride is equal or greater than the
+window size, each section (and output column) will be distinct.
 
-For multiple channels (3rd and 4th dimension), the generated matrix contains
-the same number of channels as the input matrix. Each channel of the output
-matrix corresponds to the same channel of the input.
+For inputs that have more than two dimensions, the unwrap operation will be
+applied to each 2D slice of the input. This is especially useful for
+independently processing each channel of an image (or set of images) - each
+channel (along the third dimension) on the input corresponds to the same channel
+on the output, and each image (along the fourth dimension) on the input
+corresponds to the same image on the output.
 
-So the dimensions of the output matrix are:
+The size of the output is shown below. `nsections_dim0` and `nsections_dim1`
+denote how many windows can fit along the column and row, given the padded image
+size, window size, strides, and skips (if any):
+
 \code
-[(wx * wy),         // Column height
- (No. of windows along dim 0 of input * No. of windows along dim 1 of input), // No. of columns per channel
- input.dims()[2],   // Channels
- input.dims()[3]]   // Volumns
+dim4(
+    wx * wy,                               // No. of rows (column height)
+    nsections_dim0 * nsections_dim1,       // No. of columns per channel
+    input.dims(2),                         // No. of channels
+    input.dims(3)                          // No. of images
+)
 \endcode
 
-When strides are 1, the operation is sliding window. When strides are equal to
-the respective window sizes, the option is distinct window. Other stride
-values are also allowed.
+Here are some code examples that demonstrate unwrap's usage:
 
-\code
-A [5 5 1 1]
-10 15 20 25 30
-11 16 21 26 31
-12 17 22 27 32
-13 18 23 28 33
-14 19 24 29 34
+\snippet test/unwrap.cpp ex_unwrap
 
-// Window 3x3, strides 1x1, padding 0x0
-unwrap(A, 3, 3, 1, 1, 0, 0) [9 9 1 1]
-10 11 12 15 16 17 20 21 22
-11 12 13 16 17 18 21 22 23
-12 13 14 17 18 19 22 23 24
-15 16 17 20 21 22 25 26 27
-16 17 18 21 22 23 26 27 28
-17 18 19 22 23 24 27 28 29
-20 21 22 25 26 27 30 31 32
-21 22 23 26 27 28 31 32 33
-22 23 24 27 28 29 32 33 34
+One context where unwrap can be used is pre-processing an array or image for
+making window operations efficient (i.e. convolutions, computing the average
+pixel intensity around a point in an image, etc). Since each window capture is
+laid out as a column in an unwrapped array, vectorized operations can be executed
+efficiently on it (as opposed to strided access of each row in a window in the original
+array).
 
-// Window 3x3, strides 1x1, padding 1x1
-unwrap(A, 3, 3, 1, 1, 1, 1) [9 25 1 1]
- 0  0  0  0  0  0 10 11 12 13  0 15 16 17 18  0 20 21 22 23  0 25 26 27 28
- 0  0  0  0  0 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29
- 0  0  0  0  0 11 12 13 14  0 16 17 18 19  0 21 22 23 24  0 26 27 28 29  0
- 0 10 11 12 13  0 15 16 17 18  0 20 21 22 23  0 25 26 27 28  0 30 31 32 33
-10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34
-11 12 13 14  0 16 17 18 19  0 21 22 23 24  0 26 27 28 29  0 31 32 33 34  0
- 0 15 16 17 18  0 20 21 22 23  0 25 26 27 28  0 30 31 32 33  0  0  0  0  0
-15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34  0  0  0  0  0
-16 17 18 19  0 21 22 23 24  0 26 27 28 29  0 31 32 33 34  0  0  0  0  0  0
-
-// Window 3x3, strides 3x3 ("distinct"), padding 0x0
-unwrap(A, 3, 3, 3, 3, 0, 0) [9 1 1 1]
-   10
-   11
-   12
-   15
-   16
-   17
-   20
-   21
-   22
-
-// Window 3x3, strides 3x3 ("distinct"), padding 2x2
-unwrap(A, 3, 3, 3, 3, 2, 2) [9 9 1 1]
-    0     0     0     0    16    19     0    31    34
-    0     0     0     0    17     0     0    32     0
-    0     0     0    15    18     0    30    33     0
-    0     0     0     0    21    24     0     0     0
-    0     0     0     0    22     0     0     0     0
-    0     0     0    20    23     0     0     0     0
-    0    11    14     0    26    29     0     0     0
-    0    12     0     0    27     0     0     0     0
-   10    13     0    25    28     0     0     0     0
-\endcode
-
+Note that the actual implementation of unwrap may not match the way the operation
+is described above, but the effect should be the same.
 
 =======================================================================
 

--- a/include/af/image.h
+++ b/include/af/image.h
@@ -572,17 +572,26 @@ AFAPI array colorSpace(const array& image, const CSpace to, const CSpace from);
 
 #if AF_API_VERSION >= 31
 /**
-   C++ Interface wrapper for unwrap
+   C++ Interface for rearranging windowed sections of an input into columns
+   (or rows)
 
-   \param[in]  in is the input image (or set of images)
-   \param[in]  wx is the block window size along 0th-dimension between [1, input.dims[0] + px]
-   \param[in]  wy is the block window size along 1st-dimension between [1, input.dims[1] + py]
-   \param[in]  sx is the stride along 0th-dimension
-   \param[in]  sy is the stride along 1st-dimension
-   \param[in]  px is the padding along 0th-dimension between [0, wx). Padding is applied both before and after.
-   \param[in]  py is the padding along 1st-dimension between [0, wy). Padding is applied both before and after.
-   \param[in]  is_column specifies the layout for the unwrapped patch. If is_column is false, the unrapped patch is laid out as a row.
-   \returns    an array with the image blocks as rows or columns
+   \param[in]  in is the input array
+   \param[in]  wx is the window size along dimension 0
+   \param[in]  wy is the window size along dimension 1
+   \param[in]  sx is the stride along dimension 0
+   \param[in]  sy is the stride along dimension 1
+   \param[in]  px is the padding along dimension 0
+   \param[in]  py is the padding along dimension 1
+   \param[in]  is_column determines whether the section becomes a column (if
+               true) or a row (if false)
+   \returns    an array with the input's sections rearraged as columns (or rows)
+
+   \note \p in can hold multiple images for processing if it is three or
+         four-dimensional
+   \note \p wx and \p wy must be between [1, input.dims(0 (1)) + px (py)]
+   \note \p sx and \p sy must be greater than 1
+   \note \p px and \p py must be between [0, wx (wy) - 1]. Padding becomes part of
+         the input image prior to the windowing
 
    \ingroup image_func_unwrap
 */
@@ -1328,19 +1337,29 @@ extern "C" {
 
 #if AF_API_VERSION >= 31
     /**
-       C Interface wrapper for unwrap
+       C Interface for rearranging windowed sections of an input into columns
+       (or rows)
 
-       \param[out] out is an array with image blocks as rows or columns.
-       \param[in]  in is the input image (or set of images)
-       \param[in]  wx is the block window size along 0th-dimension between [1, input.dims[0] + px]
-       \param[in]  wy is the block window size along 1st-dimension between [1, input.dims[1] + py]
-       \param[in]  sx is the stride along 0th-dimension
-       \param[in]  sy is the stride along 1st-dimension
-       \param[in]  px is the padding along 0th-dimension between [0, wx). Padding is applied both before and after.
-       \param[in]  py is the padding along 1st-dimension between [0, wy). Padding is applied both before and after.
-       \param[in]  is_column specifies the layout for the unwrapped patch. If is_column is false, the unrapped patch is laid out as a row.
-       \return     \ref AF_SUCCESS if the color transformation is successful,
-       otherwise an appropriate error code is returned.
+       \param[out] out is an array with the input's sections rearraged as columns
+                   (or rows)
+       \param[in]  in is the input array
+       \param[in]  wx is the window size along dimension 0
+       \param[in]  wy is the window size along dimension 1
+       \param[in]  sx is the stride along dimension 0
+       \param[in]  sy is the stride along dimension 1
+       \param[in]  px is the padding along dimension 0
+       \param[in]  py is the padding along dimension 1
+       \param[in]  is_column determines whether the section becomes a column (if
+                   true) or a row (if false)
+       \return     \ref AF_SUCCESS if unwrap is successful,
+                   otherwise an appropriate error code is returned.
+
+       \note \p in can hold multiple images for processing if it is three or
+             four-dimensional
+       \note \p wx and \p wy must be between [1, input.dims(0 (1)) + px (py)]
+       \note \p sx and \p sy must be greater than 1
+       \note \p px and \p py must be between [0, wx (wy) - 1]. Padding becomes
+             part of the input image prior to the windowing
 
        \ingroup image_func_unwrap
     */

--- a/test/unwrap.cpp
+++ b/test/unwrap.cpp
@@ -201,3 +201,48 @@ TEST(Unwrap, MaxDim)
 
     ASSERT_ARRAYS_EQ(gold, output);
 }
+
+TEST(Unwrap, DocSnippet) {
+    //! [ex_unwrap]
+    float hA[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    array A(dim4(3, 3), hA);
+    //  1.     4.     7.
+    //  2.     5.     8.
+    //  3.     6.     9.
+
+    array A_simple = unwrap(A,
+                            2, 2,  // window size
+                            1, 1); // stride (sliding window)
+    //  1.     2.     4.     5.
+    //  2.     3.     5.     6.
+    //  4.     5.     7.     8.
+    //  5.     6.     8.     9.
+
+    array A_padded = unwrap(A,
+                            2, 2,  // window size
+                            2, 2,  // stride (distinct)
+                            1, 1); // padding
+    //  0.     0.     0.     5.
+    //  0.     0.     4.     6.
+    //  0.     2.     0.     8.
+    //  1.     3.     7.     9.
+    //! [ex_unwrap]
+
+    float gold_hA_simple[] = {
+        1, 2, 4, 5,
+        2, 3, 5, 6,
+        4, 5, 7, 8,
+        5, 6, 8, 9
+    };
+    array gold_A_simple(dim4(4, 4), gold_hA_simple);
+    ASSERT_ARRAYS_EQ(gold_A_simple, A_simple);
+
+    float gold_hA_padded[] = {
+        0, 0, 0, 1,
+        0, 0, 2, 3,
+        0, 4, 0, 7,
+        5, 6, 8, 9
+    };
+    array gold_A_padded(dim4(4, 4), gold_hA_padded);
+    ASSERT_ARRAYS_EQ(gold_A_padded, A_padded);
+}


### PR DESCRIPTION
Added an image as well to illustrate what unwrap does. See https://github.com/arrayfire/assets/pull/6 for the PR on the assets repo.

Here's what the docs look like now:
![image](https://user-images.githubusercontent.com/19368448/46236393-258d2680-c344-11e8-8e08-25cb0695aa76.png)
![image](https://user-images.githubusercontent.com/19368448/46236409-3b025080-c344-11e8-9865-140f84f3e201.png)
![image](https://user-images.githubusercontent.com/19368448/46236490-af3cf400-c344-11e8-89b2-220064e3d869.png)
![image](https://user-images.githubusercontent.com/19368448/46236505-ced41c80-c344-11e8-8e1c-43b549c5fb3c.png)
![image](https://user-images.githubusercontent.com/19368448/46236538-f6c38000-c344-11e8-967d-93e05a0a3c48.png)
![image](https://user-images.githubusercontent.com/19368448/46236575-207ca700-c345-11e8-8768-c595c257b8af.png)
![image](https://user-images.githubusercontent.com/19368448/46236615-44d88380-c345-11e8-9a6d-391b55d5aa07.png)

