### PR TITLE
svdInPlace: Flip the inequality on the dims restriction

### DIFF
--- a/docs/details/lapack.dox
+++ b/docs/details/lapack.dox
@@ -127,21 +127,23 @@ When memory is a concern, users can perform Cholesky decomposition in place as s
 
 \ingroup lapack_factor_mat
 
-\brief Perform Singular Value Decomposition
+\brief Computes the singular value decomposition of a matrix
 
-This function factorizes a  matrix **A** into two unitary matrices **U** and **Vt**, and a diagonal matrix **S** such that
+This function factorizes a matrix \f$A\f$ into two unitary matrices, \f$U\f$ and
+\f$V^T\f$, and a diagonal matrix \f$S\f$, such that \f$A = USV^T\f$. If \f$A\f$
+has \f$M\f$ rows and \f$N\f$ columns (\f$M \times N\f$), then \f$U\f$ will be
+\f$M \times M\f$, \f$V\f$ will be \f$N \times N\f$, and \f$S\f$ will be
+\f$M \times N\f$. However, for \f$S\f$, this function only returns the non-zero
+diagonal elements as a sorted (in descending order) 1D array.
 
-     \f$A = U * S * Vt\f$
-
-If **A** has **M** rows and **N** columns, **U** is of the size **M x M** , **V** is of size **N x N**, and **S** is of size **M x N**
-
-The arrayfire function only returns the non zero diagonal elements of **S**. To reconstruct the original matrix **A** from the individual factors, the following code snuppet can be used:
-
+To reconstruct the original matrix \f$A\f$ from the individual factors, the
+following code snippet can be used:
 
 \snippet test/svd_dense.cpp ex_svd_reg
 
-When memory is a concern, and **A** is dispensible, \ref svdInPlace() can be used
-
+When memory is a concern, and \f$A\f$ is dispensable, \ref svdInPlace() can be
+used. However, this in-place version is currently limited to input arrays where
+\f$M \geq N\f$.
 
 =======================================================================
 

--- a/include/af/lapack.h
+++ b/include/af/lapack.h
@@ -30,12 +30,18 @@ namespace af
 
 #if AF_API_VERSION >= 31
     /**
-       C++ Interface for SVD decomposition
+       C++ Interface for SVD decomposition (in-place)
 
-       \param[out] u is the output array containing U
-       \param[out] s is the output array containing the diagonal values of sigma, (singular values of the input matrix))
-       \param[out] vt is the output array containing V^H
-       \param[inout] in is the input matrix and will contain random data after this operation
+       \param[out]    u is the output array containing U
+       \param[out]    s is the output array containing the diagonal values of sigma,
+                        (singular values of the input matrix))
+       \param[out]    vt is the output array containing V^H
+       \param[in,out] in is the input matrix and will contain random data after
+                         this operation
+
+       \note Currently, \p in is limited to arrays where `dim0` \f$\geq\f$ `dim1`
+       \note This is best used when minimizing memory usage and \p in is
+             dispensable
 
        \ingroup lapack_factor_func_svd
     */
@@ -294,12 +300,18 @@ extern "C" {
 
 #if AF_API_VERSION >= 31
     /**
-       C Interface for SVD decomposition
+       C Interface for SVD decomposition (in-place)
 
-       \param[out] u is the output array containing U
-       \param[out] s is the output array containing the diagonal values of sigma, (singular values of the input matrix))
-       \param[out] vt is the output array containing V^H
-       \param[inout] in is the input matrix that will contain random data after this operation
+       \param[out]    u  is the output array containing U
+       \param[out]    s  is the output array containing the diagonal values of
+                         sigma, (singular values of the input matrix))
+       \param[out]    vt is the output array containing V^H
+       \param[in,out] in is the input matrix that will contain random data after
+                         this operation
+
+       \note Currently, \p in is limited to arrays where `dim0` \f$\geq\f$ `dim1`
+       \note This is best used when minimizing memory usage and \p in is
+             dispensable
 
        \ingroup lapack_factor_func_svd
     */

--- a/src/api/c/svd.cpp
+++ b/src/api/c/svd.cpp
@@ -107,6 +107,7 @@ af_err af_svd_inplace(af_array *u, af_array *s, af_array *vt, af_array in)
         const ArrayInfo& info = getInfo(in);
         af::dim4 dims = info.dims();
 
+        DIM_ASSERT(3, dims[0] >= dims[1]);
         ARG_ASSERT(3, (dims.ndims() >= 0 && dims.ndims() <= 3));
         af_dtype type = info.getType();
 

--- a/src/api/c/svd.cpp
+++ b/src/api/c/svd.cpp
@@ -107,7 +107,6 @@ af_err af_svd_inplace(af_array *u, af_array *s, af_array *vt, af_array in)
         const ArrayInfo& info = getInfo(in);
         af::dim4 dims = info.dims();
 
-        DIM_ASSERT(3, dims[0] <= dims[1]);
         ARG_ASSERT(3, (dims.ndims() >= 0 && dims.ndims() <= 3));
         af_dtype type = info.getType();
 

--- a/test/svd_dense.cpp
+++ b/test/svd_dense.cpp
@@ -18,19 +18,21 @@
 #include <string>
 #include <testHelpers.hpp>
 
-using std::vector;
-using std::string;
-using std::cout;
-using std::endl;
-using std::abs;
 using af::array;
-using af::cfloat;
 using af::cdouble;
+using af::cfloat;
+using af::dim4;
 using af::dtype;
 using af::dtype_traits;
+using af::iota;
 using af::randu;
 using af::seq;
 using af::span;
+using std::abs;
+using std::cout;
+using std::endl;
+using std::string;
+using std::vector;
 
 template<typename T>
 class svd : public ::testing::Test
@@ -59,7 +61,6 @@ template<> double get_val<cdouble>(cdouble val)
 template<typename T>
 void svdTest(const int M, const int N)
 {
-
     if (noDoubleTests<T>()) return;
     if (noLAPACKTests()) return;
 
@@ -80,19 +81,60 @@ void svdTest(const int M, const int N)
     array AA = matmul(UU, SS, VV);
     //! [ex_svd_reg]
 
-    vector<T> hA(M * N);
-    vector<T> hAA(M * N);
-
-    A.host(&hA[0]);
-    AA.host(&hAA[0]);
-
-    for (int i = 0; i < M * N; i++) {
 #if defined(OS_MAC)
-        ASSERT_NEAR(get_val(hA[i]), get_val(hAA[i]), 3E-3);
+    ASSERT_ARRAYS_NEAR(A, AA, 3E-3);
 #else
-        ASSERT_NEAR(get_val(hA[i]), get_val(hAA[i]), 1E-3);
+    ASSERT_ARRAYS_NEAR(A, AA, 1E-3);
 #endif
-    }
+}
+
+template<typename T>
+void svdInPlaceTest(const int M, const int N)
+{
+    if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
+
+    dtype ty = (dtype)dtype_traits<T>::af_type;
+
+    array A = randu(M, N, ty);
+    array A_copy = A.copy();
+
+    array U, S, Vt;
+    af::svdInPlace(U, S, Vt, A);
+
+    const int MN = std::min(M, N);
+
+    array UU = U(span, seq(MN));
+    array SS = diag(S, 0, false).as(ty);
+    array VV = Vt(seq(MN), span);
+
+    array AA = matmul(UU, SS, VV);
+
+#if defined(OS_MAC)
+    ASSERT_ARRAYS_NEAR(A_copy, AA, 3E-3);
+#else
+    ASSERT_ARRAYS_NEAR(A_copy, AA, 1E-3);
+#endif
+}
+
+template<typename T>
+void checkInPlaceSameResults(const int M, const int N)
+{
+    if (noDoubleTests<T>()) return;
+    if (noLAPACKTests()) return;
+
+    dtype ty = (dtype)dtype_traits<T>::af_type;
+
+    array in = randu(dim4(M, N), ty);
+    array u, s, v;
+    af::svd(u, s, v, in);
+
+    array uu, ss, vv;
+    af::svdInPlace(uu, ss, vv, in);
+
+    ASSERT_ARRAYS_EQ(u, uu);
+    ASSERT_ARRAYS_EQ(s, ss);
+    ASSERT_ARRAYS_EQ(v, vv);
 }
 
 TYPED_TEST(svd, Square)
@@ -108,4 +150,34 @@ TYPED_TEST(svd, Rect0)
 TYPED_TEST(svd, Rect1)
 {
     svdTest<TypeParam>(300, 500);
+}
+
+TYPED_TEST(svd, InPlaceSquare)
+{
+    svdInPlaceTest<TypeParam>(500, 500);
+}
+
+TYPED_TEST(svd, InPlaceRect0)
+{
+    svdInPlaceTest<TypeParam>(500, 300);
+}
+
+TYPED_TEST(svd, InPlaceRect1)
+{
+    svdInPlaceTest<TypeParam>(300, 500);
+}
+
+TYPED_TEST(svd, InPlaceSameResultsSquare)
+{
+    checkInPlaceSameResults<TypeParam>(10, 10);
+}
+
+TYPED_TEST(svd, InPlaceSameResultsRect0)
+{
+    checkInPlaceSameResults<TypeParam>(10, 8);
+}
+
+TYPED_TEST(svd, InPlaceSameResultsRect1)
+{
+    checkInPlaceSameResults<TypeParam>(8, 10);
 }

--- a/test/svd_dense.cpp
+++ b/test/svd_dense.cpp
@@ -162,10 +162,11 @@ TYPED_TEST(svd, InPlaceRect0)
     svdInPlaceTest<TypeParam>(500, 300);
 }
 
-TYPED_TEST(svd, InPlaceRect1)
-{
-    svdInPlaceTest<TypeParam>(300, 500);
-}
+// dim0 < dim1 case not supported for now
+// TYPED_TEST(svd, InPlaceRect1)
+// {
+//     svdInPlaceTest<TypeParam>(300, 500);
+// }
 
 TYPED_TEST(svd, InPlaceSameResultsSquare)
 {
@@ -177,7 +178,8 @@ TYPED_TEST(svd, InPlaceSameResultsRect0)
     checkInPlaceSameResults<TypeParam>(10, 8);
 }
 
-TYPED_TEST(svd, InPlaceSameResultsRect1)
-{
-    checkInPlaceSameResults<TypeParam>(8, 10);
-}
+// dim0 < dim1 case not supported for now
+// TYPED_TEST(svd, InPlaceSameResultsRect1)
+// {
+//     checkInPlaceSameResults<TypeParam>(8, 10);
+// }


### PR DESCRIPTION
Following up on #2282, `svdInPlace` did have its inequality on the input array dims restriction [flipped](https://github.com/arrayfire/arrayfire/blob/master/src/api/c/svd.cpp#L110). It asserted before that the input's `dim0 <= dim1`, but I flipped it to `>=`, which is what it should've been (see the issue for my explanation of why this should be the case). I addded some tests to verify this and I also noted this down in the docs for future users of this function.