### PR TITLE
Move forge manager instance inside device manager

### DIFF
--- a/src/api/c/hist.cpp
+++ b/src/api/c/hist.cpp
@@ -83,12 +83,11 @@ af_err af_draw_hist(const af_window window,
                     const double minval, const double maxval,
                     const af_cell* const props)
 {
-    if(window == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
-    }
-
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+
         const ArrayInfo& Xinfo = getInfo(X);
         af_dtype Xtype  = Xinfo.getType();
 

--- a/src/api/c/hist.cpp
+++ b/src/api/c/hist.cpp
@@ -31,7 +31,7 @@ fg_chart setup_histogram(fg_window const window,
     dim_t nBins = histogramInput.elements();
 
     // Retrieve Forge Histogram with nBins and array type
-    ForgeManager& fgMngr = ForgeManager::getInstance();
+    ForgeManager& fgMngr = forgeManager();
 
     // Get the chart for the current grid position (if any)
     fg_chart chart = NULL;
@@ -107,7 +107,7 @@ af_err af_draw_hist(const af_window window,
             case u8 : chart = setup_histogram<uchar  >(window, X, minval, maxval, props); break;
             default:  TYPE_ERROR(1, Xtype);
         }
-        auto gridDims = ForgeManager::getInstance().getWindowGrid(window);
+        auto gridDims = forgeManager().getWindowGrid(window);
 
         if (props->col>-1 && props->row>-1) {
             FG_CHECK(fg_draw_chart_to_cell(window,

--- a/src/api/c/hist.cpp
+++ b/src/api/c/hist.cpp
@@ -27,6 +27,8 @@ fg_chart setup_histogram(fg_window const window,
                          const double minval, const double maxval,
                          const af_cell* const props)
 {
+    ForgeModule& _ = graphics::forgePlugin();
+
     Array<T> histogramInput = getArray<T>(in);
     dim_t nBins = histogramInput.elements();
 
@@ -44,13 +46,13 @@ fg_chart setup_histogram(fg_window const window,
     fg_histogram hist = fgMngr.getHistogram(chart, nBins, getGLType<T>());
 
     // Set histogram bar colors to ArrayFire's orange
-    FG_CHECK(fg_set_histogram_color(hist, 0.929f, 0.486f, 0.2745f, 1.0f));
+    FG_CHECK(_.fg_set_histogram_color(hist, 0.929f, 0.486f, 0.2745f, 1.0f));
 
     // If chart axes limits do not have a manual override
     // then compute and set axes limits
     if(!fgMngr.getChartAxesOverride(chart)) {
         float xMin, xMax, yMin, yMax, zMin, zMax;
-        FG_CHECK(fg_get_chart_axes_limits(&xMin, &xMax,
+        FG_CHECK(_.fg_get_chart_axes_limits(&xMin, &xMax,
                                           &yMin, &yMax,
                                           &zMin, &zMax,
                                           chart));
@@ -70,7 +72,7 @@ fg_chart setup_histogram(fg_window const window,
             // For histogram, always set yMin to 0.
             yMin = 0;
         }
-        FG_CHECK(fg_set_chart_axes_limits(chart, xMin, xMax, yMin, yMax, zMin, zMax));
+        FG_CHECK(_.fg_set_chart_axes_limits(chart, xMin, xMax, yMin, yMax, zMin, zMax));
     }
 
     copy_histogram<T>(histogramInput, hist);
@@ -108,13 +110,14 @@ af_err af_draw_hist(const af_window window,
         }
         auto gridDims = forgeManager().getWindowGrid(window);
 
+        ForgeModule& _ = graphics::forgePlugin();
         if (props->col>-1 && props->row>-1) {
-            FG_CHECK(fg_draw_chart_to_cell(window,
-                                           gridDims.first, gridDims.second,
-                                           props->row * gridDims.second + props->col,
-                                           chart, props->title));
+            FG_CHECK(_.fg_draw_chart_to_cell(window,
+                                             gridDims.first, gridDims.second,
+                                             props->row * gridDims.second + props->col,
+                                             chart, props->title));
         } else {
-            FG_CHECK(fg_draw_chart(window, chart));
+            FG_CHECK(_.fg_draw_chart(window, chart));
         }
     }
     CATCHALL;

--- a/src/api/c/image.cpp
+++ b/src/api/c/image.cpp
@@ -101,15 +101,16 @@ af_err af_draw_image(const af_window window,
             default:  TYPE_ERROR(1, type);
         }
 
+        ForgeModule& _ = graphics::forgePlugin();
         auto gridDims = forgeManager().getWindowGrid(window);
-        FG_CHECK(fg_set_window_colormap(window, (fg_color_map)props->cmap));
+        FG_CHECK(_.fg_set_window_colormap(window, (fg_color_map)props->cmap));
         if (props->col>-1 && props->row>-1) {
-            FG_CHECK(fg_draw_image_to_cell(window,
-                                           gridDims.first, gridDims.second,
-                                           props->row * gridDims.second + props->col,
-                                           image, props->title, true));
+            FG_CHECK(_.fg_draw_image_to_cell(window,
+                                             gridDims.first, gridDims.second,
+                                             props->row * gridDims.second + props->col,
+                                             image, props->title, true));
         } else {
-            FG_CHECK(fg_draw_image(window, image, true));
+            FG_CHECK(_.fg_draw_image(window, image, true));
         }
     }
     CATCHALL;

--- a/src/api/c/image.cpp
+++ b/src/api/c/image.cpp
@@ -75,11 +75,11 @@ static fg_image convert_and_copy_image(const af_array in)
 af_err af_draw_image(const af_window window,
                      const af_array in, const af_cell* const props)
 {
-    if(window == 0) {
-        fprintf(stderr, "Not a valid window\n");
-        return AF_SUCCESS;
-    }
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+
         const ArrayInfo& info = getInfo(in);
 
         af::dim4 in_dims = info.dims();

--- a/src/api/c/image.cpp
+++ b/src/api/c/image.cpp
@@ -60,7 +60,7 @@ static fg_image convert_and_copy_image(const af_array in)
 
     Array<T> imgData = reorder(_in, rdims);
 
-    ForgeManager& fgMngr = ForgeManager::getInstance();
+    ForgeManager& fgMngr = forgeManager();
 
     // The inDims[2] * 100 is a hack to convert to fg_channel_format
     // TODO Write a proper conversion function
@@ -101,7 +101,7 @@ af_err af_draw_image(const af_window window,
             default:  TYPE_ERROR(1, type);
         }
 
-        auto gridDims = ForgeManager::getInstance().getWindowGrid(window);
+        auto gridDims = forgeManager().getWindowGrid(window);
         FG_CHECK(fg_set_window_colormap(window, (fg_color_map)props->cmap));
         if (props->col>-1 && props->row>-1) {
             FG_CHECK(fg_draw_image_to_cell(window,

--- a/src/api/c/plot.cpp
+++ b/src/api/c/plot.cpp
@@ -32,6 +32,8 @@ fg_chart setup_plot(fg_window window, const af_array in_,
                     const af_cell* const props,
                     fg_plot_type ptype, fg_marker_type mtype)
 {
+    ForgeModule& _ = graphics::forgePlugin();
+
     Array<T> in = getArray<T>(in_);
 
     af::dim4 dims = in.dims();
@@ -60,14 +62,14 @@ fg_chart setup_plot(fg_window window, const af_array in_,
     fg_plot plot = fgMngr.getPlot(chart, tdims[1], getGLType<T>(), ptype, mtype);
 
     // ArrayFire LOGO Orange shade
-    FG_CHECK(fg_set_plot_color(plot, 0.929f, 0.529f, 0.212f, 1.0));
+    FG_CHECK(_.fg_set_plot_color(plot, 0.929f, 0.529f, 0.212f, 1.0));
 
     // If chart axes limits do not have a manual override
     // then compute and set axes limits
     if(!fgMngr.getChartAxesOverride(chart)) {
         float cmin[3], cmax[3];
         T     dmin[3], dmax[3];
-        FG_CHECK(fg_get_chart_axes_limits(&cmin[0], &cmax[0],
+        FG_CHECK(_.fg_get_chart_axes_limits(&cmin[0], &cmax[0],
                                           &cmin[1], &cmax[1],
                                           &cmin[2], &cmax[2],
                                           chart));
@@ -94,7 +96,7 @@ fg_chart setup_plot(fg_window window, const af_array in_,
                 if(cmax[2] < dmax[2])   cmax[2] = step_round(dmax[2], true);
             }
         }
-        FG_CHECK(fg_set_chart_axes_limits(chart,
+        FG_CHECK(_.fg_set_chart_axes_limits(chart,
                                           cmin[0], cmax[0],
                                           cmin[1], cmax[1],
                                           cmin[2], cmax[2]));
@@ -151,13 +153,14 @@ af_err plotWrapper(const af_window window,
 
         auto gridDims = forgeManager().getWindowGrid(window);
 
+        ForgeModule& _ = graphics::forgePlugin();
         if (props->col>-1 && props->row>-1) {
-            FG_CHECK(fg_draw_chart_to_cell(window,
+            FG_CHECK(_.fg_draw_chart_to_cell(window,
                                            gridDims.first, gridDims.second,
                                            props->row * gridDims.second + props->col,
                                            chart, props->title));
         } else {
-            FG_CHECK(fg_draw_chart(window, chart));
+            FG_CHECK(_.fg_draw_chart(window, chart));
         }
     }
     CATCHALL;
@@ -214,13 +217,14 @@ af_err plotWrapper(const af_window window,
         }
         auto gridDims = forgeManager().getWindowGrid(window);
 
+        ForgeModule& _ = graphics::forgePlugin();
         if (props->col>-1 && props->row>-1) {
-            FG_CHECK(fg_draw_chart_to_cell(window,
-                                           gridDims.first, gridDims.second,
-                                           props->row * gridDims.second + props->col,
-                                           chart, props->title));
+            FG_CHECK(_.fg_draw_chart_to_cell(window,
+                                             gridDims.first, gridDims.second,
+                                             props->row * gridDims.second + props->col,
+                                             chart, props->title));
         } else {
-            FG_CHECK(fg_draw_chart(window, chart));
+            FG_CHECK(_.fg_draw_chart(window, chart));
         }
 
         AF_CHECK(af_release_array(in));
@@ -272,13 +276,14 @@ af_err plotWrapper(const af_window window,
         }
         auto gridDims = forgeManager().getWindowGrid(window);
 
+        ForgeModule& _ = graphics::forgePlugin();
         if (props->col>-1 && props->row>-1) {
-            FG_CHECK(fg_draw_chart_to_cell(window,
-                                           gridDims.first, gridDims.second,
-                                           props->row * gridDims.second + props->col,
-                                           chart, props->title));
+            FG_CHECK(_.fg_draw_chart_to_cell(window,
+                                             gridDims.first, gridDims.second,
+                                             props->row * gridDims.second + props->col,
+                                             chart, props->title));
         } else {
-            FG_CHECK(fg_draw_chart(window, chart));
+            FG_CHECK(_.fg_draw_chart(window, chart));
         }
 
         AF_CHECK(af_release_array(in));

--- a/src/api/c/plot.cpp
+++ b/src/api/c/plot.cpp
@@ -46,7 +46,7 @@ fg_chart setup_plot(fg_window window, const af_array in_,
 
     af::dim4 tdims = in.dims(); //transposed dimensions
 
-    ForgeManager& fgMngr = ForgeManager::getInstance();
+    ForgeManager& fgMngr = forgeManager();
 
     // Get the chart for the current grid position (if any)
     fg_chart chart = NULL;
@@ -150,7 +150,7 @@ af_err plotWrapper(const af_window window,
             default:  TYPE_ERROR(1, type);
         }
 
-        auto gridDims = ForgeManager::getInstance().getWindowGrid(window);
+        auto gridDims = forgeManager().getWindowGrid(window);
 
         if (props->col>-1 && props->row>-1) {
             FG_CHECK(fg_draw_chart_to_cell(window,
@@ -214,7 +214,7 @@ af_err plotWrapper(const af_window window,
             case u8 : chart = setup_plot<uchar  >(window, in, 3, props, ptype, marker); break;
             default:  TYPE_ERROR(1, xType);
         }
-        auto gridDims = ForgeManager::getInstance().getWindowGrid(window);
+        auto gridDims = forgeManager().getWindowGrid(window);
 
         if (props->col>-1 && props->row>-1) {
             FG_CHECK(fg_draw_chart_to_cell(window,
@@ -273,7 +273,7 @@ af_err plotWrapper(const af_window window,
             case u8 : chart = setup_plot<uchar  >(window, in, 2, props, ptype, marker); break;
             default:  TYPE_ERROR(1, xType);
         }
-        auto gridDims = ForgeManager::getInstance().getWindowGrid(window);
+        auto gridDims = forgeManager().getWindowGrid(window);
 
         if (props->col>-1 && props->row>-1) {
             FG_CHECK(fg_draw_chart_to_cell(window,

--- a/src/api/c/plot.cpp
+++ b/src/api/c/plot.cpp
@@ -123,12 +123,11 @@ af_err plotWrapper(const af_window window,
                    fg_plot_type ptype = FG_PLOT_LINE,
                    fg_marker_type marker = FG_MARKER_NONE)
 {
-    if(window == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
-    }
-
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+
         const ArrayInfo& info = getInfo(in);
         af::dim4  dims = info.dims();
         af_dtype  type = info.getType();
@@ -171,12 +170,11 @@ af_err plotWrapper(const af_window window,
                    fg_plot_type ptype = FG_PLOT_LINE,
                    fg_marker_type marker = FG_MARKER_NONE)
 {
-    if(window == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
-    }
-
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+
         const ArrayInfo& xInfo = getInfo(X);
         af::dim4  xDims = xInfo.dims();
         af_dtype  xType = xInfo.getType();
@@ -237,12 +235,11 @@ af_err plotWrapper(const af_window window,
                    fg_plot_type ptype = FG_PLOT_LINE,
                    fg_marker_type marker = FG_MARKER_NONE)
 {
-    if(window == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
-    }
-
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+
         const ArrayInfo& xInfo = getInfo(X);
         af::dim4  xDims = xInfo.dims();
         af_dtype  xType = xInfo.getType();

--- a/src/api/c/surface.cpp
+++ b/src/api/c/surface.cpp
@@ -67,7 +67,7 @@ fg_chart setup_surface(fg_window window,
     std::vector<Array<T> > inputs{xIn, yIn, zIn};
     Array<T> Z = join(0, inputs);
 
-    ForgeManager& fgMngr = ForgeManager::getInstance();
+    ForgeManager& fgMngr = forgeManager();
 
     // Get the chart for the current grid position (if any)
     fg_chart chart = NULL;
@@ -170,7 +170,7 @@ af_err af_draw_surface(const af_window window,
             case u8 : chart = setup_surface<uchar  >(window, xVals, yVals , S, props); break;
             default:  TYPE_ERROR(1, Xtype);
         }
-        auto gridDims = ForgeManager::getInstance().getWindowGrid(window);
+        auto gridDims = forgeManager().getWindowGrid(window);
 
         if (props->col>-1 && props->row>-1) {
             FG_CHECK(fg_draw_chart_to_cell(window,

--- a/src/api/c/surface.cpp
+++ b/src/api/c/surface.cpp
@@ -129,12 +129,11 @@ af_err af_draw_surface(const af_window window,
                        const af_array xVals, const af_array yVals,
                        const af_array S, const af_cell* const props)
 {
-    if(window == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
-    }
-
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+
         const ArrayInfo& Xinfo = getInfo(xVals);
         af::dim4 X_dims = Xinfo.dims();
         af_dtype Xtype  = Xinfo.getType();

--- a/src/api/c/surface.cpp
+++ b/src/api/c/surface.cpp
@@ -31,6 +31,7 @@ fg_chart setup_surface(fg_window window,
                        const af_array zVals,
                        const af_cell* const props)
 {
+    ForgeModule& _ = graphics::forgePlugin();
     Array<T> xIn = getArray<T>(xVals);
     Array<T> yIn = getArray<T>(yVals);
     Array<T> zIn = getArray<T>(zVals);
@@ -78,14 +79,14 @@ fg_chart setup_surface(fg_window window,
 
     fg_surface surface = fgMngr.getSurface(chart, Z_dims[0], Z_dims[1], getGLType<T>());
 
-    FG_CHECK(fg_set_surface_color(surface, 0.0, 1.0, 0.0, 1.0));
+    FG_CHECK(_.fg_set_surface_color(surface, 0.0, 1.0, 0.0, 1.0));
 
     // If chart axes limits do not have a manual override
     // then compute and set axes limits
     if(!fgMngr.getChartAxesOverride(chart)) {
         float cmin[3], cmax[3];
         T     dmin[3], dmax[3];
-        FG_CHECK(fg_get_chart_axes_limits(&cmin[0], &cmax[0],
+        FG_CHECK(_.fg_get_chart_axes_limits(&cmin[0], &cmax[0],
                                           &cmin[1], &cmax[1],
                                           &cmin[2], &cmax[2],
                                           chart));
@@ -115,7 +116,7 @@ fg_chart setup_surface(fg_window window,
             if(cmax[2] < dmax[2]) cmax[2] = step_round(dmax[2], true);
         }
 
-        FG_CHECK(fg_set_chart_axes_limits(chart,
+        FG_CHECK(_.fg_set_chart_axes_limits(chart,
                                           cmin[0], cmax[0],
                                           cmin[1], cmax[1],
                                           cmin[2], cmax[2]));
@@ -171,13 +172,14 @@ af_err af_draw_surface(const af_window window,
         }
         auto gridDims = forgeManager().getWindowGrid(window);
 
+        ForgeModule& _ = graphics::forgePlugin();
         if (props->col>-1 && props->row>-1) {
-            FG_CHECK(fg_draw_chart_to_cell(window,
-                                           gridDims.first, gridDims.second,
-                                           props->row * gridDims.second + props->col,
-                                           chart, props->title));
+            FG_CHECK(_.fg_draw_chart_to_cell(window,
+                                             gridDims.first, gridDims.second,
+                                             props->row * gridDims.second + props->col,
+                                             chart, props->title));
         } else {
-            FG_CHECK(fg_draw_chart(window, chart));
+            FG_CHECK(_.fg_draw_chart(window, chart));
         }
     }
     CATCHALL;

--- a/src/api/c/vector_field.cpp
+++ b/src/api/c/vector_field.cpp
@@ -120,11 +120,11 @@ af_err vectorFieldWrapper(const af_window window,
                           const af_array points, const af_array directions,
                           const af_cell* const props)
 {
-    if(window == 0) {
-        AF_RETURN_ERROR("Not a valid window", AF_SUCCESS);
-    }
-
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+
         const ArrayInfo& pInfo = getInfo(points);
         af::dim4 pDims  = pInfo.dims();
         af_dtype pType  = pInfo.getType();
@@ -182,10 +182,11 @@ af_err vectorFieldWrapper(const af_window window,
                           const af_array zDirs,
                           const af_cell* const props)
 {
-    if(window == 0) {
-        AF_RETURN_ERROR("Not a valid window", AF_SUCCESS);
-    }
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_SUCCESS);
+        }
+
         const ArrayInfo& xpInfo = getInfo(xPoints);
         const ArrayInfo& ypInfo = getInfo(yPoints);
         const ArrayInfo& zpInfo = getInfo(zPoints);
@@ -272,11 +273,11 @@ af_err vectorFieldWrapper(const af_window window,
                           const af_array xDirs, const af_array yDirs,
                           const af_cell* const props)
 {
-    if(window == 0) {
-        AF_RETURN_ERROR("Not a valid window", AF_SUCCESS);
-    }
-
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_SUCCESS);
+        }
+
         const ArrayInfo& xpInfo = getInfo(xPoints);
         const ArrayInfo& ypInfo = getInfo(yPoints);
 

--- a/src/api/c/vector_field.cpp
+++ b/src/api/c/vector_field.cpp
@@ -52,7 +52,7 @@ fg_chart setup_vector_field(fg_window window,
         dIn = transpose<T>(dIn, false);
     }
 
-    ForgeManager& fgMngr = ForgeManager::getInstance();
+    ForgeManager& fgMngr = forgeManager();
 
     // Get the chart for the current grid position (if any)
     fg_chart chart = NULL;
@@ -158,7 +158,7 @@ af_err vectorFieldWrapper(const af_window window,
             case u8 : chart = setup_vector_field<uchar  >(window, pnts, dirs, props); break;
             default:  TYPE_ERROR(1, pType);
         }
-        auto gridDims = ForgeManager::getInstance().getWindowGrid(window);
+        auto gridDims = forgeManager().getWindowGrid(window);
 
         if (props->col>-1 && props->row>-1) {
             FG_CHECK(fg_draw_chart_to_cell(window,
@@ -252,7 +252,7 @@ af_err vectorFieldWrapper(const af_window window,
             case u8 : chart = setup_vector_field<uchar  >(window, points, directions, props); break;
             default:  TYPE_ERROR(1, xpType);
         }
-        auto gridDims = ForgeManager::getInstance().getWindowGrid(window);
+        auto gridDims = forgeManager().getWindowGrid(window);
 
         if (props->col>-1 && props->row>-1) {
             FG_CHECK(fg_draw_chart_to_cell(window,
@@ -332,7 +332,7 @@ af_err vectorFieldWrapper(const af_window window,
             default:  TYPE_ERROR(1, xpType);
         }
 
-        auto gridDims = ForgeManager::getInstance().getWindowGrid(window);
+        auto gridDims = forgeManager().getWindowGrid(window);
 
         if (props->col>-1 && props->row>-1) {
             FG_CHECK(fg_draw_chart_to_cell(window,

--- a/src/api/c/vector_field.cpp
+++ b/src/api/c/vector_field.cpp
@@ -34,6 +34,7 @@ fg_chart setup_vector_field(fg_window window,
                             const af_cell* const props,
                             const bool transpose_ = true)
 {
+    ForgeModule& _ = graphics::forgePlugin();
     vector< Array<T> > pnts;
     vector< Array<T> > dirs;
 
@@ -72,14 +73,14 @@ fg_chart setup_vector_field(fg_window window,
     fg_vector_field vfield = fgMngr.getVectorField(chart, pIn.dims()[1], getGLType<T>());
 
     // ArrayFire LOGO dark blue shade
-    FG_CHECK(fg_set_vector_field_color(vfield, 0.130f, 0.173f, 0.263f, 1.0));
+    FG_CHECK(_.fg_set_vector_field_color(vfield, 0.130f, 0.173f, 0.263f, 1.0));
 
     // If chart axes limits do not have a manual override
     // then compute and set axes limits
     if(!fgMngr.getChartAxesOverride(chart)) {
         float cmin[3], cmax[3];
         T     dmin[3], dmax[3];
-        FG_CHECK(fg_get_chart_axes_limits(&cmin[0], &cmax[0],
+        FG_CHECK(_.fg_get_chart_axes_limits(&cmin[0], &cmax[0],
                                           &cmin[1], &cmax[1],
                                           &cmin[2], &cmax[2],
                                           chart));
@@ -106,7 +107,7 @@ fg_chart setup_vector_field(fg_window window,
                 if(cmax[2] < dmax[2])   cmax[2] = step_round(dmax[2], true);
             }
         }
-        FG_CHECK(fg_set_chart_axes_limits(chart,
+        FG_CHECK(_.fg_set_chart_axes_limits(chart,
                                           cmin[0], cmax[0],
                                           cmin[1], cmax[1],
                                           cmin[2], cmax[2]));
@@ -160,13 +161,14 @@ af_err vectorFieldWrapper(const af_window window,
         }
         auto gridDims = forgeManager().getWindowGrid(window);
 
+        ForgeModule& _ = graphics::forgePlugin();
         if (props->col>-1 && props->row>-1) {
-            FG_CHECK(fg_draw_chart_to_cell(window,
-                                           gridDims.first, gridDims.second,
-                                           props->row * gridDims.second + props->col,
-                                           chart, props->title));
+            FG_CHECK(_.fg_draw_chart_to_cell(window,
+                                             gridDims.first, gridDims.second,
+                                             props->row * gridDims.second + props->col,
+                                             chart, props->title));
         } else {
-            FG_CHECK(fg_draw_chart(window, chart));
+            FG_CHECK(_.fg_draw_chart(window, chart));
         }
     }
     CATCHALL;
@@ -255,13 +257,14 @@ af_err vectorFieldWrapper(const af_window window,
         }
         auto gridDims = forgeManager().getWindowGrid(window);
 
+        ForgeModule& _ = graphics::forgePlugin();
         if (props->col>-1 && props->row>-1) {
-            FG_CHECK(fg_draw_chart_to_cell(window,
-                                           gridDims.first, gridDims.second,
-                                           props->row * gridDims.second + props->col,
-                                           chart, props->title));
+            FG_CHECK(_.fg_draw_chart_to_cell(window,
+                                             gridDims.first, gridDims.second,
+                                             props->row * gridDims.second + props->col,
+                                             chart, props->title));
         } else {
-            FG_CHECK(fg_draw_chart(window, chart));
+            FG_CHECK(_.fg_draw_chart(window, chart));
         }
     }
     CATCHALL;
@@ -335,13 +338,14 @@ af_err vectorFieldWrapper(const af_window window,
 
         auto gridDims = forgeManager().getWindowGrid(window);
 
+        ForgeModule& _ = graphics::forgePlugin();
         if (props->col>-1 && props->row>-1) {
-            FG_CHECK(fg_draw_chart_to_cell(window,
-                                           gridDims.first, gridDims.second,
-                                           props->row * gridDims.second + props->col,
-                                           chart, props->title));
+            FG_CHECK(_.fg_draw_chart_to_cell(window,
+                                             gridDims.first, gridDims.second,
+                                             props->row * gridDims.second + props->col,
+                                             chart, props->title));
         } else {
-            FG_CHECK(fg_draw_chart(window, chart));
+            FG_CHECK(_.fg_draw_chart(window, chart));
         }
     }
     CATCHALL;

--- a/src/api/c/window.cpp
+++ b/src/api/c/window.cpp
@@ -14,6 +14,7 @@
 #include <common/graphics_common.hpp>
 #include <common/err_common.hpp>
 #include <backend.hpp>
+#include <platform.hpp>
 
 using af::dim4;
 using namespace detail;
@@ -22,7 +23,7 @@ using namespace graphics;
 af_err af_create_window(af_window *out, const int width, const int height, const char* const title)
 {
     try {
-        graphics::ForgeManager& fgMngr = graphics::ForgeManager::getInstance();
+        ForgeManager& fgMngr = forgeManager();
         fg_window mainWnd = NULL;
 
         try {
@@ -84,7 +85,7 @@ af_err af_grid(const af_window wind, const int rows, const int cols)
         return AF_SUCCESS;
     }
     try {
-        ForgeManager::getInstance().setWindowChartGrid(wind, rows, cols);
+        forgeManager().setWindowChartGrid(wind, rows, cols);
     }
     CATCHALL;
     return AF_SUCCESS;
@@ -99,7 +100,7 @@ af_err af_set_axes_limits_compute(const af_window window,
         return AF_SUCCESS;
     }
     try {
-        ForgeManager& fgMngr = ForgeManager::getInstance();
+        ForgeManager& fgMngr = forgeManager();
 
         fg_chart chart = NULL;
 
@@ -150,7 +151,7 @@ af_err af_set_axes_limits_2d(const af_window window,
         return AF_SUCCESS;
     }
     try {
-        ForgeManager& fgMngr = ForgeManager::getInstance();
+        ForgeManager& fgMngr = forgeManager();
 
         fg_chart chart = NULL;
         // The ctype here below doesn't really matter as it is only fetching
@@ -193,7 +194,7 @@ af_err af_set_axes_limits_3d(const af_window window,
         return AF_SUCCESS;
     }
     try {
-        ForgeManager& fgMngr = ForgeManager::getInstance();
+        ForgeManager& fgMngr = forgeManager();
 
         fg_chart chart = NULL;
         // The ctype here below doesn't really matter as it is only fetching
@@ -240,7 +241,7 @@ af_err af_set_axes_titles(const af_window window,
         return AF_SUCCESS;
     }
     try {
-        ForgeManager& fgMngr = ForgeManager::getInstance();
+        ForgeManager& fgMngr = forgeManager();
 
         fg_chart chart = NULL;
 
@@ -298,7 +299,7 @@ af_err af_destroy_window(const af_window wind)
         return AF_SUCCESS;
     }
     try {
-        ForgeManager::getInstance().setWindowChartGrid(wind, 0, 0);
+        forgeManager().setWindowChartGrid(wind, 0, 0);
     }
     CATCHALL;
     FG_CHECK(fg_release_window(wind));

--- a/src/api/c/window.cpp
+++ b/src/api/c/window.cpp
@@ -24,16 +24,10 @@ af_err af_create_window(af_window *out, const int width, const int height, const
 {
     try {
         ForgeManager& fgMngr = forgeManager();
-        fg_window mainWnd = NULL;
+        fg_window mainWnd    = fgMngr.getMainWindow();
 
-        try {
-            mainWnd = fgMngr.getMainWindow();
-        } catch(...) {
-            std::cerr<<"OpenGL context creation failed"<<std::endl;
-        }
         if (mainWnd == 0) {
-            std::cerr<<"Not a valid window"<<std::endl;
-            return AF_SUCCESS;
+            AF_ERROR("OpenGL context creation failed", AF_ERR_INTERNAL);
         }
 
         fg_window temp = nullptr;
@@ -50,41 +44,46 @@ af_err af_create_window(af_window *out, const int width, const int height, const
 
 af_err af_set_position(const af_window wind, const unsigned x, const unsigned y)
 {
-    if(wind == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
+    try {
+        if(wind == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+        FG_CHECK(fg_set_window_position(wind, x, y));
     }
-    FG_CHECK(fg_set_window_position(wind, x, y));
+    CATCHALL;
     return AF_SUCCESS;
 }
 
 af_err af_set_title(const af_window wind, const char* const title)
 {
-    if(wind == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
+    try {
+        if(wind == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+        FG_CHECK(fg_set_window_title(wind, title));
     }
-    FG_CHECK(fg_set_window_title(wind, title));
+    CATCHALL;
     return AF_SUCCESS;
 }
 
 af_err af_set_size(const af_window wind, const unsigned w, const unsigned h)
 {
-    if(wind == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
+    try {
+        if(wind == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+        FG_CHECK(fg_set_window_size(wind, w, h));
     }
-    FG_CHECK(fg_set_window_size(wind, w, h));
+    CATCHALL;
     return AF_SUCCESS;
 }
 
 af_err af_grid(const af_window wind, const int rows, const int cols)
 {
-    if(wind == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
-    }
     try {
+        if(wind == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
         forgeManager().setWindowChartGrid(wind, rows, cols);
     }
     CATCHALL;
@@ -95,11 +94,11 @@ af_err af_set_axes_limits_compute(const af_window window,
                                   const af_array x, const af_array y, const af_array z,
                                   const bool exact, const af_cell* const props)
 {
-    if(window == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
-    }
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+
         ForgeManager& fgMngr = forgeManager();
 
         fg_chart chart = NULL;
@@ -146,11 +145,11 @@ af_err af_set_axes_limits_2d(const af_window window,
                              const float ymin, const float ymax,
                              const bool exact, const af_cell* const props)
 {
-    if(window == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
-    }
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+
         ForgeManager& fgMngr = forgeManager();
 
         fg_chart chart = NULL;
@@ -189,11 +188,11 @@ af_err af_set_axes_limits_3d(const af_window window,
                              const float zmin, const float zmax,
                              const bool exact, const af_cell* const props)
 {
-    if(window == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
-    }
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+
         ForgeManager& fgMngr = forgeManager();
 
         fg_chart chart = NULL;
@@ -236,11 +235,11 @@ af_err af_set_axes_titles(const af_window window,
                           const char * const ztitle,
                           const af_cell* const props)
 {
-    if(window == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
-    }
     try {
+        if(window == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+
         ForgeManager& fgMngr = forgeManager();
 
         fg_chart chart = NULL;
@@ -260,49 +259,53 @@ af_err af_set_axes_titles(const af_window window,
 
 af_err af_show(const af_window wind)
 {
-    if(wind == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
+    try {
+        if(wind == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+        FG_CHECK(fg_swap_window_buffers(wind));
     }
-    FG_CHECK(fg_swap_window_buffers(wind));
+    CATCHALL;
     return AF_SUCCESS;
 }
 
 af_err af_is_window_closed(bool *out, const af_window wind)
 {
-    if(wind == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
+    try {
+        if(wind == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+        FG_CHECK(fg_close_window(out, wind));
     }
-    FG_CHECK(fg_close_window(out, wind));
+    CATCHALL;
     return AF_SUCCESS;
 }
 
 af_err af_set_visibility(const af_window wind, const bool is_visible)
 {
-    if(wind == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
+    try {
+        if(wind == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
+        if (is_visible) {
+            FG_CHECK(fg_show_window(wind));
+        } else {
+            FG_CHECK(fg_hide_window(wind));
+        }
     }
-    if (is_visible) {
-        FG_CHECK(fg_show_window(wind));
-    } else {
-        FG_CHECK(fg_hide_window(wind));
-    }
+    CATCHALL;
     return AF_SUCCESS;
 }
 
 af_err af_destroy_window(const af_window wind)
 {
-    if(wind == 0) {
-        std::cerr<<"Not a valid window"<<std::endl;
-        return AF_SUCCESS;
-    }
     try {
+        if(wind == 0) {
+            AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
+        }
         forgeManager().setWindowChartGrid(wind, 0, 0);
+        FG_CHECK(fg_release_window(wind));
     }
     CATCHALL;
-    FG_CHECK(fg_release_window(wind));
     return AF_SUCCESS;
 }
-

--- a/src/api/c/window.cpp
+++ b/src/api/c/window.cpp
@@ -32,7 +32,7 @@ af_err af_create_window(af_window *out, const int width, const int height, const
 
         fg_window temp = nullptr;
 
-        FG_CHECK(fg_create_window(&temp, width, height, title, mainWnd, false));
+        FG_CHECK(forgePlugin().fg_create_window(&temp, width, height, title, mainWnd, false));
 
         fgMngr.setWindowChartGrid(temp, 1, 1);
 
@@ -48,7 +48,7 @@ af_err af_set_position(const af_window wind, const unsigned x, const unsigned y)
         if(wind == 0) {
             AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
         }
-        FG_CHECK(fg_set_window_position(wind, x, y));
+        FG_CHECK(forgePlugin().fg_set_window_position(wind, x, y));
     }
     CATCHALL;
     return AF_SUCCESS;
@@ -60,7 +60,7 @@ af_err af_set_title(const af_window wind, const char* const title)
         if(wind == 0) {
             AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
         }
-        FG_CHECK(fg_set_window_title(wind, title));
+        FG_CHECK(forgePlugin().fg_set_window_title(wind, title));
     }
     CATCHALL;
     return AF_SUCCESS;
@@ -72,7 +72,7 @@ af_err af_set_size(const af_window wind, const unsigned w, const unsigned h)
         if(wind == 0) {
             AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
         }
-        FG_CHECK(fg_set_window_size(wind, w, h));
+        FG_CHECK(forgePlugin().fg_set_window_size(wind, w, h));
     }
     CATCHALL;
     return AF_SUCCESS;
@@ -133,7 +133,7 @@ af_err af_set_axes_limits_compute(const af_window window,
         }
 
         fgMngr.setChartAxesOverride(chart);
-        FG_CHECK(fg_set_chart_axes_limits(chart, xmin, xmax,
+        FG_CHECK(forgePlugin().fg_set_chart_axes_limits(chart, xmin, xmax,
                                           ymin, ymax, zmin, zmax));
     }
     CATCHALL;
@@ -175,7 +175,7 @@ af_err af_set_axes_limits_2d(const af_window window,
         }
 
         fgMngr.setChartAxesOverride(chart);
-        FG_CHECK(fg_set_chart_axes_limits(chart, _xmin, _xmax,
+        FG_CHECK(forgePlugin().fg_set_chart_axes_limits(chart, _xmin, _xmax,
                                           _ymin, _ymax, 0.0f, 0.0f));
     }
     CATCHALL;
@@ -222,7 +222,7 @@ af_err af_set_axes_limits_3d(const af_window window,
         }
 
         fgMngr.setChartAxesOverride(chart);
-        FG_CHECK(fg_set_chart_axes_limits(chart, _xmin, _xmax,
+        FG_CHECK(forgePlugin().fg_set_chart_axes_limits(chart, _xmin, _xmax,
                                           _ymin, _ymax, _zmin, _zmax));
     }
     CATCHALL;
@@ -251,7 +251,7 @@ af_err af_set_axes_titles(const af_window window,
         else
             chart = fgMngr.getChart(window, 0, 0, ctype);
 
-        FG_CHECK(fg_set_chart_axes_titles(chart, xtitle, ytitle, ztitle));
+        FG_CHECK(forgePlugin().fg_set_chart_axes_titles(chart, xtitle, ytitle, ztitle));
     }
     CATCHALL;
     return AF_SUCCESS;
@@ -263,7 +263,7 @@ af_err af_show(const af_window wind)
         if(wind == 0) {
             AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
         }
-        FG_CHECK(fg_swap_window_buffers(wind));
+        FG_CHECK(forgePlugin().fg_swap_window_buffers(wind));
     }
     CATCHALL;
     return AF_SUCCESS;
@@ -275,7 +275,7 @@ af_err af_is_window_closed(bool *out, const af_window wind)
         if(wind == 0) {
             AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
         }
-        FG_CHECK(fg_close_window(out, wind));
+        FG_CHECK(forgePlugin().fg_close_window(out, wind));
     }
     CATCHALL;
     return AF_SUCCESS;
@@ -288,9 +288,9 @@ af_err af_set_visibility(const af_window wind, const bool is_visible)
             AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
         }
         if (is_visible) {
-            FG_CHECK(fg_show_window(wind));
+            FG_CHECK(forgePlugin().fg_show_window(wind));
         } else {
-            FG_CHECK(fg_hide_window(wind));
+            FG_CHECK(forgePlugin().fg_hide_window(wind));
         }
     }
     CATCHALL;
@@ -304,7 +304,7 @@ af_err af_destroy_window(const af_window wind)
             AF_ERROR("Not a valid window", AF_ERR_INTERNAL);
         }
         forgeManager().setWindowChartGrid(wind, 0, 0);
-        FG_CHECK(fg_release_window(wind));
+        FG_CHECK(forgePlugin().fg_release_window(wind));
     }
     CATCHALL;
     return AF_SUCCESS;

--- a/src/backend/common/InteropManager.hpp
+++ b/src/backend/common/InteropManager.hpp
@@ -44,7 +44,7 @@ class InteropManager
         res_vec_t getImageResources(const fg_window image) {
             if (mInteropMap.find(image) == mInteropMap.end()) {
                 uint32_t buffer;
-                FG_CHECK(fg_get_pixel_buffer(&buffer, image));
+                FG_CHECK(graphics::forgePlugin().fg_get_pixel_buffer(&buffer, image));
                 mInteropMap[image] =
                     static_cast<T*>(this)->registerResources({buffer});
             }
@@ -54,7 +54,7 @@ class InteropManager
         res_vec_t getPlotResources(const fg_plot plot) {
             if (mInteropMap.find(plot) == mInteropMap.end()) {
                 uint32_t buffer;
-                FG_CHECK(fg_get_plot_vertex_buffer(&buffer, plot));
+                FG_CHECK(graphics::forgePlugin().fg_get_plot_vertex_buffer(&buffer, plot));
                 mInteropMap[plot] =
                     static_cast<T*>(this)->registerResources({buffer});
             }
@@ -64,7 +64,7 @@ class InteropManager
         res_vec_t getHistogramResources(const fg_histogram histogram) {
             if (mInteropMap.find(histogram) == mInteropMap.end()) {
                 uint32_t buffer;
-                FG_CHECK(fg_get_histogram_vertex_buffer(&buffer, histogram));
+                FG_CHECK(graphics::forgePlugin().fg_get_histogram_vertex_buffer(&buffer, histogram));
                 mInteropMap[histogram] =
                     static_cast<T*>(this)->registerResources({buffer});
             }
@@ -74,7 +74,7 @@ class InteropManager
         res_vec_t getSurfaceResources(const fg_surface surface) {
             if (mInteropMap.find(surface) == mInteropMap.end()) {
                 uint32_t buffer;
-                FG_CHECK(fg_get_surface_vertex_buffer(&buffer, surface));
+                FG_CHECK(graphics::forgePlugin().fg_get_surface_vertex_buffer(&buffer, surface));
                 mInteropMap[surface] =
                     static_cast<T*>(this)->registerResources({buffer});
             }
@@ -84,8 +84,8 @@ class InteropManager
         res_vec_t getVectorFieldResources(const fg_vector_field field) {
             if (mInteropMap.find(field) == mInteropMap.end()) {
                 uint32_t verts, dirs;
-                FG_CHECK(fg_get_vector_field_vertex_buffer(&verts, field));
-                FG_CHECK(fg_get_vector_field_direction_buffer(&dirs, field));
+                FG_CHECK(graphics::forgePlugin().fg_get_vector_field_vertex_buffer(&verts, field));
+                FG_CHECK(graphics::forgePlugin().fg_get_vector_field_direction_buffer(&dirs, field));
                 mInteropMap[field] =
                     static_cast<T*>(this)->registerResources({verts, dirs});
             }

--- a/src/backend/common/forge_loader.hpp
+++ b/src/backend/common/forge_loader.hpp
@@ -92,7 +92,7 @@ ForgeModule& forgePlugin();
 
 #define FG_CHECK(fn)                           \
     do {                                       \
-        fg_err e = graphics::forgePlugin().fn; \
+        fg_err e = (fn);                       \
         if (e != FG_ERR_NONE) {                \
             AF_ERROR("forge call failed",      \
                     AF_ERR_INTERNAL);          \

--- a/src/backend/common/forge_loader.hpp
+++ b/src/backend/common/forge_loader.hpp
@@ -15,10 +15,10 @@
 
 #include <forge.h>
 
-class ForgeModule {
-    common::DependencyModule module;
-
+class ForgeModule : public common::DependencyModule {
     public:
+    ForgeModule();
+
     MODULE_MEMBER(fg_create_window);
     MODULE_MEMBER(fg_get_window_context_handle);
     MODULE_MEMBER(fg_get_window_display_handle);
@@ -84,8 +84,6 @@ class ForgeModule {
     MODULE_MEMBER(fg_append_surface_to_chart);
     MODULE_MEMBER(fg_append_vector_field_to_chart);
     MODULE_MEMBER(fg_release_chart);
-
-    ForgeModule();
 };
 
 namespace graphics {

--- a/src/backend/common/graphics_common.cpp
+++ b/src/backend/common/graphics_common.cpp
@@ -17,82 +17,89 @@
 
 using namespace std;
 
+/// Dynamically loads forge function pointer at runtime
+#define FG_MODULE_FUNCTION_INIT(NAME)                \
+    NAME = DependencyModule::getSymbol<decltype(&::NAME)>(#NAME)
+
 ForgeModule::ForgeModule()
-    : module("forge", nullptr)
+    : DependencyModule("forge", nullptr)
 {
-    if (!module.isLoaded()) {
-        string error_message = "Error loading Forge: "
-            + module.getErrorMessage()
-            + "\nForge or one of it's dependencies failed to "
-            "load. Try installing Forge or check if Forge is in the "
-            "search path.";
-        AF_ERROR(error_message.c_str(), AF_ERR_LOAD_LIB);
+    if (DependencyModule::isLoaded()) {
+        FG_MODULE_FUNCTION_INIT(fg_create_window);
+        FG_MODULE_FUNCTION_INIT(fg_get_window_context_handle);
+        FG_MODULE_FUNCTION_INIT(fg_get_window_display_handle);
+        FG_MODULE_FUNCTION_INIT(fg_make_window_current);
+        FG_MODULE_FUNCTION_INIT(fg_set_window_font);
+        FG_MODULE_FUNCTION_INIT(fg_set_window_position);
+        FG_MODULE_FUNCTION_INIT(fg_set_window_title);
+        FG_MODULE_FUNCTION_INIT(fg_set_window_size);
+        FG_MODULE_FUNCTION_INIT(fg_set_window_colormap);
+        FG_MODULE_FUNCTION_INIT(fg_draw_chart_to_cell);
+        FG_MODULE_FUNCTION_INIT(fg_draw_chart);
+        FG_MODULE_FUNCTION_INIT(fg_draw_image_to_cell);
+        FG_MODULE_FUNCTION_INIT(fg_draw_image);
+        FG_MODULE_FUNCTION_INIT(fg_swap_window_buffers);
+        FG_MODULE_FUNCTION_INIT(fg_close_window);
+        FG_MODULE_FUNCTION_INIT(fg_show_window);
+        FG_MODULE_FUNCTION_INIT(fg_hide_window);
+        FG_MODULE_FUNCTION_INIT(fg_release_window);
+
+        FG_MODULE_FUNCTION_INIT(fg_create_font);
+        FG_MODULE_FUNCTION_INIT(fg_load_system_font);
+        FG_MODULE_FUNCTION_INIT(fg_release_font);
+
+        FG_MODULE_FUNCTION_INIT(fg_create_image);
+        FG_MODULE_FUNCTION_INIT(fg_get_pixel_buffer);
+        FG_MODULE_FUNCTION_INIT(fg_get_image_size);
+        FG_MODULE_FUNCTION_INIT(fg_release_image);
+
+        FG_MODULE_FUNCTION_INIT(fg_create_plot);
+        FG_MODULE_FUNCTION_INIT(fg_set_plot_color);
+        FG_MODULE_FUNCTION_INIT(fg_get_plot_vertex_buffer);
+        FG_MODULE_FUNCTION_INIT(fg_get_plot_vertex_buffer_size);
+        FG_MODULE_FUNCTION_INIT(fg_release_plot);
+
+        FG_MODULE_FUNCTION_INIT(fg_create_histogram);
+        FG_MODULE_FUNCTION_INIT(fg_set_histogram_color);
+        FG_MODULE_FUNCTION_INIT(fg_get_histogram_vertex_buffer);
+        FG_MODULE_FUNCTION_INIT(fg_get_histogram_vertex_buffer_size);
+        FG_MODULE_FUNCTION_INIT(fg_release_histogram);
+
+        FG_MODULE_FUNCTION_INIT(fg_create_surface);
+        FG_MODULE_FUNCTION_INIT(fg_set_surface_color);
+        FG_MODULE_FUNCTION_INIT(fg_get_surface_vertex_buffer);
+        FG_MODULE_FUNCTION_INIT(fg_get_surface_vertex_buffer_size);
+        FG_MODULE_FUNCTION_INIT(fg_release_surface);
+
+        FG_MODULE_FUNCTION_INIT(fg_create_vector_field);
+        FG_MODULE_FUNCTION_INIT(fg_set_vector_field_color);
+        FG_MODULE_FUNCTION_INIT(fg_get_vector_field_vertex_buffer_size);
+        FG_MODULE_FUNCTION_INIT(fg_get_vector_field_direction_buffer_size);
+        FG_MODULE_FUNCTION_INIT(fg_get_vector_field_vertex_buffer);
+        FG_MODULE_FUNCTION_INIT(fg_get_vector_field_direction_buffer);
+        FG_MODULE_FUNCTION_INIT(fg_release_vector_field);
+
+        FG_MODULE_FUNCTION_INIT(fg_create_chart);
+        FG_MODULE_FUNCTION_INIT(fg_get_chart_type);
+        FG_MODULE_FUNCTION_INIT(fg_get_chart_axes_limits);
+        FG_MODULE_FUNCTION_INIT(fg_set_chart_axes_limits);
+        FG_MODULE_FUNCTION_INIT(fg_set_chart_axes_titles);
+        FG_MODULE_FUNCTION_INIT(fg_append_image_to_chart);
+        FG_MODULE_FUNCTION_INIT(fg_append_plot_to_chart);
+        FG_MODULE_FUNCTION_INIT(fg_append_histogram_to_chart);
+        FG_MODULE_FUNCTION_INIT(fg_append_surface_to_chart);
+        FG_MODULE_FUNCTION_INIT(fg_append_vector_field_to_chart);
+        FG_MODULE_FUNCTION_INIT(fg_release_chart);
+
+        if (!DependencyModule::symbolsLoaded()) {
+            string error_message = "Error loading Forge: "
+                + DependencyModule::getErrorMessage()
+                + "\nForge or one of it's dependencies failed to "
+                "load. Try installing Forge or check if Forge is in the "
+                "search path.";
+            AF_ERROR(error_message.c_str(), AF_ERR_LOAD_LIB);
+        }
     }
-    MODULE_FUNCTION_INIT(fg_create_window);
-    MODULE_FUNCTION_INIT(fg_get_window_context_handle);
-    MODULE_FUNCTION_INIT(fg_get_window_display_handle);
-    MODULE_FUNCTION_INIT(fg_make_window_current);
-    MODULE_FUNCTION_INIT(fg_set_window_font);
-    MODULE_FUNCTION_INIT(fg_set_window_position);
-    MODULE_FUNCTION_INIT(fg_set_window_title);
-    MODULE_FUNCTION_INIT(fg_set_window_size);
-    MODULE_FUNCTION_INIT(fg_set_window_colormap);
-    MODULE_FUNCTION_INIT(fg_draw_chart_to_cell);
-    MODULE_FUNCTION_INIT(fg_draw_chart);
-    MODULE_FUNCTION_INIT(fg_draw_image_to_cell);
-    MODULE_FUNCTION_INIT(fg_draw_image);
-    MODULE_FUNCTION_INIT(fg_swap_window_buffers);
-    MODULE_FUNCTION_INIT(fg_close_window);
-    MODULE_FUNCTION_INIT(fg_show_window);
-    MODULE_FUNCTION_INIT(fg_hide_window);
-    MODULE_FUNCTION_INIT(fg_release_window);
-
-    MODULE_FUNCTION_INIT(fg_create_font);
-    MODULE_FUNCTION_INIT(fg_load_system_font);
-    MODULE_FUNCTION_INIT(fg_release_font);
-
-    MODULE_FUNCTION_INIT(fg_create_image);
-    MODULE_FUNCTION_INIT(fg_get_pixel_buffer);
-    MODULE_FUNCTION_INIT(fg_get_image_size);
-    MODULE_FUNCTION_INIT(fg_release_image);
-
-    MODULE_FUNCTION_INIT(fg_create_plot);
-    MODULE_FUNCTION_INIT(fg_set_plot_color);
-    MODULE_FUNCTION_INIT(fg_get_plot_vertex_buffer);
-    MODULE_FUNCTION_INIT(fg_get_plot_vertex_buffer_size);
-    MODULE_FUNCTION_INIT(fg_release_plot);
-
-    MODULE_FUNCTION_INIT(fg_create_histogram);
-    MODULE_FUNCTION_INIT(fg_set_histogram_color);
-    MODULE_FUNCTION_INIT(fg_get_histogram_vertex_buffer);
-    MODULE_FUNCTION_INIT(fg_get_histogram_vertex_buffer_size);
-    MODULE_FUNCTION_INIT(fg_release_histogram);
-
-    MODULE_FUNCTION_INIT(fg_create_surface);
-    MODULE_FUNCTION_INIT(fg_set_surface_color);
-    MODULE_FUNCTION_INIT(fg_get_surface_vertex_buffer);
-    MODULE_FUNCTION_INIT(fg_get_surface_vertex_buffer_size);
-    MODULE_FUNCTION_INIT(fg_release_surface);
-
-    MODULE_FUNCTION_INIT(fg_create_vector_field);
-    MODULE_FUNCTION_INIT(fg_set_vector_field_color);
-    MODULE_FUNCTION_INIT(fg_get_vector_field_vertex_buffer_size);
-    MODULE_FUNCTION_INIT(fg_get_vector_field_direction_buffer_size);
-    MODULE_FUNCTION_INIT(fg_get_vector_field_vertex_buffer);
-    MODULE_FUNCTION_INIT(fg_get_vector_field_direction_buffer);
-    MODULE_FUNCTION_INIT(fg_release_vector_field);
-
-    MODULE_FUNCTION_INIT(fg_create_chart);
-    MODULE_FUNCTION_INIT(fg_get_chart_type);
-    MODULE_FUNCTION_INIT(fg_get_chart_axes_limits);
-    MODULE_FUNCTION_INIT(fg_set_chart_axes_limits);
-    MODULE_FUNCTION_INIT(fg_set_chart_axes_titles);
-    MODULE_FUNCTION_INIT(fg_append_image_to_chart);
-    MODULE_FUNCTION_INIT(fg_append_plot_to_chart);
-    MODULE_FUNCTION_INIT(fg_append_histogram_to_chart);
-    MODULE_FUNCTION_INIT(fg_append_surface_to_chart);
-    MODULE_FUNCTION_INIT(fg_append_vector_field_to_chart);
-    MODULE_FUNCTION_INIT(fg_release_chart);
 }
 
 template<typename T>
@@ -273,10 +280,17 @@ fg_window ForgeManager::getMainWindow()
     if (noGraphicsENV.empty()) { // If AF_DISABLE_GRAPHICS is not defined
         std::call_once(flag,
             [this] {
+                if (!this->mPlugin->isLoaded()) {
+                    string error_message = "Error loading Forge: "
+                        + this->mPlugin->getErrorMessage()
+                        + "\nForge or one of it's dependencies failed to "
+                        "load. Try installing Forge or check if Forge is in the "
+                        "search path.";
+                    AF_ERROR(error_message.c_str(), AF_ERR_LOAD_LIB);
+                }
                 fg_window w = nullptr;
-                fg_err e = mPlugin->fg_create_window(&w,
-                                                     WIDTH, HEIGHT,
-                                                     "ArrayFire", NULL, true);
+                fg_err e = this->mPlugin->fg_create_window(&w, WIDTH, HEIGHT,
+                                                           "ArrayFire", NULL, true);
                 if (e != FG_ERR_NONE) {
                     AF_ERROR("Graphics Window creation failed", AF_ERR_INTERNAL);
                 }

--- a/src/backend/common/graphics_common.cpp
+++ b/src/backend/common/graphics_common.cpp
@@ -166,7 +166,7 @@ size_t getTypeSize(GLenum type)
 
 void makeContextCurrent(fg_window window)
 {
-    FG_CHECK(fg_make_window_current(window));
+    FG_CHECK(graphics::forgePlugin().fg_make_window_current(window));
     CheckGL("End makeContextCurrent");
 }
 
@@ -320,7 +320,7 @@ void ForgeManager::setWindowChartGrid(const fg_window window,
             fg_chart chrt = (iter->second)[i];
             if (chrt) {
                 mChartAxesOverrideMap.erase(chrt);
-                FG_CHECK(fg_release_chart(chrt));
+                FG_CHECK(mPlugin->fg_release_chart(chrt));
             }
         }
         (iter->second).clear();
@@ -368,18 +368,18 @@ fg_chart ForgeManager::getChart(const fg_window window,
 
         if (chart == NULL) {
             // Chart has not been created
-            FG_CHECK(fg_create_chart(&chart, ctype));
+            FG_CHECK(mPlugin->fg_create_chart(&chart, ctype));
             (iter->second)[c * gRows + r] = chart;
             // Set Axes override to false
             mChartAxesOverrideMap[chart] = false;
         } else {
             fg_chart_type chart_type;
-            FG_CHECK(fg_get_chart_type(&chart_type, chart));
+            FG_CHECK(mPlugin->fg_get_chart_type(&chart_type, chart));
             if (chart_type != ctype) {
                 // Existing chart is of incompatible type
                 mChartAxesOverrideMap.erase(chart);
-                FG_CHECK(fg_release_chart(chart));
-                FG_CHECK(fg_create_chart(&chart, ctype));
+                FG_CHECK(mPlugin->fg_release_chart(chart));
+                FG_CHECK(mPlugin->fg_create_chart(&chart, ctype));
                 (iter->second)[c * gRows + r] = chart;
                 // Set Axes override to false
                 mChartAxesOverrideMap[chart] = false;
@@ -411,7 +411,7 @@ fg_image ForgeManager::getImage(int w, int h, fg_channel_format mode, fg_dtype t
 
     if (iter==mImgMap.end()) {
         fg_image img = nullptr;
-        FG_CHECK(fg_create_image(&img, w, h, mode, type));
+        FG_CHECK(mPlugin->fg_create_image(&img, w, h, mode, type));
         mImgMap[keypair] = img;
     }
 
@@ -437,16 +437,16 @@ fg_image ForgeManager::getImage(fg_chart chart, int w, int h,
 
     if (iter==mImgMap.end()) {
         fg_chart_type chart_type;
-        FG_CHECK(fg_get_chart_type(&chart_type, chart));
+        FG_CHECK(mPlugin->fg_get_chart_type(&chart_type, chart));
         if(chart_type != FG_CHART_2D)
             AF_ERROR("Image can only be added to chart of type FG_CHART_2D",
                      AF_ERR_TYPE);
 
         fg_image img = nullptr;
-        FG_CHECK(fg_create_image(&img, w, h, mode, type));
+        FG_CHECK(mPlugin->fg_create_image(&img, w, h, mode, type));
         mImgMap[keypair] = img;
 
-        FG_CHECK(fg_append_image_to_chart(chart, img));
+        FG_CHECK(mPlugin->fg_append_image_to_chart(chart, img));
     }
 
     return mImgMap[keypair];
@@ -464,13 +464,13 @@ fg_plot ForgeManager::getPlot(fg_chart chart, int nPoints, fg_dtype dtype,
 
     if (iter==mPltMap.end()) {
         fg_chart_type chart_type;
-        FG_CHECK(fg_get_chart_type(&chart_type, chart));
+        FG_CHECK(mPlugin->fg_get_chart_type(&chart_type, chart));
 
         fg_plot plt = nullptr;
-        FG_CHECK(fg_create_plot(&plt, nPoints, dtype, chart_type, ptype, mtype));
+        FG_CHECK(mPlugin->fg_create_plot(&plt, nPoints, dtype, chart_type, ptype, mtype));
         mPltMap[keypair] = plt;
 
-        FG_CHECK(fg_append_plot_to_chart(chart, plt));
+        FG_CHECK(mPlugin->fg_append_plot_to_chart(chart, plt));
     }
 
     return mPltMap[keypair];
@@ -486,16 +486,16 @@ fg_histogram ForgeManager::getHistogram(fg_chart chart, int nBins, fg_dtype type
 
     if (iter==mHstMap.end()) {
         fg_chart_type chart_type;
-        FG_CHECK(fg_get_chart_type(&chart_type, chart));
+        FG_CHECK(mPlugin->fg_get_chart_type(&chart_type, chart));
         if(chart_type != FG_CHART_2D)
             AF_ERROR("Histogram can only be added to chart of type FG_CHART_2D",
                      AF_ERR_TYPE);
 
         fg_histogram hst = nullptr;
-        FG_CHECK(fg_create_histogram(&hst, nBins, type));
+        FG_CHECK(mPlugin->fg_create_histogram(&hst, nBins, type));
         mHstMap[keypair] = hst;
 
-        FG_CHECK(fg_append_histogram_to_chart(chart, hst));
+        FG_CHECK(mPlugin->fg_append_histogram_to_chart(chart, hst));
     }
 
     return mHstMap[keypair];
@@ -517,17 +517,17 @@ fg_surface ForgeManager::getSurface(fg_chart chart, int nX, int nY, fg_dtype typ
 
     if (iter==mSfcMap.end()) {
         fg_chart_type chart_type;
-        FG_CHECK(fg_get_chart_type(&chart_type, chart));
+        FG_CHECK(mPlugin->fg_get_chart_type(&chart_type, chart));
         if(chart_type != FG_CHART_3D)
             AF_ERROR("Surface can only be added to chart of type FG_CHART_3D",
                      AF_ERR_TYPE);
 
         fg_surface surf = nullptr;
-        FG_CHECK(fg_create_surface(&surf, nX, nY, type,
+        FG_CHECK(mPlugin->fg_create_surface(&surf, nX, nY, type,
                                    FG_PLOT_SURFACE, FG_MARKER_NONE));
         mSfcMap[keypair] = surf;
 
-        FG_CHECK(fg_append_surface_to_chart(chart, surf));
+        FG_CHECK(mPlugin->fg_append_surface_to_chart(chart, surf));
     }
 
     return mSfcMap[keypair];
@@ -543,13 +543,13 @@ fg_vector_field ForgeManager::getVectorField(fg_chart chart, int nPoints, fg_dty
 
     if (iter==mVcfMap.end()) {
         fg_chart_type chart_type;
-        FG_CHECK(fg_get_chart_type(&chart_type, chart));
+        FG_CHECK(mPlugin->fg_get_chart_type(&chart_type, chart));
 
         fg_vector_field vfield = nullptr;
-        FG_CHECK(fg_create_vector_field(&vfield, nPoints, type, chart_type));
+        FG_CHECK(mPlugin->fg_create_vector_field(&vfield, nPoints, type, chart_type));
         mVcfMap[keypair] = vfield;
 
-        FG_CHECK(fg_append_vector_field_to_chart(chart, vfield));
+        FG_CHECK(mPlugin->fg_append_vector_field_to_chart(chart, vfield));
     }
 
     return mVcfMap[keypair];

--- a/src/backend/common/graphics_common.hpp
+++ b/src/backend/common/graphics_common.hpp
@@ -14,6 +14,7 @@
 
 #include <vector>
 #include <map>
+#include <memory>
 #include <utility>
 
 // default to f32(float) type
@@ -69,20 +70,27 @@ typedef std::map<fg_chart, bool> ChartAxesOverride_t;
 typedef ChartAxesOverride_t::iterator ChartAxesOverrideIter;
 
 /**
- * ForgeManager class follows a single pattern. Any user of this class, has
- * to call ForgeManager::getInstance inorder to use Forge resources for rendering.
- * It manages the windows, and other renderables (given below) that are drawed
- * onto chosen window.
+ * Only device manager class can create objects of this class.
+ * You have to call forgeManager() defined in platform.hpp to
+ * access the object. It manages the windows, and other
+ * renderables (given below) that are drawed onto chosen window.
  * Renderables:
- *             fg_image
- *             fg_plot
- *             fg_histogram
- *             fg_surface
- *             fg_vector_field
+ *      fg_image
+ *      fg_plot
+ *      fg_histogram
+ *      fg_surface
+ *      fg_vector_field
  * */
 class ForgeManager
 {
+    struct Window {
+        fg_window handle;
+    };
+
     private:
+        ForgeModule* mPlugin;
+        std::unique_ptr<Window> wnd;
+
         ImageMap_t          mImgMap;
         PlotMap_t           mPltMap;
         HistogramMap_t      mHstMap;
@@ -93,14 +101,10 @@ class ForgeManager
         WindGridMap_t       mWndGridMap;
         ChartAxesOverride_t mChartAxesOverrideMap;
 
-        ForgeModule* mPlugin;
-
     public:
-        static ForgeManager& getInstance();
+        ForgeManager();
         ~ForgeManager();
-
-        friend ForgeModule& forgePlugin();
-
+        ForgeModule& plugin();
         fg_window getMainWindow();
 
         void            setWindowChartGrid(const fg_window window,
@@ -130,10 +134,9 @@ class ForgeManager
         void setChartAxesOverride(fg_chart chart, bool flag = true);
 
     protected:
-        ForgeManager();
         ForgeManager(ForgeManager const&);
-        void operator=(ForgeManager const&);
+        ForgeManager& operator=(ForgeManager const&);
+        ForgeManager(ForgeManager &&);
+        ForgeManager& operator=(ForgeManager &&);
 };
 }
-
-#define MAIN_WINDOW graphics::ForgeManager::getInstance().getMainWindow()

--- a/src/backend/common/graphics_common.hpp
+++ b/src/backend/common/graphics_common.hpp
@@ -103,6 +103,10 @@ class ForgeManager
 
     public:
         ForgeManager();
+        ForgeManager(ForgeManager const&) = delete;
+        ForgeManager& operator=(ForgeManager const&) = delete;
+        ForgeManager(ForgeManager &&) = delete;
+        ForgeManager& operator=(ForgeManager &&) = delete;
         ~ForgeManager();
         ForgeModule& plugin();
         fg_window getMainWindow();
@@ -132,11 +136,5 @@ class ForgeManager
 
         bool getChartAxesOverride(fg_chart chart);
         void setChartAxesOverride(fg_chart chart, bool flag = true);
-
-    protected:
-        ForgeManager(ForgeManager const&);
-        ForgeManager& operator=(ForgeManager const&);
-        ForgeManager(ForgeManager &&);
-        ForgeManager& operator=(ForgeManager &&);
 };
 }

--- a/src/backend/cpu/hist_graphics.cpp
+++ b/src/backend/cpu/hist_graphics.cpp
@@ -23,8 +23,8 @@ void copy_histogram(const Array<T> &data, fg_histogram hist)
 
     CheckGL("Begin copy_histogram");
     unsigned bytes = 0, buffer = 0;
-    FG_CHECK(fg_get_histogram_vertex_buffer(&buffer, hist));
-    FG_CHECK(fg_get_histogram_vertex_buffer_size(&bytes, hist));
+    FG_CHECK(_.fg_get_histogram_vertex_buffer(&buffer, hist));
+    FG_CHECK(_.fg_get_histogram_vertex_buffer_size(&bytes, hist));
 
     glBindBuffer(GL_ARRAY_BUFFER, buffer);
     glBufferSubData(GL_ARRAY_BUFFER, 0, bytes, data.get());

--- a/src/backend/cpu/image.cpp
+++ b/src/backend/cpu/image.cpp
@@ -31,8 +31,8 @@ void copy_image(const Array<T> &in, fg_image image)
     CheckGL("Before CopyArrayToImage");
     const T *d_X = in.get();
     unsigned data_size = 0, buffer = 0;
-    FG_CHECK(fg_get_pixel_buffer(&buffer, image));
-    FG_CHECK(fg_get_image_size(&data_size, image));
+    FG_CHECK(_.fg_get_pixel_buffer(&buffer, image));
+    FG_CHECK(_.fg_get_image_size(&data_size, image));
 
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, buffer);
     glBufferSubData(GL_PIXEL_UNPACK_BUFFER, 0, data_size, d_X);

--- a/src/backend/cpu/platform.cpp
+++ b/src/backend/cpu/platform.cpp
@@ -9,8 +9,9 @@
 
 #include <af/version.h>
 #include <platform.hpp>
-#include <common/defines.hpp>
 #include <version.hpp>
+#include <common/defines.hpp>
+#include <common/graphics_common.hpp>
 #include <common/host_memory.hpp>
 
 #include <cctype>
@@ -269,6 +270,17 @@ MemoryManager& memoryManager()
 {
     DeviceManager& inst = DeviceManager::getInstance();
     return *(inst.memManager);
+}
+
+graphics::ForgeManager& forgeManager()
+{
+    static std::once_flag flag;
+
+    DeviceManager& inst = DeviceManager::getInstance();
+
+    std::call_once(flag, [&]() { inst.fgMngr.reset(new graphics::ForgeManager()); });
+
+    return *(inst.fgMngr);
 }
 
 DeviceManager& DeviceManager::getInstance()

--- a/src/backend/cpu/platform.cpp
+++ b/src/backend/cpu/platform.cpp
@@ -263,7 +263,8 @@ bool& evalFlag()
 
 DeviceManager::DeviceManager()
     : queues(MAX_QUEUES)
-    , memManager(new MemoryManager()) {}
+    , memManager(new MemoryManager()),
+      fgMngr(new graphics::ForgeManager()){}
 
 
 MemoryManager& memoryManager()
@@ -274,13 +275,7 @@ MemoryManager& memoryManager()
 
 graphics::ForgeManager& forgeManager()
 {
-    static std::once_flag flag;
-
-    DeviceManager& inst = DeviceManager::getInstance();
-
-    std::call_once(flag, [&]() { inst.fgMngr.reset(new graphics::ForgeManager()); });
-
-    return *(inst.fgMngr);
+    return *(DeviceManager::getInstance().fgMngr);
 }
 
 DeviceManager& DeviceManager::getInstance()

--- a/src/backend/cpu/platform.hpp
+++ b/src/backend/cpu/platform.hpp
@@ -78,6 +78,10 @@ class CPUInfo {
         bool   mIsHTT;
 };
 
+namespace graphics {
+  class ForgeManager;
+}
+
 namespace cpu
 {
 int getBackend();
@@ -108,6 +112,8 @@ bool& evalFlag();
 
 MemoryManager& memoryManager();
 
+graphics::ForgeManager& forgeManager();
+
 class DeviceManager
 {
     public:
@@ -122,6 +128,8 @@ class DeviceManager
 
         friend MemoryManager& memoryManager();
 
+        friend graphics::ForgeManager& forgeManager();
+
         CPUInfo getCPUInfo() const;
 
     private:
@@ -134,8 +142,10 @@ class DeviceManager
         void operator=(DeviceManager const&) = delete;
 
         // Attributes
+        std::unique_ptr<graphics::ForgeManager> fgMngr;
+        std::unique_ptr<MemoryManager> memManager;
         std::vector<queue> queues;
         const CPUInfo cinfo;
-        std::unique_ptr<MemoryManager> memManager;
+
 };
 }

--- a/src/backend/cpu/plot.cpp
+++ b/src/backend/cpu/plot.cpp
@@ -27,8 +27,8 @@ void copy_plot(const Array<T> &P, fg_plot plot)
 
     CheckGL("Before CopyArrayToVBO");
     unsigned bytes = 0, buffer = 0;
-    FG_CHECK(fg_get_plot_vertex_buffer(&buffer, plot));
-    FG_CHECK(fg_get_plot_vertex_buffer_size(&bytes, plot));
+    FG_CHECK(_.fg_get_plot_vertex_buffer(&buffer, plot));
+    FG_CHECK(_.fg_get_plot_vertex_buffer_size(&bytes, plot));
 
     glBindBuffer(GL_ARRAY_BUFFER, buffer);
     glBufferSubData(GL_ARRAY_BUFFER, 0, bytes, P.get());

--- a/src/backend/cpu/surface.cpp
+++ b/src/backend/cpu/surface.cpp
@@ -27,8 +27,8 @@ void copy_surface(const Array<T> &P, fg_surface surface)
 
     CheckGL("Before CopyArrayToVBO");
     unsigned bytes = 0, buffer = 0;
-    FG_CHECK(fg_get_surface_vertex_buffer(&buffer, surface));
-    FG_CHECK(fg_get_surface_vertex_buffer_size(&bytes, surface));
+    FG_CHECK(_.fg_get_surface_vertex_buffer(&buffer, surface));
+    FG_CHECK(_.fg_get_surface_vertex_buffer_size(&bytes, surface));
 
     glBindBuffer(GL_ARRAY_BUFFER, buffer);
     glBufferSubData(GL_ARRAY_BUFFER, 0, bytes, P.get());

--- a/src/backend/cpu/vector_field.cpp
+++ b/src/backend/cpu/vector_field.cpp
@@ -31,10 +31,10 @@ void copy_vector_field(const Array<T> &points, const Array<T> &directions,
 
     unsigned size1 = 0, size2 = 0;
     unsigned buff1 = 0, buff2 = 0;
-    FG_CHECK(fg_get_vector_field_vertex_buffer_size(&size1, vfield));
-    FG_CHECK(fg_get_vector_field_direction_buffer_size(&size2, vfield));
-    FG_CHECK(fg_get_vector_field_vertex_buffer(&buff1, vfield));
-    FG_CHECK(fg_get_vector_field_direction_buffer(&buff2, vfield));
+    FG_CHECK(_.fg_get_vector_field_vertex_buffer_size(&size1, vfield));
+    FG_CHECK(_.fg_get_vector_field_direction_buffer_size(&size2, vfield));
+    FG_CHECK(_.fg_get_vector_field_vertex_buffer(&buff1, vfield));
+    FG_CHECK(_.fg_get_vector_field_direction_buffer(&buff2, vfield));
 
     glBindBuffer(GL_ARRAY_BUFFER, buff1);
     glBufferSubData(GL_ARRAY_BUFFER, 0, size1, points.get());

--- a/src/backend/cuda/hist_graphics.cpp
+++ b/src/backend/cuda/hist_graphics.cpp
@@ -18,7 +18,6 @@ namespace cuda {
 template<typename T>
 void copy_histogram(const Array<T> &data, fg_histogram hist)
 {
-    ForgeModule& _ = graphics::forgePlugin();
     auto stream = cuda::getActiveStream();
     if(DeviceManager::checkGraphicsInteropCapability()) {
         const T *d_P = data.get();
@@ -37,9 +36,10 @@ void copy_histogram(const Array<T> &data, fg_histogram hist)
 
         POST_LAUNCH_CHECK();
     } else {
+        ForgeModule& _ = graphics::forgePlugin();
         unsigned bytes = 0, buffer = 0;
-        FG_CHECK(fg_get_histogram_vertex_buffer(&buffer, hist));
-        FG_CHECK(fg_get_histogram_vertex_buffer_size(&bytes, hist));
+        FG_CHECK(_.fg_get_histogram_vertex_buffer(&buffer, hist));
+        FG_CHECK(_.fg_get_histogram_vertex_buffer_size(&bytes, hist));
 
         CheckGL("Begin CUDA fallback-resource copy");
         glBindBuffer(GL_ARRAY_BUFFER, buffer);

--- a/src/backend/cuda/image.cpp
+++ b/src/backend/cuda/image.cpp
@@ -23,7 +23,6 @@ namespace cuda {
 template<typename T>
 void copy_image(const Array<T> &in, fg_image image)
 {
-    ForgeModule& _ = graphics::forgePlugin();
     auto stream = cuda::getActiveStream();
     if(DeviceManager::checkGraphicsInteropCapability()) {
         auto res = interopManager().getImageResources(image);
@@ -40,10 +39,11 @@ void copy_image(const Array<T> &in, fg_image image)
         POST_LAUNCH_CHECK();
         CheckGL("After cuda resource copy");
     } else {
+        ForgeModule& _ = graphics::forgePlugin();
         CheckGL("Begin CUDA fallback-resource copy");
         unsigned data_size = 0, buffer = 0;
-        FG_CHECK(fg_get_image_size(&data_size, image));
-        FG_CHECK(fg_get_pixel_buffer(&buffer, image));
+        FG_CHECK(_.fg_get_image_size(&data_size, image));
+        FG_CHECK(_.fg_get_pixel_buffer(&buffer, image));
 
         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, buffer);
         glBufferData(GL_PIXEL_UNPACK_BUFFER, data_size, 0, GL_STREAM_DRAW);

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -430,6 +430,17 @@ MemoryManagerPinned& pinnedMemoryManager()
     return *(inst.pinnedMemManager.get());
 }
 
+graphics::ForgeManager& forgeManager()
+{
+    static std::once_flag flag;
+
+    DeviceManager& inst = DeviceManager::getInstance();
+
+    std::call_once(flag, [&]() { inst.fgMngr.reset(new graphics::ForgeManager()); });
+
+    return *(inst.fgMngr);
+}
+
 GraphicsResourceManager& interopManager()
 {
     static std::once_flag initFlags[DeviceManager::MAX_DEVICES];

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -432,13 +432,7 @@ MemoryManagerPinned& pinnedMemoryManager()
 
 graphics::ForgeManager& forgeManager()
 {
-    static std::once_flag flag;
-
-    DeviceManager& inst = DeviceManager::getInstance();
-
-    std::call_once(flag, [&]() { inst.fgMngr.reset(new graphics::ForgeManager()); });
-
-    return *(inst.fgMngr);
+    return *(DeviceManager::getInstance().fgMngr);
 }
 
 GraphicsResourceManager& interopManager()
@@ -517,7 +511,7 @@ SparseHandle sparseHandle()
 }
 
 DeviceManager::DeviceManager()
-    : cuDevices(0), nDevices(0)
+    : cuDevices(0), nDevices(0), fgMngr(new graphics::ForgeManager())
 {
     CUDA_CHECK(cudaGetDeviceCount(&nDevices));
     if (nDevices == 0)

--- a/src/backend/cuda/platform.hpp
+++ b/src/backend/cuda/platform.hpp
@@ -26,6 +26,11 @@
 namespace spdlog {
   class logger;
 }
+
+namespace graphics {
+  class ForgeManager;
+}
+
 namespace cuda
 {
 int getBackend();
@@ -84,6 +89,8 @@ MemoryManager& memoryManager();
 
 MemoryManagerPinned& pinnedMemoryManager();
 
+graphics::ForgeManager& forgeManager();
+
 GraphicsResourceManager& interopManager();
 
 PlanCache& fftManager();
@@ -108,6 +115,8 @@ class DeviceManager
         friend MemoryManager& memoryManager();
 
         friend MemoryManagerPinned& pinnedMemoryManager();
+
+        friend graphics::ForgeManager& forgeManager();
 
         friend GraphicsResourceManager& interopManager();
 
@@ -154,6 +163,8 @@ class DeviceManager
 
         int nDevices;
         cudaStream_t streams[MAX_DEVICES];
+
+        std::unique_ptr<graphics::ForgeManager> fgMngr;
 
         std::unique_ptr<MemoryManager> memManager;
 

--- a/src/backend/cuda/plot.cpp
+++ b/src/backend/cuda/plot.cpp
@@ -20,7 +20,6 @@ namespace cuda {
 template<typename T>
 void copy_plot(const Array<T> &P, fg_plot plot)
 {
-    ForgeModule& _ = graphics::forgePlugin();
     auto stream = cuda::getActiveStream();
     if(DeviceManager::checkGraphicsInteropCapability()) {
         const T *d_P = P.get();
@@ -39,9 +38,10 @@ void copy_plot(const Array<T> &P, fg_plot plot)
 
         POST_LAUNCH_CHECK();
     } else {
+        ForgeModule& _ = graphics::forgePlugin();
         unsigned bytes = 0, buffer = 0;
-        FG_CHECK(fg_get_plot_vertex_buffer(&buffer, plot));
-        FG_CHECK(fg_get_plot_vertex_buffer_size(&bytes, plot));
+        FG_CHECK(_.fg_get_plot_vertex_buffer(&buffer, plot));
+        FG_CHECK(_.fg_get_plot_vertex_buffer_size(&bytes, plot));
 
         CheckGL("Begin CUDA fallback-resource copy");
         glBindBuffer(GL_ARRAY_BUFFER, buffer);

--- a/src/backend/cuda/surface.cpp
+++ b/src/backend/cuda/surface.cpp
@@ -20,7 +20,6 @@ namespace cuda {
 template<typename T>
 void copy_surface(const Array<T> &P, fg_surface surface)
 {
-    ForgeModule& _ = graphics::forgePlugin();
     auto stream = cuda::getActiveStream();
     if(DeviceManager::checkGraphicsInteropCapability()) {
         const T *d_P = P.get();
@@ -39,9 +38,10 @@ void copy_surface(const Array<T> &P, fg_surface surface)
 
         POST_LAUNCH_CHECK();
     } else {
+        ForgeModule& _ = graphics::forgePlugin();
         unsigned bytes = 0, buffer = 0;
-        FG_CHECK(fg_get_surface_vertex_buffer(&buffer, surface));
-        FG_CHECK(fg_get_surface_vertex_buffer_size(&bytes, surface));
+        FG_CHECK(_.fg_get_surface_vertex_buffer(&buffer, surface));
+        FG_CHECK(_.fg_get_surface_vertex_buffer_size(&bytes, surface));
 
         CheckGL("Begin CUDA fallback-resource copy");
         glBindBuffer(GL_ARRAY_BUFFER, buffer);

--- a/src/backend/cuda/vector_field.cpp
+++ b/src/backend/cuda/vector_field.cpp
@@ -21,7 +21,6 @@ template<typename T>
 void copy_vector_field(const Array<T> &points, const Array<T> &directions,
                        fg_vector_field vfield)
 {
-    ForgeModule& _ = graphics::forgePlugin();
     auto stream = cuda::getActiveStream();
     if(DeviceManager::checkGraphicsInteropCapability()) {
         auto res = interopManager().getVectorFieldResources(vfield);
@@ -53,13 +52,14 @@ void copy_vector_field(const Array<T> &points, const Array<T> &directions,
 
         POST_LAUNCH_CHECK();
     } else {
+        ForgeModule& _ = graphics::forgePlugin();
         CheckGL("Begin CUDA fallback-resource copy");
         unsigned size1 = 0, size2 = 0;
         unsigned buff1 = 0, buff2 = 0;
-        FG_CHECK(fg_get_vector_field_vertex_buffer_size(&size1, vfield));
-        FG_CHECK(fg_get_vector_field_direction_buffer_size(&size2, vfield));
-        FG_CHECK(fg_get_vector_field_vertex_buffer(&buff1, vfield));
-        FG_CHECK(fg_get_vector_field_direction_buffer(&buff2, vfield));
+        FG_CHECK(_.fg_get_vector_field_vertex_buffer_size(&size1, vfield));
+        FG_CHECK(_.fg_get_vector_field_direction_buffer_size(&size2, vfield));
+        FG_CHECK(_.fg_get_vector_field_vertex_buffer(&buff1, vfield));
+        FG_CHECK(_.fg_get_vector_field_direction_buffer(&buff2, vfield));
 
         // Points
         glBindBuffer(GL_ARRAY_BUFFER, buff1);

--- a/src/backend/opencl/hist_graphics.cpp
+++ b/src/backend/opencl/hist_graphics.cpp
@@ -23,7 +23,7 @@ void copy_histogram(const Array<T> &data, fg_histogram hist)
         CheckGL("Begin OpenCL resource copy");
         const cl::Buffer *d_P = data.get();
         unsigned bytes = 0;
-        FG_CHECK(fg_get_histogram_vertex_buffer_size(&bytes, hist));
+        FG_CHECK(_.fg_get_histogram_vertex_buffer_size(&bytes, hist));
 
         auto res = interopManager().getHistogramResources(hist);
 
@@ -46,8 +46,8 @@ void copy_histogram(const Array<T> &data, fg_histogram hist)
         CheckGL("End OpenCL resource copy");
     } else {
         unsigned bytes = 0, buffer = 0;
-        FG_CHECK(fg_get_histogram_vertex_buffer(&buffer, hist));
-        FG_CHECK(fg_get_histogram_vertex_buffer_size(&bytes, hist));
+        FG_CHECK(_.fg_get_histogram_vertex_buffer(&buffer, hist));
+        FG_CHECK(_.fg_get_histogram_vertex_buffer_size(&bytes, hist));
 
         CheckGL("Begin OpenCL fallback-resource copy");
         glBindBuffer(GL_ARRAY_BUFFER, buffer);

--- a/src/backend/opencl/image.cpp
+++ b/src/backend/opencl/image.cpp
@@ -30,7 +30,7 @@ void copy_image(const Array<T> &in, fg_image image)
         const cl::Buffer *d_X = in.get();
 
         unsigned bytes = 0;
-        FG_CHECK(fg_get_image_size(&bytes, image));
+        FG_CHECK(_.fg_get_image_size(&bytes, image));
 
         std::vector<cl::Memory> shared_objects;
         shared_objects.push_back(*(res[0].get()));
@@ -52,8 +52,8 @@ void copy_image(const Array<T> &in, fg_image image)
     } else {
         CheckGL("Begin OpenCL fallback-resource copy");
         unsigned bytes = 0, buffer = 0;
-        FG_CHECK(fg_get_image_size(&bytes, image));
-        FG_CHECK(fg_get_pixel_buffer(&buffer, image));
+        FG_CHECK(_.fg_get_image_size(&bytes, image));
+        FG_CHECK(_.fg_get_pixel_buffer(&buffer, image));
 
         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, buffer);
         glBufferData(GL_PIXEL_UNPACK_BUFFER, bytes, 0, GL_STREAM_DRAW);

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -818,6 +818,7 @@ DeviceManager::~DeviceManager()
 
 DeviceManager::DeviceManager()
     : mUserDeviceOffset(0),
+      fgMngr(new graphics::ForgeManager()),
       mFFTSetup(new clfftSetupData)
 {
     std::vector<cl::Platform>   platforms;
@@ -919,22 +920,9 @@ DeviceManager::DeviceManager()
         }
     }
 
-    try {
-        // If forgeManager instantiation fails,
-        // ignore and proceed
-        fgMngr.reset(new graphics::ForgeManager());
-    } catch (AfError &error) {
-        if (error.getError() == AF_ERR_LOAD_LIB) {
-            //Ignore , gfx libs are not present, hence,
-            //that functionality will be disabled.
-        } else {
-            throw;
-        }
-    }
-
     // Define AF_DISABLE_GRAPHICS with any value to disable initialization
     std::string noGraphicsENV = getEnvVar("AF_DISABLE_GRAPHICS");
-    if (fgMngr &&  noGraphicsENV.empty()) {
+    if (fgMngr->plugin().isLoaded() && noGraphicsENV.empty()) {
         // If forge library was successfully loaded and
         // AF_DISABLE_GRAPHICS is not defined
         try {

--- a/src/backend/opencl/platform.hpp
+++ b/src/backend/opencl/platform.hpp
@@ -36,6 +36,10 @@ namespace boost {
   }
 }
 
+namespace graphics {
+  class ForgeManager;
+}
+
 // Forward declaration from clFFT.h
 struct clfftSetupData_;
 typedef clfftSetupData_ clfftSetupData;
@@ -102,6 +106,8 @@ MemoryManager& memoryManager();
 
 MemoryManagerPinned& pinnedMemoryManager();
 
+graphics::ForgeManager& forgeManager();
+
 GraphicsResourceManager& interopManager();
 
 PlanCache& fftManager();
@@ -119,6 +125,8 @@ class DeviceManager
     friend MemoryManager& memoryManager();
 
     friend MemoryManagerPinned& pinnedMemoryManager();
+
+    friend graphics::ForgeManager& forgeManager();
 
     friend GraphicsResourceManager& interopManager();
 
@@ -191,6 +199,7 @@ class DeviceManager
         std::vector<int>         mPlatforms;
         unsigned mUserDeviceOffset;
 
+        std::unique_ptr<graphics::ForgeManager> fgMngr;
         std::unique_ptr<MemoryManager> memManager;
         std::unique_ptr<MemoryManagerPinned> pinnedMemManager;
         std::unique_ptr<GraphicsResourceManager> gfxManagers[MAX_DEVICES];

--- a/src/backend/opencl/plot.cpp
+++ b/src/backend/opencl/plot.cpp
@@ -25,7 +25,7 @@ void copy_plot(const Array<T> &P, fg_plot plot)
         CheckGL("Begin OpenCL resource copy");
         const cl::Buffer *d_P = P.get();
         unsigned bytes = 0;
-        FG_CHECK(fg_get_plot_vertex_buffer_size(&bytes, plot));
+        FG_CHECK(_.fg_get_plot_vertex_buffer_size(&bytes, plot));
 
         auto res = interopManager().getPlotResources(plot);
 
@@ -48,8 +48,8 @@ void copy_plot(const Array<T> &P, fg_plot plot)
         CheckGL("End OpenCL resource copy");
     } else {
         unsigned bytes = 0, buffer = 0;
-        FG_CHECK(fg_get_plot_vertex_buffer(&buffer, plot));
-        FG_CHECK(fg_get_plot_vertex_buffer_size(&bytes, plot));
+        FG_CHECK(_.fg_get_plot_vertex_buffer(&buffer, plot));
+        FG_CHECK(_.fg_get_plot_vertex_buffer_size(&bytes, plot));
 
         CheckGL("Begin OpenCL fallback-resource copy");
         glBindBuffer(GL_ARRAY_BUFFER, buffer);

--- a/src/backend/opencl/surface.cpp
+++ b/src/backend/opencl/surface.cpp
@@ -28,7 +28,7 @@ void copy_surface(const Array<T> &P, fg_surface surface)
         CheckGL("Begin OpenCL resource copy");
         const cl::Buffer *d_P = P.get();
         unsigned bytes = 0;
-        FG_CHECK(fg_get_surface_vertex_buffer_size(&bytes, surface));
+        FG_CHECK(_.fg_get_surface_vertex_buffer_size(&bytes, surface));
 
         auto res = interopManager().getSurfaceResources(surface);
 
@@ -51,8 +51,8 @@ void copy_surface(const Array<T> &P, fg_surface surface)
         CheckGL("End OpenCL resource copy");
     } else {
         unsigned bytes = 0, buffer = 0;
-        FG_CHECK(fg_get_surface_vertex_buffer(&buffer, surface));
-        FG_CHECK(fg_get_surface_vertex_buffer_size(&bytes, surface));
+        FG_CHECK(_.fg_get_surface_vertex_buffer(&buffer, surface));
+        FG_CHECK(_.fg_get_surface_vertex_buffer_size(&bytes, surface));
 
         CheckGL("Begin OpenCL fallback-resource copy");
         glBindBuffer(GL_ARRAY_BUFFER, buffer);

--- a/src/backend/opencl/vector_field.cpp
+++ b/src/backend/opencl/vector_field.cpp
@@ -28,8 +28,8 @@ void copy_vector_field(const Array<T> &points, const Array<T> &directions,
         const cl::Buffer *d_directions  = directions.get();
         unsigned pBytes = 0;
         unsigned dBytes = 0;
-        FG_CHECK(fg_get_vector_field_vertex_buffer_size(&pBytes, vfield));
-        FG_CHECK(fg_get_vector_field_direction_buffer_size(&dBytes, vfield));
+        FG_CHECK(_.fg_get_vector_field_vertex_buffer_size(&pBytes, vfield));
+        FG_CHECK(_.fg_get_vector_field_direction_buffer_size(&dBytes, vfield));
 
         auto res = interopManager().getVectorFieldResources(vfield);
 
@@ -55,10 +55,10 @@ void copy_vector_field(const Array<T> &points, const Array<T> &directions,
     } else {
         unsigned size1 = 0, size2 = 0;
         unsigned buff1 = 0, buff2 = 0;
-        FG_CHECK(fg_get_vector_field_vertex_buffer_size(&size1, vfield));
-        FG_CHECK(fg_get_vector_field_direction_buffer_size(&size2, vfield));
-        FG_CHECK(fg_get_vector_field_vertex_buffer(&buff1, vfield));
-        FG_CHECK(fg_get_vector_field_direction_buffer(&buff2, vfield));
+        FG_CHECK(_.fg_get_vector_field_vertex_buffer_size(&size1, vfield));
+        FG_CHECK(_.fg_get_vector_field_direction_buffer_size(&size2, vfield));
+        FG_CHECK(_.fg_get_vector_field_vertex_buffer(&buff1, vfield));
+        FG_CHECK(_.fg_get_vector_field_direction_buffer(&buff2, vfield));
 
         CheckGL("Begin OpenCL fallback-resource copy");
 


### PR DESCRIPTION
This helps making forge manager resources to be released after
interop manager and other memory managers are cleared out.