### PR TITLE
Fix issues with tile with a large repeat dimension

### DIFF
--- a/src/backend/cuda/math.hpp
+++ b/src/backend/cuda/math.hpp
@@ -14,7 +14,7 @@
 #include "types.hpp"
 
 #ifdef __CUDACC__
-#include <math_functions.h>
+#include <cuda_runtime_api.h>
 #include <math_constants.h>
 #endif
 

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -518,7 +518,7 @@ DeviceManager::DeviceManager()
     for(int i = 0; i < nDevices; i++) {
         cudaDevice_t dev;
         cudaGetDeviceProperties(&dev.prop, i);
-        if (dev.prop.major<getMinSupportedCompute(cudaMajorVer)) {
+        if (dev.prop.major < getMinSupportedCompute(cudaMajorVer)) {
             continue;
         } else {
             dev.flops = dev.prop.multiProcessorCount *


### PR DESCRIPTION
The tile function was failing for larger sizes because JIT kernels were not able to handle repeated x blocks. The kernels were exiting early which caused the next iteration to fail.