### PR TITLE
Use smart pointer to clean up forge resources

### DIFF
--- a/src/api/c/window.cpp
+++ b/src/api/c/window.cpp
@@ -22,20 +22,7 @@ using namespace graphics;
 af_err af_create_window(af_window* out, const int width, const int height,
                         const char* const title) {
     try {
-        ForgeManager& fgMngr = forgeManager();
-        fg_window mainWnd    = fgMngr.getMainWindow();
-
-        if (mainWnd == 0) {
-            AF_ERROR("OpenGL context creation failed", AF_ERR_INTERNAL);
-        }
-
-        fg_window temp = nullptr;
-
-        FG_CHECK(forgePlugin().fg_create_window(&temp, width, height, title,
-                                                mainWnd, false));
-
-        fgMngr.setWindowChartGrid(temp, 1, 1);
-
+        fg_window temp = forgeManager().getWindow(width, height, title, false);
         std::swap(*out, temp);
     }
     CATCHALL;

--- a/src/backend/common/graphics_common.cpp
+++ b/src/backend/common/graphics_common.cpp
@@ -232,39 +232,6 @@ ForgeModule& forgePlugin() { return detail::forgeManager().plugin(); }
 
 ForgeManager::ForgeManager() : mPlugin(new ForgeModule()) {}
 
-ForgeManager::~ForgeManager() {
-    if (mPlugin->isLoaded()) {
-        /* clear all OpenGL resource objects (images, plots, histograms etc) first
-         * and then delete the windows */
-        for (ImgMapIter iter = mImgMap.begin(); iter != mImgMap.end(); iter++)
-            mPlugin->fg_release_image(iter->second);
-
-        for (PltMapIter iter = mPltMap.begin(); iter != mPltMap.end(); iter++)
-            mPlugin->fg_release_plot(iter->second);
-
-        for (HstMapIter iter = mHstMap.begin(); iter != mHstMap.end(); iter++)
-            mPlugin->fg_release_histogram(iter->second);
-
-        for (SfcMapIter iter = mSfcMap.begin(); iter != mSfcMap.end(); iter++)
-            mPlugin->fg_release_surface(iter->second);
-
-        for (VcfMapIter iter = mVcfMap.begin(); iter != mVcfMap.end(); iter++)
-            mPlugin->fg_release_vector_field(iter->second);
-
-        for (ChartMapIter iter = mChartMap.begin(); iter != mChartMap.end();
-            iter++) {
-            for (int i = 0; i < (int)(iter->second).size(); i++) {
-                fg_chart chrt = (iter->second)[i];
-                if (chrt) {
-                    mChartAxesOverrideMap.erase((chrt));
-                    mPlugin->fg_release_chart(chrt);
-                }
-            }
-        }
-        if(wnd) mPlugin->fg_release_window(wnd->handle);
-    }
-}
-
 ForgeModule& ForgeManager::plugin() { return *mPlugin; }
 
 fg_window ForgeManager::getMainWindow() {
@@ -289,33 +256,44 @@ fg_window ForgeManager::getMainWindow() {
             if (e != FG_ERR_NONE) {
                 AF_ERROR("Graphics Window creation failed", AF_ERR_INTERNAL);
             }
-            this->mPlugin->fg_make_window_current(w);
             this->setWindowChartGrid(w, 1, 1);
-            this->wnd.reset(new Window({w}));
+            this->mPlugin->fg_make_window_current(w);
+            this->mMainWindow.reset(new Window({w}));
             if (!gladLoadGL()) { AF_ERROR("GL Load Failed", AF_ERR_LOAD_LIB); }
         });
     }
 
-    return wnd->handle;
+    return mMainWindow->handle;
 }
 
-void ForgeManager::setWindowChartGrid(const fg_window window, const int r,
-                                      const int c) {
-    ChartMapIter iter = mChartMap.find(window);
-    GridMapIter gIter = mWndGridMap.find(window);
+fg_window ForgeManager::getWindow(const int w, const int h,
+                                  const char* const title,
+                                  const bool invisible) {
+    fg_window retVal = 0;
+    FG_CHECK(mPlugin->fg_create_window(&retVal, w, h, title,
+                getMainWindow(), invisible));
+    if (retVal == 0) {
+        AF_ERROR("Window creation failed", AF_ERR_INTERNAL);
+    }
+    setWindowChartGrid(retVal, 1, 1);
+    return retVal;
+}
+
+void ForgeManager::setWindowChartGrid(const fg_window window,
+                                      const int r, const int c) {
+    ChartMapIterator iter = mChartMap.find(window);
+    WindGridMapIterator gIter = mWndGridMap.find(window);
 
     if (iter != mChartMap.end()) {
         // ChartVec found. Clear it.
         // This has to be cleared as there is no guarantee that existing
         // chart types(2D/3D) match the future grid requirements
-        for (int i = 0; i < (int)(iter->second).size(); i++) {
-            fg_chart chrt = (iter->second)[i];
-            if (chrt) {
-                mChartAxesOverrideMap.erase(chrt);
-                FG_CHECK(mPlugin->fg_release_chart(chrt));
+        for (const ChartPtr& c: iter->second) {
+            if (c) {
+                mChartAxesOverrideMap.erase(c->handle);
             }
         }
-        (iter->second).clear();
+        (iter->second).clear(); // Clear ChartList
         gIter->second = std::make_pair<int, int>(1, 1);
     }
 
@@ -323,131 +301,119 @@ void ForgeManager::setWindowChartGrid(const fg_window window, const int r,
         mChartMap.erase(window);
         mWndGridMap.erase(window);
     } else {
-        mChartMap[window]   = std::vector<fg_chart>(r * c);
+        mChartMap[window]   = ChartList(r * c);
         mWndGridMap[window] = std::make_pair(r, c);
     }
 }
 
-WindGridDims_t ForgeManager::getWindowGrid(const fg_window window) {
-    GridMapIter gIter = mWndGridMap.find(window);
-
+ForgeManager::WindowGridDims
+ForgeManager::getWindowGrid(const fg_window window) {
+    WindGridMapIterator gIter = mWndGridMap.find(window);
     if (gIter == mWndGridMap.end()) {
         mWndGridMap[window] = std::make_pair(1, 1);
     }
-
     return mWndGridMap[window];
 }
 
 fg_chart ForgeManager::getChart(const fg_window window, const int r,
                                 const int c, const fg_chart_type ctype) {
-    fg_chart chart    = NULL;
-    ChartMapIter iter = mChartMap.find(window);
-    GridMapIter gIter = mWndGridMap.find(window);
+    fg_chart retVal   = NULL;
+    ChartMapIterator iter = mChartMap.find(window);
+    WindGridMapIterator gIter = mWndGridMap.find(window);
 
-    if (iter != mChartMap.end()) {
-        int gRows = std::get<0>(gIter->second);
-        int gCols = std::get<1>(gIter->second);
+    int rows = std::get<0>(gIter->second);
+    int cols = std::get<1>(gIter->second);
 
-        if (c >= gCols || r >= gRows)
-            AF_ERROR("Grid points are out of bounds", AF_ERR_TYPE);
+    if (c >= cols || r >= rows)
+        AF_ERROR("Window Grid points are out of bounds", AF_ERR_TYPE);
 
-        // upgrade to exclusive access to make changes
-        chart = (iter->second)[c * gRows + r];
+    // upgrade to exclusive access to make changes
+    ChartPtr& chart = (iter->second)[c * rows + r];
 
-        if (chart == NULL) {
-            // Chart has not been created
-            FG_CHECK(mPlugin->fg_create_chart(&chart, ctype));
-            (iter->second)[c * gRows + r] = chart;
-            // Set Axes override to false
-            mChartAxesOverrideMap[chart] = false;
-        } else {
-            fg_chart_type chart_type;
-            FG_CHECK(mPlugin->fg_get_chart_type(&chart_type, chart));
-            if (chart_type != ctype) {
-                // Existing chart is of incompatible type
-                mChartAxesOverrideMap.erase(chart);
-                FG_CHECK(mPlugin->fg_release_chart(chart));
-                FG_CHECK(mPlugin->fg_create_chart(&chart, ctype));
-                (iter->second)[c * gRows + r] = chart;
-                // Set Axes override to false
-                mChartAxesOverrideMap[chart] = false;
-            }
-        }
+    if (!chart) {
+        fg_chart temp = NULL;
+        FG_CHECK(mPlugin->fg_create_chart(&temp, ctype));
+        chart.reset(new Chart({temp}));
+        mChartAxesOverrideMap[chart->handle] = false;
     } else {
-        // The chart map for this was never created
-        // Which should never happen
+        fg_chart_type chart_type;
+        FG_CHECK(mPlugin->fg_get_chart_type(&chart_type, chart->handle));
+        if (chart_type != ctype) {
+            // Existing chart is of incompatible type
+            mChartAxesOverrideMap.erase(chart->handle);
+            fg_chart temp = 0;
+            FG_CHECK(mPlugin->fg_create_chart(&temp, ctype));
+            chart.reset(new Chart({temp}));
+            mChartAxesOverrideMap[chart->handle] = false;
+        }
     }
-
-    return chart;
+    return chart->handle;
 }
 
-fg_image ForgeManager::getImage(int w, int h, fg_channel_format mode,
-                                fg_dtype type) {
-    /* w, h needs to fall in the range of [0, 2^16]
-     * for the ForgeManager to correctly retrieve
-     * the necessary Forge Image object. So, this implementation
-     * is a limitation on how big of an image can be rendered
-     * using arrayfire graphics funtionality */
+/// Assumptions of getImage member functions:
+///
+/// The width and height of image needs to fall in the range of [0, 2^16]
+/// for the ForgeManager to correctly retrieve the necessary Forge Image
+/// object. This is an implementation limitation on how big of an image
+/// can be rendered using arrayfire graphics funtionality
+fg_image ForgeManager::getImage(int w, int h,
+                                fg_channel_format mode, fg_dtype type) {
     assert(w <= 2ll << 16);
     assert(h <= 2ll << 16);
     long long key = ((w & _16BIT) << 16) | (h & _16BIT);
     key           = (((key << 16) | mode) << 16) | type;
 
-    ChartKey_t keypair = std::make_pair(key, nullptr);
+    ChartKey keypair = std::make_pair(key, nullptr);
 
-    ImgMapIter iter = mImgMap.find(keypair);
+    ImageMapIterator iter = mImgMap.find(keypair);
 
     if (iter == mImgMap.end()) {
         fg_image img = nullptr;
         FG_CHECK(mPlugin->fg_create_image(&img, w, h, mode, type));
-        mImgMap[keypair] = img;
+        mImgMap[keypair] = ImagePtr(new Image({img}));
     }
 
-    return mImgMap[keypair];
+    return mImgMap[keypair]->handle;
 }
 
 fg_image ForgeManager::getImage(fg_chart chart, int w, int h,
                                 fg_channel_format mode, fg_dtype type) {
-    /* w, h needs to fall in the range of [0, 2^16]
-     * for the ForgeManager to correctly retrieve
-     * the necessary Forge Image object. So, this implementation
-     * is a limitation on how big of an image can be rendered
-     * using arrayfire graphics funtionality */
     assert(w <= 2ll << 16);
     assert(h <= 2ll << 16);
     long long key = ((w & _16BIT) << 16) | (h & _16BIT);
     key           = (((key << 16) | mode) << 16) | type;
 
-    ChartKey_t keypair = std::make_pair(key, chart);
+    ChartKey keypair = std::make_pair(key, chart);
 
-    ImgMapIter iter = mImgMap.find(keypair);
+    ImageMapIterator iter = mImgMap.find(keypair);
 
     if (iter == mImgMap.end()) {
         fg_chart_type chart_type;
         FG_CHECK(mPlugin->fg_get_chart_type(&chart_type, chart));
-        if (chart_type != FG_CHART_2D)
+        if (chart_type != FG_CHART_2D) {
             AF_ERROR("Image can only be added to chart of type FG_CHART_2D",
                      AF_ERR_TYPE);
-
+        }
         fg_image img = nullptr;
         FG_CHECK(mPlugin->fg_create_image(&img, w, h, mode, type));
-        mImgMap[keypair] = img;
-
         FG_CHECK(mPlugin->fg_append_image_to_chart(chart, img));
+
+        mImgMap[keypair] = ImagePtr(new Image({img}));
     }
 
-    return mImgMap[keypair];
+    return mImgMap[keypair]->handle;
 }
 
 fg_plot ForgeManager::getPlot(fg_chart chart, int nPoints, fg_dtype dtype,
                               fg_plot_type ptype, fg_marker_type mtype) {
-    long long key = ((nPoints & _48BIT) << 48);
+    long long np  = nPoints;
+    long long key = ((np & _48BIT) << 48);
     key |= (((((dtype & 0x000F) << 12) | (ptype & 0x000F)) << 8) |
             (mtype & 0x000F));
 
-    ChartKey_t keypair = std::make_pair(key, chart);
+    ChartKey keypair = std::make_pair(key, chart);
 
-    PltMapIter iter = mPltMap.find(keypair);
+    PlotMapIterator iter = mPltMap.find(keypair);
 
     if (iter == mPltMap.end()) {
         fg_chart_type chart_type;
@@ -456,78 +422,79 @@ fg_plot ForgeManager::getPlot(fg_chart chart, int nPoints, fg_dtype dtype,
         fg_plot plt = nullptr;
         FG_CHECK(mPlugin->fg_create_plot(&plt, nPoints, dtype, chart_type,
                                          ptype, mtype));
-        mPltMap[keypair] = plt;
-
         FG_CHECK(mPlugin->fg_append_plot_to_chart(chart, plt));
+
+        mPltMap[keypair] = PlotPtr(new Plot({plt}));
     }
 
-    return mPltMap[keypair];
+    return mPltMap[keypair]->handle;
 }
 
 fg_histogram ForgeManager::getHistogram(fg_chart chart, int nBins,
                                         fg_dtype type) {
-    long long key = ((nBins & _48BIT) << 48) | (type & _16BIT);
+    long long bins = nBins;
+    long long key  = ((bins & _48BIT) << 48) | (type & _16BIT);
 
-    ChartKey_t keypair = std::make_pair(key, chart);
+    ChartKey keypair = std::make_pair(key, chart);
 
-    HstMapIter iter = mHstMap.find(keypair);
+    HistogramMapIterator iter = mHstMap.find(keypair);
 
     if (iter == mHstMap.end()) {
         fg_chart_type chart_type;
         FG_CHECK(mPlugin->fg_get_chart_type(&chart_type, chart));
-        if (chart_type != FG_CHART_2D)
+        if (chart_type != FG_CHART_2D) {
             AF_ERROR("Histogram can only be added to chart of type FG_CHART_2D",
                      AF_ERR_TYPE);
-
+        }
         fg_histogram hst = nullptr;
         FG_CHECK(mPlugin->fg_create_histogram(&hst, nBins, type));
-        mHstMap[keypair] = hst;
-
         FG_CHECK(mPlugin->fg_append_histogram_to_chart(chart, hst));
+        mHstMap[keypair] = HistogramPtr(new Histogram({hst}));
     }
 
-    return mHstMap[keypair];
+    return mHstMap[keypair]->handle;
 }
 
-fg_surface ForgeManager::getSurface(fg_chart chart, int nX, int nY,
-                                    fg_dtype type) {
+fg_surface ForgeManager::getSurface(fg_chart chart,
+                                    int nX, int nY, fg_dtype type) {
     /* nX * nY needs to fall in the range of [0, 2^48]
      * for the ForgeManager to correctly retrieve
      * the necessary Forge Plot object. So, this implementation
      * is a limitation on how big of an plot graph can be rendered
      * using arrayfire graphics funtionality */
-    assert((long long)nX * nY <= 2ll << 48);
-    long long key = (((nX * nY) & _48BIT) << 48) | (type & _16BIT);
+    long long surfaceSize = nX * (long long)(nY);
+    assert(surfaceSize <= 2ll << 48);
+    long long key = ((surfaceSize & _48BIT) << 48) | (type & _16BIT);
 
-    ChartKey_t keypair = std::make_pair(key, chart);
+    ChartKey keypair = std::make_pair(key, chart);
 
-    SfcMapIter iter = mSfcMap.find(keypair);
+    SurfaceMapIterator iter = mSfcMap.find(keypair);
 
     if (iter == mSfcMap.end()) {
         fg_chart_type chart_type;
         FG_CHECK(mPlugin->fg_get_chart_type(&chart_type, chart));
-        if (chart_type != FG_CHART_3D)
+        if (chart_type != FG_CHART_3D) {
             AF_ERROR("Surface can only be added to chart of type FG_CHART_3D",
                      AF_ERR_TYPE);
-
+        }
         fg_surface surf = nullptr;
         FG_CHECK(mPlugin->fg_create_surface(&surf, nX, nY, type,
                                             FG_PLOT_SURFACE, FG_MARKER_NONE));
-        mSfcMap[keypair] = surf;
-
         FG_CHECK(mPlugin->fg_append_surface_to_chart(chart, surf));
+        mSfcMap[keypair] = SurfacePtr(new Surface({surf}));
     }
 
-    return mSfcMap[keypair];
+    return mSfcMap[keypair]->handle;
 }
 
-fg_vector_field ForgeManager::getVectorField(fg_chart chart, int nPoints,
-                                             fg_dtype type) {
-    long long key = (((nPoints)&_48BIT) << 48) | (type & _16BIT);
+fg_vector_field ForgeManager::getVectorField(fg_chart chart,
+                                             int nPoints, fg_dtype type) {
+    long long np  = nPoints;
+    long long key = ((np & _48BIT) << 48) | (type & _16BIT);
 
-    ChartKey_t keypair = std::make_pair(key, chart);
+    ChartKey keypair = std::make_pair(key, chart);
 
-    VcfMapIter iter = mVcfMap.find(keypair);
+    VecFieldMapIterator iter = mVcfMap.find(keypair);
 
     if (iter == mVcfMap.end()) {
         fg_chart_type chart_type;
@@ -535,25 +502,25 @@ fg_vector_field ForgeManager::getVectorField(fg_chart chart, int nPoints,
 
         fg_vector_field vfield = nullptr;
         FG_CHECK(mPlugin->fg_create_vector_field(&vfield, nPoints, type,
-                                                 chart_type));
-        mVcfMap[keypair] = vfield;
-
-        FG_CHECK(mPlugin->fg_append_vector_field_to_chart(chart, vfield));
+                    chart_type));
+        FG_CHECK(mPlugin->fg_append_vector_field_to_chart(chart,
+                    vfield));
+        mVcfMap[keypair] = VectorFieldPtr(new VectorField({vfield}));
     }
 
-    return mVcfMap[keypair];
+    return mVcfMap[keypair]->handle;
 }
 
-bool ForgeManager::getChartAxesOverride(fg_chart chart) {
-    ChartAxesOverrideIter iter = mChartAxesOverrideMap.find(chart);
+bool ForgeManager::getChartAxesOverride(const fg_chart chart) {
+    AxesOverrideIterator iter = mChartAxesOverrideMap.find(chart);
     if (iter == mChartAxesOverrideMap.end()) {
         AF_ERROR("Chart Not Found!", AF_ERR_INTERNAL);
     }
     return mChartAxesOverrideMap[chart];
 }
 
-void ForgeManager::setChartAxesOverride(fg_chart chart, bool flag) {
-    ChartAxesOverrideIter iter = mChartAxesOverrideMap.find(chart);
+void ForgeManager::setChartAxesOverride(const fg_chart chart, bool flag) {
+    AxesOverrideIterator iter = mChartAxesOverrideMap.find(chart);
     if (iter == mChartAxesOverrideMap.end()) {
         AF_ERROR("Chart Not Found!", AF_ERR_INTERNAL);
     }

--- a/src/backend/common/graphics_common.hpp
+++ b/src/backend/common/graphics_common.hpp
@@ -35,18 +35,19 @@ double step_round(const double in, const bool dir);
 
 namespace graphics {
 
-/**
- * Only device manager class can create objects of this class.
- * You have to call forgeManager() defined in platform.hpp to
- * access the object. It manages the windows, and other
- * renderables (given below) that are drawed onto chosen window.
- * Renderables:
- *      fg_image
- *      fg_plot
- *      fg_histogram
- *      fg_surface
- *      fg_vector_field
- * */
+/// \brief The singleton manager class for Forge resources
+///
+/// Only device manager class can create objects of this class.
+/// You have to call forgeManager() defined in platform.hpp to
+/// access the object. It manages the windows, and other
+/// renderables (given below) that are drawed onto chosen window.
+/// Renderables:
+///      fg_image
+///      fg_plot
+///      fg_histogram
+///      fg_surface
+///      fg_vector_field
+///
 class ForgeManager {
   public:
     using WindowGridDims = std::pair<int, int>;
@@ -57,63 +58,219 @@ class ForgeManager {
     ForgeManager(ForgeManager&&)                 = delete;
     ForgeManager& operator=(ForgeManager&&) = delete;
 
+    /// \brief Module used to invoke forge API calls
     ForgeModule& plugin();
 
+    /// \brief The main window with which all other windows share GL context
     fg_window getMainWindow();
 
-    fg_window getWindow(const int width, const int height, const char* const title,
-                        const bool invisible=false);
+    /// \brief Create a window
+    ///
+    /// \param[in] width of the window
+    /// \param[in] height of the window
+    /// \param[in] title is the window title
+    /// \param[in] invisible indicates that if an invisible window
+    ///            has to be ceated
+    ///
+    /// \note Any window created will always shared OpenGL context with
+    ///       with the primary(getMainWindow()) window.
+    fg_window getWindow(const int width, const int height,
+                        const char* const title, const bool invisible = false);
 
+    /// \brief Set grid layout for a given Window
+    ///
+    /// Grid layout dictates how many renderables can be shown in a
+    /// single window. For example, if r = 2, c = 2, the entire rendering
+    /// area of the window will be split into four sections into which
+    /// different renderables can be drawn.
+    ///
+    /// \param[in] window is the target rendering context
+    /// \param[in] r is the number of rows in the grid
+    /// \param[in] c is the number of cols in the grid
     void setWindowChartGrid(const fg_window window, const int r, const int c);
 
+    /// \brief Get grid layout of a window
+    ///
+    /// This function fetches the grid layout set for given window, probably
+    /// which was set by the function \ref ForgeManager::setWindowChartGrid
+    ///
+    /// \param[in] window is the target rendering context
     WindowGridDims getWindowGrid(const fg_window window);
 
+    /// \brief Find/Create a Chart
+    ///
+    /// This function tries to find a chart fitting the given attributes
+    /// from forge resource cache. If a match is found, the matching chart
+    /// resource handle is returned. If no match is found, a new chart
+    /// with given parameters is created, cached and returned.
+    ///
+    /// \param[in] window is the target rendering context
+    /// \param[in] r is indicates the row index in the grid layout
+    ///            of the given \p window. This is usually 0 for grids having
+    ///            single cell a.k.a capable of drawing one renderable.
+    /// \param[in] c is indicates the col index in the grid layout
+    ///            of the given \p window. This is usually 0 for grids having
+    ///            single cell a.k.a capable of drawing one renderable.
+    /// \param[in] ctype is type renderables to be rendered on chart, 2D or 3D
     fg_chart getChart(const fg_window window, const int r, const int c,
                       const fg_chart_type ctype);
 
+    /// \brief Find/Create an Image
+    ///
+    /// This function tries to find an image fitting the given attributes
+    /// from forge resource cache. If a match is found, the matching image
+    /// resource handle is returned. If no match is found, a new image
+    /// with given parameters is created, cached and returned.
+    ///
+    /// Also do keep in mind this function has to be used only when you
+    /// are rendering just an image to the window. If you want to render
+    /// an image embedded into set of plots or anything else, use the getImage
+    /// member function that takes in \ref fg_chart as first parameter.
+    ///
+    /// \param[in] w is width of the image
+    /// \param[in] h is height of the image
+    /// \param[in] mode is the pixel packing format in the image
+    /// \param[in] type is type of data to be stored in image buffer
+    ///
+    /// \note The width and height of image needs to fall in the range of
+    /// [0, 2^16] for the ForgeManager to correctly retrieve the necessary
+    /// Forge Image object. This is an implementation limitation on how big
+    /// of an image can be rendered using arrayfire graphics funtionality
     fg_image getImage(int w, int h, fg_channel_format mode, fg_dtype type);
 
+    /// \brief Find/Create an Image to render in a Chart
+    ///
+    /// This function tries to find an image fitting the given attributes
+    /// from forge resource cache. If a match is found, the matching image
+    /// resource handle is returned. If no match is found, a new image
+    /// with given parameters is created, cached and returned.
+    ///
+    /// \param[in] chart is the chart to which image will be rendered
+    /// \param[in] w is width of the image
+    /// \param[in] h is height of the image
+    /// \param[in] mode is the pixel packing format in the image
+    /// \param[in] type is type of data to be stored in image buffer
+    ///
+    /// \note The width and height of image needs to fall in the range of
+    /// [0, 2^16] for the ForgeManager to correctly retrieve the necessary
+    /// Forge Image object. This is an implementation limitation on how big
+    /// of an image can be rendered using arrayfire graphics funtionality
     fg_image getImage(fg_chart chart, int w, int h,
                       fg_channel_format mode, fg_dtype type);
 
+    /// \brief Find/Create a Plot to render in a Chart
+    ///
+    /// This function tries to find a plot fitting the given attributes
+    /// from forge resource cache. If a match is found, the matching plot
+    /// resource handle is returned. If no match is found, a new plot
+    /// with given parameters is created, cached and returned.
+    ///
+    /// \param[in] chart is the chart to which plot will be rendered
+    /// \param[in] nPoints is number of points in the plot
+    /// \param[in] dtype is type of data to be stored in plot buffer
+    /// \param[in] ptype indicates the type of plot \ref fg_plot_type
+    /// \param[in] mtype indicates the type of marker/sprite to render original
+    ///            points passed in the data buffer, \ref fg_marker_type
+    ///
+    /// \note \p nPoints needs to fall in the range of [0, 2^48]
+    /// for the ForgeManager to correctly retrieve the necessary Forge
+    /// plot object. This is an implementation limitation on how big of a
+    /// plot can be rendered using arrayfire graphics funtionality
     fg_plot getPlot(fg_chart chart, int nPoints, fg_dtype dtype,
                     fg_plot_type ptype, fg_marker_type mtype);
 
+    /// \brief Find/Create a Histogram to render in a Chart
+    ///
+    /// This function tries to find a histogram fitting the given attributes
+    /// from forge resource cache. If a match is found, the matching histogram
+    /// resource handle is returned. If no match is found, a new histogram
+    /// with given parameters is created, cached and returned.
+    ///
+    /// \param[in] chart is the chart to which histogram will be rendered
+    /// \param[in] nBins is the total number of bins in the histogram
+    /// \param[in] type is type of data to be stored in histogram buffer
+    ///
+    /// \note \p nBins needs to fall in the range of [0, 2^48]
+    /// for the ForgeManager to correctly retrieve the necessary Forge
+    /// histogram object. This is an implementation limitation on how big
+    /// of a histogram can be rendered using arrayfire graphics funtionality
     fg_histogram getHistogram(fg_chart chart, int nBins, fg_dtype type);
 
+    /// \brief Find/Create a Surface to render in a Chart
+    ///
+    /// This function tries to find a surface fitting the given attributes
+    /// from forge resource cache. If a match is found, the matching surface
+    /// resource handle is returned. If no match is found, a new surface
+    /// with given parameters is created, cached and returned.
+    ///
+    /// \param[in] chart is the chart to which surface will be rendered
+    /// \param[in] nX is length of the surface grid
+    /// \param[in] nY is width of the surface grid
+    /// \param[in] type is type of data to be stored in image buffer
+    ///
+    /// \note \p nX * \p nY needs to fall in the range of [0, 2^48]
+    /// for the ForgeManager to correctly retrieve the necessary Forge Surface
+    /// object. This is an implementation limitation on how big of a surface
+    /// can be rendered using arrayfire graphics funtionality
     fg_surface getSurface(fg_chart chart, int nX, int nY, fg_dtype type);
 
+    /// \brief Find/Create a Vector Field to render in a Chart
+    ///
+    /// This function tries to find a vector field fitting the given attributes
+    /// from forge resource cache. If a match is found, the matching vector
+    /// field resource handle is returned. If no match is found, a new vector
+    /// field with given parameters is created, cached and returned.
+    ///
+    /// \param[in] chart is the chart to which plot will be rendered
+    /// \param[in] nPoints is number of points in the 2D vector field
+    /// \param[in] type is type of data to be stored in plot buffer
+    ///
+    /// \note \p nPoints needs to fall in the range of [0, 2^48]
+    /// for the ForgeManager to correctly retrieve the necessary Forge vector
+    /// field object. This is an implementation limitation on how big of a
+    /// vector field can be rendered using arrayfire graphics funtionality
     fg_vector_field getVectorField(fg_chart chart, int nPoints, fg_dtype type);
 
+    /// \brief Get chart axes limits override flag
+    ///
+    /// \param[in] chart is the target chart for which axes limits will be
+    /// overriden
     bool getChartAxesOverride(const fg_chart chart);
+
+    /// \brief Set chart axes limits override flag
+    ///
+    /// \param[in] chart is the target chart for which axes limits will be
+    /// overriden \param[in] flag indicates if axes limits are overriden or not
     void setChartAxesOverride(const fg_chart chart, bool flag = true);
 
   private:
     constexpr static unsigned int WIDTH = 1280;
     constexpr static unsigned int HEIGHT = 720;
+    constexpr static long long _4BIT     = 0x000000000000000F;
+    constexpr static long long _8BIT     = 0x00000000000000FF;
     constexpr static long long _16BIT = 0x000000000000FFFF;
     constexpr static long long _32BIT = 0x00000000FFFFFFFF;
     constexpr static long long _48BIT = 0x0000FFFFFFFFFFFF;
 
-#define DEFINE_WRAPPER_OBJECT(Object, ReleaseFunc)          \
-struct Object {                                             \
-    void* handle;                                           \
-    struct Deleter {                                        \
-        void operator()(Object* pHandle) const {            \
-            if (pHandle) {                                  \
-                forgePlugin().ReleaseFunc(pHandle->handle); \
-            }                                               \
-        }                                                   \
-    };                                                      \
-}
+    long long genImageKey(int w, int h, fg_channel_format mode, fg_dtype type);
 
-DEFINE_WRAPPER_OBJECT(Window     , fg_release_window      );
-DEFINE_WRAPPER_OBJECT(Image      , fg_release_image       );
-DEFINE_WRAPPER_OBJECT(Chart      , fg_release_chart       );
-DEFINE_WRAPPER_OBJECT(Plot       , fg_release_plot        );
-DEFINE_WRAPPER_OBJECT(Histogram  , fg_release_histogram   );
-DEFINE_WRAPPER_OBJECT(Surface    , fg_release_surface     );
-DEFINE_WRAPPER_OBJECT(VectorField, fg_release_vector_field);
+#define DEFINE_WRAPPER_OBJECT(OBJECT, RELEASE)                           \
+    struct OBJECT {                                                      \
+        void* handle;                                                    \
+        struct Deleter {                                                 \
+            void operator()(OBJECT* pHandle) const {                     \
+                if (pHandle) { forgePlugin().RELEASE(pHandle->handle); } \
+            }                                                            \
+        };                                                               \
+    }
+
+    DEFINE_WRAPPER_OBJECT(Window, fg_release_window);
+    DEFINE_WRAPPER_OBJECT(Image, fg_release_image);
+    DEFINE_WRAPPER_OBJECT(Chart, fg_release_chart);
+    DEFINE_WRAPPER_OBJECT(Plot, fg_release_plot);
+    DEFINE_WRAPPER_OBJECT(Histogram, fg_release_histogram);
+    DEFINE_WRAPPER_OBJECT(Surface, fg_release_surface);
+    DEFINE_WRAPPER_OBJECT(VectorField, fg_release_vector_field);
 
 #undef DEFINE_WRAPPER_OBJECT
 


### PR DESCRIPTION
Removed some unnecessary typedefs and moved all type aliases into
ForgeManager class scope.