### PR TITLE
Improve wrap documentation

### DIFF
--- a/docs/details/image.dox
+++ b/docs/details/image.dox
@@ -843,9 +843,73 @@ is described above, but the effect should be the same.
 \defgroup image_func_wrap wrap
 \ingroup image_mod_mat
 
-Wrap takes an unwrapped image (see \ref unwrap()) and converts it back to an image.
+Performs the opposite of \ref unwrap().
 
-The inputs to this function should be the same as the inputs used to generate the unwrapped image.
+More specifically, wrap takes each column (or row if `is_column` is false) of the
+\f$m \times n\f$ input array and reshapes them into `wx` \f$\times\f$ `wy`
+patches (where \f$m =\f$ `wx` \f$\times\f$ `wy`) of the `ox` \f$\times\f$ `oy`
+output array. Wrap is typically used on an array that has been previously
+unwrapped - for example, in the case of image processing, one can unwrap an
+image, process the unwrapped array, and then compose it back into an image using
+wrap. 
+
+The figure below illustrates how wrap works. The process can be visualized as a
+moving window (orange boxes in the figure) taking a column from the input
+(top-left), reshaping it into a patch (bottom-left), and then placing that patch
+on its corresponding position in the output array (right; numbers in yellow show
+correspondence). It starts placing a patch on the output's top-left corner, then
+moves `sx` units along the column, and `sy` units along the row whenever it
+exhausts a column. If padding exists in the input array (gray-filled boxes),
+which typically happens when padding was applied on the previous unwrap, then
+`px` and `py` must be specified in order for the padding to be removed on the
+output array (in the figure, the output array on the right will actually only
+contain the inner boxes, size `ox` \f$\times\f$ `oy`).
+
+\image html wrap_distinct.png "Wrap on a 4x6 input array, using a 2x2 window, 2x2 stride, 1x1 padding. The output array is 3x4"
+
+There are some things that must be considered when wrapping a previously
+unwrapped array. First, wrap must use the same parameters that unwrap used, and
+must use the original array's size (before unwrap) as `ox` and `oy`. This is
+necessary to correctly elicit wrap's behavior as the opposite of unwrap. Second,
+one must consider whether the previous unwrap used a distinct or sliding window
+configuration, since the element-wise mapping from the input array to the output
+depends on the configuration. If the distinct window configuration (the stride is
+at least as large as the window size) was used, then the mapping is
+straightforward - each column will map to a unique section in the output array,
+and therefore each element in the input will map to a unique position in the
+output (shown in the figure above). However, in the case of the sliding window
+configuration (the stride is smaller than the window size), some of the columns
+will map to overlapping sections in the output array, and so elements from
+multiple columns will map to the same position on the output array. Recomposing
+the array then requires some way to choose between competing elements to place in
+that position. To address this contention, wrap simply sums all of the competing
+elements and places the sum in that position. The figure below illustrates this
+behavior: the fourth element of the first column and the third element of the
+second column in the input array both map to the same position on the output
+array, and thus their sum is placed on that position (this happens on the second
+and third column of the input as well - they both map to the third element of the
+second column in the output). Given this behavior, it is up to the user to
+pre-process the input (unwrapped) array (or post-process the output (wrapped)
+array) in a way that somehow takes all of the competing elements into
+consideration.
+
+\image html wrap_sliding.png "Wrap on the same array as above, but with 1x1 stride (sliding window)"
+
+Here are some code examples that demonstrate wrap's usage. The first one shows
+wrapping a previously unwrapped array that used a 1x1 padding and a distinct
+window configuration. Notice how the arguments used in unwrap are the same as
+those used in wrap:
+
+\snippet test/wrap.cpp ex_wrap_1
+
+The next one shows what happens when both unwrap and wrap uses the sliding window
+configuration. Notice how the original array is not recovered through wrap;
+instead, overlapping elements are summed, just as described above:
+
+\snippet test/wrap.cpp ex_wrap_2
+
+Note that the actual implementation of unwrap may not match the way the operation
+is visualized above, but the effect should be the same.
 
 =======================================================================
 

--- a/docs/details/image.dox
+++ b/docs/details/image.dox
@@ -895,6 +895,13 @@ consideration.
 
 \image html wrap_sliding.png "Wrap on the same array as above, but with 1x1 stride (sliding window)"
 
+For inputs that have more than two dimensions, the wrap operation will be
+applied to each 2D slice of the input. This is especially useful for
+independently processing each channel of an image (or set of images) - each
+channel (along the third dimension) on the input corresponds to the same channel
+on the output, and each image (along the fourth dimension) on the input
+corresponds to the same image on the output.
+
 Here are some code examples that demonstrate wrap's usage. The first one shows
 wrapping a previously unwrapped array that used a 1x1 padding and a distinct
 window configuration. Notice how the arguments used in unwrap are the same as

--- a/include/af/image.h
+++ b/include/af/image.h
@@ -628,8 +628,8 @@ AFAPI array unwrap(const array& in, const dim_t wx, const dim_t wy,
          \p is_column is false), must equal \f$nx \times\ ny\f$, where
          \f$\displaystyle nx = \frac{ox + 2px - wx}{sx} + 1\f$ and
          \f$\displaystyle ny = \frac{oy + 2py - wy}{sy} + 1\f$
-   \note Batched wrap can be performed on multiple unwrapped images if \p in is
-         three or four dimensional and each 2D slice is an unwrapped image.
+   \note Batched wrap can be performed on multiple 2D slices at once if \p in
+         is three or four-dimensional
 
    \ingroup image_func_wrap
 */
@@ -1414,8 +1414,8 @@ extern "C" {
              \p is_column is false), must equal \f$nx \times\ ny\f$, where
              \f$\displaystyle nx = \frac{ox + 2px - wx}{sx} + 1\f$ and
              \f$\displaystyle ny = \frac{oy + 2py - wy}{sy} + 1\f$
-       \note Batched wrap can be performed on multiple unwrapped images if \p in is
-             three or four dimensional and each 2D slice is an unwrapped image.
+       \note Batched wrap can be performed on multiple 2D slices at once if \p in
+             is three or four-dimensional
 
        \ingroup image_func_wrap
     */

--- a/include/af/image.h
+++ b/include/af/image.h
@@ -602,19 +602,34 @@ AFAPI array unwrap(const array& in, const dim_t wx, const dim_t wy,
 
 #if AF_API_VERSION >= 31
 /**
-   C++ Interface wrapper for wrap
+   C++ Interface for performing the opposite of \ref unwrap()
 
-   \param[in]  in is the input image (or set of images)
-   \param[in]  ox is the 0th-dimension of output
-   \param[in]  oy is the ist-dimension of output
-   \param[in]  wx is the block window size along 0th-dimension between
-   \param[in]  wy is the block window size along 1st-dimension between
-   \param[in]  sx is the stride along 0th-dimension
-   \param[in]  sy is the stride along 1st-dimension
-   \param[in]  px is the padding used along 0th-dimension between [0, wx).
-   \param[in]  py is the padding used along 1st-dimension between [0, wy).
-   \param[in]  is_column specifies the layout for the unwrapped patch. If is_column is false, the rows are treated as patches
-   \returns    an array of images after converting rows or columns into image windows
+   \param[in]  in is the input array
+   \param[in]  ox is the output's dimension 0 size
+   \param[in]  oy is the output's dimension 1 size
+   \param[in]  wx is the window size along dimension 0
+   \param[in]  wy is the window size along dimension 1
+   \param[in]  sx is the stride along dimension 0
+   \param[in]  sy is the stride along dimension 1
+   \param[in]  px is the padding along dimension 0
+   \param[in]  py is the padding along dimension 1
+   \param[in]  is_column determines whether an output patch is formed from a
+               column (if true) or a row (if false)
+   \returns    an array with the input's columns (or rows) reshaped as patches
+
+   \note Wrap is typically used to recompose an unwrapped image. If this is the
+         case, use the same parameters that were used in \ref unwrap(). Also
+         use the original image size (before unwrap) for \p ox and \p oy.
+   \note The window/patch size, \p wx \f$\times\f$ \p wy, must equal
+         `input.dims(0)` (or `input.dims(1)` if \p is_column is false).
+   \note \p sx and \p sy must be at least 1
+   \note \p px and \p py must be between [0, wx) and [0, wy), respectively
+   \note The number of patches, `input.dims(1)` (or `input.dims(0)` if
+         \p is_column is false), must equal \f$nx \times\ ny\f$, where
+         \f$\displaystyle nx = \frac{ox + 2px - wx}{sx} + 1\f$ and
+         \f$\displaystyle ny = \frac{oy + 2py - wy}{sy} + 1\f$
+   \note Batched wrap can be performed on multiple unwrapped images if \p in is
+         three or four dimensional and each 2D slice is an unwrapped image.
 
    \ingroup image_func_wrap
 */
@@ -1370,23 +1385,37 @@ extern "C" {
 
 #if AF_API_VERSION >= 31
     /**
-       C Interface wrapper for wrap
+       C Interface for performing the opposite of \ref unwrap()
 
-       \param[out] out is an array after converting
+       \param[out] out is an array with the input's columns (or rows) reshaped as
+                   patches
        \param[in]  in is the input array
-       \param[in]  ox is the 0th-dimension of \p out
-       \param[in]  oy is the ist-dimension of \p out
-       \param[in]  wx is the block window size along 0th-dimension between
-       \param[in]  wy is the block window size along 1st-dimension between
-       \param[in]  sx is the stride along 0th-dimension
-       \param[in]  sy is the stride along 1st-dimension
-       \param[in]  px is the padding used along 0th-dimension between [0, wx).
-       \param[in]  py is the padding used along 1st-dimension between [0, wy).
-       \param[in]  is_column specifies the layout for the unwrapped patch. If is_column is false, the rows are treated as the patches
+       \param[in]  ox is the output's dimension 0 size
+       \param[in]  oy is the output's dimension 1 size
+       \param[in]  wx is the window size along dimension 0
+       \param[in]  wy is the window size along dimension 1
+       \param[in]  sx is the stride along dimension 0
+       \param[in]  sy is the stride along dimension 1
+       \param[in]  px is the padding along dimension 0
+       \param[in]  py is the padding along dimension 1
+       \param[in]  is_column determines whether an output patch is formed from a
+                   column (if true) or a row (if false)
        \return     \ref AF_SUCCESS if the color transformation is successful,
        otherwise an appropriate error code is returned.
 
-       \note The padding used in \ref af_unwrap is calculated from the provided parameters
+       \note Wrap is typically used to recompose an unwrapped image. If this is the
+             case, use the same parameters that were used in \ref unwrap(). Also
+             use the original image size (before unwrap) for \p ox and \p oy.
+       \note The window/patch size, \p wx \f$\times\f$ \p wy, must equal
+             `input.dims(0)` (or `input.dims(1)` if \p is_column is false).
+       \note \p sx and \p sy must be at least 1
+       \note \p px and \p py must be between [0, wx) and [0, wy), respectively
+       \note The number of patches, `input.dims(1)` (or `input.dims(0)` if
+             \p is_column is false), must equal \f$nx \times\ ny\f$, where
+             \f$\displaystyle nx = \frac{ox + 2px - wx}{sx} + 1\f$ and
+             \f$\displaystyle ny = \frac{oy + 2py - wy}{sy} + 1\f$
+       \note Batched wrap can be performed on multiple unwrapped images if \p in is
+             three or four dimensional and each 2D slice is an unwrapped image.
 
        \ingroup image_func_wrap
     */

--- a/test/wrap.cpp
+++ b/test/wrap.cpp
@@ -19,19 +19,20 @@
 #include <testHelpers.hpp>
 #include <algorithm>
 
-using std::vector;
-using std::string;
-using std::cout;
-using std::endl;
-using std::abs;
 using af::allTrue;
 using af::array;
-using af::cfloat;
 using af::cdouble;
+using af::cfloat;
+using af::dim4;
 using af::dtype;
 using af::dtype_traits;
 using af::randu;
 using af::range;
+using std::abs;
+using std::cout;
+using std::endl;
+using std::string;
+using std::vector;
 
 template<typename T>
 class Wrap : public ::testing::Test
@@ -201,4 +202,60 @@ TEST(Wrap, MaxDim)
     array output = wrap(unwrapped, 5, 5, wx, wy, sx, sy, px, py);
 
     ASSERT_ARRAYS_EQ(output, input);
+}
+
+TEST(Wrap, DocSnippet) {
+    //! [ex_wrap_1]
+    float hA[] = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+    array A(dim4(3, 3), hA);
+    //  1.     4.     7.
+    //  2.     5.     8.
+    //  3.     6.     9.
+
+    array A_unwrapped = unwrap(A,
+                               2, 2,  // window size
+                               2, 2,  // stride (distinct)
+                               1, 1); // padding
+    //  0.     0.     0.     5.
+    //  0.     0.     4.     6.
+    //  0.     2.     0.     8.
+    //  1.     3.     7.     9.
+
+    array A_wrapped = wrap(A_unwrapped,
+                           3, 3,  // A's size
+                           2, 2,  // window size
+                           2, 2,  // stride (distinct)
+                           1, 1); // padding
+    //  1.     4.     7.
+    //  2.     5.     8.
+    //  3.     6.     9.
+    //! [ex_wrap_1]
+
+    ASSERT_ARRAYS_EQ(A, A_wrapped);
+
+    //! [ex_wrap_2]
+    float hB[] = {1, 1, 1, 1, 1, 1, 1, 1, 1};
+    array B(dim4(3, 3), hB);
+    //  1.     1.     1.
+    //  1.     1.     1.
+    //  1.     1.     1.
+    array B_unwrapped = unwrap(B,
+                               2, 2,  // window size
+                               1, 1); // stride (sliding)
+    //  1.     1.     1.     1.
+    //  1.     1.     1.     1.
+    //  1.     1.     1.     1.
+    //  1.     1.     1.     1.
+    array B_wrapped = wrap(B_unwrapped,
+                           3, 3,  // B's size
+                           2, 2,  // window size
+                           1, 1); // stride (sliding)
+    //  1.     2.     1.
+    //  2.     4.     2.
+    //  1.     2.     1.
+    //! [ex_wrap_2]
+
+    float gold_hB_wrapped[] = {1, 2, 1, 2, 4, 2, 1, 2, 1};
+    array gold_B_wrapped(dim4(3, 3), gold_hB_wrapped);
+    ASSERT_ARRAYS_EQ(gold_B_wrapped, B_wrapped);
 }


### PR DESCRIPTION
In light of this [Google groups conversation about wrap](https://groups.google.com/forum/#!msg/arrayfire-users/3sDt3mj9D5Y/HTMSh3jUAgAJ), I'm adding more detail to the wrap documentation. I myself thought that every wrap after unwrap will return the original array, but of course that turns out to be inaccurate.

In any case, here's my first attempt at improving the docs. Please let me know your thoughts!

![image](https://user-images.githubusercontent.com/19368448/47181637-8a0f2600-d2f1-11e8-9b74-df8554b01b74.png)
![image](https://user-images.githubusercontent.com/19368448/47181659-9bf0c900-d2f1-11e8-8c0f-7d53e8ff8a96.png)
![image](https://user-images.githubusercontent.com/19368448/47181681-aca13f00-d2f1-11e8-973d-23ccc38947e4.png)
![image](https://user-images.githubusercontent.com/19368448/47181729-c80c4a00-d2f1-11e8-8b17-3974504f2f2a.png)
![image](https://user-images.githubusercontent.com/19368448/47181769-e114fb00-d2f1-11e8-9aaa-2055de7e2828.png)
![image](https://user-images.githubusercontent.com/19368448/47181796-effbad80-d2f1-11e8-92ac-e9dd600ed4eb.png)
![image](https://user-images.githubusercontent.com/19368448/47181816-f9851580-d2f1-11e8-878f-c9d2234e7dca.png)

