### PR TITLE
Added samples to sparse documentation

### DIFF
--- a/include/af/sparse.h
+++ b/include/af/sparse.h
@@ -32,6 +32,8 @@ namespace af
        \param[in] stype is the storage format of the sparse array
        \return \ref af::array for the sparse array
 
+       \snippet test/sparse.cpp ex_sparse_af_arrays
+
        \ingroup sparse_func_create
      */
     AFAPI array sparse(const dim_t nRows, const dim_t nCols,
@@ -60,6 +62,8 @@ namespace af
                   if the arrays are device arrays.
        \return \ref af::array for the sparse array
 
+       \snippet test/sparse.cpp ex_sparse_host_arrays
+
        \ingroup sparse_func_create
      */
     AFAPI array sparse(const dim_t nRows, const dim_t nCols, const dim_t nNZ,
@@ -76,6 +80,8 @@ namespace af
        \param[in] dense is the source dense matrix
        \param[in] stype is the storage format of the sparse array
        \return \ref af::array for the sparse array with the given storage type
+
+       \snippet test/sparse.cpp ex_sparse_from_dense
 
        \ingroup sparse_func_create
      */
@@ -97,6 +103,8 @@ namespace af
     /**
        \param[in] sparse is the source sparse matrix
        \return dense \ref af::array from sparse
+
+       \snippet test/sparse.cpp ex_dense_from_sparse
 
        \ingroup sparse_func_dense
      */

--- a/src/api/c/sparse.cpp
+++ b/src/api/c/sparse.cpp
@@ -45,7 +45,7 @@ const SparseArrayBase &getSparseArrayBase(const af_array in,
 // Sparse Creation
 ////////////////////////////////////////////////////////////////////////////////
 template<typename T>
-af_array createSparseArrayFromData(const af::dim4 &dims, const af_array values,
+af_array createSparseArrayFromData(const dim4 &dims, const af_array values,
                                    const af_array rowIdx, const af_array colIdx,
                                    const af::storage stype) {
     SparseArray<T> sparse = common::createArrayDataSparseArray(
@@ -96,9 +96,9 @@ af_err af_create_sparse_array(af_array *out, const dim_t nRows,
             DIM_ASSERT(5, (dim_t)cInfo.elements() == nCols + 1);
         }
 
-        af_array output = 0;
+        af_array output = nullptr;
 
-        af::dim4 dims(nRows, nCols);
+        dim4 dims(nRows, nCols);
 
         switch (vInfo.getType()) {
             case f32:
@@ -168,9 +168,9 @@ af_err af_create_sparse_array_from_ptr(
 
         TYPE_ASSERT(type == f32 || type == f64 || type == c32 || type == c64);
 
-        af_array output = 0;
+        af_array output = nullptr;
 
-        af::dim4 dims(nRows, nCols);
+        dim4 dims(nRows, nCols);
 
         switch (type) {
             case f32:
@@ -319,9 +319,9 @@ af_err af_sparse_convert_to(af_array *out, const af_array in,
             return af_create_sparse_array_from_dense(out, in, destStorage);
         }
 
-        af_array output = 0;
+        af_array output = nullptr;
 
-        const SparseArrayBase base = getSparseArrayBase(in);
+        const SparseArrayBase &base = getSparseArrayBase(in);
 
         // Dense not allowed as input -> Should never happen with
         // SparseArrayBase CSC is currently not supported
@@ -360,9 +360,9 @@ af_err af_sparse_convert_to(af_array *out, const af_array in,
 
 af_err af_sparse_to_dense(af_array *out, const af_array in) {
     try {
-        af_array output = 0;
+        af_array output = nullptr;
 
-        const SparseArrayBase base = getSparseArrayBase(in);
+        const SparseArrayBase &base = getSparseArrayBase(in);
 
         // Dense not allowed as input -> Should never happen
         // To convert from dense to type, use the create* functions
@@ -414,7 +414,7 @@ af_err af_sparse_get_values(af_array *out, const af_array in) {
     try {
         const SparseArrayBase base = getSparseArrayBase(in);
 
-        af_array output = 0;
+        af_array output = nullptr;
 
         switch (base.getType()) {
             case f32: output = getSparseValues<float>(in); break;


### PR DESCRIPTION
Samples added for:

```
array sparse(const dim_t nRows, const dim_t nCols,
                       const array values, const array rowIdx, const array colIdx,
                       const af::storage stype = AF_STORAGE_CSR);

array sparse(const dim_t nRows, const dim_t nCols, const dim_t nNZ,
                       const void* const values,
                       const int * const rowIdx, const int * const colIdx,
                       const dtype type = f32, const af::storage stype = AF_STORAGE_CSR,
                       const af::source src = afHost);

array sparse(const array dense, const af::storage stype = AF_STORAGE_CSR);

array dense(const array sparse);
```



Also made a few minor improvements to sparse backend and API code.