### PR TITLE
Remove initArray. Add missing varBias typedef. Fix order of approx functions

### DIFF
--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -66,63 +66,63 @@ typedef enum {
     ///
     /// The function returned successfully
     ///
-    AF_SUCCESS            =   0,
+    AF_SUCCESS            =   0
 
     // 100-199 Errors in environment
 
     ///
     /// The system or device ran out of memory
     ///
-    AF_ERR_NO_MEM         = 101,
+    , AF_ERR_NO_MEM         = 101
 
     ///
     /// There was an error in the device driver
     ///
-    AF_ERR_DRIVER         = 102,
+    , AF_ERR_DRIVER         = 102
 
     ///
     /// There was an error with the runtime environment
     ///
-    AF_ERR_RUNTIME        = 103,
+    , AF_ERR_RUNTIME        = 103
 
     // 200-299 Errors in input parameters
 
     ///
     /// The input array is not a valid af_array object
     ///
-    AF_ERR_INVALID_ARRAY  = 201,
+    , AF_ERR_INVALID_ARRAY  = 201
 
     ///
     /// One of the function arguments is incorrect
     ///
-    AF_ERR_ARG            = 202,
+    , AF_ERR_ARG            = 202
 
     ///
     /// The size is incorrect
     ///
-    AF_ERR_SIZE           = 203,
+    , AF_ERR_SIZE           = 203
 
     ///
     /// The type is not suppported by this function
     ///
-    AF_ERR_TYPE           = 204,
+    , AF_ERR_TYPE           = 204
 
     ///
     /// The type of the input arrays are not compatible
     ///
-    AF_ERR_DIFF_TYPE      = 205,
+    , AF_ERR_DIFF_TYPE      = 205
 
     ///
     /// Function does not support GFOR / batch mode
     ///
-    AF_ERR_BATCH          = 207,
+    , AF_ERR_BATCH          = 207
 
 
 #if AF_API_VERSION >= 33
     ///
     /// Input does not belong to the current device.
     ///
-    AF_ERR_DEVICE         = 208,
+    , AF_ERR_DEVICE         = 208
 #endif
 
     // 300-399 Errors for missing software features
@@ -130,18 +130,18 @@ typedef enum {
     ///
     /// The option is not supported
     ///
-    AF_ERR_NOT_SUPPORTED  = 301,
+    , AF_ERR_NOT_SUPPORTED  = 301
 
     ///
     /// This build of ArrayFire does not support this feature
     ///
-    AF_ERR_NOT_CONFIGURED = 302,
+    , AF_ERR_NOT_CONFIGURED = 302
 
 #if AF_API_VERSION >= 32
     ///
     /// This build of ArrayFire is not compiled with "nonfree" algorithms
     ///
-    AF_ERR_NONFREE        = 303,
+    , AF_ERR_NONFREE        = 303
 #endif
 
     // 400-499 Errors for missing hardware features
@@ -149,13 +149,13 @@ typedef enum {
     ///
     /// This device does not support double
     ///
-    AF_ERR_NO_DBL         = 401,
+    , AF_ERR_NO_DBL         = 401
 
     ///
     /// This build of ArrayFire was not built with graphics or this device does
     /// not support graphics
     ///
-    AF_ERR_NO_GFX         = 402,
+    , AF_ERR_NO_GFX         = 402
 
     // 500-599 Errors specific to heterogenous API
 
@@ -163,21 +163,21 @@ typedef enum {
     ///
     /// There was an error when loading the libraries
     ///
-    AF_ERR_LOAD_LIB       = 501,
+    , AF_ERR_LOAD_LIB       = 501
 #endif
 
 #if AF_API_VERSION >= 32
     ///
     /// There was an error when loading the symbols
     ///
-    AF_ERR_LOAD_SYM       = 502,
+    , AF_ERR_LOAD_SYM       = 502
 #endif
 
 #if AF_API_VERSION >= 32
     ///
     /// There was a mismatch between the input array and the active backend
     ///
-    AF_ERR_ARR_BKND_MISMATCH    = 503,
+    , AF_ERR_ARR_BKND_MISMATCH    = 503
 #endif
 
     // 900-999 Errors from upstream libraries and runtimes
@@ -186,12 +186,12 @@ typedef enum {
     /// There was an internal error either in ArrayFire or in a project
     /// upstream
     ///
-    AF_ERR_INTERNAL       = 998,
+    , AF_ERR_INTERNAL       = 998
 
     ///
     /// Unknown Error
     ///
-    AF_ERR_UNKNOWN        = 999
+    , AF_ERR_UNKNOWN        = 999
 } af_err;
 
 typedef enum {
@@ -204,18 +204,18 @@ typedef enum {
     u32,    ///< 32-bit unsigned integral values
     u8 ,    ///< 8-bit unsigned integral values
     s64,    ///< 64-bit signed integral values
-    u64,    ///< 64-bit unsigned integral values
+    u64    ///< 64-bit unsigned integral values
 #if AF_API_VERSION >= 32
-    s16,    ///< 16-bit signed integral values
+    , s16    ///< 16-bit signed integral values
 #endif
 #if AF_API_VERSION >= 32
-    u16,    ///< 16-bit unsigned integral values
+    , u16    ///< 16-bit unsigned integral values
 #endif
 } af_dtype;
 
 typedef enum {
     afDevice,   ///< Device pointer
-    afHost,     ///< Host pointer
+    afHost     ///< Host pointer
 } af_source;
 
 #define AF_MAX_DIMS 4
@@ -228,21 +228,21 @@ typedef enum {
     AF_INTERP_LINEAR,          ///< Linear Interpolation
     AF_INTERP_BILINEAR,        ///< Bilinear Interpolation
     AF_INTERP_CUBIC,           ///< Cubic Interpolation
-    AF_INTERP_LOWER,           ///< Floor Indexed
+    AF_INTERP_LOWER           ///< Floor Indexed
 #if AF_API_VERSION >= 34
-    AF_INTERP_LINEAR_COSINE,   ///< Linear Interpolation with cosine smoothing
+    , AF_INTERP_LINEAR_COSINE   ///< Linear Interpolation with cosine smoothing
 #endif
 #if AF_API_VERSION >= 34
-    AF_INTERP_BILINEAR_COSINE, ///< Bilinear Interpolation with cosine smoothing
+    , AF_INTERP_BILINEAR_COSINE ///< Bilinear Interpolation with cosine smoothing
 #endif
 #if AF_API_VERSION >= 34
-    AF_INTERP_BICUBIC,         ///< Bicubic Interpolation
+    , AF_INTERP_BICUBIC         ///< Bicubic Interpolation
 #endif
 #if AF_API_VERSION >= 34
-    AF_INTERP_CUBIC_SPLINE,    ///< Cubic Interpolation with Catmull-Rom splines
+    , AF_INTERP_CUBIC_SPLINE    ///< Cubic Interpolation with Catmull-Rom splines
 #endif
 #if AF_API_VERSION >= 34
-    AF_INTERP_BICUBIC_SPLINE,  ///< Bicubic Interpolation with Catmull-Rom splines
+    , AF_INTERP_BICUBIC_SPLINE  ///< Bicubic Interpolation with Catmull-Rom splines
 #endif
 
 } af_interp_type;
@@ -261,7 +261,7 @@ typedef enum {
     ///
     /// Out of bound values are clamped to the edge
     ///
-    AF_PAD_CLAMP_TO_EDGE,
+    AF_PAD_CLAMP_TO_EDGE
 } af_border_type;
 
 typedef enum {
@@ -286,13 +286,13 @@ typedef enum {
     ///
     /// Output of the convolution is signal_len + filter_len - 1
     ///
-    AF_CONV_EXPAND,
+    AF_CONV_EXPAND
 } af_conv_mode;
 
 typedef enum {
     AF_CONV_AUTO,    ///< ArrayFire automatically picks the right convolution algorithm
     AF_CONV_SPATIAL, ///< Perform convolution in spatial domain
-    AF_CONV_FREQ,    ///< Perform convolution in frequency domain
+    AF_CONV_FREQ     ///< Perform convolution in frequency domain
 } af_conv_domain;
 
 typedef enum {
@@ -311,16 +311,16 @@ typedef enum {
 typedef enum {
     AF_YCC_601 = 601,  ///< ITU-R BT.601 (formerly CCIR 601) standard
     AF_YCC_709 = 709,  ///< ITU-R BT.709 standard
-    AF_YCC_2020 = 2020  ///< ITU-R BT.2020 standard
+    AF_YCC_2020 = 2020 ///< ITU-R BT.2020 standard
 } af_ycc_std;
 #endif
 
 typedef enum {
     AF_GRAY = 0, ///< Grayscale
     AF_RGB,      ///< 3-channel RGB
-    AF_HSV,      ///< 3-channel HSV
+    AF_HSV       ///< 3-channel HSV
 #if AF_API_VERSION >= 31
-    AF_YCbCr     ///< 3-channel YCbCr
+    , AF_YCbCr     ///< 3-channel YCbCr
 #endif
 } af_cspace_t;
 
@@ -349,7 +349,7 @@ typedef enum {
     AF_NORM_MATRIX_2,      ///< returns the max singular value). Currently NOT SUPPORTED
     AF_NORM_MATRIX_L_PQ,   ///< returns Lpq-norm
 
-    AF_NORM_EUCLID = AF_NORM_VECTOR_2, ///< The default. Same as AF_NORM_VECTOR_2
+    AF_NORM_EUCLID = AF_NORM_VECTOR_2 ///< The default. Same as AF_NORM_VECTOR_2
 } af_norm_type;
 
 #if AF_API_VERSION >= 31
@@ -393,7 +393,7 @@ typedef enum {
     AF_BACKEND_DEFAULT = 0,  ///< Default backend order: OpenCL -> CUDA -> CPU
     AF_BACKEND_CPU     = 1,  ///< CPU a.k.a sequential algorithms
     AF_BACKEND_CUDA    = 2,  ///< CUDA Compute Backend
-    AF_BACKEND_OPENCL  = 4,  ///< OpenCL Compute Backend
+    AF_BACKEND_OPENCL  = 4   ///< OpenCL Compute Backend
 } af_backend;
 #endif
 
@@ -460,7 +460,7 @@ typedef enum {
 #if AF_API_VERSION >= 35
 typedef enum {
     AF_CANNY_THRESHOLD_MANUAL    = 0, ///< User has to define canny thresholds manually
-    AF_CANNY_THRESHOLD_AUTO_OTSU = 1, ///< Determine canny algorithm thresholds using Otsu algorithm
+    AF_CANNY_THRESHOLD_AUTO_OTSU = 1  ///< Determine canny algorithm thresholds using Otsu algorithm
 } af_canny_threshold;
 #endif
 
@@ -469,7 +469,7 @@ typedef enum {
     AF_STORAGE_DENSE     = 0,   ///< Storage type is dense
     AF_STORAGE_CSR       = 1,   ///< Storage type is CSR
     AF_STORAGE_CSC       = 2,   ///< Storage type is CSC
-    AF_STORAGE_COO       = 3,   ///< Storage type is COO
+    AF_STORAGE_COO       = 3    ///< Storage type is COO
 } af_storage;
 #endif
 
@@ -495,12 +495,12 @@ typedef enum {
 typedef enum {
     AF_ITERATIVE_DECONV_LANDWEBER       = 1,        ///< Landweber Deconvolution
     AF_ITERATIVE_DECONV_RICHARDSONLUCY  = 2,        ///< Richardson-Lucy Deconvolution
-    AF_ITERATIVE_DECONV_DEFAULT         = 0,        ///< Default is Landweber deconvolution
+    AF_ITERATIVE_DECONV_DEFAULT         = 0         ///< Default is Landweber deconvolution
 } af_iterative_deconv_algo;
 
 typedef enum {
     AF_INVERSE_DECONV_TIKHONOV       = 1,        ///< Tikhonov Inverse deconvolution
-    AF_INVERSE_DECONV_DEFAULT        = 0,        ///< Default is Tikhonov deconvolution
+    AF_INVERSE_DECONV_DEFAULT        = 0         ///< Default is Tikhonov deconvolution
 } af_inverse_deconv_algo;
 
 #endif
@@ -509,7 +509,7 @@ typedef enum {
 typedef enum {
               AF_VARIANCE_DEFAULT    = 0, ///< Default (Population) variance
               AF_VARIANCE_SAMPLE     = 1, ///< Sample variance
-              AF_VARIANCE_POPULATION = 2, ///< Population variance
+              AF_VARIANCE_POPULATION = 2  ///< Population variance
 } af_var_bias;
 #endif
 

--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -564,6 +564,9 @@ namespace af
     typedef af_iterative_deconv_algo iterativeDeconvAlgo;
     typedef af_inverse_deconv_algo inverseDeconvAlgo;
 #endif
+#if AF_API_VERSION >= 37
+    typedef af_var_bias varBias;
+#endif
 }
 
 #endif

--- a/include/af/vision.h
+++ b/include/af/vision.h
@@ -40,7 +40,7 @@ class array;
     \ingroup cv_func_fast
  */
 AFAPI features fast(const array& in, const float thr=20.0f, const unsigned arc_length=9,
-                    const bool non_max=true, const float feature_ratio=0.05,
+                    const bool non_max=true, const float feature_ratio=0.05f,
                     const unsigned edge=3);
 
 #if AF_API_VERSION >= 31

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -19,16 +19,18 @@
 using af::dim4;
 using namespace detail;
 
-template<typename Ty, typename Tp>
-static inline void approx1(af_array *yo, const af_array yi,
-                           const af_array xo, const int xdim,
-                           const Tp &xi_beg, const Tp &xi_step,
-                           const af_interp_type method, const float offGrid)
-{
-    approx1<Ty>(getArray<Ty>(*yo), getArray<Ty>(yi),
-                getArray<Tp>(xo), xdim,
-                xi_beg, xi_step,
-                method, offGrid);
+namespace {
+    template<typename Ty, typename Tp>
+    inline void approx1(af_array *yo, const af_array yi,
+                        const af_array xo, const int xdim,
+                        const Tp &xi_beg, const Tp &xi_step,
+                        const af_interp_type method, const float offGrid)
+    {
+        approx1<Ty>(getArray<Ty>(*yo), getArray<Ty>(yi),
+                    getArray<Tp>(xo), xdim,
+                    xi_beg, xi_step,
+                    method, offGrid);
+    }
 }
 
 template<typename Ty, typename Tp>
@@ -41,12 +43,6 @@ static inline af_array approx2(const af_array zi,
                                  getArray<Tp>(xo), xdim, xi_beg, xi_step,
                                  getArray<Tp>(yo), ydim, yi_beg, yi_step,
                                  method, offGrid));
-}
-
-af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
-                  const af_interp_type method, const float offGrid)
-{
-    return af_approx1_uniform(yo, yi, xo, 0, 0.0, 1.0, method, offGrid);
 }
 
 af_err af_approx1_uniform(af_array *yo, const af_array yi,
@@ -116,10 +112,11 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi,
     return AF_SUCCESS;
 }
 
-af_err af_approx2(af_array *zo, const af_array zi, const af_array xo, const af_array yo,
+
+af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
                   const af_interp_type method, const float offGrid)
 {
-    return af_approx2_uniform(zo, zi, xo, 0, 0.0, 1.0, yo, 1, 0.0, 1.0, method, offGrid);
+  return af_approx1_uniform(yo, yi, xo, 0, 0.0, 1.0, method, offGrid);
 }
 
 af_err af_approx2_uniform(af_array *zo, const af_array zi,
@@ -187,3 +184,10 @@ af_err af_approx2_uniform(af_array *zo, const af_array zi,
 
     return AF_SUCCESS;
 }
+
+af_err af_approx2(af_array *zo, const af_array zi, const af_array xo, const af_array yo,
+                  const af_interp_type method, const float offGrid)
+{
+  return af_approx2_uniform(zo, zi, xo, 0, 0.0, 1.0, yo, 1, 0.0, 1.0, method, offGrid);
+}
+

--- a/src/api/c/pinverse.cpp
+++ b/src/api/c/pinverse.cpp
@@ -36,8 +36,6 @@ using std::swap;
 
 using namespace detail;
 
-const double dfltTol = 1e-6;
-
 template<typename T>
 Array<T> getSubArray(const Array<T> &in, const bool copy,
                        uint dim0begin = 0, uint dim0end = 0,

--- a/src/api/c/var.cpp
+++ b/src/api/c/var.cpp
@@ -82,8 +82,8 @@ meanvar(const Array<inType> &in, const Array<typename baseOutType<outType>::type
     Array<outType> input = cast<outType>(in);
     dim4 iDims = input.dims();
 
-    Array<outType> meanArr = *initArray<outType>();
-    Array<outType> normArr = *initArray<outType>();
+    Array<outType> meanArr = createEmptyArray<outType>({0});
+    Array<outType> normArr = createEmptyArray<outType>({0});
     if(weights.isEmpty()) {
         meanArr = mean<outType, weightType, outType>(input, dim);
         auto val = 1.0 / (bias == AF_VARIANCE_POPULATION ? iDims[dim] : iDims[dim]-1);
@@ -121,9 +121,9 @@ meanvar(const af_array &in, const af_array &weights,
         const af_var_bias bias, const dim_t dim) {
 
   typedef typename baseOutType<outType>::type weightType;
-  Array<outType> mean = *initArray<outType>(), var = *initArray<outType>();
+  Array<outType> mean = createEmptyArray<outType>({0}), var = createEmptyArray<outType>({0});
 
-  Array<weightType> w = *initArray<weightType>();
+  Array<weightType> w = createEmptyArray<weightType>({0});
   if(weights != 0) {
     w = getArray<weightType>(weights);
   }
@@ -142,7 +142,7 @@ var(const Array<inType>& in,
     const Array<typename baseOutType<outType>::type>& weights,
     const af_var_bias bias, int dim)
 {
-    Array<outType> variance = *initArray<outType>();
+    Array<outType> variance = createEmptyArray<outType>({0});
     tie(ignore, variance) = meanvar<inType, outType>(in, weights, bias, dim);
     return variance;
 }
@@ -152,10 +152,10 @@ static af_array var_(const af_array& in, const af_array& weights,
                      const af_var_bias bias, int dim) {
   using bType = typename baseOutType<outType>::type;
   if(weights == 0) {
-    Array<bType> empty = *initArray<bType>();
-    return getHandle(var<inType, outType>(getArray<inType>(in), empty, bias, dim));
+      Array<bType> empty = createEmptyArray<bType>({0});
+      return getHandle(var<inType, outType>(getArray<inType>(in), empty, bias, dim));
   } else {
-    return getHandle(var<inType, outType>(getArray<inType>(in), getArray<bType>(weights), bias, dim));
+      return getHandle(var<inType, outType>(getArray<inType>(in), getArray<bType>(weights), bias, dim));
   }
 }
 

--- a/src/backend/common/Logger.cpp
+++ b/src/backend/common/Logger.cpp
@@ -50,7 +50,7 @@ loggerFactory(string name) {
 }
 
 string bytesToString(size_t bytes) {
-    static array<const char *, 5> units{"B", "KB", "MB", "GB", "TB"};
+    static array<const char *, 5> units{{"B", "KB", "MB", "GB", "TB"}};
     size_t count = 0;
     double fbytes = static_cast<double>(bytes);
     size_t num_units = units.size();

--- a/src/backend/common/lapacke.cpp
+++ b/src/backend/common/lapacke.cpp
@@ -9,6 +9,7 @@
 
 #if defined(__APPLE__) && !defined(AF_CUDA)
 #include <common/lapacke.hpp>
+#include <common/defines.hpp>
 #include <Accelerate/Accelerate.h>
 #include <traits.hpp>
 
@@ -29,6 +30,7 @@
 #define LAPACK_FUNC(X, T, TO)                                                       \
 int LAPACKE_##X##geqrf(int layout, int M, int N, T *A, int lda, T *tau)             \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     int lwork = N * BS;                                                             \
     T *work = new T[lwork];                                                         \
     int info = 0;                                                                   \
@@ -39,12 +41,14 @@ int LAPACKE_##X##geqrf(int layout, int M, int N, T *A, int lda, T *tau)         
 int LAPACKE_##X##geqrf_work(int layout, int M, int N, T *A, int lda,                \
                             T *tau, T *work, int lwork)                             \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     int info = 0;                                                                   \
     X##geqrf_(&M, &N, (TO)A, &lda, (TO)tau, (TO)work, &lwork, &info);               \
     return info;                                                                    \
 }                                                                                   \
 int LAPACKE_##X##getrf(int layout, int M, int N, T *A, int lda, int *pivot)         \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     int info = 0;                                                                   \
     X##getrf_(&M, &N, (TO)A, &lda, pivot, &info);                                   \
     return info;                                                                    \
@@ -52,12 +56,14 @@ int LAPACKE_##X##getrf(int layout, int M, int N, T *A, int lda, int *pivot)     
 int LAPACKE_##X##getrs(int layout, char trans, int M, int N, const T *A,            \
                        int lda, const int *pivot, T *B, int ldb)                    \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     int info = 0;                                                                   \
     X##getrs_(&trans, &M, &N, (TO)A, &lda, (int *)pivot, (TO)B, &ldb, &info);       \
     return info;                                                                    \
 }                                                                                   \
 int LAPACKE_##X##potrf(int layout, char uplo, int N, T *A, int lda)                 \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     int info = 0;                                                                   \
     X##potrf_(&uplo, &N, (TO)A, &lda, &info);                                       \
     return info;                                                                    \
@@ -65,6 +71,7 @@ int LAPACKE_##X##potrf(int layout, char uplo, int N, T *A, int lda)             
 int LAPACKE_##X##gesv(int layout, int N, int nrhs, T *A, int lda,                   \
                       int *pivot, T *B, int ldb)                                    \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     int info = 0;                                                                   \
     X##gesv_(&N, &nrhs, (TO)A, &lda, pivot, (TO)B, &ldb, &info);                    \
     return info;                                                                    \
@@ -72,6 +79,7 @@ int LAPACKE_##X##gesv(int layout, int N, int nrhs, T *A, int lda,               
 int LAPACKE_##X##gels(int layout, char trans, int M, int N, int nrhs,               \
                       T *A, int lda, T *B, int ldb)                                 \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     int lwork = std::min(M, N) + std::max(M, std::max(N, nrhs)) * BS;               \
     T *work = new T[lwork];                                                         \
     int info = 0;                                                                   \
@@ -82,6 +90,7 @@ int LAPACKE_##X##gels(int layout, char trans, int M, int N, int nrhs,           
 }                                                                                   \
 int LAPACKE_##X##getri(int layout, int N, T *A, int lda, const int *pivot)          \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     int lwork = N * BS;                                                             \
     T *work = new T[lwork];                                                         \
     int info = 0;                                                                   \
@@ -92,6 +101,7 @@ int LAPACKE_##X##getri(int layout, int N, T *A, int lda, const int *pivot)      
 }                                                                                   \
 int LAPACKE_##X##trtri(int layout, char uplo, char diag, int N, T *A, int lda)      \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     int info = 0;                                                                   \
     X##trtri_(&uplo, &diag, &N, (TO)A, &lda, &info);                                \
     return info;                                                                    \
@@ -99,6 +109,7 @@ int LAPACKE_##X##trtri(int layout, char uplo, char diag, int N, T *A, int lda)  
 int LAPACKE_##X##trtrs(int layout, char uplo, char trans, char diag,                \
                        int N, int NRHS, const T *A, int lda, T *B, int ldb)         \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     int info = 0;                                                                   \
     X##trtrs_(&uplo, &trans, &diag, &N, &NRHS, (TO)A, &lda, (TO)B, &ldb, &info);    \
     return info;                                                                    \
@@ -106,6 +117,7 @@ int LAPACKE_##X##trtrs(int layout, char uplo, char trans, char diag,            
 int LAPACKE_##X##larft(int layout, char direct, char storev, int N, int K,          \
                        const T *v, int ldv, const T *tau, T *t, int ldt)            \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     X##larft_(&direct, &storev, &N, &K, (TO)v, &ldv,                                \
                         (TO)const_cast<T*>(tau), (TO)t, &ldt);                      \
     return 0;                                                                       \
@@ -113,6 +125,7 @@ int LAPACKE_##X##larft(int layout, char direct, char storev, int N, int K,      
 int LAPACKE_##X##laswp(int layout, int N, T *A, int lda,                            \
                        int k1, int k2, const int *pivot, int incx)                  \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     X##laswp_(&N, (TO)A, &lda, &k1, &k2, const_cast<int*>(pivot), &incx);           \
     return 0;                                                                       \
 }                                                                                   \
@@ -125,6 +138,7 @@ LAPACK_FUNC(z, cdouble, __CLPK_doublecomplex*)
 #define LAPACK_GQR(P, X, T, TO)                                                     \
 int LAPACKE_##X##P(int layout, int M, int N, int K, T *A, int lda, const T *tau)    \
 {                                                                                   \
+    UNUSED(layout);                                                       \
     int lwork = N * 32;                                                             \
     T *work = new T[lwork];                                                         \
     int info = 0;                                                                   \
@@ -142,6 +156,7 @@ LAPACK_GQR(ungqr, z, cdouble, __CLPK_doublecomplex*)
 int LAPACKE_##X##P##_work(int layout, int M, int N, int K, T *A, int lda,           \
                           const T *tau, T *work, int lwork)                         \
 {                                                                                   \
+    UNUSED(layout);                                                                 \
     int info = 0;                                                                   \
     X##P##_(&M, &N, &K, (TO)A, &lda, (TO)tau, (TO)work, &lwork, &info);             \
     return info;                                                                    \
@@ -157,6 +172,7 @@ int LAPACKE_##X##P##_work(int layout, char side, char trans, int M, int N, int K
                           const T *A, int lda, const T *tau, T *c, int ldc,         \
                           T *work, int lwork)                                       \
 {                                                                                   \
+    UNUSED(layout);                                                        \
     int info = 0;                                                                   \
     X##P##_(&side, &trans, &M, &N, &K, (TO)A, &lda, (TO)tau, (TO)c, &ldc,           \
                       (TO)work, &lwork, &info);                                     \
@@ -178,6 +194,7 @@ LAPACK_MQR_WORK(unmqr, z, cdouble, __CLPK_doublecomplex*)
                        T* u, int ldu,               \
                        T* vt, int ldvt)             \
     {                                               \
+        UNUSED(layout);                             \
         int info = 0;                               \
         int lwork = -1;                             \
         T work_param = 0;                           \
@@ -204,6 +221,7 @@ LAPACK_MQR_WORK(unmqr, z, cdouble, __CLPK_doublecomplex*)
                        T* u, int ldu,               \
                        T* vt, int ldvt)             \
     {                                               \
+        UNUSED(layout);                             \
         int info = 0;                               \
         int max_mn = std::max(m, n);                \
         int min_mn = std::max(m, n);                \
@@ -240,6 +258,7 @@ LAPACK_LAMCH(d, double)
                            int lda, T* b,                       \
                            int ldb )                            \
     {                                                           \
+        UNUSED(matrix_order);                                   \
         int info = 0;                                           \
         X##lacpy_(&uplo, &m, &n, (TO)a, &lda, (TO)b, &ldb);     \
         return info;                                            \
@@ -256,6 +275,7 @@ LAPACK_LACPY(z, cdouble,__CLPK_doublecomplex*)
                               int lda, const T* tau, T* work,       \
                               int lwork )                           \
     {                                                               \
+        UNUSED(matrix_order);                                       \
         int info = 0;                                               \
         X##P##_(&vect, &m, &n, &k, (TO)a, &lda,                     \
                 (TO)tau, (TO)work, &lwork, &info);                  \
@@ -275,6 +295,7 @@ LAPACK_GBR_WORK(ungbr, z, cdouble,__CLPK_doublecomplex*)
                                  int ldu, T* c,                         \
                                  int ldc, Tr* work)                     \
     {                                                                   \
+        UNUSED(matrix_order);                                           \
         int info = 0;                                                   \
         X##bdsqr_(&uplo, &n, &ncvt, &nru, &ncc, d, e,                   \
                   (TO)vt, &ldvt, (TO)u, &ldu,                           \
@@ -296,6 +317,7 @@ LAPACK_BDSQR_WORK(z, cdouble, double,__CLPK_doublecomplex*)
                                  T* taup,                           \
                                  T* work, int lwork )               \
     {                                                               \
+        UNUSED(matrix_order);                                       \
         int info = 0;                                               \
         X##gebrd_(&m, &n, (TO)a, &lda, d, e, (TO)tauq, (TO)taup,    \
                   (TO)work, &lwork, &info);                         \

--- a/src/backend/cpu/Array.cpp
+++ b/src/backend/cpu/Array.cpp
@@ -215,9 +215,6 @@ createEmptyArray(const dim4 &size)
 }
 
 template<typename T>
-Array<T> *initArray() { return new Array<T>(dim4()); }
-
-template<typename T>
 Array<T>
 createNodeArray(const dim4 &dims, Node_ptr node)
 {
@@ -346,7 +343,6 @@ Array<T>::setDataDims(const dim4 &new_dims)
     template       Array<T>  createDeviceDataArray<T> (const dim4 &size, const void *data); \
     template       Array<T>  createValueArray<T>      (const dim4 &size, const T &value); \
     template       Array<T>  createEmptyArray<T>      (const dim4 &size); \
-    template       Array<T>  *initArray<T      >      ();               \
     template       Array<T>  createSubArray<T>        (const Array<T> &parent, \
                                                        const vector<af_seq> &index, \
                                                        bool copy);      \

--- a/src/backend/cpu/Array.hpp
+++ b/src/backend/cpu/Array.hpp
@@ -218,7 +218,7 @@ namespace cpu
         int useCount() const
         {
             if (!data.get()) eval();
-            return data.use_count();
+            return static_cast<int>(data.use_count());
         }
 
         operator Param<T>()

--- a/src/backend/cpu/Array.hpp
+++ b/src/backend/cpu/Array.hpp
@@ -72,11 +72,6 @@ namespace cpu
     template<typename T>
     void writeDeviceDataArray(Array<T> &arr, const void * const data, const size_t bytes);
 
-    /// Create an Array object and do not assign any values to it.
-    /// \NOTE: This object should not be used to initalize an array. Use
-    ///       createEmptyArray instead
-    template<typename T> Array<T> *initArray();
-
     /// Creates an empty array of a given size. No data is initialized
     ///
     /// \param[in] size The dimension of the output array
@@ -247,7 +242,6 @@ namespace cpu
                                               const T * const in_data, bool is_device);
 
 
-        friend Array<T> *initArray<T>();
         friend Array<T> createEmptyArray<T>(const af::dim4 &size);
         friend Array<T> createNodeArray<T>(const af::dim4 &dims, jit::Node_ptr node);
 

--- a/src/backend/cpu/jit/BinaryNode.hpp
+++ b/src/backend/cpu/jit/BinaryNode.hpp
@@ -25,6 +25,8 @@ namespace cpu
                   const jit::array<Ti> &rhs,
                   int lim) const
         {
+            UNUSED(lhs);
+            UNUSED(rhs);
             for (int i = 0; i < lim; i++) {
                 out[i] = scalar<To>(0);
             }

--- a/src/backend/cpu/kernel/meanshift.hpp
+++ b/src/backend/cpu/kernel/meanshift.hpp
@@ -32,9 +32,9 @@ void meanShift(Param<T> out, CParam<T> in, const float spatialSigma,
     const AccType cvar      = chromaticSigma * chromaticSigma;
 
 
-    std::array<AccType, 4> currentCenterColors{0};
-    std::array<AccType, 4> currentMeanColors{0};
-    std::array<AccType, 4> tempColors{0};
+    std::array<AccType, 4> currentCenterColors{{ 0 }};
+    std::array<AccType, 4> currentMeanColors{{ 0 }};
+    std::array<AccType, 4> tempColors{{ 0 }};
     for (dim_t b3=0; b3<dims[3]; ++b3) {
         for (unsigned b2=0; b2<bCount; ++b2) {
 

--- a/src/backend/cpu/kernel/pad_array_borders.hpp
+++ b/src/backend/cpu/kernel/pad_array_borders.hpp
@@ -16,7 +16,8 @@ namespace cpu
 {
 namespace kernel
 {
-static dim_t
+namespace {
+static inline dim_t
 idxByndEdge(const dim_t i, const dim_t lb,
             const dim_t len, const af::borderType btype)
 {
@@ -33,6 +34,7 @@ idxByndEdge(const dim_t i, const dim_t lb,
             break;
     }
     return retVal;
+}
 }
 
 template<typename T>

--- a/src/backend/cpu/kernel/resize.hpp
+++ b/src/backend/cpu/kernel/resize.hpp
@@ -49,6 +49,14 @@ struct resize_op
               const af::dim4 &ostrides, const af::dim4 &istrides,
               const dim_t x, const dim_t y)
     {
+        UNUSED(outPtr);
+        UNUSED(inPtr);
+        UNUSED(odims);
+        UNUSED(idims);
+        UNUSED(ostrides);
+        UNUSED(istrides);
+        UNUSED(x);
+        UNUSED(y);
         return;
     }
 };

--- a/src/backend/cpu/kernel/sparse_arith.hpp
+++ b/src/backend/cpu/kernel/sparse_arith.hpp
@@ -21,6 +21,8 @@ struct arith_op
 {
     T operator()(T v1, T v2)
     {
+        UNUSED(v1);
+        UNUSED(v2);
         return scalar<T>(0);
     }
 };

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -316,12 +316,6 @@ namespace cuda
     }
 
     template<typename T>
-    Array<T> *initArray()
-    {
-        return new Array<T>(dim4());
-    }
-
-    template<typename T>
     Array<T> createSubArray(const Array<T>& parent,
                             const std::vector<af_seq> &index,
                             bool copy)
@@ -421,7 +415,6 @@ namespace cuda
     template       Array<T>  createDeviceDataArray<T> (const dim4 &size, const void *data); \
     template       Array<T>  createValueArray<T>      (const dim4 &size, const T &value); \
     template       Array<T>  createEmptyArray<T>      (const dim4 &size); \
-    template       Array<T>  *initArray<T      >      ();               \
     template       Array<T>  createParamArray<T>      (Param<T> &tmp, bool owner); \
     template       Array<T>  createSubArray<T>        (const Array<T> &parent, \
                                                        const std::vector<af_seq> &index, \

--- a/src/backend/cuda/Array.hpp
+++ b/src/backend/cuda/Array.hpp
@@ -62,11 +62,6 @@ namespace cuda
     template<typename T>
     void writeDeviceDataArray(Array<T> &arr, const void * const data, const size_t bytes);
 
-    /// Create an Array object and do not assign any values to it.
-    /// \NOTE: This object should not be used to initalize an array. Use
-    ///       createEmptyArray instead
-    template<typename T> Array<T> *initArray();
-
     /// Creates an empty array of a given size. No data is initialized
     ///
     /// \param[in] size The dimension of the output array
@@ -240,7 +235,6 @@ namespace cuda
         friend Array<T> createStridedArray<T>(af::dim4 dims, af::dim4 strides, dim_t offset,
                                               const T * const in_data, bool is_device);
 
-        friend Array<T> *initArray<T>();
         friend Array<T> createEmptyArray<T>(const af::dim4 &size);
         friend Array<T> createParamArray<T>(Param<T> &tmp, bool owner);
         friend Array<T> createNodeArray<T>(const af::dim4 &dims, common::Node_ptr node);

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -379,12 +379,6 @@ namespace opencl
     }
 
     template<typename T>
-    Array<T> *initArray()
-    {
-        return new Array<T>(dim4());
-    }
-
-    template<typename T>
     Array<T>
     createParamArray(Param &tmp, bool owner)
     {
@@ -451,7 +445,6 @@ namespace opencl
     template       Array<T>  createDeviceDataArray<T> (const dim4 &size, const void *data, bool copy); \
     template       Array<T>  createValueArray<T>      (const dim4 &size, const T &value); \
     template       Array<T>  createEmptyArray<T>      (const dim4 &size); \
-    template       Array<T>  *initArray<T      >      ();               \
     template       Array<T>  createParamArray<T>      (Param &tmp, bool owner);    \
     template       Array<T>  createSubArray<T>        (const Array<T> &parent, \
                                                        const vector<af_seq> &index, \

--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -62,11 +62,6 @@ namespace opencl
     template<typename T>
     void writeDeviceDataArray(Array<T> &arr, const void * const data, const size_t bytes);
 
-    /// Create an Array object and do not assign any values to it.
-    /// \NOTE: This object should not be used to initalize an array. Use
-    ///       createEmptyArray instead
-    template<typename T> Array<T> *initArray();
-
     /// Creates an empty array of a given size. No data is initialized
     ///
     /// \param[in] size The dimension of the output array
@@ -285,7 +280,6 @@ namespace opencl
         friend Array<T> createStridedArray<T>(af::dim4 dims, af::dim4 strides, dim_t offset,
                                               const T * const in_data, bool is_device);
 
-        friend Array<T> *initArray<T>();
         friend Array<T> createEmptyArray<T>(const af::dim4 &size);
         friend Array<T> createParamArray<T>(Param &tmp, bool owner);
         friend Array<T> createNodeArray<T>(const af::dim4 &dims, common::Node_ptr node);

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -91,7 +91,7 @@ void readTests(const std::string &FileName, std::vector<af::dim4> &inputDims,
 
         testInputs.resize(inputCount,vector<inType>(0));
         for(unsigned k=0; k<inputCount; k++) {
-            unsigned nElems = inputDims[k].elements();
+            dim_t nElems = inputDims[k].elements();
             testInputs[k].resize(nElems);
             FileElementType tmp;
             for(unsigned i = 0; i < nElems; i++) {
@@ -143,7 +143,7 @@ void readTestsFromFile(const std::string &FileName, std::vector<af::dim4> &input
 
         testInputs.resize(inputCount,vector<inType>(0));
         for(unsigned k=0; k<inputCount; k++) {
-            unsigned nElems = inputDims[k].elements();
+            dim_t nElems = inputDims[k].elements();
             testInputs[k].resize(nElems);
             inType tmp;
             for(unsigned i = 0; i < nElems; i++) {
@@ -470,10 +470,10 @@ af::array cpu_randu(const af::dim4 dims)
     bool isTypeCplx = is_same_type<T, af::cfloat>::value || is_same_type<T, af::cdouble>::value;
     bool isTypeFloat = is_same_type<BT, float>::value || is_same_type<BT, double>::value;
 
-    dim_t elements = (isTypeCplx ? 2 : 1) * dims.elements();
+    size_t elements = (isTypeCplx ? 2 : 1) * dims.elements();
 
     std::vector<BT> out(elements);
-    for(int i = 0; i < (int)elements; i++) {
+    for(size_t i = 0; i < elements; i++) {
         out[i] = isTypeFloat ? (BT)(rand())/RAND_MAX : rand() % 100;
     }
 
@@ -608,12 +608,12 @@ std::string printContext(const std::vector<T>& hGold, std::string goldName,
     coordsMaxBound[0] = arrDims[0] - 1;
 
     // dim0 positions that can be displayed
-    dim_t dim0Start = std::max<int>(0, coords[0] - ctxWidth);
-    dim_t dim0End = std::min<int>(coords[0] + ctxWidth + 1, arrDims[0]);
+    dim_t dim0Start = std::max<dim_t>(0LL, coords[0] - ctxWidth);
+    dim_t dim0End = std::min<dim_t>(coords[0] + ctxWidth + 1LL, arrDims[0]);
 
     // Linearized indices of values in vectors that can be displayed
-    dim_t vecStartIdx = std::max<int>(ravelIdx(coordsMinBound, arrStrides),
-                                      idx - ctxWidth);
+    dim_t vecStartIdx = std::max<dim_t>(ravelIdx(coordsMinBound, arrStrides),
+                                        idx - ctxWidth);
 
     // Display as minimal coordinates as needed
     // First value is the range of dim0 positions that will be displayed
@@ -626,7 +626,7 @@ std::string printContext(const std::vector<T>& hGold, std::string goldName,
         os << ", " << coords[3];
     os << "), dims are (" << arrDims << ") strides: (" << arrStrides << ")\n";
 
-    uint ctxElems = dim0End - dim0Start;
+    dim_t ctxElems = dim0End - dim0Start;
     std::vector<int> valFieldWidths(ctxElems);
     std::vector<std::string> ctxDim0(ctxElems);
     std::vector<std::string> ctxOutVals(ctxElems);
@@ -637,19 +637,19 @@ std::string printContext(const std::vector<T>& hGold, std::string goldName,
     // Also get the max string length between the position and out/ref values
     // per item so that it can be used later as the field width for
     // displaying each item in the context window
-    for (uint i = 0; i < ctxElems; ++i) {
+    for (dim_t i = 0; i < ctxElems; ++i) {
         std::ostringstream tmpOs;
 
-        uint dim0 = dim0Start + i;
+        dim_t dim0 = dim0Start + i;
         if (dim0 == coords[0])
             tmpOs << "[" << dim0 << "]";
         else
             tmpOs << dim0;
         ctxDim0[i] = tmpOs.str();
-        int dim0Len = tmpOs.str().length();
+        size_t dim0Len = tmpOs.str().length();
         tmpOs.str(std::string());
 
-        uint valIdx = vecStartIdx + i;
+        dim_t valIdx = vecStartIdx + i;
 
         if (valIdx == idx) {
             tmpOs << "[" << +hOut[valIdx] << "]";
@@ -658,7 +658,7 @@ std::string printContext(const std::vector<T>& hGold, std::string goldName,
             tmpOs << +hOut[valIdx];
         }
         ctxOutVals[i] = tmpOs.str();
-        int outLen = tmpOs.str().length();
+        size_t outLen = tmpOs.str().length();
         tmpOs.str(std::string());
 
         if (valIdx == idx) {
@@ -668,7 +668,7 @@ std::string printContext(const std::vector<T>& hGold, std::string goldName,
             tmpOs << +hGold[valIdx];
         }
         ctxGoldVals[i] = tmpOs.str();
-        int goldLen = tmpOs.str().length();
+        size_t goldLen = tmpOs.str().length();
         tmpOs.str(std::string());
 
         int maxWidth = std::max<int>(dim0Len, outLen);
@@ -676,7 +676,7 @@ std::string printContext(const std::vector<T>& hGold, std::string goldName,
         valFieldWidths[i] = maxWidth;
     }
 
-    int varNameWidth = std::max<int>(goldName.length(), outName.length());
+    size_t varNameWidth = std::max<size_t>(goldName.length(), outName.length());
 
     // Display dim0 positions, output values, and reference values
     os << std::right << std::setw(varNameWidth) << "" << "   ";
@@ -789,10 +789,10 @@ template<typename T>
         FloatTag, IntegerTag>::type TagType;
     TagType tag;
 
-    std::vector<T> hA(a.elements());
+    std::vector<T> hA(static_cast<size_t>(a.elements()));
     a.host(hA.data());
 
-    std::vector<T> hB(b.elements());
+    std::vector<T> hB(static_cast<size_t>(b.elements()));
     b.host(hB.data());
     return elemWiseEq<T>(aName, bName, hA, a.dims(), hB, b.dims(), maxAbsDiff, tag);
 }


### PR DESCRIPTION
Removed the initArray Function which returned a raw pointer to an Array<T> object. This was the cause of a few leaks. A better approach is the use createEmptyArray.

Fix an error on OSX which was caused by the order of operations in approx.

Added a missing c++ typedef for 3.7.

Fixed several warnings on clang and OSX