### PR TITLE
Fix memory leaks on pinverse C tests

### DIFF
--- a/test/pinverse.cpp
+++ b/test/pinverse.cpp
@@ -283,27 +283,29 @@ TEST(Pinverse, CustomTol) {
 
 TEST(Pinverse, C) {
     array in = readTestInput<float>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
-    af_array inpinv = 0, out = 0;
+    af_array inpinv = 0, identity = 0, out = 0;
     ASSERT_SUCCESS(af_pinverse(&inpinv, in.get(), 1e-6, AF_MAT_NONE));
-    ASSERT_SUCCESS(af_matmul(&out, in.get(), inpinv, AF_MAT_NONE, AF_MAT_NONE));
-    ASSERT_SUCCESS(af_matmul(&out, out, in.get(), AF_MAT_NONE, AF_MAT_NONE));
+    ASSERT_SUCCESS(af_matmul(&identity, in.get(), inpinv, AF_MAT_NONE, AF_MAT_NONE));
+    ASSERT_SUCCESS(af_matmul(&out, identity, in.get(), AF_MAT_NONE, AF_MAT_NONE));
 
     ASSERT_ARRAYS_NEAR(in.get(), out, eps<float>());
 
     ASSERT_SUCCESS(af_release_array(out));
+    ASSERT_SUCCESS(af_release_array(identity));
     ASSERT_SUCCESS(af_release_array(inpinv));
 }
 
 TEST(Pinverse, C_CustomTol) {
     array in = readTestInput<float>(string(TEST_DIR"/pinverse/pinverse10x8.test"));
-    af_array inpinv = 0, out = 0;
+    af_array inpinv = 0, identity = 0, out = 0;
     ASSERT_SUCCESS(af_pinverse(&inpinv, in.get(), 1e-12, AF_MAT_NONE));
-    ASSERT_SUCCESS(af_matmul(&out, in.get(), inpinv, AF_MAT_NONE, AF_MAT_NONE));
-    ASSERT_SUCCESS(af_matmul(&out, out, in.get(), AF_MAT_NONE, AF_MAT_NONE));
+    ASSERT_SUCCESS(af_matmul(&identity, in.get(), inpinv, AF_MAT_NONE, AF_MAT_NONE));
+    ASSERT_SUCCESS(af_matmul(&out, identity, in.get(), AF_MAT_NONE, AF_MAT_NONE));
 
     ASSERT_ARRAYS_NEAR(in.get(), out, eps<float>());
 
     ASSERT_SUCCESS(af_release_array(out));
+    ASSERT_SUCCESS(af_release_array(identity));
     ASSERT_SUCCESS(af_release_array(inpinv));
 }
 


### PR DESCRIPTION
The C API tests of `pinverse` were using an `af_array` that is used twice as an output by two consecutive `af_matmul` calls. Because `af_matmul` is allocating memory for its output every time it's called, if the same `af_array` used as its output more than one time, then the previously allocated memory never gets released (unless `af_release_array` is called in between the two `af_matmul`s, which cannot be done in this case because the previous output is used also as an input to the next `af_matmul`).

A quick fix for the tests is introduced to use an intermediate array in the string of calculations such that each `af_* function` corresponds to an `af_release_array` (a long term fix would be to apply to `af_matmul` the same kind of changes done in #2324).