### PR TITLE
Use sizeof(Param<T>) to determine JIT eval. Add NodeIterator

### DIFF
--- a/src/backend/common/CMakeLists.txt
+++ b/src/backend/common/CMakeLists.txt
@@ -19,6 +19,7 @@ target_sources(afcommon_interface
     ${CMAKE_CURRENT_SOURCE_DIR}/MatrixAlgebraHandle.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/MemoryManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/MersenneTwister.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/NodeIterator.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SparseArray.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SparseArray.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/blas_headers.hpp

--- a/src/backend/common/NodeIterator.hpp
+++ b/src/backend/common/NodeIterator.hpp
@@ -1,0 +1,107 @@
+/*******************************************************
+ * Copyright (c) 2018, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+#include <JIT/Node.hpp>
+#include <backend.hpp>
+
+#include <cstddef>
+#include <iterator>
+#include <vector>
+
+namespace common {
+  // TODO: unify all definitions of MAX_CHILDREN
+  constexpr int MAX_CHILDREN = 3;
+
+/// A node iterator that performs a breadth first traversal of the node tree
+class NodeIterator : public std::iterator<std::input_iterator_tag, detail::JIT::Node> {
+    std::vector<pointer> tree;
+    int index;
+
+    /// Copies the children of the \p n Node to the end of the tree vector
+    void copy_children_to_end(detail::JIT::Node* n) {
+        for(int i = 0; n->m_children[i] != nullptr && i < MAX_CHILDREN; i++) {
+            auto ptr = n->m_children[i].get();
+            if(find(begin(tree), end(tree), ptr) == end(tree)) {
+                tree.push_back(ptr);
+            }
+        }
+    }
+
+  public:
+    using pointer   = detail::JIT::Node*;
+    using reference = detail::JIT::Node&;
+
+    /// NodeIterator Constructor
+    ///
+    /// \param[in] root The root node of the tree
+    NodeIterator(pointer root) : tree{root}, index(0) {
+        tree.reserve(root->getHeight()*8);
+    }
+
+    /// The equality operator
+    ///
+    /// \param[in] other the rhs of the node
+    bool operator==(const NodeIterator& other) const noexcept {
+        // If the tree vector is empty in the other iterator then this means that the other
+        // iterator is a sentinel(end) node.
+        if(other.tree.empty()) {
+            // If the index is the same as the tree size then the index is past the
+            // end of the tree
+            return index == tree.size();
+        }
+        return index == other.index && tree == other.tree;
+    }
+
+    bool operator!=(const NodeIterator& other) const noexcept {
+        return !operator==(other);
+    }
+
+    /// Advances the iterator by one node in the tree
+    NodeIterator& operator++() noexcept {
+        if(index < tree.size()) {
+            copy_children_to_end(tree[index]);
+        }
+        index++;
+        return *this;
+    }
+
+    /// @copydoc operator++()
+    NodeIterator operator++(int) noexcept {
+        NodeIterator before(*this);
+        operator++();
+        return before;
+    }
+
+    /// Advances the iterator by count nodes
+    NodeIterator& operator+=(std::size_t count) noexcept {
+        while (count-- > 0) {
+            operator++();
+        }
+        return *this;
+    }
+
+    reference operator*() const noexcept {
+        return *tree[index];
+    }
+
+    pointer operator->() const noexcept {
+        return tree[index];
+    }
+
+    /// Creates a sentinel iterator. This is equivalent to the end iterator
+    NodeIterator() = default;
+    NodeIterator(const NodeIterator& other) = default;
+    NodeIterator(NodeIterator&& other) noexcept = default;
+    ~NodeIterator() noexcept = default;
+    NodeIterator& operator=(const NodeIterator& other) noexcept = default;
+    NodeIterator& operator=(NodeIterator&& other) noexcept = default;
+};
+
+}

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -394,6 +394,7 @@ cuda_add_library(afcuda
     JIT/BinaryNode.hpp
     JIT/BufferNode.hpp
     JIT/Node.hpp
+    JIT/Node.cpp
     JIT/ScalarNode.hpp
     JIT/UnaryNode.hpp
     JIT/NaryNode.hpp

--- a/src/backend/cuda/JIT/BufferNode.hpp
+++ b/src/backend/cuda/JIT/BufferNode.hpp
@@ -38,7 +38,7 @@ namespace JIT
         {
         }
 
-        bool isBuffer() { return true; }
+        bool isBuffer() const final { return true; }
 
         void setData(Param<T> param, std::shared_ptr<T> data, const unsigned bytes, bool is_linear)
         {
@@ -50,7 +50,7 @@ namespace JIT
                 });
         }
 
-        bool isLinear(dim_t dims[4])
+        bool isLinear(dim_t dims[4]) const final
         {
             bool same_dims = true;
             for (int i = 0; same_dims && i < 4; i++) {
@@ -59,13 +59,13 @@ namespace JIT
             return m_linear_buffer && same_dims;
         }
 
-        void genKerName(std::stringstream &kerStream, Node_ids ids)
+        void genKerName(std::stringstream &kerStream, Node_ids ids) const final
         {
             kerStream << "_" << m_name_str;
             kerStream << std::setw(3) << std::setfill('0') << std::dec << ids.id << std::dec;
         }
 
-        void genParams(std::stringstream &kerStream, int id, bool is_linear)
+        void genParams(std::stringstream &kerStream, int id, bool is_linear) const final
         {
             if (is_linear) {
                 kerStream << m_type_str << " *in" << id << "_ptr,\n";
@@ -75,7 +75,7 @@ namespace JIT
             }
         }
 
-        void setArgs(std::vector<void *> &args, bool is_linear)
+        void setArgs(std::vector<void *> &args, bool is_linear) const final
         {
             if (is_linear) {
                 args.push_back((void *)&m_param.ptr);
@@ -84,7 +84,7 @@ namespace JIT
             }
         }
 
-        void genOffsets(std::stringstream &kerStream, int id, bool is_linear)
+        void genOffsets(std::stringstream &kerStream, int id, bool is_linear) const final
         {
             std::string idx_str = std::string("int idx") + std::to_string(id);
 
@@ -106,21 +106,33 @@ namespace JIT
             }
         }
 
-        void genFuncs(std::stringstream &kerStream, Node_ids ids)
+        void genFuncs(std::stringstream &kerStream, Node_ids ids) const final
         {
             kerStream << m_type_str << " val" << ids.id << " = "
                       << "in" << ids.id << "_ptr[idx" << ids.id << "];"
                       << "\n";
         }
 
-        void getInfo(unsigned &len, unsigned &buf_count, unsigned &bytes)
+        void getInfo(unsigned &len, unsigned &buf_count, unsigned &bytes) const final
         {
             len++;
             buf_count++;
             bytes += m_bytes;
             return;
         }
+
+        // Return the size of the size of the buffer node in bytes. Zero otherwise
+        virtual size_t getBytes() const final {
+            return m_bytes;
+        }
+
+        // Return the size of the parameter in bytes that will be passed to the
+        // kernel
+        virtual short getParamBytes() const final {
+            return m_linear_buffer ? sizeof(T*) : sizeof(Param<T>);
+        }
     };
+
 
 }
 

--- a/src/backend/cuda/JIT/NaryNode.hpp
+++ b/src/backend/cuda/JIT/NaryNode.hpp
@@ -37,7 +37,8 @@ namespace JIT
               m_op_str(op_str)
         {
         }
-        void genKerName(std::stringstream &kerStream, Node_ids ids)
+
+        void genKerName(std::stringstream &kerStream, Node_ids ids) const final
         {
             // Make the dec representation of enum part of the Kernel name
             kerStream << "_" << std::setw(3) << std::setfill('0') << std::dec << m_op;
@@ -50,7 +51,7 @@ namespace JIT
             kerStream << std::setw(3) << std::setfill('0') << std::dec << ids.id << std::dec;
         }
 
-        void genFuncs(std::stringstream &kerStream, Node_ids ids)
+        void genFuncs(std::stringstream &kerStream, Node_ids ids) const final
         {
             kerStream << m_type_str << " val" << ids.id << " = " << m_op_str << "(";
             for (int i = 0; i < m_num_children; i++) {

--- a/src/backend/cuda/JIT/Node.cpp
+++ b/src/backend/cuda/JIT/Node.cpp
@@ -1,0 +1,40 @@
+/*******************************************************
+ * Copyright (c) 2018, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Node.hpp>
+
+#include <string>
+#include <vector>
+using namespace std;
+
+namespace cuda {
+namespace JIT {
+
+  int Node::getNodesMap(Node_map_t &node_map,
+                vector<const Node *> &full_nodes,
+                vector<Node_ids> &full_ids) const {
+    auto iter = node_map.find(this);
+    if (iter == node_map.end()) {
+        Node_ids ids;
+
+        for (int i = 0; i < MAX_CHILDREN && m_children[i] != nullptr; i++) {
+            ids.child_ids[i] = m_children[i]->getNodesMap(node_map, full_nodes,
+                                                          full_ids);
+        }
+        ids.id = node_map.size();
+        node_map[this] = ids.id;
+        full_nodes.push_back(this);
+        full_ids.push_back(ids);
+        return ids.id;
+    }
+    return iter->second;
+}
+
+  }
+}

--- a/src/backend/cuda/JIT/Node.hpp
+++ b/src/backend/cuda/JIT/Node.hpp
@@ -16,17 +16,20 @@
 #include <memory>
 #include <unordered_map>
 
+namespace common {
+    class NodeIterator;
+}
+using std::shared_ptr;
+using std::vector;
+
 namespace cuda
 {
 
 namespace JIT
 {
 
-    static const int MAX_CHILDREN = 3;
+    constexpr int MAX_CHILDREN = 3;
     class Node;
-    using std::shared_ptr;
-    using std::vector;
-    typedef shared_ptr<Node> Node_ptr;
 
     typedef struct
     {
@@ -34,63 +37,56 @@ namespace JIT
         std::array<int, MAX_CHILDREN> child_ids;
     } Node_ids;
 
-    typedef std::unordered_map<Node *, int> Node_map_t;
-    typedef Node_map_t::iterator Node_map_iter;
+    using Node_ptr = shared_ptr<Node>;
+    using Node_map_t = std::unordered_map<const Node *, int> ;
+    using Node_map_iter = Node_map_t::iterator;
 
     class Node
     {
     protected:
-        const int m_height;
         const std::string m_type_str;
         const std::string m_name_str;
         const std::array<Node_ptr, MAX_CHILDREN> m_children;
+        const int m_height;
+        friend class common::NodeIterator;
 
     public:
 
         Node(const char *type_str, const char *name_str, const int height,
              const std::array<Node_ptr, MAX_CHILDREN> children)
-            : m_height(height),
-              m_type_str(type_str),
+            : m_type_str(type_str),
               m_name_str(name_str),
-              m_children(children)
-        {}
+              m_children(children),
+              m_height(height) {}
 
         int getNodesMap(Node_map_t &node_map,
-                        vector<Node *> &full_nodes,
-                        vector<Node_ids> &full_ids)
-        {
-            auto iter = node_map.find(this);
-            if (iter == node_map.end()) {
-                Node_ids ids;
-                for (int i = 0; i < MAX_CHILDREN && m_children[i] != nullptr; i++) {
-                    ids.child_ids[i] = m_children[i]->getNodesMap(node_map, full_nodes, full_ids);
-                }
-                ids.id = node_map.size();
-                node_map[this] = ids.id;
-                full_nodes.push_back(this);
-                full_ids.push_back(ids);
-                return ids.id;
-            }
-            return iter->second;
-        }
+                        vector<const Node *> &full_nodes,
+                        vector<Node_ids> &full_ids) const;
 
-        virtual void genKerName (std::stringstream &kerStream, Node_ids ids) {}
-        virtual void genParams  (std::stringstream &kerStream, int id, bool is_linear) {}
-        virtual void genOffsets (std::stringstream &kerStream, int id, bool is_linear) {}
-        virtual void genFuncs   (std::stringstream &kerStream, Node_ids) {}
+        virtual void genKerName (std::stringstream &kerStream, Node_ids ids) const {}
+        virtual void genParams  (std::stringstream &kerStream, int id, bool is_linear) const {}
+        virtual void genOffsets (std::stringstream &kerStream, int id, bool is_linear) const {}
+        virtual void genFuncs   (std::stringstream &kerStream, Node_ids) const {}
 
-        virtual void setArgs (std::vector<void *> &args, bool is_linear) { }
+        virtual void setArgs (std::vector<void *> &args, bool is_linear) const { }
 
-        virtual void getInfo(unsigned &len, unsigned &buf_count, unsigned &bytes)
-        {
+        virtual void getInfo(unsigned &len, unsigned &buf_count, unsigned &bytes) const {
             len++;
         }
 
-        virtual bool isBuffer() { return false; }
-        virtual bool isLinear(dim_t dims[4]) { return true; }
-        std::string getTypeStr() { return m_type_str; }
-        int getHeight()  { return m_height; }
-        std::string getNameStr() { return m_name_str; }
+        // Return the size of the parameter in bytes that will be passed to the
+        // kernel
+        virtual short getParamBytes() const {
+            return 0;
+        }
+
+        // Return the size of the size of the buffer node in bytes. Zero otherwise
+        virtual size_t getBytes() const { return 0; }
+        virtual bool isBuffer() const { return false; }
+        virtual bool isLinear(dim_t dims[4]) const { return true; }
+        std::string getTypeStr() const { return m_type_str; }
+        int getHeight()  const { return m_height; }
+        std::string getNameStr() const { return m_name_str; }
 
         virtual ~Node() {}
     };

--- a/src/backend/cuda/JIT/ScalarNode.hpp
+++ b/src/backend/cuda/JIT/ScalarNode.hpp
@@ -33,28 +33,31 @@ namespace JIT
         {
         }
 
-        void genKerName(std::stringstream &kerStream, Node_ids ids)
+        void genKerName(std::stringstream &kerStream, Node_ids ids) const final
         {
             kerStream << "_" << m_name_str;
             kerStream << std::setw(3) << std::setfill('0') << std::dec << ids.id << std::dec;
         }
 
-        void genParams(std::stringstream &kerStream, int id, bool is_linear)
+        void genParams(std::stringstream &kerStream, int id, bool is_linear) const final
         {
             kerStream << m_type_str << " scalar" << id << ", " << "\n";
         }
 
-        void setArgs(std::vector<void *> &args, bool is_linear)
+        void setArgs(std::vector<void *> &args, bool is_linear) const final
         {
             args.push_back((void *)&m_val);
         }
 
-        void genFuncs(std::stringstream &kerStream, Node_ids ids)
+        void genFuncs(std::stringstream &kerStream, Node_ids ids) const final
         {
             kerStream << m_type_str << " val" << ids.id << " = "
                       << "scalar" << ids.id << ";"
                       << "\n";
         }
+
+        // Return the info for the params and the size of the buffers
+        virtual short getParamBytes() const final { return static_cast<short>(sizeof(T)); }
     };
 
 }

--- a/src/backend/cuda/JIT/ShiftNode.hpp
+++ b/src/backend/cuda/JIT/ShiftNode.hpp
@@ -38,26 +38,24 @@ namespace JIT
         {
         }
 
-        bool isBuffer() { return false; }
-
         void setData(Param<T> param, std::shared_ptr<T> data, const unsigned bytes, bool is_linear)
         {
             auto node_ptr = m_buffer_node.get();
             dynamic_cast<BufferNode<T> *>(node_ptr)->setData(param, data, bytes, is_linear);
         }
 
-        bool isLinear(dim_t dims[4])
+        bool isLinear(dim_t dims[4]) const final
         {
             return false;
         }
 
-        void genKerName(std::stringstream &kerStream, Node_ids ids)
+        void genKerName(std::stringstream &kerStream, Node_ids ids) const final
         {
             kerStream << "_" << m_name_str;
             kerStream << std::setw(3) << std::setfill('0') << std::dec << ids.id << std::dec;
         }
 
-        void genParams(std::stringstream &kerStream, int id, bool is_linear)
+        void genParams(std::stringstream &kerStream, int id, bool is_linear) const final
         {
             auto node_ptr = m_buffer_node.get();
             dynamic_cast<BufferNode<T> *>(node_ptr)->genParams(kerStream, id, is_linear);
@@ -66,7 +64,7 @@ namespace JIT
             }
         }
 
-        void setArgs(std::vector<void *> &args, bool is_linear)
+        void setArgs(std::vector<void *> &args, bool is_linear) const final
         {
             auto node_ptr = m_buffer_node.get();
             dynamic_cast<BufferNode<T> *>(node_ptr)->setArgs(args, is_linear);
@@ -76,7 +74,7 @@ namespace JIT
             }
         }
 
-        void genOffsets(std::stringstream &kerStream, int id, bool is_linear)
+        void genOffsets(std::stringstream &kerStream, int id, bool is_linear) const final
         {
             std::string idx_str = std::string("idx") + std::to_string(id);
             std::string info_str = std::string("in") + std::to_string(id);
@@ -107,14 +105,14 @@ namespace JIT
             kerStream << m_type_str << " *in" << id << "_ptr = in" << id << ".ptr;\n";
         }
 
-        void genFuncs(std::stringstream &kerStream, Node_ids ids)
+        void genFuncs(std::stringstream &kerStream, Node_ids ids) const final
         {
             kerStream << m_type_str << " val" << ids.id << " = "
                       << "in" << ids.id << "_ptr[idx" << ids.id << "];"
                       << "\n";
         }
 
-        void getInfo(unsigned &len, unsigned &buf_count, unsigned &bytes)
+        void getInfo(unsigned &len, unsigned &buf_count, unsigned &bytes) const final
         {
             auto node_ptr = m_buffer_node.get();
             dynamic_cast<BufferNode<T> *>(node_ptr)->getInfo(len, buf_count, bytes);

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -48,7 +48,7 @@ using std::unique_ptr;
 using std::vector;
 
 static string getFuncName(const vector<Node *> &output_nodes,
-                          const vector<Node *> &full_nodes,
+                          const vector<const Node *> &full_nodes,
                           const vector<Node_ids> &full_ids,
                           bool is_linear)
 {
@@ -74,7 +74,7 @@ static string getFuncName(const vector<Node *> &output_nodes,
 }
 
 static string getKernelString(const string funcName,
-                              const vector<Node *> &full_nodes,
+                              const vector<const Node *> &full_nodes,
                               const vector<Node_ids> &full_ids,
                               const vector<int> &output_ids,
                               bool is_linear)
@@ -333,7 +333,7 @@ static kc_entry_t compileKernel(const char *ker_name, string jit_ker)
     CU_LINK_CHECK(cuLinkAddData(linkState, CU_JIT_INPUT_PTX, (void*)ptx.data(),
                                 ptx.size(), ker_name, 0, NULL, NULL));
 
-    void *cubin;
+    void *cubin = nullptr;
     size_t cubinSize;
 
     CUmodule module;
@@ -348,7 +348,7 @@ static kc_entry_t compileKernel(const char *ker_name, string jit_ker)
 
 static CUfunction getKernel(const vector<Node *> &output_nodes,
                             const vector<int> &output_ids,
-                            const vector<Node *> &full_nodes,
+                            const vector<const Node *> &full_nodes,
                             const vector<Node_ids> &full_ids,
                             const bool is_linear)
 {
@@ -383,7 +383,7 @@ void evalNodes(vector<Param<T>>& outputs, vector<Node *> output_nodes)
 
     // Use thread local to reuse the memory every time you are here.
     thread_local Node_map_t nodes;
-    thread_local vector<Node *> full_nodes;
+    thread_local vector<const Node *> full_nodes;
     thread_local vector<Node_ids> full_ids;
     thread_local vector<int> output_ids;
 

--- a/src/backend/opencl/JIT/NaryNode.hpp
+++ b/src/backend/opencl/JIT/NaryNode.hpp
@@ -10,6 +10,7 @@
 #pragma once
 #include "Node.hpp"
 #include <iomanip>
+#include <utility>
 
 namespace opencl
 {
@@ -29,15 +30,16 @@ namespace JIT
                  const char *name_str,
                  const char *op_str,
                  const int num_children,
-                 const std::array<Node_ptr, MAX_CHILDREN> &children,
+                 const std::array<Node_ptr, MAX_CHILDREN>&& children,
                  const int op, const int height)
-            : Node(out_type_str, name_str, height, children),
+          : Node(out_type_str, name_str, height,
+                 std::forward<const std::array<Node_ptr, MAX_CHILDREN>>(children)),
               m_num_children(num_children),
               m_op(op),
               m_op_str(op_str)
         {
         }
-        void genKerName(std::stringstream &kerStream, Node_ids ids)
+        void genKerName(std::stringstream &kerStream, Node_ids ids) const final
         {
             // Make the dec representation of enum part of the Kernel name
             kerStream << "_" << std::setw(3) << std::setfill('0') << std::dec << m_op;
@@ -50,7 +52,7 @@ namespace JIT
             kerStream << std::setw(3) << std::setfill('0') << std::dec << ids.id << std::dec;
         }
 
-        void genFuncs(std::stringstream &kerStream, Node_ids ids)
+        void genFuncs(std::stringstream &kerStream, Node_ids ids) const final
         {
             kerStream << m_type_str << " val" << ids.id << " = " << m_op_str << "(";
             for (int i = 0; i < m_num_children; i++) {

--- a/src/backend/opencl/JIT/Node.hpp
+++ b/src/backend/opencl/JIT/Node.hpp
@@ -16,17 +16,21 @@
 #include <memory>
 #include <unordered_map>
 
+using std::shared_ptr;
+using std::vector;
+
+namespace common {
+    class NodeIterator;
+}
+
 namespace opencl
 {
 
 namespace JIT
 {
 
-    static const int MAX_CHILDREN = 3;
+    constexpr int MAX_CHILDREN = 3;
     class Node;
-    using std::shared_ptr;
-    using std::vector;
-    typedef shared_ptr<Node> Node_ptr;
 
     typedef struct
     {
@@ -34,8 +38,9 @@ namespace JIT
         std::array<int, MAX_CHILDREN> child_ids;
     } Node_ids;
 
-    typedef std::unordered_map<Node *, int> Node_map_t;
-    typedef Node_map_t::iterator Node_map_iter;
+    using Node_ptr = shared_ptr<Node>;
+    using Node_map_t = std::unordered_map<const Node *, int>;
+    using Node_map_iter = Node_map_t::iterator;
 
     class Node
     {
@@ -44,11 +49,14 @@ namespace JIT
         const std::string m_name_str;
         const int m_height;
         const std::array<Node_ptr, MAX_CHILDREN> m_children;
+        friend common::NodeIterator;
 
     public:
 
+        virtual bool isBuffer() const { return false; }
+
         Node(const char *type_str, const char *name_str, const int height,
-             const std::array<Node_ptr, MAX_CHILDREN> children)
+             const std::array<Node_ptr, MAX_CHILDREN>&& children)
             : m_type_str(type_str),
               m_name_str(name_str),
               m_height(height),
@@ -56,8 +64,8 @@ namespace JIT
         {}
 
         int getNodesMap(Node_map_t &node_map,
-                        vector<Node *> &full_nodes,
-                        vector<Node_ids> &full_ids)
+                        vector<const Node *> &full_nodes,
+                        vector<Node_ids> &full_ids) const
         {
             auto iter = node_map.find(this);
             if (iter == node_map.end()) {
@@ -74,25 +82,35 @@ namespace JIT
             return iter->second;
         }
 
-        virtual void genKerName(std::stringstream &kerStream, Node_ids ids) {}
-        virtual void genParams  (std::stringstream &kerStream, int id, bool is_linear) {}
-        virtual void genOffsets (std::stringstream &kerStream, int id, bool is_linear) {}
-        virtual void genFuncs   (std::stringstream &kerStream, Node_ids) {}
+        virtual void genKerName(std::stringstream &kerStream, Node_ids ids) const {}
+        virtual void genParams  (std::stringstream &kerStream, int id, bool is_linear) const {}
+        virtual void genOffsets (std::stringstream &kerStream, int id, bool is_linear) const {}
+        virtual void genFuncs   (std::stringstream &kerStream, Node_ids) const {}
 
-        virtual int setArgs (cl::Kernel &ker, int id, bool is_linear) { return id; }
+        virtual int setArgs (cl::Kernel &ker, int id, bool is_linear) const { return id; }
 
-        virtual void getInfo(unsigned &len, unsigned &buf_count, unsigned &bytes)
+        virtual void getInfo(unsigned &len, unsigned &buf_count, unsigned &bytes) const
         {
             len++;
         }
 
-        virtual bool isBuffer() { return false; }
-        virtual bool isLinear(dim_t dims[4]) { return true; }
-        std::string getTypeStr() { return m_type_str; }
-        int getHeight()  { return m_height; }
-        std::string getNameStr() { return m_name_str; }
+        // Return the size of the parameter in bytes that will be passed to the
+        // kernel
+        virtual short getParamBytes() const {
+            return 0;
+        }
+
+        virtual bool isLinear(dim_t dims[4]) const { return true; }
+        std::string getTypeStr() const { return m_type_str; }
+        int getHeight() const  { return m_height; }
+        virtual size_t getBytes() const { return 0; }
+        std::string getNameStr() const { return m_name_str; }
 
         virtual ~Node() {}
+        Node(const Node& other) = delete;
+        Node(const Node&& other) = delete;
+        Node& operator=(const Node& other) = delete;
+        Node& operator=(const Node&& other) = delete;
     };
 }
 

--- a/src/backend/opencl/JIT/ScalarNode.hpp
+++ b/src/backend/opencl/JIT/ScalarNode.hpp
@@ -33,29 +33,32 @@ namespace JIT
         {
         }
 
-        void genKerName(std::stringstream &kerStream, Node_ids ids)
+        void genKerName(std::stringstream &kerStream, Node_ids ids) const final
         {
             kerStream << "_" << m_name_str;
             kerStream << std::setw(3) << std::setfill('0') << std::dec << ids.id << std::dec;
         }
 
-        void genParams(std::stringstream &kerStream, int id, bool is_linear)
+        void genParams(std::stringstream &kerStream, int id, bool is_linear) const final
         {
             kerStream << m_type_str << " scalar" << id << ", " << "\n";
         }
 
-        int setArgs(cl::Kernel &ker, int id, bool is_linear)
+        int setArgs(cl::Kernel &ker, int id, bool is_linear) const final
         {
             ker.setArg(id, m_val);
             return id + 1;
         }
 
-        void genFuncs(std::stringstream &kerStream, Node_ids ids)
+        void genFuncs(std::stringstream &kerStream, Node_ids ids) const final
         {
             kerStream << m_type_str << " val" << ids.id << " = "
                       << "scalar" << ids.id << ";"
                       << "\n";
         }
+
+        // Return the info for the params and the size of the buffers
+        virtual short getParamBytes() const final { return static_cast<short>(sizeof(T)); }
     };
 
 }

--- a/src/backend/opencl/JIT/ShiftNode.hpp
+++ b/src/backend/opencl/JIT/ShiftNode.hpp
@@ -37,26 +37,24 @@ namespace JIT
         {
         }
 
-        bool isBuffer() { return false; }
-
         void setData(KParam info, std::shared_ptr<cl::Buffer> data, const unsigned bytes, bool is_linear)
         {
             auto node_ptr = m_buffer_node.get();
             dynamic_cast<BufferNode *>(node_ptr)->setData(info, data, bytes, is_linear);
         }
 
-        bool isLinear(dim_t dims[4])
+        bool isLinear(dim_t dims[4]) const final
         {
             return false;
         }
 
-        void genKerName(std::stringstream &kerStream, Node_ids ids)
+        void genKerName(std::stringstream &kerStream, Node_ids ids) const final
         {
             kerStream << "_" << m_name_str;
             kerStream << std::setw(3) << std::setfill('0') << std::dec << ids.id << std::dec;
         }
 
-        void genParams(std::stringstream &kerStream, int id, bool is_linear)
+        void genParams(std::stringstream &kerStream, int id, bool is_linear) const final
         {
             auto node_ptr = m_buffer_node.get();
             dynamic_cast<BufferNode *>(node_ptr)->genParams(kerStream, id, is_linear);
@@ -65,7 +63,7 @@ namespace JIT
             }
         }
 
-        int setArgs(cl::Kernel &ker, int id, bool is_linear)
+        int setArgs(cl::Kernel &ker, int id, bool is_linear) const final
         {
             auto node_ptr = m_buffer_node.get();
             int curr_id = dynamic_cast<BufferNode *>(node_ptr)->setArgs(ker, id, is_linear);
@@ -75,7 +73,7 @@ namespace JIT
             return curr_id + 4;
         }
 
-        void genOffsets(std::stringstream &kerStream, int id, bool is_linear)
+        void genOffsets(std::stringstream &kerStream, int id, bool is_linear) const final
         {
             std::string idx_str = std::string("idx") + std::to_string(id);
             std::string info_str = std::string("iInfo") + std::to_string(id);
@@ -105,14 +103,14 @@ namespace JIT
                       << "\n";
         }
 
-        void genFuncs(std::stringstream &kerStream, Node_ids ids)
+        void genFuncs(std::stringstream &kerStream, Node_ids ids) const final
         {
             kerStream << m_type_str << " val" << ids.id << " = "
                       << "in" << ids.id << "[idx" << ids.id << "];"
                       << "\n";
         }
 
-        void getInfo(unsigned &len, unsigned &buf_count, unsigned &bytes)
+        void getInfo(unsigned &len, unsigned &buf_count, unsigned &bytes) const final
         {
             auto node_ptr = m_buffer_node.get();
             dynamic_cast<BufferNode *>(node_ptr)->getInfo(len, buf_count, bytes);

--- a/src/backend/opencl/jit.cpp
+++ b/src/backend/opencl/jit.cpp
@@ -39,7 +39,7 @@ using std::stringstream;
 using std::vector;
 
 static string getFuncName(const vector<Node *> &output_nodes,
-                          const vector<Node *> &full_nodes,
+                          const vector<const Node *> &full_nodes,
                           const vector<Node_ids> &full_ids,
                           bool is_linear)
 {
@@ -66,7 +66,7 @@ static string getFuncName(const vector<Node *> &output_nodes,
 }
 
 static string getKernelString(const string funcName,
-                              const vector<Node *> &full_nodes,
+                              const vector<const Node *> &full_nodes,
                               const vector<Node_ids> &full_ids,
                               const vector<int> &output_ids,
                               bool is_linear)
@@ -167,7 +167,7 @@ static string getKernelString(const string funcName,
 
 static Kernel getKernel(const vector<Node *> &output_nodes,
                         const vector<int> &output_ids,
-                        const vector<Node *> &full_nodes,
+                        const vector<const Node *> &full_nodes,
                         const vector<Node_ids> &full_ids,
                         const bool is_linear)
 {
@@ -205,7 +205,7 @@ void evalNodes(vector<Param> &outputs, vector<Node *> output_nodes)
 
     // Use thread local to reuse the memory every time you are here.
     thread_local Node_map_t nodes;
-    thread_local vector<Node *> full_nodes;
+    thread_local vector<const Node *> full_nodes;
     thread_local vector<Node_ids> full_ids;
     thread_local vector<int> output_ids;
 


### PR DESCRIPTION
Uses the the size of the Param<T> object to determine when the JIT node should
be evaluated. This is required because there is a limit to the size of the
parameters you can send to a CUDA kernel.

Also created a NodeIterator which traverses the node tree. This improves the
readability of the code.