### PR TITLE
Cleanup cuda libraries in DeviceManager destructor

### DIFF
--- a/src/backend/cuda/platform.hpp
+++ b/src/backend/cuda/platform.hpp
@@ -109,6 +109,7 @@ class DeviceManager {
     static bool checkGraphicsInteropCapability();
 
     static DeviceManager& getInstance();
+    ~DeviceManager();
 
     spdlog::logger* getLogger();
 


### PR DESCRIPTION
The following are the resource handles whose cleanup
has been moved to destructor of DeviceManager in CUDA backend.
- cuBLAS
- cuSparse
- cuSolver

fft plancache cleanup has also been moved to DeviceManager destructor

Hopefully Fixes #2374 