### PR TITLE
Fix errors caused by large JIT kernels

### DIFF
--- a/src/backend/common/jit/BufferNodeBase.hpp
+++ b/src/backend/common/jit/BufferNodeBase.hpp
@@ -80,12 +80,12 @@ class BufferNodeBase : public common::Node {
 
     void genOffsets(std::stringstream &kerStream, int id,
                     bool is_linear) const final {
-        detail::generateBufferOffsets(kerStream, id, is_linear, m_type_str);
+        detail::generateBufferOffsets(kerStream, id, is_linear);
     }
 
-    void genFuncs(std::stringstream &kerStream, const common::Node_ids &ids,
-                  bool is_linear) const final {
-        detail::generateBufferRead(kerStream, ids.id, is_linear, m_type_str);
+    void genFuncs(std::stringstream &kerStream,
+                  const common::Node_ids &ids) const final {
+        detail::generateBufferRead(kerStream, ids.id, m_type_str);
     }
 
     void getInfo(unsigned &len, unsigned &buf_count,

--- a/src/backend/common/jit/BufferNodeBase.hpp
+++ b/src/backend/common/jit/BufferNodeBase.hpp
@@ -9,8 +9,11 @@
 
 #pragma once
 #include <backend.hpp>
+#include <common/jit/Node.hpp>
 #include <jit/kernel_generators.hpp>
 
+#include <iomanip>
+#include <mutex>
 #include <sstream>
 
 namespace common {
@@ -22,6 +25,7 @@ class BufferNodeBase : public common::Node {
     ParamType m_param;
     unsigned m_bytes;
     std::once_flag m_set_data_flag;
+    int param_index;
     bool m_linear_buffer;
 
    public:
@@ -64,9 +68,13 @@ class BufferNodeBase : public common::Node {
     int setArgs(int start_id, bool is_linear,
                 std::function<void(int id, const void *ptr, size_t arg_size)>
                     setArg) const override {
+        printf("param_index: %d\n", param_index);
         return detail::setKernelArguments(start_id, is_linear, setArg, m_data,
-                                          m_param);
+                                          m_param, param_index);
     }
+
+    void setParamIndex(int index) { param_index = index; }
+    int getParamIndex() { return param_index; }
 
     void genOffsets(std::stringstream &kerStream, int id,
                     bool is_linear) const final {
@@ -86,6 +94,7 @@ class BufferNodeBase : public common::Node {
     }
 
     size_t getBytes() const final { return m_bytes; }
+    ParamType &getParam() { return m_param; }
 };
 
 }  // namespace common

--- a/src/backend/common/jit/NaryNode.hpp
+++ b/src/backend/common/jit/NaryNode.hpp
@@ -52,7 +52,7 @@ class NaryNode : public Node {
     }
 
     void genFuncs(std::stringstream &kerStream,
-                  const common::Node_ids &ids, bool is_linear) const final {
+                  const common::Node_ids &ids) const final {
         kerStream << m_type_str << " val" << ids.id << " = " << m_op_str << "(";
         for (int i = 0; i < m_num_children; i++) {
             if (i > 0) kerStream << ", ";

--- a/src/backend/common/jit/NaryNode.hpp
+++ b/src/backend/common/jit/NaryNode.hpp
@@ -52,7 +52,7 @@ class NaryNode : public Node {
     }
 
     void genFuncs(std::stringstream &kerStream,
-                  const common::Node_ids &ids) const final {
+                  const common::Node_ids &ids, bool is_linear) const final {
         kerStream << m_type_str << " val" << ids.id << " = " << m_op_str << "(";
         for (int i = 0; i < m_num_children; i++) {
             if (i > 0) kerStream << ", ";

--- a/src/backend/common/jit/Node.hpp
+++ b/src/backend/common/jit/Node.hpp
@@ -49,28 +49,46 @@ class Node {
     int getNodesMap(Node_map_t &node_map, std::vector<const Node *> &full_nodes,
                     std::vector<Node_ids> &full_ids) const;
 
+    /// Generates the string that will be used to hash the kernel
     virtual void genKerName(std::stringstream &kerStream,
-                            const Node_ids &ids) const {
-        UNUSED(kerStream);
-        UNUSED(ids);
-    }
+                            const Node_ids &ids) const = 0;
+
+    /// Generates the function parameters for the node.
+    ///
+    /// \param[in/out] kerStream  The string will be written to this stream
+    /// \param[in]     ids        The integer id of the node and its children
+    /// \param[in]     is_linear  True if the kernel is a linear kernel
     virtual void genParams(std::stringstream &kerStream, int id,
                            bool is_linear) const {
         UNUSED(kerStream);
         UNUSED(id);
         UNUSED(is_linear);
     }
+
+    /// Generates the variable that stores the thread's/work-item's offset into
+    /// the memory.
+    ///
+    /// \param[in/out] kerStream  The string will be written to this stream
+    /// \param[in]     ids        The integer id of the node and its children
+    /// \param[in]     is_linear  True if the kernel is a linear kernel
     virtual void genOffsets(std::stringstream &kerStream, int id,
                             bool is_linear) const {
         UNUSED(kerStream);
         UNUSED(id);
         UNUSED(is_linear);
     }
-    virtual void genFuncs(std::stringstream &kerStream,
-                          const Node_ids &ids) const {
-        UNUSED(kerStream);
-        UNUSED(ids);
-    }
+
+    /// Generates the code for the operation of the node.
+    ///
+    /// Generates the soruce code of the operation that the node needs to
+    /// perform. For example this function will create the string
+    /// "val2 = __add(val1, val2);" for the addition node.
+    ///
+    /// \param[in/out] kerStream  The string will be written to this stream
+    /// \param[in]     ids        The integer id of the node and its children
+    /// \param[in]     is_linear  True if the kernel is a linear kernel
+    virtual void genFuncs(std::stringstream &kerStream, const Node_ids &ids,
+                          bool is_linear) const = 0;
 
     /// Calls the setArg function on each of the arguments passed into the
     /// kernel
@@ -90,6 +108,11 @@ class Node {
         return start_id;
     }
 
+    // Sets the index of the Param object stored in global memory. (CUDA ONLY)
+    virtual void setParamIndex(int index) {}
+    // Gets the index of the Param object stored in global memory. (CUDA ONLY)
+    virtual int getParamIndex() const { return -1; }
+
     virtual void getInfo(unsigned &len, unsigned &buf_count,
                          unsigned &bytes) const {
         UNUSED(buf_count);
@@ -97,12 +120,15 @@ class Node {
         len++;
     }
 
-    // Return the size of the parameter in bytes that will be passed to the
-    // kernel
-    virtual short getParamBytes() const { return 0; }
-
     // Return the size of the size of the buffer node in bytes. Zero otherwise
     virtual size_t getBytes() const { return 0; }
+
+    // Returns true if the node requires global memory access. This is true
+    // for buffer nodes and shift nodes. This implies that the Node needs
+    // access to the shape of the object to perform indexing operations
+    virtual bool requiresGlobalMemoryAccess() const { return false; }
+
+    // Returns true if this node is a Buffer
     virtual bool isBuffer() const { return false; }
     virtual bool isLinear(dim_t dims[4]) const {
         UNUSED(dims);
@@ -114,6 +140,10 @@ class Node {
 
     virtual ~Node() {}
 };
+
+static bool requiresGlobalMemoryAccess(Node &node) {
+    return node.requiresGlobalMemoryAccess();
+}
 
 struct Node_ids {
     std::array<int, Node::kMaxChildren> child_ids;

--- a/src/backend/common/jit/Node.hpp
+++ b/src/backend/common/jit/Node.hpp
@@ -87,8 +87,8 @@ class Node {
     /// \param[in/out] kerStream  The string will be written to this stream
     /// \param[in]     ids        The integer id of the node and its children
     /// \param[in]     is_linear  True if the kernel is a linear kernel
-    virtual void genFuncs(std::stringstream &kerStream, const Node_ids &ids,
-                          bool is_linear) const = 0;
+    virtual void genFuncs(std::stringstream &kerStream,
+                          const Node_ids &ids) const = 0;
 
     /// Calls the setArg function on each of the arguments passed into the
     /// kernel
@@ -109,7 +109,7 @@ class Node {
     }
 
     // Sets the index of the Param object stored in global memory. (CUDA ONLY)
-    virtual void setParamIndex(int index) {}
+    virtual void setParamIndex(int index) { UNUSED(index); }
     // Gets the index of the Param object stored in global memory. (CUDA ONLY)
     virtual int getParamIndex() const { return -1; }
 
@@ -141,7 +141,7 @@ class Node {
     virtual ~Node() {}
 };
 
-static bool requiresGlobalMemoryAccess(Node &node) {
+static inline bool requiresGlobalMemoryAccess(Node &node) {
     return node.requiresGlobalMemoryAccess();
 }
 

--- a/src/backend/common/jit/ScalarNode.hpp
+++ b/src/backend/common/jit/ScalarNode.hpp
@@ -48,7 +48,7 @@ class ScalarNode : public common::Node {
     }
 
     void genFuncs(std::stringstream& kerStream,
-                  const common::Node_ids& ids, bool is_linear) const final {
+                  const common::Node_ids& ids) const final {
         kerStream << m_type_str << " val" << ids.id << " = scalar" << ids.id
                   << ";\n";
     }

--- a/src/backend/common/jit/ScalarNode.hpp
+++ b/src/backend/common/jit/ScalarNode.hpp
@@ -48,14 +48,9 @@ class ScalarNode : public common::Node {
     }
 
     void genFuncs(std::stringstream& kerStream,
-                  const common::Node_ids& ids) const final {
+                  const common::Node_ids& ids, bool is_linear) const final {
         kerStream << m_type_str << " val" << ids.id << " = scalar" << ids.id
                   << ";\n";
-    }
-
-    // Return the info for the params and the size of the buffers
-    virtual short getParamBytes() const final {
-        return static_cast<short>(sizeof(T));
     }
 };
 

--- a/src/backend/common/jit/ShiftNodeBase.hpp
+++ b/src/backend/common/jit/ShiftNodeBase.hpp
@@ -9,13 +9,16 @@
 
 #pragma once
 
+#include <common/jit/Node.hpp>
 #include <jit/BufferNode.hpp>
 #include <jit/kernel_generators.hpp>
 
+#include <Param.hpp>
 #include <backend.hpp>
-#include <iomanip>
 
 #include <array>
+#include <functional>
+#include <iomanip>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -40,6 +43,8 @@ class ShiftNodeBase : public Node {
         UNUSED(dims);
         return false;
     }
+
+    bool requiresGlobalMemoryAccess() const final { return true; }
 
     void genKerName(std::stringstream &kerStream,
                     const common::Node_ids &ids) const final {
@@ -67,13 +72,21 @@ class ShiftNodeBase : public Node {
         return curr_id + 4;
     }
 
+    void setParamIndex(int index) final { m_buffer_node->setParamIndex(index); }
+    int getParamIndex() const final { return m_buffer_node->getParamIndex(); }
+
+    typename BufferNode::param_type getParam() {
+        return m_buffer_node->getParam();
+    }
+
     void genOffsets(std::stringstream &kerStream, int id,
                     bool is_linear) const final {
         detail::generateShiftNodeOffsets(kerStream, id, is_linear, m_type_str);
     }
 
-    void genFuncs(std::stringstream &kerStream,
-                  const common::Node_ids &ids) const final {
+    void genFuncs(std::stringstream &kerStream, const common::Node_ids &ids,
+                  bool is_linear) const final {
+        UNUSED(is_linear);
         detail::generateShiftNodeRead(kerStream, ids.id, m_type_str);
     }
 

--- a/src/backend/common/jit/ShiftNodeBase.hpp
+++ b/src/backend/common/jit/ShiftNodeBase.hpp
@@ -81,12 +81,12 @@ class ShiftNodeBase : public Node {
 
     void genOffsets(std::stringstream &kerStream, int id,
                     bool is_linear) const final {
-        detail::generateShiftNodeOffsets(kerStream, id, is_linear, m_type_str);
+        UNUSED(is_linear);
+        detail::generateShiftNodeOffsets(kerStream, id);
     }
 
-    void genFuncs(std::stringstream &kerStream, const common::Node_ids &ids,
-                  bool is_linear) const final {
-        UNUSED(is_linear);
+    void genFuncs(std::stringstream &kerStream,
+                  const common::Node_ids &ids) const final {
         detail::generateShiftNodeRead(kerStream, ids.id, m_type_str);
     }
 

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -239,7 +239,6 @@ Array<T> createNodeArray(const dim4 &dims, Node_ptr node) {
                 Node *n = node.get();
 
                 NodeIterator<> end_node;
-                dim4 outdim = out.dims();
 
                 // Calculate the total bytes allocated by the buffers of this
                 // tree. This is done so that we can make sure that we are

--- a/src/backend/cuda/Param.hpp
+++ b/src/backend/cuda/Param.hpp
@@ -15,29 +15,51 @@
 #ifndef __CUDACC_RTC__
 #include <af/defines.h>
 #endif
+#include <algorithm>  // TODO(umar): remove this
 
 namespace cuda {
 
 template<typename T>
 class Param {
    public:
-    T *ptr;
     dim_t dims[4];
     dim_t strides[4];
+    T *ptr;
+    bool is_linear;
 
     __DH__ Param() : ptr(nullptr) {}
 
     __DH__ Param(T *iptr, const dim_t *idims, const dim_t *istrides)
-        : ptr(iptr) {
-        for (int i = 0; i < 4; i++) {
-            dims[i]    = idims[i];
-            strides[i] = istrides[i];
-        }
+        : dims{idims[0], idims[1], idims[2], idims[3]}
+        , strides{istrides[0], istrides[1], istrides[2], istrides[3]}
+        , ptr(iptr) {
+        // for (int i = 0; i < 4; i++) { dims[i] = idims[i]; }
+        // for (int i = 0; i < 4; i++) { strides[i] = istrides[i]; }
     }
+
     __DH__ size_t elements() const noexcept {
         return dims[0] * dims[1] * dims[2] * dims[3];
     }
+
+    Param<T> &operator=(const Param<T> &other) {
+        ptr = other.ptr;
+        std::copy(other.dims, other.dims + AF_MAX_DIMS, dims);
+        std::copy(other.strides, other.strides + AF_MAX_DIMS, strides);
+        return *this;
+    }
 };
+
+template<typename TL, typename TR>
+bool equal_shape(const Param<TL> &lhs, const Param<TR> &rhs) {
+    return std::equal(lhs.dims, lhs.dims + 4, rhs.dims) &&
+           std::equal(lhs.strides, lhs.strides + 4, rhs.strides);
+}
+
+template<typename TL, typename TR>
+bool less_stride(const Param<TL> &lhs, const Param<TR> &rhs) {
+    return std::lexicographical_compare(lhs.strides, lhs.strides + AF_MAX_DIMS,
+                                        rhs.strides, rhs.strides + AF_MAX_DIMS);
+}
 
 template<typename T>
 Param<T> flat(Param<T> in) {
@@ -74,5 +96,4 @@ class CParam {
         return dims[0] * dims[1] * dims[2] * dims[3];
     }
 };
-
 }  // namespace cuda

--- a/src/backend/cuda/Param.hpp
+++ b/src/backend/cuda/Param.hpp
@@ -15,7 +15,6 @@
 #ifndef __CUDACC_RTC__
 #include <af/defines.h>
 #endif
-#include <algorithm>  // TODO(umar): remove this
 
 namespace cuda {
 
@@ -25,41 +24,32 @@ class Param {
     dim_t dims[4];
     dim_t strides[4];
     T *ptr;
-    bool is_linear;
 
     __DH__ Param() : ptr(nullptr) {}
 
     __DH__ Param(T *iptr, const dim_t *idims, const dim_t *istrides)
         : dims{idims[0], idims[1], idims[2], idims[3]}
         , strides{istrides[0], istrides[1], istrides[2], istrides[3]}
-        , ptr(iptr) {
-        // for (int i = 0; i < 4; i++) { dims[i] = idims[i]; }
-        // for (int i = 0; i < 4; i++) { strides[i] = istrides[i]; }
-    }
+        , ptr(iptr) {}
 
     __DH__ size_t elements() const noexcept {
         return dims[0] * dims[1] * dims[2] * dims[3];
     }
 
     Param<T> &operator=(const Param<T> &other) {
-        ptr = other.ptr;
-        std::copy(other.dims, other.dims + AF_MAX_DIMS, dims);
-        std::copy(other.strides, other.strides + AF_MAX_DIMS, strides);
+        ptr     = other.ptr;
+        dims[0] = other.dims[0];
+        dims[1] = other.dims[1];
+        dims[2] = other.dims[2];
+        dims[3] = other.dims[3];
+
+        strides[0] = other.strides[0];
+        strides[1] = other.strides[1];
+        strides[2] = other.strides[2];
+        strides[3] = other.strides[3];
         return *this;
     }
 };
-
-template<typename TL, typename TR>
-bool equal_shape(const Param<TL> &lhs, const Param<TR> &rhs) {
-    return std::equal(lhs.dims, lhs.dims + 4, rhs.dims) &&
-           std::equal(lhs.strides, lhs.strides + 4, rhs.strides);
-}
-
-template<typename TL, typename TR>
-bool less_stride(const Param<TL> &lhs, const Param<TR> &rhs) {
-    return std::lexicographical_compare(lhs.strides, lhs.strides + AF_MAX_DIMS,
-                                        rhs.strides, rhs.strides + AF_MAX_DIMS);
-}
 
 template<typename T>
 Param<T> flat(Param<T> in) {
@@ -73,24 +63,19 @@ Param<T> flat(Param<T> in) {
 template<typename T>
 class CParam {
    public:
-    const T *ptr;
     dim_t dims[4];
     dim_t strides[4];
+    const T *ptr;
 
     __DH__ CParam(const T *iptr, const dim_t *idims, const dim_t *istrides)
-        : ptr(iptr) {
-        for (int i = 0; i < 4; i++) {
-            dims[i]    = idims[i];
-            strides[i] = istrides[i];
-        }
-    }
+        : dims{idims[0], idims[1], idims[2], idims[3]}
+        , strides{istrides[0], istrides[1], istrides[2], istrides[3]}
+        , ptr(iptr) {}
 
-    __DH__ CParam(Param<T> &in) : ptr(in.ptr) {
-        for (int i = 0; i < 4; i++) {
-            dims[i]    = in.dims[i];
-            strides[i] = in.strides[i];
-        }
-    }
+    __DH__ CParam(Param<T> &in)
+        : dims{in.dims[0], in.dims[1], in.dims[2], in.dims[3]}
+        , strides{in.strides[0], in.strides[1], in.strides[2], in.strides[3]}
+        , ptr(in.ptr) {}
 
     __DH__ size_t elements() const noexcept {
         return dims[0] * dims[1] * dims[2] * dims[3];

--- a/src/backend/cuda/binary.hpp
+++ b/src/backend/cuda/binary.hpp
@@ -134,6 +134,8 @@ Array<To> createBinaryNode(const Array<Ti> &lhs, const Array<Ti> &rhs,
                            const af::dim4 &odims) {
     BinOp<To, Ti, op> bop;
 
+    if(lhs.getNode()->getHeight() > 25) lhs.eval();
+    if(rhs.getNode()->getHeight() > 25) rhs.eval();
     common::Node_ptr lhs_node = lhs.getNode();
     common::Node_ptr rhs_node = rhs.getNode();
     common::BinaryNode *node =

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -179,7 +179,7 @@ struct Param
         // Generate input offsets, only needs current id
         node->genOffsets(offsetsStream, ids_curr.id, is_linear);
         // Generate the core function body, needs children ids as well
-        node->genFuncs(opsStream, ids_curr, is_linear);
+        node->genFuncs(opsStream, ids_curr);
     }
 
     for (int i = 0; i < (int)output_ids.size(); i++) {

--- a/src/backend/cuda/jit/BufferNode.hpp
+++ b/src/backend/cuda/jit/BufferNode.hpp
@@ -15,5 +15,5 @@ namespace cuda {
 namespace jit {
 template<typename T>
 using BufferNode = common::BufferNodeBase<std::shared_ptr<T>, Param<T>>;
-}
+}  // namespace jit
 }  // namespace cuda

--- a/src/backend/cuda/jit/ShiftNode.hpp
+++ b/src/backend/cuda/jit/ShiftNode.hpp
@@ -1,0 +1,20 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <common/jit/BufferNodeBase.hpp>
+#include <common/jit/ShiftNodeBase.hpp>
+
+namespace cuda {
+namespace jit {
+
+template<typename T>
+using ShiftNode = common::ShiftNodeBase<BufferNode<T>>;
+
+}  // namespace jit
+}  // namespace cuda

--- a/src/backend/cuda/jit/kernel_generators.hpp
+++ b/src/backend/cuda/jit/kernel_generators.hpp
@@ -54,7 +54,7 @@ inline int setKernelArguments(
 /// Generates the code to calculate the offsets for a buffer
 inline void generateBufferOffsets(std::stringstream& kerStream, int id,
                                   bool is_linear) {
-    std::string idx_str = std::string("\n\t\tint idx") + std::to_string(id);
+    std::string idx_str = std::string("\n\t\tdim_t idx") + std::to_string(id);
 
     if (is_linear) {
         kerStream << idx_str << " = idx;";

--- a/src/backend/cuda/jit/kernel_generators.hpp
+++ b/src/backend/cuda/jit/kernel_generators.hpp
@@ -22,8 +22,9 @@ namespace cuda {
 namespace {
 
 /// Creates a string that will be used to declare the parameter of kernel
-void generateParamDeclaration(std::stringstream& kerStream, int id,
-                              bool is_linear, const std::string& m_type_str) {
+inline void generateParamDeclaration(std::stringstream& kerStream, int id,
+                                     bool is_linear,
+                                     const std::string& m_type_str) {
     if (is_linear) {
         kerStream << m_type_str << " *in" << id << "_ptr,\n";
     } else {
@@ -36,7 +37,7 @@ void generateParamDeclaration(std::stringstream& kerStream, int id,
 
 /// Calls the setArg function to set the arguments for a kernel call
 template<typename T>
-int setKernelArguments(
+inline int setKernelArguments(
     int start_id, bool is_linear,
     std::function<void(int id, const void* ptr, size_t arg_size)>& setArg,
     const std::shared_ptr<T>& ptr, const Param<T>& info,
@@ -53,32 +54,25 @@ int setKernelArguments(
 }
 
 /// Generates the code to calculate the offsets for a buffer
-void generateBufferOffsets(std::stringstream& kerStream, int id, bool is_linear,
-                           const std::string& type_str) {
+inline void generateBufferOffsets(std::stringstream& kerStream, int id,
+                                  bool is_linear) {
     std::string idx_str = std::string("int idx") + std::to_string(id);
 
-    assert(is_linear);
     if (is_linear) {
         kerStream << idx_str << " = idx;\n";
+    } else {
+        kerStream << idx_str << " = offsets[in_index" << id << "];\n";
     }
 }
 
 /// Generates the code to read a buffer and store it in a local variable
-void generateBufferRead(std::stringstream& kerStream, int id, bool is_linear,
-                        const std::string& type_str) {
-    if (is_linear) {
-        kerStream << type_str << " val" << id << " = in" << id << "_ptr[idx"
-                  << id << "];\n";
-    } else {
-        kerStream << type_str << " val" << id << " = in" << id
-                  << "_ptr[offsets["
-                  << "in_index" << id << "]];\n";
-    }
+inline void generateBufferRead(std::stringstream& kerStream, int id,
+                               const std::string& type_str) {
+    kerStream << type_str << " val" << id << " = in" << id << "_ptr[idx" << id
+              << "];\n";
 }
 
-void generateShiftNodeOffsets(std::stringstream& kerStream, int id,
-                              bool is_linear, const std::string& type_str) {
-    UNUSED(is_linear);
+inline void generateShiftNodeOffsets(std::stringstream& kerStream, int id) {
     std::string idx_str   = std::string("idx") + std::to_string(id);
     std::string info_str  = std::string("in") + std::to_string(id);
     std::string id_str    = std::string("sh_id_") + std::to_string(id) + "_";
@@ -105,8 +99,8 @@ void generateShiftNodeOffsets(std::stringstream& kerStream, int id,
               << ".dims[0]) * " << id_str << "0;\n";
 }
 
-void generateShiftNodeRead(std::stringstream& kerStream, int id,
-                           const std::string& type_str) {
+inline void generateShiftNodeRead(std::stringstream& kerStream, int id,
+                                  const std::string& type_str) {
     kerStream << type_str << " val" << id << " = in" << id << "_ptr[idx" << id
               << "];\n";
 }

--- a/src/backend/cuda/jit/kernel_generators.hpp
+++ b/src/backend/cuda/jit/kernel_generators.hpp
@@ -57,22 +57,9 @@ void generateBufferOffsets(std::stringstream& kerStream, int id, bool is_linear,
                            const std::string& type_str) {
     std::string idx_str = std::string("int idx") + std::to_string(id);
 
+    assert(is_linear);
     if (is_linear) {
         kerStream << idx_str << " = idx;\n";
-    } else {
-        // std::string info_str = std::string("in") + std::to_string(id);
-        // kerStream << type_str << " *in" << id << "_ptr = ( " << type_str <<
-        // *")in" << id << ".ptr;\n";
-
-        // kerStream << idx_str << " = (id3 < " << info_str << ".dims[3]) * "
-        //          << info_str << ".strides[3] * id3 + (id2 < " << info_str
-        //          << ".dims[2]) * " << info_str << ".strides[2] * id2 + (id1 <
-        //          "
-        //          << info_str << ".dims[1]) * " << info_str
-        //          << ".strides[1] * id1 + (id0 < " << info_str
-        //          << ".dims[0]) * id0;\n";
-        // kerStream << type_str << " *in" << id << "_ptr = in" << id <<
-        // ".ptr;\n";
     }
 }
 

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -68,6 +68,7 @@ using kc_t = map<string, Kernel>;
         char* logptr = log.get();                      \
         nvrtcGetProgramLog(prog, logptr);              \
         logptr[logSize] = '\x0';                       \
+        puts(logptr);                                  \
         AF_ERROR("NVRTC ERROR", AF_ERR_INTERNAL);      \
     } while (0)
 #else

--- a/src/backend/cuda/shift.cpp
+++ b/src/backend/cuda/shift.cpp
@@ -11,6 +11,7 @@
 #include <common/jit/ShiftNodeBase.hpp>
 #include <err_cuda.hpp>
 #include <jit/BufferNode.hpp>
+#include <jit/ShiftNode.hpp>
 #include <shift.hpp>
 
 #include <memory>
@@ -21,6 +22,7 @@ using common::Node_ptr;
 using common::ShiftNodeBase;
 
 using cuda::jit::BufferNode;
+using cuda::jit::ShiftNode;
 
 using std::array;
 using std::make_shared;
@@ -28,12 +30,10 @@ using std::static_pointer_cast;
 using std::string;
 
 namespace cuda {
-template<typename T>
-using ShiftNode = ShiftNodeBase<BufferNode<T>>;
 
 template<typename T>
 Array<T> shift(const Array<T> &in, const int sdims[4]) {
-    // Shift should only be the first node in the JIT tree.
+    // Shift should only be the leaf node in the JIT tree.
     // Force input to be evaluated so that in is always a buffer.
     in.eval();
 

--- a/src/backend/opencl/jit.cpp
+++ b/src/backend/opencl/jit.cpp
@@ -127,7 +127,7 @@ static string getKernelString(const string funcName,
         // Generate input offsets, only needs current id
         node->genOffsets(offsetsStream, ids_curr.id, is_linear);
         // Generate the core function body, needs children ids as well
-        node->genFuncs(opsStream, ids_curr, is_linear);
+        node->genFuncs(opsStream, ids_curr);
     }
 
     for (int i = 0; i < (int)output_ids.size(); i++) {

--- a/src/backend/opencl/jit.cpp
+++ b/src/backend/opencl/jit.cpp
@@ -127,7 +127,7 @@ static string getKernelString(const string funcName,
         // Generate input offsets, only needs current id
         node->genOffsets(offsetsStream, ids_curr.id, is_linear);
         // Generate the core function body, needs children ids as well
-        node->genFuncs(opsStream, ids_curr);
+        node->genFuncs(opsStream, ids_curr, is_linear);
     }
 
     for (int i = 0; i < (int)output_ids.size(); i++) {
@@ -221,7 +221,7 @@ void evalNodes(vector<Param> &outputs, vector<Node *> output_nodes) {
     }
 
     bool is_linear = true;
-    for (auto node : full_nodes) {
+    for (const auto &node : full_nodes) {
         is_linear &= node->isLinear(outputs[0].info.dims);
     }
 

--- a/src/backend/opencl/jit/kernel_generators.hpp
+++ b/src/backend/opencl/jit/kernel_generators.hpp
@@ -16,8 +16,9 @@ namespace opencl {
 namespace {
 
 /// Creates a string that will be used to declare the parameter of kernel
-void generateParamDeclaration(std::stringstream& kerStream, int id,
-                              bool is_linear, const std::string& m_type_str) {
+inline void generateParamDeclaration(std::stringstream& kerStream, int id,
+                                     bool is_linear,
+                                     const std::string& m_type_str) {
     if (is_linear) {
         kerStream << "__global " << m_type_str << " *in" << id
                   << ", dim_t iInfo" << id << "_offset, \n";
@@ -28,11 +29,12 @@ void generateParamDeclaration(std::stringstream& kerStream, int id,
 }
 
 /// Calls the setArg function to set the arguments for a kernel call
-int setKernelArguments(
+inline int setKernelArguments(
     int start_id, bool is_linear,
     std::function<void(int id, const void* ptr, size_t arg_size)>& setArg,
     const std::shared_ptr<cl::Buffer>& ptr, const KParam& info,
     const int& param_index) {
+    UNUSED(param_index);
     setArg(start_id + 0, static_cast<const void*>(&ptr.get()->operator()()),
            sizeof(cl_mem));
     if (is_linear) {
@@ -45,9 +47,8 @@ int setKernelArguments(
 }
 
 /// Generates the code to calculate the offsets for a buffer
-void generateBufferOffsets(std::stringstream& kerStream, int id, bool is_linear,
-                           const std::string& type_str) {
-    UNUSED(type_str);
+inline void generateBufferOffsets(std::stringstream& kerStream, int id,
+                                  bool is_linear) {
     std::string idx_str  = std::string("int idx") + std::to_string(id);
     std::string info_str = std::string("iInfo") + std::to_string(id);
 
@@ -64,17 +65,13 @@ void generateBufferOffsets(std::stringstream& kerStream, int id, bool is_linear,
 }
 
 /// Generates the code to read a buffer and store it in a local variable
-void generateBufferRead(std::stringstream& kerStream, int id, bool is_linear,
-                        const std::string& type_str) {
+inline void generateBufferRead(std::stringstream& kerStream, int id,
+                               const std::string& type_str) {
     kerStream << type_str << " val" << id << " = in" << id << "[idx" << id
               << "];\n";
 }
 
-inline void generateShiftNodeOffsets(std::stringstream& kerStream, int id,
-                                     bool is_linear,
-                                     const std::string& type_str) {
-    UNUSED(is_linear);
-    UNUSED(type_str);
+inline void generateShiftNodeOffsets(std::stringstream& kerStream, int id) {
     std::string idx_str   = std::string("idx") + std::to_string(id);
     std::string info_str  = std::string("iInfo") + std::to_string(id);
     std::string id_str    = std::string("sh_id_") + std::to_string(id) + "_";

--- a/src/backend/opencl/jit/kernel_generators.hpp
+++ b/src/backend/opencl/jit/kernel_generators.hpp
@@ -31,7 +31,8 @@ void generateParamDeclaration(std::stringstream& kerStream, int id,
 int setKernelArguments(
     int start_id, bool is_linear,
     std::function<void(int id, const void* ptr, size_t arg_size)>& setArg,
-    const std::shared_ptr<cl::Buffer>& ptr, const KParam& info) {
+    const std::shared_ptr<cl::Buffer>& ptr, const KParam& info,
+    const int& param_index) {
     setArg(start_id + 0, static_cast<const void*>(&ptr.get()->operator()()),
            sizeof(cl_mem));
     if (is_linear) {
@@ -63,7 +64,7 @@ void generateBufferOffsets(std::stringstream& kerStream, int id, bool is_linear,
 }
 
 /// Generates the code to read a buffer and store it in a local variable
-void generateBufferRead(std::stringstream& kerStream, int id,
+void generateBufferRead(std::stringstream& kerStream, int id, bool is_linear,
                         const std::string& type_str) {
     kerStream << type_str << " val" << id << " = in" << id << "[idx" << id
               << "];\n";

--- a/test/jit.cpp
+++ b/test/jit.cpp
@@ -426,4 +426,22 @@ TEST(JIT, ConstEval7) {
         eval(a, b, c, d, e, f, g);
         af::sync();
       });
+
+}
+
+TEST(JIT, TwoLargeNonLinear) {
+    array a(10, 10);
+    array b(10, 10);
+
+    for (int i = 0; i < 1; i++) {
+        a += tile(randu(10), 1, 10) + randu(10, 10);
+    }
+
+    for (int i = 0; i < 1; i++) {
+        b += tile(randu(10), 1, 10) + randu(10, 10);
+    }
+
+    array c = a + b;
+    c.eval();
+    af::sync();
 }

--- a/test/jit.cpp
+++ b/test/jit.cpp
@@ -469,3 +469,44 @@ TEST(JIT, TwoLargeNonLinear) {
     vector<float> gold(a.elements(), val * 2);
     ASSERT_VEC_ARRAY_EQ(gold, a.dims(), c);
 }
+
+TEST(JIT, Indexing) {
+  array a = randu(32, 512);
+  array b = randu(1, 512);
+
+  array c = a(31, af::span) + b;
+
+  c.eval();
+
+  af::sync();
+}
+
+TEST(JIT, ManyConstants) {
+  array res = constant(1, 1);
+  array res2 = tile(res, 1, 10);
+  array res3 = randu(1);
+  array res4 = tile(res3, 1, 10);
+  array res5 = randu(1);
+  array res6 = tile(res5, 1, 10);
+  array res7 = randu(1);
+  array res8 = tile(res7, 1, 10);
+
+  for(int i = 0; i < 196; i++) {
+    res2 = res2 + constant(1, 1, 10);
+  }
+  //for(int i = 0; i < 190; i++) {
+  //res4 = res4 + tile(constant(1, 1), 1, 10);
+  //}
+  //for(int i = 0; i < 190; i++) {
+  //res6 = res6 + tile(constant(1, 1), 1, 10);
+  //}
+  //for(int i = 0; i < 190; i++) {
+  //res8 = res8 + 1.0f;
+  //}
+
+  res2.eval();
+  //eval(res2, res4, res6, res8);
+  af::sync();
+
+
+}

--- a/test/jit.cpp
+++ b/test/jit.cpp
@@ -495,31 +495,24 @@ TEST(JIT, IndexingRow) {
 }
 
 TEST(JIT, ManyConstants) {
-  array res = constant(1, 1);
-  array res2 = tile(res, 1, 10);
-  array res3 = randu(1);
-  array res4 = tile(res3, 1, 10);
-  array res5 = randu(1);
-  array res6 = tile(res5, 1, 10);
-  array res7 = randu(1);
-  array res8 = tile(res7, 1, 10);
+    array res  = constant(1, 1);
+    array res2 = tile(res, 1, 10);
 
-  for(int i = 0; i < 196; i++) {
-    res2 = res2 + constant(1, 1, 10);
-  }
-  //for(int i = 0; i < 190; i++) {
-  //res4 = res4 + tile(constant(1, 1), 1, 10);
-  //}
-  //for(int i = 0; i < 190; i++) {
-  //res6 = res6 + tile(constant(1, 1), 1, 10);
-  //}
-  //for(int i = 0; i < 190; i++) {
-  //res8 = res8 + 1.0f;
-  //}
+    for (int i = 0; i < 300; i++) { res2 = res2 + constant(1, 1, 10); }
 
-  res2.eval();
-  //eval(res2, res4, res6, res8);
-  af::sync();
+    res2.eval();
+    af::sync();
+}
 
+TEST(JIT, IncrementingBinary) {
+    array a = randu(20, 5);
+    array b = randu(20, 1);
+    array c = randu(20, 1);
+    for (int i = 0; i < 500; i++) {
+        b += cos(pow(sin(c * 0.3f), 2) + pow(randu(20, 1) - 3, 2) * 1.1f + 3);
+        a = floor(a + tile(b, 1, 5));
+    }
 
+    a.eval();
+    af::sync();
 }

--- a/test/jit.cpp
+++ b/test/jit.cpp
@@ -470,15 +470,28 @@ TEST(JIT, TwoLargeNonLinear) {
     ASSERT_VEC_ARRAY_EQ(gold, a.dims(), c);
 }
 
-TEST(JIT, Indexing) {
-  array a = randu(32, 512);
-  array b = randu(1, 512);
+TEST(JIT, IndexingColumn) {
+    array a = constant(1, 512, 32);
+    array b = constant(2, 512);
+    a.eval();
+    b.eval();
 
-  array c = a(31, af::span) + b;
+    array c = a(af::span, 31) + b;
 
-  c.eval();
+    vector<float> gold(512, 3.0f);
+    ASSERT_VEC_ARRAY_EQ(gold, dim4(512), c);
+}
 
-  af::sync();
+TEST(JIT, IndexingRow) {
+    array a = constant(1, 32, 512);
+    array b = constant(2, 1, 512);
+    a.eval();
+    b.eval();
+
+    array c = a(31, af::span) + b;
+
+    vector<float> gold(512, 3.0f);
+    ASSERT_VEC_ARRAY_EQ(gold, dim4(1, 512), c);
 }
 
 TEST(JIT, ManyConstants) {


### PR DESCRIPTION
Fixes errors caused by JIT kernels that were too large. The errors occurred because the size of the arguments passed to the JIT kernel was greater than 4kb. This is the limit on NVIDIA devices. This PR fixes this by passing the shape information via global memory. The kernels have been modified so that the parameter array is read into the shared memory and then used in the rest of the kernel.

Here is an example of a non-linear kernel with the new changes. Notice that I am passing the pointer and the index. This index is the index in the `dims` Param array that stores the dimensions and strides of that buffer.
```
extern "C" __global__ void
KER6346349204703026994(
int *in0_ptr, int in_index0,
int *in1_ptr, int in_index1,
Param out2, 
Param out3, 
Param* dims, int num_params, uint blocks_x, uint blocks_y, uint blocks_x_total, uint num_odims)
{

const Param &outref = out2;

        extern __shared__ Param params[];
        long long offsets[8];

        if (threadIdx.x < num_params) { params[threadIdx.x] = dims[threadIdx.x]; }
        __syncthreads();
    
    for (int blockIdx_x = blockIdx.x; blockIdx_x < blocks_x_total; blockIdx_x += gridDim.x) {
    
        long long id0 = 0, id1 = 0, id2 = 0, id3 = 0;
        long blockIdx_y = blockIdx.z * gridDim.y + blockIdx.y;
        if (num_odims > 2) {
            id2 = blockIdx_x / blocks_x;
            id0 = blockIdx_x - id2 * blocks_x;
            id0 = threadIdx.x + id0 * blockDim.x;
            if (num_odims > 3) {
                id3 = blockIdx_y / blocks_y;
                id1 = blockIdx_y - id3 * blocks_y;
                id1 = threadIdx.y + id1 * blockDim.y;
            } else {
                id1 = threadIdx.y + blockDim.y * blockIdx_y;
            }
        } else {
            id3 = 0;
            id2 = 0;
            id1 = threadIdx.y + blockDim.y * blockIdx_y;
            id0 = threadIdx.x + blockDim.x * blockIdx_x;
        }

        bool cond = id0 < outref.dims[0] &&
                    id1 < outref.dims[1] &&
                    id2 < outref.dims[2] &&
                    id3 < outref.dims[3];

        if (!cond) { continue; }

        long long idx = outref.strides[3] * id3 +
                        outref.strides[2] * id2 +
                        outref.strides[1] * id1 + id0;

        for(int i = 0; i < num_params; i++) {
            offsets[i] = (id3 < params[i].dims[3]) * params[i].strides[3] * id3 +
                         (id2 < params[i].dims[2]) * params[i].strides[2] * id2 +
                         (id1 < params[i].dims[1]) * params[i].strides[1] * id1 +
                         (id0 < params[i].dims[0]) * id0;
        }
        int val0 = in0_ptr[offsets[in_index0]];
int val1 = in1_ptr[offsets[in_index1]];
int val2 = __add(val0, val1);
int val3 = __sub(val0, val1);
((int*)(out2.ptr))[idx] = val2;
((int*)(out3.ptr))[idx] = val3;
}
```

Fixes: #2436 #2389 