### PR TITLE
Allow af_approx1 to use an existing af_array for output

### DIFF
--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -753,17 +753,17 @@ extern "C" {
 /**
    C Interface for signals interpolation on one dimensional signals.
 
-   \param[in,out] out the interpolated array.
-   \param[in]     in is the multidimensional input array. Values assumed to lie
-                  uniformly spaced indices in the range of `[0, n)`, where `n`
-                  is the number of elements in the array.
-   \param[in]     pos positions of the interpolation points along the first
-                  dimension.
-   \param[in]     method is the interpolation method to be used. The following
-                  types (defined in enum \ref af_interp_type) are supported:
-                  nearest neighbor, linear, and cubic.
+   \param[in,out] out      is the interpolated array.
+   \param[in]     in       is the multidimensional input array. Values assumed to
+                           lie uniformly spaced indices in the range of `[0, n)`,
+                           where `n` is the number of elements in the array.
+   \param[in]     pos      positions of the interpolation points along the first
+                           dimension.
+   \param[in]     method   is the interpolation method to be used. The following
+                           types (defined in enum \ref af_interp_type)
+                           are supported: nearest neighbor, linear, and cubic.
    \param[in]     off_grid is the default value for any indices outside the
-                  valid range of indices.
+                           valid range of indices.
    \return        \ref AF_SUCCESS if the interpolation operation is successful,
                   otherwise an appropriate error code is returned.
 

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -810,19 +810,22 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
    The blue dots represent indices whose values are known. The red dots
    represent indices whose values are unknown.
 
-   \param[in,out] out the interpolated array.
-   \param[in]     in is the multidimensional input array. Values lie on uniforml
-                  spaced indices determined by `idx_start` and `idx_step`.
-   \param[in]     pos positions of the interpolation points along `interp_dim`.
+   \param[in,out] out        the interpolated array.
+   \param[in]     in         is the multidimensional input array. Values lie on
+                             uniformly spaced indices determined by `idx_start`
+                             and `idx_step`.
+   \param[in]     pos        positions of the interpolation points along
+                             `interp_dim`.
    \param[in]     interp_dim is the dimension to perform interpolation across.
-   \param[in]     idx_start is the first index value along `interp_dim`.
-   \param[in]     idx_step is the uniform spacing value between subsequent
-                  indices along `interp_dim`.
-   \param[in]     method is the interpolation method to be used. The following
-                  types (defined in enum \ref af_interp_type) are supported:
-                  nearest neighbor, linear, and cubic.
-   \param[in]     off_grid is the default value for any indices outside the valid
-                  range of indices.
+   \param[in]     idx_start  is the first index value along `interp_dim`.
+   \param[in]     idx_step   is the uniform spacing value between subsequent
+                             indices along `interp_dim`.
+   \param[in]     method     is the interpolation method to be used. The
+                             following types (defined in enum
+                             \ref af_interp_type) are supported: nearest
+                             neighbor, linear, and cubic.
+   \param[in]     off_grid   is the default value for any indices outside the
+                             valid range of indices.
    \return        \ref AF_SUCCESS if the interpolation operation is successful,
                   otherwise an appropriate error code is returned.
 

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -753,13 +753,23 @@ extern "C" {
 /**
    C Interface for signals interpolation on one dimensional signals.
 
-   \param[out] out the interpolated array.
-   \param[in]  in is the multidimensional input array. Values assumed to lie uniformly spaced indices in the range of `[0, n)`, where `n` is the number of elements in the array.
-   \param[in]  pos positions of the interpolation points along the first dimension.
-   \param[in]  method is the interpolation method to be used. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
-   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
-   \return     \ref AF_SUCCESS if the interpolation operation is successful,
-               otherwise an appropriate error code is returned.
+   \param[in,out] out the interpolated array.
+   \param[in]     in is the multidimensional input array. Values assumed to lie
+                  uniformly spaced indices in the range of `[0, n)`, where `n`
+                  is the number of elements in the array.
+   \param[in]     pos positions of the interpolation points along the first
+                  dimension.
+   \param[in]     method is the interpolation method to be used. The following
+                  types (defined in enum \ref af_interp_type) are supported:
+                  nearest neighbor, linear, and cubic.
+   \param[in]     off_grid is the default value for any indices outside the
+                  valid range of indices.
+   \return        \ref AF_SUCCESS if the interpolation operation is successful,
+                  otherwise an appropriate error code is returned.
+
+   \note \p out can either be a null or existing `af_array` object. If it is a
+         sub-array of an existing `af_array`, only the corresponding portion of
+         the `af_array` will be overwritten
 
    \ingroup signal_func_approx1
  */
@@ -800,16 +810,25 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
    The blue dots represent indices whose values are known. The red dots
    represent indices whose values are unknown.
 
-   \param[out] out the interpolated array.
-   \param[in]  in is the multidimensional input array. Values lie on uniformly spaced indices determined by `idx_start` and `idx_step`.
-   \param[in]  pos positions of the interpolation points along `interp_dim`.
-   \param[in]  interp_dim is the dimension to perform interpolation across.
-   \param[in]  idx_start is the first index value along `interp_dim`.
-   \param[in]  idx_step is the uniform spacing value between subsequent indices along `interp_dim`.
-   \param[in]  method is the interpolation method to be used. The following types (defined in enum \ref af_interp_type) are supported: nearest neighbor, linear, and cubic.
-   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
-   \return     \ref AF_SUCCESS if the interpolation operation is successful,
-               otherwise an appropriate error code is returned.
+   \param[in,out] out the interpolated array.
+   \param[in]     in is the multidimensional input array. Values lie on uniforml
+                  spaced indices determined by `idx_start` and `idx_step`.
+   \param[in]     pos positions of the interpolation points along `interp_dim`.
+   \param[in]     interp_dim is the dimension to perform interpolation across.
+   \param[in]     idx_start is the first index value along `interp_dim`.
+   \param[in]     idx_step is the uniform spacing value between subsequent
+                  indices along `interp_dim`.
+   \param[in]     method is the interpolation method to be used. The following
+                  types (defined in enum \ref af_interp_type) are supported:
+                  nearest neighbor, linear, and cubic.
+   \param[in]     off_grid is the default value for any indices outside the valid
+                  range of indices.
+   \return        \ref AF_SUCCESS if the interpolation operation is successful,
+                  otherwise an appropriate error code is returned.
+
+   \note \p out can either be a null or existing `af_array` object. If it is a
+         sub-array of an existing `af_array`, only the corresponding portion of
+         the `af_array` will be overwritten
 
    \ingroup signal_func_approx1
  */

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -58,8 +58,8 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi,
         const ArrayInfo& yi_info = getInfo(yi);
         const ArrayInfo& xo_info = getInfo(xo);
 
-        dim4 yi_dims = yi_info.dims();
-        dim4 xo_dims = xo_info.dims();
+        const dim4 yi_dims = yi_info.dims();
+        const dim4 xo_dims = xo_info.dims();
 
         ARG_ASSERT(1, yi_info.isFloating());                        // Only floating and complex types
         ARG_ASSERT(2, xo_info.isRealFloating()) ;                   // Only floating types

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -83,13 +83,14 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi,
                        method == AF_INTERP_NEAREST));
 
         if (yi_dims.ndims() == 0 || xo_dims.ndims() ==  0) {
-            return af_create_handle(yo, 0, nullptr, yi_info.getType());
+            *yo = createHandle(dim4(0,0,0,0), yi_info.getType());;
+            return AF_SUCCESS;
         }
 
         dim4 yo_dims = yi_dims;
         yo_dims[xdim] = xo_dims[xdim];
         if (*yo == 0) {
-            af_create_handle(yo, yo_dims.ndims(), yo_dims.get(), yi_info.getType());
+            *yo = createHandle(yo_dims, yi_info.getType());
         }
 
         DIM_ASSERT(1, getInfo(*yo).dims() == yo_dims);

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -83,7 +83,7 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi,
                        method == AF_INTERP_NEAREST));
 
         if (yi_dims.ndims() == 0 || xo_dims.ndims() ==  0) {
-            *yo = createHandle(dim4(0,0,0,0), yi_info.getType());;
+            *yo = createHandle(dim4(0,0,0,0), yi_info.getType());
             return AF_SUCCESS;
         }
 

--- a/src/api/c/fft.cpp
+++ b/src/api/c/fft.cpp
@@ -91,7 +91,7 @@ af_err af_ifft3(af_array *out, const af_array in, const double norm_factor, cons
 }
 
 template<typename T, int rank, bool direction>
-static void fft_inplace(const af_array in, const double norm_factor)
+static void fft_inplace(af_array in, const double norm_factor)
 {
     Array<T> &input = getWritableArray<T>(in);
     fft_inplace<T, rank, direction>(input);

--- a/src/api/c/handle.hpp
+++ b/src/api/c/handle.hpp
@@ -81,9 +81,9 @@ detail::Array<To> castArray(const af_array &in)
 
 template<typename T>
 static detail::Array<T> &
-getWritableArray(const af_array &arr)
+getWritableArray(af_array &arr)
 {
-    const detail::Array<T> &A = getArray<T>(arr);
+    const detail::Array<T> &A = getArray<T>((const af_array) arr);
     ARG_ASSERT(0, A.isSparse() == false);
     return const_cast<detail::Array<T>&>(A);
 }

--- a/src/backend/cpu/approx.cpp
+++ b/src/backend/cpu/approx.cpp
@@ -16,18 +16,13 @@ namespace cpu
 {
 
 template<typename Ty, typename Tp>
-Array<Ty> approx1(const Array<Ty> &yi,
-                  const Array<Tp> &xo, const int xdim,
-                  const Tp &xi_beg, const Tp &xi_step,
-                  const af_interp_type method, const float offGrid)
+void approx1(Array<Ty> &yo, const Array<Ty> &yi,
+             const Array<Tp> &xo, const int xdim,
+             const Tp &xi_beg, const Tp &xi_step,
+             const af_interp_type method, const float offGrid)
 {
     yi.eval();
     xo.eval();
-
-    dim4 odims = yi.dims();
-    odims[xdim] = xo.dims()[xdim];
-
-    Array<Ty> yo = createEmptyArray<Ty>(odims);
 
     switch(method) {
     case AF_INTERP_NEAREST:
@@ -48,7 +43,6 @@ Array<Ty> approx1(const Array<Ty> &yi,
     default:
         break;
     }
-    return yo;
 }
 
 template<typename Ty, typename Tp>
@@ -102,13 +96,14 @@ Array<Ty> approx2(const Array<Ty> &zi,
 }
 
 #define INSTANTIATE(Ty, Tp)                                         \
-    template Array<Ty> approx1<Ty, Tp>(const Array<Ty> &yi,         \
-                                       const Array<Tp> &xo,         \
-                                       const int xdim,              \
-                                       const Tp &xi_beg,            \
-                                       const Tp &xi_step,           \
-                                       const af_interp_type method, \
-                                       const float offGrid);        \
+    template void approx1<Ty, Tp>(Array<Ty> &yo,                    \
+                                  const Array<Ty> &yi,              \
+                                  const Array<Tp> &xo,              \
+                                  const int xdim,                   \
+                                  const Tp &xi_beg,                 \
+                                  const Tp &xi_step,                \
+                                  const af_interp_type method,      \
+                                  const float offGrid);             \
     template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &zi,         \
                                        const Array<Tp> &xo,         \
                                        const int xdim,              \

--- a/src/backend/cpu/approx.hpp
+++ b/src/backend/cpu/approx.hpp
@@ -13,10 +13,10 @@
 namespace cpu
 {
     template<typename Ty, typename Tp>
-    Array<Ty> approx1(const Array<Ty> &yi,
-                      const Array<Tp> &xo, const int xdim,
-                      const Tp &xi_beg, const Tp &xi_step,
-                      const af_interp_type method, const float offGrid);
+    void approx1(Array<Ty> &yo, const Array<Ty> &yi,
+                 const Array<Tp> &xo, const int xdim,
+                 const Tp &xi_beg, const Tp &xi_step,
+                 const af_interp_type method, const float offGrid);
 
     template<typename Ty, typename Tp>
     Array<Ty> approx2(const Array<Ty> &zi,

--- a/src/backend/cuda/approx.cu
+++ b/src/backend/cuda/approx.cu
@@ -16,17 +16,11 @@
 namespace cuda
 {
     template<typename Ty, typename Tp>
-    Array<Ty> approx1(const Array<Ty> &yi,
-                      const Array<Tp> &xo, const int xdim,
-                      const Tp &xi_beg, const Tp &xi_step,
-                      const af_interp_type method, const float offGrid)
+    void approx1(Array<Ty> &yo, const Array<Ty> &yi,
+                 const Array<Tp> &xo, const int xdim,
+                 const Tp &xi_beg, const Tp &xi_step,
+                 const af_interp_type method, const float offGrid)
     {
-        af::dim4 odims = yi.dims();
-        odims[xdim] = xo.dims()[xdim];
-
-        // Create output placeholder
-        Array<Ty> yo = createEmptyArray<Ty>(odims);
-
         switch(method) {
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
@@ -43,7 +37,6 @@ namespace cuda
         default:
             break;
         }
-        return yo;
     }
 
     template<typename Ty, typename Tp>
@@ -92,13 +85,14 @@ namespace cuda
     }
 
 #define INSTANTIATE(Ty, Tp)                                         \
-    template Array<Ty> approx1<Ty, Tp>(const Array<Ty> &yi,         \
-                                       const Array<Tp> &xo,         \
-                                       const int xdim,              \
-                                       const Tp &xi_beg,            \
-                                       const Tp &xi_step,           \
-                                       const af_interp_type method, \
-                                       const float offGrid);        \
+    template void approx1<Ty, Tp>(Array<Ty> &yo,                    \
+                                  const Array<Ty> &yi,              \
+                                  const Array<Tp> &xo,              \
+                                  const int xdim,                   \
+                                  const Tp &xi_beg,                 \
+                                  const Tp &xi_step,                \
+                                  const af_interp_type method,      \
+                                  const float offGrid);             \
     template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &zi,         \
                                        const Array<Tp> &xo,         \
                                        const int xdim,              \

--- a/src/backend/cuda/approx.hpp
+++ b/src/backend/cuda/approx.hpp
@@ -12,10 +12,10 @@
 namespace cuda
 {
     template<typename Ty, typename Tp>
-    Array<Ty> approx1(const Array<Ty> &yi,
-                      const Array<Tp> &xo, const int xdim,
-                      const Tp &xi_beg, const Tp &xi_step,
-                      const af_interp_type method, const float offGrid);
+    void approx1(Array<Ty> &yo, const Array<Ty> &yi,
+                 const Array<Tp> &xo, const int xdim,
+                 const Tp &xi_beg, const Tp &xi_step,
+                 const af_interp_type method, const float offGrid);
 
     template<typename Ty, typename Tp>
     Array<Ty> approx2(const Array<Ty> &zi,

--- a/src/backend/opencl/approx.cpp
+++ b/src/backend/opencl/approx.cpp
@@ -16,16 +16,11 @@
 namespace opencl
 {
     template<typename Ty, typename Tp>
-    Array<Ty> approx1(const Array<Ty> &yi,
-                      const Array<Tp> &xo, const int xdim,
-                      const Tp &xi_beg, const Tp &xi_step,
-                      const af_interp_type method, const float offGrid)
+    void approx1(Array<Ty> &yo, const Array<Ty> &yi,
+                 const Array<Tp> &xo, const int xdim,
+                 const Tp &xi_beg, const Tp &xi_step,
+                 const af_interp_type method, const float offGrid)
     {
-        af::dim4 odims = yi.dims();
-        odims[xdim] = xo.dims()[xdim];
-
-        // Create output placeholder
-        Array<Ty> yo = createEmptyArray<Ty>(odims);
         switch(method) {
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
@@ -42,7 +37,6 @@ namespace opencl
         default:
             break;
         }
-        return yo;
     }
 
     template<typename Ty, typename Tp>
@@ -92,13 +86,14 @@ namespace opencl
     }
 
 #define INSTANTIATE(Ty, Tp)                                         \
-    template Array<Ty> approx1<Ty, Tp>(const Array<Ty> &yi,         \
-                                       const Array<Tp> &xo,         \
-                                       const int xdim,              \
-                                       const Tp &xi_beg,            \
-                                       const Tp &xi_step,           \
-                                       const af_interp_type method, \
-                                       const float offGrid);        \
+    template void approx1<Ty, Tp>(Array<Ty> &yo,                    \
+                                  const Array<Ty> &yi,              \
+                                  const Array<Tp> &xo,              \
+                                  const int xdim,                   \
+                                  const Tp &xi_beg,                 \
+                                  const Tp &xi_step,                \
+                                  const af_interp_type method,      \
+                                  const float offGrid);             \
     template Array<Ty> approx2<Ty, Tp>(const Array<Ty> &zi,         \
                                        const Array<Tp> &xo,         \
                                        const int xdim,              \

--- a/src/backend/opencl/approx.hpp
+++ b/src/backend/opencl/approx.hpp
@@ -12,10 +12,10 @@
 namespace opencl
 {
     template<typename Ty, typename Tp>
-    Array<Ty> approx1(const Array<Ty> &yi,
-                      const Array<Tp> &xo, const int xdim,
-                      const Tp &xi_beg, const Tp &xi_step,
-                      const af_interp_type method, const float offGrid);
+    void approx1(Array<Ty> &yo, const Array<Ty> &yi,
+                 const Array<Tp> &xo, const int xdim,
+                 const Tp &xi_beg, const Tp &xi_step,
+                 const af_interp_type method, const float offGrid);
 
     template<typename Ty, typename Tp>
     Array<Ty> approx2(const Array<Ty> &zi,

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -843,17 +843,16 @@ TEST(Approx1, CPPEmptyPosAndInput)
 
 TEST(Approx1, UseNullInitialOutput) {
     float h_in[3] = {10, 20, 30};
-    dim_t h_in_dims[1] = {3};
+    dim_t h_in_dims = 3;
 
     af_array in = 0;
-    af_create_array(&in, &h_in[0], 1, &h_in_dims[0], f32);
+    af_create_array(&in, &h_in[0], 1, &h_in_dims, f32);
 
     float h_pos[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
-    dim_t h_pos_dims[1] = {5};
+    dim_t h_pos_dims = 5;
     af_array pos = 0;
-    af_create_array(&pos, &h_pos[0], 1, &h_pos_dims[0], f32);
+    af_create_array(&pos, &h_pos[0], 1, &h_pos_dims, f32);
 
-    dim_t h_out_dims[1] = {5};
     af_array out = 0;
     af_approx1(&out, in, pos, AF_INTERP_LINEAR, 0);
 
@@ -862,19 +861,19 @@ TEST(Approx1, UseNullInitialOutput) {
 
 TEST(Approx1, UseExistingOutputArray) {
     float h_in[3] = {10, 20, 30};
-    dim_t h_in_dims[1] = {3};
+    dim_t h_in_dims = 3;
 
     af_array in = 0;
-    af_create_array(&in, &h_in[0], 1, &h_in_dims[0], f32);
+    af_create_array(&in, &h_in[0], 1, &h_in_dims, f32);
 
     float h_pos[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
-    dim_t h_pos_dims[1] = {5};
+    dim_t h_pos_dims = 5;
     af_array pos = 0;
-    af_create_array(&pos, &h_pos[0], 1, &h_pos_dims[0], f32);
+    af_create_array(&pos, &h_pos[0], 1, &h_pos_dims, f32);
 
-    dim_t h_out_dims[1] = {5};
+    dim_t h_out_dims = 5;
     af_array out_ptr = 0;
-    af_create_handle(&out_ptr, 1, &h_out_dims[0], f32);
+    af_create_handle(&out_ptr, 1, &h_out_dims, f32);
     af_array out_ptr_copy = out_ptr;
     af_approx1(&out_ptr, in, pos, AF_INTERP_LINEAR, 0);
 
@@ -885,15 +884,15 @@ TEST(Approx1, UseExistingOutputArray) {
 
 TEST(Approx1, UseExistingOutputSlice) {
     float h_in[3] = {10, 20, 30};
-    dim_t h_in_dims[1] = {3};
+    dim_t h_in_dims = 3;
 
     af_array in = 0;
-    af_create_array(&in, &h_in[0], 1, &h_in_dims[0], f32);
+    af_create_array(&in, &h_in[0], 1, &h_in_dims, f32);
 
     float h_pos[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
-    dim_t h_pos_dims[1] = {5};
+    dim_t h_pos_dims = 5;
     af_array pos = 0;
-    af_create_array(&pos, &h_pos[0], 1, &h_pos_dims[0], f32);
+    af_create_array(&pos, &h_pos[0], 1, &h_pos_dims, f32);
 
     float h_out[15] = {1.0, 1.5, 2.0, 2.5, 3.0,
                        4.0, 4.5, 5.0, 5.5, 6.0,

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -877,9 +877,15 @@ TEST(Approx1, UseExistingOutputArray) {
     af_array out_ptr_copy = out_ptr;
     ASSERT_SUCCESS(af_approx1(&out_ptr, in, pos, AF_INTERP_LINEAR, 0));
 
+    // Verify that the original output af_array memory was used
     ASSERT_EQ(out_ptr_copy, out_ptr);
-    // Verify that the original ASSERT_SUCCESS(af_array does contain the results
-    ASSERT_ARRAYS_EQ(out_ptr_copy, out_ptr);
+
+    af_array out_no_alloc = 0;
+    ASSERT_SUCCESS(af_approx1(&out_no_alloc, in, pos, AF_INTERP_LINEAR, 0));
+
+    // Verify that the contents of an approx with a previously allocated output
+    // and that of a non-allocated output match
+    ASSERT_ARRAYS_EQ(out_ptr, out_no_alloc);
 }
 
 TEST(Approx1, UseExistingOutputSlice) {

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -846,15 +846,15 @@ TEST(Approx1, UseNullInitialOutput) {
     dim_t h_in_dims = 3;
 
     af_array in = 0;
-    af_create_array(&in, &h_in[0], 1, &h_in_dims, f32);
+    ASSERT_SUCCESS(af_create_array(&in, &h_in[0], 1, &h_in_dims, f32));
 
     float h_pos[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
     dim_t h_pos_dims = 5;
     af_array pos = 0;
-    af_create_array(&pos, &h_pos[0], 1, &h_pos_dims, f32);
+    ASSERT_SUCCESS(af_create_array(&pos, &h_pos[0], 1, &h_pos_dims, f32));
 
     af_array out = 0;
-    af_approx1(&out, in, pos, AF_INTERP_LINEAR, 0);
+    ASSERT_SUCCESS(af_approx1(&out, in, pos, AF_INTERP_LINEAR, 0));
 
     ASSERT_FALSE(out == 0);
 }
@@ -864,21 +864,21 @@ TEST(Approx1, UseExistingOutputArray) {
     dim_t h_in_dims = 3;
 
     af_array in = 0;
-    af_create_array(&in, &h_in[0], 1, &h_in_dims, f32);
+    ASSERT_SUCCESS(af_create_array(&in, &h_in[0], 1, &h_in_dims, f32));
 
     float h_pos[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
     dim_t h_pos_dims = 5;
     af_array pos = 0;
-    af_create_array(&pos, &h_pos[0], 1, &h_pos_dims, f32);
+    ASSERT_SUCCESS(af_create_array(&pos, &h_pos[0], 1, &h_pos_dims, f32));
 
     dim_t h_out_dims = 5;
     af_array out_ptr = 0;
-    af_create_handle(&out_ptr, 1, &h_out_dims, f32);
+    ASSERT_SUCCESS(af_create_handle(&out_ptr, 1, &h_out_dims, f32));
     af_array out_ptr_copy = out_ptr;
-    af_approx1(&out_ptr, in, pos, AF_INTERP_LINEAR, 0);
+    ASSERT_SUCCESS(af_approx1(&out_ptr, in, pos, AF_INTERP_LINEAR, 0));
 
     ASSERT_EQ(out_ptr_copy, out_ptr);
-    // Verify that the original af_array does contain the results
+    // Verify that the original ASSERT_SUCCESS(af_array does contain the results
     ASSERT_ARRAYS_EQ(out_ptr_copy, out_ptr);
 }
 
@@ -887,34 +887,34 @@ TEST(Approx1, UseExistingOutputSlice) {
     dim_t h_in_dims = 3;
 
     af_array in = 0;
-    af_create_array(&in, &h_in[0], 1, &h_in_dims, f32);
+    ASSERT_SUCCESS(af_create_array(&in, &h_in[0], 1, &h_in_dims, f32));
 
     float h_pos[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
     dim_t h_pos_dims = 5;
     af_array pos = 0;
-    af_create_array(&pos, &h_pos[0], 1, &h_pos_dims, f32);
+    ASSERT_SUCCESS(af_create_array(&pos, &h_pos[0], 1, &h_pos_dims, f32));
 
     float h_out[15] = {1.0, 1.5, 2.0, 2.5, 3.0,
                        4.0, 4.5, 5.0, 5.5, 6.0,
                        7.0, 7.5, 8.0, 8.5, 9.0};
     dim_t h_out_dims[2] = {5, 3};
     af_array out = 0;
-    af_create_array(&out, &h_out[0], 2, &h_out_dims[0], f32);
+    ASSERT_SUCCESS(af_create_array(&out, &h_out[0], 2, &h_out_dims[0], f32));
     af_seq idx_dim1 = {1, 1, 1}; // get slice 1 of dim1
     af_seq idx[2] = {af_span, idx_dim1};
     af_array out_slice = 0;
-    af_index(&out_slice, out, 2, &idx[0]);
-    af_approx1(&out_slice, in, pos, AF_INTERP_LINEAR, 0);
+    ASSERT_SUCCESS(af_index(&out_slice, out, 2, &idx[0]));
+    ASSERT_SUCCESS(af_approx1(&out_slice, in, pos, AF_INTERP_LINEAR, 0));
 
     dim_t nelems = 0;
-    af_get_elements(&nelems, out);
+    ASSERT_SUCCESS(af_get_elements(&nelems, out));
     vector<float> h_out_approx(nelems);
-    af_get_data_ptr(&h_out_approx.front(), out);
+    ASSERT_SUCCESS(af_get_data_ptr(&h_out_approx.front(), out));
 
     float h_gold_arr[5] = {10.0, 15.0, 20.0, 25.0, 30.0};
 
     // Check slice 1 of dim2 (elements 5 to 9 of h_out_approx) to see if they
-    // contain af_approx1's results (without additional intermediate processing
+    // contain ASSERT_SUCCESS(af_approx1's results (without additional intermediate processing
     // like indexing)
     for (int i = 0; i < 5; ++i) {
         EXPECT_EQ(h_gold_arr[i], h_out_approx[5+i]) << "at i: " << i << endl;

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -873,17 +873,17 @@ TEST(Approx1, UseExistingOutputArray) {
     af_create_array(&pos, &h_pos[0], 1, &h_pos_dims[0], f32);
 
     dim_t h_out_dims[1] = {5};
-    af_array out = 0;
-    af_create_handle(&out, 1, &h_out_dims[0], f32);
-    // af_print_array_gen("out", out, 4);
-    af_array out_copy = out;
-    // af_print_array_gen("out_copy", out_copy, 4);
-    af_approx1(&out, in, pos, AF_INTERP_LINEAR, 0);
-    // af_print_array_gen("out", out, 4);
-    // af_print_array_gen("out_copy", out_copy, 4);
+    af_array out_ptr = 0;
+    af_create_handle(&out_ptr, 1, &h_out_dims[0], f32);
+    // af_print_array_gen("out_ptr", out_ptr, 4);
+    af_array out_ptr_copy = out_ptr;
+    // af_print_array_gen("out_ptr_copy", out_ptr_copy, 4);
+    af_approx1(&out_ptr, in, pos, AF_INTERP_LINEAR, 0);
+    // af_print_array_gen("out_ptr", out_ptr, 4);
+    // af_print_array_gen("out_ptr_copy", out_ptr_copy, 4);
 
-    ASSERT_EQ(out_copy, out);
-    ASSERT_ARRAYS_EQ(out_copy, out);
+    ASSERT_EQ(out_ptr_copy, out_ptr);
+    ASSERT_ARRAYS_EQ(out_ptr_copy, out_ptr);
 }
 
 TEST(Approx1, UseExistingOutputSlice) {
@@ -905,7 +905,7 @@ TEST(Approx1, UseExistingOutputSlice) {
     af_array out = 0;
     af_create_array(&out, &h_out[0], 2, &h_out_dims[0], f32);
     // af_print_array_gen("out", out, 4);
-    af_seq idx_dim1 = {1, 1, 1};
+    af_seq idx_dim1 = {1, 1, 1}; // get slice 1 of dim1
     af_seq idx[2] = {af_span, idx_dim1};
     af_array out_slice = 0;
     af_index(&out_slice, out, 2, &idx[0]);
@@ -914,7 +914,16 @@ TEST(Approx1, UseExistingOutputSlice) {
     // af_print_array_gen("out_slice", out_slice, 4);
     // af_print_array_gen("out", out, 4);
 
+    dim_t nelems = 0;
+    af_get_elements(&nelems, out);
+    vector<float> h_out_approx(nelems);
+    af_get_data_ptr(&h_out_approx.front(), out);
+
     float h_gold_arr[5] = {10.0, 15.0, 20.0, 25.0, 30.0};
-    vector<float> h_gold(h_gold_arr, h_gold_arr + 5);
-    ASSERT_VEC_ARRAY_EQ(h_gold, dim4(5), out_slice);
+
+    // Check slice 1 of dim1 (elements 5 to 9 of h_out_approx) to see if they
+    // contain af_approx1's results
+    for (int i = 0; i < 5; ++i) {
+        EXPECT_EQ(h_gold_arr[i], h_out_approx[5+i]) << "at i: " << i << endl;
+    }
 }

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -840,3 +840,81 @@ TEST(Approx1, CPPEmptyPosAndInput)
     ASSERT_TRUE(pos.isempty());
     ASSERT_TRUE(interp.isempty());
 }
+
+TEST(Approx1, UseNullInitialOutput) {
+    float h_in[3] = {10, 20, 30};
+    dim_t h_in_dims[1] = {3};
+
+    af_array in = 0;
+    af_create_array(&in, &h_in[0], 1, &h_in_dims[0], f32);
+
+    float h_pos[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
+    dim_t h_pos_dims[1] = {5};
+    af_array pos = 0;
+    af_create_array(&pos, &h_pos[0], 1, &h_pos_dims[0], f32);
+
+    dim_t h_out_dims[1] = {5};
+    af_array out = 0;
+    af_approx1(&out, in, pos, AF_INTERP_LINEAR, 0);
+
+    ASSERT_FALSE(out == 0);
+}
+
+TEST(Approx1, UseExistingOutputArray) {
+    float h_in[3] = {10, 20, 30};
+    dim_t h_in_dims[1] = {3};
+
+    af_array in = 0;
+    af_create_array(&in, &h_in[0], 1, &h_in_dims[0], f32);
+
+    float h_pos[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
+    dim_t h_pos_dims[1] = {5};
+    af_array pos = 0;
+    af_create_array(&pos, &h_pos[0], 1, &h_pos_dims[0], f32);
+
+    dim_t h_out_dims[1] = {5};
+    af_array out = 0;
+    af_create_handle(&out, 1, &h_out_dims[0], f32);
+    // af_print_array_gen("out", out, 4);
+    af_array out_copy = out;
+    // af_print_array_gen("out_copy", out_copy, 4);
+    af_approx1(&out, in, pos, AF_INTERP_LINEAR, 0);
+    // af_print_array_gen("out", out, 4);
+    // af_print_array_gen("out_copy", out_copy, 4);
+
+    ASSERT_EQ(out_copy, out);
+    ASSERT_ARRAYS_EQ(out_copy, out);
+}
+
+TEST(Approx1, UseExistingOutputSlice) {
+    float h_in[3] = {10, 20, 30};
+    dim_t h_in_dims[1] = {3};
+
+    af_array in = 0;
+    af_create_array(&in, &h_in[0], 1, &h_in_dims[0], f32);
+
+    float h_pos[5] = {0.0, 0.5, 1.0, 1.5, 2.0};
+    dim_t h_pos_dims[1] = {5};
+    af_array pos = 0;
+    af_create_array(&pos, &h_pos[0], 1, &h_pos_dims[0], f32);
+
+    float h_out[15] = {1.0, 1.5, 2.0, 2.5, 3.0,
+                       4.0, 4.5, 5.0, 5.5, 6.0,
+                       7.0, 7.5, 8.0, 8.5, 9.0};
+    dim_t h_out_dims[2] = {5, 3};
+    af_array out = 0;
+    af_create_array(&out, &h_out[0], 2, &h_out_dims[0], f32);
+    // af_print_array_gen("out", out, 4);
+    af_seq idx_dim1 = {1, 1, 1};
+    af_seq idx[2] = {af_span, idx_dim1};
+    af_array out_slice = 0;
+    af_index(&out_slice, out, 2, &idx[0]);
+    // af_print_array_gen("out_slice", out_slice, 4);
+    af_approx1(&out_slice, in, pos, AF_INTERP_LINEAR, 0);
+    // af_print_array_gen("out_slice", out_slice, 4);
+    // af_print_array_gen("out", out, 4);
+
+    float h_gold_arr[5] = {10.0, 15.0, 20.0, 25.0, 30.0};
+    vector<float> h_gold(h_gold_arr, h_gold_arr + 5);
+    ASSERT_VEC_ARRAY_EQ(h_gold, dim4(5), out_slice);
+}

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -911,12 +911,10 @@ TEST(Approx1, UseExistingOutputSlice) {
     vector<float> h_out_approx(nelems);
     ASSERT_SUCCESS(af_get_data_ptr(&h_out_approx.front(), out));
 
-    float h_gold_arr[5] = {10.0, 15.0, 20.0, 25.0, 30.0};
-
-    // Check slice 1 of dim2 (elements 5 to 9 of h_out_approx) to see if they
-    // contain ASSERT_SUCCESS(af_approx1's results (without additional intermediate processing
-    // like indexing)
-    for (int i = 0; i < 5; ++i) {
-        EXPECT_EQ(h_gold_arr[i], h_out_approx[5+i]) << "at i: " << i << endl;
-    }
+    float h_gold[15] = {1.0, 1.5, 2.0, 2.5, 3.0,
+                        10.0, 15.0, 20.0, 25.0, 30.0,
+                        7.0, 7.5, 8.0, 8.5, 9.0};
+    af_array gold = 0;
+    ASSERT_SUCCESS(af_create_array(&gold, &h_gold[0], 2, &h_out_dims[0], f32));
+    ASSERT_ARRAYS_EQ(gold, out);
 }

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -875,14 +875,11 @@ TEST(Approx1, UseExistingOutputArray) {
     dim_t h_out_dims[1] = {5};
     af_array out_ptr = 0;
     af_create_handle(&out_ptr, 1, &h_out_dims[0], f32);
-    // af_print_array_gen("out_ptr", out_ptr, 4);
     af_array out_ptr_copy = out_ptr;
-    // af_print_array_gen("out_ptr_copy", out_ptr_copy, 4);
     af_approx1(&out_ptr, in, pos, AF_INTERP_LINEAR, 0);
-    // af_print_array_gen("out_ptr", out_ptr, 4);
-    // af_print_array_gen("out_ptr_copy", out_ptr_copy, 4);
 
     ASSERT_EQ(out_ptr_copy, out_ptr);
+    // Verify that the original af_array does contain the results
     ASSERT_ARRAYS_EQ(out_ptr_copy, out_ptr);
 }
 
@@ -904,15 +901,11 @@ TEST(Approx1, UseExistingOutputSlice) {
     dim_t h_out_dims[2] = {5, 3};
     af_array out = 0;
     af_create_array(&out, &h_out[0], 2, &h_out_dims[0], f32);
-    // af_print_array_gen("out", out, 4);
     af_seq idx_dim1 = {1, 1, 1}; // get slice 1 of dim1
     af_seq idx[2] = {af_span, idx_dim1};
     af_array out_slice = 0;
     af_index(&out_slice, out, 2, &idx[0]);
-    // af_print_array_gen("out_slice", out_slice, 4);
     af_approx1(&out_slice, in, pos, AF_INTERP_LINEAR, 0);
-    // af_print_array_gen("out_slice", out_slice, 4);
-    // af_print_array_gen("out", out, 4);
 
     dim_t nelems = 0;
     af_get_elements(&nelems, out);
@@ -921,8 +914,9 @@ TEST(Approx1, UseExistingOutputSlice) {
 
     float h_gold_arr[5] = {10.0, 15.0, 20.0, 25.0, 30.0};
 
-    // Check slice 1 of dim1 (elements 5 to 9 of h_out_approx) to see if they
-    // contain af_approx1's results
+    // Check slice 1 of dim2 (elements 5 to 9 of h_out_approx) to see if they
+    // contain af_approx1's results (without additional intermediate processing
+    // like indexing)
     for (int i = 0; i < 5; ++i) {
         EXPECT_EQ(h_gold_arr[i], h_out_approx[5+i]) << "at i: " << i << endl;
     }


### PR DESCRIPTION
@umar456 had an idea to allow arrayfire functions to be able to use existing arrays to place their output on, instead of the functions creating new output arrays all the time. This saves overhead time, memory, and extraneous code especially if the user already has an existing memory block allocated for results to be placed in. `af_approx1` is the first function that we tried this idea on, and here's the implementation.

Note that this can only be done on the C API for now.