### PR TITLE
Fix MKL linking order to enable threaded BLAS

### DIFF
--- a/CMakeModules/FindMKL.cmake
+++ b/CMakeModules/FindMKL.cmake
@@ -260,14 +260,14 @@ if(MKL_FOUND)
     set_target_properties(MKL::MKL
       PROPERTIES
         IMPORTED_LOCATION "${MKL_Core_LINK_LIBRARY}"
-        INTERFACE_LINK_LIBRARIES "MKL::ThreadLayer;MKL::Interface;${CMAKE_DL_LIBS};${M_LIB}"
+        INTERFACE_LINK_LIBRARIES "MKL::Interface;MKL::ThreadLayer;${CMAKE_DL_LIBS};${M_LIB}"
         INTERFACE_INCLUDE_DIRECTORIES "${MKL_INCLUDE_DIR};${MKL_FFTW_INCLUDE_DIR}"
         IMPORTED_NO_SONAME TRUE)
   else()
     set_target_properties(MKL::MKL
       PROPERTIES
         IMPORTED_LOCATION "${MKL_Core_LINK_LIBRARY}"
-        INTERFACE_LINK_LIBRARIES "MKL::ThreadLayer;MKL::Interface;MKL::ThreadingLibrary;${CMAKE_DL_LIBS};${M_LIB}"
+        INTERFACE_LINK_LIBRARIES "MKL::Interface;MKL::ThreadLayer;MKL::ThreadingLibrary;${CMAKE_DL_LIBS};${M_LIB}"
         INTERFACE_INCLUDE_DIRECTORIES "${MKL_INCLUDE_DIR};${MKL_FFTW_INCLUDE_DIR}"
         IMPORTED_NO_SONAME TRUE)
   endif()


### PR DESCRIPTION
The DLL linking order given in FindMKL does not follow that in
Intel's Link Line Advisory.  More specifically, thread layering
is linked before the interface library.  This causes MKL to not
to schedule BLAS level 3 operations (and gemv) on the threads it
created.