### PR TITLE
Remove the use of addition and scalars in tile jit nodes

### DIFF
--- a/src/api/c/tile.cpp
+++ b/src/api/c/tile.cpp
@@ -13,6 +13,8 @@
 #include <common/err_common.hpp>
 #include <handle.hpp>
 #include <tile.hpp>
+
+#include <unary.hpp>
 #include <af/arith.h>
 #include <af/data.h>
 
@@ -39,10 +41,7 @@ static inline af_array tile(const af_array in, const af::dim4 &tileDims) {
     }
 
     if (take_jit_path) {
-        // FIXME: This Should ideally call a NOP function, but adding 0 should
-        // be OK This does not allocate any memory, just a JIT node
-        Array<T> tmpArray = createValueArray<T>(outDims, scalar<T>(0));
-        return getHandle(arithOp<T, af_add_t>(inArray, tmpArray, outDims));
+        return getHandle(unaryOp<T, af_noop_t>(inArray, outDims));
     } else {
         return getHandle(tile<T>(inArray, tileDims));
     }

--- a/src/backend/cpu/unary.hpp
+++ b/src/backend/cpu/unary.hpp
@@ -73,11 +73,12 @@ UNARY_OP(lgamma)
 #undef UNARY_OP_FN
 
 template<typename T, af_op_t op>
-Array<T> unaryOp(const Array<T> &in) {
+Array<T> unaryOp(const Array<T> &in, dim4 outDim = dim4(-1, -1, -1, -1)) {
     jit::Node_ptr in_node          = in.getNode();
     jit::UnaryNode<T, T, op> *node = new jit::UnaryNode<T, T, op>(in_node);
 
-    return createNodeArray<T>(in.dims(), jit::Node_ptr(node));
+    if (outDim == dim4(-1, -1, -1, -1)) { outDim = in.dims(); }
+    return createNodeArray<T>(outDim, jit::Node_ptr(node));
 }
 
 #define iszero(a) ((a) == 0)
@@ -96,12 +97,13 @@ CHECK_FN(iszero, iszero)
 #undef iszero
 
 template<typename T, af_op_t op>
-Array<char> checkOp(const Array<T> &in) {
+Array<char> checkOp(const Array<T> &in, dim4 outDim = dim4(-1, -1, -1, -1)) {
     jit::Node_ptr in_node = in.getNode();
     jit::UnaryNode<char, T, op> *node =
         new jit::UnaryNode<char, T, op>(in_node);
 
-    return createNodeArray<char>(in.dims(), jit::Node_ptr(node));
+    if (outDim == dim4(-1, -1, -1, -1)) { outDim = in.dims(); }
+    return createNodeArray<char>(outDim, jit::Node_ptr(node));
 }
 
 }  // namespace cpu

--- a/src/backend/cuda/unary.hpp
+++ b/src/backend/cuda/unary.hpp
@@ -69,29 +69,36 @@ UNARY_FN(floor)
 UNARY_FN(isinf)
 UNARY_FN(isnan)
 UNARY_FN(iszero)
+UNARY_DECL(noop, "__noop")
 
 #undef UNARY_DECL
 #undef UNARY_FN
 
 template<typename T, af_op_t op>
-Array<T> unaryOp(const Array<T> &in) {
+Array<T> unaryOp(const Array<T> &in, dim4 outDim = dim4(-1, -1, -1, -1)) {
     common::Node_ptr in_node = in.getNode();
 
     common::UnaryNode *node = new common::UnaryNode(
         getFullName<T>(), shortname<T>(true), unaryName<op>(), in_node, op);
 
-    return createNodeArray<T>(in.dims(), common::Node_ptr(node));
+    if(outDim == dim4(-1, -1, -1, -1)) {
+        outDim = in.dims();
+    }
+    return createNodeArray<T>(outDim, common::Node_ptr(node));
 }
 
 template<typename T, af_op_t op>
-Array<char> checkOp(const Array<T> &in) {
+Array<char> checkOp(const Array<T> &in, dim4 outDim = dim4(-1, -1, -1, -1)) {
     common::Node_ptr in_node = in.getNode();
 
     common::UnaryNode *node =
         new common::UnaryNode(getFullName<char>(), shortname<char>(true),
                               unaryName<op>(), in_node, op);
 
-    return createNodeArray<char>(in.dims(), common::Node_ptr(node));
+    if(outDim == dim4(-1, -1, -1, -1)) {
+        outDim = in.dims();
+    }
+    return createNodeArray<char>(outDim, common::Node_ptr(node));
 }
 
 }  // namespace cuda

--- a/src/backend/opencl/unary.hpp
+++ b/src/backend/opencl/unary.hpp
@@ -69,29 +69,32 @@ UNARY_FN(floor)
 UNARY_FN(isinf)
 UNARY_FN(isnan)
 UNARY_FN(iszero)
+UNARY_DECL(noop, "__noop")
 
 #undef UNARY_FN
 
 template<typename T, af_op_t op>
-Array<T> unaryOp(const Array<T> &in) {
+Array<T> unaryOp(const Array<T> &in, dim4 outDim = dim4(-1, -1, -1, -1)) {
     common::Node_ptr in_node = in.getNode();
 
     common::UnaryNode *node =
         new common::UnaryNode(dtype_traits<T>::getName(), shortname<T>(true),
                               unaryName<op>(), in_node, op);
 
-    return createNodeArray<T>(in.dims(), common::Node_ptr(node));
+    if (outDim == dim4(-1, -1, -1, -1)) { outDim = in.dims(); }
+    return createNodeArray<T>(outDim, common::Node_ptr(node));
 }
 
 template<typename T, af_op_t op>
-Array<char> checkOp(const Array<T> &in) {
+Array<char> checkOp(const Array<T> &in, dim4 outDim = dim4(-1, -1, -1, -1)) {
     common::Node_ptr in_node = in.getNode();
 
     common::UnaryNode *node = new common::UnaryNode(
         dtype_traits<char>::getName(), shortname<char>(true), unaryName<op>(),
         in_node, op);
 
-    return createNodeArray<char>(in.dims(), common::Node_ptr(node));
+    if (outDim == dim4(-1, -1, -1, -1)) { outDim = in.dims(); }
+    return createNodeArray<char>(outDim, common::Node_ptr(node));
 }
 
 }  // namespace opencl


### PR DESCRIPTION
Tiles used to be performed using the add jit node with a zero scalar. This
performed extra operations and created an extra parameter which was
unnecessary.