### PR TITLE
Apply suggestions from clang-tidy tool on array.cpp

### DIFF
--- a/src/api/cpp/error.hpp
+++ b/src/api/cpp/error.hpp
@@ -20,7 +20,7 @@
         af::exception ex(msg, __PRETTY_FUNCTION__, __AF_FILENAME__, __LINE__, \
                          __err);                                              \
         af_free_host(msg);                                                    \
-        throw ex;                                                             \
+        throw ex; /* NOLINT(misc-throw-by-value-catch-by-reference)*/         \
     } while (0)
 
 #define AF_THROW_ERR(__msg, __err)                                       \


### PR DESCRIPTION
Clang-tidy is a tool for static analysis and other quality checks on software.
These changes are some of the suggestions from clang-tidy on the array.cpp file.
This commit does not add the clang-tidy config file because that is still a
work in progress.