### PR TITLE
Allow custom library path for loading dynamic backend libraries

### DIFF
--- a/docs/pages/configuring_arrayfire_environment.md
+++ b/docs/pages/configuring_arrayfire_environment.md
@@ -212,3 +212,13 @@ When set, this environment variable specifies the maximum length of the CPU JIT
 tree after which evaluation is forced.
 
 The default value, as of v3.4, 100. This value was 20 for older versions.
+
+AF_BUILD_LIB_CUSTOM_PATH {#af_build_lib_custom_path}
+-------------------------------------------------------------------------------
+
+When set, this environment variable specifies a custom path along which the
+symbol manager will search for dynamic (shared library) backends to load. This 
+is useful for specialized build configurations that use the unified backend and
+build shared libraries separately.
+
+By default, no additional path will be searched for an empty value.

--- a/src/api/unified/symbol_manager.cpp
+++ b/src/api/unified/symbol_manager.cpp
@@ -112,6 +112,7 @@ LibHandle openDynLibrary(const af_backend bknd_idx, int flag=RTLD_LAZY)
         join_path(getEnvVar("AF_BUILD_PATH"), "src", "backend", getBackendDirectoryName(bknd_idx)),
         join_path(getEnvVar("AF_PATH"), "lib"),
         join_path(getEnvVar("AF_PATH"), "lib64"),
+        getEnvVar("AF_BUILD_LIB_CUSTOM_PATH"),
 
         // Common install paths
 #if !defined(OS_WIN)


### PR DESCRIPTION
Adds a check to the `AF_BUILD_LIB_CUSTOM_PATH` environment variable as one of the paths searched when attempting to dynamically open backends.

Important for specialized build configurations in which shared backend libraries may be built in a non-standard directory.