### PR TITLE
Suppress Windows warnings in mmio lib

### DIFF
--- a/test/mmio/CMakeLists.txt
+++ b/test/mmio/CMakeLists.txt
@@ -17,3 +17,7 @@ target_include_directories(mmio
     )
 
 target_compile_definitions(mmio PUBLIC USE_MTX)
+
+if(WIN32)
+  target_compile_definitions(mmio PRIVATE _CRT_SECURE_NO_WARNINGS)
+endif()


### PR DESCRIPTION
Suppress some windows warnings in the mmio library seen here:

http://ci.arrayfire.org/viewBuildError.php?type=1&buildid=2465