### PR TITLE
Fixed failing `write` tests.

### DIFF
--- a/test/write.cpp
+++ b/test/write.cpp
@@ -60,7 +60,6 @@ void writeTest(dim4 dims)
     ASSERT_ARRAYS_EQ(B_copy, A);
     ASSERT_ARRAYS_EQ(A_copy, B);
 
-    af_free_device(b_dev);
     freeHost(a_host);
 }
 


### PR DESCRIPTION
Tests were failing due to af_free_device() call which is only necessary when
calling unlock().