### PR TITLE
Treat all JIT buffer parameters as non-linear parameters

### DIFF
--- a/src/backend/common/jit/Node.hpp
+++ b/src/backend/common/jit/Node.hpp
@@ -99,7 +99,7 @@ class Node {
 
     // Return the size of the parameter in bytes that will be passed to the
     // kernel
-    virtual short getParamBytes() const { return 0; }
+    virtual size_t getParamBytes() const { return 0; }
 
     // Return the size of the size of the buffer node in bytes. Zero otherwise
     virtual size_t getBytes() const { return 0; }

--- a/src/backend/common/jit/ScalarNode.hpp
+++ b/src/backend/common/jit/ScalarNode.hpp
@@ -54,8 +54,8 @@ class ScalarNode : public common::Node {
     }
 
     // Return the info for the params and the size of the buffers
-    virtual short getParamBytes() const final {
-        return static_cast<short>(sizeof(T));
+    virtual size_t getParamBytes() const final {
+        return sizeof(T);
     }
 };
 

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -241,7 +241,7 @@ Array<T> createNodeArray(const dim4 &dims, Node_ptr node) {
             // TODO: Find better solution than the following emperical solution.
             if (node->getHeight() > 25 || isBufferLimit) {
                 // This is the size of the params that are passed by default
-                constexpr int param_base_size =
+                constexpr size_t param_base_size =
                     sizeof(Param<T>) + (4 * sizeof(uint));
 
                 // This is the maximum size of the params that can be allowed by
@@ -249,30 +249,25 @@ Array<T> createNodeArray(const dim4 &dims, Node_ptr node) {
                 // some_buffer_size) BUT kernels who's kernel sizes come close
                 // to this value are not passing and cuModuleLoadDataEx is
                 // failing with CUDA_ERROR_INVALID_IMAGE(200). 35*sizeof(int)
-                // seems to be the magic number that passes all tests. I have no
-                // idea why this is the case.
-                constexpr int max_param_size =
+                // seems to be the magic number that passes all tests.
+                constexpr size_t max_param_size =
                     (4096 - (sizeof(Param<T>) + 35 * sizeof(uint)));
                 Node *n = node.get();
 
                 struct tree_info {
-                    size_t buffer_size;
-                    int num_buffers;
-                    int param_scalar_size;
-                    bool is_linear;
+                    size_t total_buffer_size;
+                    size_t num_buffers;
+                    size_t param_scalar_size;
                 };
                 NodeIterator<> end_node;
-                dim4 outdim    = out.dims();
                 tree_info info = accumulate(
-                    NodeIterator<>(n), end_node, tree_info{0, 0, 0, true},
+                    NodeIterator<>(n), end_node, tree_info{0, 0, 0},
                     [=](tree_info &prev, const Node &node) {
                         if (node.isBuffer()) {
                             const auto &buf_node =
                                 static_cast<const BufferNode<T> &>(node);
-                            prev.buffer_size += buf_node.getBytes();
+                            prev.total_buffer_size += buf_node.getBytes();
                             prev.num_buffers++;
-                            prev.is_linear &=
-                                buf_node.isLinear((dim_t *)outdim.get());
                         } else {
                             prev.param_scalar_size += node.getParamBytes();
                         }
@@ -280,19 +275,15 @@ Array<T> createNodeArray(const dim4 &dims, Node_ptr node) {
                         // arrays will be represented by their parent size.
                         return prev;
                     });
-                int param_size = param_base_size + info.param_scalar_size;
-                if (info.is_linear) {
-                    param_size += info.num_buffers * sizeof(T *);
-                } else {
-                    param_size += info.num_buffers * sizeof(Param<T>);
-                }
+                size_t param_size = param_base_size + info.param_scalar_size;
+                param_size += info.num_buffers * sizeof(Param<T>);
 
                 // TODO: the buffer_size check here is very conservative. It
                 // will trigger an evaluation of the node in most cases. We
                 // should be checking the amount of memory available to guard
                 // this eval
                 if (param_size >= max_param_size ||
-                    info.buffer_size * 2 > lock_bytes) {
+                    info.total_buffer_size * 2 > lock_bytes) {
                     out.eval();
                 }
             }

--- a/test/sparse_common.hpp
+++ b/test/sparse_common.hpp
@@ -138,7 +138,7 @@ static void sparseTransposeTester(const int m, const int n, const int k,
 }
 
 template<typename T>
-static void convertCSR(const int M, const int N, const float ratio,
+static void convertCSR(const int M, const int N, const double ratio,
                        int targetDevice = -1) {
     if (targetDevice >= 0) af::setDevice(targetDevice);
 


### PR DESCRIPTION
This commit addresses very large kernels that were generated by the
JIT for smaller buffers. This was occuring because of how we were
estimating the JIT parameter sizes.

When targeting linear kernels we only pass the pointer to the kernel
instead of the entire dims and stride arrays. This generates smaller
parameter sets so we calculated kernels based on the pointer size
instead of the Param<T> size.

The issue occured when this kernel came in below the threshold for
evaluation but when it was used as a node to another operation, the
generated kernel became a non-linear kernel requiring us to pass
the Param<T> object for each buffer. This causes the size to go past
the limit of the parameters supported by CUDA and compilation fails.

This commit treats all kernels as non-linear kernel when calculating
the parameter sizes.

Fixes #2436 #2389