### PR TITLE
Remove cudaMemcpys to the default streams in the CUDA backend

### DIFF
--- a/src/backend/cuda/copy.cu
+++ b/src/backend/cuda/copy.cu
@@ -18,47 +18,49 @@ namespace cuda
 {
 
     template<typename T>
-    void copyData(T *data, const Array<T> &A)
+    void copyData(T *dst, const Array<T> &src)
     {
         // FIXME: Merge this with copyArray
-        A.eval();
+        src.eval();
 
-        Array<T> out = A;
+        Array<T> out = src;
         const T *ptr = NULL;
 
-        if (A.isLinear() || // No offsets, No strides
-            A.ndims() == 1 // Simple offset, no strides.
+        if (src.isLinear() || // No offsets, No strides
+            src.ndims() == 1 // Simple offset, no strides.
             ) {
 
             //A.get() gets data with offsets
-            ptr = A.get();
+            ptr = src.get();
         } else {
             //FIXME: Think about implementing eval
-            out = copyArray(A);
+            out = copyArray(src);
             ptr = out.get();
         }
 
-        CUDA_CHECK(cudaMemcpy(data, ptr,
-                              A.elements() * sizeof(T),
-                              cudaMemcpyDeviceToHost));
-
+        auto stream = cuda::getActiveStream();
+        CUDA_CHECK(cudaMemcpyAsync(dst, ptr,
+                                   src.elements() * sizeof(T),
+                                   cudaMemcpyDeviceToHost,
+                                   stream));
+        CUDA_CHECK(cudaStreamSynchronize(stream));
         return;
     }
 
     template<typename T>
-    Array<T> copyArray(const Array<T> &A)
+    Array<T> copyArray(const Array<T> &src)
     {
-        Array<T> out = createEmptyArray<T>(A.dims());
+        Array<T> out = createEmptyArray<T>(src.dims());
 
-        if (A.isLinear()) {
-            CUDA_CHECK(cudaMemcpyAsync(out.get(), A.get(),
-                                       A.elements() * sizeof(T),
+        if (src.isLinear()) {
+            CUDA_CHECK(cudaMemcpyAsync(out.get(), src.get(),
+                                       src.elements() * sizeof(T),
                                        cudaMemcpyDeviceToDevice,
                                        cuda::getActiveStream()));
         } else {
             // FIXME: Seems to fail when using Param<T>
-            kernel::memcopy(out.get(), out.strides().get(), A.get(), A.dims().get(),
-                            A.strides().get(), (uint)A.ndims());
+            kernel::memcopy(out.get(), out.strides().get(), src.get(), src.dims().get(),
+                            src.strides().get(), (uint)src.ndims());
         }
         return out;
     }
@@ -114,9 +116,9 @@ namespace cuda
         copyFn(out, in);
     }
 
-#define INSTANTIATE(T)                                              \
-    template void      copyData<T> (T *data, const Array<T> &from); \
-    template Array<T> copyArray<T>(const Array<T> &A);              \
+#define INSTANTIATE(T)                                                  \
+    template void      copyData<T> (T *dst, const Array<T> &src);       \
+    template Array<T>  copyArray<T>(const Array<T> &src);               \
     template void      multiply_inplace<T> (Array<T> &in, double norm); \
 
     INSTANTIATE(float  )

--- a/src/backend/cuda/copy.hpp
+++ b/src/backend/cuda/copy.hpp
@@ -12,11 +12,22 @@
 
 namespace cuda
 {
+    // Copies(blocking) data from an Array<T> object to a contiguous host side
+    // pointer.
+    //
+    // \param dst The destination pointer on the host system.
+    // \param src    The source array
     template<typename T>
-    void copyData(T *data, const Array<T> &A);
+    void copyData(T *dst, const Array<T> &src);
 
+    // Create a deep copy of the \p src Array with the same size and shape. The new
+    // Array will not maintain the subarray metadata of the \p src array.
+    //
+    // \param   src  The source Array<T> object.
+    // \returns      A new Array<T> object with the same shape and data as the
+    //               \p src Array<T>
     template<typename T>
-    Array<T> copyArray(const Array<T> &A);
+    Array<T> copyArray(const Array<T> &src);
 
     template<typename inType, typename outType>
     void copyArray(Array<outType> &out, const Array<inType> &in);

--- a/src/backend/cuda/hist_graphics.cpp
+++ b/src/backend/cuda/hist_graphics.cpp
@@ -43,7 +43,9 @@ void copy_histogram(const Array<T> &data, const forge::Histogram* hist)
         glBindBuffer((gl::GLenum)GL_ARRAY_BUFFER, hist->vertices());
         gl::GLubyte* ptr = (gl::GLubyte*)glMapBuffer((gl::GLenum)GL_ARRAY_BUFFER, (gl::GLenum)GL_WRITE_ONLY);
         if (ptr) {
-            CUDA_CHECK(cudaMemcpy(ptr, data.get(), hist->verticesSize(), cudaMemcpyDeviceToHost));
+            auto stream = cuda::getActiveStream();
+            CUDA_CHECK(cudaMemcpyAsync(ptr, data.get(), hist->verticesSize(), cudaMemcpyDeviceToHost, stream));
+            CUDA_CHECK(cudaStreamSynchronize(stream));
             glUnmapBuffer((gl::GLenum)GL_ARRAY_BUFFER);
         }
         glBindBuffer((gl::GLenum)GL_ARRAY_BUFFER, 0);

--- a/src/backend/cuda/image.cpp
+++ b/src/backend/cuda/image.cpp
@@ -47,7 +47,9 @@ void copy_image(const Array<T> &in, const forge::Image* image)
         glBufferData((gl::GLenum)GL_PIXEL_UNPACK_BUFFER, image->size(), 0, (gl::GLenum)GL_STREAM_DRAW);
         gl::GLubyte* ptr = (gl::GLubyte*)glMapBuffer((gl::GLenum)GL_PIXEL_UNPACK_BUFFER, (gl::GLenum)GL_WRITE_ONLY);
         if (ptr) {
-            CUDA_CHECK(cudaMemcpy(ptr, in.get(), image->size(), cudaMemcpyDeviceToHost));
+            CUDA_CHECK(cudaMemcpyAsync(ptr, in.get(), image->size(),
+                                       cudaMemcpyDeviceToHost, cuda::getActiveStream()));
+            CUDA_CHECK(cudaStreamSynchronize(cuda::getActiveStream()));
             glUnmapBuffer((gl::GLenum)GL_PIXEL_UNPACK_BUFFER);
         }
         glBindBuffer((gl::GLenum)GL_PIXEL_UNPACK_BUFFER, 0);

--- a/src/backend/cuda/plot.cpp
+++ b/src/backend/cuda/plot.cpp
@@ -48,7 +48,10 @@ void copy_plot(const Array<T> &P, forge::Plot* plot)
         glBindBuffer((gl::GLenum)GL_ARRAY_BUFFER, plot->vertices());
         gl::GLubyte* ptr = (gl::GLubyte*)glMapBuffer((gl::GLenum)GL_ARRAY_BUFFER, (gl::GLenum)GL_WRITE_ONLY);
         if (ptr) {
-            CUDA_CHECK(cudaMemcpy(ptr, P.get(), plot->verticesSize(), cudaMemcpyDeviceToHost));
+            auto stream = cuda::getActiveStream();
+            CUDA_CHECK(cudaMemcpyAsync(ptr, P.get(), plot->verticesSize(),
+                                       cudaMemcpyDeviceToHost, stream));
+            CUDA_CHECK(cudaStreamSynchronize(stream));
             glUnmapBuffer((gl::GLenum)GL_ARRAY_BUFFER);
         }
         glBindBuffer((gl::GLenum)GL_ARRAY_BUFFER, 0);

--- a/src/backend/cuda/surface.cpp
+++ b/src/backend/cuda/surface.cpp
@@ -48,7 +48,10 @@ void copy_surface(const Array<T> &P, forge::Surface* surface)
         glBindBuffer((gl::GLenum)GL_ARRAY_BUFFER, surface->vertices());
         gl::GLubyte* ptr = (gl::GLubyte*)glMapBuffer((gl::GLenum)GL_ARRAY_BUFFER, (gl::GLenum)GL_WRITE_ONLY);
         if (ptr) {
-            CUDA_CHECK(cudaMemcpy(ptr, P.get(), surface->verticesSize(), cudaMemcpyDeviceToHost));
+            auto stream = cuda::getActiveStream();
+            CUDA_CHECK(cudaMemcpyAsync(ptr, P.get(), surface->verticesSize(),
+                                       cudaMemcpyDeviceToHost, stream));
+            CUDA_CHECK(cudaStreamSynchronize(stream));
             glUnmapBuffer((gl::GLenum)GL_ARRAY_BUFFER);
         }
         glBindBuffer((gl::GLenum)GL_ARRAY_BUFFER, 0);

--- a/src/backend/cuda/vector_field.cpp
+++ b/src/backend/cuda/vector_field.cpp
@@ -59,7 +59,10 @@ void copy_vector_field(const Array<T> &points, const Array<T> &directions,
         glBindBuffer((gl::GLenum)GL_ARRAY_BUFFER, vector_field->vertices());
         gl::GLubyte* ptr = (gl::GLubyte*)glMapBuffer((gl::GLenum)GL_ARRAY_BUFFER, (gl::GLenum)GL_WRITE_ONLY);
         if (ptr) {
-            CUDA_CHECK(cudaMemcpy(ptr, points.get(), vector_field->verticesSize(), cudaMemcpyDeviceToHost));
+            auto stream = cuda::getActiveStream();
+            CUDA_CHECK(cudaMemcpyAsync(ptr, points.get(), vector_field->verticesSize(),
+                                       cudaMemcpyDeviceToHost, stream));
+            CUDA_CHECK(cudaStreamSynchronize(stream));
             glUnmapBuffer((gl::GLenum)GL_ARRAY_BUFFER);
         }
         glBindBuffer((gl::GLenum)GL_ARRAY_BUFFER, 0);


### PR DESCRIPTION
There were some calls being made to the default CUDA stream. This is
problematic because the default cuda stream is blocks and blocks
all other streams when executing. We should only perform calls on
the current stream.