### PR TITLE
FEAT: sparse-sparse add/sub support

### DIFF
--- a/src/backend/cpu/kernel/sparse.hpp
+++ b/src/backend/cpu/kernel/sparse.hpp
@@ -45,7 +45,7 @@ void coo2dense(Param<T> output,
 }
 
 template<typename T>
-void dense_csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
+void dense2csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
                CParam<T> in)
 {
     const T * iPtr = in.get();
@@ -70,8 +70,8 @@ void dense_csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
 }
 
 template<typename T>
-void csr_dense(Param<T> out,
-                CParam<T> values, CParam<int> rowIdx, CParam<int> colIdx)
+void csr2dense(Param<T> out,
+               CParam<T> values, CParam<int> rowIdx, CParam<int> colIdx)
 {
     T   *oPtr = out.get();
     const T   *vPtr = values.get();
@@ -107,7 +107,7 @@ struct SpKIPCompareK
 };
 
 template<typename T>
-void csr_coo(Param<T> ovalues, Param<int> orowIdx, Param<int> ocolIdx,
+void csr2coo(Param<T> ovalues, Param<int> orowIdx, Param<int> ocolIdx,
              CParam<T> ivalues, CParam<int> irowIdx, CParam<int> icolIdx)
 {
     // First calculate the linear index
@@ -143,7 +143,7 @@ void csr_coo(Param<T> ovalues, Param<int> orowIdx, Param<int> ocolIdx,
 }
 
 template<typename T>
-void coo_csr(Param<T> ovalues, Param<int> orowIdx, Param<int> ocolIdx,
+void coo2csr(Param<T> ovalues, Param<int> orowIdx, Param<int> ocolIdx,
              CParam<T> ivalues, CParam<int> irowIdx, CParam<int> icolIdx)
 {
     T   * ovPtr = ovalues.get();

--- a/src/backend/cpu/sparse.cpp
+++ b/src/backend/cpu/sparse.cpp
@@ -26,366 +26,114 @@
 #include <reduce.hpp>
 #include <where.hpp>
 
-using common::is_complex;
+namespace cpu {
+
 using common::SparseArray;
 using common::createArrayDataSparseArray;
 using common::createEmptySparseArray;
 
-using std::add_const;
-using std::add_pointer;
-using std::enable_if;
-using std::is_floating_point;
-using std::remove_const;
-using std::conditional;
-using std::is_same;
-
-namespace cpu
-{
-
-template<typename T, class Enable = void>
-struct blas_base {
-    using type = T;
-};
-
-template<typename T>
-struct blas_base <T, typename enable_if<is_complex<T>::value>::type> {
-    using type = typename conditional<is_same<T, cdouble>::value,
-                                      sp_cdouble, sp_cfloat>::type;
-};
-
-template<typename T>
-using cptr_type     =   typename conditional<   is_complex<T>::value,
-                                                const typename blas_base<T>::type *,
-                                                const T*>::type;
-template<typename T>
-using ptr_type     =    typename conditional<   is_complex<T>::value,
-                                                typename blas_base<T>::type *,
-                                                T*>::type;
-template<typename T>
-using scale_type   =    typename conditional<   is_complex<T>::value,
-                                                const typename blas_base<T>::type *,
-                                                const T *>::type;
-
-#ifdef USE_MKL
-
-// void mkl_zdnscsr (const MKL_INT *job ,
-//                   const MKL_INT *m , const MKL_INT *n ,
-//                   MKL_Complex16 *adns , const MKL_INT *lda ,
-//                   MKL_Complex16 *acsr ,
-//                   MKL_INT *ja , MKL_INT *ia ,
-//                   MKL_INT *info );
-template<typename T>
-using dnscsr_func_def = void (*)(const int *,
-                                 const int *, const int *,
-                                 ptr_type<T>, const int *,
-                                 ptr_type<T>,
-                                 int *, int *,
-                                 int *);
-
-//void mkl_zcsrcsc (const MKL_INT *job ,
-//                  const MKL_INT *n ,
-//                  MKL_Complex16 *acsr ,
-//                  MKL_INT *ja , MKL_INT *ia ,
-//                  MKL_Complex16 *acsc ,
-//                  MKL_INT *ja1 , MKL_INT *ia1 ,
-//                  MKL_INT *info );
-template<typename T>
-using csrcsc_func_def = void (*)(const int *,
-                                 const int *,
-                                 ptr_type<T>, int *, int *,
-                                 ptr_type<T>,
-                                 int *, int *,
-                                 int *);
-
-#define SPARSE_FUNC_DEF( FUNC )                         \
-template<typename T> FUNC##_func_def<T> FUNC##_func();
-
-#define SPARSE_FUNC( FUNC, TYPE, PREFIX )               \
-  template<> FUNC##_func_def<TYPE> FUNC##_func<TYPE>()  \
-{ return &mkl_##PREFIX##FUNC; }
-
-SPARSE_FUNC_DEF(dnscsr)
-SPARSE_FUNC(dnscsr, float,  s)
-SPARSE_FUNC(dnscsr, double, d)
-SPARSE_FUNC(dnscsr, cfloat, c)
-SPARSE_FUNC(dnscsr, cdouble,z)
-
-SPARSE_FUNC_DEF(csrcsc)
-SPARSE_FUNC(csrcsc, float,  s)
-SPARSE_FUNC(csrcsc, double, d)
-SPARSE_FUNC(csrcsc, cfloat, c)
-SPARSE_FUNC(csrcsc, cdouble,z)
-
-#undef SPARSE_FUNC
-#undef SPARSE_FUNC_DEF
-
-#endif // USE_MKL
-
-////////////////////////////////////////////////////////////////////////////////
-// Common Funcs for MKL and Non-MKL Code Paths
-////////////////////////////////////////////////////////////////////////////////
-
-// Partial template specialization of sparseConvertDenseToStorage for COO
-// However, template specialization is not allowed
-template<typename T>
-SparseArray<T> sparseConvertDenseToCOO(const Array<T> &in)
+template<typename T, af_storage stype>
+SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in)
 {
     in.eval();
 
-    Array<uint> nonZeroIdx_ = where<T>(in);
-    Array<int> nonZeroIdx = cast<int, uint>(nonZeroIdx_);
+    if (stype == AF_STORAGE_CSR) {
+        uint nNZ = reduce_all<af_notzero_t, T, uint>(in);
 
-    dim_t nNZ = nonZeroIdx.elements();
+        auto sparse = createEmptySparseArray<T>(in.dims(), nNZ, stype);
+        sparse.eval();
 
-    Array<int> constDim = createValueArray<int>(dim4(nNZ), in.dims()[0]);
-    constDim.eval();
+        Array<T  > values = sparse.getValues();
+        Array<int> rowIdx = sparse.getRowIdx();
+        Array<int> colIdx = sparse.getColIdx();
 
-    Array<int> rowIdx = arithOp<int, af_mod_t>(nonZeroIdx, constDim, nonZeroIdx.dims());
-    Array<int> colIdx = arithOp<int, af_div_t>(nonZeroIdx, constDim, nonZeroIdx.dims());
+        getQueue().enqueue(kernel::dense2csr<T>, values, rowIdx, colIdx, in);
 
-    Array<T> values = copyArray<T>(in);
-    values.modDims(dim4(values.elements()));
-    values = lookup<T, int>(values, nonZeroIdx, 0);
+        return sparse;
+    } else if (stype == AF_STORAGE_COO) {
+        auto nonZeroIdx = cast<int, uint>(where<T>(in));
 
-    return createArrayDataSparseArray<T>(in.dims(), values, rowIdx, colIdx, AF_STORAGE_COO);
+        dim_t nNZ = nonZeroIdx.elements();
+
+        auto cnst = createValueArray<int>(dim4(nNZ), in.dims()[0]);
+        cnst.eval();
+
+        auto rowIdx = arithOp<int, af_mod_t>(nonZeroIdx, cnst, nonZeroIdx.dims());
+        auto colIdx = arithOp<int, af_div_t>(nonZeroIdx, cnst, nonZeroIdx.dims());
+
+        Array<T> values = copyArray<T>(in);
+        values.modDims(dim4(values.elements()));
+        values = lookup<T, int>(values, nonZeroIdx, 0);
+
+        return createArrayDataSparseArray<T>(in.dims(), values, rowIdx, colIdx, stype);
+    } else {
+        AF_ERROR("CPU Backend only supports Dense to CSR or COO", AF_ERR_NOT_SUPPORTED);
+    }
 }
 
-// Partial template specialization of sparseConvertStorageToDense for COO
-// However, template specialization is not allowed
-template<typename T>
-Array<T> sparseConvertCOOToDense(const SparseArray<T> &in)
+template<typename T, af_storage stype>
+Array<T> sparseConvertStorageToDense(const SparseArray<T> &in)
 {
     in.eval();
 
     Array<T> dense = createValueArray<T>(in.dims(), scalar<T>(0));
     dense.eval();
 
-    const Array<T>   values = in.getValues();
-    const Array<int> rowIdx = in.getRowIdx();
-    const Array<int> colIdx = in.getColIdx();
+    Array<T  > values = in.getValues();
+    Array<int> rowIdx = in.getRowIdx();
+    Array<int> colIdx = in.getColIdx();
 
-    getQueue().enqueue(kernel::coo2dense<T>, dense, values, rowIdx, colIdx);
+    if(stype == AF_STORAGE_CSR)
+        getQueue().enqueue(kernel::csr2dense<T>, dense, values, rowIdx, colIdx);
+    else if (stype == AF_STORAGE_COO)
+        getQueue().enqueue(kernel::coo2dense<T>, dense, values, rowIdx, colIdx);
+    else
+        AF_ERROR("CPU Backend only supports CSR or COO to Dense", AF_ERR_NOT_SUPPORTED);
 
     return dense;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-#ifdef USE_MKL // Implementation using MKL
-////////////////////////////////////////////////////////////////////////////////
-
-template<typename T, af_storage stype>
-SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in_)
-{
-    in_.eval();
-
-    // MKL only has dns->csr.
-    // CSR <-> CSC is only supported if input is square
-    uint nNZ = reduce_all<af_notzero_t, T, uint>(in_);
-
-    SparseArray<T> sparse_ = createEmptySparseArray<T>(in_.dims(), nNZ, AF_STORAGE_CSR);
-    sparse_.eval();
-
-    auto func = [=] (Param<T> values, Param<int> rowIdx, Param<int> colIdx, int num, CParam<T> in) {
-        // Read: https://software.intel.com/en-us/node/520848
-        // But job description is incorrect with regards to job[1]
-        // 0 implies row major and 1 implies column major
-        int j1 = 1, j2 = 0;
-        const int job[] = {0, j1, j2, 2, num, 1};
-
-        const int M = in.dims(0);
-        const int N = in.dims(1);
-
-        int ldd = in.strides(1);
-
-        int info = 0;
-
-        // Have to mess up all const correctness because MKL dnscsr function
-        // is bidirectional and has input/output on all pointers
-        dnscsr_func<T>()(
-                job, &M, &N,
-                reinterpret_cast<ptr_type<T>>(const_cast<T*>(in.get())), &ldd,
-                reinterpret_cast<ptr_type<T>>(values.get()),
-                colIdx.get(),
-                rowIdx.get(),
-                &info);
-    };
-
-
-    Array<T  > &values = sparse_.getValues();
-    Array<int> &rowIdx = sparse_.getRowIdx();
-    Array<int> &colIdx = sparse_.getColIdx();
-
-    getQueue().enqueue(func, values, rowIdx, colIdx, (int)sparse_.elements(), in_);
-
-    if(stype == AF_STORAGE_CSR)
-        return sparse_;
-    else
-        AF_ERROR("CPU Backend only supports Dense to CSR or COO", AF_ERR_NOT_SUPPORTED);
-
-    return sparse_;
-}
-
-template<typename T, af_storage stype>
-Array<T> sparseConvertStorageToDense(const SparseArray<T> &in_)
-{
-    // MKL only has dns<->csr.
-    // CSR <-> CSC is only supported if input is square
-
-    if(stype == AF_STORAGE_CSC)
-        AF_ERROR("CPU Backend only supports Dense to CSR or COO", AF_ERR_NOT_SUPPORTED);
-
-    in_.eval();
-
-    Array<T> dense_ = createValueArray<T>(in_.dims(), scalar<T>(0));
-    dense_.eval();
-
-    auto func = [=] (Param<T> dense,
-                     CParam<T> values, CParam<int> rowIdx,
-                     CParam<int> colIdx, int num) {
-        // Read: https://software.intel.com/en-us/node/520848
-        // But job description is incorrect with regards to job[1]
-        // 0 implies row major and 1 implies column major
-        int j1 = 1, j2 = 0;
-        const int job[] = {1, j1, j2, 2, num, 1};
-
-        const int M = dense.dims(0);
-        const int N = dense.dims(1);
-
-        int ldd = dense.strides(1);
-
-        int info = 0;
-
-        // Have to mess up all const correctness because MKL dnscsr function
-        // is bidirectional and has input/output on all pointers
-        dnscsr_func<T>()(
-                job, &M, &N,
-                reinterpret_cast<ptr_type<T>>(dense.get()), &ldd,
-                reinterpret_cast<ptr_type<T>>(const_cast<T*>(values.get())),
-                const_cast<int*>(colIdx.get()),
-                const_cast<int*>(rowIdx.get()),
-                &info);
-    };
-
-    Array<T  > values = in_.getValues();
-    Array<int> rowIdx = in_.getRowIdx();
-    Array<int> colIdx = in_.getColIdx();
-
-    getQueue().enqueue(func, dense_, values, rowIdx, colIdx, (int)in_.elements());
-
-    if(stype == AF_STORAGE_CSR)
-        return dense_;
-    else
-        AF_ERROR("CPU Backend only supports Dense to CSR or COO", AF_ERR_NOT_SUPPORTED);
-
-    return dense_;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-#else // Implementation without using MKL
-////////////////////////////////////////////////////////////////////////////////
-
-template<typename T, af_storage stype>
-SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in_)
-{
-    in_.eval();
-
-    uint nNZ = reduce_all<af_notzero_t, T, uint>(in_);
-
-    SparseArray<T> sparse_ = createEmptySparseArray<T>(in_.dims(), nNZ, AF_STORAGE_CSR);
-    sparse_.eval();
-
-    Array<T  > values = sparse_.getValues();
-    Array<int> rowIdx = sparse_.getRowIdx();
-    Array<int> colIdx = sparse_.getColIdx();
-
-    if(stype == AF_STORAGE_CSR)
-        getQueue().enqueue(kernel::dense_csr<T>, values, rowIdx, colIdx, in_);
-    else
-        AF_ERROR("CPU Backend only supports Dense to CSR or COO", AF_ERR_NOT_SUPPORTED);
-
-
-    return sparse_;
-}
-
-template<typename T, af_storage stype>
-Array<T> sparseConvertStorageToDense(const SparseArray<T> &in_)
-{
-    in_.eval();
-
-    Array<T> dense_ = createValueArray<T>(in_.dims(), scalar<T>(0));
-    dense_.eval();
-
-    Array<T  > values = in_.getValues();
-    Array<int> rowIdx = in_.getRowIdx();
-    Array<int> colIdx = in_.getColIdx();
-
-    if(stype == AF_STORAGE_CSR)
-        getQueue().enqueue(kernel::csr_dense<T>, dense_, values, rowIdx, colIdx);
-    else
-        AF_ERROR("CPU Backend only supports CSR or COO to Dense", AF_ERR_NOT_SUPPORTED);
-
-    return dense_;
-}
-
-////////////////////////////////////////////////////////////////////////////////
-#endif //USE_MKL
-////////////////////////////////////////////////////////////////////////////////
-
-////////////////////////////////////////////////////////////////////////////////
-// Common Funcs for MKL and Non-MKL Code Paths
-////////////////////////////////////////////////////////////////////////////////
 template<typename T, af_storage dest, af_storage src>
 SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in)
 {
     in.eval();
 
-    SparseArray<T> converted = createEmptySparseArray<T>(in.dims(), (int)in.getNNZ(), dest);
+    auto converted = createEmptySparseArray<T>(in.dims(), (int)in.getNNZ(), dest);
     converted.eval();
 
     function<void (Param<T>, Param<int>, Param<int>,
-                   CParam<T>, CParam<int>, CParam<int>)
-            > converter;
+                   CParam<T>, CParam<int>, CParam<int>)> converter;
 
     if(src == AF_STORAGE_CSR && dest == AF_STORAGE_COO) {
-        converter = kernel::csr_coo<T>;
+        converter = kernel::csr2coo<T>;
     } else if (src == AF_STORAGE_COO && dest == AF_STORAGE_CSR) {
-        converter = kernel::coo_csr<T>;
+        converter = kernel::coo2csr<T>;
     } else {
         // Should never come here
         AF_ERROR("CPU Backend invalid conversion combination", AF_ERR_NOT_SUPPORTED);
     }
-
-    getQueue().enqueue(converter,
-                       converted.getValues(), converted.getRowIdx(), converted.getColIdx(),
+    getQueue().enqueue(converter, converted.getValues(),
+                       converted.getRowIdx(), converted.getColIdx(),
                        in.getValues(), in.getRowIdx(), in.getColIdx());
-
     return converted;
 }
 
-#define INSTANTIATE_TO_STORAGE(T, S)                                                                        \
-    template SparseArray<T> sparseConvertStorageToStorage<T, S, AF_STORAGE_CSR>(const SparseArray<T> &in);  \
-    template SparseArray<T> sparseConvertStorageToStorage<T, S, AF_STORAGE_CSC>(const SparseArray<T> &in);  \
-    template SparseArray<T> sparseConvertStorageToStorage<T, S, AF_STORAGE_COO>(const SparseArray<T> &in);  \
+#define INSTANTIATE_TO_STORAGE(T, S)                                                                \
+template SparseArray<T> sparseConvertStorageToStorage<T, S, AF_STORAGE_CSR>(const SparseArray<T>&); \
+template SparseArray<T> sparseConvertStorageToStorage<T, S, AF_STORAGE_CSC>(const SparseArray<T>&); \
+template SparseArray<T> sparseConvertStorageToStorage<T, S, AF_STORAGE_COO>(const SparseArray<T>&); \
 
-#define INSTANTIATE_COO_SPECIAL(T)                                                                      \
-    template<> SparseArray<T> sparseConvertDenseToStorage<T, AF_STORAGE_COO>(const Array<T> &in)        \
-    { return sparseConvertDenseToCOO<T>(in); }                                                          \
-    template<> Array<T> sparseConvertStorageToDense<T, AF_STORAGE_COO>(const SparseArray<T> &in)        \
-    { return sparseConvertCOOToDense<T>(in); }                                                          \
-
-#define INSTANTIATE_SPARSE(T)                                                                           \
-    template SparseArray<T> sparseConvertDenseToStorage<T, AF_STORAGE_CSR>(const Array<T> &in);         \
-    template SparseArray<T> sparseConvertDenseToStorage<T, AF_STORAGE_CSC>(const Array<T> &in);         \
-                                                                                                        \
-    template Array<T> sparseConvertStorageToDense<T, AF_STORAGE_CSR>(const SparseArray<T> &in);         \
-    template Array<T> sparseConvertStorageToDense<T, AF_STORAGE_CSC>(const SparseArray<T> &in);         \
-                                                                                                        \
-    INSTANTIATE_COO_SPECIAL(T)                                                                          \
-                                                                                                        \
-    INSTANTIATE_TO_STORAGE(T, AF_STORAGE_CSR)                                                           \
-    INSTANTIATE_TO_STORAGE(T, AF_STORAGE_CSC)                                                           \
-    INSTANTIATE_TO_STORAGE(T, AF_STORAGE_COO)                                                           \
-
+#define INSTANTIATE_SPARSE(T)                                                               \
+template SparseArray<T> sparseConvertDenseToStorage<T, AF_STORAGE_CSR>(const Array<T> &in); \
+template SparseArray<T> sparseConvertDenseToStorage<T, AF_STORAGE_CSC>(const Array<T> &in); \
+template SparseArray<T> sparseConvertDenseToStorage<T, AF_STORAGE_COO>(const Array<T> &in); \
+template Array<T> sparseConvertStorageToDense<T, AF_STORAGE_CSR>(const SparseArray<T> &in); \
+template Array<T> sparseConvertStorageToDense<T, AF_STORAGE_CSC>(const SparseArray<T> &in); \
+template Array<T> sparseConvertStorageToDense<T, AF_STORAGE_COO>(const SparseArray<T> &in); \
+                                                                                            \
+INSTANTIATE_TO_STORAGE(T, AF_STORAGE_CSR)                                                   \
+INSTANTIATE_TO_STORAGE(T, AF_STORAGE_CSC)                                                   \
+INSTANTIATE_TO_STORAGE(T, AF_STORAGE_COO)                                                   \
 
 INSTANTIATE_SPARSE(float)
 INSTANTIATE_SPARSE(double)
@@ -393,7 +141,6 @@ INSTANTIATE_SPARSE(cfloat)
 INSTANTIATE_SPARSE(cdouble)
 
 #undef INSTANTIATE_TO_STORAGE
-#undef INSTANTIATE_COO_SPECIAL
 #undef INSTANTIATE_SPARSE
 
 }

--- a/src/backend/cpu/sparse.hpp
+++ b/src/backend/cpu/sparse.hpp
@@ -12,21 +12,8 @@
 #include <Array.hpp>
 #include <common/SparseArray.hpp>
 
-#ifdef USE_MKL
-#include <mkl_spblas.h>
-#endif
-
 namespace cpu
 {
-
-#ifdef USE_MKL
-typedef MKL_Complex8  sp_cfloat;
-typedef MKL_Complex16 sp_cdouble;
-#else
-typedef cfloat        sp_cfloat;
-typedef cdouble       sp_cdouble;
-#endif
-
 template<typename T, af_storage stype>
 common::SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in);
 
@@ -35,5 +22,4 @@ Array<T> sparseConvertStorageToDense(const common::SparseArray<T> &in);
 
 template<typename T, af_storage dest, af_storage src>
 common::SparseArray<T> sparseConvertStorageToStorage(const common::SparseArray<T> &in);
-
 }

--- a/src/backend/cpu/sparse_arith.hpp
+++ b/src/backend/cpu/sparse_arith.hpp
@@ -7,6 +7,8 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#pragma once
+
 #include <Array.hpp>
 #include <common/SparseArray.hpp>
 #include <sparse.hpp>
@@ -14,7 +16,6 @@
 
 namespace cpu
 {
-
 // These two functions cannot be overloaded by return type.
 // So have to give them separate names.
 template<typename T, af_op_t op>
@@ -25,4 +26,7 @@ template<typename T, af_op_t op>
 common::SparseArray<T> arithOpS(const common::SparseArray<T> &lhs, const Array<T> &rhs,
                                 const bool reverse = false);
 
+template<typename T, af_op_t op>
+common::SparseArray<T> arithOp(const common::SparseArray<T> &lhs,
+                               const common::SparseArray<T> &rhs);
 }

--- a/src/backend/cuda/sparse_arith.hpp
+++ b/src/backend/cuda/sparse_arith.hpp
@@ -25,5 +25,7 @@ template<typename T, af_op_t op>
 common::SparseArray<T> arithOpS(const common::SparseArray<T> &lhs, const Array<T> &rhs,
                                 const bool reverse = false);
 
+template<typename T, af_op_t op>
+common::SparseArray<T> arithOp(const common::SparseArray<T> &lhs,
+                               const common::SparseArray<T> &rhs);
 }
-

--- a/src/backend/opencl/kernel/sp_sp_arith_csr.cl
+++ b/src/backend/opencl/kernel/sp_sp_arith_csr.cl
@@ -1,0 +1,62 @@
+/*******************************************************
+ * Copyright (c) 2018, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+//TODO_PERF(pradeep) More performance improvements are possible
+__attribute__((reqd_work_group_size(256, 1, 1)))
+kernel
+void ssarith_csr_kernel(global T* oVals, global int* oColIdx,
+                        global const int* oRowIdx,
+                        uint M, uint N,
+                        uint nnza, global const T *lVals,
+                        global const int *lRowIdx, global const int *lColIdx,
+                        uint nnzb, global const T *rVals,
+                        global const int *rRowIdx, global const int *rColIdx)
+{
+    const uint row     = get_global_id(0);
+
+    const bool valid = row < M;
+
+    const uint lEnd    = (valid ? lRowIdx[row+1] : 0);
+    const uint rEnd    = (valid ? rRowIdx[row+1] : 0);
+    const uint offset  = (valid ? oRowIdx[row]   : 0);
+
+    global   T *ovPtr = oVals + offset;
+    global int *ocPtr = oColIdx + offset;
+
+    uint l = (valid ? lRowIdx[row] : 0);
+    uint r = (valid ? rRowIdx[row] : 0);
+
+    uint nnz = 0;
+    while (l < lEnd && r < rEnd) {
+        uint lci = lColIdx[l];
+        uint rci = rColIdx[r];
+
+        T lhs = (lci <= rci ? lVals[l] : IDENTITY_VALUE);
+        T rhs = (lci >= rci ? rVals[r] : IDENTITY_VALUE);
+
+        ovPtr[ nnz ] = OP(lhs, rhs);
+        ocPtr[ nnz ] = (lci <= rci) ? lci : rci;
+
+        l += (lci <= rci);
+        r += (lci >= rci);
+        nnz++;
+    }
+    while (l < lEnd) {
+        ovPtr[nnz] = OP(lVals[l], IDENTITY_VALUE);
+        ocPtr[nnz] = lColIdx[l];
+        l++;
+        nnz++;
+    }
+    while (r < rEnd) {
+        ovPtr[nnz] = OP(IDENTITY_VALUE, rVals[r]);
+        ocPtr[nnz] = rColIdx[r];
+        r++;
+        nnz++;
+    }
+}

--- a/src/backend/opencl/kernel/sparse_arith.hpp
+++ b/src/backend/opencl/kernel/sparse_arith.hpp
@@ -11,24 +11,21 @@
 #include <kernel_headers/sparse_arith_csr.hpp>
 #include <kernel_headers/sparse_arith_coo.hpp>
 #include <kernel_headers/sparse_arith_common.hpp>
+#include <kernel_headers/ssarith_calc_out_nnz.hpp>
+#include <kernel_headers/sp_sp_arith_csr.hpp>
 #include <program.hpp>
 #include <traits.hpp>
 #include <string>
 #include <mutex>
 #include <map>
+#include <common/complex.hpp>
 #include <common/dispatch.hpp>
 #include <Param.hpp>
 #include <debug_opencl.hpp>
 #include <cache.hpp>
 #include <type_util.hpp>
-
-using cl::Buffer;
-using cl::Program;
-using cl::Kernel;
-using cl::KernelFunctor;
-using cl::EnqueueArgs;
-using cl::NDRange;
-using std::string;
+#include <types.hpp>
+#include <math.hpp>
 
 namespace opencl
 {
@@ -83,24 +80,24 @@ namespace opencl
                 const char *ker_strs[] = {sparse_arith_common_cl    , sparse_arith_csr_cl};
                 const int   ker_lens[] = {sparse_arith_common_cl_len, sparse_arith_csr_cl_len};
 
-                Program prog;
+                cl::Program prog;
                 buildProgram(prog, 2, ker_strs, ker_lens, options.str());
-                entry.prog = new Program(prog);
-                entry.ker  = new Kernel(*entry.prog, "sparse_arith_csr_kernel");
+                entry.prog = new cl::Program(prog);
+                entry.ker  = new cl::Kernel(*entry.prog, "sparse_arith_csr_kernel");
 
                 addKernelToCache(device, ref_name, entry);
             }
 
-            auto sparseArithCSROp = KernelFunctor<Buffer, const KParam,
-                 const Buffer, const Buffer, const Buffer,
+            auto sparseArithCSROp = cl::KernelFunctor<cl::Buffer, const KParam,
+                 const cl::Buffer, const cl::Buffer, const cl::Buffer,
                  const int,
-                 const Buffer, const KParam,
+                 const cl::Buffer, const KParam,
                  const int>(*entry.ker);
 
-            NDRange local(TX, TY, 1);
-            NDRange global(divup(out.info.dims[0], TY) * TX, TY, 1);
+            cl::NDRange local(TX, TY, 1);
+            cl::NDRange global(divup(out.info.dims[0], TY) * TX, TY, 1);
 
-            sparseArithCSROp(EnqueueArgs(getQueue(), global, local),
+            sparseArithCSROp(cl::EnqueueArgs(getQueue(), global, local),
                     *out.data, out.info,
                     *values.data, *rowIdx.data, *colIdx.data, values.info.dims[0],
                     *rhs.data, rhs.info, reverse);
@@ -139,24 +136,24 @@ namespace opencl
                 const char *ker_strs[] = {sparse_arith_common_cl    , sparse_arith_coo_cl};
                 const int   ker_lens[] = {sparse_arith_common_cl_len, sparse_arith_coo_cl_len};
 
-                Program prog;
+                cl::Program prog;
                 buildProgram(prog, 2, ker_strs, ker_lens, options.str());
-                entry.prog = new Program(prog);
-                entry.ker  = new Kernel(*entry.prog, "sparse_arith_coo_kernel");
+                entry.prog = new cl::Program(prog);
+                entry.ker  = new cl::Kernel(*entry.prog, "sparse_arith_coo_kernel");
 
                 addKernelToCache(device, ref_name, entry);
             }
 
-            auto sparseArithCOOOp = KernelFunctor<Buffer, const KParam,
-                 const Buffer, const Buffer, const Buffer,
+            auto sparseArithCOOOp = cl::KernelFunctor<cl::Buffer, const KParam,
+                 const cl::Buffer, const cl::Buffer, const cl::Buffer,
                  const int,
-                 const Buffer, const KParam,
+                 const cl::Buffer, const KParam,
                  const int>(*entry.ker);
 
-            NDRange local(THREADS, 1, 1);
-            NDRange global(divup(values.info.dims[0], THREADS) * THREADS, 1, 1);
+            cl::NDRange local(THREADS, 1, 1);
+            cl::NDRange global(divup(values.info.dims[0], THREADS) * THREADS, 1, 1);
 
-            sparseArithCOOOp(EnqueueArgs(getQueue(), global, local),
+            sparseArithCOOOp(cl::EnqueueArgs(getQueue(), global, local),
                     *out.data, out.info,
                     *values.data, *rowIdx.data, *colIdx.data, values.info.dims[0],
                     *rhs.data, rhs.info, reverse);
@@ -196,23 +193,23 @@ namespace opencl
                 const char *ker_strs[] = {sparse_arith_common_cl    , sparse_arith_csr_cl};
                 const int   ker_lens[] = {sparse_arith_common_cl_len, sparse_arith_csr_cl_len};
 
-                Program prog;
+                cl::Program prog;
                 buildProgram(prog, 2, ker_strs, ker_lens, options.str());
-                entry.prog = new Program(prog);
-                entry.ker  = new Kernel(*entry.prog, "sparse_arith_csr_kernel_S");
+                entry.prog = new cl::Program(prog);
+                entry.ker  = new cl::Kernel(*entry.prog, "sparse_arith_csr_kernel_S");
 
                 addKernelToCache(device, ref_name, entry);
             }
 
-            auto sparseArithCSROp = KernelFunctor<const Buffer, const Buffer, const Buffer,
+            auto sparseArithCSROp = cl::KernelFunctor<const cl::Buffer, const cl::Buffer, const cl::Buffer,
                  const int,
-                 const Buffer, const KParam,
+                 const cl::Buffer, const KParam,
                  const int>(*entry.ker);
 
-            NDRange local(TX, TY, 1);
-            NDRange global(divup(rhs.info.dims[0], TY) * TX, TY, 1);
+            cl::NDRange local(TX, TY, 1);
+            cl::NDRange global(divup(rhs.info.dims[0], TY) * TX, TY, 1);
 
-            sparseArithCSROp(EnqueueArgs(getQueue(), global, local),
+            sparseArithCSROp(cl::EnqueueArgs(getQueue(), global, local),
                     *values.data, *rowIdx.data, *colIdx.data, values.info.dims[0],
                     *rhs.data, rhs.info, reverse);
 
@@ -250,25 +247,124 @@ namespace opencl
                 const char *ker_strs[] = {sparse_arith_common_cl    , sparse_arith_coo_cl};
                 const int   ker_lens[] = {sparse_arith_common_cl_len, sparse_arith_coo_cl_len};
 
-                Program prog;
+                cl::Program prog;
                 buildProgram(prog, 2, ker_strs, ker_lens, options.str());
-                entry.prog = new Program(prog);
-                entry.ker  = new Kernel(*entry.prog, "sparse_arith_coo_kernel_S");
+                entry.prog = new cl::Program(prog);
+                entry.ker  = new cl::Kernel(*entry.prog, "sparse_arith_coo_kernel_S");
 
                 addKernelToCache(device, ref_name, entry);
             }
 
-            auto sparseArithCOOOp = KernelFunctor<Buffer, Buffer, Buffer,
+            auto sparseArithCOOOp = cl::KernelFunctor<cl::Buffer, cl::Buffer, cl::Buffer,
                  const int,
-                 const Buffer, const KParam,
+                 const cl::Buffer, const KParam,
                  const int>(*entry.ker);
 
-            NDRange local(THREADS, 1, 1);
-            NDRange global(divup(values.info.dims[0], THREADS) * THREADS, 1, 1);
+            cl::NDRange local(THREADS, 1, 1);
+            cl::NDRange global(divup(values.info.dims[0], THREADS) * THREADS, 1, 1);
 
-            sparseArithCOOOp(EnqueueArgs(getQueue(), global, local),
+            sparseArithCOOOp(cl::EnqueueArgs(getQueue(), global, local),
                     *values.data, *rowIdx.data, *colIdx.data, values.info.dims[0],
                     *rhs.data, rhs.info, reverse);
+
+            CL_DEBUG_FINISH(getQueue());
+        }
+
+        static
+        void csrCalcOutNNZ(Param outRowIdx, unsigned &nnzC,
+                const uint M, const uint N,
+                uint nnzA, const Param lrowIdx, const Param lcolIdx,
+                uint nnzB, const Param rrowIdx, const Param rcolIdx)
+        {
+            std::string refName = std::string("csr_calc_output_NNZ");
+            int device = getActiveDeviceId();
+            kc_entry_t entry = kernelCache(device, refName);
+
+            if (entry.prog==0 && entry.ker==0) {
+                const char *kerStrs[] = { ssarith_calc_out_nnz_cl };
+                const int kerLens[] = { ssarith_calc_out_nnz_cl_len };
+
+                cl::Program prog;
+                buildProgram(prog, 1, kerStrs, kerLens, std::string(""));
+                entry.prog = new cl::Program(prog);
+                entry.ker = new cl::Kernel(*entry.prog, "csr_calc_out_nnz");
+
+                addKernelToCache(device, refName, entry);
+            }
+            auto calcNNZop = cl::KernelFunctor<cl::Buffer, cl::Buffer, unsigned,
+                 const cl::Buffer, const cl::Buffer,
+                 const cl::Buffer, const cl::Buffer,
+                 cl::LocalSpaceArg>(*entry.ker);
+
+            cl::NDRange local(256, 1);
+            cl::NDRange global(divup(M, local[0])*local[0], 1, 1);
+
+            nnzC = 0;
+            cl::Buffer* out = bufferAlloc(sizeof(unsigned));
+            getQueue().enqueueWriteBuffer(*out, CL_TRUE, 0, sizeof(unsigned), &nnzC);
+
+            calcNNZop(cl::EnqueueArgs(getQueue(), global, local),
+                      *out, *outRowIdx.data, M,
+                      *lrowIdx.data, *lcolIdx.data,
+                      *rrowIdx.data, *rcolIdx.data,
+                      cl::Local(local[0]*sizeof(unsigned int)));
+            getQueue().enqueueReadBuffer(*out, CL_TRUE, 0, sizeof(unsigned), &nnzC);
+
+            CL_DEBUG_FINISH(getQueue());
+        }
+
+        template<typename T, af_op_t op>
+        void ssArithCSR(Param oVals, Param oColIdx,
+                const Param oRowIdx, const uint M, const uint N,
+                unsigned nnzA, const Param lVals, const Param lRowIdx, const Param lColIdx,
+                unsigned nnzB, const Param rVals, const Param rRowIdx, const Param rColIdx)
+        {
+            std::string refName = std::string("ss_arith_csr_") +
+                                  getOpString<op>() + "_" +
+                                  std::string(dtype_traits<T>::getName());
+            int device = getActiveDeviceId();
+            kc_entry_t entry = kernelCache(device, refName);
+
+            if (entry.prog==0 && entry.ker==0) {
+                const T iden_val = (op == af_mul_t || op == af_div_t ?
+                                      scalar<T>(1) : scalar<T>(0));
+                ToNumStr<T> toNumStr;
+                std::ostringstream options;
+                options << " -D T="  << dtype_traits<T>::getName()
+                        << " -D OP=" << getOpString<op>()
+                        << " -D IDENTITY_VALUE=(T)(" << af::scalar_to_option(iden_val) << ")";
+
+                options << " -D IS_CPLX=" << common::is_complex<T>::value;
+                if (std::is_same<T, double>::value ||
+                        std::is_same<T, cdouble>::value) {
+                    options << " -D USE_DOUBLE";
+                }
+
+                const char *kerStrs[] = { sparse_arith_common_cl, sp_sp_arith_csr_cl };
+                const int kerLens[] = { sparse_arith_common_cl_len, sp_sp_arith_csr_cl_len };
+
+                cl::Program prog;
+                buildProgram(prog, 2, kerStrs, kerLens, options.str());
+                entry.prog = new cl::Program(prog);
+                entry.ker = new cl::Kernel(*entry.prog, "ssarith_csr_kernel");
+
+                addKernelToCache(device, refName, entry);
+            }
+            auto arithOp = cl::KernelFunctor<cl::Buffer, cl::Buffer,
+                 cl::Buffer, unsigned, unsigned,
+                 unsigned, const cl::Buffer,
+                 const cl::Buffer, const cl::Buffer,
+                 unsigned, const cl::Buffer,
+                 const cl::Buffer, const cl::Buffer>(*entry.ker);
+
+            cl::NDRange local(256, 1);
+            cl::NDRange global(divup(M, local[0])*local[0], 1, 1);
+
+            arithOp(cl::EnqueueArgs(getQueue(), global, local),
+                      *oVals.data, *oColIdx.data,
+                      *oRowIdx.data, M, N,
+                      nnzA, *lVals.data, *lRowIdx.data, *lColIdx.data,
+                      nnzB, *rVals.data, *rRowIdx.data, *rColIdx.data);
 
             CL_DEBUG_FINISH(getQueue());
         }

--- a/src/backend/opencl/kernel/ssarith_calc_out_nnz.cl
+++ b/src/backend/opencl/kernel/ssarith_calc_out_nnz.cl
@@ -1,0 +1,58 @@
+/*******************************************************
+ * Copyright (c) 2018, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+kernel
+void csr_calc_out_nnz(global unsigned* nnzc,
+                      global int* oRowIdx, uint M,
+                      global const int *lRowIdx, global const int *lColIdx,
+                      global const int *rRowIdx, global const int *rColIdx,
+                      local uint* blkNnz)
+{
+    const uint row  = get_global_id(0);
+    const uint tid  = get_local_id(0);
+
+    const bool valid = row < M;
+
+    const uint lEnd = (valid ? lRowIdx[row+1] : 0);
+    const uint rEnd = (valid ? rRowIdx[row+1] : 0);
+
+    blkNnz[tid] = 0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    uint l = (valid ? lRowIdx[row] : 0);
+    uint r = (valid ? rRowIdx[row] : 0);
+    uint nnz = 0;
+    while (l < lEnd && r < rEnd) {
+        uint lci = lColIdx[l];
+        uint rci = rColIdx[r];
+        l += (lci <= rci);
+        r += (lci >= rci);
+        nnz++;
+    }
+    nnz += (lEnd-l);
+    nnz += (rEnd-r);
+
+    blkNnz[tid] = nnz;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (valid)
+        oRowIdx[row+1] = nnz;
+
+    for(uint s=get_local_size(0)/2; s>0; s>>=1) {
+        if (tid < s) {
+            blkNnz[tid] += blkNnz[tid + s];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (tid == 0) {
+        nnz = blkNnz[0];
+        atomic_add(nnzc, nnz);
+    }
+}

--- a/src/backend/opencl/sparse_arith.hpp
+++ b/src/backend/opencl/sparse_arith.hpp
@@ -25,6 +25,7 @@ template<typename T, af_op_t op>
 common::SparseArray<T> arithOpS(const common::SparseArray<T> &lhs, const Array<T> &rhs,
                                 const bool reverse = false);
 
+template<typename T, af_op_t op>
+common::SparseArray<T> arithOp(const common::SparseArray<T> &lhs,
+                               const common::SparseArray<T> &rhs);
 }
-
-

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,15 @@
 # The complete license agreement can be obtained at:
 # http://arrayfire.com/licenses/BSD-3-Clause
 
+set(AF_TEST_WITH_MTX_FILES
+    ON CACHE BOOL
+    "Download and run tests on large matrices form sparse.tamu.edu")
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
+if (AF_TEST_WITH_MTX_FILES)
+  include(download_sparse_datasets)
+endif ()
+
 if(NOT TARGET gtest)
   # gtest targets cmake version 2.6 which throws warnings for policy CMP0042 on
   # newer cmakes. This sets the default global setting for that policy.
@@ -27,6 +36,10 @@ if(NOT TARGET gtest)
     gtest_disable_pthreads
     gtest_force_shared_crt
     gtest_hide_internal_symbols)
+endif()
+
+if(AF_TEST_WITH_MTX_FILES AND NOT TARGET mmio)
+  add_subdirectory(mmio)
 endif()
 
 # Reset the CXX flags for tests
@@ -265,8 +278,10 @@ make_test(SRC solve_dense.cpp       CXX11 SERIAL)
 make_test(SRC sort.cpp)
 make_test(SRC sort_by_key.cpp)
 make_test(SRC sort_index.cpp)
-make_test(SRC sparse.cpp            SERIAL)
-make_test(SRC sparse_arith.cpp)
+make_test(SRC sparse.cpp            SERIAL
+          LIBRARIES mmio)
+make_test(SRC sparse_arith.cpp
+          LIBRARIES mmio)
 make_test(SRC sparse_convert.cpp)
 make_test(SRC stdev.cpp)
 make_test(SRC susan.cpp)
@@ -287,6 +302,9 @@ make_test(SRC wrap.cpp)
 make_test(SRC write.cpp)
 make_test(SRC ycbcr_rgb.cpp)
 
+if(AF_TEST_WITH_MTX_FILES)
+    make_test(SRC matrixmarket.cpp LIBRARIES mmio)
+endif()
 
 add_executable(print_info print_info.cpp)
 if(AF_BUILD_UNIFIED)

--- a/test/CMakeModules/download_sparse_datasets.cmake
+++ b/test/CMakeModules/download_sparse_datasets.cmake
@@ -1,0 +1,74 @@
+# Copyright (c) 2018, ArrayFire
+# All rights reserved.
+#
+# This file is distributed under 3-clause BSD license.
+# The complete license agreement can be obtained at:
+# http://arrayfire.com/licenses/BSD-3-Clause
+
+set(URL "https://sparse.tamu.edu")
+
+function(download_mtx name group)
+  set(file_name "${group}/${name}.tar.gz")
+  if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/matrixmarket/${file_name}")
+    file(DOWNLOAD
+        "${URL}/MM/${file_name}"
+        ${CMAKE_CURRENT_BINARY_DIR}/matrixmarket/${file_name}
+        INACTIVITY_TIMEOUT 600
+        SHOW_PROGRESS
+        STATUS out_status
+        TLS_VERIFY ON
+        )
+    list(GET out_status 0 error_code)
+    list(GET out_status 1 error_string)
+    if (${error_code} EQUAL 0)
+      message("Downloaded ${name} file from sparse.tamu.edu")
+      file(MAKE_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/data/matrixmarket/${group}")
+      execute_process(
+        COMMAND ${CMAKE_COMMAND} -E tar xzf "${CMAKE_CURRENT_BINARY_DIR}/matrixmarket/${file_name}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/data/matrixmarket/${group}"
+        )
+      message("Extracted mtx files to test data directory")
+    else ()
+      if (${error_code} EQUAL 503)
+          message(FATAL_ERROR "${URL} service unavailable")
+      elseif (${error_code} EQUAL 504)
+          message(FATAL_ERROR "Request to ${URL} timedout")
+      elseif (${error_code} EQUAL 521)
+        # CLOUDFLARE error code
+        message(FATAL_ERROR "Request to ${URL} has been refused")
+      elseif (${error_code} EQUAL 523)
+        # CLOUDFLARE error code
+        message(FATAL_ERROR "${URL} is unreachable")
+      else ()
+        message("Failed to download ${name} file from sparse.tamu.edu")
+        message("Failure message: ${error_string}")
+      endif ()
+      file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/matrixmarket/${file_name}")
+
+      #Force test with mtx files to be turned since one of the downloads failed
+      set(AF_TEST_WITH_MTX_FILES OFF)
+    endif ()
+  endif ()
+endfunction()
+
+# Following files are used for testing mtx read fn
+# integer data
+download_mtx("Trec4" "JGD_Kocay")
+# real data
+download_mtx("bcsstm02" "HB")
+# complex data
+download_mtx("young4c" "HB")
+
+#Following files are used for sparse-sparse arith
+# real data
+#linear programming problem
+download_mtx("lpi_vol1" "LPnetlib")
+download_mtx("lpi_qual" "LPnetlib")
+#Subsequent Circuit Simulation problem
+download_mtx("oscil_dcop_12" "Sandia")
+download_mtx("oscil_dcop_42" "Sandia")
+
+# complex data
+#Quantum Chemistry problem
+download_mtx("conf6_0-4x4-20" "QCD")
+download_mtx("conf6_0-4x4-30" "QCD")

--- a/test/matrixmarket.cpp
+++ b/test/matrixmarket.cpp
@@ -1,0 +1,32 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <gtest/gtest.h>
+#include <testHelpers.hpp>
+
+TEST(Sparse, ReadRealMTXFile)
+{
+    af::array out;
+    std::string file(TEST_DIR "/matrixmarket/HB/bcsstm02/bcsstm02.mtx");
+    ASSERT_TRUE(mtxReadSparseMatrix(out, file.c_str()));
+}
+
+TEST(Sparse, ReadComplexMTXFile)
+{
+    af::array out;
+    std::string file(TEST_DIR "/matrixmarket/HB/young4c/young4c.mtx");
+    ASSERT_TRUE(mtxReadSparseMatrix(out, file.c_str()));
+}
+
+TEST(Sparse, FailIntegerMTXRead)
+{
+    af::array out;
+    std::string file(TEST_DIR "/matrixmarket/JGD_Kocay/Trec4/Trec4.mtx");
+    ASSERT_FALSE(mtxReadSparseMatrix(out, file.c_str()));
+}

--- a/test/mmio/CMakeLists.txt
+++ b/test/mmio/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) 2018, ArrayFire
+# All rights reserved.
+#
+# This file is distributed under 3-clause BSD license.
+# The complete license agreement can be obtained at:
+# http://arrayfire.com/licenses/BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.5)
+
+project(MatrixMarketIO LANGUAGES C)
+
+add_library(mmio STATIC mmio.c)
+
+target_include_directories(mmio
+    PUBLIC
+      $<BUILD_INTERFACE:${MatrixMarketIO_SOURCE_DIR}>
+    )
+
+target_compile_definitions(mmio PUBLIC USE_MTX)

--- a/test/mmio/mmio.c
+++ b/test/mmio/mmio.c
@@ -1,0 +1,510 @@
+/*
+*   Matrix Market I/O library for ANSI C
+*
+*   See http://math.nist.gov/MatrixMarket for details.
+*
+*
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+
+#include "mmio.h"
+
+int mm_read_unsymmetric_sparse(const char *fname, int *M_, int *N_, int *nz_,
+                double **val_, int **I_, int **J_)
+{
+    FILE *f;
+    MM_typecode matcode;
+    int M, N, nz;
+    int i;
+    double *val;
+    int *I, *J;
+
+    if ((f = fopen(fname, "r")) == NULL)
+            return -1;
+
+
+    if (mm_read_banner(f, &matcode) != 0)
+    {
+        printf("mm_read_unsymetric: Could not process Matrix Market banner ");
+        printf(" in file [%s]\n", fname);
+        return -1;
+    }
+
+
+
+    if ( !(mm_is_real(matcode) && mm_is_matrix(matcode) &&
+            mm_is_sparse(matcode)))
+    {
+        fprintf(stderr, "Sorry, this application does not support ");
+        fprintf(stderr, "Market Market type: [%s]\n",
+                mm_typecode_to_str(matcode));
+        return -1;
+    }
+
+    /* find out size of sparse matrix: M, N, nz .... */
+
+    if (mm_read_mtx_crd_size(f, &M, &N, &nz) !=0)
+    {
+        fprintf(stderr, "read_unsymmetric_sparse(): could not parse matrix size.\n");
+        return -1;
+    }
+
+    *M_ = M;
+    *N_ = N;
+    *nz_ = nz;
+
+    /* reseve memory for matrices */
+
+    I = (int *) malloc(nz * sizeof(int));
+    J = (int *) malloc(nz * sizeof(int));
+    val = (double *) malloc(nz * sizeof(double));
+
+    *val_ = val;
+    *I_ = I;
+    *J_ = J;
+
+    /* NOTE: when reading in doubles, ANSI C requires the use of the "l"  */
+    /*   specifier as in "%lg", "%lf", "%le", otherwise errors will occur */
+    /*  (ANSI C X3.159-1989, Sec. 4.9.6.2, p. 136 lines 13-15)            */
+
+    for (i=0; i<nz; i++)
+    {
+        fscanf(f, "%d %d %lg\n", &I[i], &J[i], &val[i]);
+        I[i]--;  /* adjust from 1-based to 0-based */
+        J[i]--;
+    }
+    fclose(f);
+
+    return 0;
+}
+
+int mm_is_valid(MM_typecode matcode)
+{
+    if (!mm_is_matrix(matcode)) return 0;
+    if (mm_is_dense(matcode) && mm_is_pattern(matcode)) return 0;
+    if (mm_is_real(matcode) && mm_is_hermitian(matcode)) return 0;
+    if (mm_is_pattern(matcode) && (mm_is_hermitian(matcode) ||
+                mm_is_skew(matcode))) return 0;
+    return 1;
+}
+
+int mm_read_banner(FILE *f, MM_typecode *matcode)
+{
+    char line[MM_MAX_LINE_LENGTH];
+    char banner[MM_MAX_TOKEN_LENGTH];
+    char mtx[MM_MAX_TOKEN_LENGTH];
+    char crd[MM_MAX_TOKEN_LENGTH];
+    char data_type[MM_MAX_TOKEN_LENGTH];
+    char storage_scheme[MM_MAX_TOKEN_LENGTH];
+    char *p;
+
+
+    mm_clear_typecode(matcode);
+
+    if (fgets(line, MM_MAX_LINE_LENGTH, f) == NULL)
+        return MM_PREMATURE_EOF;
+
+    if (sscanf(line, "%s %s %s %s %s", banner, mtx, crd, data_type,
+        storage_scheme) != 5)
+        return MM_PREMATURE_EOF;
+
+    for (p=mtx; *p!='\0'; *p=tolower(*p),p++);  /* convert to lower case */
+    for (p=crd; *p!='\0'; *p=tolower(*p),p++);
+    for (p=data_type; *p!='\0'; *p=tolower(*p),p++);
+    for (p=storage_scheme; *p!='\0'; *p=tolower(*p),p++);
+
+    /* check for banner */
+    if (strncmp(banner, MatrixMarketBanner, strlen(MatrixMarketBanner)) != 0)
+        return MM_NO_HEADER;
+
+    /* first field should be "mtx" */
+    if (strcmp(mtx, MM_MTX_STR) != 0)
+        return  MM_UNSUPPORTED_TYPE;
+    mm_set_matrix(matcode);
+
+
+    /* second field describes whether this is a sparse matrix (in coordinate
+            storgae) or a dense array */
+
+
+    if (strcmp(crd, MM_SPARSE_STR) == 0)
+        mm_set_sparse(matcode);
+    else
+    if (strcmp(crd, MM_DENSE_STR) == 0)
+            mm_set_dense(matcode);
+    else
+        return MM_UNSUPPORTED_TYPE;
+
+
+    /* third field */
+
+    if (strcmp(data_type, MM_REAL_STR) == 0)
+        mm_set_real(matcode);
+    else
+    if (strcmp(data_type, MM_COMPLEX_STR) == 0)
+        mm_set_complex(matcode);
+    else
+    if (strcmp(data_type, MM_PATTERN_STR) == 0)
+        mm_set_pattern(matcode);
+    else
+    if (strcmp(data_type, MM_INT_STR) == 0)
+        mm_set_integer(matcode);
+    else
+        return MM_UNSUPPORTED_TYPE;
+
+
+    /* fourth field */
+
+    if (strcmp(storage_scheme, MM_GENERAL_STR) == 0)
+        mm_set_general(matcode);
+    else
+    if (strcmp(storage_scheme, MM_SYMM_STR) == 0)
+        mm_set_symmetric(matcode);
+    else
+    if (strcmp(storage_scheme, MM_HERM_STR) == 0)
+        mm_set_hermitian(matcode);
+    else
+    if (strcmp(storage_scheme, MM_SKEW_STR) == 0)
+        mm_set_skew(matcode);
+    else
+        return MM_UNSUPPORTED_TYPE;
+
+
+    return 0;
+}
+
+int mm_write_mtx_crd_size(FILE *f, int M, int N, int nz)
+{
+    if (fprintf(f, "%d %d %d\n", M, N, nz) != 3)
+        return MM_COULD_NOT_WRITE_FILE;
+    else
+        return 0;
+}
+
+int mm_read_mtx_crd_size(FILE *f, int *M, int *N, int *nz )
+{
+    char line[MM_MAX_LINE_LENGTH];
+    int num_items_read;
+
+    /* set return null parameter values, in case we exit with errors */
+    *M = *N = *nz = 0;
+
+    /* now continue scanning until you reach the end-of-comments */
+    do
+    {
+        if (fgets(line,MM_MAX_LINE_LENGTH,f) == NULL)
+            return MM_PREMATURE_EOF;
+    }while (line[0] == '%');
+
+    /* line[] is either blank or has M,N, nz */
+    if (sscanf(line, "%d %d %d", M, N, nz) == 3)
+        return 0;
+
+    else
+    do
+    {
+        num_items_read = fscanf(f, "%d %d %d", M, N, nz);
+        if (num_items_read == EOF) return MM_PREMATURE_EOF;
+    }
+    while (num_items_read != 3);
+
+    return 0;
+}
+
+
+int mm_read_mtx_array_size(FILE *f, int *M, int *N)
+{
+    char line[MM_MAX_LINE_LENGTH];
+    int num_items_read;
+    /* set return null parameter values, in case we exit with errors */
+    *M = *N = 0;
+
+    /* now continue scanning until you reach the end-of-comments */
+    do
+    {
+        if (fgets(line,MM_MAX_LINE_LENGTH,f) == NULL)
+            return MM_PREMATURE_EOF;
+    }while (line[0] == '%');
+
+    /* line[] is either blank or has M,N, nz */
+    if (sscanf(line, "%d %d", M, N) == 2)
+        return 0;
+
+    else /* we have a blank line */
+    do
+    {
+        num_items_read = fscanf(f, "%d %d", M, N);
+        if (num_items_read == EOF) return MM_PREMATURE_EOF;
+    }
+    while (num_items_read != 2);
+
+    return 0;
+}
+
+int mm_write_mtx_array_size(FILE *f, int M, int N)
+{
+    if (fprintf(f, "%d %d\n", M, N) != 2)
+        return MM_COULD_NOT_WRITE_FILE;
+    else
+        return 0;
+}
+
+
+
+/*-------------------------------------------------------------------------*/
+
+/******************************************************************/
+/* use when I[], J[], and val[]J, and val[] are already allocated */
+/******************************************************************/
+
+int mm_read_mtx_crd_data(FILE *f, int M, int N, int nz, int I[], int J[],
+        double val[], MM_typecode matcode)
+{
+    int i;
+    if (mm_is_complex(matcode))
+    {
+        for (i=0; i<nz; i++)
+            if (fscanf(f, "%d %d %lg %lg", &I[i], &J[i], &val[2*i], &val[2*i+1])
+                != 4) return MM_PREMATURE_EOF;
+    }
+    else if (mm_is_real(matcode))
+    {
+        for (i=0; i<nz; i++)
+        {
+            if (fscanf(f, "%d %d %lg\n", &I[i], &J[i], &val[i])
+                != 3) return MM_PREMATURE_EOF;
+
+        }
+    }
+
+    else if (mm_is_pattern(matcode))
+    {
+        for (i=0; i<nz; i++)
+            if (fscanf(f, "%d %d", &I[i], &J[i])
+                != 2) return MM_PREMATURE_EOF;
+    }
+    else
+        return MM_UNSUPPORTED_TYPE;
+
+    return 0;
+
+}
+
+int mm_read_mtx_crd_entry(FILE *f, int *I, int *J,
+        double *real, double *imag, MM_typecode matcode)
+{
+    if (mm_is_complex(matcode))
+    {
+            if (fscanf(f, "%d %d %lg %lg", I, J, real, imag)
+                != 4) return MM_PREMATURE_EOF;
+    }
+    else if (mm_is_real(matcode))
+    {
+            if (fscanf(f, "%d %d %lg\n", I, J, real)
+                != 3) return MM_PREMATURE_EOF;
+
+    }
+
+    else if (mm_is_pattern(matcode))
+    {
+            if (fscanf(f, "%d %d", I, J) != 2) return MM_PREMATURE_EOF;
+    }
+    else
+        return MM_UNSUPPORTED_TYPE;
+
+    return 0;
+
+}
+
+
+/************************************************************************
+    mm_read_mtx_crd()  fills M, N, nz, array of values, and return
+                        type code, e.g. 'MCRS'
+
+                        if matrix is complex, values[] is of size 2*nz,
+                            (nz pairs of real/imaginary values)
+************************************************************************/
+
+int mm_read_mtx_crd(char *fname, int *M, int *N, int *nz, int **I, int **J,
+        double **val, MM_typecode *matcode)
+{
+    int ret_code;
+    FILE *f;
+
+    if (strcmp(fname, "stdin") == 0) f=stdin;
+    else
+    if ((f = fopen(fname, "r")) == NULL)
+        return MM_COULD_NOT_READ_FILE;
+
+
+    if ((ret_code = mm_read_banner(f, matcode)) != 0)
+        return ret_code;
+
+    if (!(mm_is_valid(*matcode) && mm_is_sparse(*matcode) &&
+            mm_is_matrix(*matcode)))
+        return MM_UNSUPPORTED_TYPE;
+
+    if ((ret_code = mm_read_mtx_crd_size(f, M, N, nz)) != 0)
+        return ret_code;
+
+
+    *I = (int *)  malloc(*nz * sizeof(int));
+    *J = (int *)  malloc(*nz * sizeof(int));
+    *val = NULL;
+
+    if (mm_is_complex(*matcode))
+    {
+        *val = (double *) malloc(*nz * 2 * sizeof(double));
+        ret_code = mm_read_mtx_crd_data(f, *M, *N, *nz, *I, *J, *val,
+                *matcode);
+        if (ret_code != 0) return ret_code;
+    }
+    else if (mm_is_real(*matcode))
+    {
+        *val = (double *) malloc(*nz * sizeof(double));
+        ret_code = mm_read_mtx_crd_data(f, *M, *N, *nz, *I, *J, *val,
+                *matcode);
+        if (ret_code != 0) return ret_code;
+    }
+
+    else if (mm_is_pattern(*matcode))
+    {
+        ret_code = mm_read_mtx_crd_data(f, *M, *N, *nz, *I, *J, *val,
+                *matcode);
+        if (ret_code != 0) return ret_code;
+    }
+
+    if (f != stdin) fclose(f);
+    return 0;
+}
+
+int mm_write_banner(FILE *f, MM_typecode matcode)
+{
+    char *str = mm_typecode_to_str(matcode);
+    int ret_code;
+
+    ret_code = fprintf(f, "%s %s\n", MatrixMarketBanner, str);
+    free(str);
+    if (ret_code !=2 )
+        return MM_COULD_NOT_WRITE_FILE;
+    else
+        return 0;
+}
+
+int mm_write_mtx_crd(char fname[], int M, int N, int nz, int I[], int J[],
+        double val[], MM_typecode matcode)
+{
+    FILE *f;
+    int i;
+
+    if (strcmp(fname, "stdout") == 0)
+        f = stdout;
+    else
+    if ((f = fopen(fname, "w")) == NULL)
+        return MM_COULD_NOT_WRITE_FILE;
+
+    /* print banner followed by typecode */
+    fprintf(f, "%s ", MatrixMarketBanner);
+    fprintf(f, "%s\n", mm_typecode_to_str(matcode));
+
+    /* print matrix sizes and nonzeros */
+    fprintf(f, "%d %d %d\n", M, N, nz);
+
+    /* print values */
+    if (mm_is_pattern(matcode))
+        for (i=0; i<nz; i++)
+            fprintf(f, "%d %d\n", I[i], J[i]);
+    else
+    if (mm_is_real(matcode))
+        for (i=0; i<nz; i++)
+            fprintf(f, "%d %d %20.16g\n", I[i], J[i], val[i]);
+    else
+    if (mm_is_complex(matcode))
+        for (i=0; i<nz; i++)
+            fprintf(f, "%d %d %20.16g %20.16g\n", I[i], J[i], val[2*i],
+                        val[2*i+1]);
+    else
+    {
+        if (f != stdout) fclose(f);
+        return MM_UNSUPPORTED_TYPE;
+    }
+
+    if (f !=stdout) fclose(f);
+
+    return 0;
+}
+
+
+/**
+*  Create a new copy of a string s.  mm_strdup() is a common routine, but
+*  not part of ANSI C, so it is included here.  Used by mm_typecode_to_str().
+*
+*/
+char *mm_strdup(const char *s)
+{
+	int len = strlen(s);
+	char *s2 = (char *) malloc((len+1)*sizeof(char));
+	return strcpy(s2, s);
+}
+
+char  *mm_typecode_to_str(MM_typecode matcode)
+{
+    char buffer[MM_MAX_LINE_LENGTH];
+    char *types[4];
+	char *mm_strdup(const char *);
+    int error =0;
+
+    /* check for MTX type */
+    if (mm_is_matrix(matcode))
+        types[0] = MM_MTX_STR;
+    else
+        error=1;
+
+    /* check for CRD or ARR matrix */
+    if (mm_is_sparse(matcode))
+        types[1] = MM_SPARSE_STR;
+    else
+    if (mm_is_dense(matcode))
+        types[1] = MM_DENSE_STR;
+    else
+        return NULL;
+
+    /* check for element data type */
+    if (mm_is_real(matcode))
+        types[2] = MM_REAL_STR;
+    else
+    if (mm_is_complex(matcode))
+        types[2] = MM_COMPLEX_STR;
+    else
+    if (mm_is_pattern(matcode))
+        types[2] = MM_PATTERN_STR;
+    else
+    if (mm_is_integer(matcode))
+        types[2] = MM_INT_STR;
+    else
+        return NULL;
+
+
+    /* check for symmetry type */
+    if (mm_is_general(matcode))
+        types[3] = MM_GENERAL_STR;
+    else
+    if (mm_is_symmetric(matcode))
+        types[3] = MM_SYMM_STR;
+    else
+    if (mm_is_hermitian(matcode))
+        types[3] = MM_HERM_STR;
+    else
+    if (mm_is_skew(matcode))
+        types[3] = MM_SKEW_STR;
+    else
+        return NULL;
+
+    sprintf(buffer,"%s %s %s %s", types[0], types[1], types[2], types[3]);
+    return mm_strdup(buffer);
+
+}

--- a/test/mmio/mmio.h
+++ b/test/mmio/mmio.h
@@ -1,0 +1,139 @@
+/*
+*   Matrix Market I/O library for ANSI C
+*
+*   See http://math.nist.gov/MatrixMarket for details.
+*
+*
+*/
+
+#ifndef MM_IO_H
+#define MM_IO_H
+
+#define MM_MAX_LINE_LENGTH 1025
+#define MatrixMarketBanner "%%MatrixMarket"
+#define MM_MAX_TOKEN_LENGTH 64
+
+typedef char MM_typecode[4];
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+char *mm_typecode_to_str(MM_typecode matcode);
+
+int mm_read_banner(FILE *f, MM_typecode *matcode);
+int mm_read_mtx_crd_size(FILE *f, int *M, int *N, int *nz);
+int mm_read_mtx_array_size(FILE *f, int *M, int *N);
+
+int mm_write_banner(FILE *f, MM_typecode matcode);
+int mm_write_mtx_crd_size(FILE *f, int M, int N, int nz);
+int mm_write_mtx_array_size(FILE *f, int M, int N);
+
+
+/********************* MM_typecode query fucntions ***************************/
+
+#define mm_is_matrix(typecode)	((typecode)[0]=='M')
+
+#define mm_is_sparse(typecode)	((typecode)[1]=='C')
+#define mm_is_coordinate(typecode)((typecode)[1]=='C')
+#define mm_is_dense(typecode)	((typecode)[1]=='A')
+#define mm_is_array(typecode)	((typecode)[1]=='A')
+
+#define mm_is_complex(typecode)	((typecode)[2]=='C')
+#define mm_is_real(typecode)		((typecode)[2]=='R')
+#define mm_is_pattern(typecode)	((typecode)[2]=='P')
+#define mm_is_integer(typecode) ((typecode)[2]=='I')
+
+#define mm_is_symmetric(typecode)((typecode)[3]=='S')
+#define mm_is_general(typecode)	((typecode)[3]=='G')
+#define mm_is_skew(typecode)	((typecode)[3]=='K')
+#define mm_is_hermitian(typecode)((typecode)[3]=='H')
+
+int mm_is_valid(MM_typecode matcode);		/* too complex for a macro */
+
+
+/********************* MM_typecode modify fucntions ***************************/
+
+#define mm_set_matrix(typecode)	((*typecode)[0]='M')
+#define mm_set_coordinate(typecode)	((*typecode)[1]='C')
+#define mm_set_array(typecode)	((*typecode)[1]='A')
+#define mm_set_dense(typecode)	mm_set_array(typecode)
+#define mm_set_sparse(typecode)	mm_set_coordinate(typecode)
+
+#define mm_set_complex(typecode)((*typecode)[2]='C')
+#define mm_set_real(typecode)	((*typecode)[2]='R')
+#define mm_set_pattern(typecode)((*typecode)[2]='P')
+#define mm_set_integer(typecode)((*typecode)[2]='I')
+
+
+#define mm_set_symmetric(typecode)((*typecode)[3]='S')
+#define mm_set_general(typecode)((*typecode)[3]='G')
+#define mm_set_skew(typecode)	((*typecode)[3]='K')
+#define mm_set_hermitian(typecode)((*typecode)[3]='H')
+
+#define mm_clear_typecode(typecode) ((*typecode)[0]=(*typecode)[1]= \
+									(*typecode)[2]=' ',(*typecode)[3]='G')
+
+#define mm_initialize_typecode(typecode) mm_clear_typecode(typecode)
+
+
+/********************* Matrix Market error codes ***************************/
+
+
+#define MM_COULD_NOT_READ_FILE	11
+#define MM_PREMATURE_EOF		12
+#define MM_NOT_MTX				13
+#define MM_NO_HEADER			14
+#define MM_UNSUPPORTED_TYPE		15
+#define MM_LINE_TOO_LONG		16
+#define MM_COULD_NOT_WRITE_FILE	17
+
+
+/******************** Matrix Market internal definitions ********************
+
+   MM_matrix_typecode: 4-character sequence
+
+				    ojbect 		sparse/   	data        storage
+						  		dense     	type        scheme
+
+   string position:	 [0]        [1]			[2]         [3]
+
+   Matrix typecode:  M(atrix)  C(oord)		R(eal)   	G(eneral)
+						        A(array)	C(omplex)   H(ermitian)
+											P(attern)   S(ymmetric)
+								    		I(nteger)	K(kew)
+
+ ***********************************************************************/
+
+#define MM_MTX_STR		"matrix"
+#define MM_ARRAY_STR	"array"
+#define MM_DENSE_STR	"array"
+#define MM_COORDINATE_STR "coordinate"
+#define MM_SPARSE_STR	"coordinate"
+#define MM_COMPLEX_STR	"complex"
+#define MM_REAL_STR		"real"
+#define MM_INT_STR		"integer"
+#define MM_GENERAL_STR  "general"
+#define MM_SYMM_STR		"symmetric"
+#define MM_HERM_STR		"hermitian"
+#define MM_SKEW_STR		"skew-symmetric"
+#define MM_PATTERN_STR  "pattern"
+
+
+/*  high level routines */
+
+int mm_write_mtx_crd(char fname[], int M, int N, int nz, int I[], int J[],
+		 double val[], MM_typecode matcode);
+int mm_read_mtx_crd_data(FILE *f, int M, int N, int nz, int I[], int J[],
+		double val[], MM_typecode matcode);
+int mm_read_mtx_crd_entry(FILE *f, int *I, int *J, double *real, double *img,
+			MM_typecode matcode);
+
+int mm_read_unsymmetric_sparse(const char *fname, int *M_, int *N_, int *nz_,
+                double **val_, int **I_, int **J_);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
* CPU backend:
    - Use mkl sparse-sparse add/sub when available
    - Fallback cpu implementation: has support for mul and div too

* CUDA backend sparse-sparse add/sub
* OpenCL backend sparse-sparse add/sub/div/mul

The output of sub/div/mul is not guaranteed to have only
non-zero results of the arithmetic operation. The user has
to take care of pruning the zero results from the output.

Support for div/mul isn't exposed to the user yet as it is not uniform across all backends or even within CPU backend at the moment.

Also moved mkl interface defs in CPU backend into single source file