### PR TITLE
Reorder: Use Array::setDataDims instead of Array::modDims when x is 0

### DIFF
--- a/src/api/c/reorder.cpp
+++ b/src/api/c/reorder.cpp
@@ -50,7 +50,7 @@ static inline af_array reorder(const af_array in, const af::dim4 &rdims0)
             ostrides[i] = istrides[rdims[i]];
         }
         Array<T> Out = In;
-        Out.modDims(odims);
+        Out.setDataDims(odims);
         Out.modStrides(ostrides);
         out = getHandle(Out);
     } else {

--- a/test/reorder.cpp
+++ b/test/reorder.cpp
@@ -18,18 +18,18 @@
 #include <string>
 #include <testHelpers.hpp>
 
-using std::vector;
-using std::string;
-using std::cout;
-using std::endl;
 using af::allTrue;
 using af::array;
-using af::cfloat;
 using af::cdouble;
+using af::cfloat;
 using af::dim4;
 using af::dtype_traits;
 using af::reorder;
+using af::seq;
+using af::span;
 using af::tile;
+using std::string;
+using std::vector;
 
 
 template<typename T>
@@ -187,6 +187,21 @@ TEST(Reorder, MaxDim)
     array output = reorder(input, 2, 1, 0);
 
     array gold = range(dim4(2, largeDim, 2));
+
+    ASSERT_ARRAYS_EQ(gold, output);
+}
+
+TEST(Reorder, Issue2273) {
+    int h_idx[2] = {1, 1};
+    array idx(2, h_idx);
+
+    float h_input[12] = {0.f, 1.f, 2.f, 3.f, 4.f, 5.f, 6.f, 7.f, 8.f, 9.f, 10.f, 11.f};
+    array input(2, 3, 2, h_input);
+    array input_reord = reorder(input, 0, 2, 1);
+    array output = input_reord(span, idx, span);
+
+    float h_gold[12] = {2.f, 3.f, 2.f, 3.f, 6.f, 7.f, 6.f, 7.f, 10.f, 11.f, 10.f, 11.f};
+    array gold(2, 2, 3, h_gold);
 
     ASSERT_ARRAYS_EQ(gold, output);
 }


### PR DESCRIPTION
This addresses #2273. I noticed that the user suggested that doing `moddims` on the reordered array using its new dimensions fixes the problem, but in `src/api/c/reorder.cpp`, we already call `Array::modDims` after adjusting the strides. I think that the reason why the problem still appears is that `Array::modDims` does not adjust `Array::data_dims` (which is in turn used by the internal `index` function in the backend through `Array::getDataDims`) after the fact. In comparison, I saw that `Array::setDataDims` does, and so I think it's better to use it in this case. However, if anyone thinks that there's a better approach for the solution, please let me know in the comments?

Also, if anyone has a better name for the test I just added, please suggest so. I can't think of a short, concise, yet descriptive name for the case that the issue raises, especially considering the fact that the problem doesn't appear if I use `(span, 1, span)` as the slice index. It has to be `(span, idx, span)`, where `idx` is an array that looks like (1, 1).