### PR TITLE
Fix output indices on broadcast step of exclusive scan

### DIFF
--- a/src/backend/cuda/kernel/scan_first.hpp
+++ b/src/backend/cuda/kernel/scan_first.hpp
@@ -145,7 +145,7 @@ namespace kernel
 
         int offset = !inclusive_scan;
         for (int k = 0, id = xid;
-             k < lim && id < out.dims[0];
+             k < lim && id + offset < out.dims[0];
              k++, id += blockDim.x) {
             optr[id + offset] = binop(accum, optr[id + offset]);
         }

--- a/src/backend/opencl/kernel/scan_dim.cl
+++ b/src/backend/opencl/kernel/scan_dim.cl
@@ -141,7 +141,11 @@ void bcast_dim_kernel(__global To *oData, KParam oInfo,
         tData += ids[3] * tInfo.strides[3] + ids[2] * tInfo.strides[2] + ids[1] * tInfo.strides[1] + ids[0];
 
         ids[dim] = ids[dim] * DIMY * lim + lidy;
-        oData  += ids[3] * oInfo.strides[3] + ids[2] * oInfo.strides[2] + ids[1] * oInfo.strides[1] + ids[0];
+        oData += ids[3] * oInfo.strides[3] + ids[2] * oInfo.strides[2] + ids[1] * oInfo.strides[1] + ids[0];
+
+        // Shift broadcast one step to the right for exclusive scan (#2366)
+        int offset = inclusive_scan ? 0 : oInfo.strides[dim];
+        oData += offset;
 
         const int id_dim = ids[dim];
         const int out_dim = oInfo.dims[dim];

--- a/src/backend/opencl/kernel/scan_first.cl
+++ b/src/backend/opencl/kernel/scan_first.cl
@@ -120,7 +120,7 @@ void bcast_first_kernel(__global To *oData, KParam oInfo,
 
             int offset = !inclusive_scan;
             for (int k = 0, id = xid;
-                 k < lim && id < oInfo.dims[0];
+                 k < lim && id + offset < oInfo.dims[0];
                  k++, id += DIMX) {
 
                 oData[id + offset] = binOp(accum, oData[id + offset]);

--- a/src/backend/opencl/kernel/scan_first.cl
+++ b/src/backend/opencl/kernel/scan_first.cl
@@ -118,11 +118,12 @@ void bcast_first_kernel(__global To *oData, KParam oInfo,
 
             To accum = tData[groupId_x - 1];
 
+            int offset = !inclusive_scan;
             for (int k = 0, id = xid;
                  k < lim && id < oInfo.dims[0];
                  k++, id += DIMX) {
 
-                oData[id] = binOp(accum, oData[id]);
+                oData[id + offset] = binOp(accum, oData[id + offset]);
             }
         }
     }

--- a/src/backend/opencl/kernel/scan_first.cl
+++ b/src/backend/opencl/kernel/scan_first.cl
@@ -118,12 +118,13 @@ void bcast_first_kernel(__global To *oData, KParam oInfo,
 
             To accum = tData[groupId_x - 1];
 
+            // Shift broadcast one step to the right for exclusive scan (#2366)
             int offset = !inclusive_scan;
-            for (int k = 0, id = xid;
-                 k < lim && id + offset < oInfo.dims[0];
+            for (int k = 0, id = xid + offset;
+                 k < lim && id < oInfo.dims[0];
                  k++, id += DIMX) {
 
-                oData[id + offset] = binOp(accum, oData[id + offset]);
+                oData[id] = binOp(accum, oData[id]);
             }
         }
     }

--- a/test/scan.cpp
+++ b/test/scan.cpp
@@ -282,3 +282,22 @@ TEST(Scan, ExclusiveSum1D) {
     ASSERT_VEC_ARRAY_EQ(h_gold, dim4(in_size), out);
 }
 
+TEST(Scan, ExclusiveSum2D_Dim0) {
+    const int in_size = 80000 * 2;
+    // const int in_size = 16386;
+    // const int in_size = 8192 * 4;
+    vector<int> h_in(in_size, 1);
+    vector<int> h_gold(in_size, 0);
+    for (int i = 1; i < h_gold.size() / 2; ++i) {
+        h_gold[i] = h_in[i] + h_gold[i - 1];
+    }
+    for (int i = h_gold.size() / 2 + 1; i < h_gold.size(); ++i) {
+        h_gold[i] = h_in[i] + h_gold[i - 1];
+    }
+
+    array in(in_size / 2, 2, &h_in.front());
+    array out = scan(in, 0, AF_BINARY_ADD, false);
+    array gold(in_size / 2, 2, &h_gold.front());
+
+    ASSERT_ARRAYS_EQ(gold, out);
+}

--- a/test/scan.cpp
+++ b/test/scan.cpp
@@ -269,16 +269,16 @@ TEST(Accum, DocSnippet) {
 }
 
 TEST(Scan, ExclusiveSum1D) {
-    const int block_work_size = 6912;
-    vector<int> h_in(block_work_size * 4, 1);
-    vector<int> h_gold(block_work_size * 4, 0);
+    const int in_size = 80000;
+    vector<int> h_in(in_size, 1);
+    vector<int> h_gold(in_size, 0);
     for (int i = 1; i < h_gold.size(); ++i) {
         h_gold[i] = h_in[i] + h_gold[i-1];
     }
 
-    array in(block_work_size * 4, &h_in.front());
+    array in(in_size, &h_in.front());
     array out = scan(in, 0, AF_BINARY_ADD, false);
 
-    ASSERT_VEC_ARRAY_EQ(h_gold, dim4(block_work_size * 4), out);
+    ASSERT_VEC_ARRAY_EQ(h_gold, dim4(in_size), out);
 }
 

--- a/test/scan.cpp
+++ b/test/scan.cpp
@@ -284,8 +284,6 @@ TEST(Scan, ExclusiveSum1D) {
 
 TEST(Scan, ExclusiveSum2D_Dim0) {
     const int in_size = 80000 * 2;
-    // const int in_size = 16386;
-    // const int in_size = 8192 * 4;
     vector<int> h_in(in_size, 1);
     vector<int> h_gold(in_size, 0);
     for (int i = 1; i < h_gold.size() / 2; ++i) {
@@ -300,4 +298,61 @@ TEST(Scan, ExclusiveSum2D_Dim0) {
     array gold(in_size / 2, 2, &h_gold.front());
 
     ASSERT_ARRAYS_EQ(gold, out);
+}
+
+TEST(Scan, ExclusiveSum2D_Dim1) {
+    const int in_size = 80000 * 2;
+    vector<int> h_in(in_size, 1);
+    vector<int> h_gold(in_size, 0);
+    for (int i = 1; i < h_gold.size() / 2; ++i) {
+        h_gold[i] = h_in[i] + h_gold[i - 1];
+    }
+    for (int i = h_gold.size() / 2 + 1; i < h_gold.size(); ++i) {
+        h_gold[i] = h_in[i] + h_gold[i - 1];
+    }
+
+    array in(2, in_size / 2, &h_in.front());
+    array out = scan(in, 1, AF_BINARY_ADD, false);
+    array gold(in_size / 2, 2, &h_gold.front());
+    gold = gold.T();
+
+    ASSERT_ARRAYS_EQ(gold, out);
+}
+
+TEST(Scan, ExclusiveSum2D_Dim2) {
+    const int in_size = 80000 * 2;
+    vector<int> h_in(in_size, 1);
+    vector<int> h_gold(in_size, 0);
+    for (int i = 1; i < h_gold.size() / 2; ++i) {
+        h_gold[i] = h_in[i] + h_gold[i - 1];
+    }
+    for (int i = h_gold.size() / 2 + 1; i < h_gold.size(); ++i) {
+        h_gold[i] = h_in[i] + h_gold[i - 1];
+    }
+
+    array in(1, 2, in_size / 2, &h_in.front());
+    array out = scan(in, 2, AF_BINARY_ADD, false);
+    array gold(in_size / 2, 2, &h_gold.front());
+    gold = af::reorder(gold, 2, 1, 0);
+
+    ASSERT_ARRAYS_EQ(gold, out);
+}
+
+TEST(Scan, ExclusiveSum2D_Dim3) {
+  const int in_size = 80000 * 2;
+  vector<int> h_in(in_size, 1);
+  vector<int> h_gold(in_size, 0);
+  for (int i = 1; i < h_gold.size() / 2; ++i) {
+    h_gold[i] = h_in[i] + h_gold[i - 1];
+  }
+  for (int i = h_gold.size() / 2 + 1; i < h_gold.size(); ++i) {
+    h_gold[i] = h_in[i] + h_gold[i - 1];
+  }
+
+  array in(1, 1, 2, in_size / 2, &h_in.front());
+  array out = scan(in, 3, AF_BINARY_ADD, false);
+  array gold(in_size / 2, 2, &h_gold.front());
+  gold = af::reorder(gold, 2, 3, 1, 0);
+
+  ASSERT_ARRAYS_EQ(gold, out);
 }


### PR DESCRIPTION
Addresses part of #2085. ~~This fixes only the 1-dimensional exclusive scan on CUDA. I still have to apply this fix to multiple dimensions (batched case) and on OpenCL.~~ This fixes exclusive scan along any dimension, on both CUDA and OpenCL

The problem lies in the last step of GPU scan where the scanned total sums of each block's data are broadcast to each block's scan results. The broadcast is performed one element early in the exclusive scan case, which means that the last element of each block data gets the cumulative sum that was supposed to be added on the next block's data. To illustrate for blocks of 5:

```
input           : 1 1 1 1 1 | 1 1 1 1 1  |  1  1  1  1  1
blockwise scan  : 0 1 2 3 4 | 0 1 2 3 4  |  0  1  2  3  4
block sums      : 5         | 5          |  5            
block sums scan : 0         | 5          | 10            
broadcast add*  : 0 0 0 0 5 | 5 5 5 5 10 | 10 10 10 10 15
global scan     : 0 1 2 3 9^| 5 6 7 8 14^| 10 12 13 14 19^

*where the bug lies. note however that the addition of zeros on the first four
elements is not really performed in the code itself.

^where the effects of the bug are seen

```

The solution then is to shift the broadcast addition (see [this line](https://github.com/arrayfire/arrayfire/blob/1b792bc3c12b6014079646d99c4f733c998d98af/src/backend/cuda/kernel/scan_first.hpp#L152)) one element to the right for exclusive scan. This pull request implements exactly that.

~~For multiple dimensions, I think I have to apply a similar change to `scan_dim.hpp`.~~ Both `scan_first.hpp` and `scan_dim.hpp` on CUDA and OpenCL have been modified for this fix.