### PR TITLE
Fix int overflow in flops calculation

### DIFF
--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -521,7 +521,7 @@ DeviceManager::DeviceManager()
         if (dev.prop.major < getMinSupportedCompute(cudaMajorVer)) {
             continue;
         } else {
-            dev.flops = dev.prop.multiProcessorCount *
+            dev.flops = static_cast<size_t>(dev.prop.multiProcessorCount) *
                         compute2cores(dev.prop.major, dev.prop.minor) *
                         dev.prop.clockRate;
             dev.nativeId = i;


### PR DESCRIPTION
caught by ubsan: runtime error: signed integer overflow: 3072 * 1112000 cannot be represented in type 'int'