### PR TITLE
Remove setDevice from af::array destructor

### DIFF
--- a/src/api/c/array.cpp
+++ b/src/api/c/array.cpp
@@ -194,9 +194,6 @@ af_err af_release_array(af_array arr)
                 default : TYPE_ERROR(0, type);
             }
         } else {
-
-            setDevice(info.getDevId());
-
             switch(type) {
             case f32:   releaseHandle<float   >(arr); break;
             case c32:   releaseHandle<cfloat  >(arr); break;
@@ -212,8 +209,6 @@ af_err af_release_array(af_array arr)
             case u16:   releaseHandle<ushort  >(arr); break;
             default:    TYPE_ERROR(0, type);
             }
-
-            setDevice(dev);
         }
     }
     CATCHALL


### PR DESCRIPTION
The setDevice call is unnecessary because the memory manager does not
free the array. Also, it seems that cudaFree doesn't require that
the device is set based on my experiments.