### PR TITLE
Remove dims restriction from svdInPlace

### DIFF
--- a/src/api/c/svd.cpp
+++ b/src/api/c/svd.cpp
@@ -107,7 +107,6 @@ af_err af_svd_inplace(af_array *u, af_array *s, af_array *vt, af_array in)
         const ArrayInfo& info = getInfo(in);
         af::dim4 dims = info.dims();
 
-        DIM_ASSERT(3, dims[0] <= dims[1]);
         ARG_ASSERT(3, (dims.ndims() >= 0 && dims.ndims() <= 3));
         af_dtype type = info.getType();
 

--- a/test/svd_dense.cpp
+++ b/test/svd_dense.cpp
@@ -18,19 +18,21 @@
 #include <string>
 #include <testHelpers.hpp>
 
-using std::vector;
-using std::string;
-using std::cout;
-using std::endl;
-using std::abs;
 using af::array;
-using af::cfloat;
 using af::cdouble;
+using af::cfloat;
+using af::dim4;
 using af::dtype;
 using af::dtype_traits;
+using af::iota;
 using af::randu;
 using af::seq;
 using af::span;
+using std::abs;
+using std::cout;
+using std::endl;
+using std::string;
+using std::vector;
 
 template<typename T>
 class svd : public ::testing::Test
@@ -59,7 +61,6 @@ template<> double get_val<cdouble>(cdouble val)
 template<typename T>
 void svdTest(const int M, const int N)
 {
-
     if (noDoubleTests<T>()) return;
     if (noLAPACKTests()) return;
 
@@ -80,19 +81,60 @@ void svdTest(const int M, const int N)
     array AA = matmul(UU, SS, VV);
     //! [ex_svd_reg]
 
-    vector<T> hA(M * N);
-    vector<T> hAA(M * N);
-
-    A.host(&hA[0]);
-    AA.host(&hAA[0]);
-
-    for (int i = 0; i < M * N; i++) {
 #if defined(OS_MAC)
-        ASSERT_NEAR(get_val(hA[i]), get_val(hAA[i]), 3E-3);
+    ASSERT_ARRAYS_NEAR(A, AA, 3E-3);
 #else
-        ASSERT_NEAR(get_val(hA[i]), get_val(hAA[i]), 1E-3);
+    ASSERT_ARRAYS_NEAR(A, AA, 1E-3);
 #endif
-    }
+}
+
+template<typename T>
+void svdInPlaceTest(const int M, const int N)
+{
+    if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
+
+    dtype ty = (dtype)dtype_traits<T>::af_type;
+
+    array A = randu(M, N, ty);
+    array A_copy = A.copy();
+
+    array U, S, Vt;
+    af::svdInPlace(U, S, Vt, A);
+
+    const int MN = std::min(M, N);
+
+    array UU = U(span, seq(MN));
+    array SS = diag(S, 0, false).as(ty);
+    array VV = Vt(seq(MN), span);
+
+    array AA = matmul(UU, SS, VV);
+
+#if defined(OS_MAC)
+    ASSERT_ARRAYS_NEAR(A_copy, AA, 3E-3);
+#else
+    ASSERT_ARRAYS_NEAR(A_copy, AA, 1E-3);
+#endif
+}
+
+template<typename T>
+void checkInPlaceSameResults(const int M, const int N)
+{
+    if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
+
+    dtype ty = (dtype)dtype_traits<T>::af_type;
+
+    array in = randu(dim4(M, N), ty);
+    array u, s, v;
+    af::svd(u, s, v, in);
+
+    array uu, ss, vv;
+    af::svdInPlace(uu, ss, vv, in);
+
+    ASSERT_ARRAYS_EQ(u, uu);
+    ASSERT_ARRAYS_EQ(s, ss);
+    ASSERT_ARRAYS_EQ(v, vv);
 }
 
 TYPED_TEST(svd, Square)
@@ -108,4 +150,34 @@ TYPED_TEST(svd, Rect0)
 TYPED_TEST(svd, Rect1)
 {
     svdTest<TypeParam>(300, 500);
+}
+
+TYPED_TEST(svd, InPlaceSquare)
+{
+    svdInPlaceTest<TypeParam>(500, 500);
+}
+
+TYPED_TEST(svd, InPlaceRect0)
+{
+    svdInPlaceTest<TypeParam>(500, 300);
+}
+
+TYPED_TEST(svd, InPlaceRect1)
+{
+    svdInPlaceTest<TypeParam>(300, 500);
+}
+
+TYPED_TEST(svd, InPlaceSameResultsSquare)
+{
+    checkInPlaceSameResults<TypeParam>(10, 10);
+}
+
+TYPED_TEST(svd, InPlaceSameResultsRect0)
+{
+    checkInPlaceSameResults<TypeParam>(10, 8);
+}
+
+TYPED_TEST(svd, InPlaceSameResultsRect1)
+{
+    checkInPlaceSameResults<TypeParam>(8, 10);
 }


### PR DESCRIPTION
Fixes #2282. `svdInPlace` can now take in arrays where `dim0 > dim1`. I added tests too since there weren't any for `svdInPlace`, just regular `svd`.