### PR TITLE
Correct constness on createDeviceArray and Array<T> constructor

### DIFF
--- a/src/api/c/sparse.cpp
+++ b/src/api/c/sparse.cpp
@@ -140,8 +140,9 @@ af_array createSparseArrayFromPtr(const af::dim4 &dims, const dim_t nNZ,
             sparse = common::createHostDataSparseArray(dims, nNZ, values,
                                                        rowIdx, colIdx, stype);
         else if (source == afDevice)
-            sparse = common::createDeviceDataSparseArray(dims, nNZ, values,
-                                                         rowIdx, colIdx, stype);
+            sparse = common::createDeviceDataSparseArray(
+                dims, nNZ, const_cast<T *>(values), const_cast<int *>(rowIdx),
+                const_cast<int *>(colIdx), stype);
     }
 
     return getHandle(sparse);

--- a/src/backend/common/SparseArray.cpp
+++ b/src/backend/common/SparseArray.cpp
@@ -48,11 +48,10 @@ SparseArrayBase::SparseArrayBase(af::dim4 _dims, dim_t _nNZ,
 #endif
 }
 
-SparseArrayBase::SparseArrayBase(af::dim4 _dims, dim_t _nNZ,
-                                 const int *const _rowIdx,
-                                 const int *const _colIdx,
-                                 const af::storage _storage, af_dtype _type,
-                                 bool _is_device, bool _copy_device)
+SparseArrayBase::SparseArrayBase(af::dim4 _dims, dim_t _nNZ, int *const _rowIdx,
+                                 int *const _colIdx, const af::storage _storage,
+                                 af_dtype _type, bool _is_device,
+                                 bool _copy_device)
     : info(getActiveDeviceId(), _dims, 0, calcStrides(_dims), _type, true)
     , stype(_storage)
     , rowIdx(_is_device
@@ -127,15 +126,18 @@ SparseArray<T> createHostDataSparseArray(const af::dim4 &_dims, const dim_t nNZ,
                                          const int *const _rowIdx,
                                          const int *const _colIdx,
                                          const af::storage _storage) {
-    return SparseArray<T>(_dims, nNZ, _values, _rowIdx, _colIdx, _storage,
-                          false);
+    return SparseArray<T>(_dims, nNZ, const_cast<T *>(_values),
+                          const_cast<int *>(_rowIdx),
+                          const_cast<int *>(_colIdx), _storage, false);
 }
 
 template<typename T>
-SparseArray<T> createDeviceDataSparseArray(
-    const af::dim4 &_dims, const dim_t nNZ, const T *const _values,
-    const int *const _rowIdx, const int *const _colIdx,
-    const af::storage _storage, const bool _copy) {
+SparseArray<T> createDeviceDataSparseArray(const af::dim4 &_dims,
+                                           const dim_t nNZ, T *const _values,
+                                           int *const _rowIdx,
+                                           int *const _colIdx,
+                                           const af::storage _storage,
+                                           const bool _copy) {
     return SparseArray<T>(_dims, nNZ, _values, _rowIdx, _colIdx, _storage, true,
                           _copy);
 }
@@ -179,8 +181,8 @@ SparseArray<T>::SparseArray(dim4 _dims, dim_t _nNZ, af::storage _storage)
 }
 
 template<typename T>
-SparseArray<T>::SparseArray(af::dim4 _dims, dim_t _nNZ, const T *const _values,
-                            const int *const _rowIdx, const int *const _colIdx,
+SparseArray<T>::SparseArray(af::dim4 _dims, dim_t _nNZ, T *const _values,
+                            int *const _rowIdx, int *const _colIdx,
                             const af::storage _storage, bool _is_device,
                             bool _copy_device)
     : base(_dims, _nNZ, _rowIdx, _colIdx, _storage,
@@ -219,9 +221,9 @@ SparseArray<T>::~SparseArray() {}
         const int *const _rowIdx, const int *const _colIdx,                  \
         const af::storage _storage);                                         \
     template SparseArray<T> createDeviceDataSparseArray<T>(                  \
-        const af::dim4 &_dims, const dim_t _nNZ, const T *const _values,     \
-        const int *const _rowIdx, const int *const _colIdx,                  \
-        const af::storage _storage, const bool _copy);                       \
+        const af::dim4 &_dims, const dim_t _nNZ, T *const _values,           \
+        int *const _rowIdx, int *const _colIdx, const af::storage _storage,  \
+        const bool _copy);                                                   \
     template SparseArray<T> createArrayDataSparseArray<T>(                   \
         const af::dim4 &_dims, const Array<T> &_values,                      \
         const Array<int> &_rowIdx, const Array<int> &_colIdx,                \
@@ -233,9 +235,9 @@ SparseArray<T>::~SparseArray() {}
     template SparseArray<T>::SparseArray(af::dim4 _dims, dim_t _nNZ,         \
                                          af::storage _storage);              \
     template SparseArray<T>::SparseArray(                                    \
-        af::dim4 _dims, dim_t _nNZ, const T *const _values,                  \
-        const int *const _rowIdx, const int *const _colIdx,                  \
-        const af::storage _storage, bool _is_device, bool _copy_device);     \
+        af::dim4 _dims, dim_t _nNZ, T *const _values, int *const _rowIdx,    \
+        int *const _colIdx, const af::storage _storage, bool _is_device,     \
+        bool _copy_device);                                                  \
     template SparseArray<T>::SparseArray(                                    \
         af::dim4 _dims, const Array<T> &_values, const Array<int> &_rowIdx,  \
         const Array<int> &_colIdx, const af::storage _storage, bool _copy);  \

--- a/src/backend/common/SparseArray.hpp
+++ b/src/backend/common/SparseArray.hpp
@@ -43,8 +43,8 @@ class SparseArrayBase {
     SparseArrayBase(af::dim4 _dims, dim_t _nNZ, af::storage _storage,
                     af_dtype _type);
 
-    SparseArrayBase(af::dim4 _dims, dim_t _nNZ, const int *const _rowIdx,
-                    const int *const _colIdx, const af::storage _storage,
+    SparseArrayBase(af::dim4 _dims, dim_t _nNZ, int *const _rowIdx,
+                    int *const _colIdx, const af::storage _storage,
                     af_dtype _type, bool _is_device = false,
                     bool _copy_device = false);
 
@@ -133,8 +133,8 @@ class SparseArray {
 
     SparseArray(af::dim4 _dims, dim_t _nNZ, af::storage stype);
 
-    explicit SparseArray(af::dim4 _dims, dim_t _nNZ, const T *const _values,
-                         const int *const _rowIdx, const int *const _colIdx,
+    explicit SparseArray(af::dim4 _dims, dim_t _nNZ, T *const _values,
+                         int *const _rowIdx, int *const _colIdx,
                          const af::storage _storage, bool _is_device = false,
                          bool _copy_device = false);
 
@@ -218,9 +218,9 @@ class SparseArray {
         const af::storage _storage);
 
     friend SparseArray<T> createDeviceDataSparseArray<T>(
-        const af::dim4 &_dims, const dim_t nNZ, const T *const _values,
-        const int *const _rowIdx, const int *const _colIdx,
-        const af::storage _storage, const bool _copy);
+        const af::dim4 &_dims, const dim_t nNZ, T *const _values,
+        int *const _rowIdx, int *const _colIdx, const af::storage _storage,
+        const bool _copy);
 
     friend SparseArray<T> createArrayDataSparseArray<T>(
         const af::dim4 &_dims, const Array<T> &_values,

--- a/src/backend/common/sparse_helpers.hpp
+++ b/src/backend/common/sparse_helpers.hpp
@@ -33,10 +33,12 @@ SparseArray<T> createHostDataSparseArray(const af::dim4 &_dims, const dim_t nNZ,
                                          const af::storage _storage);
 
 template<typename T>
-SparseArray<T> createDeviceDataSparseArray(
-    const af::dim4 &_dims, const dim_t nNZ, const T *const _values,
-    const int *const _rowIdx, const int *const _colIdx,
-    const af::storage _storage, const bool _copy = false);
+SparseArray<T> createDeviceDataSparseArray(const af::dim4 &_dims,
+                                           const dim_t nNZ, T *const _values,
+                                           int *const _rowIdx,
+                                           int *const _colIdx,
+                                           const af::storage _storage,
+                                           const bool _copy = false);
 
 template<typename T>
 SparseArray<T> createArrayDataSparseArray(const af::dim4 &_dims,

--- a/src/backend/cpu/Array.hpp
+++ b/src/backend/cpu/Array.hpp
@@ -46,22 +46,24 @@ void evalMultiple(std::vector<Array<T> *> arrays);
 
 // Creates a new Array object on the heap and returns a reference to it.
 template<typename T>
-Array<T> createNodeArray(const af::dim4 &size, jit::Node_ptr node);
-
-// Creates a new Array object on the heap and returns a reference to it.
-template<typename T>
-Array<T> createValueArray(const af::dim4 &size, const T &value);
-
-// Creates a new Array object on the heap and returns a reference to it.
-template<typename T>
-Array<T> createHostDataArray(const af::dim4 &size, const T *const data);
+Array<T> createNodeArray(const af::dim4 &dims, jit::Node_ptr node);
 
 template<typename T>
-Array<T> createDeviceDataArray(const af::dim4 &size, const void *data);
+Array<T> createValueArray(const af::dim4 &dims, const T &value);
+
+// Creates an array and copies from the \p data pointer located in host memory
+//
+// \param[in] dims The dimension of the array
+// \param[in] data The data that will be copied to the array
+template<typename T>
+Array<T> createHostDataArray(const af::dim4 &dims, const T *const data);
+
+template<typename T>
+Array<T> createDeviceDataArray(const af::dim4 &dims, void *data);
 
 template<typename T>
 Array<T> createStridedArray(af::dim4 dims, af::dim4 strides, dim_t offset,
-                            const T *const in_data, bool is_device) {
+                            T *const in_data, bool is_device) {
     return Array<T>(dims, strides, offset, in_data, is_device);
 }
 
@@ -78,7 +80,7 @@ void writeDeviceDataArray(Array<T> &arr, const void *const data,
 ///
 /// \param[in] size The dimension of the output array
 template<typename T>
-Array<T> createEmptyArray(const af::dim4 &size);
+Array<T> createEmptyArray(const af::dim4 &dims);
 
 template<typename T>
 Array<T> createSubArray(const Array<T> &parent,
@@ -118,13 +120,13 @@ class Array {
     Array() = default;
     Array(dim4 dims);
 
-    explicit Array(dim4 dims, const T *const in_data, bool is_device,
+    explicit Array(const af::dim4 &dims, T *const in_data, bool is_device,
                    bool copy_device = false);
-    Array(const Array<T> &parnt, const dim4 &dims, const dim_t &offset,
+    Array(const Array<T> &parent, const dim4 &dims, const dim_t &offset,
           const dim4 &stride);
-    explicit Array(af::dim4 dims, jit::Node_ptr n);
-    Array(af::dim4 dims, af::dim4 strides, dim_t offset, const T *const in_data,
-          bool is_device = false);
+    explicit Array(const af::dim4 &dims, jit::Node_ptr n);
+    Array(const af::dim4 &dims, const af::dim4 &strides, dim_t offset,
+          T *const in_data, bool is_device = false);
 
    public:
     void resetInfo(const af::dim4 &dims) { info.resetInfo(dims); }
@@ -223,16 +225,15 @@ class Array {
 
     friend void evalMultiple<T>(std::vector<Array<T> *> arrays);
 
-    friend Array<T> createValueArray<T>(const af::dim4 &size, const T &value);
-    friend Array<T> createHostDataArray<T>(const af::dim4 &size,
+    friend Array<T> createValueArray<T>(const af::dim4 &dims, const T &value);
+    friend Array<T> createHostDataArray<T>(const af::dim4 &dims,
                                            const T *const data);
-    friend Array<T> createDeviceDataArray<T>(const af::dim4 &size,
-                                             const void *data);
+    friend Array<T> createDeviceDataArray<T>(const af::dim4 &dims, void *data);
     friend Array<T> createStridedArray<T>(af::dim4 dims, af::dim4 strides,
-                                          dim_t offset, const T *const in_data,
+                                          dim_t offset, T *const in_data,
                                           bool is_device);
 
-    friend Array<T> createEmptyArray<T>(const af::dim4 &size);
+    friend Array<T> createEmptyArray<T>(const af::dim4 &dims);
     friend Array<T> createNodeArray<T>(const af::dim4 &dims,
                                        jit::Node_ptr node);
 

--- a/src/backend/cpu/harris.cpp
+++ b/src/backend/cpu/harris.cpp
@@ -42,8 +42,8 @@ unsigned harris(Array<float> &x_out, Array<float> &y_out,
     } else {
         gaussian1D<convAccT>(h_filter.get(), (int)filter_len, sigma);
     }
-    Array<convAccT> filter = createDeviceDataArray<convAccT>(
-        dim4(filter_len), (const void *)h_filter.release());
+    Array<convAccT> filter =
+        createDeviceDataArray<convAccT>(dim4(filter_len), h_filter.release());
     unsigned border_len = filter_len / 2 + 1;
 
     Array<T> ix = createEmptyArray<T>(idims);

--- a/src/backend/cpu/kernel/sort.hpp
+++ b/src/backend/cpu/kernel/sort.hpp
@@ -24,7 +24,7 @@ void sort0Iterative(Param<T> val, bool isAscending) {
     // initialize original index locations
     T *val_ptr = val.get();
 
-    function<bool(T, T)> op = std::greater<T>();
+    std::function<bool(T, T)> op = std::greater<T>();
     if (isAscending) { op = std::less<T>(); }
 
     T *comp_ptr = nullptr;

--- a/src/backend/cpu/sparse.cpp
+++ b/src/backend/cpu/sparse.cpp
@@ -26,6 +26,10 @@
 #include <reduce.hpp>
 #include <where.hpp>
 
+#include <functional>
+
+using std::function;
+
 namespace cpu {
 
 using common::createArrayDataSparseArray;

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -303,23 +303,27 @@ Array<T> createNodeArray(const dim4 &dims, Node_ptr node) {
 }
 
 template<typename T>
-Array<T> createHostDataArray(const dim4 &size, const T *const data) {
-    return Array<T>(size, data, false);
+Array<T> createHostDataArray(const dim4 &dims, const T *const data) {
+    bool is_device   = false;
+    bool copy_device = false;
+    return Array<T>(dims, data, is_device, copy_device);
 }
 
 template<typename T>
-Array<T> createDeviceDataArray(const dim4 &size, const void *data) {
-    return Array<T>(size, (const T *const)data, true);
+Array<T> createDeviceDataArray(const dim4 &dims, void *data) {
+    bool is_device   = true;
+    bool copy_device = false;
+    return Array<T>(dims, static_cast<T *>(data), is_device, copy_device);
 }
 
 template<typename T>
-Array<T> createValueArray(const dim4 &size, const T &value) {
-    return createScalarNode<T>(size, value);
+Array<T> createValueArray(const dim4 &dims, const T &value) {
+    return createScalarNode<T>(dims, value);
 }
 
 template<typename T>
-Array<T> createEmptyArray(const dim4 &size) {
-    return Array<T>(size);
+Array<T> createEmptyArray(const dim4 &dims) {
+    return Array<T>(dims);
 }
 
 template<typename T>
@@ -403,8 +407,7 @@ void Array<T>::setDataDims(const dim4 &new_dims) {
 #define INSTANTIATE(T)                                                        \
     template Array<T> createHostDataArray<T>(const dim4 &size,                \
                                              const T *const data);            \
-    template Array<T> createDeviceDataArray<T>(const dim4 &size,              \
-                                               const void *data);             \
+    template Array<T> createDeviceDataArray<T>(const dim4 &size, void *data); \
     template Array<T> createValueArray<T>(const dim4 &size, const T &value);  \
     template Array<T> createEmptyArray<T>(const dim4 &size);                  \
     template Array<T> createParamArray<T>(Param<T> & tmp, bool owner);        \

--- a/src/backend/cuda/Array.hpp
+++ b/src/backend/cuda/Array.hpp
@@ -42,11 +42,15 @@ Array<T> createNodeArray(const af::dim4 &size, common::Node_ptr node);
 template<typename T>
 Array<T> createValueArray(const af::dim4 &size, const T &value);
 
+// Creates an array and copies from the \p data pointer located in host memory
+//
+// \param[in] dims The dimension of the array
+// \param[in] data The data that will be copied to the array
 template<typename T>
-Array<T> createHostDataArray(const af::dim4 &size, const T *const data);
+Array<T> createHostDataArray(const af::dim4 &dims, const T *const data);
 
 template<typename T>
-Array<T> createDeviceDataArray(const af::dim4 &size, const void *data);
+Array<T> createDeviceDataArray(const af::dim4 &size, void *data);
 
 template<typename T>
 Array<T> createStridedArray(af::dim4 dims, af::dim4 strides, dim_t offset,
@@ -222,8 +226,7 @@ class Array {
     friend Array<T> createValueArray<T>(const af::dim4 &size, const T &value);
     friend Array<T> createHostDataArray<T>(const af::dim4 &size,
                                            const T *const data);
-    friend Array<T> createDeviceDataArray<T>(const af::dim4 &size,
-                                             const void *data);
+    friend Array<T> createDeviceDataArray<T>(const af::dim4 &size, void *data);
     friend Array<T> createStridedArray<T>(af::dim4 dims, af::dim4 strides,
                                           dim_t offset, const T *const in_data,
                                           bool is_device);

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -335,28 +335,29 @@ Array<T> createSubArray(const Array<T> &parent, const vector<af_seq> &index,
 }
 
 template<typename T>
-Array<T> createHostDataArray(const dim4 &size, const T *const data) {
+Array<T> createHostDataArray(const dim4 &dims, const T *const data) {
     verifyDoubleSupport<T>();
-    return Array<T>(size, data);
+    return Array<T>(dims, data);
 }
 
 template<typename T>
-Array<T> createDeviceDataArray(const dim4 &size, const void *data, bool copy) {
+Array<T> createDeviceDataArray(const dim4 &dims, void *data) {
     verifyDoubleSupport<T>();
 
-    return Array<T>(size, (cl_mem)(data), 0, copy);
+    bool copy_device = false;
+    return Array<T>(dims, static_cast<cl_mem>(data), 0, copy_device);
 }
 
 template<typename T>
-Array<T> createValueArray(const dim4 &size, const T &value) {
+Array<T> createValueArray(const dim4 &dims, const T &value) {
     verifyDoubleSupport<T>();
-    return createScalarNode<T>(size, value);
+    return createScalarNode<T>(dims, value);
 }
 
 template<typename T>
-Array<T> createEmptyArray(const dim4 &size) {
+Array<T> createEmptyArray(const dim4 &dims) {
     verifyDoubleSupport<T>();
-    return Array<T>(size);
+    return Array<T>(dims);
 }
 
 template<typename T>
@@ -404,32 +405,31 @@ void Array<T>::setDataDims(const dim4 &new_dims) {
     if (node->isBuffer()) { node = bufferNodePtr<T>(); }
 }
 
-#define INSTANTIATE(T)                                                       \
-    template Array<T> createHostDataArray<T>(const dim4 &size,               \
-                                             const T *const data);           \
-    template Array<T> createDeviceDataArray<T>(const dim4 &size,             \
-                                               const void *data, bool copy); \
-    template Array<T> createValueArray<T>(const dim4 &size, const T &value); \
-    template Array<T> createEmptyArray<T>(const dim4 &size);                 \
-    template Array<T> createParamArray<T>(Param & tmp, bool owner);          \
-    template Array<T> createSubArray<T>(                                     \
-        const Array<T> &parent, const vector<af_seq> &index, bool copy);     \
-    template void destroyArray<T>(Array<T> * A);                             \
-    template Array<T> createNodeArray<T>(const dim4 &size, Node_ptr node);   \
-    template Array<T>::Array(dim4 dims, dim4 strides, dim_t offset,          \
-                             const T *const in_data, bool is_device);        \
-    template Array<T>::Array(dim4 dims, cl_mem mem, size_t src_offset,       \
-                             bool copy);                                     \
-    template Array<T>::~Array();                                             \
-    template Node_ptr Array<T>::getNode() const;                             \
-    template void Array<T>::eval();                                          \
-    template void Array<T>::eval() const;                                    \
-    template Buffer *Array<T>::device();                                     \
-    template void writeHostDataArray<T>(Array<T> & arr, const T *const data, \
-                                        const size_t bytes);                 \
-    template void writeDeviceDataArray<T>(                                   \
-        Array<T> & arr, const void *const data, const size_t bytes);         \
-    template void evalMultiple<T>(vector<Array<T> *> arrays);                \
+#define INSTANTIATE(T)                                                        \
+    template Array<T> createHostDataArray<T>(const dim4 &dims,                \
+                                             const T *const data);            \
+    template Array<T> createDeviceDataArray<T>(const dim4 &dims, void *data); \
+    template Array<T> createValueArray<T>(const dim4 &dims, const T &value);  \
+    template Array<T> createEmptyArray<T>(const dim4 &dims);                  \
+    template Array<T> createParamArray<T>(Param & tmp, bool owner);           \
+    template Array<T> createSubArray<T>(                                      \
+        const Array<T> &parent, const vector<af_seq> &index, bool copy);      \
+    template void destroyArray<T>(Array<T> * A);                              \
+    template Array<T> createNodeArray<T>(const dim4 &dims, Node_ptr node);    \
+    template Array<T>::Array(dim4 dims, dim4 strides, dim_t offset,           \
+                             const T *const in_data, bool is_device);         \
+    template Array<T>::Array(dim4 dims, cl_mem mem, size_t src_offset,        \
+                             bool copy);                                      \
+    template Array<T>::~Array();                                              \
+    template Node_ptr Array<T>::getNode() const;                              \
+    template void Array<T>::eval();                                           \
+    template void Array<T>::eval() const;                                     \
+    template Buffer *Array<T>::device();                                      \
+    template void writeHostDataArray<T>(Array<T> & arr, const T *const data,  \
+                                        const size_t bytes);                  \
+    template void writeDeviceDataArray<T>(                                    \
+        Array<T> & arr, const void *const data, const size_t bytes);          \
+    template void evalMultiple<T>(vector<Array<T> *> arrays);                 \
     template void Array<T>::setDataDims(const dim4 &new_dims);
 
 INSTANTIATE(float)

--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -34,19 +34,18 @@ void evalNodes(std::vector<Param> &outputs, std::vector<common::Node *> nodes);
 
 /// Creates a new Array object on the heap and returns a reference to it.
 template<typename T>
-Array<T> createNodeArray(const af::dim4 &size, common::Node_ptr node);
+Array<T> createNodeArray(const af::dim4 &dims, common::Node_ptr node);
 
 /// Creates a new Array object on the heap and returns a reference to it.
 template<typename T>
-Array<T> createValueArray(const af::dim4 &size, const T &value);
+Array<T> createValueArray(const af::dim4 &dims, const T &value);
 
 /// Creates a new Array object on the heap and returns a reference to it.
 template<typename T>
-Array<T> createHostDataArray(const af::dim4 &size, const T *const data);
+Array<T> createHostDataArray(const af::dim4 &dims, const T *const data);
 
 template<typename T>
-Array<T> createDeviceDataArray(const af::dim4 &size, const void *data,
-                               bool copy = false);
+Array<T> createDeviceDataArray(const af::dim4 &dims, void *data);
 
 template<typename T>
 Array<T> createStridedArray(af::dim4 dims, af::dim4 strides, dim_t offset,
@@ -67,7 +66,7 @@ void writeDeviceDataArray(Array<T> &arr, const void *const data,
 ///
 /// \param[in] size The dimension of the output array
 template<typename T>
-Array<T> createEmptyArray(const af::dim4 &size);
+Array<T> createEmptyArray(const af::dim4 &dims);
 
 /// Create an Array object from Param object.
 ///
@@ -255,16 +254,15 @@ class Array {
 
     friend void evalMultiple<T>(std::vector<Array<T> *> arrays);
 
-    friend Array<T> createValueArray<T>(const af::dim4 &size, const T &value);
-    friend Array<T> createHostDataArray<T>(const af::dim4 &size,
+    friend Array<T> createValueArray<T>(const af::dim4 &dims, const T &value);
+    friend Array<T> createHostDataArray<T>(const af::dim4 &dims,
                                            const T *const data);
-    friend Array<T> createDeviceDataArray<T>(const af::dim4 &size,
-                                             const void *data, bool copy);
+    friend Array<T> createDeviceDataArray<T>(const af::dim4 &dims, void *data);
     friend Array<T> createStridedArray<T>(af::dim4 dims, af::dim4 strides,
                                           dim_t offset, const T *const in_data,
                                           bool is_device);
 
-    friend Array<T> createEmptyArray<T>(const af::dim4 &size);
+    friend Array<T> createEmptyArray<T>(const af::dim4 &dims);
     friend Array<T> createParamArray<T>(Param &tmp, bool owner);
     friend Array<T> createNodeArray<T>(const af::dim4 &dims,
                                        common::Node_ptr node);


### PR DESCRIPTION
The createDeviceArray pointer was const when it shouldn't be. This is
similiar to correcting the const in the api function but applies it
to the internal functions.