### PR TITLE
Indexing: Use Param/Array::strides instead of toStride

### DIFF
--- a/src/api/c/reorder.cpp
+++ b/src/api/c/reorder.cpp
@@ -50,6 +50,7 @@ static inline af_array reorder(const af_array in, const af::dim4 &rdims0)
             ostrides[i] = istrides[rdims[i]];
         }
         Array<T> Out = In;
+        // Use modDims instead of setDataDims to only modify the ArrayInfo
         Out.modDims(odims);
         Out.modStrides(ostrides);
         out = getHandle(Out);

--- a/src/backend/cpu/kernel/index.hpp
+++ b/src/backend/cpu/kernel/index.hpp
@@ -24,7 +24,7 @@ void index(Param<T> out, CParam<T> in, const af::dim4 dDims,
 {
     const af::dim4 iDims    = in.dims();
     const af::dim4 iOffs    = toOffset(seqs, dDims);
-    const af::dim4 iStrds   = toStride(seqs, dDims);
+    const af::dim4 iStrds   = in.strides();
     const af::dim4 oDims    = out.dims();
     const af::dim4 oStrides = out.strides();
     const T *src        = in.get();

--- a/src/backend/cuda/index.cu
+++ b/src/backend/cuda/index.cu
@@ -37,7 +37,7 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[])
     dim4 dDims = in.getDataDims();
     dim4 oDims = toDims  (seqs, iDims);
     dim4 iOffs = toOffset(seqs, dDims);
-    dim4 iStrds= toStride(seqs, dDims);
+    dim4 iStrds= in.strides();
 
     for (dim_t i=0; i<4; ++i) {
         p.isSeq[i] = idxrs[i].isSeq;

--- a/src/backend/opencl/index.cpp
+++ b/src/backend/opencl/index.cpp
@@ -36,7 +36,7 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[])
     dim4 dDims = in.getDataDims();
     dim4 oDims = toDims  (seqs, iDims);
     dim4 iOffs = toOffset(seqs, dDims);
-    dim4 iStrds= toStride(seqs, dDims);
+    dim4 iStrds= in.strides();
 
     for (dim_t i=0; i<4; ++i) {
         p.isSeq[i] = idxrs[i].isSeq;

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -1657,3 +1657,42 @@ TEST(Index, InvalidSequence_NegativeRangePositiveStep)
 {
     EXPECT_THROW(af::seq(-1,-5,1), af::exception);
 }
+
+TEST(Index, ISSUE_2273) {
+    int h_idx[2] = {1, 1};
+    array idx(2, h_idx);
+
+    float h_input[12] = {0.f, 1.f, 2.f, 3.f, 4.f, 5.f,
+                         6.f, 7.f, 8.f, 9.f, 10.f, 11.f};
+    array input(2, 3, 2, h_input);
+    array input_reord = reorder(input, 0, 2, 1);
+    array output = input_reord(span, idx, span);
+
+    float h_gold[12] = {6.f, 7.f, 6.f, 7.f,
+                        8.f, 9.f, 8.f, 9.f,
+                        10.f, 11.f, 10.f, 11.f};
+    array gold(2, 2, 3, h_gold);
+
+    ASSERT_ARRAYS_EQ(gold, output);
+}
+
+TEST(Index, ISSUE_2273_Flipped) {
+    int h_idx[2] = {1, 1};
+    array idx(2, h_idx);
+
+    float h_input[12] = {0.f, 1.f, 6.f, 7.f,
+                         2.f, 3.f, 8.f, 9.f,
+                         4.f, 5.f, 10.f, 11.f};
+    array input(2, 2, 3, h_input);
+    array input_reord = reorder(input, 0, 2, 1);
+    array input_slice = input_reord(span, span, idx);
+
+    array input_ref = iota(dim4(2, 3, 2));
+    array input_ref_slice = input_ref(span, span, idx);
+
+    float h_gold[12] = {6.f, 7.f, 8.f, 9.f, 10.f, 11.f,
+                        6.f, 7.f, 8.f, 9.f, 10.f, 11.f};
+    array input_slice_gold(2, 3, 2, h_gold);
+
+    ASSERT_ARRAYS_EQ(input_slice_gold, input_slice);
+}

--- a/test/reorder.cpp
+++ b/test/reorder.cpp
@@ -18,18 +18,18 @@
 #include <string>
 #include <testHelpers.hpp>
 
-using std::vector;
-using std::string;
-using std::cout;
-using std::endl;
 using af::allTrue;
 using af::array;
-using af::cfloat;
 using af::cdouble;
+using af::cfloat;
 using af::dim4;
 using af::dtype_traits;
 using af::reorder;
+using af::seq;
+using af::span;
 using af::tile;
+using std::string;
+using std::vector;
 
 
 template<typename T>
@@ -189,4 +189,14 @@ TEST(Reorder, MaxDim)
     array gold = range(dim4(2, largeDim, 2));
 
     ASSERT_ARRAYS_EQ(gold, output);
+}
+
+TEST(Reorder, InputArrayUnchanged) {
+    float h_input[12] = {0.f, 1.f, 2.f, 3.f, 4.f, 5.f,
+                         6.f, 7.f, 8.f, 9.f, 10.f, 11.f};
+    array input(2, 3, 2, h_input);
+    array input_reord = reorder(input, 0, 2, 1);
+
+    array input_gold(2, 3, 2, h_input);
+    ASSERT_ARRAYS_EQ(input_gold, input);
 }


### PR DESCRIPTION
This addresses #2273, and is a change of approach from the original PR #2303, since the problem doesn't lie in `reorder` itself, but in indexing (one of the tests in that PR was wrong too, which led me to believe that I was initially going the right direction there). This is a special case of reordering (or in general, modifying the dims/strides of) an array before indexing it, and more specifically using an `af::array` to index. For calculating the input offsets, indexing (on all backends) call `src/backend/common/ArrayInfo.cpp:toStride`, which calculates the input stride based on the `seqs` given, but the given `af::array` index is not an `af::seq` object, and thus produces the wrong input strides. To get the correct strides (the result of the `Array::modStrides` call within the internal `reorder`), I think that we should use the `Param/Array::strides` function instead.

Please feel free to suggest any better approaches that you might think of.