### PR TITLE
New Window method: setAxesLabelFormat

### DIFF
--- a/include/af/graphics.h
+++ b/include/af/graphics.h
@@ -496,9 +496,9 @@ class AFAPI Window {
 
            \ingroup gfx_func_window
         */
-        void setAxesLabelFormat(const char *const xtitle = "4.1%f",
-                                const char *const ytitle = "4.1%f",
-                                const char *const ztitle = NULL);
+        void setAxesLabelFormat(const char *const xformat = "4.1%f",
+                                const char *const yformat = "4.1%f",
+                                const char *const zformat = NULL);
 #endif
 
         /**

--- a/include/af/graphics.h
+++ b/include/af/graphics.h
@@ -485,6 +485,22 @@ class AFAPI Window {
                            const char * const ytitle = "Y-Axis",
                            const char * const ztitle = NULL);
 #endif
+
+#if AF_API_VERSION >= 37
+        /**
+           Setup the axes label formats for charts
+
+           \param[in] xformat is a printf-style format specifier for x-axis
+           \param[in] yformat is a printf-style format specifier for y-axis
+           \param[in] zformat is a printf-style format specifier for z-axis
+
+           \ingroup gfx_func_window
+        */
+        void setAxesLabelFormat(const char *const xtitle = "4.1%f",
+                                const char *const ytitle = "4.1%f",
+                                const char *const ztitle = NULL);
+#endif
+
         /**
            Setup grid layout for multiview mode in a window
 
@@ -1086,6 +1102,35 @@ AFAPI af_err af_set_axes_titles(const af_window wind,
                                 const char * const ytitle,
                                 const char * const ztitle,
                                 const af_cell* const props);
+#endif
+
+#if AF_API_VERSION >= 37
+/**
+   C Interface wrapper for setting axes labels formats for charts
+
+   Axes labels use printf style format specifiers. Default specifier for the
+   data displayed as labels is `%4.1f`. This function lets the user change this
+   label formatting to whichever format that fits their data range and precision.
+
+   \param[in] wind is the window handle
+   \param[in] xformat is a printf-style format specifier for x-axis
+   \param[in] yformat is a printf-style format specifier for y-axis
+   \param[in] zformat is a printf-style format specifier for z-axis
+   \param[in] props is structure \ref af_cell that has the properties that
+              are used for the current rendering.
+
+   \note \p zformat can be NULL in which case ArrayFire understands that the
+   label formats are meant for a 2D chart corresponding to this \p wind
+   or a specific cell in multi-viewport mode (provided via \p props argument).
+   A non NULL value to \p zformat means the label formats belong to a 3D chart.
+
+   \ingroup gfx_func_window
+*/
+AFAPI af_err af_set_axes_label_format(const af_window wind,
+                                      const char *const xformat,
+                                      const char *const yformat,
+                                      const char *const zformat,
+                                      const af_cell *const props);
 #endif
 
 /**

--- a/src/api/c/window.cpp
+++ b/src/api/c/window.cpp
@@ -221,6 +221,41 @@ af_err af_set_axes_titles(const af_window window, const char* const xtitle,
     return AF_SUCCESS;
 }
 
+af_err af_set_axes_label_format(const af_window window,
+                                const char* const xformat,
+                                const char* const yformat,
+                                const char* const zformat,
+                                const af_cell* const props) {
+    try {
+        if (window == 0) { AF_ERROR("Not a valid window", AF_ERR_INTERNAL); }
+
+        ARG_ASSERT(2, xformat != nullptr);
+        ARG_ASSERT(3, yformat != nullptr);
+        ARG_ASSERT(4, zformat != nullptr);
+
+        ForgeManager& fgMngr = forgeManager();
+
+        fg_chart chart = nullptr;
+
+        fg_chart_type ctype = (zformat ? FG_CHART_3D : FG_CHART_2D);
+
+        if (props->col > -1 && props->row > -1)
+            chart = fgMngr.getChart(window, props->row, props->col, ctype);
+        else
+            chart = fgMngr.getChart(window, 0, 0, ctype);
+
+        if (ctype == FG_CHART_2D) {
+            FG_CHECK(forgePlugin().fg_set_chart_label_format(chart, xformat,
+                                                             yformat, "3.2%f"));
+        } else {
+            FG_CHECK(forgePlugin().fg_set_chart_label_format(chart, xformat,
+                                                             yformat, zformat));
+        }
+    }
+    CATCHALL;
+    return AF_SUCCESS;
+}
+
 af_err af_show(const af_window wind) {
     try {
         if (wind == 0) { AF_ERROR("Not a valid window", AF_ERR_INTERNAL); }

--- a/src/api/c/window.cpp
+++ b/src/api/c/window.cpp
@@ -231,7 +231,6 @@ af_err af_set_axes_label_format(const af_window window,
 
         ARG_ASSERT(2, xformat != nullptr);
         ARG_ASSERT(3, yformat != nullptr);
-        ARG_ASSERT(4, zformat != nullptr);
 
         ForgeManager& fgMngr = forgeManager();
 
@@ -248,6 +247,7 @@ af_err af_set_axes_label_format(const af_window window,
             FG_CHECK(forgePlugin().fg_set_chart_label_format(chart, xformat,
                                                              yformat, "3.2%f"));
         } else {
+            ARG_ASSERT(4, zformat != nullptr);
             FG_CHECK(forgePlugin().fg_set_chart_label_format(chart, xformat,
                                                              yformat, zformat));
         }

--- a/src/api/cpp/graphics.cpp
+++ b/src/api/cpp/graphics.cpp
@@ -189,6 +189,13 @@ void Window::setAxesTitles(const char* const xtitle, const char* const ytitle,
     AF_THROW(af_set_axes_titles(get(), xtitle, ytitle, ztitle, &temp));
 }
 
+void Window::setAxesLabelFormat(const char* const xformat,
+                                const char* const yformat,
+                                const char* const zformat) {
+    af_cell temp{_r, _c, NULL, AF_COLORMAP_DEFAULT};
+    AF_THROW(af_set_axes_label_format(get(), xformat, yformat, zformat, &temp));
+}
+
 void Window::show() {
     AF_THROW(af_show(get()));
     _r = -1;

--- a/src/api/unified/graphics.cpp
+++ b/src/api/unified/graphics.cpp
@@ -172,6 +172,13 @@ af_err af_set_axes_titles(const af_window wind, const char* const xtitle,
     return CALL(wind, xtitle, ytitle, ztitle, props);
 }
 
+af_err af_set_axes_label_format(const af_window wind, const char* const xformat,
+                                const char* const yformat,
+                                const char* const zformat,
+                                const af_cell* const props) {
+    return CALL(wind, xformat, yformat, zformat, props);
+}
+
 af_err af_show(const af_window wind) { return CALL(wind); }
 
 af_err af_is_window_closed(bool* out, const af_window wind) {

--- a/src/backend/common/forge_loader.hpp
+++ b/src/backend/common/forge_loader.hpp
@@ -78,6 +78,7 @@ class ForgeModule : public common::DependencyModule {
     MODULE_MEMBER(fg_get_chart_axes_limits);
     MODULE_MEMBER(fg_set_chart_axes_limits);
     MODULE_MEMBER(fg_set_chart_axes_titles);
+    MODULE_MEMBER(fg_set_chart_label_format);
     MODULE_MEMBER(fg_append_image_to_chart);
     MODULE_MEMBER(fg_append_plot_to_chart);
     MODULE_MEMBER(fg_append_histogram_to_chart);

--- a/src/backend/common/graphics_common.cpp
+++ b/src/backend/common/graphics_common.cpp
@@ -82,6 +82,7 @@ ForgeModule::ForgeModule() : DependencyModule("forge", nullptr) {
         FG_MODULE_FUNCTION_INIT(fg_get_chart_axes_limits);
         FG_MODULE_FUNCTION_INIT(fg_set_chart_axes_limits);
         FG_MODULE_FUNCTION_INIT(fg_set_chart_axes_titles);
+        FG_MODULE_FUNCTION_INIT(fg_set_chart_label_format);
         FG_MODULE_FUNCTION_INIT(fg_append_image_to_chart);
         FG_MODULE_FUNCTION_INIT(fg_append_plot_to_chart);
         FG_MODULE_FUNCTION_INIT(fg_append_histogram_to_chart);


### PR DESCRIPTION
This member function of af::Window class enables the user
to set the format in which chart axes labels are generated.

The formats for each axis are specified as a printf-style
format specifier.

Resolves #2006 