### PR TITLE
Change the af_device_array pointer to a non-const pointer

### DIFF
--- a/include/af/device.h
+++ b/include/af/device.h
@@ -335,7 +335,7 @@ extern "C" {
        Create array from device memory
        \ingroup construct_mat
     */
-    AFAPI af_err af_device_array(af_array *arr, const void *data, const unsigned ndims, const dim_t * const dims, const af_dtype type);
+    AFAPI af_err af_device_array(af_array *arr, void *data, const unsigned ndims, const dim_t * const dims, const af_dtype type);
 
     /**
        Get memory information from the memory manager

--- a/src/api/c/memory.cpp
+++ b/src/api/c/memory.cpp
@@ -21,7 +21,7 @@
 
 using namespace detail;
 
-af_err af_device_array(af_array *arr, const void *data, const unsigned ndims,
+af_err af_device_array(af_array *arr, void *data, const unsigned ndims,
                        const dim_t *const dims, const af_dtype type) {
     try {
         AF_CHECK(af_init());

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -129,7 +129,7 @@ static void initDataArray(af_array *arr, const T *ptr, af::source src, dim_t d0,
                                      my_dims, ty));
             break;
         case afDevice:
-            AF_THROW(af_device_array(arr, (const void *)ptr, AF_MAX_DIMS,
+            AF_THROW(af_device_array(arr, (void *)ptr, AF_MAX_DIMS,
                                      my_dims, ty));
             break;
         default:

--- a/src/api/unified/device.cpp
+++ b/src/api/unified/device.cpp
@@ -89,7 +89,7 @@ af_err af_free_host(void *ptr) {
     return AF_SUCCESS;
 }
 
-af_err af_device_array(af_array *arr, const void *data, const unsigned ndims,
+af_err af_device_array(af_array *arr, void *data, const unsigned ndims,
                        const dim_t *const dims, const af_dtype type) {
     return CALL(arr, data, ndims, dims, type);
 }


### PR DESCRIPTION
The af_device_array pointer is currently const. This is not appropriate
because the pointer may be changed in other operations. This commit
removes the const decorator from the pointer