### PR TITLE
Move parameters to shared memory

### DIFF
--- a/src/backend/common/jit/Node.hpp
+++ b/src/backend/common/jit/Node.hpp
@@ -108,9 +108,9 @@ class Node {
         return start_id;
     }
 
-    // Sets the index of the Param object stored in global memory. (CUDA ONLY)
+    // Sets the index of the Param object stored in global memory.
     virtual void setParamIndex(int index) { UNUSED(index); }
-    // Gets the index of the Param object stored in global memory. (CUDA ONLY)
+    // Gets the index of the Param object stored in global memory.
     virtual int getParamIndex() const { return -1; }
 
     virtual void getInfo(unsigned &len, unsigned &buf_count,
@@ -145,6 +145,9 @@ class Node {
     virtual ~Node() {}
 };
 
+// Returns true if the node requires global memory access. This is true
+// for buffer nodes and shift nodes. This implies that the Node needs
+// access to the shape of the object to perform indexing operations
 static inline bool requiresGlobalMemoryAccess(Node &node) {
     return node.requiresGlobalMemoryAccess();
 }

--- a/src/backend/common/jit/ShiftNodeBase.hpp
+++ b/src/backend/common/jit/ShiftNodeBase.hpp
@@ -9,13 +9,16 @@
 
 #pragma once
 
+#include <common/jit/Node.hpp>
 #include <jit/BufferNode.hpp>
 #include <jit/kernel_generators.hpp>
 
+#include <Param.hpp>
 #include <backend.hpp>
-#include <iomanip>
 
 #include <array>
+#include <functional>
+#include <iomanip>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -40,6 +43,8 @@ class ShiftNodeBase : public Node {
         UNUSED(dims);
         return false;
     }
+
+    bool requiresGlobalMemoryAccess() const final { return true; }
 
     void genKerName(std::stringstream &kerStream,
                     const common::Node_ids &ids) const final {
@@ -67,9 +72,17 @@ class ShiftNodeBase : public Node {
         return curr_id + 4;
     }
 
+    void setParamIndex(int index) final { m_buffer_node->setParamIndex(index); }
+    int getParamIndex() const final { return m_buffer_node->getParamIndex(); }
+
+    typename BufferNode::param_type getParam() {
+        return m_buffer_node->getParam();
+    }
+
     void genOffsets(std::stringstream &kerStream, int id,
                     bool is_linear) const final {
-        detail::generateShiftNodeOffsets(kerStream, id, is_linear, m_type_str);
+        UNUSED(is_linear);
+        detail::generateShiftNodeOffsets(kerStream, id);
     }
 
     void genFuncs(std::stringstream &kerStream,

--- a/src/backend/cuda/Param.hpp
+++ b/src/backend/cuda/Param.hpp
@@ -21,21 +21,33 @@ namespace cuda {
 template<typename T>
 class Param {
    public:
-    T *ptr;
     dim_t dims[4];
     dim_t strides[4];
+    T *ptr;
 
     __DH__ Param() : ptr(nullptr) {}
 
     __DH__ Param(T *iptr, const dim_t *idims, const dim_t *istrides)
-        : ptr(iptr) {
-        for (int i = 0; i < 4; i++) {
-            dims[i]    = idims[i];
-            strides[i] = istrides[i];
-        }
-    }
+        : dims{idims[0], idims[1], idims[2], idims[3]}
+        , strides{istrides[0], istrides[1], istrides[2], istrides[3]}
+        , ptr(iptr) {}
+
     __DH__ size_t elements() const noexcept {
         return dims[0] * dims[1] * dims[2] * dims[3];
+    }
+
+    Param<T> &operator=(const Param<T> &other) {
+        ptr     = other.ptr;
+        dims[0] = other.dims[0];
+        dims[1] = other.dims[1];
+        dims[2] = other.dims[2];
+        dims[3] = other.dims[3];
+
+        strides[0] = other.strides[0];
+        strides[1] = other.strides[1];
+        strides[2] = other.strides[2];
+        strides[3] = other.strides[3];
+        return *this;
     }
 };
 
@@ -51,28 +63,22 @@ Param<T> flat(Param<T> in) {
 template<typename T>
 class CParam {
    public:
-    const T *ptr;
     dim_t dims[4];
     dim_t strides[4];
+    const T *ptr;
 
     __DH__ CParam(const T *iptr, const dim_t *idims, const dim_t *istrides)
-        : ptr(iptr) {
-        for (int i = 0; i < 4; i++) {
-            dims[i]    = idims[i];
-            strides[i] = istrides[i];
-        }
-    }
+        : dims{idims[0], idims[1], idims[2], idims[3]}
+        , strides{istrides[0], istrides[1], istrides[2], istrides[3]}
+        , ptr(iptr) {}
 
-    __DH__ CParam(Param<T> &in) : ptr(in.ptr) {
-        for (int i = 0; i < 4; i++) {
-            dims[i]    = in.dims[i];
-            strides[i] = in.strides[i];
-        }
-    }
+    __DH__ CParam(Param<T> &in)
+        : dims{in.dims[0], in.dims[1], in.dims[2], in.dims[3]}
+        , strides{in.strides[0], in.strides[1], in.strides[2], in.strides[3]}
+        , ptr(in.ptr) {}
 
     __DH__ size_t elements() const noexcept {
         return dims[0] * dims[1] * dims[2] * dims[3];
     }
 };
-
 }  // namespace cuda

--- a/src/backend/cuda/Param.hpp
+++ b/src/backend/cuda/Param.hpp
@@ -25,9 +25,9 @@ class Param {
     dim_t strides[4];
     T *ptr;
 
-    __DH__ Param() : ptr(nullptr) {}
+    __DH__ Param() noexcept : ptr(nullptr) {}
 
-    __DH__ Param(T *iptr, const dim_t *idims, const dim_t *istrides)
+    __DH__ Param(T *iptr, const dim_t *idims, const dim_t *istrides) noexcept
         : dims{idims[0], idims[1], idims[2], idims[3]}
         , strides{istrides[0], istrides[1], istrides[2], istrides[3]}
         , ptr(iptr) {}
@@ -36,19 +36,10 @@ class Param {
         return dims[0] * dims[1] * dims[2] * dims[3];
     }
 
-    Param<T> &operator=(const Param<T> &other) {
-        ptr     = other.ptr;
-        dims[0] = other.dims[0];
-        dims[1] = other.dims[1];
-        dims[2] = other.dims[2];
-        dims[3] = other.dims[3];
-
-        strides[0] = other.strides[0];
-        strides[1] = other.strides[1];
-        strides[2] = other.strides[2];
-        strides[3] = other.strides[3];
-        return *this;
-    }
+    Param(const Param<T> &other) noexcept = default;
+    Param(Param<T> &&other) noexcept = default;
+    Param<T> &operator=(const Param<T> &other) noexcept = default;
+    Param<T> &operator=(Param<T> &&other) noexcept = default;
 };
 
 template<typename T>
@@ -80,5 +71,10 @@ class CParam {
     __DH__ size_t elements() const noexcept {
         return dims[0] * dims[1] * dims[2] * dims[3];
     }
+
+    CParam(const CParam<T> &other) noexcept = default;
+    CParam(CParam<T> &&other) noexcept      = default;
+    CParam<T> &operator=(const CParam<T> &other) noexcept = default;
+    CParam<T> &operator=(CParam<T> &&other) noexcept = default;
 };
 }  // namespace cuda

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -13,7 +13,11 @@
 
 #include <Array.hpp>
 #include <common/jit/Node.hpp>
+#include <common/jit/NodeIterator.hpp>
 #include <copy.hpp>
+#include <debug_cuda.hpp>
+#include <jit/BufferNode.hpp>
+#include <jit/ShiftNode.hpp>
 #include <math.hpp>
 #include <platform.hpp>
 
@@ -32,12 +36,22 @@ namespace cuda {
 using common::Node;
 using common::Node_ids;
 using common::Node_map_t;
+using common::NodeIterator;
+using common::requiresGlobalMemoryAccess;
+using cuda::jit::BufferNode;
+using cuda::jit::ShiftNode;
 
 using std::hash;
 using std::map;
 using std::string;
 using std::stringstream;
 using std::vector;
+
+template<typename TL, typename TR>
+bool equal_shape(const Param<TL> &lhs, const Param<TR> &rhs) {
+    return std::equal(lhs.dims, lhs.dims + 4, rhs.dims) &&
+           std::equal(lhs.strides, lhs.strides + 4, rhs.strides);
+}
 
 static string getFuncName(const vector<Node *> &output_nodes,
                           const vector<const Node *> &full_nodes,
@@ -72,12 +86,11 @@ static string getKernelString(const string funcName,
     const std::string includeFileStr(jit_cuh, jit_cuh_len);
 
     const std::string paramTStr = R"JIT(
-template<typename T>
 struct Param
 {
-  T *ptr;
   dim_t dims[4];
   dim_t strides[4];
+  void *ptr;
 };
 )JIT";
 
@@ -91,7 +104,9 @@ struct Param
 
     static const char *kernelVoid = "extern \"C\" __global__ void\n";
     static const char *dimParams =
-        "uint blocks_x, uint blocks_y, uint blocks_x_total, uint num_odims";
+        "uint blocks_x, uint blocks_y, uint "
+        "blocks_x_total, uint num_odims";
+    static const char *globalParams = "Param* dims, int num_params, ";
 
     static const char *loopStart = R"JIT(
     for (int blockIdx_x = blockIdx.x; blockIdx_x < blocks_x_total; blockIdx_x += gridDim.x) {
@@ -99,46 +114,52 @@ struct Param
     static const char *loopEnd   = "}\n\n";
 
     static const char *blockStart = "{\n\n";
-    static const char *blockEnd   = "\n\n}";
+    static const char *blockEnd   = "\n}\n";
 
     static const char *linearIndex = R"JIT(
-        uint threadId = threadIdx.x;
-        long long idx = blockIdx_x * blockDim.x * blockDim.y + threadId;
-        if (idx >= outref.dims[3] * outref.strides[3]) return;
-        )JIT";
+    uint threadId = threadIdx.x;
+    dim_t idx = blockIdx_x * blockDim.x * blockDim.y + threadId;
+    if (idx >= outref.dims[3] * outref.strides[3]) continue;
+    )JIT";
 
     static const char *generalIndex = R"JIT(
-        long long id0 = 0, id1 = 0, id2 = 0, id3 = 0;
-        long blockIdx_y = blockIdx.z * gridDim.y + blockIdx.y;
-        if (num_odims > 2) {
-            id2 = blockIdx_x / blocks_x;
-            id0 = blockIdx_x - id2 * blocks_x;
-            id0 = threadIdx.x + id0 * blockDim.x;
-            if (num_odims > 3) {
-                id3 = blockIdx_y / blocks_y;
-                id1 = blockIdx_y - id3 * blocks_y;
-                id1 = threadIdx.y + id1 * blockDim.y;
-            } else {
-                id1 = threadIdx.y + blockDim.y * blockIdx_y;
-            }
+    dim_t id0 = 0, id1 = 0, id2 = 0, id3 = 0;
+    dim_t blockIdx_y = blockIdx.z * gridDim.y + blockIdx.y;
+    if (num_odims > 2) {
+        id2 = blockIdx_x / blocks_x;
+        id0 = blockIdx_x - id2 * blocks_x;
+        id0 = threadIdx.x + id0 * blockDim.x;
+        if (num_odims > 3) {
+            id3 = blockIdx_y / blocks_y;
+            id1 = blockIdx_y - id3 * blocks_y;
+            id1 = threadIdx.y + id1 * blockDim.y;
         } else {
-            id3 = 0;
-            id2 = 0;
             id1 = threadIdx.y + blockDim.y * blockIdx_y;
-            id0 = threadIdx.x + blockDim.x * blockIdx_x;
         }
+    } else {
+        id3 = 0;
+        id2 = 0;
+        id1 = threadIdx.y + blockDim.y * blockIdx_y;
+        id0 = threadIdx.x + blockDim.x * blockIdx_x;
+    }
 
-        bool cond = id0 < outref.dims[0] &&
-                    id1 < outref.dims[1] &&
-                    id2 < outref.dims[2] &&
-                    id3 < outref.dims[3];
+    bool cond = id0 < outref.dims[0] &&
+                id1 < outref.dims[1] &&
+                id2 < outref.dims[2] &&
+                id3 < outref.dims[3];
 
-        if (!cond) { continue; }
+    dim_t idx = outref.strides[3] * id3 +
+                outref.strides[2] * id2 +
+                outref.strides[1] * id1 + id0;
 
-        long long idx = outref.strides[3] * id3 +
-                        outref.strides[2] * id2 +
-                        outref.strides[1] * id1 + id0;
-        )JIT";
+    if (threadIdx.x < num_params && threadIdx.y == 0) {
+        int tidx = threadIdx.x;
+        block_offsets[tidx] = (id3 < params[tidx].dims[3]) * params[tidx].strides[3] * id3 +
+                              (id2 < params[tidx].dims[2]) * params[tidx].strides[2] * id2;
+    }
+    __syncthreads();
+    if (cond) {
+    )JIT";
 
     stringstream inParamStream;
     stringstream outParamStream;
@@ -146,6 +167,9 @@ struct Param
     stringstream offsetsStream;
     stringstream opsStream;
     stringstream outrefstream;
+    stringstream paramreadstream;
+
+    outrefstream << "const Param &outref = out" << output_ids[0] << ";\n";
 
     for (int i = 0; i < (int)full_nodes.size(); i++) {
         const auto &node     = full_nodes[i];
@@ -158,17 +182,25 @@ struct Param
         node->genFuncs(opsStream, ids_curr);
     }
 
-    outrefstream << "const Param<" << full_nodes[output_ids[0]]->getTypeStr()
-                 << "> &outref = out" << output_ids[0] << ";\n";
-
     for (int i = 0; i < (int)output_ids.size(); i++) {
         int id = output_ids[i];
         // Generate output parameters
-        outParamStream << "Param<" << full_nodes[id]->getTypeStr() << "> out"
-                       << id << ", \n";
+        outParamStream << "Param out" << id << ", \n";
+
         // Generate code to write the output
-        outWriteStream << "out" << id << ".ptr[idx] = val" << id << ";\n";
+        outWriteStream << "((" << full_nodes[id]->getTypeStr() << "*)(out" << id
+                       << ".ptr))"
+                       << "[idx] = val" << id << ";\n";
     }
+
+    paramreadstream << R"JIT(
+        extern __shared__ char smem[];
+        Param *params = reinterpret_cast<Param*>(smem);
+        dim_t *block_offsets = reinterpret_cast<dim_t*>(smem+(num_params * sizeof(Param)));
+
+        if (threadIdx.x < num_params) { params[threadIdx.x] = dims[threadIdx.x]; }
+        __syncthreads();
+    )JIT";
 
     // Put various blocks into a single stream
     stringstream kerStream;
@@ -180,10 +212,12 @@ struct Param
     kerStream << "(\n";
     kerStream << inParamStream.str();
     kerStream << outParamStream.str();
+    if (!is_linear) { kerStream << globalParams; }
     kerStream << dimParams;
     kerStream << ")\n";
     kerStream << blockStart;
     kerStream << outrefstream.str();
+    if (!is_linear) { kerStream << paramreadstream.str(); }
     kerStream << loopStart;
     if (is_linear) {
         kerStream << linearIndex;
@@ -194,6 +228,7 @@ struct Param
     kerStream << opsStream.str();
     kerStream << outWriteStream.str();
     kerStream << loopEnd;
+    if (!is_linear) kerStream << "}";
     kerStream << blockEnd;
 
     return kerStream.str();
@@ -235,7 +270,6 @@ void evalNodes(vector<Param<T>> &outputs, vector<Node *> output_nodes) {
 
     if (num_outputs == 0) return;
 
-    // Use thread local to reuse the memory every time you are here.
     thread_local Node_map_t nodes;
     thread_local vector<const Node *> full_nodes;
     thread_local vector<Node_ids> full_ids;
@@ -249,9 +283,39 @@ void evalNodes(vector<Param<T>> &outputs, vector<Node *> output_nodes) {
         full_ids.reserve(1024);
     }
 
+    vector<Param<T>> params;
     for (auto &node : output_nodes) {
         int id = node->getNodesMap(nodes, full_nodes, full_ids);
         output_ids.push_back(id);
+
+        NodeIterator<> end_node;
+        auto bufit = NodeIterator<>(node);
+        while (bufit != end_node) {
+            bufit = find_if(bufit, end_node, requiresGlobalMemoryAccess);
+            if (bufit != end_node) {
+                Param<T> param;
+
+                // TODO(umar): This is a hack. We need to clean up this API
+                // so that the if statement is not necessary
+                if (bufit->isBuffer()) {
+                    param = static_cast<BufferNode<T> &>(*bufit).getParam();
+                } else {
+                    param = static_cast<ShiftNode<T> &>(*bufit).getParam();
+                }
+
+                auto it = find_if(begin(params), end(params),
+                                  [&param](const Param<T> &p) {
+                                      return equal_shape<T, T>(param, p);
+                                  });
+                if (it == end(params)) {
+                    params.push_back(param);
+                    bufit->setParamIndex(params.size() - 1);
+                } else {
+                    bufit->setParamIndex(distance(begin(params), it));
+                }
+                bufit++;
+            }
+        }
     }
 
     bool is_linear = true;
@@ -307,7 +371,6 @@ void evalNodes(vector<Param<T>> &outputs, vector<Node *> output_nodes) {
     }
 
     vector<void *> args;
-
     for (const auto &node : full_nodes) {
         node->setArgs(0, is_linear,
                       [&](int /*id*/, const void *ptr, size_t /*size*/) {
@@ -319,14 +382,32 @@ void evalNodes(vector<Param<T>> &outputs, vector<Node *> output_nodes) {
         args.push_back((void *)&outputs[i]);
     }
 
+    uptr<uchar> dparam;
+    void *ptr         = nullptr;
+    int param_count   = 0;
+    size_t smem_bytes = 0;
+    if (!is_linear) {
+        smem_bytes  = (sizeof(Param<T>) + sizeof(dim_t)) * params.size();
+        param_count = params.size();
+        dparam      = memAlloc<uchar>(params.size() * sizeof(Param<T>));
+        CUDA_CHECK(cudaMemcpyAsync(dparam.get(), params.data(),
+                                   params.size() * sizeof(Param<T>),
+                                   cudaMemcpyHostToDevice, getActiveStream()));
+        ptr = dparam.get();
+        args.push_back(&ptr);
+        args.push_back((void *)&param_count);
+    }
+
     args.push_back((void *)&blocks_x_);
     args.push_back((void *)&blocks_y_);
     args.push_back((void *)&blocks_x_total);
     args.push_back((void *)&num_odims);
 
     CU_CHECK(cuLaunchKernel(ker, blocks_x, blocks_y, blocks_z, threads_x,
-                            threads_y, 1, 0, getActiveStream(), args.data(),
-                            NULL));
+                            threads_y, 1, smem_bytes, getActiveStream(),
+                            args.data(), NULL));
+
+    POST_LAUNCH_CHECK();
 
     // Reset the thread local vectors
     nodes.clear();

--- a/src/backend/cuda/jit/ShiftNode.hpp
+++ b/src/backend/cuda/jit/ShiftNode.hpp
@@ -1,5 +1,5 @@
 /*******************************************************
- * Copyright (c) 2014, ArrayFire
+ * Copyright (c) 2019, ArrayFire
  * All rights reserved.
  *
  * This file is distributed under 3-clause BSD license.
@@ -7,13 +7,14 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#pragma once
 #include <common/jit/BufferNodeBase.hpp>
-#include "../Param.hpp"
+#include <common/jit/ShiftNodeBase.hpp>
 
 namespace cuda {
 namespace jit {
+
 template<typename T>
-using BufferNode = common::BufferNodeBase<std::shared_ptr<T>, Param<T>>;
+using ShiftNode = common::ShiftNodeBase<BufferNode<T>>;
+
 }  // namespace jit
 }  // namespace cuda

--- a/src/backend/cuda/jit/kernel_generators.hpp
+++ b/src/backend/cuda/jit/kernel_generators.hpp
@@ -8,6 +8,7 @@
  ********************************************************/
 
 #pragma once
+#include <Param.hpp>
 #include <common/jit/Node.hpp>
 
 #include <functional>
@@ -21,64 +22,70 @@ namespace cuda {
 namespace {
 
 /// Creates a string that will be used to declare the parameter of kernel
-void generateParamDeclaration(std::stringstream& kerStream, int id,
-                              bool is_linear, const std::string& m_type_str) {
+inline void generateParamDeclaration(std::stringstream& kerStream, int id,
+                                     bool is_linear,
+                                     const std::string& m_type_str) {
     if (is_linear) {
         kerStream << m_type_str << " *in" << id << "_ptr,\n";
     } else {
-        kerStream << "Param<" << m_type_str << "> in" << id << ",\n";
+        kerStream << m_type_str << " *in" << id << "_ptr, int in_index" << id
+                  << ",\n";
     }
 }
 
 /// Calls the setArg function to set the arguments for a kernel call
 template<typename T>
-int setKernelArguments(
+inline int setKernelArguments(
     int start_id, bool is_linear,
     std::function<void(int id, const void* ptr, size_t arg_size)>& setArg,
-    const std::shared_ptr<T>& ptr, const Param<T>& info) {
+    const std::shared_ptr<T>& ptr, const Param<T>& info,
+    const int& param_index) {
     UNUSED(ptr);
     if (is_linear) {
         setArg(start_id, static_cast<const void*>(&info.ptr), sizeof(T*));
     } else {
-        setArg(start_id, static_cast<const void*>(&info), sizeof(Param<T>));
+        // setArg(start_id, static_cast<const void*>(&info), sizeof(Param<T>));
+        setArg(start_id++, static_cast<const void*>(&info.ptr), sizeof(T*));
+        setArg(start_id, &param_index, sizeof(int));
     }
     return start_id + 1;
 }
 
 /// Generates the code to calculate the offsets for a buffer
-void generateBufferOffsets(std::stringstream& kerStream, int id, bool is_linear,
-                           const std::string& type_str) {
-    std::string idx_str = std::string("int idx") + std::to_string(id);
+inline void generateBufferOffsets(std::stringstream& kerStream, int id,
+                                  bool is_linear) {
+    std::string idx_str = std::string("\n\t\tdim_t idx") + std::to_string(id);
 
     if (is_linear) {
-        kerStream << idx_str << " = idx;\n";
+        kerStream << idx_str << " = idx;";
     } else {
-        std::string info_str = std::string("in") + std::to_string(id);
-        kerStream << idx_str << " = (id3 < " << info_str << ".dims[3]) * "
-                  << info_str << ".strides[3] * id3 + (id2 < " << info_str
-                  << ".dims[2]) * " << info_str << ".strides[2] * id2 + (id1 < "
-                  << info_str << ".dims[1]) * " << info_str
-                  << ".strides[1] * id1 + (id0 < " << info_str
-                  << ".dims[0]) * id0;\n";
-        kerStream << type_str << " *in" << id << "_ptr = in" << id << ".ptr;\n";
+        // clang-format off
+        std::string in_index = "in_index" + std::to_string(id);
+        std::string block_offset = "block_offsets[" + in_index + "]";
+        std::string in_param = "params[" + in_index + "]";
+
+        kerStream << idx_str << " = " << block_offset
+                  << "\n + ((id1 < " << in_param << ".dims[1]) * " << in_param << ".strides[1] * id1)"
+                  << "\n + ((id0 < " << in_param << ".dims[0]) * id0);";
+        // clang-format on
     }
 }
 
 /// Generates the code to read a buffer and store it in a local variable
-void generateBufferRead(std::stringstream& kerStream, int id,
-                        const std::string& type_str) {
+inline void generateBufferRead(std::stringstream& kerStream, int id,
+                               const std::string& type_str) {
     kerStream << type_str << " val" << id << " = in" << id << "_ptr[idx" << id
               << "];\n";
 }
 
-void generateShiftNodeOffsets(std::stringstream& kerStream, int id,
-                              bool is_linear, const std::string& type_str) {
-    UNUSED(is_linear);
+inline void generateShiftNodeOffsets(std::stringstream& kerStream, int id) {
     std::string idx_str   = std::string("idx") + std::to_string(id);
     std::string info_str  = std::string("in") + std::to_string(id);
     std::string id_str    = std::string("sh_id_") + std::to_string(id) + "_";
     std::string shift_str = std::string("shift") + std::to_string(id) + "_";
 
+    kerStream << "Param& " << info_str << " = "
+              << "params[in_index" << id << "];\n";
     for (int i = 0; i < 4; i++) {
         kerStream << "int " << id_str << i << " = __circular_mod(id" << i
                   << " + " << shift_str << i << ", " << info_str << ".dims["
@@ -96,11 +103,10 @@ void generateShiftNodeOffsets(std::stringstream& kerStream, int id,
               << "1;\n";
     kerStream << idx_str << " += (" << id_str << "0 < " << info_str
               << ".dims[0]) * " << id_str << "0;\n";
-    kerStream << type_str << " *in" << id << "_ptr = in" << id << ".ptr;\n";
 }
 
-void generateShiftNodeRead(std::stringstream& kerStream, int id,
-                           const std::string& type_str) {
+inline void generateShiftNodeRead(std::stringstream& kerStream, int id,
+                                  const std::string& type_str) {
     kerStream << type_str << " val" << id << " = in" << id << "_ptr[idx" << id
               << "];\n";
 }

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -74,6 +74,7 @@ using kc_t = map<string, Kernel>;
         char* logptr = log.get();                      \
         nvrtcGetProgramLog(prog, logptr);              \
         logptr[logSize] = '\x0';                       \
+        puts(logptr);                                  \
         AF_ERROR("NVRTC ERROR", AF_ERR_INTERNAL);      \
     } while (0)
 #else

--- a/src/backend/cuda/shift.cpp
+++ b/src/backend/cuda/shift.cpp
@@ -11,6 +11,7 @@
 #include <common/jit/ShiftNodeBase.hpp>
 #include <err_cuda.hpp>
 #include <jit/BufferNode.hpp>
+#include <jit/ShiftNode.hpp>
 #include <shift.hpp>
 
 #include <memory>
@@ -21,6 +22,7 @@ using common::Node_ptr;
 using common::ShiftNodeBase;
 
 using cuda::jit::BufferNode;
+using cuda::jit::ShiftNode;
 
 using std::array;
 using std::make_shared;
@@ -28,12 +30,10 @@ using std::static_pointer_cast;
 using std::string;
 
 namespace cuda {
-template<typename T>
-using ShiftNode = ShiftNodeBase<BufferNode<T>>;
 
 template<typename T>
 Array<T> shift(const Array<T> &in, const int sdims[4]) {
-    // Shift should only be the first node in the JIT tree.
+    // Shift should only be the leaf node in the JIT tree.
     // Force input to be evaluated so that in is always a buffer.
     in.eval();
 

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -342,6 +342,7 @@ target_sources(afopencl
 target_sources(afopencl
   PRIVATE
     jit/BufferNode.hpp
+    jit/ShiftNode.hpp
     jit/kernel_generators.hpp
   )
 

--- a/src/backend/opencl/jit.cpp
+++ b/src/backend/opencl/jit.cpp
@@ -124,7 +124,6 @@ static string getKernelString(const string funcName,
                     id1 < oInfo.dims[1] &&
                     id2 < oInfo.dims[2] &&
                     id3 < oInfo.dims[3];
-        if (!cond) return;
         size_t idx = oInfo.strides[3] * id3 +
                      oInfo.strides[2] * id2 +
                      oInfo.strides[1] * id1 +
@@ -136,6 +135,7 @@ static string getKernelString(const string funcName,
                                   (id2 < params[tidx].dims[2]) * params[tidx].strides[2] * id2;
         }
         barrier(CLK_LOCAL_MEM_FENCE);
+        if (!cond) return;
         )JIT";
 
     stringstream inParamStream;

--- a/src/backend/opencl/jit.cpp
+++ b/src/backend/opencl/jit.cpp
@@ -221,7 +221,7 @@ void evalNodes(vector<Param> &outputs, vector<Node *> output_nodes) {
     }
 
     bool is_linear = true;
-    for (auto node : full_nodes) {
+    for (const auto &node : full_nodes) {
         is_linear &= node->isLinear(outputs[0].info.dims);
     }
 

--- a/src/backend/opencl/jit/ShiftNode.hpp
+++ b/src/backend/opencl/jit/ShiftNode.hpp
@@ -1,3 +1,11 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
 
 #include <common/jit/ShiftNodeBase.hpp>
 #include <jit/BufferNode.hpp>
@@ -5,5 +13,5 @@
 namespace opencl {
 namespace jit {
   using ShiftNode = common::ShiftNodeBase<BufferNode>;
-}
-}
+} //  namespace jit
+} //  namespace opencl

--- a/src/backend/opencl/jit/ShiftNode.hpp
+++ b/src/backend/opencl/jit/ShiftNode.hpp
@@ -1,0 +1,9 @@
+
+#include <common/jit/ShiftNodeBase.hpp>
+#include <jit/BufferNode.hpp>
+
+namespace opencl {
+namespace jit {
+  using ShiftNode = common::ShiftNodeBase<BufferNode>;
+}
+}

--- a/src/backend/opencl/jit/kernel_generators.hpp
+++ b/src/backend/opencl/jit/kernel_generators.hpp
@@ -16,8 +16,9 @@ namespace opencl {
 namespace {
 
 /// Creates a string that will be used to declare the parameter of kernel
-void generateParamDeclaration(std::stringstream& kerStream, int id,
-                              bool is_linear, const std::string& m_type_str) {
+inline void generateParamDeclaration(std::stringstream& kerStream, int id,
+                                     bool is_linear,
+                                     const std::string& m_type_str) {
     if (is_linear) {
         kerStream << "__global " << m_type_str << " *in" << id
                   << ", dim_t iInfo" << id << "_offset, \n";
@@ -28,10 +29,12 @@ void generateParamDeclaration(std::stringstream& kerStream, int id,
 }
 
 /// Calls the setArg function to set the arguments for a kernel call
-int setKernelArguments(
+inline int setKernelArguments(
     int start_id, bool is_linear,
     std::function<void(int id, const void* ptr, size_t arg_size)>& setArg,
-    const std::shared_ptr<cl::Buffer>& ptr, const KParam& info) {
+    const std::shared_ptr<cl::Buffer>& ptr, const KParam& info,
+    const int& param_index) {
+    UNUSED(param_index);
     setArg(start_id + 0, static_cast<const void*>(&ptr.get()->operator()()),
            sizeof(cl_mem));
     if (is_linear) {
@@ -44,9 +47,7 @@ int setKernelArguments(
 }
 
 /// Generates the code to calculate the offsets for a buffer
-inline void generateBufferOffsets(std::stringstream& kerStream, int id, bool is_linear,
-                                  const std::string& type_str) {
-    UNUSED(type_str);
+inline void generateBufferOffsets(std::stringstream& kerStream, int id, bool is_linear) {
     std::string idx_str  = std::string("int idx") + std::to_string(id);
     std::string info_str = std::string("iInfo") + std::to_string(id);
 
@@ -69,11 +70,7 @@ inline void generateBufferRead(std::stringstream& kerStream, int id,
               << "];\n";
 }
 
-inline void generateShiftNodeOffsets(std::stringstream& kerStream, int id,
-                                     bool is_linear,
-                                     const std::string& type_str) {
-    UNUSED(is_linear);
-    UNUSED(type_str);
+inline void generateShiftNodeOffsets(std::stringstream& kerStream, int id) {
     std::string idx_str   = std::string("idx") + std::to_string(id);
     std::string info_str  = std::string("iInfo") + std::to_string(id);
     std::string id_str    = std::string("sh_id_") + std::to_string(id) + "_";

--- a/src/backend/opencl/jit/kernel_generators.hpp
+++ b/src/backend/opencl/jit/kernel_generators.hpp
@@ -11,6 +11,11 @@
 #include <sstream>
 #include <string>
 
+#include <functional>
+#include <memory>
+#include <sstream>
+#include <string>
+
 namespace opencl {
 
 namespace {
@@ -19,12 +24,12 @@ namespace {
 inline void generateParamDeclaration(std::stringstream& kerStream, int id,
                                      bool is_linear,
                                      const std::string& m_type_str) {
+    kerStream << "__global " << m_type_str << " *in" << id << "_ptr, dim_t in"
+              << id << "_offset, ";
     if (is_linear) {
-        kerStream << "__global " << m_type_str << " *in" << id
-                  << ", dim_t iInfo" << id << "_offset, \n";
+        kerStream << "\n";
     } else {
-        kerStream << "__global " << m_type_str << " *in" << id
-                  << ", KParam iInfo" << id << ", \n";
+        kerStream << "int in_index" << id << ", \n";
     }
 }
 
@@ -34,48 +39,50 @@ inline int setKernelArguments(
     std::function<void(int id, const void* ptr, size_t arg_size)>& setArg,
     const std::shared_ptr<cl::Buffer>& ptr, const KParam& info,
     const int& param_index) {
-    UNUSED(param_index);
-    setArg(start_id + 0, static_cast<const void*>(&ptr.get()->operator()()),
-           sizeof(cl_mem));
-    if (is_linear) {
-        setArg(start_id + 1, static_cast<const void*>(&info.offset),
-               sizeof(dim_t));
-    } else {
-        setArg(start_id + 1, static_cast<const void*>(&info), sizeof(KParam));
+    cl_mem& buf = (*ptr)();
+    setArg(start_id++, static_cast<const void*>(&buf), sizeof(cl_mem));
+    setArg(start_id++, static_cast<const void*>(&info.offset), sizeof(dim_t));
+    if (is_linear == false) {
+        setArg(start_id++, static_cast<const void*>(&param_index), sizeof(int));
     }
-    return start_id + 2;
+    return start_id;
 }
 
 /// Generates the code to calculate the offsets for a buffer
-inline void generateBufferOffsets(std::stringstream& kerStream, int id, bool is_linear) {
-    std::string idx_str  = std::string("int idx") + std::to_string(id);
-    std::string info_str = std::string("iInfo") + std::to_string(id);
+inline void generateBufferOffsets(std::stringstream& kerStream, int id,
+                                  bool is_linear) {
+    std::string idx_str    = std::string("dim_t idx") + std::to_string(id);
+    std::string offset_str = std::string("in") + std::to_string(id) + "_offset";
 
     if (is_linear) {
-        kerStream << idx_str << " = idx + " << info_str << "_offset;\n";
+        kerStream << idx_str << " = idx + " << offset_str << ";\n";
     } else {
-        kerStream << idx_str << " = (id3 < " << info_str << ".dims[3]) * "
-                  << info_str << ".strides[3] * id3 + (id2 < " << info_str
-                  << ".dims[2]) * " << info_str << ".strides[2] * id2 + (id1 < "
-                  << info_str << ".dims[1]) * " << info_str
-                  << ".strides[1] * id1 + (id0 < " << info_str
-                  << ".dims[0]) * id0 + " << info_str << ".offset;\n";
+        std::string in_index     = "in_index" + std::to_string(id);
+        std::string block_offset = "block_offsets[" + in_index + "]";
+        std::string in_param     = "params[" + in_index + "]";
+
+        kerStream << idx_str << " = " << block_offset << "\n + ((id1 < "
+                  << in_param << ".dims[1]) * " << in_param
+                  << ".strides[1] * id1)"
+                  << "\n + ((id0 < " << in_param << ".dims[0]) * id0) + "
+                  << offset_str << ";\n";
     }
 }
 
 /// Generates the code to read a buffer and store it in a local variable
 inline void generateBufferRead(std::stringstream& kerStream, int id,
                                const std::string& type_str) {
-    kerStream << type_str << " val" << id << " = in" << id << "[idx" << id
+    kerStream << type_str << " val" << id << " = in" << id << "_ptr[idx" << id
               << "];\n";
 }
 
 inline void generateShiftNodeOffsets(std::stringstream& kerStream, int id) {
     std::string idx_str   = std::string("idx") + std::to_string(id);
-    std::string info_str  = std::string("iInfo") + std::to_string(id);
+    std::string info_str  = std::string("in") + std::to_string(id);
     std::string id_str    = std::string("sh_id_") + std::to_string(id) + "_";
     std::string shift_str = std::string("shift") + std::to_string(id) + "_";
 
+    kerStream << "KParam " << info_str << " = params[in_index" << id << "];\n";
     for (int i = 0; i < 4; i++) {
         kerStream << "int " << id_str << i << " = __circular_mod(id" << i
                   << " + " << shift_str << i << ", " << info_str << ".dims["
@@ -92,12 +99,12 @@ inline void generateShiftNodeOffsets(std::stringstream& kerStream, int id) {
               << ".dims[1]) * " << info_str << ".strides[1] * " << id_str
               << "1;\n";
     kerStream << idx_str << " += (" << id_str << "0 < " << info_str
-              << ".dims[0]) * " << id_str << "0 + " << info_str << ".offset;\n";
+              << ".dims[0]) * " << id_str << "0 + " << info_str << "_offset;\n";
 }
 
 inline void generateShiftNodeRead(std::stringstream& kerStream, int id,
                                   const std::string& type_str) {
-    kerStream << type_str << " val" << id << " = in" << id << "[idx" << id
+    kerStream << type_str << " val" << id << " = in" << id << "_ptr[idx" << id
               << "];\n";
 }
 }  // namespace

--- a/src/backend/opencl/memory.cpp
+++ b/src/backend/opencl/memory.cpp
@@ -50,12 +50,11 @@ void printMemInfo(const char *msg, const int device) {
 }
 
 template<typename T>
-unique_ptr<cl::Buffer, function<void(cl::Buffer *)>> memAlloc(
+uptr memAlloc(
     const size_t &elements) {
     cl::Buffer *ptr = static_cast<cl::Buffer *>(
         memoryManager().alloc(elements * sizeof(T), false));
-    return unique_ptr<cl::Buffer, function<void(cl::Buffer *)>>(ptr,
-                                                                bufferFree);
+    return uptr(ptr, bufferFree);
 }
 
 void *memAllocUser(const size_t &bytes) {

--- a/src/backend/opencl/memory.hpp
+++ b/src/backend/opencl/memory.hpp
@@ -24,9 +24,11 @@ namespace opencl {
 cl::Buffer *bufferAlloc(const size_t &bytes);
 void bufferFree(cl::Buffer *buf);
 
+using uptr = std::unique_ptr<cl::Buffer, std::function<void(cl::Buffer *)>>;
+
 template<typename T>
-std::unique_ptr<cl::Buffer, std::function<void(cl::Buffer *)>> memAlloc(
-    const size_t &elements);
+uptr memAlloc(const size_t &elements);
+
 void *memAllocUser(const size_t &bytes);
 
 // Need these as 2 separate function and not a default argument

--- a/src/backend/opencl/shift.cpp
+++ b/src/backend/opencl/shift.cpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #include <Array.hpp>
-#include <common/jit/ShiftNodeBase.hpp>
+#include <opencl/jit/ShiftNode.hpp>
 #include <err_opencl.hpp>
 #include <shift.hpp>
 
@@ -18,7 +18,7 @@
 using af::dim4;
 
 using common::Node_ptr;
-using common::ShiftNodeBase;
+using opencl::jit::ShiftNode;
 using opencl::jit::BufferNode;
 
 using std::array;
@@ -27,7 +27,6 @@ using std::static_pointer_cast;
 using std::string;
 
 namespace opencl {
-using ShiftNode = ShiftNodeBase<BufferNode>;
 
 template<typename T>
 Array<T> shift(const Array<T> &in, const int sdims[4]) {

--- a/test/jit.cpp
+++ b/test/jit.cpp
@@ -16,6 +16,7 @@
 
 using af::array;
 using af::constant;
+using af::dim4;
 using af::eval;
 using af::freeHost;
 using af::gforSet;
@@ -124,10 +125,16 @@ TEST(JIT, CPP_Multi_linear) {
     x.host(&hx[0]);
     y.host(&hy[0]);
 
+    vector<int> goldx(num);
+    vector<int> goldy(num);
+
     for (int i = 0; i < num; i++) {
-        ASSERT_EQ((ha[i] + hb[i]), hx[i]);
-        ASSERT_EQ((ha[i] - hb[i]), hy[i]);
+        goldx[i] = ha[i] + hb[i];
+        goldy[i] = ha[i] - hb[i];
     }
+
+    ASSERT_VEC_ARRAY_EQ(goldx, dim4(num), x);
+    ASSERT_VEC_ARRAY_EQ(goldy, dim4(num), y);
 }
 
 TEST(JIT, CPP_strided) {
@@ -603,4 +610,83 @@ TEST(JIT, LargeJitTree) {
         eval(a);
         af::sync();
     });
+}
+
+TEST(JIT, TwoLargeNonLinear) {
+    int dimsize = 10;
+    array a     = constant(0, dimsize, dimsize);
+    array aa    = constant(0, dimsize, dimsize);
+    array b     = constant(0, dimsize, dimsize);
+    array bb    = constant(0, dimsize, dimsize);
+
+    int val = 0;
+    for (int i = 0; i < 24; i++) {
+        array ones = constant(1, dimsize, dimsize);
+        ones.eval();
+        array twos = constant(2, dimsize);
+        twos.eval();
+
+        a += tile(twos, 1, dimsize) + ones;
+        aa += tile(twos, 1, dimsize) + ones;
+        val += 3;
+    }
+
+    for (int i = 0; i < 24; i++) {
+        array ones = constant(1, dimsize, dimsize);
+        ones.eval();
+        array twos = constant(2, dimsize);
+        twos.eval();
+        b += tile(twos, 1, dimsize) + ones;
+        bb += tile(twos, 1, dimsize) + ones;
+    }
+    array c  = a + b;
+    array cc = aa + bb;
+    eval(c, cc);
+
+    vector<float> gold(a.elements(), val * 2);
+    ASSERT_VEC_ARRAY_EQ(gold, a.dims(), c);
+}
+
+TEST(JIT, IndexingColumn) {
+    array a = constant(1, 512, 32);
+    array b = constant(2, 512);
+    a.eval();
+    b.eval();
+
+    array c = a(af::span, 31) + b;
+
+    vector<float> gold(512, 3.0f);
+    ASSERT_VEC_ARRAY_EQ(gold, dim4(512), c);
+}
+
+TEST(JIT, IndexingRow) {
+    array a = constant(1, 32, 512);
+    array b = constant(2, 1, 512);
+    a.eval();
+    b.eval();
+
+    array c = a(31, af::span) + b;
+
+    vector<float> gold(512, 3.0f);
+    ASSERT_VEC_ARRAY_EQ(gold, dim4(1, 512), c);
+}
+
+TEST(JIT, DISABLED_ManyConstants) {
+    array res  = constant(1, 1);
+    array res2 = tile(res, 1, 10);
+    array res3 = randu(1);
+    array res4 = tile(res3, 1, 10);
+    array res5 = randu(1);
+    array res6 = tile(res5, 1, 10);
+    array res7 = randu(1);
+    array res8 = tile(res7, 1, 10);
+
+    for (int i = 0; i < 80; i++) { res2 = res2 + randu(1, 10); }
+    for (int i = 0; i < 80; i++) { res4 = res4 + tile(randu(1), 1, 10); }
+    for (int i = 0; i < 80; i++) { res6 = res6 + tile(randu(1), 1, 10); }
+    for (int i = 0; i < 80; i++) { res8 = res8 + 1.0f; }
+
+    // This still fails in the current implementation
+    eval(res2, res4, res6);//, res8);
+    af::sync();
 }


### PR DESCRIPTION
This PR refactors the JIT kernels to load the Params into shared memory instead of passing them as parameters in non-linear kernels. This will decrease the likelyhood of a invalid image kernel and increase the size of kernels that can be generated by JIT. The larger sizes take a significant amount of time to compile so at some point we may need to limit their size artificially.

- [x] Implement same in OpenCL