### PR TITLE
Fix af_window typedef in graphics header

### DIFF
--- a/include/af/graphics.h
+++ b/include/af/graphics.h
@@ -12,7 +12,7 @@
 #include <af/defines.h>
 #include <af/array.h>
 
-typedef unsigned long long af_window;
+typedef void* af_window;
 
 typedef struct {
     int row;

--- a/src/api/c/hist.cpp
+++ b/src/api/c/hist.cpp
@@ -93,7 +93,7 @@ af_err af_draw_hist(const af_window wind, const af_array X, const double minval,
 
         ARG_ASSERT(0, Xinfo.isVector());
 
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
         makeContextCurrent(window);
 
         forge::Chart* chart = NULL;

--- a/src/api/c/image.cpp
+++ b/src/api/c/image.cpp
@@ -90,7 +90,7 @@ af_err af_draw_image(const af_window wind, const af_array in, const af_cell* con
         DIM_ASSERT(0, in_dims[2] == 1 || in_dims[2] == 3 || in_dims[2] == 4);
         DIM_ASSERT(0, in_dims[3] == 1);
 
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
         makeContextCurrent(window);
         forge::Image* image = NULL;
 

--- a/src/api/c/plot.cpp
+++ b/src/api/c/plot.cpp
@@ -137,7 +137,7 @@ af_err plotWrapper(const af_window wind, const af_array in, const int order_dim,
         DIM_ASSERT(0, dims.ndims() == 2);
         DIM_ASSERT(0, dims[order_dim] == 2 || dims[order_dim] == 3);
 
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
         makeContextCurrent(window);
 
         forge::Chart* chart = NULL;
@@ -200,7 +200,7 @@ af_err plotWrapper(const af_window wind, const af_array X, const af_array Y, con
         af_array pIn[] = {X, Y, Z};
         AF_CHECK(af_join_many(&in, 1, 3, pIn));
 
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
         makeContextCurrent(window);
 
         forge::Chart* chart = NULL;
@@ -257,7 +257,7 @@ af_err plotWrapper(const af_window wind, const af_array X, const af_array Y,
         af_array in = 0;
         AF_CHECK(af_join(&in, 1, X, Y));
 
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
         makeContextCurrent(window);
 
         forge::Chart* chart = NULL;

--- a/src/api/c/surface.cpp
+++ b/src/api/c/surface.cpp
@@ -153,7 +153,7 @@ af_err af_draw_surface(const af_window wind, const af_array xVals, const af_arra
             DIM_ASSERT(3, ( X_dims[0] * Y_dims[0] == (dim_t)Sinfo.elements()));
         }
 
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
         makeContextCurrent(window);
 
         forge::Chart* chart = NULL;

--- a/src/api/c/vector_field.cpp
+++ b/src/api/c/vector_field.cpp
@@ -138,7 +138,7 @@ af_err vectorFieldWrapper(const af_window wind, const af_array points, const af_
 
         TYPE_ASSERT(pType == dType);
 
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
         makeContextCurrent(window);
 
         forge::Chart* chart = NULL;
@@ -225,7 +225,7 @@ af_err vectorFieldWrapper(const af_window wind,
         DIM_ASSERT(1, xpType == ypType);
         DIM_ASSERT(1, xpType == zpType);
 
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
         makeContextCurrent(window);
 
         forge::Chart* chart = NULL;
@@ -306,7 +306,7 @@ af_err vectorFieldWrapper(const af_window wind,
 
         DIM_ASSERT(1, xpType == ypType);
 
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
         makeContextCurrent(window);
 
         forge::Chart* chart = NULL;

--- a/src/api/c/window.cpp
+++ b/src/api/c/window.cpp
@@ -48,7 +48,7 @@ af_err af_create_window(af_window *out, const int width, const int height, const
         // Create a chart map
         fgMngr.setWindowChartGrid(wnd, 1, 1);
 
-        *out = reinterpret_cast<af_window>(wnd);
+        *out = static_cast<af_window>(wnd);
     }
     CATCHALL;
     return AF_SUCCESS;
@@ -70,7 +70,7 @@ af_err af_set_position(const af_window wind, const unsigned x, const unsigned y)
     }
 
     try {
-        forge::Window* wnd = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* wnd = static_cast<forge::Window*>(wind);
         wnd->setPos(x, y);
     }
     CATCHALL;
@@ -92,7 +92,7 @@ af_err af_set_title(const af_window wind, const char* const title)
     }
 
     try {
-        forge::Window* wnd = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* wnd = static_cast<forge::Window*>(wind);
         wnd->setTitle(title);
     }
     CATCHALL;
@@ -113,7 +113,7 @@ af_err af_set_size(const af_window wind, const unsigned w, const unsigned h)
     }
 
     try {
-        forge::Window* wnd = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* wnd = static_cast<forge::Window*>(wind);
         wnd->setSize(w, h);
     }
     CATCHALL;
@@ -135,7 +135,7 @@ af_err af_grid(const af_window wind, const int rows, const int cols)
     }
 
     try {
-        forge::Window* wnd = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* wnd = static_cast<forge::Window*>(wind);
 
         // Recreate a chart map
         ForgeManager& fgMngr = ForgeManager::getInstance();
@@ -162,7 +162,7 @@ af_err af_set_axes_limits_compute(const af_window wind,
     }
 
     try {
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
 
         // Recreate a chart map
         ForgeManager& fgMngr = ForgeManager::getInstance();
@@ -226,7 +226,7 @@ af_err af_set_axes_limits_2d(const af_window wind,
     }
 
     try {
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
 
         // Recreate a chart map
         ForgeManager& fgMngr = ForgeManager::getInstance();
@@ -283,7 +283,7 @@ af_err af_set_axes_limits_3d(const af_window wind,
     }
 
     try {
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
 
         // Recreate a chart map
         ForgeManager& fgMngr = ForgeManager::getInstance();
@@ -346,7 +346,7 @@ af_err af_set_axes_titles(const af_window wind,
     }
 
     try {
-        forge::Window* window = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* window = static_cast<forge::Window*>(wind);
 
         // Recreate a chart map
         ForgeManager& fgMngr = ForgeManager::getInstance();
@@ -383,7 +383,7 @@ af_err af_show(const af_window wind)
     }
 
     try {
-        forge::Window* wnd = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* wnd = static_cast<forge::Window*>(wind);
         wnd->swapBuffers();
     }
     CATCHALL;
@@ -403,7 +403,7 @@ af_err af_is_window_closed(bool *out, const af_window wind)
     }
 
     try {
-        forge::Window* wnd = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* wnd = static_cast<forge::Window*>(wind);
         *out = wnd->close();
     }
     CATCHALL;
@@ -424,7 +424,7 @@ af_err af_set_visibility(const af_window wind, const bool is_visible)
     }
 
     try {
-        forge::Window* wnd = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* wnd = static_cast<forge::Window*>(wind);
         if (is_visible)
             wnd->show();
         else
@@ -448,7 +448,7 @@ af_err af_destroy_window(const af_window wind)
     }
 
     try {
-        forge::Window* wnd = reinterpret_cast<forge::Window*>(wind);
+        forge::Window* wnd = static_cast<forge::Window*>(wind);
 
         // Delete chart map
         ForgeManager& fgMngr = ForgeManager::getInstance();


### PR DESCRIPTION
`af_window` was earlier a typedef to normal integral type instead of
using either intptr_t/uintptr_t or void*. This is not portable code.

I have verified that the ABI doesn't change with this, so we are good if we want to backport it.
Update: Used g++ and clang++. Haven't tested on windows though. Will do.