### PR TITLE
 Refactor sparse-dense arith fn name in backend API 

### DIFF
--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -50,7 +50,7 @@ static inline af_array arithSparseDenseOp(const af_array lhs, const af_array rhs
     if(op == af_add_t || op == af_sub_t)
         return getHandle(arithOpD<T, op>(castSparse<T>(lhs), castArray<T>(rhs), reverse));
     else if(op == af_mul_t || op == af_div_t)
-        return getHandle(arithOpS<T, op>(castSparse<T>(lhs), castArray<T>(rhs), reverse));
+        return getHandle(arithOp<T, op>(castSparse<T>(lhs), castArray<T>(rhs), reverse));
 
 }
 

--- a/src/backend/cpu/sparse_arith.cpp
+++ b/src/backend/cpu/sparse_arith.cpp
@@ -89,7 +89,7 @@ Array<T> arithOpD(const SparseArray<T> &lhs, const Array<T> &rhs, const bool rev
 }
 
 template<typename T, af_op_t op>
-SparseArray<T> arithOpS(const SparseArray<T> &lhs, const Array<T> &rhs, const bool reverse)
+SparseArray<T> arithOp(const SparseArray<T> &lhs, const Array<T> &rhs, const bool reverse)
 {
     lhs.eval();
     rhs.eval();
@@ -158,13 +158,13 @@ SparseArray<T> arithOp(const SparseArray<T> &lhs, const SparseArray<T> &rhs)
                                             const bool reverse);                                    \
     template Array<T> arithOpD<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,         \
                                             const bool reverse);                                    \
-    template SparseArray<T> arithOpS<T, af_add_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+    template SparseArray<T> arithOp<T, af_add_t>(const SparseArray<T> &lhs, const Array<T> &rhs,    \
                                                   const bool reverse);                              \
-    template SparseArray<T> arithOpS<T, af_sub_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+    template SparseArray<T> arithOp<T, af_sub_t>(const SparseArray<T> &lhs, const Array<T> &rhs,    \
                                                   const bool reverse);                              \
-    template SparseArray<T> arithOpS<T, af_mul_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+    template SparseArray<T> arithOp<T, af_mul_t>(const SparseArray<T> &lhs, const Array<T> &rhs,    \
                                                   const bool reverse);                              \
-    template SparseArray<T> arithOpS<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+    template SparseArray<T> arithOp<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,    \
                                                  const bool reverse);                               \
     template SparseArray<T> arithOp<T, af_add_t>(const common::SparseArray<T> &lhs,                 \
                                                  const common::SparseArray<T> &rhs);                \

--- a/src/backend/cpu/sparse_arith.hpp
+++ b/src/backend/cpu/sparse_arith.hpp
@@ -23,8 +23,8 @@ Array<T> arithOpD(const common::SparseArray<T> &lhs, const Array<T> &rhs,
                  const bool reverse = false);
 
 template<typename T, af_op_t op>
-common::SparseArray<T> arithOpS(const common::SparseArray<T> &lhs, const Array<T> &rhs,
-                                const bool reverse = false);
+common::SparseArray<T> arithOp(const common::SparseArray<T> &lhs, const Array<T> &rhs,
+                               const bool reverse = false);
 
 template<typename T, af_op_t op>
 common::SparseArray<T> arithOp(const common::SparseArray<T> &lhs,

--- a/src/backend/cpu/sparse_blas.cpp
+++ b/src/backend/cpu/sparse_blas.cpp
@@ -34,6 +34,14 @@ using sp_cdouble = MKL_Complex16;
 #else
 using sp_cfloat = cfloat;
 using sp_cdouble = cdouble;
+
+// From mkl_spblas.h
+typedef enum
+{
+    SPARSE_OPERATION_NON_TRANSPOSE          = 10,
+    SPARSE_OPERATION_TRANSPOSE              = 11,
+    SPARSE_OPERATION_CONJUGATE_TRANSPOSE    = 12,
+} sparse_operation_t;
 #endif
 
 template<typename T, class Enable = void>
@@ -291,14 +299,6 @@ Array<T> matmul(const common::SparseArray<T> lhs, const Array<T> rhs,
 }
 
 #else // #if USE_MKL
-
-// From mkl_spblas.h
-typedef enum
-{
-    SPARSE_OPERATION_NON_TRANSPOSE          = 10,
-    SPARSE_OPERATION_TRANSPOSE              = 11,
-    SPARSE_OPERATION_CONJUGATE_TRANSPOSE    = 12,
-} sparse_operation_t;
 
 template<typename T>
 T getConjugate(const T &in)

--- a/src/backend/cuda/sparse_arith.cu
+++ b/src/backend/cuda/sparse_arith.cu
@@ -78,7 +78,7 @@ Array<T> arithOpD(const SparseArray<T> &lhs, const Array<T> &rhs, const bool rev
 }
 
 template<typename T, af_op_t op>
-SparseArray<T> arithOpS(const SparseArray<T> &lhs, const Array<T> &rhs, const bool reverse)
+SparseArray<T> arithOp(const SparseArray<T> &lhs, const Array<T> &rhs, const bool reverse)
 {
     lhs.eval();
     rhs.eval();
@@ -195,13 +195,13 @@ SparseArray<T> arithOp(const SparseArray<T> &lhs, const SparseArray<T> &rhs)
                                             const bool reverse);                                    \
     template Array<T> arithOpD<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,         \
                                             const bool reverse);                                    \
-    template SparseArray<T> arithOpS<T, af_add_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+    template SparseArray<T> arithOp<T, af_add_t>(const SparseArray<T> &lhs, const Array<T> &rhs,    \
                                                   const bool reverse);                              \
-    template SparseArray<T> arithOpS<T, af_sub_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+    template SparseArray<T> arithOp<T, af_sub_t>(const SparseArray<T> &lhs, const Array<T> &rhs,    \
                                                   const bool reverse);                              \
-    template SparseArray<T> arithOpS<T, af_mul_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+    template SparseArray<T> arithOp<T, af_mul_t>(const SparseArray<T> &lhs, const Array<T> &rhs,    \
                                                   const bool reverse);                              \
-    template SparseArray<T> arithOpS<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+    template SparseArray<T> arithOp<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,    \
                                                   const bool reverse);                              \
     template SparseArray<T> arithOp<T, af_add_t>(const common::SparseArray<T> &lhs,                 \
                                                  const common::SparseArray<T> &rhs);                \

--- a/src/backend/cuda/sparse_arith.hpp
+++ b/src/backend/cuda/sparse_arith.hpp
@@ -22,8 +22,8 @@ Array<T> arithOpD(const common::SparseArray<T> &lhs, const Array<T> &rhs,
                  const bool reverse = false);
 
 template<typename T, af_op_t op>
-common::SparseArray<T> arithOpS(const common::SparseArray<T> &lhs, const Array<T> &rhs,
-                                const bool reverse = false);
+common::SparseArray<T> arithOp(const common::SparseArray<T> &lhs, const Array<T> &rhs,
+                               const bool reverse = false);
 
 template<typename T, af_op_t op>
 common::SparseArray<T> arithOp(const common::SparseArray<T> &lhs,

--- a/src/backend/opencl/sparse_arith.cpp
+++ b/src/backend/opencl/sparse_arith.cpp
@@ -79,7 +79,7 @@ Array<T> arithOpD(const SparseArray<T> &lhs, const Array<T> &rhs, const bool rev
 }
 
 template<typename T, af_op_t op>
-SparseArray<T> arithOpS(const SparseArray<T> &lhs, const Array<T> &rhs, const bool reverse)
+SparseArray<T> arithOp(const SparseArray<T> &lhs, const Array<T> &rhs, const bool reverse)
 {
     lhs.eval();
     rhs.eval();
@@ -152,13 +152,13 @@ SparseArray<T> arithOp(const SparseArray<T> &lhs, const SparseArray<T> &rhs)
                                             const bool reverse);                                    \
     template Array<T> arithOpD<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,         \
                                             const bool reverse);                                    \
-    template SparseArray<T> arithOpS<T, af_add_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
-                                                  const bool reverse);                              \
-    template SparseArray<T> arithOpS<T, af_sub_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
-                                                  const bool reverse);                              \
-    template SparseArray<T> arithOpS<T, af_mul_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
-                                                  const bool reverse);                              \
-    template SparseArray<T> arithOpS<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,   \
+    template SparseArray<T> arithOp<T, af_add_t>(const SparseArray<T> &lhs, const Array<T> &rhs,    \
+                                                 const bool reverse);                               \
+    template SparseArray<T> arithOp<T, af_sub_t>(const SparseArray<T> &lhs, const Array<T> &rhs,    \
+                                                 const bool reverse);                               \
+    template SparseArray<T> arithOp<T, af_mul_t>(const SparseArray<T> &lhs, const Array<T> &rhs,    \
+                                                 const bool reverse);                               \
+    template SparseArray<T> arithOp<T, af_div_t>(const SparseArray<T> &lhs, const Array<T> &rhs,    \
                                                   const bool reverse);                              \
     template SparseArray<T> arithOp<T, af_add_t>(const common::SparseArray<T> &lhs,                 \
                                                  const common::SparseArray<T> &rhs);                \

--- a/src/backend/opencl/sparse_arith.hpp
+++ b/src/backend/opencl/sparse_arith.hpp
@@ -22,8 +22,8 @@ Array<T> arithOpD(const common::SparseArray<T> &lhs, const Array<T> &rhs,
                  const bool reverse = false);
 
 template<typename T, af_op_t op>
-common::SparseArray<T> arithOpS(const common::SparseArray<T> &lhs, const Array<T> &rhs,
-                                const bool reverse = false);
+common::SparseArray<T> arithOp(const common::SparseArray<T> &lhs, const Array<T> &rhs,
+                               const bool reverse = false);
 
 template<typename T, af_op_t op>
 common::SparseArray<T> arithOp(const common::SparseArray<T> &lhs,


### PR DESCRIPTION
Also has a minor fix specific to gcc 8 in cpu backend.