### PR TITLE
Fix BLAS gemm func generators with newest MSVC 19 on VS 2017

### DIFF
--- a/src/backend/cpu/blas.cpp
+++ b/src/backend/cpu/blas.cpp
@@ -151,10 +151,10 @@ using gemm_batch_func_def = void (*)(
     template<typename T>    \
     FUNC##_func_def<T> FUNC##_func();
 
-#define BLAS_FUNC(FUNC, TYPE, PREFIX)           \
-    template<>                                  \
-    FUNC##_func_def<TYPE> FUNC##_func<TYPE>() { \
-        return &cblas_##PREFIX##FUNC;           \
+#define BLAS_FUNC(FUNC, TYPE, PREFIX)                        \
+    template<>                                               \
+    FUNC##_func_def<TYPE> FUNC##_func<TYPE>() {              \
+        return (FUNC##_func_def<TYPE>)&cblas_##PREFIX##FUNC; \
     }
 
 BLAS_FUNC_DEF(gemm)


### PR DESCRIPTION
- Build fails with Microsoft Visual Studio 2017/MSVC OC `19.15.26732` for x64
- Reinterpret or explicit cast required to convert `gemm_batch_func_dev<void*>` to `gemm_vatch_func_dev<T>` (same with gemv) for types `cfloat` and `cdouble`