### PR TITLE
Use SUPPORTED_TYPE_CHECK macro to test for supported type

### DIFF
--- a/test/anisotropic_diffusion.cpp
+++ b/test/anisotropic_diffusion.cpp
@@ -49,7 +49,7 @@ void imageTest(string pTestFile, const float dt, const float K,
         typename cond_type<is_same_type<T, double>::value, double, float>::type
             OutType;
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     using af::dim4;

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -60,7 +60,7 @@ template<typename T>
 void approx1Test(string pTestFile, const unsigned resultIdx,
                  const af_interp_type method, bool isSubRef = false,
                  const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     typedef typename dtype_traits<T>::base_type BT;
     vector<dim4> numDims;
@@ -133,7 +133,7 @@ template<typename T>
 void approx1CubicTest(string pTestFile, const unsigned resultIdx,
                       const af_interp_type method, bool isSubRef = false,
                       const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     typedef typename dtype_traits<T>::base_type BT;
     vector<dim4> numDims;
@@ -221,7 +221,7 @@ TYPED_TEST(Approx1, Approx1Cubic) {
 template<typename T>
 void approx1ArgsTest(string pTestFile, const af_interp_type method,
                      const af_err err) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     typedef typename dtype_traits<T>::base_type BT;
     vector<dim4> numDims;
     vector<vector<BT> > in;
@@ -268,7 +268,7 @@ TYPED_TEST(Approx1, Approx1ArgsInterpBilinear) {
 template<typename T>
 void approx1ArgsTestPrecision(string pTestFile, const unsigned,
                               const af_interp_type method) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     vector<dim4> numDims;
     vector<vector<T> > in;
     vector<vector<T> > tests;
@@ -425,8 +425,6 @@ TEST(Approx1, CPPCubicBatch) {
 }
 
 TEST(Approx1, CPPNearestMaxDims) {
-    if (noDoubleTests<float>()) return;
-
     const size_t largeDim = 65535 * 32 + 1;
     array input           = randu(1, largeDim);
     array pos             = input.dims(0) * randu(1, largeDim);
@@ -444,8 +442,6 @@ TEST(Approx1, CPPNearestMaxDims) {
 }
 
 TEST(Approx1, CPPLinearMaxDims) {
-    if (noDoubleTests<float>()) return;
-
     const size_t largeDim = 65535 * 32 + 1;
     array input           = iota(dim4(1, largeDim), c32);
     array pos             = input.dims(0) * randu(1, largeDim);
@@ -463,8 +459,6 @@ TEST(Approx1, CPPLinearMaxDims) {
 }
 
 TEST(Approx1, CPPCubicMaxDims) {
-    if (noDoubleTests<float>()) return;
-
     const size_t largeDim = 65535 * 32 + 1;
     array input           = iota(dim4(1, largeDim), c32);
     array pos             = input.dims(0) * randu(1, largeDim);

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -56,7 +56,7 @@ template<typename T>
 void approx2Test(string pTestFile, const unsigned resultIdx,
                  const af_interp_type method, bool isSubRef = false,
                  const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     typedef typename dtype_traits<T>::base_type BT;
     vector<dim4> numDims;
     vector<vector<BT> > in;
@@ -143,7 +143,7 @@ TYPED_TEST(Approx2, LinearBatch) {
 template<typename T>
 void approx2ArgsTest(string pTestFile, const af_interp_type method,
                      const af_err err) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     typedef typename dtype_traits<T>::base_type BT;
     vector<dim4> numDims;
     vector<vector<BT> > in;
@@ -200,7 +200,7 @@ template<typename T>
 void approx2ArgsTestPrecision(string pTestFile, const unsigned resultIdx,
                               const af_interp_type method) {
     UNUSED(resultIdx);
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     vector<dim4> numDims;
     vector<vector<T> > in;
     vector<vector<T> > tests;
@@ -392,8 +392,6 @@ TEST(Approx2, CPPLinearBatch) {
 }
 
 TEST(Approx2, CPPNearestMaxDims) {
-    if (noDoubleTests<float>()) return;
-
     const size_t largeDim = 65535 * 32 + 1;
 
     array input = randu(1, largeDim);
@@ -415,8 +413,6 @@ TEST(Approx2, CPPNearestMaxDims) {
 }
 
 TEST(Approx2, CPPLinearMaxDims) {
-    if (noDoubleTests<float>()) return;
-
     const size_t largeDim = 65535 * 32 + 1;
 
     array input = randu(1, largeDim);
@@ -438,8 +434,6 @@ TEST(Approx2, CPPLinearMaxDims) {
 }
 
 TEST(Approx2, CPPCubicMaxDims) {
-    if (noDoubleTests<float>()) return;
-
     const size_t largeDim = 65535 * 32 + 1;
 
     array input = randu(1, largeDim);

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -47,7 +47,7 @@ TEST(Array, ConstructorDefault) {
 }
 
 TYPED_TEST(Array, ConstructorEmptyDim4) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dtype type = (dtype)dtype_traits<TypeParam>::af_type;
     dim4 dims(3, 3, 3, 3);
@@ -62,7 +62,7 @@ TYPED_TEST(Array, ConstructorEmptyDim4) {
 }
 
 TYPED_TEST(Array, ConstructorEmpty1D) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dtype type = (dtype)dtype_traits<TypeParam>::af_type;
     array a(2, type);
@@ -76,7 +76,7 @@ TYPED_TEST(Array, ConstructorEmpty1D) {
 }
 
 TYPED_TEST(Array, ConstructorEmpty2D) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dtype type = (dtype)dtype_traits<TypeParam>::af_type;
     array a(2, 2, type);
@@ -90,7 +90,7 @@ TYPED_TEST(Array, ConstructorEmpty2D) {
 }
 
 TYPED_TEST(Array, ConstructorEmpty3D) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dtype type = (dtype)dtype_traits<TypeParam>::af_type;
     array a(2, 2, 2, type);
@@ -104,7 +104,7 @@ TYPED_TEST(Array, ConstructorEmpty3D) {
 }
 
 TYPED_TEST(Array, ConstructorEmpty4D) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dtype type = (dtype)dtype_traits<TypeParam>::af_type;
     array a(2, 2, 2, 2, type);
@@ -118,7 +118,7 @@ TYPED_TEST(Array, ConstructorEmpty4D) {
 }
 
 TYPED_TEST(Array, ConstructorHostPointer1D) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dtype type    = (dtype)dtype_traits<TypeParam>::af_type;
     size_t nelems = 10;
@@ -138,7 +138,7 @@ TYPED_TEST(Array, ConstructorHostPointer1D) {
 }
 
 TYPED_TEST(Array, ConstructorHostPointer2D) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dtype type      = (dtype)dtype_traits<TypeParam>::af_type;
     size_t ndims    = 2;
@@ -160,7 +160,7 @@ TYPED_TEST(Array, ConstructorHostPointer2D) {
 }
 
 TYPED_TEST(Array, ConstructorHostPointer3D) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dtype type      = (dtype)dtype_traits<TypeParam>::af_type;
     size_t ndims    = 3;
@@ -182,7 +182,7 @@ TYPED_TEST(Array, ConstructorHostPointer3D) {
 }
 
 TYPED_TEST(Array, ConstructorHostPointer4D) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dtype type      = (dtype)dtype_traits<TypeParam>::af_type;
     size_t ndims    = 4;
@@ -204,7 +204,7 @@ TYPED_TEST(Array, ConstructorHostPointer4D) {
 }
 
 TYPED_TEST(Array, TypeAttributes) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dtype type = (dtype)dtype_traits<TypeParam>::af_type;
     array one(10, type);
@@ -484,7 +484,7 @@ TEST(Device, JIT) {
 }
 
 TYPED_TEST(Array, Scalar) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dtype type = (dtype)dtype_traits<TypeParam>::af_type;
     array a    = randu(dim4(1), type);

--- a/test/assign.cpp
+++ b/test/assign.cpp
@@ -100,8 +100,8 @@ TYPED_TEST_CASE(ArrayAssign, TestTypes);
 
 template<typename inType, typename outType>
 void assignTest(string pTestFile, const vector<af_seq> *seqv) {
-    if (noDoubleTests<inType>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(inType);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<inType> > in;
@@ -145,7 +145,7 @@ void assignTest(string pTestFile, const vector<af_seq> *seqv) {
 
 template<typename T>
 void assignTestCPP(string pTestFile, const vector<af_seq> &seqv) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     try {
         vector<dim4> numDims;
         vector<vector<T> > in;
@@ -284,7 +284,7 @@ TYPED_TEST(ArrayAssign, Cube2HyperCubeCPP) {
 
 template<typename T>
 void assignScalarCPP(string pTestFile, const vector<af_seq> &seqv) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     try {
         vector<dim4> numDims;
         vector<vector<T> > in;
@@ -354,7 +354,7 @@ TYPED_TEST(ArrayAssign, Scalar4DCPP) {
 }
 
 TYPED_TEST(ArrayAssign, AssignRowCPP) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     const int dimsize = 10;
     vector<TypeParam> input(100, 1);
@@ -405,7 +405,7 @@ TYPED_TEST(ArrayAssign, AssignRowCPP) {
 }
 
 TYPED_TEST(ArrayAssign, AssignColumnCPP) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     const int dimsize = 10;
     vector<TypeParam> input(100, 1);
@@ -456,7 +456,7 @@ TYPED_TEST(ArrayAssign, AssignColumnCPP) {
 }
 
 TYPED_TEST(ArrayAssign, AssignSliceCPP) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
     const int dimsize = 10;
     vector<TypeParam> input(1000, 1);
     vector<TypeParam> sq(dimsize * dimsize);

--- a/test/basic.cpp
+++ b/test/basic.cpp
@@ -20,8 +20,6 @@ using af::dim4;
 using std::vector;
 
 TEST(BasicTests, constant1000x1000) {
-    if (noDoubleTests<float>()) return;
-
     static const int ndims    = 2;
     static const int dim_size = 1000;
     dim_t d[ndims]            = {dim_size, dim_size};
@@ -40,8 +38,6 @@ TEST(BasicTests, constant1000x1000) {
 }
 
 TEST(BasicTests, constant10x10) {
-    if (noDoubleTests<float>()) return;
-
     static const int ndims    = 2;
     static const int dim_size = 10;
     dim_t d[2]                = {dim_size, dim_size};
@@ -60,8 +56,6 @@ TEST(BasicTests, constant10x10) {
 }
 
 TEST(BasicTests, constant100x100) {
-    if (noDoubleTests<float>()) return;
-
     static const int ndims    = 2;
     static const int dim_size = 100;
     dim_t d[2]                = {dim_size, dim_size};
@@ -81,8 +75,7 @@ TEST(BasicTests, constant100x100) {
 
 // TODO: Test All The Types \o/
 TEST(BasicTests, AdditionSameType) {
-    if (noDoubleTests<float>()) return;
-    if (noDoubleTests<double>()) return;
+    SUPPORTED_TYPE_CHECK(double);
 
     static const int ndims    = 2;
     static const int dim_size = 100;
@@ -129,7 +122,7 @@ TEST(BasicTests, AdditionSameType) {
 }
 
 TEST(BasicTests, Additionf64f64) {
-    if (noDoubleTests<double>()) return;
+    SUPPORTED_TYPE_CHECK(double);
 
     static const int ndims    = 2;
     static const int dim_size = 100;
@@ -164,8 +157,7 @@ TEST(BasicTests, Additionf64f64) {
 }
 
 TEST(BasicTests, Additionf32f64) {
-    if (noDoubleTests<float>()) return;
-    if (noDoubleTests<double>()) return;
+    SUPPORTED_TYPE_CHECK(double);
 
     static const int ndims    = 2;
     static const int dim_size = 100;
@@ -200,8 +192,6 @@ TEST(BasicTests, Additionf32f64) {
 }
 
 TEST(BasicArrayTests, constant10x10) {
-    if (noDoubleTests<float>()) return;
-
     dim_t dim_size = 10;
     double valA    = 3.14;
     array a        = constant(valA, dim_size, dim_size, f32);
@@ -218,8 +208,6 @@ TEST(BasicArrayTests, constant10x10) {
 using af::dim4;
 
 TEST(BasicTests, constant100x100_CPP) {
-    if (noDoubleTests<float>()) return;
-
     static const int dim_size = 100;
     dim_t d[2]                = {dim_size, dim_size};
 
@@ -236,8 +224,7 @@ TEST(BasicTests, constant100x100_CPP) {
 
 // TODO: Test All The Types \o/
 TEST(BasicTests, AdditionSameType_CPP) {
-    if (noDoubleTests<float>()) return;
-    if (noDoubleTests<double>()) return;
+    SUPPORTED_TYPE_CHECK(double);
 
     static const int dim_size = 100;
     dim_t d[2]                = {dim_size, dim_size};
@@ -274,8 +261,7 @@ TEST(BasicTests, AdditionSameType_CPP) {
 }
 
 TEST(BasicTests, Additionf32f64_CPP) {
-    if (noDoubleTests<float>()) return;
-    if (noDoubleTests<double>()) return;
+    SUPPORTED_TYPE_CHECK(double);
 
     static const int dim_size = 100;
     dim_t d[2]                = {dim_size, dim_size};

--- a/test/bilateral.cpp
+++ b/test/bilateral.cpp
@@ -24,7 +24,7 @@ using std::vector;
 
 template<typename T, bool isColor>
 void bilateralTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;
@@ -88,7 +88,7 @@ TYPED_TEST_CASE(BilateralOnData, DataTestTypes);
 
 template<typename inType>
 void bilateralDataTest(string pTestFile) {
-    if (noDoubleTests<inType>()) return;
+    SUPPORTED_TYPE_CHECK(inType);
 
     typedef typename cond_type<is_same_type<inType, double>::value, double,
                                float>::type outType;
@@ -135,7 +135,7 @@ TYPED_TEST(BilateralOnData, Rectangle_Batch) {
 }
 
 TYPED_TEST(BilateralOnData, InvalidArgs) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     vector<TypeParam> in(100, 1);
 
@@ -158,8 +158,6 @@ using af::array;
 using af::bilateral;
 
 TEST(Bilateral, CPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<dim4> numDims;
     vector<vector<float> > in;
     vector<vector<float> > tests;

--- a/test/binary.cpp
+++ b/test/binary.cpp
@@ -45,9 +45,9 @@ af::array randgen(const int num, dtype ty) {
 
 #define BINARY_TESTS(Ta, Tb, Tc, func)                                \
     TEST(BinaryTests, Test_##func##_##Ta##_##Tb) {                    \
-        if (noDoubleTests<Ta>()) return;                              \
-        if (noDoubleTests<Tb>()) return;                              \
-        if (noDoubleTests<Tc>()) return;                              \
+        SUPPORTED_TYPE_CHECK(Ta);                                     \
+        SUPPORTED_TYPE_CHECK(Tb);                                     \
+        SUPPORTED_TYPE_CHECK(Tc);                                     \
                                                                       \
         af_dtype ta = (af_dtype)dtype_traits<Ta>::af_type;            \
         af_dtype tb = (af_dtype)dtype_traits<Tb>::af_type;            \
@@ -66,8 +66,8 @@ af::array randgen(const int num, dtype ty) {
     }                                                                 \
                                                                       \
     TEST(BinaryTests, Test_##func##_##Ta##_##Tb##_left) {             \
-        if (noDoubleTests<Ta>()) return;                              \
-        if (noDoubleTests<Tb>()) return;                              \
+        SUPPORTED_TYPE_CHECK(Ta);                                     \
+        SUPPORTED_TYPE_CHECK(Tb);                                     \
                                                                       \
         af_dtype ta = (af_dtype)dtype_traits<Ta>::af_type;            \
         af::array a = randgen(num, ta);                               \
@@ -83,8 +83,8 @@ af::array randgen(const int num, dtype ty) {
     }                                                                 \
                                                                       \
     TEST(BinaryTests, Test_##func##_##Ta##_##Tb##_right) {            \
-        if (noDoubleTests<Ta>()) return;                              \
-        if (noDoubleTests<Tb>()) return;                              \
+        SUPPORTED_TYPE_CHECK(Ta);                                     \
+        SUPPORTED_TYPE_CHECK(Tb);                                     \
                                                                       \
         af_dtype tb = (af_dtype)dtype_traits<Tb>::af_type;            \
         Ta h_a      = 5.0;                                            \
@@ -101,9 +101,9 @@ af::array randgen(const int num, dtype ty) {
 
 #define BINARY_TESTS_NEAR_GENERAL(Ta, Tb, Tc, Td, Te, func, err)      \
     TEST(BinaryTestsFloating, Test_##func##_##Ta##_##Tb) {            \
-        if (noDoubleTests<Ta>()) return;                              \
-        if (noDoubleTests<Tb>()) return;                              \
-        if (noDoubleTests<Tc>()) return;                              \
+        SUPPORTED_TYPE_CHECK(Ta);                                     \
+        SUPPORTED_TYPE_CHECK(Tb);                                     \
+        SUPPORTED_TYPE_CHECK(Tc);                                     \
                                                                       \
         af_dtype ta = (af_dtype)dtype_traits<Ta>::af_type;            \
         af_dtype tb = (af_dtype)dtype_traits<Tb>::af_type;            \
@@ -122,8 +122,8 @@ af::array randgen(const int num, dtype ty) {
     }                                                                 \
                                                                       \
     TEST(BinaryTestsFloating, Test_##func##_##Ta##_##Tb##_left) {     \
-        if (noDoubleTests<Ta>()) return;                              \
-        if (noDoubleTests<Tb>()) return;                              \
+        SUPPORTED_TYPE_CHECK(Ta);                                     \
+        SUPPORTED_TYPE_CHECK(Tb);                                     \
                                                                       \
         af_dtype ta = (af_dtype)dtype_traits<Ta>::af_type;            \
         af::array a = randgen(num, ta);                               \
@@ -139,9 +139,9 @@ af::array randgen(const int num, dtype ty) {
     }                                                                 \
                                                                       \
     TEST(BinaryTestsFloating, Test_##func##_##Ta##_##Tb##_right) {    \
-        if (noDoubleTests<Ta>()) return;                              \
-        if (noDoubleTests<Tb>()) return;                              \
-        if (noDoubleTests<Tc>()) return;                              \
+        SUPPORTED_TYPE_CHECK(Ta);                                     \
+        SUPPORTED_TYPE_CHECK(Tb);                                     \
+        SUPPORTED_TYPE_CHECK(Tc);                                     \
                                                                       \
         af_dtype tb = (af_dtype)dtype_traits<Tb>::af_type;            \
         Ta h_a      = 0.3;                                            \
@@ -308,7 +308,7 @@ TEST(BinaryTests, Test_pow_cfloat_float) {
 }
 
 TEST(BinaryTests, Test_pow_cdouble_cdouble) {
-    if (noDoubleTests<cdouble>()) return;
+    SUPPORTED_TYPE_CHECK(cdouble);
     af::array a         = randgen(num, c64);
     af::array b         = randgen(num, c64);
     af::array c         = af::pow(a, b);

--- a/test/blas.cpp
+++ b/test/blas.cpp
@@ -43,7 +43,7 @@ TYPED_TEST_CASE(MatrixMultiply, TestTypes);
 
 template<typename T, bool isBVector>
 void MatMulCheck(string TestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 
@@ -122,7 +122,7 @@ TYPED_TEST(MatrixMultiply, RectangleVector) {
 
 template<typename T, bool isBVector>
 void cppMatMulCheck(string TestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 

--- a/test/canny.cpp
+++ b/test/canny.cpp
@@ -36,7 +36,7 @@ TYPED_TEST_CASE(CannyEdgeDetector, TestTypes);
 
 template<typename T>
 void cannyTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -81,7 +81,7 @@ TYPED_TEST(CannyEdgeDetector, ArraySizeEqualBlockSize16x16) {
 
 template<typename T>
 void cannyImageOtsuTest(string pTestFile, bool isColor) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     using af::dim4;

--- a/test/cast.cpp
+++ b/test/cast.cpp
@@ -22,8 +22,8 @@ const int num = 10;
 
 template<typename Ti, typename To>
 void cast_test() {
-    if (noDoubleTests<Ti>()) return;
-    if (noDoubleTests<To>()) return;
+    SUPPORTED_TYPE_CHECK(Ti);
+    SUPPORTED_TYPE_CHECK(To);
 
     af_dtype ta = (af_dtype)dtype_traits<Ti>::af_type;
     af_dtype tb = (af_dtype)dtype_traits<To>::af_type;
@@ -75,8 +75,8 @@ CPLX_TEST_INVOKE(cdouble)
 // conversion explicit.
 template<typename Ti, typename To>
 void cast_test_complex_real() {
-    if (noDoubleTests<Ti>()) return;
-    if (noDoubleTests<To>()) return;
+    SUPPORTED_TYPE_CHECK(Ti);
+    SUPPORTED_TYPE_CHECK(To);
 
     af_dtype ta = (af_dtype)dtype_traits<Ti>::af_type;
     af_dtype tb = (af_dtype)dtype_traits<To>::af_type;

--- a/test/cholesky_dense.cpp
+++ b/test/cholesky_dense.cpp
@@ -33,7 +33,7 @@ using std::vector;
 
 template<typename T>
 void choleskyTester(const int n, double eps, bool is_upper) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 
     dtype ty = (dtype)dtype_traits<T>::af_type;

--- a/test/compare.cpp
+++ b/test/compare.cpp
@@ -29,7 +29,7 @@ TYPED_TEST_CASE(Compare, TestTypes);
 #define COMPARE(OP, Name)                                   \
     TYPED_TEST(Compare, Test_##Name) {                      \
         typedef TypeParam T;                                \
-        if (noDoubleTests<T>()) return;                     \
+        SUPPORTED_TYPE_CHECK(T);                            \
         const int num = 1 << 20;                            \
         af_dtype ty   = (af_dtype)dtype_traits<T>::af_type; \
         array a       = randu(num, ty);                     \

--- a/test/complex.cpp
+++ b/test/complex.cpp
@@ -22,9 +22,9 @@ const int num = 10;
 
 #define COMPLEX_TESTS(Ta, Tb, Tc)                                     \
     TEST(ComplexTests, Test_##Ta##_##Tb) {                            \
-        if (noDoubleTests<Ta>()) return;                              \
-        if (noDoubleTests<Tb>()) return;                              \
-        if (noDoubleTests<Tc>()) return;                              \
+        SUPPORTED_TYPE_CHECK(Ta);                                     \
+        SUPPORTED_TYPE_CHECK(Tb);                                     \
+        SUPPORTED_TYPE_CHECK(Tc);                                     \
                                                                       \
         af_dtype ta   = (af_dtype)dtype_traits<Ta>::af_type;          \
         af_dtype tb   = (af_dtype)dtype_traits<Tb>::af_type;          \
@@ -42,8 +42,8 @@ const int num = 10;
         freeHost(h_c);                                                \
     }                                                                 \
     TEST(ComplexTests, Test_cplx_##Ta##_##Tb##_left) {                \
-        if (noDoubleTests<Ta>()) return;                              \
-        if (noDoubleTests<Tb>()) return;                              \
+        SUPPORTED_TYPE_CHECK(Ta);                                     \
+        SUPPORTED_TYPE_CHECK(Tb);                                     \
                                                                       \
         af_dtype ta   = (af_dtype)dtype_traits<Ta>::af_type;          \
         array a       = randu(num, ta);                               \
@@ -59,8 +59,8 @@ const int num = 10;
     }                                                                 \
                                                                       \
     TEST(ComplexTests, Test_cplx_##Ta##_##Tb##_right) {               \
-        if (noDoubleTests<Ta>()) return;                              \
-        if (noDoubleTests<Tb>()) return;                              \
+        SUPPORTED_TYPE_CHECK(Ta);                                     \
+        SUPPORTED_TYPE_CHECK(Tb);                                     \
                                                                       \
         af_dtype tb   = (af_dtype)dtype_traits<Tb>::af_type;          \
         Ta h_a        = 0.3;                                          \
@@ -75,9 +75,9 @@ const int num = 10;
         freeHost(h_c);                                                \
     }                                                                 \
     TEST(ComplexTests, Test_##Ta##_##Tb##_Real) {                     \
-        if (noDoubleTests<Ta>()) return;                              \
-        if (noDoubleTests<Tb>()) return;                              \
-        if (noDoubleTests<Tc>()) return;                              \
+        SUPPORTED_TYPE_CHECK(Ta);                                     \
+        SUPPORTED_TYPE_CHECK(Tb);                                     \
+        SUPPORTED_TYPE_CHECK(Tc);                                     \
                                                                       \
         af_dtype ta = (af_dtype)dtype_traits<Ta>::af_type;            \
         af_dtype tb = (af_dtype)dtype_traits<Tb>::af_type;            \
@@ -93,9 +93,9 @@ const int num = 10;
         freeHost(h_d);                                                \
     }                                                                 \
     TEST(ComplexTests, Test_##Ta##_##Tb##_Imag) {                     \
-        if (noDoubleTests<Ta>()) return;                              \
-        if (noDoubleTests<Tb>()) return;                              \
-        if (noDoubleTests<Tc>()) return;                              \
+        SUPPORTED_TYPE_CHECK(Ta);                                     \
+        SUPPORTED_TYPE_CHECK(Tb);                                     \
+        SUPPORTED_TYPE_CHECK(Tc);                                     \
                                                                       \
         af_dtype ta = (af_dtype)dtype_traits<Ta>::af_type;            \
         af_dtype tb = (af_dtype)dtype_traits<Tb>::af_type;            \
@@ -111,9 +111,9 @@ const int num = 10;
         freeHost(h_d);                                                \
     }                                                                 \
     TEST(ComplexTests, Test_##Ta##_##Tb##_Conj) {                     \
-        if (noDoubleTests<Ta>()) return;                              \
-        if (noDoubleTests<Tb>()) return;                              \
-        if (noDoubleTests<Tc>()) return;                              \
+        SUPPORTED_TYPE_CHECK(Ta);                                     \
+        SUPPORTED_TYPE_CHECK(Tb);                                     \
+        SUPPORTED_TYPE_CHECK(Tc);                                     \
                                                                       \
         af_dtype ta   = (af_dtype)dtype_traits<Ta>::af_type;          \
         af_dtype tb   = (af_dtype)dtype_traits<Tb>::af_type;          \

--- a/test/constant.cpp
+++ b/test/constant.cpp
@@ -34,7 +34,7 @@ TYPED_TEST_CASE(Constant, TestTypes);
 
 template<typename T>
 void ConstantCPPCheck(T value) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     const int num = 1000;
     T val         = value;
@@ -49,7 +49,7 @@ void ConstantCPPCheck(T value) {
 
 template<typename T>
 void ConstantCCheck(T value) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     const int num = 1000;
     typedef typename dtype_traits<T>::base_type BT;
@@ -68,7 +68,7 @@ void ConstantCCheck(T value) {
 
 template<typename T>
 void IdentityCPPCheck() {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     int num   = 1000;
     dtype dty = (dtype)dtype_traits<T>::af_type;
@@ -106,7 +106,7 @@ void IdentityCPPCheck() {
 
 template<typename T>
 void IdentityLargeDimCheck() {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     const size_t largeDim = 65535 * 8 + 1;
 
@@ -126,7 +126,7 @@ void IdentityLargeDimCheck() {
 
 template<typename T>
 void IdentityCCheck() {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     static const int num = 1000;
     dtype dty            = (dtype)dtype_traits<T>::af_type;
@@ -150,7 +150,7 @@ void IdentityCCheck() {
 
 template<typename T>
 void IdentityCPPError() {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     static const int num = 1000;
     dtype dty            = (dtype)dtype_traits<T>::af_type;

--- a/test/convolve.cpp
+++ b/test/convolve.cpp
@@ -42,7 +42,7 @@ TYPED_TEST_CASE(Convolve, TestTypes);
 
 template<typename T>
 void convolveTest(string pTestFile, int baseDim, bool expand) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -215,7 +215,7 @@ TYPED_TEST(Convolve, Same_Cuboid_One2Many) {
 
 template<typename T>
 void sepConvolveTest(string pTestFile, bool expand) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -307,9 +307,6 @@ TYPED_TEST(Convolve, Separable2D_Same_Rectangle_Batch) {
 }
 
 TEST(Convolve, Separable_TypeCheck) {
-    if (noDoubleTests<float>()) return;
-    if (noDoubleTests<int>()) return;
-
     dim4 sDims(10, 1, 1, 1);
     dim4 fDims(4, 1, 1, 1);
 
@@ -340,9 +337,6 @@ TEST(Convolve, Separable_TypeCheck) {
 }
 
 TEST(Convolve, Separable_DimCheck) {
-    if (noDoubleTests<float>()) return;
-    if (noDoubleTests<int>()) return;
-
     dim4 sDims(10, 1, 1, 1);
     dim4 fDims(4, 1, 1, 1);
 
@@ -383,8 +377,6 @@ using af::span;
 using af::sum;
 
 TEST(Convolve1, CPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<dim4> numDims;
     vector<vector<float> > in;
     vector<vector<float> > tests;
@@ -418,8 +410,6 @@ TEST(Convolve1, CPP) {
 }
 
 TEST(Convolve2, CPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<dim4> numDims;
     vector<vector<float> > in;
     vector<vector<float> > tests;
@@ -456,8 +446,6 @@ TEST(Convolve2, CPP) {
 }
 
 TEST(Convolve3, CPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<dim4> numDims;
     vector<vector<float> > in;
     vector<vector<float> > tests;
@@ -493,8 +481,6 @@ TEST(Convolve3, CPP) {
 }
 
 TEST(Convolve, separable_CPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<dim4> numDims;
     vector<vector<float> > in;
     vector<vector<float> > tests;
@@ -717,7 +703,7 @@ TEST(Convolve, 3D_C32) {
 }
 
 TEST(Convolve, 1D_C64) {
-    if (noDoubleTests<double>()) return;
+    SUPPORTED_TYPE_CHECK(double);
 
     array A = randu(10, c64);
     array B = randu(3, c64);
@@ -732,7 +718,7 @@ TEST(Convolve, 1D_C64) {
 }
 
 TEST(Convolve, 2D_C64) {
-    if (noDoubleTests<double>()) return;
+    SUPPORTED_TYPE_CHECK(double);
 
     array A = randu(10, 10, c64);
     array B = randu(3, 3, c64);
@@ -747,7 +733,7 @@ TEST(Convolve, 2D_C64) {
 }
 
 TEST(Convolve, 3D_C64) {
-    if (noDoubleTests<double>()) return;
+    SUPPORTED_TYPE_CHECK(double);
 
     array A = randu(10, 10, 3, c64);
     array B = randu(3, 3, 3, c64);
@@ -762,8 +748,6 @@ TEST(Convolve, 3D_C64) {
 }
 
 TEST(ConvolveLargeDim1D, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const size_t n        = 10;
     const size_t largeDim = 65535 + 1;
 
@@ -782,8 +766,6 @@ TEST(ConvolveLargeDim1D, CPP) {
 }
 
 TEST(ConvolveLargeDim2D, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const size_t n        = 10;
     const size_t largeDim = 65535 + 1;
 
@@ -801,8 +783,6 @@ TEST(ConvolveLargeDim2D, CPP) {
 }
 
 TEST(DISABLED_ConvolveLargeDim3D, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const size_t n        = 3;
     const size_t largeDim = 65535 * 16 + 1;
 

--- a/test/corrcoef.cpp
+++ b/test/corrcoef.cpp
@@ -69,8 +69,8 @@ struct ccOutType {
 
 TYPED_TEST(CorrelationCoefficient, All) {
     typedef typename ccOutType<TypeParam>::type outType;
-    if (noDoubleTests<TypeParam>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<int> > in;

--- a/test/covariance.cpp
+++ b/test/covariance.cpp
@@ -74,8 +74,8 @@ struct covOutType {
 template<typename T>
 void covTest(string pFileName, bool isbiased = false) {
     typedef typename covOutType<T>::type outType;
-    if (noDoubleTests<T>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(T);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<int> > in;
@@ -126,7 +126,7 @@ TEST(Covariance, c32) {
 }
 
 TEST(Covariance, c64) {
-    if (noDoubleTests<double>()) return;
+    SUPPORTED_TYPE_CHECK(double);
     array a = constant(cdouble(1.0, -1.0), 10, c64);
     array b = constant(cdouble(2.0, -1.0), 10, c64);
     ASSERT_THROW(cov(a, b), exception);

--- a/test/diagonal.cpp
+++ b/test/diagonal.cpp
@@ -33,7 +33,7 @@ typedef ::testing::Types<float, double, int, uint, char, unsigned char>
 TYPED_TEST_CASE(Diagonal, TestTypes);
 
 TYPED_TEST(Diagonal, Create) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
     try {
         static const int size = 1000;
         vector<TypeParam> input(size * size);
@@ -58,7 +58,7 @@ TYPED_TEST(Diagonal, Create) {
 }
 
 TYPED_TEST(Diagonal, DISABLED_CreateLargeDim) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
     try {
         deviceGC();
         {
@@ -72,7 +72,7 @@ TYPED_TEST(Diagonal, DISABLED_CreateLargeDim) {
 }
 
 TYPED_TEST(Diagonal, Extract) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     try {
         static const int size = 1000;
@@ -93,7 +93,7 @@ TYPED_TEST(Diagonal, Extract) {
 }
 
 TYPED_TEST(Diagonal, ExtractLargeDim) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     try {
         static const size_t n        = 10;
@@ -113,7 +113,7 @@ TYPED_TEST(Diagonal, ExtractLargeDim) {
 }
 
 TYPED_TEST(Diagonal, ExtractRect) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     try {
         static const int size0 = 1000, size1 = 900;

--- a/test/diff1.cpp
+++ b/test/diff1.cpp
@@ -55,7 +55,7 @@ TYPED_TEST_CASE(Diff1, TestTypes);
 template<typename T>
 void diff1Test(string pTestFile, unsigned dim, bool isSubRef = false,
                const vector<af_seq> *seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 
@@ -147,7 +147,7 @@ TYPED_TEST(Diff1, Subref2) {
 
 template<typename T>
 void diff1ArgsTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 
@@ -211,8 +211,6 @@ TEST(Diff1, DiffLargeDim) {
 }
 
 TEST(Diff1, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const unsigned dim = 0;
     vector<dim4> numDims;
 

--- a/test/diff2.cpp
+++ b/test/diff2.cpp
@@ -60,7 +60,7 @@ TYPED_TEST_CASE(Diff2, TestTypes);
 template<typename T>
 void diff2Test(string pTestFile, unsigned dim, bool isSubRef = false,
                const vector<af_seq> *seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 
@@ -149,7 +149,7 @@ TYPED_TEST(Diff2, Subref2) {
 
 template<typename T>
 void diff2ArgsTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 
@@ -206,8 +206,6 @@ TEST(Diff2, DiffLargeDim) {
 ////////////////////////////////// CPP ////////////////////////////////////////
 //
 TEST(Diff2, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const unsigned dim = 1;
     vector<dim4> numDims;
 

--- a/test/dog.cpp
+++ b/test/dog.cpp
@@ -40,7 +40,7 @@ typedef ::testing::Types<float, double, int, uint, char, uchar, short, ushort>
 TYPED_TEST_CASE(DOG, TestTypes);
 
 TYPED_TEST(DOG, Basic) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dim4 iDims(512, 512, 1, 1);
     array in = constant(1, iDims, (af_dtype)dtype_traits<float>::af_type);
@@ -58,7 +58,7 @@ TYPED_TEST(DOG, Basic) {
 }
 
 TYPED_TEST(DOG, Batch) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     dim4 iDims(512, 512, 3, 1);
     array in = constant(1, iDims, (af_dtype)dtype_traits<float>::af_type);

--- a/test/dot.cpp
+++ b/test/dot.cpp
@@ -51,7 +51,7 @@ template<typename T>
 void dotTest(string pTestFile, const int resultIdx,
              const af_mat_prop optLhs = AF_MAT_NONE,
              const af_mat_prop optRhs = AF_MAT_NONE) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -112,7 +112,7 @@ template<typename T>
 void dotAllTest(string pTestFile, const int resultIdx,
                 const af_mat_prop optLhs = AF_MAT_NONE,
                 const af_mat_prop optRhs = AF_MAT_NONE) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;

--- a/test/fast.cpp
+++ b/test/fast.cpp
@@ -68,7 +68,7 @@ TYPED_TEST_CASE(FixedFAST, FixedTestTypes);
 
 template<typename T>
 void fastTest(string pTestFile, bool nonmax) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;
@@ -180,7 +180,6 @@ using af::features;
 using af::loadImage;
 
 TEST(FloatFAST, CPP) {
-    if (noDoubleTests<float>()) return;
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;

--- a/test/fft.cpp
+++ b/test/fft.cpp
@@ -59,8 +59,6 @@ TEST(fft, Invalid_Type) {
 }
 
 TEST(fft2, Invalid_Array) {
-    if (noDoubleTests<float>()) return;
-
     vector<float> in(100, 1);
 
     af_array inArray  = 0;
@@ -76,8 +74,6 @@ TEST(fft2, Invalid_Array) {
 }
 
 TEST(fft3, Invalid_Array) {
-    if (noDoubleTests<float>()) return;
-
     vector<float> in(100, 1);
 
     af_array inArray  = 0;
@@ -93,8 +89,6 @@ TEST(fft3, Invalid_Array) {
 }
 
 TEST(ifft2, Invalid_Array) {
-    if (noDoubleTests<float>()) return;
-
     vector<float> in(100, 1);
 
     af_array inArray  = 0;
@@ -110,8 +104,6 @@ TEST(ifft2, Invalid_Array) {
 }
 
 TEST(ifft3, Invalid_Array) {
-    if (noDoubleTests<float>()) return;
-
     vector<float> in(100, 1);
 
     af_array inArray  = 0;
@@ -128,8 +120,8 @@ TEST(ifft3, Invalid_Array) {
 
 template<typename inType, typename outType, bool isInverse>
 void fftTest(string pTestFile, dim_t pad0 = 0, dim_t pad1 = 0, dim_t pad2 = 0) {
-    if (noDoubleTests<inType>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(inType);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<inType> > in;
@@ -294,8 +286,8 @@ INSTANTIATE_TEST(ifft3, C2C_Double, true, cdouble, cdouble,
 template<typename inType, typename outType, int rank, bool isInverse>
 void fftBatchTest(string pTestFile, dim_t pad0 = 0, dim_t pad1 = 0,
                   dim_t pad2 = 0) {
-    if (noDoubleTests<inType>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(inType);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<inType> > in;
@@ -431,8 +423,8 @@ INSTANTIATE_BATCH_TEST(fft2, C2C_Double_Pad, 2, false, cdouble, cdouble,
 //
 template<typename inType, typename outType, bool isInverse>
 void cppFFTTest(string pTestFile) {
-    if (noDoubleTests<inType>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(inType);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<inType> > in;
@@ -477,8 +469,8 @@ void cppFFTTest(string pTestFile) {
 
 template<typename inType, typename outType, bool isInverse>
 void cppDFTTest(string pTestFile) {
-    if (noDoubleTests<inType>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(inType);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<inType> > in;

--- a/test/fft_real.cpp
+++ b/test/fft_real.cpp
@@ -54,7 +54,7 @@ array fft(const array &in, double norm) {
 template<typename Tc, int rank>
 void fft_real(dim4 dims) {
     typedef typename dtype_traits<Tc>::base_type Tr;
-    if (noDoubleTests<Tr>()) return;
+    SUPPORTED_TYPE_CHECK(Tr);
 
     dtype ty = (dtype)dtype_traits<Tr>::af_type;
     array a  = randu(dims, ty);

--- a/test/fftconvolve.cpp
+++ b/test/fftconvolve.cpp
@@ -50,7 +50,7 @@ TYPED_TEST_CASE(FFTConvolveLarge, TestTypesLarge);
 
 template<typename T, int baseDim>
 void fftconvolveTest(string pTestFile, bool expand) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -107,7 +107,7 @@ void fftconvolveTest(string pTestFile, bool expand) {
 template<typename T, int baseDim>
 void fftconvolveTestLarge(int sDim, int fDim, int sBatch, int fBatch,
                           bool expand) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     using af::seq;
 
@@ -344,8 +344,6 @@ TYPED_TEST(FFTConvolve, Same_Cuboid_One2Many) {
 }
 
 TEST(FFTConvolve1, CPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<dim4> numDims;
     vector<vector<float> > in;
     vector<vector<float> > tests;
@@ -379,8 +377,6 @@ TEST(FFTConvolve1, CPP) {
 }
 
 TEST(FFTConvolve2, CPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<dim4> numDims;
     vector<vector<float> > in;
     vector<vector<float> > tests;
@@ -417,8 +413,6 @@ TEST(FFTConvolve2, CPP) {
 }
 
 TEST(FFTConvolve3, CPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<dim4> numDims;
     vector<vector<float> > in;
     vector<vector<float> > tests;

--- a/test/gaussiankernel.cpp
+++ b/test/gaussiankernel.cpp
@@ -34,7 +34,7 @@ TYPED_TEST_CASE(GaussianKernel, TestTypes);
 
 template<typename T>
 void gaussianKernelTest(string pFileName, double sigma) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<int> > in;

--- a/test/gloh_nonfree.cpp
+++ b/test/gloh_nonfree.cpp
@@ -139,7 +139,7 @@ TYPED_TEST_CASE(GLOH, TestTypes);
 template<typename T>
 void glohTest(string pTestFile) {
 #ifdef AF_WITH_NONFREE_SIFT
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;
@@ -270,7 +270,6 @@ GLOH_INIT(man, man);
 //
 TEST(GLOH, CPP) {
 #ifdef AF_WITH_NONFREE_SIFT
-    if (noDoubleTests<float>()) return;
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;

--- a/test/gradient.cpp
+++ b/test/gradient.cpp
@@ -47,7 +47,7 @@ template<typename T>
 void gradTest(string pTestFile, const unsigned resultIdx0,
               const unsigned resultIdx1, bool isSubRef = false,
               const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -124,8 +124,6 @@ GRAD_INIT(Grad2, grad3D, 0, 1);
 using af::array;
 
 TEST(Grad, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const unsigned resultIdx0 = 0;
     const unsigned resultIdx1 = 1;
 
@@ -170,8 +168,6 @@ TEST(Grad, CPP) {
 TEST(Grad, MaxDim) {
     using af::constant;
     using af::sum;
-
-    if (noDoubleTests<float>()) return;
 
     const size_t largeDim = 65535 * 8 + 1;
 

--- a/test/harris.cpp
+++ b/test/harris.cpp
@@ -60,7 +60,7 @@ TYPED_TEST_CASE(Harris, TestTypes);
 
 template<typename T>
 void harrisTest(string pTestFile, float sigma, unsigned block_size) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;
@@ -167,7 +167,6 @@ using af::harris;
 using af::loadImage;
 
 TEST(FloatHarris, CPP) {
-    if (noDoubleTests<float>()) return;
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;

--- a/test/histogram.cpp
+++ b/test/histogram.cpp
@@ -41,8 +41,8 @@ TYPED_TEST_CASE(Histogram, TestTypes);
 
 template<typename inType, typename outType>
 void histTest(string pTestFile, unsigned nbins, double minval, double maxval) {
-    if (noDoubleTests<inType>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(inType);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
 
@@ -114,9 +114,6 @@ using af::seq;
 using af::span;
 
 TEST(Histogram, CPP) {
-    if (noDoubleTests<float>()) return;
-    if (noDoubleTests<int>()) return;
-
     const unsigned nbins = 100;
     const double minval  = 0.0;
     const double maxval  = 99.0;

--- a/test/homography.cpp
+++ b/test/homography.cpp
@@ -48,7 +48,7 @@ void homographyTest(string pTestFile, const af_homography_type htype,
     using af::dtype_traits;
     using af::Pi;
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;

--- a/test/iir.cpp
+++ b/test/iir.cpp
@@ -42,7 +42,7 @@ TYPED_TEST_CASE(filter, TestTypes);
 template<typename T>
 void firTest(const int xrows, const int xcols, const int brows,
              const int bcols) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     try {
         dtype ty = (dtype)dtype_traits<T>::af_type;
         array x  = randu(xrows, xcols, ty);
@@ -81,7 +81,7 @@ TYPED_TEST(filter, firMatMat) { firTest<TypeParam>(5000, 10, 50, 10); }
 template<typename T>
 void iirA0Test(const int xrows, const int xcols, const int brows,
                const int bcols) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     try {
         dtype ty    = (dtype)dtype_traits<T>::af_type;
         array x     = randu(xrows, xcols, ty);
@@ -121,7 +121,7 @@ TYPED_TEST(filter, iirA0MatMat) { iirA0Test<TypeParam>(5000, 10, 50, 10); }
 
 template<typename T>
 void iirTest(const char *testFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     vector<dim4> inDims;
 
     vector<vector<T> > inputs;

--- a/test/imageio.cpp
+++ b/test/imageio.cpp
@@ -36,7 +36,6 @@ typedef ::testing::Types<float> TestTypes;
 TYPED_TEST_CASE(ImageIO, TestTypes);
 
 void loadImageTest(string pTestFile, string pImageFile, const bool isColor) {
-    if (noDoubleTests<float>()) return;
     if (noImageIOTests()) return;
 
     vector<dim4> numDims;
@@ -123,7 +122,6 @@ using af::saveImageMem;
 using af::span;
 
 TEST(ImageIO, CPP) {
-    if (noDoubleTests<float>()) return;
     if (noImageIOTests()) return;
 
     vector<dim4> numDims;
@@ -186,7 +184,6 @@ TEST(ImageIO, SaveBMPCPP) {
 }
 
 TEST(ImageMem, SaveMemPNG) {
-    if (noDoubleTests<float>()) return;
     if (noImageIOTests()) return;
 
     array img =
@@ -202,7 +199,6 @@ TEST(ImageMem, SaveMemPNG) {
 }
 
 TEST(ImageMem, SaveMemJPG1) {
-    if (noDoubleTests<float>()) return;
     if (noImageIOTests()) return;
 
     array img =
@@ -220,7 +216,6 @@ TEST(ImageMem, SaveMemJPG1) {
 }
 
 TEST(ImageMem, SaveMemJPG3) {
-    if (noDoubleTests<float>()) return;
     if (noImageIOTests()) return;
 
     array img =
@@ -238,7 +233,6 @@ TEST(ImageMem, SaveMemJPG3) {
 }
 
 TEST(ImageMem, SaveMemBMP) {
-    if (noDoubleTests<float>()) return;
     if (noImageIOTests()) return;
 
     array img =

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -43,7 +43,7 @@ void checkValues(const af_seq &seq, const T *data, const T *indexed_data,
 
 template<typename T>
 void DimCheck(const vector<af_seq> &seqs) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     static const int ndims   = 1;
     static const size_t dims = 100;
@@ -325,7 +325,7 @@ class Indexing2D : public ::testing::Test {
 template<typename T>
 void DimCheck2D(const vector<vector<af_seq> > &seqs, string TestFile,
                 size_t NDims) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 
@@ -539,7 +539,7 @@ class Indexing : public ::testing::Test {
 template<typename T>
 void DimCheckND(const vector<vector<af_seq> > &seqs, string TestFile,
                 size_t NDims) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     // DimCheck2D function is generalized enough
     // to check 3d and 4d indexing
@@ -656,8 +656,6 @@ using af::span;
 using af::where;
 
 TEST(Indexing2D, ColumnContiniousCPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<vector<af_seq> > seqs;
 
     seqs.push_back(make_vec(af_span, af_make_seq(0, 6, 1)));
@@ -714,7 +712,7 @@ TYPED_TEST_CASE(lookup, ArrIdxTestTypes);
 
 template<typename T>
 void arrayIndexTest(string pTestFile, int dim) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -1252,7 +1250,7 @@ class IndexedMembers : public ::testing::Test {
 TYPED_TEST_CASE(IndexedMembers, AllTypes);
 
 TYPED_TEST(IndexedMembers, MemFuncs) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     const dim_t dimsize = 100;
     vector<TypeParam> in(dimsize * dimsize);

--- a/test/inverse_deconv.cpp
+++ b/test/inverse_deconv.cpp
@@ -37,7 +37,7 @@ void invDeconvImageTest(string pTestFile, const float gamma,
         typename cond_type<is_same_type<T, double>::value, double, float>::type
             OutType;
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     using af::dim4;

--- a/test/inverse_dense.cpp
+++ b/test/inverse_dense.cpp
@@ -33,7 +33,7 @@ using std::abs;
 
 template<typename T>
 void inverseTester(const int m, const int n, double eps) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 #if 1
     array A = cpu_randu<T>(dim4(m, n));

--- a/test/iota.cpp
+++ b/test/iota.cpp
@@ -47,7 +47,7 @@ TYPED_TEST_CASE(Iota, TestTypes);
 
 template<typename T>
 void iotaTest(const dim4 idims, const dim4 tdims) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     af_array outArray = 0;
 
@@ -102,8 +102,6 @@ using af::array;
 using af::iota;
 
 TEST(Iota, CPP) {
-    if (noDoubleTests<float>()) return;
-
     dim4 idims(23, 15, 1, 1);
     dim4 tdims(2, 2, 1, 1);
     dim4 fulldims;

--- a/test/ireduce.cpp
+++ b/test/ireduce.cpp
@@ -29,7 +29,7 @@ using std::vector;
 
 #define MINMAXOP(fn, ty)                                        \
     TEST(IndexedReduce, fn##_##ty##_0) {                        \
-        if (noDoubleTests<ty>()) return;                        \
+        SUPPORTED_TYPE_CHECK(ty);                               \
         dtype dty    = (dtype)dtype_traits<ty>::af_type;        \
         const int nx = 10000;                                   \
         const int ny = 100;                                     \
@@ -52,7 +52,7 @@ using std::vector;
         af_free_host(h_idx);                                    \
     }                                                           \
     TEST(IndexedReduce, fn##_##ty##_1) {                        \
-        if (noDoubleTests<ty>()) return;                        \
+        SUPPORTED_TYPE_CHECK(ty);                               \
         dtype dty    = (dtype)dtype_traits<ty>::af_type;        \
         const int nx = 100;                                     \
         const int ny = 100;                                     \
@@ -76,7 +76,7 @@ using std::vector;
         af_free_host(h_idx);                                    \
     }                                                           \
     TEST(IndexedReduce, fn##_##ty##_all) {                      \
-        if (noDoubleTests<ty>()) return;                        \
+        SUPPORTED_TYPE_CHECK(ty);                               \
         dtype dty     = (dtype)dtype_traits<ty>::af_type;       \
         const int num = 100000;                                 \
         array in      = randu(num, dty);                        \

--- a/test/iterative_deconv.cpp
+++ b/test/iterative_deconv.cpp
@@ -37,7 +37,7 @@ void iterDeconvImageTest(string pTestFile, const unsigned iters, const float rf,
         typename cond_type<is_same_type<T, double>::value, double, float>::type
             OutType;
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     using af::dim4;

--- a/test/join.cpp
+++ b/test/join.cpp
@@ -54,7 +54,7 @@ template<typename T>
 void joinTest(string pTestFile, const unsigned dim, const unsigned in0,
               const unsigned in1, const unsigned resultIdx,
               bool isSubRef = false, const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -153,8 +153,6 @@ TEST(Join, JoinLargeDim) {
 ///////////////////////////////// CPP ////////////////////////////////////
 //
 TEST(Join, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const unsigned resultIdx = 2;
     const unsigned dim       = 2;
 
@@ -179,8 +177,6 @@ TEST(Join, CPP) {
 }
 
 TEST(JoinMany0, CPP) {
-    if (noDoubleTests<float>()) return;
-
     array a0 = randu(10, 5);
     array a1 = randu(20, 5);
     array a2 = randu(5, 5);
@@ -192,8 +188,6 @@ TEST(JoinMany0, CPP) {
 }
 
 TEST(JoinMany1, CPP) {
-    if (noDoubleTests<float>()) return;
-
     array a0 = randu(20, 200);
     array a1 = randu(20, 400);
     array a2 = randu(20, 10);

--- a/test/lu_dense.cpp
+++ b/test/lu_dense.cpp
@@ -37,7 +37,6 @@ using std::string;
 using std::vector;
 
 TEST(LU, InPlaceSmall) {
-    if (noDoubleTests<float>()) return;
     if (noLAPACKTests()) return;
 
     int resultIdx = 0;
@@ -76,7 +75,6 @@ TEST(LU, InPlaceSmall) {
 }
 
 TEST(LU, SplitSmall) {
-    if (noDoubleTests<float>()) return;
     if (noLAPACKTests()) return;
 
     int resultIdx = 0;
@@ -129,7 +127,7 @@ TEST(LU, SplitSmall) {
 
 template<typename T>
 void luTester(const int m, const int n, double eps) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 
 #if 1

--- a/test/match_template.cpp
+++ b/test/match_template.cpp
@@ -42,7 +42,7 @@ void matchTemplateTest(string pTestFile, af_match_type pMatchType) {
     typedef
         typename cond_type<is_same_type<T, double>::value, double, float>::type
             outType;
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;

--- a/test/math.cpp
+++ b/test/math.cpp
@@ -36,7 +36,7 @@ T sigmoid(T in) {
 #define TEST_REAL(T, func, err, lo, hi)                          \
     TEST(MathTests, Test_##func##_##T) {                         \
         try {                                                    \
-            if (noDoubleTests<T>()) return;                      \
+            SUPPORTED_TYPE_CHECK(T);                             \
             af_dtype ty = (af_dtype)dtype_traits<T>::af_type;    \
             array a     = (hi - lo) * randu(num, ty) + lo + err; \
             eval(a);                                             \
@@ -56,7 +56,7 @@ T sigmoid(T in) {
 #define TEST_CPLX(T, func, err, lo, hi)                          \
     TEST(MathTests, Test_##func##_##T) {                         \
         try {                                                    \
-            if (noDoubleTests<T>()) return;                      \
+            SUPPORTED_TYPE_CHECK(T);                             \
             af_dtype ty = (af_dtype)dtype_traits<T>::af_type;    \
             array a     = (hi - lo) * randu(num, ty) + lo + err; \
             eval(a);                                             \

--- a/test/mean.cpp
+++ b/test/mean.cpp
@@ -75,8 +75,8 @@ struct meanOutType {
 template<typename T>
 void meanDimTest(string pFileName, dim_t dim, bool isWeighted = false) {
     typedef typename meanOutType<T>::type outType;
-    if (noDoubleTests<T>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(T);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<int> > in;
@@ -173,8 +173,8 @@ TYPED_TEST(Mean, Wtd_Dim1Matrix) {
 template<typename T>
 void meanAllTest(T const_value, dim4 dims) {
     typedef typename meanOutType<T>::type outType;
-    if (noDoubleTests<T>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(T);
+    SUPPORTED_TYPE_CHECK(outType);
 
     using af::array;
     using af::mean;
@@ -241,9 +241,9 @@ template<typename T, typename wtsType>
 void weightedMeanAllTest(dim4 dims) {
     typedef typename meanOutType<T>::type outType;
 
-    if (noDoubleTests<T>()) return;
-    if (noDoubleTests<outType>()) return;
-    if (noDoubleTests<wtsType>()) return;
+    SUPPORTED_TYPE_CHECK(T);
+    SUPPORTED_TYPE_CHECK(outType);
+    SUPPORTED_TYPE_CHECK(wtsType);
 
     using af::array;
     using af::mean;

--- a/test/meanshift.cpp
+++ b/test/meanshift.cpp
@@ -35,7 +35,7 @@ typedef ::testing::Types<float, double, int, uint, char, uchar, short, ushort,
 TYPED_TEST_CASE(Meanshift, TestTypes);
 
 TYPED_TEST(Meanshift, InvalidArgs) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     vector<TypeParam> in(100, 1);
 
@@ -53,7 +53,7 @@ TYPED_TEST(Meanshift, InvalidArgs) {
 
 template<typename T, bool isColor>
 void meanshiftTest(string pTestFile, const float ss) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;
@@ -138,7 +138,6 @@ using af::seq;
 using af::span;
 
 TEST(Meanshift, Color_CPP) {
-    if (noDoubleTests<float>()) return;
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;

--- a/test/medfilt.cpp
+++ b/test/medfilt.cpp
@@ -45,7 +45,7 @@ TYPED_TEST_CASE(MedianFilter1d, TestTypes);
 template<typename T>
 void medfiltTest(string pTestFile, dim_t w_len, dim_t w_wid,
                  af_border_type pad) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -105,7 +105,7 @@ TYPED_TEST(MedianFilter, BATCH_SYMMETRIC_PAD_3x3) {
 
 template<typename T>
 void medfilt1_Test(string pTestFile, dim_t w_wid, af_border_type pad) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -165,7 +165,7 @@ TYPED_TEST(MedianFilter1d, BATCH_SYMMETRIC_PAD_3) {
 
 template<typename T, bool isColor>
 void medfiltImageTest(string pTestFile, dim_t w_len, dim_t w_wid) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;
@@ -212,7 +212,7 @@ void medfiltImageTest(string pTestFile, dim_t w_len, dim_t w_wid) {
 
 template<typename T>
 void medfiltInputTest(void) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     af_array inArray  = 0;
     af_array outArray = 0;
@@ -241,7 +241,7 @@ TYPED_TEST(MedianFilter, InvalidArray) { medfiltInputTest<TypeParam>(); }
 
 template<typename T>
 void medfiltWindowTest(void) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     af_array inArray  = 0;
     af_array outArray = 0;
@@ -264,7 +264,7 @@ TYPED_TEST(MedianFilter, InvalidWindow) { medfiltWindowTest<TypeParam>(); }
 
 template<typename T>
 void medfilt1d_WindowTest(void) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     af_array inArray  = 0;
     af_array outArray = 0;
@@ -287,7 +287,7 @@ TYPED_TEST(MedianFilter1d, InvalidWindow) { medfilt1d_WindowTest<TypeParam>(); }
 
 template<typename T>
 void medfiltPadTest(void) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     af_array inArray  = 0;
     af_array outArray = 0;
@@ -314,7 +314,7 @@ TYPED_TEST(MedianFilter, InvalidPadType) { medfiltPadTest<TypeParam>(); }
 
 template<typename T>
 void medfilt1d_PadTest(void) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     af_array inArray  = 0;
     af_array outArray = 0;
@@ -345,8 +345,6 @@ TYPED_TEST(MedianFilter1d, InvalidPadType) { medfilt1d_PadTest<TypeParam>(); }
 using af::array;
 
 TEST(MedianFilter, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const dim_t w_len = 3;
     const dim_t w_wid = 3;
 
@@ -374,8 +372,6 @@ TEST(MedianFilter, CPP) {
 }
 
 TEST(MedianFilter1d, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const dim_t w_wid = 3;
 
     vector<dim4> numDims;

--- a/test/median.cpp
+++ b/test/median.cpp
@@ -45,7 +45,7 @@ array generateArray<unsigned int>(int nx, int ny, int nz, int nw) {
 
 template<typename To, typename Ti>
 void median_flat(int nx, int ny = 1, int nz = 1, int nw = 1) {
-    if (noDoubleTests<Ti>()) return;
+    SUPPORTED_TYPE_CHECK(Ti);
     array a = generateArray<Ti>(nx, ny, nz, nw);
 
     // Verification
@@ -71,7 +71,7 @@ void median_flat(int nx, int ny = 1, int nz = 1, int nw = 1) {
 
 template<typename To, typename Ti, int dim>
 void median_test(int nx, int ny = 1, int nz = 1, int nw = 1) {
-    if (noDoubleTests<Ti>()) return;
+    SUPPORTED_TYPE_CHECK(Ti);
 
     array a = generateArray<Ti>(nx, ny, nz, nw);
 

--- a/test/memory.cpp
+++ b/test/memory.cpp
@@ -82,7 +82,7 @@ size_t roundUpToStep(size_t bytes) {
 
 template<typename T>
 void memAllocArrayScopeTest(int elements) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     size_t alloc_bytes, alloc_buffers;
     size_t lock_bytes, lock_buffers;
@@ -112,7 +112,7 @@ void memAllocArrayScopeTest(int elements) {
 
 template<typename T>
 void memAllocPtrScopeTest(int elements) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     size_t alloc_bytes, alloc_buffers;
     size_t lock_bytes, lock_buffers;

--- a/test/moddims.cpp
+++ b/test/moddims.cpp
@@ -46,7 +46,7 @@ TYPED_TEST_CASE(Moddims, TestTypes);
 template<typename T>
 void moddimsTest(string pTestFile, bool isSubRef = false,
                  const vector<af_seq> *seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 
@@ -127,7 +127,7 @@ TYPED_TEST(Moddims, Subref) {
 
 template<typename T>
 void moddimsArgsTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 
@@ -160,7 +160,7 @@ TYPED_TEST(Moddims, InvalidArgs) {
 
 template<typename T>
 void moddimsMismatchTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 
@@ -196,7 +196,7 @@ using af::array;
 template<typename T>
 void cppModdimsTest(string pTestFile, bool isSubRef = false,
                     const vector<af_seq> *seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 

--- a/test/moments.cpp
+++ b/test/moments.cpp
@@ -43,7 +43,7 @@ TYPED_TEST_CASE(Image, TestTypes);
 
 template<typename T>
 void momentsTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 

--- a/test/morph.cpp
+++ b/test/morph.cpp
@@ -38,7 +38,7 @@ TYPED_TEST_CASE(Morph, TestTypes);
 
 template<typename inType, bool isDilation, bool isVolume>
 void morphTest(string pTestFile) {
-    if (noDoubleTests<inType>()) return;
+    SUPPORTED_TYPE_CHECK(inType);
 
     vector<dim4> numDims;
     vector<vector<inType> > in;
@@ -135,7 +135,7 @@ TYPED_TEST(Morph, Erode4x4x4) {
 
 template<typename T, bool isDilation, bool isColor>
 void morphImageTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;
@@ -198,7 +198,7 @@ TEST(Morph, ColorImage) {
 
 template<typename T, bool isDilation>
 void morphInputTest(void) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     af_array inArray   = 0;
     af_array maskArray = 0;
@@ -235,7 +235,7 @@ TYPED_TEST(Morph, ErodeInvalidInput) { morphInputTest<TypeParam, false>(); }
 
 template<typename T, bool isDilation>
 void morphMaskTest(void) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     af_array inArray   = 0;
     af_array maskArray = 0;
@@ -286,7 +286,7 @@ TYPED_TEST(Morph, ErodeInvalidMask) { morphMaskTest<TypeParam, false>(); }
 
 template<typename T, bool isDilation>
 void morph3DMaskTest(void) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     af_array inArray   = 0;
     af_array maskArray = 0;
@@ -354,7 +354,7 @@ using af::span;
 
 template<typename T, bool isDilation, bool isColor>
 void cppMorphImageTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;

--- a/test/nearest_neighbour.cpp
+++ b/test/nearest_neighbour.cpp
@@ -65,7 +65,7 @@ TYPED_TEST_CASE(NearestNeighbour, TestTypes);
 template<typename T>
 void nearestNeighbourTest(string pTestFile, int feat_dim,
                           const af_match_type type) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     typedef typename otype_t<T>::otype To;
 

--- a/test/orb.cpp
+++ b/test/orb.cpp
@@ -129,7 +129,7 @@ TYPED_TEST_CASE(ORB, TestTypes);
 
 template<typename T>
 void orbTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;
@@ -247,7 +247,6 @@ TYPED_TEST(ORB, Lena) { orbTest<TypeParam>(string(TEST_DIR "/orb/lena.test")); }
 ///////////////////////////////////// CPP ////////////////////////////////
 //
 TEST(ORB, CPP) {
-    if (noDoubleTests<float>()) return;
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;

--- a/test/qr_dense.cpp
+++ b/test/qr_dense.cpp
@@ -34,7 +34,6 @@ using std::vector;
 
 ///////////////////////////////// CPP ////////////////////////////////////
 TEST(QRFactorized, CPP) {
-    if (noDoubleTests<float>()) return;
     if (noLAPACKTests()) return;
 
     int resultIdx = 0;
@@ -90,7 +89,7 @@ TEST(QRFactorized, CPP) {
 template<typename T>
 void qrTester(const int m, const int n, double eps) {
     try {
-        if (noDoubleTests<T>()) return;
+        SUPPORTED_TYPE_CHECK(T);
         if (noLAPACKTests()) return;
 
 #if 1

--- a/test/random.cpp
+++ b/test/random.cpp
@@ -87,7 +87,7 @@ TYPED_TEST_CASE(RandomSeed, TestTypesSeed);
 
 template<typename T>
 void randuTest(dim4 &dims) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     af_array outArray = 0;
     ASSERT_SUCCESS(af_randu(&outArray, dims.ndims(), dims.get(),
@@ -98,7 +98,7 @@ void randuTest(dim4 &dims) {
 
 template<typename T>
 void randnTest(dim4 &dims) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     af_array outArray = 0;
     ASSERT_SUCCESS(af_randn(&outArray, dims.ndims(), dims.get(),
@@ -150,7 +150,7 @@ RAND(45, 1, 1, 1);
 
 template<typename T>
 void randuArgsTest() {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     dim_t ndims       = 4;
     dim_t dims[]      = {1, 2, 3, 0};
@@ -165,7 +165,7 @@ TYPED_TEST(Random, InvalidArgs) { randuArgsTest<TypeParam>(); }
 
 template<typename T>
 void randuDimsTest() {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     dim4 dims(1, 65535 * 32, 1, 1);
     array large_rand = randu(dims, (af_dtype)dtype_traits<T>::af_type);
@@ -207,8 +207,6 @@ TEST(RandomEngine, Default) {
 }
 
 TEST(Random, CPP) {
-    if (noDoubleTests<float>()) return;
-
     // TEST will fail if exception is thrown, which are thrown
     // when only wrong inputs are thrown on bad access happens
     dim4 dims(1, 2, 3, 1);
@@ -228,7 +226,7 @@ TEST(Random, CPP) {
 
 template<typename T>
 void testSetSeed(const uintl seed0, const uintl seed1) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     uintl orig_seed = getSeed();
 
@@ -280,7 +278,7 @@ TYPED_TEST(RandomSeed, setSeed) { testSetSeed<TypeParam>(10101, 23232); }
 
 template<typename T>
 void testGetSeed(const uintl seed0, const uintl seed1) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     uintl orig_seed = getSeed();
 
@@ -306,7 +304,7 @@ TYPED_TEST(Random, getSeed) { testGetSeed<TypeParam>(1234, 9876); }
 
 template<typename T>
 void testRandomEngineUniform(randomEngineType type) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     dtype ty = (dtype)dtype_traits<T>::af_type;
 
     int elem = 16 * 1024 * 1024;
@@ -320,7 +318,7 @@ void testRandomEngineUniform(randomEngineType type) {
 
 template<typename T>
 void testRandomEngineNormal(randomEngineType type) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     dtype ty = (dtype)dtype_traits<T>::af_type;
 
     int elem = 16 * 1024 * 1024;
@@ -404,7 +402,7 @@ TYPED_TEST(RandomEngineSeed, mersenneSeedUniform) {
 
 template<typename T>
 void testRandomEnginePeriod(randomEngineType type) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     dtype ty = (dtype)dtype_traits<T>::af_type;
 
     int elem  = 1024 * 1024;
@@ -441,7 +439,7 @@ T chi2_statistic(array input, array expected) {
 
 template<typename T>
 void testRandomEngineUniformChi2(randomEngineType type) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     dtype ty = (dtype)dtype_traits<T>::af_type;
 
     int elem  = 256 * 1024 * 1024;

--- a/test/range.cpp
+++ b/test/range.cpp
@@ -51,7 +51,7 @@ TYPED_TEST_CASE(Range, TestTypes);
 template<typename T>
 void rangeTest(const uint x, const uint y, const uint z, const uint w,
                const uint dim) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     dim4 idims(x, y, z, w);
 
@@ -119,8 +119,6 @@ RANGE_INIT(Range1DMaxDim3, 1, 1, 1, 65535 * 32 + 1, 0);
 ///////////////////////////////// CPP ////////////////////////////////////
 //
 TEST(Range, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const unsigned x   = 23;
     const unsigned y   = 15;
     const unsigned z   = 4;

--- a/test/rank_dense.cpp
+++ b/test/rank_dense.cpp
@@ -45,7 +45,7 @@ TYPED_TEST_CASE(Det, TestTypes);
 
 template<typename T>
 void rankSmall() {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 
     T ha[] = {1, 4, 7, 2, 5, 8, 3, 6, 20};
@@ -56,7 +56,7 @@ void rankSmall() {
 
 template<typename T>
 void rankBig(const int num) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 
     dtype dt = (dtype)dtype_traits<T>::af_type;
@@ -70,7 +70,7 @@ void rankBig(const int num) {
 
 template<typename T>
 void rankLow(const int num) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 
     dtype dt = (dtype)dtype_traits<T>::af_type;
@@ -92,7 +92,7 @@ TYPED_TEST(Rank, low) { rankBig<TypeParam>(512); }
 
 template<typename T>
 void detTest() {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 
     dtype dt = (dtype)dtype_traits<T>::af_type;

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -41,8 +41,8 @@ typedef af_err (*reduceFunc)(af_array *, const af_array, const int);
 template<typename Ti, typename To, reduceFunc af_reduce>
 void reduceTest(string pTestFile, int off = 0, bool isSubRef = false,
                 const vector<af_seq> seqv = vector<af_seq>()) {
-    if (noDoubleTests<Ti>()) return;
-    if (noDoubleTests<To>()) return;
+    SUPPORTED_TYPE_CHECK(Ti);
+    SUPPORTED_TYPE_CHECK(To);
 
     vector<dim4> numDims;
 
@@ -173,16 +173,12 @@ REDUCE_TESTS(count, unsigned);
 #undef REDUCE_TESTS
 
 TEST(Reduce, Test_Reduce_Big0) {
-    if (noDoubleTests<int>()) return;
-
     reduceTest<int, int, af_sum>(string(TEST_DIR "/reduce/big0.test"), 0);
 }
 
 /*
 TEST(Reduce,Test_Reduce_Big1)
 {
-    if (noDoubleTests<int>()) return;
-
     reduceTest<int, int, af_sum>(
         string(TEST_DIR"/reduce/big1.test"),
         1
@@ -211,8 +207,8 @@ using af::sum;
 
 template<typename Ti, typename To, ReductionOp reduce>
 void cppReduceTest(string pTestFile) {
-    if (noDoubleTests<Ti>()) return;
-    if (noDoubleTests<To>()) return;
+    SUPPORTED_TYPE_CHECK(Ti);
+    SUPPORTED_TYPE_CHECK(To);
 
     vector<dim4> numDims;
 
@@ -360,7 +356,7 @@ TEST(Reduce, Test_Count_Global) {
 }
 
 TEST(Reduce, Test_min_Global) {
-    if (noDoubleTests<double>()) return;
+    SUPPORTED_TYPE_CHECK(double);
 
     const int num = 10000;
     array a       = randu(num, 1, f64);
@@ -368,7 +364,7 @@ TEST(Reduce, Test_min_Global) {
     double *h_a   = a.host<double>();
     double gold   = std::numeric_limits<double>::max();
 
-    if (noDoubleTests<double>()) return;
+    SUPPORTED_TYPE_CHECK(double);
 
     for (int i = 0; i < num; i++) { gold = std::min(gold, h_a[i]); }
 
@@ -420,7 +416,7 @@ void typed_assert_eq<cdouble>(cdouble lhs, cdouble rhs, bool both) {
 }
 
 TYPED_TEST(Reduce, Test_All_Global) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     // Input size test
     for (int i = 1; i < 1000; i += 100) {
@@ -453,7 +449,7 @@ TYPED_TEST(Reduce, Test_All_Global) {
 }
 
 TYPED_TEST(Reduce, Test_Any_Global) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     // Input size test
     for (int i = 1; i < 1000; i += 100) {

--- a/test/regions.cpp
+++ b/test/regions.cpp
@@ -44,7 +44,7 @@ TYPED_TEST_CASE(Regions, TestTypes);
 template<typename T>
 void regionsTest(string pTestFile, af_connectivity connectivity,
                  bool isSubRef = false, const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<uchar> > in;
@@ -109,8 +109,6 @@ REGIONS_INIT(Regions3, regions_128x128, 8, AF_CONNECTIVITY_8);
 ///////////////////////////////////// CPP ////////////////////////////////
 //
 TEST(Regions, CPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<dim4> numDims;
     vector<vector<float> > in;
     vector<vector<float> > tests;

--- a/test/reorder.cpp
+++ b/test/reorder.cpp
@@ -54,7 +54,7 @@ template<typename T>
 void reorderTest(string pTestFile, const unsigned resultIdx, const uint x,
                  const uint y, const uint z, const uint w,
                  bool isSubRef = false, const vector<af_seq> *seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -179,8 +179,6 @@ TEST(Reorder, ISSUE_1777) {
 }
 
 TEST(Reorder, MaxDim) {
-    if (noDoubleTests<float>()) return;
-
     const size_t largeDim = 65535 * 32 + 1;
 
     array input  = range(dim4(2, largeDim, 2), 2);

--- a/test/replace.cpp
+++ b/test/replace.cpp
@@ -39,7 +39,7 @@ TYPED_TEST_CASE(Replace, TestTypes);
 
 template<typename T>
 void replaceTest(const dim4 &dims) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     dtype ty = (dtype)dtype_traits<T>::af_type;
 
     array a = randu(dims, ty);
@@ -75,7 +75,7 @@ void replaceTest(const dim4 &dims) {
 
 template<typename T>
 void replaceScalarTest(const dim4 &dims) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     dtype ty = (dtype)dtype_traits<T>::af_type;
 
     array a = randu(dims, ty);

--- a/test/resize.cpp
+++ b/test/resize.cpp
@@ -64,7 +64,7 @@ TYPED_TEST_CASE(Resize, TestTypesF);
 TYPED_TEST_CASE(ResizeI, TestTypesI);
 
 TYPED_TEST(Resize, InvalidDims) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     vector<TypeParam> in(8 * 8);
 
@@ -116,7 +116,7 @@ template<typename T>
 void resizeTest(string pTestFile, const unsigned resultIdx, const dim_t odim0,
                 const dim_t odim1, const af_interp_type method,
                 bool isSubRef = false, const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -317,7 +317,7 @@ TYPED_TEST(ResizeI, Resize1CLargeDownLinear) {
 template<typename T>
 void resizeArgsTest(af_err err, string pTestFile, const dim4 odims,
                     const af_interp_type method) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -362,8 +362,6 @@ using af::seq;
 using af::span;
 
 TEST(Resize, CPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<dim4> numDims;
     vector<vector<float> > in;
     vector<vector<float> > tests;
@@ -379,8 +377,6 @@ TEST(Resize, CPP) {
 }
 
 TEST(ResizeScale1, CPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<dim4> numDims;
     vector<vector<float> > in;
     vector<vector<float> > tests;
@@ -396,8 +392,6 @@ TEST(ResizeScale1, CPP) {
 }
 
 TEST(ResizeScale2, CPP) {
-    if (noDoubleTests<float>()) return;
-
     vector<dim4> numDims;
     vector<vector<float> > in;
     vector<vector<float> > tests;

--- a/test/rotate.cpp
+++ b/test/rotate.cpp
@@ -46,7 +46,7 @@ template<typename T>
 void rotateTest(string pTestFile, const unsigned resultIdx, const float angle,
                 const bool crop, bool isSubRef = false,
                 const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -160,8 +160,6 @@ ROTATE_INIT(Rectangle00CropRecenter, rotate2, 23, 0, true);
 ////////////////////////////////// CPP //////////////////////////////////////
 //
 TEST(Rotate, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const unsigned resultIdx = 0;
     const float angle        = 180;
     const bool crop          = false;

--- a/test/rotate_linear.cpp
+++ b/test/rotate_linear.cpp
@@ -51,7 +51,7 @@ template<typename T>
 void rotateTest(string pTestFile, const unsigned resultIdx, const float angle,
                 const bool crop, bool isSubRef = false,
                 const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -177,8 +177,6 @@ ROTATE_INIT(Rectangle00CropRecenter, rotatelinear2, 23, 0, true);
 ////////////////////////////////// CPP //////////////////////////////////////
 
 TEST(RotateLinear, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const unsigned resultIdx = 0;
     const float angle        = 180;
     const bool crop          = false;

--- a/test/sat.cpp
+++ b/test/sat.cpp
@@ -39,7 +39,7 @@ typedef ::testing::Types<float, double, int, uint, char, uchar, uintl, intl,
 TYPED_TEST_CASE(SAT, TestTypes);
 
 TYPED_TEST(SAT, IntegralImage) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     array a = randu(530, 671, (af_dtype)dtype_traits<TypeParam>::af_type);
     array b = accum(a, 0);

--- a/test/scan.cpp
+++ b/test/scan.cpp
@@ -44,7 +44,7 @@ typedef af_err (*scanFunc)(af_array *, const af_array, const int);
 template<typename Ti, typename To, scanFunc af_scan>
 void scanTest(string pTestFile, int off = 0, bool isSubRef = false,
               const vector<af_seq> seqv = vector<af_seq>()) {
-    if (noDoubleTests<Ti>()) return;
+    SUPPORTED_TYPE_CHECK(Ti);
 
     vector<dim4> numDims;
 
@@ -135,8 +135,6 @@ TEST(Accum, CPP) {
     dim4 dims = numDims[0];
 
     vector<float> in(data[0].begin(), data[0].end());
-
-    if (noDoubleTests<float>()) return;
 
     array input(dims, &(in.front()));
 

--- a/test/select.cpp
+++ b/test/select.cpp
@@ -48,7 +48,7 @@ TYPED_TEST_CASE(Select, TestTypes);
 
 template<typename T>
 void selectTest(const dim4& dims) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     dtype ty = (dtype)dtype_traits<T>::af_type;
 
     array a = randu(dims, ty);
@@ -82,7 +82,7 @@ void selectTest(const dim4& dims) {
 
 template<typename T, bool is_right>
 void selectScalarTest(const dim4& dims) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     dtype ty = (dtype)dtype_traits<T>::af_type;
 
     array a    = randu(dims, ty);

--- a/test/set.cpp
+++ b/test/set.cpp
@@ -28,7 +28,7 @@ using std::vector;
 
 template<typename T>
 void uniqueTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 
@@ -88,7 +88,7 @@ typedef af_err (*setFunc)(af_array *, const af_array, const af_array,
 
 template<typename T, setFunc af_set_func>
 void setTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 

--- a/test/shift.cpp
+++ b/test/shift.cpp
@@ -51,7 +51,7 @@ template<typename T>
 void shiftTest(string pTestFile, const unsigned resultIdx, const int x,
                const int y, const int z, const int w, bool isSubRef = false,
                const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -111,8 +111,6 @@ SHIFT_INIT(Shift14, shift4d, 14, -21, -21, -21, -21);
 ////////////////////////////////// CPP ///////////////////////////////////
 //
 TEST(Shift, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const unsigned resultIdx = 0;
     const unsigned x         = 2;
     const unsigned y         = 0;
@@ -133,8 +131,6 @@ TEST(Shift, CPP) {
 }
 
 TEST(Shift, MaxDim) {
-    if (noDoubleTests<float>()) return;
-
     const size_t largeDim  = 65535 * 32 + 1;
     const unsigned shift_x = 1;
 

--- a/test/sift_nonfree.cpp
+++ b/test/sift_nonfree.cpp
@@ -139,7 +139,7 @@ template<typename T>
 void siftTest(string pTestFile, unsigned nLayers, float contrastThr,
               float edgeThr, float initSigma, bool doubleInput) {
 #ifdef AF_WITH_NONFREE_SIFT
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;
@@ -280,7 +280,6 @@ SIFT_INIT(Man_NoDoubleInput, man_nodoubleinput, 3, 0.04f, 10.0f, 1.6f, false);
 //
 TEST(SIFT, CPP) {
 #ifdef AF_WITH_NONFREE_SIFT
-    if (noDoubleTests<float>()) return;
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;

--- a/test/sobel.cpp
+++ b/test/sobel.cpp
@@ -44,7 +44,7 @@ TYPED_TEST_CASE(Sobel_Integer, TestTypesInt);
 
 template<typename Ti, typename To>
 void testSobelDerivatives(string pTestFile) {
-    if (noDoubleTests<Ti>()) return;
+    SUPPORTED_TYPE_CHECK(Ti);
 
     vector<dim4> numDims;
     vector<vector<Ti> > in;

--- a/test/solve_common.hpp
+++ b/test/solve_common.hpp
@@ -35,7 +35,7 @@ void solveTester(const int m, const int n, const int k, double eps,
 
     af::deviceGC();
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 
 #if 1
@@ -74,7 +74,7 @@ void solveLUTester(const int n, const int k, double eps,
 
     af::deviceGC();
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 
 #if 1
@@ -113,7 +113,7 @@ void solveTriangleTester(const int n, const int k, bool is_upper, double eps,
 
     af::deviceGC();
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 
 #if 1

--- a/test/sort.cpp
+++ b/test/sort.cpp
@@ -50,7 +50,7 @@ TYPED_TEST_CASE(Sort, TestTypes);
 template<typename T>
 void sortTest(string pTestFile, const bool dir, const unsigned resultIdx0,
               bool isSubRef = false, const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -125,8 +125,6 @@ SORT_INIT(SortLargeFalse, sort_large, false, 2);
 ////////////////////////////////////// CPP ////////////////////////////////
 //
 TEST(Sort, CPPDim0) {
-    if (noDoubleTests<float>()) return;
-
     const bool dir            = true;
     const unsigned resultIdx0 = 0;
 
@@ -158,8 +156,6 @@ TEST(Sort, CPPDim0) {
 }
 
 TEST(Sort, CPPDim1) {
-    if (noDoubleTests<float>()) return;
-
     const bool dir            = true;
     const unsigned resultIdx0 = 0;
 
@@ -196,8 +192,6 @@ TEST(Sort, CPPDim1) {
 }
 
 TEST(Sort, CPPDim2) {
-    if (noDoubleTests<float>()) return;
-
     const bool dir            = false;
     const unsigned resultIdx0 = 2;
 

--- a/test/sort_by_key.cpp
+++ b/test/sort_by_key.cpp
@@ -51,7 +51,7 @@ template<typename T>
 void sortTest(string pTestFile, const bool dir, const unsigned resultIdx0,
               const unsigned resultIdx1, bool isSubRef = false,
               const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -122,8 +122,6 @@ SORT_INIT(SortLargeFalse, sort_by_key_large, false, 2, 3);
 ////////////////////////////////////// CPP ///////////////////////////////
 //
 TEST(SortByKey, CPPDim0) {
-    if (noDoubleTests<float>()) return;
-
     const bool dir            = true;
     const unsigned resultIdx0 = 0;
     const unsigned resultIdx1 = 1;
@@ -145,8 +143,6 @@ TEST(SortByKey, CPPDim0) {
 }
 
 TEST(SortByKey, CPPDim1) {
-    if (noDoubleTests<float>()) return;
-
     const bool dir            = true;
     const unsigned resultIdx0 = 0;
     const unsigned resultIdx1 = 1;
@@ -175,8 +171,6 @@ TEST(SortByKey, CPPDim1) {
 }
 
 TEST(SortByKey, CPPDim2) {
-    if (noDoubleTests<float>()) return;
-
     const bool dir            = false;
     const unsigned resultIdx0 = 2;
     const unsigned resultIdx1 = 3;

--- a/test/sort_index.cpp
+++ b/test/sort_index.cpp
@@ -51,7 +51,7 @@ template<typename T>
 void sortTest(string pTestFile, const bool dir, const unsigned resultIdx0,
               const unsigned resultIdx1, bool isSubRef = false,
               const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -122,8 +122,6 @@ SORT_INIT(SortLargeFalse, sort_large, false, 2, 3);
 //////////////////////////////////// CPP /////////////////////////////////
 //
 TEST(SortIndex, CPPDim0) {
-    if (noDoubleTests<float>()) return;
-
     const bool dir            = true;
     const unsigned resultIdx0 = 0;
     const unsigned resultIdx1 = 1;
@@ -146,8 +144,6 @@ TEST(SortIndex, CPPDim0) {
 }
 
 TEST(SortIndex, CPPDim1) {
-    if (noDoubleTests<float>()) return;
-
     const bool dir            = true;
     const unsigned resultIdx0 = 0;
     const unsigned resultIdx1 = 1;
@@ -175,8 +171,6 @@ TEST(SortIndex, CPPDim1) {
 }
 
 TEST(SortIndex, CPPDim2) {
-    if (noDoubleTests<float>()) return;
-
     const bool dir            = false;
     const unsigned resultIdx0 = 2;
     const unsigned resultIdx1 = 3;

--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -187,7 +187,7 @@ typedef ::testing::Types<float, cfloat, double, cdouble> SparseTypes;
 TYPED_TEST_CASE(Sparse, SparseTypes);
 
 TYPED_TEST(Sparse, DeepCopy) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     cleanSlate();
 
@@ -232,7 +232,7 @@ TYPED_TEST(Sparse, DeepCopy) {
 }
 
 TYPED_TEST(Sparse, Empty) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     af_array ret = 0;
     dim_t rows = 0, cols = 0, nnz = 0;
@@ -247,7 +247,7 @@ TYPED_TEST(Sparse, Empty) {
 }
 
 TYPED_TEST(Sparse, EmptyDeepCopy) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     array a = sparse(0, 0, array(0, (af_dtype)dtype_traits<TypeParam>::af_type),
                      array(1, s32), array(0, s32));

--- a/test/sparse_arith.cpp
+++ b/test/sparse_arith.cpp
@@ -132,7 +132,7 @@ template<typename T, af_op_t op>
 void sparseArithTester(const int m, const int n, int factor, const double eps) {
     deviceGC();
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
 #if 1
     array A = cpu_randu<T>(dim4(m, n));
@@ -175,7 +175,7 @@ void sparseArithTesterMul(const int m, const int n, int factor,
                           const double eps) {
     deviceGC();
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
 #if 1
     array A = cpu_randu<T>(dim4(m, n));
@@ -235,7 +235,7 @@ void sparseArithTesterDiv(const int m, const int n, int factor,
                           const double eps) {
     deviceGC();
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
 #if 1
     array A = cpu_randu<T>(dim4(m, n));
@@ -306,7 +306,7 @@ template<typename T, af_op_t op>
 void ssArithmetic(const int m, const int n, int factor, const double eps) {
     deviceGC();
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
 #if 1
     array A = cpu_randu<T>(dim4(m, n));
@@ -362,7 +362,7 @@ template<af_op_t op>
 void ssArithmeticMTX(const char* op1, const char* op2) {
     deviceGC();
 
-    // Re-enable when double is enabled if (noDoubleTests<T>()) return;
+    // Re-enable when double is enabled SUPPORTED_TYPE_CHECK(T);
 
     array cooA, cooB;
     ASSERT_TRUE(mtxReadSparseMatrix(cooA, op1));

--- a/test/sparse_common.hpp
+++ b/test/sparse_common.hpp
@@ -72,7 +72,7 @@ static void sparseTester(const int m, const int n, const int k, int factor,
 
     af::deviceGC();
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
 #if 1
     af::array A = cpu_randu<T>(af::dim4(m, n));
@@ -106,7 +106,7 @@ static void sparseTransposeTester(const int m, const int n, const int k,
 
     af::deviceGC();
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
 #if 1
     af::array A = cpu_randu<T>(af::dim4(m, n));
@@ -142,7 +142,7 @@ static void convertCSR(const int M, const int N, const float ratio,
                        int targetDevice = -1) {
     if (targetDevice >= 0) af::setDevice(targetDevice);
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 #if 1
     af::array a = cpu_randu<T>(af::dim4(M, N));
 #else
@@ -178,8 +178,8 @@ static void createFunction() {
 
 template<typename Ti, typename To>
 static void sparseCastTester(const int m, const int n, int factor) {
-    if (noDoubleTests<Ti>()) return;
-    if (noDoubleTests<To>()) return;
+    SUPPORTED_TYPE_CHECK(Ti);
+    SUPPORTED_TYPE_CHECK(To);
 
     af::array A = cpu_randu<Ti>(af::dim4(m, n));
 

--- a/test/sparse_convert.cpp
+++ b/test/sparse_convert.cpp
@@ -63,7 +63,7 @@ array makeSparse<cdouble>(array A, int factor) {
 
 template<typename T, af_storage src, af_storage dest>
 void sparseConvertTester(const int m, const int n, int factor) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     array A = cpu_randu<T>(dim4(m, n));
 

--- a/test/stdev.cpp
+++ b/test/stdev.cpp
@@ -76,8 +76,8 @@ struct sdOutType {
 template<typename T>
 void stdevDimTest(string pFileName, dim_t dim = -1) {
     typedef typename sdOutType<T>::type outType;
-    if (noDoubleTests<T>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(T);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<int> > in;
@@ -136,8 +136,8 @@ TEST(StandardDev, InvalidType) {
 template<typename T>
 void stdevDimIndexTest(string pFileName, dim_t dim = -1) {
     typedef typename sdOutType<T>::type outType;
-    if (noDoubleTests<T>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(T);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<int> > in;
@@ -182,8 +182,8 @@ TYPED_TEST(StandardDev, IndexedArrayDim1) {
 
 TYPED_TEST(StandardDev, All) {
     typedef typename sdOutType<TypeParam>::type outType;
-    if (noDoubleTests<TypeParam>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<int> > in;

--- a/test/susan.cpp
+++ b/test/susan.cpp
@@ -66,7 +66,7 @@ TYPED_TEST_CASE(Susan, TestTypes);
 
 template<typename T>
 void susanTest(string pTestFile, float t, float g) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inDims;

--- a/test/svd_dense.cpp
+++ b/test/svd_dense.cpp
@@ -57,7 +57,7 @@ double get_val<cdouble>(cdouble val) {
 
 template<typename T>
 void svdTest(const int M, const int N) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 
     dtype ty = (dtype)dtype_traits<T>::af_type;
@@ -86,7 +86,7 @@ void svdTest(const int M, const int N) {
 
 template<typename T>
 void svdInPlaceTest(const int M, const int N) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 
     dtype ty = (dtype)dtype_traits<T>::af_type;
@@ -114,7 +114,7 @@ void svdInPlaceTest(const int M, const int N) {
 
 template<typename T>
 void checkInPlaceSameResults(const int M, const int N) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noLAPACKTests()) return;
 
     dtype ty = (dtype)dtype_traits<T>::af_type;

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -439,6 +439,9 @@ bool noDoubleTests() {
     return ((isTypeDouble && !isDoubleSupported) ? true : false);
 }
 
+#define SUPPORTED_TYPE_CHECK(type) \
+    if (noDoubleTests<type>()) return;
+
 inline bool noImageIOTests() {
     bool ret = !af::isImageIOAvailable();
     if (ret) printf("Image IO Not Configured. Test will exit\n");

--- a/test/tile.cpp
+++ b/test/tile.cpp
@@ -54,7 +54,7 @@ template<typename T>
 void tileTest(string pTestFile, const unsigned resultIdx, const uint x,
               const uint y, const uint z, const uint w, bool isSubRef = false,
               const vector<af_seq>* seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -117,8 +117,6 @@ TILE_INIT(Tile2D231, tile_large2D, 4, 2, 3, 1, 1);
 ///////////////////////////////// CPP ////////////////////////////////////
 //
 TEST(Tile, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const unsigned resultIdx = 0;
     const unsigned x         = 2;
     const unsigned y         = 2;
@@ -140,8 +138,6 @@ TEST(Tile, CPP) {
 }
 
 TEST(Tile, MaxDim) {
-    if (noDoubleTests<float>()) return;
-
     const size_t largeDim = 65535 * 32 + 1;
     const unsigned x      = 1;
     const unsigned z      = 1;

--- a/test/transform.cpp
+++ b/test/transform.cpp
@@ -46,7 +46,7 @@ TYPED_TEST_CASE(TransformInt, TestTypesInt);
 template<typename T>
 void transformTest(string pTestFile, string pHomographyFile,
                    const af_interp_type method, const bool invert) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
     if (noImageIOTests()) return;
 
     vector<dim4> inNumDims;

--- a/test/transform_coordinates.cpp
+++ b/test/transform_coordinates.cpp
@@ -35,7 +35,7 @@ TYPED_TEST_CASE(TransformCoordinates, TestTypes);
 
 template<typename T>
 void transformCoordinatesTest(string pTestFile) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> inDims;
     vector<vector<T> > in;

--- a/test/translate.cpp
+++ b/test/translate.cpp
@@ -49,7 +49,7 @@ template<typename T>
 void translateTest(string pTestFile, const unsigned resultIdx, dim4 odims,
                    const float tx, const float ty, const af_interp_type method,
                    const float max_fail_count = 0.0001) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;

--- a/test/transpose.cpp
+++ b/test/transpose.cpp
@@ -52,7 +52,7 @@ TYPED_TEST_CASE(Transpose, TestTypes);
 template<typename T>
 void trsTest(string pTestFile, bool isSubRef = false,
              const vector<af_seq> *seqv = NULL) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 
@@ -160,7 +160,7 @@ void trsCPPTest(string pFileName) {
     readTests<T, T, int>(pFileName, numDims, in, tests);
     dim4 dims = numDims[0];
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     array input(dims, &(in[0].front()));
     array output = transpose(input);
@@ -195,7 +195,7 @@ void trsCPPConjTest(dim_t d0, dim_t d1 = 1, dim_t d2 = 1, dim_t d3 = 1) {
 
     dim4 dims(d0, d1, d2, d3);
 
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     array input    = randu(dims, (af_dtype)dtype_traits<T>::af_type);
     array output_t = transpose(input, false);

--- a/test/transpose_inplace.cpp
+++ b/test/transpose_inplace.cpp
@@ -39,7 +39,7 @@ TYPED_TEST_CASE(Transpose, TestTypes);
 
 template<typename T>
 void transposeip_test(dim4 dims) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     af_array inArray  = 0;
     af_array outArray = 0;
@@ -72,8 +72,6 @@ INIT_TEST(25, 2, 2);
 ////////////////////////////////////// CPP //////////////////////////////////
 //
 void transposeInPlaceCPPTest() {
-    if (noDoubleTests<float>()) return;
-
     dim4 dims(64, 64, 1, 1);
 
     array input  = randu(dims);

--- a/test/triangle.cpp
+++ b/test/triangle.cpp
@@ -39,7 +39,7 @@ TYPED_TEST_CASE(Triangle, TestTypes);
 
 template<typename T>
 void triangleTester(const dim4 dims, bool is_upper, bool is_unit_diag = false) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 #if 1
     array in = cpu_randu<T>(dims);
 #else

--- a/test/unwrap.cpp
+++ b/test/unwrap.cpp
@@ -47,7 +47,7 @@ template<typename T>
 void unwrapTest(string pTestFile, const unsigned resultIdx, const dim_t wx,
                 const dim_t wy, const dim_t sx, const dim_t sy, const dim_t px,
                 const dim_t py) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
     vector<vector<T> > in;
@@ -152,8 +152,6 @@ UNWRAP_INIT(UnwrapSmall46, unwrap_small, 46, 16, 18, 16, 18, 0, 1);
 ///////////////////////////////// CPP ////////////////////////////////////
 //
 TEST(Unwrap, CPP) {
-    if (noDoubleTests<float>()) return;
-
     const unsigned resultIdx = 20;
     const unsigned wx        = 4;
     const unsigned wy        = 4;

--- a/test/var.cpp
+++ b/test/var.cpp
@@ -53,8 +53,8 @@ struct varOutType {
 template<typename T>
 void testCPPVar(T const_value, dim4 dims) {
     typedef typename varOutType<T>::type outType;
-    if (noDoubleTests<T>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(T);
+    SUPPORTED_TYPE_CHECK(outType);
 
     using af::array;
     using af::var;
@@ -103,8 +103,8 @@ TYPED_TEST(Var, AllCPPLarge) {
 TYPED_TEST(Var, DimCPPSmall) {
     typedef typename varOutType<TypeParam>::type outType;
 
-    if (noDoubleTests<TypeParam>()) return;
-    if (noDoubleTests<outType>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
+    SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<TypeParam> > in;

--- a/test/where.cpp
+++ b/test/where.cpp
@@ -41,7 +41,7 @@ TYPED_TEST_CASE(Where, TestTypes);
 template<typename T>
 void whereTest(string pTestFile, bool isSubRef = false,
                const vector<af_seq> seqv = vector<af_seq>()) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     vector<dim4> numDims;
 
@@ -94,7 +94,7 @@ TYPED_TEST(Where, BasicC) {
 //////////////////////////////////// CPP /////////////////////////////////
 //
 TYPED_TEST(Where, CPP) {
-    if (noDoubleTests<TypeParam>()) return;
+    SUPPORTED_TYPE_CHECK(TypeParam);
 
     vector<dim4> numDims;
 

--- a/test/wrap.cpp
+++ b/test/wrap.cpp
@@ -77,7 +77,7 @@ template<typename T>
 void wrapTest(const dim_t ix, const dim_t iy, const dim_t wx, const dim_t wy,
               const dim_t sx, const dim_t sy, const dim_t px, const dim_t py,
               bool cond) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     const int nc = 1;
 

--- a/test/write.cpp
+++ b/test/write.cpp
@@ -42,7 +42,7 @@ TYPED_TEST_CASE(Write, TestTypes);
 
 template<typename T>
 void writeTest(dim4 dims) {
-    if (noDoubleTests<T>()) return;
+    SUPPORTED_TYPE_CHECK(T);
 
     array A = randu(dims, (af_dtype)dtype_traits<T>::af_type);
     array B = randu(dims, (af_dtype)dtype_traits<T>::af_type);


### PR DESCRIPTION
This is a more general macro which will check if the device surpports
the types being checked. This is done to support double types but
will be required for fp16 in the future