### PR TITLE
Fix performance bug in JIT caused by redundant access to memory

### DIFF
--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -102,7 +102,8 @@ struct Param
     // Common CUDA code
     // This part of the code does not change with the kernel.
 
-    static const char *kernelVoid = "extern \"C\" __global__ void\n";
+    static const char *kernelVoid =
+        "extern \"C\" __global__ void __launch_bounds__(128, 8)\n";
     static const char *dimParams =
         "uint blocks_x, uint blocks_y, uint "
         "blocks_x_total, uint num_odims";
@@ -341,7 +342,7 @@ void evalNodes(vector<Param<T>> &outputs, vector<Node *> output_nodes) {
     }
 
     if (is_linear) {
-        threads_x = 256;
+        threads_x = 128;
         threads_y = 1;
 
         blocks_x_total = divup((outputs[0].dims[0] * outputs[0].dims[1] *
@@ -352,7 +353,7 @@ void evalNodes(vector<Param<T>> &outputs, vector<Node *> output_nodes) {
         blocks_x     = divup(blocks_x_total, repeat_x);
     } else {
         threads_x = 32;
-        threads_y = 8;
+        threads_y = 4;
 
         blocks_x_ = divup(outputs[0].dims[0], threads_x);
         blocks_y_ = divup(outputs[0].dims[1], threads_y);

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -152,10 +152,9 @@ struct Param
                 outref.strides[2] * id2 +
                 outref.strides[1] * id1 + id0;
 
-    if (threadIdx.x < num_params && threadIdx.y == 0) {
-        int tidx = threadIdx.x;
-        block_offsets[tidx] = (id3 < params[tidx].dims[3]) * params[tidx].strides[3] * id3 +
-                              (id2 < params[tidx].dims[2]) * params[tidx].strides[2] * id2;
+    if (lidx < num_params) {
+        block_offsets[lidx] = (id3 < params[lidx].dims[3]) * params[lidx].strides[3] * id3 +
+                              (id2 < params[lidx].dims[2]) * params[lidx].strides[2] * id2;
     }
     __syncthreads();
     if (cond) {
@@ -166,7 +165,8 @@ struct Param
         Param *params = reinterpret_cast<Param*>(smem);
         dim_t *block_offsets = reinterpret_cast<dim_t*>(smem+(num_params * sizeof(Param)));
 
-        if (threadIdx.x < num_params) { params[threadIdx.x] = dims[threadIdx.x]; }
+        int lidx = threadIdx.y * blockDim.x + threadIdx.x;
+        if (lidx < num_params) { params[lidx] = dims[lidx]; }
         __syncthreads();
     )JIT";
 


### PR DESCRIPTION
The conditional statements to access the shared memory was not
correctly masking the threads. This fix uses linear indexing
instead of threadIdx. to index into shared memory.

Fixes #2494 

This should be slightly slower than v3.6.2 but pretty close. I have a couple of other changes that will improve this but they are not ready yet. I will add them in another commit to this PR.