### PR TITLE
Fix typo in matmul batch info table

### DIFF
--- a/docs/details/blas.dox
+++ b/docs/details/blas.dox
@@ -29,14 +29,17 @@ data from memory. This results in no additional memory being used for temporary
 buffers.
 
 Batched matrix multiplications are supported. Given below are the supported
-formats for given matrices A and B.
+types of batch operations for any given set of two matrices A and B.
 
-| Input Matrix A             | Input Matrix B             | Output Matrix Size          |
+| Size of Input Matrix A     | Size of Input Matrix B     | Output Matrix Size          |
 |:--------------------------:|:--------------------------:|:---------------------------:|
-| \f$ \{ M, K,  1,  1 \} \f$ | \f$ \{ K, N,  1,  1 \} \f$ |  \f$ \{ K, N,  1,  1 \} \f$ |
-| \f$ \{ M, K, b2, b3 \} \f$ | \f$ \{ K, N, b2, b3 \} \f$ |  \f$ \{ K, N, b2, b3 \} \f$ |
-| \f$ \{ M, K,  1,  1 \} \f$ | \f$ \{ K, N, b2, b3 \} \f$ |  \f$ \{ K, N, b2, b3 \} \f$ |
-| \f$ \{ M, K, b2, b3 \} \f$ | \f$ \{ K, N,  1,  1 \} \f$ |  \f$ \{ K, N, b2, b3 \} \f$ |
+| \f$ \{ M, K,  1,  1 \} \f$ | \f$ \{ K, N,  1,  1 \} \f$ |  \f$ \{ M, N,  1,  1 \} \f$ |
+| \f$ \{ M, K, b2, b3 \} \f$ | \f$ \{ K, N, b2, b3 \} \f$ |  \f$ \{ M, N, b2, b3 \} \f$ |
+| \f$ \{ M, K,  1,  1 \} \f$ | \f$ \{ K, N, b2, b3 \} \f$ |  \f$ \{ M, N, b2, b3 \} \f$ |
+| \f$ \{ M, K, b2, b3 \} \f$ | \f$ \{ K, N,  1,  1 \} \f$ |  \f$ \{ M, N, b2, b3 \} \f$ |
+
+where M, K, N are dimensions of the matrix and b2, b3 indicate batch size along the
+respective dimension.
 
 For the last two entries in the above table, the 2D matrix is broadcasted to
 match the dimensions of 3D/4D array. This broadcast doesn't involve any additional


### PR DESCRIPTION
@mlloreda docs need to be updated because of this fix. I don't think we need to update 3.6 branch yet. that's @umar456 call.

Sorry about the typo.