### PR TITLE
Fix OpenGL errors when building on osx.

### DIFF
--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -435,6 +435,11 @@ if(AF_WITH_NONFREE)
   target_compile_definitions(afopencl PRIVATE AF_WITH_NONFREE_SIFT)
 endif()
 
+if(APPLE)
+  target_link_libraries(afopencl
+    PRIVATE OpenGL::GL)
+endif()
+
 if(LAPACK_FOUND OR MKL_FOUND)
   target_sources(afopencl
     PRIVATE

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -23,6 +23,10 @@
 #include <platform.hpp>
 #include <version.hpp>
 
+#ifdef OS_MAC
+#include <OpenGL/CGLCurrent.h>
+#endif
+
 #include <boost/compute/context.hpp>
 #include <boost/compute/utility/program_cache.hpp>
 

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -1048,7 +1048,7 @@ mtxReadSparseMatrix(af::array &out, const char* fileName)
         std::vector<int> J(nz);
         std::vector<float> V(nz);
 
-        for (unsigned i=0; i<nz; ++i) {
+        for (int i=0; i < nz; ++i) {
             int c, r;
             double v;
             int readCount = fscanf(fileHandle, "%d %d %lg\n", &r, &c, &v);
@@ -1071,7 +1071,7 @@ mtxReadSparseMatrix(af::array &out, const char* fileName)
         std::vector<int> J(nz);
         std::vector<af::cfloat> V(nz);
 
-        for (unsigned i=0; i<nz; ++i) {
+        for (int i=0; i < nz; ++i) {
             int c, r;
             double real, imag;
             int readCount = fscanf(fileHandle, "%d %d %lg %lg\n", &r, &c, &real, &imag);
@@ -1332,6 +1332,7 @@ testWriteToOutputArray(std::string gold_name, std::string result_name,
                                          std::string metadataName,
                                          const af_array a, const af_array b,
                                          TestOutputArrayInfo *metadata) {
+    UNUSED(metadataName);
     return testWriteToOutputArray(aName, bName, a, b, metadata);
 }
 


### PR DESCRIPTION
Added library and headers to compile on OSX. The OpenGL library was not being linked correctly.