### PR TITLE
Improve CUDA version checking code

### DIFF
--- a/src/backend/cpu/platform.cpp
+++ b/src/backend/cpu/platform.cpp
@@ -248,7 +248,8 @@ bool& evalFlag() {
 DeviceManager::DeviceManager()
     : queues(MAX_QUEUES)
     , memManager(new MemoryManager())
-    , fgMngr(new graphics::ForgeManager()) {}
+    , fgMngr(new graphics::ForgeManager())
+    {}
 
 MemoryManager& memoryManager() {
     DeviceManager& inst = DeviceManager::getInstance();

--- a/src/backend/cpu/platform.hpp
+++ b/src/backend/cpu/platform.hpp
@@ -143,9 +143,9 @@ class DeviceManager {
     void operator=(DeviceManager const&) = delete;
 
     // Attributes
-    std::unique_ptr<graphics::ForgeManager> fgMngr;
-    std::unique_ptr<MemoryManager> memManager;
     std::vector<queue> queues;
+    std::unique_ptr<MemoryManager> memManager;
+    std::unique_ptr<graphics::ForgeManager> fgMngr;
     const CPUInfo cinfo;
 };
 }  // namespace cpu

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -137,7 +137,7 @@ static inline int getMinSupportedCompute(int cudaMajorVer) {
     // Vector of minimum supported compute versions
     // for CUDA toolkit (i+1).* where i is the index
     // of the vector
-    static const std::array<int, 10> minSV{1, 1, 1, 1, 1, 1, 2, 2, 3, 3};
+    static const std::array<int, 10> minSV{{1, 1, 1, 1, 1, 1, 2, 2, 3, 3}};
 
     int CVSize = static_cast<int>(minSV.size());
     return (cudaMajorVer > CVSize ? minSV[CVSize - 1]
@@ -198,9 +198,7 @@ bool isDoubleSupported(int device) {
 }
 
 void devprop(char *d_name, char *d_platform, char *d_toolkit, char *d_compute) {
-    if (getDeviceCount() <= 0) {
-        return;
-    }
+    if (getDeviceCount() <= 0) { return; }
 
     cudaDeviceProp dev = getDeviceProp(getActiveDeviceId());
 
@@ -606,10 +604,11 @@ void DeviceManager::checkCudaVsDriverVersion() {
 }
 
 DeviceManager::DeviceManager()
-    : cuDevices(0)
+    : logger(common::loggerFactory("platform"))
+    , cuDevices(0)
     , nDevices(0)
     , fgMngr(new graphics::ForgeManager())
-    , logger(common::loggerFactory("platform")) {
+    {
     checkCudaVsDriverVersion();
 
     CUDA_CHECK(cudaGetDeviceCount(&nDevices));
@@ -635,7 +634,7 @@ DeviceManager::DeviceManager()
                         dev.prop.clockRate;
             dev.nativeId = i;
             AF_TRACE(
-                "Found device: {} ({:3.3} GB | ~{} GFLOPs | {} SMs)",
+                "Found device: {} ({:0.3} GB | ~{} GFLOPs | {} SMs)",
                 dev.prop.name, dev.prop.totalGlobalMem / 1024. / 1024. / 1024.,
                 dev.flops / 1024. / 1024. * 2, dev.prop.multiProcessorCount);
             cuDevices.push_back(dev);

--- a/src/backend/cuda/platform.hpp
+++ b/src/backend/cuda/platform.hpp
@@ -150,15 +150,16 @@ class DeviceManager {
     void operator=(DeviceManager const&);
 
     // Attributes
-    std::vector<cudaDevice_t> cuDevices;
-    std::shared_ptr<spdlog::logger> logger;
-
     enum sort_mode { flops = 0, memory = 1, compute = 2, none = 3 };
 
     void checkCudaVsDriverVersion();
     void sortDevices(sort_mode mode = flops);
 
     int setActiveDevice(int device, int native = -1);
+
+    std::shared_ptr<spdlog::logger> logger;
+
+    std::vector<cudaDevice_t> cuDevices;
 
     int nDevices;
     cudaStream_t streams[MAX_DEVICES];

--- a/test/scan.cpp
+++ b/test/scan.cpp
@@ -258,7 +258,7 @@ TEST(Scan, ExclusiveSum1D) {
     const int in_size = 80000;
     vector<int> h_in(in_size, 1);
     vector<int> h_gold(in_size, 0);
-    for (int i = 1; i < h_gold.size(); ++i) {
+    for (size_t i = 1; i < h_gold.size(); ++i) {
         h_gold[i] = h_in[i] + h_gold[i - 1];
     }
 
@@ -272,10 +272,10 @@ TEST(Scan, ExclusiveSum2D_Dim0) {
     const int in_size = 80000 * 2;
     vector<int> h_in(in_size, 1);
     vector<int> h_gold(in_size, 0);
-    for (int i = 1; i < h_gold.size() / 2; ++i) {
+    for (size_t i = 1; i < h_gold.size() / 2; ++i) {
         h_gold[i] = h_in[i] + h_gold[i - 1];
     }
-    for (int i = h_gold.size() / 2 + 1; i < h_gold.size(); ++i) {
+    for (size_t i = h_gold.size() / 2 + 1; i < h_gold.size(); ++i) {
         h_gold[i] = h_in[i] + h_gold[i - 1];
     }
 
@@ -290,10 +290,10 @@ TEST(Scan, ExclusiveSum2D_Dim1) {
     const int in_size = 80000 * 2;
     vector<int> h_in(in_size, 1);
     vector<int> h_gold(in_size, 0);
-    for (int i = 1; i < h_gold.size() / 2; ++i) {
+    for (size_t i = 1; i < h_gold.size() / 2; ++i) {
         h_gold[i] = h_in[i] + h_gold[i - 1];
     }
-    for (int i = h_gold.size() / 2 + 1; i < h_gold.size(); ++i) {
+    for (size_t i = h_gold.size() / 2 + 1; i < h_gold.size(); ++i) {
         h_gold[i] = h_in[i] + h_gold[i - 1];
     }
 
@@ -309,10 +309,10 @@ TEST(Scan, ExclusiveSum2D_Dim2) {
     const int in_size = 80000 * 2;
     vector<int> h_in(in_size, 1);
     vector<int> h_gold(in_size, 0);
-    for (int i = 1; i < h_gold.size() / 2; ++i) {
+    for (size_t i = 1; i < h_gold.size() / 2; ++i) {
         h_gold[i] = h_in[i] + h_gold[i - 1];
     }
-    for (int i = h_gold.size() / 2 + 1; i < h_gold.size(); ++i) {
+    for (size_t i = h_gold.size() / 2 + 1; i < h_gold.size(); ++i) {
         h_gold[i] = h_in[i] + h_gold[i - 1];
     }
 
@@ -328,10 +328,10 @@ TEST(Scan, ExclusiveSum2D_Dim3) {
     const int in_size = 80000 * 2;
     vector<int> h_in(in_size, 1);
     vector<int> h_gold(in_size, 0);
-    for (int i = 1; i < h_gold.size() / 2; ++i) {
+    for (size_t i = 1; i < h_gold.size() / 2; ++i) {
         h_gold[i] = h_in[i] + h_gold[i - 1];
     }
-    for (int i = h_gold.size() / 2 + 1; i < h_gold.size(); ++i) {
+    for (size_t i = h_gold.size() / 2 + 1; i < h_gold.size(); ++i) {
         h_gold[i] = h_in[i] + h_gold[i - 1];
     }
 


### PR DESCRIPTION
* Use cudaRuntimeGetVersion and cudaDriverGetVersion to check the
  compatibility of the toolkit versions vs driver version
* Prints warning messages if the driver version is not included in the
  CudaToDriverVersion in Debug builds.
* Fix int_version_to_string function