### PR TITLE
Used pinned memory to store pointers in batched gemm

### DIFF
--- a/src/backend/common/pinned_allocator.hpp
+++ b/src/backend/common/pinned_allocator.hpp
@@ -1,0 +1,43 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <backend.hpp>
+#include <memory.hpp>
+
+namespace common {
+template<typename T>
+class pinned_allocator {
+   public:
+    using value_type = T;
+
+    pinned_allocator() noexcept {}  // not required, unless used
+    template<typename U>
+    pinned_allocator(std::allocator<U> const&) noexcept {}
+
+    value_type* allocate(std::size_t n) {
+        return detail::pinnedAlloc<value_type>(n);
+    }
+
+    void deallocate(value_type* p, std::size_t) noexcept {
+        detail::pinnedFree(p);
+    }
+};
+
+template<typename T, typename U>
+bool operator==(pinned_allocator<T> const&,
+                pinned_allocator<U> const&) noexcept {
+    return true;
+}
+
+template<typename T, typename U>
+bool operator!=(pinned_allocator<T> const& x,
+                pinned_allocator<U> const& y) noexcept {
+    return !(x == y);
+}
+}  // namespace common

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -41,6 +41,7 @@ using std::lock_guard;
 using std::recursive_mutex;
 using std::unique_ptr;
 
+
 namespace cuda {
 void setMemStepSize(size_t step_bytes) {
     memoryManager().setMemStepSize(step_bytes);
@@ -119,6 +120,8 @@ INSTANTIATE(intl)
 INSTANTIATE(uintl)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
+INSTANTIATE(void*)
+INSTANTIATE(void const*)
 
 MemoryManager::MemoryManager()
     : common::MemoryManager<cuda::MemoryManager>(
@@ -136,6 +139,7 @@ MemoryManager::~MemoryManager() {
             continue;  // Do not throw any errors while shutting down
         }
     }
+
 }
 
 int MemoryManager::getActiveDeviceId() { return cuda::getActiveDeviceId(); }

--- a/test/blas.cpp
+++ b/test/blas.cpp
@@ -234,8 +234,8 @@ TEST(MatrixMultiply, Batched) {
     const int M  = 512;
     const int K  = 512;
     const int N  = 10;
-    const int D2 = 2;
-    const int D3 = 3;
+    const int D2 = 20;
+    const int D3 = 30;
     for (int d3 = 1; d3 <= D3; d3 *= D3) {
         for (int d2 = 1; d2 <= D2; d2 *= D2) {
             array a = randu(M, K, d2, d3);
@@ -248,7 +248,7 @@ TEST(MatrixMultiply, Batched) {
                     array b_ij = b(span, span, i, j);
                     array c_ij = c(span, span, i, j);
                     array res  = matmul(a_ij, b_ij);
-                    ASSERT_ARRAYS_NEAR(c_ij, res, 2E-4);
+                    ASSERT_ARRAYS_NEAR(c_ij, res, 3E-4);
                 }
             }
         }
@@ -274,8 +274,8 @@ TEST(MatrixMultiply, LhsBroadcastBatched) {
     const int M  = 512;
     const int K  = 512;
     const int N  = 10;
-    const int D2 = 2;
-    const int D3 = 3;
+    const int D2 = 20;
+    const int D3 = 300;
 
     for (int d3 = 1; d3 <= D3; d3 *= D3) {
         for (int d2 = 1; d2 <= D2; d2 *= D2) {
@@ -288,7 +288,7 @@ TEST(MatrixMultiply, LhsBroadcastBatched) {
                     array b_ij = b(span, span, i, j);
                     array c_ij = c(span, span, i, j);
                     array res  = matmul(a, b_ij);
-                    ASSERT_ARRAYS_NEAR(c_ij, res, 2E-4);
+                    ASSERT_ARRAYS_NEAR(c_ij, res, 3E-4);
                 }
             }
         }
@@ -299,8 +299,8 @@ TEST(MatrixMultiply, RhsBroadcastBatched) {
     const int M  = 512;
     const int K  = 512;
     const int N  = 10;
-    const int D2 = 2;
-    const int D3 = 3;
+    const int D2 = 20;
+    const int D3 = 30;
 
     for (int d3 = 1; d3 <= D3; d3 *= D3) {
         for (int d2 = 1; d2 <= D2; d2 *= D2) {
@@ -313,7 +313,7 @@ TEST(MatrixMultiply, RhsBroadcastBatched) {
                     array a_ij = a(span, span, i, j);
                     array c_ij = c(span, span, i, j);
                     array res  = matmul(a_ij, b);
-                    ASSERT_ARRAYS_NEAR(c_ij, res, 2E-4);
+                    ASSERT_ARRAYS_NEAR(c_ij, res, 3E-4);
                 }
             }
         }


### PR DESCRIPTION
We were using vectors to store the pointers to matrices in the
blas function when performing batched operations. This caused
them to be synchronous because the memory wasn't pinned.

Fixes:  #2416