### PR TITLE
Moved testHelpers << operator overload to global namespace

### DIFF
--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -47,6 +47,30 @@ typedef uintl uintl;
 using aft::uintl;
 using aft::intl;
 
+std::ostream &operator<<(std::ostream &os, af_err e) {
+    return os << af_err_to_string(e);
+}
+
+std::ostream &operator<<(std::ostream &os, af::dtype type) {
+    std::string name;
+    switch (type) {
+    case f32: name = "f32"; break;
+    case c32: name = "c32"; break;
+    case f64: name = "f64"; break;
+    case c64: name = "c64"; break;
+    case b8 : name = "b8" ; break;
+    case s32: name = "s32"; break;
+    case u32: name = "u32"; break;
+    case u8 : name = "u8" ; break;
+    case s64: name = "s64"; break;
+    case u64: name = "u64"; break;
+    case s16: name = "s16"; break;
+    case u16: name = "u16"; break;
+    default: assert(false && "Invalid type");
+    }
+    return os << name;
+}
+
 namespace {
 
 typedef unsigned char  uchar;
@@ -507,30 +531,6 @@ void cleanSlate()
 }
 
 //********** arrayfire custom test asserts ***********
-
-std::ostream& operator<<(std::ostream& os, af_err e) {
-    return os << af_err_to_string(e);
-}
-
-std::ostream& operator<<(std::ostream& os, af::dtype type) {
-    std::string name;
-    switch (type) {
-    case f32: name = "f32"; break;
-    case c32: name = "c32"; break;
-    case f64: name = "f64"; break;
-    case c64: name = "c64"; break;
-    case b8:  name = "b8";  break;
-    case s32: name = "s32"; break;
-    case u32: name = "u32"; break;
-    case u8:  name = "u8";  break;
-    case s64: name = "s64"; break;
-    case u64: name = "u64"; break;
-    case s16: name = "s16"; break;
-    case u16: name = "u16"; break;
-    default: assert(false && "Invalid type");
-    }
-    return os << name;
-}
 
 // Overloading unary + op is needed to make unsigned char values printable
 //  as numbers
@@ -1100,7 +1100,7 @@ mtxReadSparseMatrix(af::array &out, const char* fileName)
 }
 #endif //USE_MTX
 
-}
+} // namespace
 
 enum TestOutputArrayType {
     // Test af_* function when given a null array as its output


### PR DESCRIPTION
In some cases, the `<<` operator overload in tests are not called by the gtest assert/expect functions, so printing out an `af::dtype` only shows the enum numbers (not human-friendly). I'd assume that this also happens in some cases for `af_err`. Anyway, I dug through gtest and found out that the overload must be in global namespace for the overload to be called correctly (see [this line](https://github.com/google/googletest/blob/278aba369c41e90e9e77a6f51443beb3692919cf/googletest/include/gtest/gtest-message.h#L130), as well as the comment above it). Thus I moved the two `<<` overloads (both `af::dtype` and `af_err`) out of `testHelper.hpp`'s anonymous namespace into global.