### PR TITLE
Make unified backend accept ArrayFire libraries in arbitrary paths

### DIFF
--- a/docs/details/backend.dox
+++ b/docs/details/backend.dox
@@ -18,15 +18,16 @@ will return in an exception.
 
 \defgroup unified_func_addbackendlibrary addBackendLibrary
 
-\brief Register a custom ArrayFire library for use
+\brief Register an ArrayFire library located in an arbitrary path for use
 
 The custom library's path can be anywhere in the local file system, even outside
 of where the ArrayFire libraries are found by default (e.g. `LD_LIBRARY_PATH` in
 Unix and System or User Path in Windows). Use this in tandem with
-\ref setBackendLibrary(). The order of when this was called for a specific
-library determines the index to be used in \ref setBackendLibrary() in order to
-activate this library. This is useful especially for comparing the results or
-performance between different versions of the arrayfire libraries.
+\ref setBackendLibrary(). The order of when this function was called for a
+specific library determines the index to be used in \ref setBackendLibrary() in
+order to activate the desired library. This is useful especially for comparing
+the results or performance between different versions of the ArrayFire
+libraries.
 
 This is a noop when using any one of the standalone CPU, CUDA, or OpenCL backends.
 
@@ -37,7 +38,6 @@ af::addBackendLibrary("/path/to/custom/2/afcpu.so");
 
 af::setBackendLibrary(0); // Activates .../1/afcpu.so
 af::setBackendLibrary(1); // Activates .../2/afcpu.so
-
 \endcode
 
 \ingroup unified_func
@@ -47,11 +47,11 @@ af::setBackendLibrary(1); // Activates .../2/afcpu.so
 
 \defgroup unified_func_setbackendlibrary setBackendLibrary
 
-\brief Activate a custom arrayfire library for use
+\brief Activate an ArrayFire library located in an arbitrary path for use
 
-Must be used after the custom arrayfire library has been registered through
+Must be used after the ArrayFire library has been registered through
 \ref addBackendLibrary(). The index to be passed in must be the order of when
-`addBackendLibrary` was called for the target library. This is useful especially
+\ref addBackendLibrary() was called for the target library. This is useful especially
 for comparing the results or performance between different versions of the
 arrayfire libraries.
 

--- a/docs/details/backend.dox
+++ b/docs/details/backend.dox
@@ -71,6 +71,18 @@ af_set_backend_library(1); // Activates .../2/afcpu.so
 
 =======================================================================
 
+\defgroup unified_func_checkunifiedbackend af_check_unified_backend
+
+\brief Check if the application uses the unified backend or not
+
+\p result will contain `true` if the unified backend is being used. Otherwise,
+it will contain `false`.
+
+\ingroup unified_func
+\ingroup arrayfire_func
+
+=======================================================================
+
 \defgroup unified_func_getbackendcount getBackendCount
 
 \brief Get the number of backends whose libraries were successfully loaded.

--- a/docs/details/backend.dox
+++ b/docs/details/backend.dox
@@ -27,7 +27,8 @@ with \ref af_set_backend_library(). The order of when this function was called
 for a specific library determines the index to be used in
 \ref af_set_backend_library() in order to activate the desired library. This is
 useful especially for comparing the results or performance between different
-versions of the ArrayFire libraries.
+versions of the ArrayFire libraries. Note however that the number of libraries
+that can be registered is limited to 7.
 
 This is a noop when using any one of the standalone CPU, CUDA, or OpenCL backends.
 

--- a/docs/details/backend.dox
+++ b/docs/details/backend.dox
@@ -16,28 +16,28 @@ will return in an exception.
 
 =======================================================================
 
-\defgroup unified_func_addbackendlibrary addBackendLibrary
+\defgroup unified_func_addbackendlibrary af_add_backend_library
 
 \brief Register an ArrayFire library located in an arbitrary path for use
 
 The custom library's path can be anywhere in the local file system, even outside
-of where the ArrayFire libraries are found by default (e.g. `LD_LIBRARY_PATH` in
-Unix and System or User Path in Windows). Use this in tandem with
-\ref setBackendLibrary(). The order of when this function was called for a
-specific library determines the index to be used in \ref setBackendLibrary() in
-order to activate the desired library. This is useful especially for comparing
-the results or performance between different versions of the ArrayFire
-libraries.
+of where the ArrayFire libraries are found by default (e.g. outside
+`LD_LIBRARY_PATH` in Unix and System or User Path in Windows). Use this in tandem
+with \ref af_set_backend_library(). The order of when this function was called
+for a specific library determines the index to be used in
+\ref af_set_backend_library() in order to activate the desired library. This is
+useful especially for comparing the results or performance between different
+versions of the ArrayFire libraries.
 
 This is a noop when using any one of the standalone CPU, CUDA, or OpenCL backends.
 
 The following is an example of how this can be used:
 \code
-af::addBackendLibrary("/path/to/custom/1/afcpu.so");
-af::addBackendLibrary("/path/to/custom/2/afcpu.so");
+af_add_backend_library("/path/to/custom/1/afcpu.so");
+af_add_backend_library("/path/to/custom/2/afcpu.so");
 
-af::setBackendLibrary(0); // Activates .../1/afcpu.so
-af::setBackendLibrary(1); // Activates .../2/afcpu.so
+af_set_backend_library(0); // Activates .../1/afcpu.so
+af_set_backend_library(1); // Activates .../2/afcpu.so
 \endcode
 
 \ingroup unified_func
@@ -45,13 +45,13 @@ af::setBackendLibrary(1); // Activates .../2/afcpu.so
 
 =======================================================================
 
-\defgroup unified_func_setbackendlibrary setBackendLibrary
+\defgroup unified_func_setbackendlibrary af_set_backend_library
 
 \brief Activate an ArrayFire library located in an arbitrary path for use
 
 Must be used after the ArrayFire library has been registered through
-\ref addBackendLibrary(). The index to be passed in must be the order of when
-\ref addBackendLibrary() was called for the target library. This is useful especially
+\ref af_add_backend_library(). The index to be passed in must be the order of when
+\ref af_add_backend_library() was called for the target library. This is useful especially
 for comparing the results or performance between different versions of the
 arrayfire libraries.
 
@@ -59,11 +59,11 @@ This is a noop when using any one of the standalone CPU, CUDA, or OpenCL backend
 
 The following is an example of how this can be used:
 \code
-af::addBackendLibrary("/path/to/custom/1/afcpu.so");
-af::addBackendLibrary("/path/to/custom/2/afcpu.so");
+af_add_backend_library("/path/to/custom/1/afcpu.so");
+af_add_backend_library("/path/to/custom/2/afcpu.so");
 
-af::setBackendLibrary(0); // Activates .../1/afcpu.so
-af::setBackendLibrary(1); // Activates .../2/afcpu.so
+af_set_backend_library(0); // Activates .../1/afcpu.so
+af_set_backend_library(1); // Activates .../2/afcpu.so
 \endcode
 
 \ingroup unified_func

--- a/docs/details/backend.dox
+++ b/docs/details/backend.dox
@@ -18,13 +18,13 @@ will return in an exception.
 
 \defgroup unified_func_addbackendlibrary addBackendLibrary
 
-\brief Register a custom arrayfire library for use
+\brief Register a custom ArrayFire library for use
 
-The custom library's path can be anywhere in the local file system, outside
-where the arrayfire libraries are found by default (e.g. `LD_LIBRARY_PATH` in
+The custom library's path can be anywhere in the local file system, even outside
+of where the ArrayFire libraries are found by default (e.g. `LD_LIBRARY_PATH` in
 Unix and System or User Path in Windows). Use this in tandem with
 \ref setBackendLibrary(). The order of when this was called for a specific
-library determines the index to be used in `setBackendLibrary` in order to
+library determines the index to be used in \ref setBackendLibrary() in order to
 activate this library. This is useful especially for comparing the results or
 performance between different versions of the arrayfire libraries.
 
@@ -37,6 +37,7 @@ af::addBackendLibrary("/path/to/custom/2/afcpu.so");
 
 af::setBackendLibrary(0); // Activates .../1/afcpu.so
 af::setBackendLibrary(1); // Activates .../2/afcpu.so
+
 \endcode
 
 \ingroup unified_func

--- a/docs/details/backend.dox
+++ b/docs/details/backend.dox
@@ -16,6 +16,60 @@ will return in an exception.
 
 =======================================================================
 
+\defgroup unified_func_addbackendlibrary addBackendLibrary
+
+\brief Register a custom arrayfire library for use
+
+The custom library's path can be anywhere in the local file system, outside
+where the arrayfire libraries are found by default (e.g. `LD_LIBRARY_PATH` in
+Unix and System or User Path in Windows). Use this in tandem with
+\ref setBackendLibrary(). The order of when this was called for a specific
+library determines the index to be used in `setBackendLibrary` in order to
+activate this library. This is useful especially for comparing the results or
+performance between different versions of the arrayfire libraries.
+
+This is a noop when using any one of the standalone CPU, CUDA, or OpenCL backends.
+
+The following is an example of how this can be used:
+\code
+af::addBackendLibrary("/path/to/custom/1/afcpu.so");
+af::addBackendLibrary("/path/to/custom/2/afcpu.so");
+
+af::setBackendLibrary(0); // Activates .../1/afcpu.so
+af::setBackendLibrary(1); // Activates .../2/afcpu.so
+\endcode
+
+\ingroup unified_func
+\ingroup arrayfire_func
+
+=======================================================================
+
+\defgroup unified_func_setbackendlibrary setBackendLibrary
+
+\brief Activate a custom arrayfire library for use
+
+Must be used after the custom arrayfire library has been registered through
+\ref addBackendLibrary(). The index to be passed in must be the order of when
+`addBackendLibrary` was called for the target library. This is useful especially
+for comparing the results or performance between different versions of the
+arrayfire libraries.
+
+This is a noop when using any one of the standalone CPU, CUDA, or OpenCL backends.
+
+The following is an example of how this can be used:
+\code
+af::addBackendLibrary("/path/to/custom/1/afcpu.so");
+af::addBackendLibrary("/path/to/custom/2/afcpu.so");
+
+af::setBackendLibrary(0); // Activates .../1/afcpu.so
+af::setBackendLibrary(1); // Activates .../2/afcpu.so
+\endcode
+
+\ingroup unified_func
+\ingroup arrayfire_func
+
+=======================================================================
+
 \defgroup unified_func_getbackendcount getBackendCount
 
 \brief Get the number of backends whose libraries were successfully loaded.

--- a/include/af/backend.h
+++ b/include/af/backend.h
@@ -24,12 +24,25 @@ extern "C" {
 AFAPI af_err af_set_backend(const af_backend bknd);
 #endif
 
-#if AF_API_VERSION >= 36
-    AFAPI af_err af_add_backend_library(const char *lib_path);
+#if AF_API_VERSION >= 37
+/**
+   \param[in] lib_path is the path of the custom arrayfire library to
+              be registered
+
+   \ingroup unified_func_addbackendlibrary
+*/
+AFAPI af_err af_add_backend_library(const char *lib_path);
 #endif
 
-#if AF_API_VERSION >= 36
-    AFAPI af_err af_set_backend_library(int lib_idx);
+#if AF_API_VERSION >= 37
+/**
+   \param[in] lib_idx is the index of a registered custom arrayfire library to
+              be activated for use. Must match the order of when the library
+              was registered
+
+   \ingroup unified_func_setbackendlibrary
+*/
+AFAPI af_err af_set_backend_library(int lib_idx);
 #endif
 
 #if AF_API_VERSION >= 32
@@ -117,11 +130,24 @@ class array;
 AFAPI void setBackend(const Backend bknd);
 #endif
 
-#if AF_API_VERSION >= 36
+#if AF_API_VERSION >= 37
+/**
+   \param[in] lib_path is the path of the custom arrayfire library to
+              be registered
+
+   \ingroup unified_func_addbackendlibrary
+*/
 AFAPI void addBackendLibrary(const char *lib_path);
 #endif
 
-#if AF_API_VERSION >= 36
+#if AF_API_VERSION >= 37
+/**
+   \param[in] lib_idx is the index of a registered custom arrayfire library to
+              be activated for use. Must match the order of when the library
+              was registered
+
+   \ingroup unified_func_setbackendlibrary
+*/
 AFAPI void setBackendLibrary(int lib_idx);
 #endif
 

--- a/include/af/backend.h
+++ b/include/af/backend.h
@@ -28,6 +28,7 @@ AFAPI af_err af_set_backend(const af_backend bknd);
 /**
    \param[in] lib_path is the path of the custom arrayfire library to
               be registered
+   \returns   \ref af_err error code
 
    \ingroup unified_func_addbackendlibrary
 */
@@ -39,10 +40,22 @@ AFAPI af_err af_add_backend_library(const char *lib_path);
    \param[in] lib_idx is the index of a registered custom arrayfire library to
               be activated for use. Must match the order of when the library
               was registered
+   \returns   \ref af_err error code
 
    \ingroup unified_func_setbackendlibrary
 */
 AFAPI af_err af_set_backend_library(int lib_idx);
+#endif
+
+#if AF_API_VERSION >= 37
+/**
+   \param[out] result reports whether the application is using the unified
+               backend or not
+   \returns    \ref af_err error code
+
+   \ingroup unified_func_checkunifiedbackend
+*/
+AFAPI af_err af_check_unified_backend(bool *result);
 #endif
 
 #if AF_API_VERSION >= 32

--- a/include/af/backend.h
+++ b/include/af/backend.h
@@ -24,6 +24,14 @@ extern "C" {
 AFAPI af_err af_set_backend(const af_backend bknd);
 #endif
 
+#if AF_API_VERSION >= 36
+    AFAPI af_err af_add_backend_library(const char *lib_path);
+#endif
+
+#if AF_API_VERSION >= 36
+    AFAPI af_err af_set_backend_library(int lib_idx);
+#endif
+
 #if AF_API_VERSION >= 32
 /**
    \param[out] num_backends Number of available backends
@@ -107,6 +115,14 @@ class array;
    \ingroup unified_func_setbackend
  */
 AFAPI void setBackend(const Backend bknd);
+#endif
+
+#if AF_API_VERSION >= 36
+AFAPI void addBackendLibrary(const char *lib_path);
+#endif
+
+#if AF_API_VERSION >= 36
+AFAPI void setBackendLibrary(int lib_idx);
 #endif
 
 #if AF_API_VERSION >= 32

--- a/include/af/backend.h
+++ b/include/af/backend.h
@@ -130,27 +130,6 @@ class array;
 AFAPI void setBackend(const Backend bknd);
 #endif
 
-#if AF_API_VERSION >= 37
-/**
-   \param[in] lib_path is the path of the custom arrayfire library to
-              be registered
-
-   \ingroup unified_func_addbackendlibrary
-*/
-AFAPI void addBackendLibrary(const char *lib_path);
-#endif
-
-#if AF_API_VERSION >= 37
-/**
-   \param[in] lib_idx is the index of a registered custom arrayfire library to
-              be activated for use. Must match the order of when the library
-              was registered
-
-   \ingroup unified_func_setbackendlibrary
-*/
-AFAPI void setBackendLibrary(int lib_idx);
-#endif
-
 #if AF_API_VERSION >= 32
 /**
    \returns Number of available backends

--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -30,24 +30,6 @@ af_err af_set_backend(const af_backend bknd) {
     return AF_SUCCESS;
 }
 
-af_err af_add_backend_library(const char *lib_path) {
-    try {
-        // what to do here? not supposed to be called outside of the unified backend
-    }
-    CATCHALL;
-
-    return AF_SUCCESS;
-}
-
-af_err af_set_backend_library(int lib_idx) {
-    try {
-        // what to do here? not supposed to be called outside of the unified backend
-    }
-    CATCHALL;
-
-    return AF_SUCCESS;
-}
-
 af_err af_get_backend_count(unsigned* num_backends) {
     *num_backends = 1;
     return AF_SUCCESS;

--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -30,6 +30,24 @@ af_err af_set_backend(const af_backend bknd) {
     return AF_SUCCESS;
 }
 
+af_err af_add_backend_library(const char *lib_path) {
+    try {
+        // what to do here? not supposed to be called outside of the unified backend
+    }
+    CATCHALL;
+
+    return AF_SUCCESS;
+}
+
+af_err af_set_backend_library(int lib_idx) {
+    try {
+        // what to do here? not supposed to be called outside of the unified backend
+    }
+    CATCHALL;
+
+    return AF_SUCCESS;
+}
+
 af_err af_get_backend_count(unsigned* num_backends) {
     *num_backends = 1;
     return AF_SUCCESS;

--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -34,6 +34,11 @@ af_err af_add_backend_library(const char* lib_path) { return AF_SUCCESS; }
 
 af_err af_set_backend_library(int lib_idx) { return AF_SUCCESS; }
 
+af_err af_check_unified_backend(bool* result) {
+    *result = false;
+    return AF_SUCCESS;
+}
+
 af_err af_get_backend_count(unsigned* num_backends) {
     *num_backends = 1;
     return AF_SUCCESS;

--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -30,6 +30,10 @@ af_err af_set_backend(const af_backend bknd) {
     return AF_SUCCESS;
 }
 
+af_err af_add_backend_library(const char* lib_path) { return AF_SUCCESS; }
+
+af_err af_set_backend_library(int lib_idx) { return AF_SUCCESS; }
+
 af_err af_get_backend_count(unsigned* num_backends) {
     *num_backends = 1;
     return AF_SUCCESS;

--- a/src/api/cpp/device.cpp
+++ b/src/api/cpp/device.cpp
@@ -17,6 +17,12 @@
 
 namespace af {
 void setBackend(const Backend bknd) { AF_THROW(af_set_backend(bknd)); }
+void addBackendLibrary(const char *lib_path) {
+    AF_THROW(af_add_backend_library(lib_path));
+}
+void setBackendLibrary(int lib_idx) {
+    AF_THROW(af_set_backend_library(lib_idx));
+}
 
 unsigned getBackendCount() {
     unsigned temp = 1;

--- a/src/api/cpp/device.cpp
+++ b/src/api/cpp/device.cpp
@@ -17,12 +17,6 @@
 
 namespace af {
 void setBackend(const Backend bknd) { AF_THROW(af_set_backend(bknd)); }
-void addBackendLibrary(const char *lib_path) {
-    AF_THROW(af_add_backend_library(lib_path));
-}
-void setBackendLibrary(int lib_idx) {
-    AF_THROW(af_set_backend_library(lib_idx));
-}
 
 unsigned getBackendCount() {
     unsigned temp = 1;

--- a/src/api/unified/device.cpp
+++ b/src/api/unified/device.cpp
@@ -16,6 +16,14 @@ af_err af_set_backend(const af_backend bknd) {
     return unified::AFSymbolManager::getInstance().setBackend(bknd);
 }
 
+af_err af_add_backend_library(const char *lib_path) {
+    return unified::AFSymbolManager::getInstance().addBackendLibrary(lib_path);
+}
+
+af_err af_set_backend_library(int lib_idx) {
+    return unified::AFSymbolManager::getInstance().setBackendLibrary(lib_idx);
+}
+
 af_err af_get_backend_count(unsigned *num_backends) {
     *num_backends = unified::AFSymbolManager::getInstance().getBackendCount();
     return AF_SUCCESS;

--- a/src/api/unified/device.cpp
+++ b/src/api/unified/device.cpp
@@ -24,6 +24,11 @@ af_err af_set_backend_library(int lib_idx) {
     return unified::AFSymbolManager::getInstance().setBackendLibrary(lib_idx);
 }
 
+af_err af_check_unified_backend(bool *result) {
+    *result = true;
+    return AF_SUCCESS;
+}
+
 af_err af_get_backend_count(unsigned *num_backends) {
     *num_backends = unified::AFSymbolManager::getInstance().getBackendCount();
     return AF_SUCCESS;

--- a/src/api/unified/symbol_manager.cpp
+++ b/src/api/unified/symbol_manager.cpp
@@ -172,7 +172,8 @@ spdlog::logger* AFSymbolManager::getLogger() { return logger.get(); }
 AFSymbolManager::AFSymbolManager()
     : activeHandle(nullptr)
     , defaultHandle(nullptr)
-    , numBackendHandles(0)
+    , numBackends(0)
+    , numBackendHandles(NUM_BACKENDS)
     , backendsAvailable(0)
     , logger(loggerFactory("unified")) {
     // In order of priority.
@@ -192,7 +193,7 @@ AFSymbolManager::AFSymbolManager()
         if (bkndHandles[backend]) {
             activeHandle  = bkndHandles[backend];
             activeBackend = (af_backend)order[i];
-            numBackendHandles++;
+            numBackends++;
             backendsAvailable += order[i];
         }
     }
@@ -213,7 +214,7 @@ AFSymbolManager::~AFSymbolManager() {
     }
 }
 
-unsigned AFSymbolManager::getBackendCount() { return numBackendHandles; }
+unsigned AFSymbolManager::getBackendCount() { return numBackends; }
 
 int AFSymbolManager::getAvailableBackends() { return backendsAvailable; }
 

--- a/src/api/unified/symbol_manager.cpp
+++ b/src/api/unified/symbol_manager.cpp
@@ -20,8 +20,6 @@
 #include <string>
 #include <type_traits>
 
-#include <iostream>
-
 #ifdef OS_WIN
 #include <Windows.h>
 #else

--- a/src/api/unified/symbol_manager.hpp
+++ b/src/api/unified/symbol_manager.hpp
@@ -103,6 +103,7 @@ class AFSymbolManager {
     LibHandle activeHandle;
     LibHandle prevHandle;
     LibHandle defaultHandle;
+    unsigned numBackends;
     unsigned numBackendHandles;
     int backendsAvailable;
     af_backend activeBackend;

--- a/src/api/unified/symbol_manager.hpp
+++ b/src/api/unified/symbol_manager.hpp
@@ -23,6 +23,7 @@
 namespace unified {
 
 const int NUM_BACKENDS = 3;
+const int MAX_BKND_HANDLES = 10;
 
 #define UNIFIED_ERROR_LOAD_LIB()                                       \
     AF_RETURN_ERROR(                                                   \
@@ -50,7 +51,9 @@ class AFSymbolManager {
 
     int getAvailableBackends();
 
-    af_err setBackend(af::Backend bnkd);
+    af_err setBackend(af::Backend bknd);
+    af_err addBackendLibrary(const char *lib_path);
+    af_err setBackendLibrary(int lib_idx);
 
     af::Backend getActiveBackend() { return activeBackend; }
 
@@ -65,7 +68,9 @@ class AFSymbolManager {
         int index           = backend_index(getActiveBackend());
         af_func& funcHandle = funcHandles[index][symbolName];
 
-        if (!funcHandle) {
+        if (!funcHandle ||
+            activeHandle != prevHandle) { // Load funcHandle also if backend is
+                                          // the same but library will be changed
             AF_TRACE("Loading: {}", symbolName);
             funcHandle =
                 (af_func)common::getFunctionPointer(activeHandle, symbolName);
@@ -94,11 +99,11 @@ class AFSymbolManager {
     void operator=(AFSymbolManager const&);
 
    private:
-    LibHandle bkndHandles[NUM_BACKENDS];
-
+    LibHandle bkndHandles[MAX_BKND_HANDLES];
     LibHandle activeHandle;
+    LibHandle prevHandle;
     LibHandle defaultHandle;
-    unsigned numBackends;
+    unsigned numBackendHandles;
     int backendsAvailable;
     af_backend activeBackend;
     af_backend defaultBackend;

--- a/src/backend/common/module_loading_unix.cpp
+++ b/src/backend/common/module_loading_unix.cpp
@@ -24,6 +24,7 @@ void* getFunctionPointer(LibHandle handle, const char* symbolName) {
 LibHandle loadLibrary(const char* library_name) {
     return dlopen(library_name, RTLD_LAZY);
 }
+
 void unloadLibrary(LibHandle handle) { dlclose(handle); }
 
 string getErrorMessage() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,10 @@
 # The complete license agreement can be obtained at:
 # http://arrayfire.com/licenses/BSD-3-Clause
 
+
+set(BUILD_DIR "${CMAKE_BINARY_DIR}")
+add_definitions("-DBUILD_DIR=\"${BUILD_DIR}\"")
+
 set(AF_TEST_WITH_MTX_FILES
     ON CACHE BOOL
     "Download and run tests on large matrices form sparse.tamu.edu")

--- a/test/backend.cpp
+++ b/test/backend.cpp
@@ -32,15 +32,22 @@ using af::transpose;
 using std::string;
 using std::vector;
 
-#if defined(OS_WIN)
-string library_suffix = ".dll";
-string library_prefix = "";
+const string build_dir_str = BUILD_DIR;
+#if defined(_WIN32)
+const string library_suffix = ".dll";
+const string library_prefix_cpu = "/bin/afcpu";
+const string library_prefix_cuda = "/bin/afcuda";
+const string library_prefix_opencl = "/bin/afopencl";
 #elif defined(__APPLE__)
-string library_suffix = ".dylib";
-string library_prefix = "lib";
+const string library_suffix = ".dylib";
+const string library_prefix_cpu = "/src/backend/cpu/libafcpu";
+const string library_prefix_cuda = "/src/backend/cuda/libafcuda";
+const string library_prefix_opencl = "/src/backend/opencl/libafopencl";
 #elif defined(__linux__)
-string library_suffix = ".so";
-string library_prefix = "lib";
+const string library_suffix = ".so";
+const string library_prefix_cpu = "/src/backend/cpu/libafcpu";
+const string library_prefix_cuda = "/src/backend/cuda/libafcuda";
+const string library_prefix_opencl = "/src/backend/opencl/libafopencl";
 #else
 #error "Unsupported platform"
 #endif
@@ -131,7 +138,7 @@ TEST(BACKEND_TEST, SetCustomCpuLibrary) {
 
             if (backends & AF_BACKEND_CPU) {
                 string lib_path =
-                    BUILD_DIR "/src/backend/cpu/libafcpu" + library_suffix;
+                    build_dir_str + library_prefix_cpu + library_suffix;
                 addBackendLibrary(lib_path.c_str());
                 setBackendLibrary(0);
                 testFunction<float>();
@@ -160,7 +167,7 @@ TEST(BACKEND_TEST, SetCustomCudaLibrary) {
 
             if (backends & AF_BACKEND_CUDA) {
                 string lib_path =
-                    BUILD_DIR "/src/backend/cuda/libafcuda" + library_suffix;
+                    build_dir_str + library_prefix_cuda + library_suffix;
                 addBackendLibrary(lib_path.c_str());
                 setBackendLibrary(0);
                 testFunction<float>();
@@ -189,7 +196,7 @@ TEST(BACKEND_TEST, SetCustomOpenclLibrary) {
 
             if (backends & AF_BACKEND_OPENCL) {
                 string lib_path =
-                    BUILD_DIR "/src/backend/opencl/libafopencl" + library_suffix;
+                    build_dir_str + library_prefix_opencl + library_suffix;
                 addBackendLibrary(lib_path.c_str());
                 setBackendLibrary(0);
                 testFunction<float>();
@@ -269,9 +276,9 @@ TEST(BACKEND_TEST, UseArrayAfterSwitchingLibraries) {
             bool cuda   = backends & AF_BACKEND_CUDA;
             bool opencl = backends & AF_BACKEND_OPENCL;
 
-            string cpu_path    = BUILD_DIR "/src/backend/cpu/libafcpu" + library_suffix;
-            string cuda_path   = BUILD_DIR "/src/backend/cuda/libafcuda" + library_suffix;
-            string opencl_path = BUILD_DIR "/src/backend/opencl/libafopencl" + library_suffix;
+            string cpu_path    = build_dir_str + library_prefix_cpu + library_suffix;
+            string cuda_path   = build_dir_str + library_prefix_cuda + library_suffix;
+            string opencl_path = build_dir_str + library_prefix_opencl + library_suffix;
 
             int num_backends = getBackendCount();
             ASSERT_GT(num_backends, 0);

--- a/test/backend.cpp
+++ b/test/backend.cpp
@@ -34,13 +34,13 @@ using std::vector;
 
 #if defined(OS_WIN)
 string library_suffix = ".dll";
-string libraryPrefix = "";
+string library_prefix = "";
 #elif defined(__APPLE__)
 string library_suffix = ".dylib";
-string libraryPrefix = "lib";
-#elif defined(OS_LNX)
+string library_prefix = "lib";
+#elif defined(__linux__)
 string library_suffix = ".so";
-string libraryPrefix = "lib";
+string library_prefix = "lib";
 #else
 #error "Unsupported platform"
 #endif
@@ -58,8 +58,9 @@ template<typename T>
 void testFunction() {
     af_backend activeBackend = (af_backend)0;
     af_get_active_backend(&activeBackend);
+    af_info();
 
-    printf("Active Backend Enum = %s\n", getActiveBackendString(activeBackend));
+    // printf("Active Backend Enum = %s\n", getActiveBackendString(activeBackend));
 
     af_array outArray = 0;
     dim_t dims[]      = {32, 32};
@@ -130,7 +131,7 @@ TEST(BACKEND_TEST, SetCustomCpuLibrary) {
 
             if (backends & AF_BACKEND_CPU) {
                 string lib_path =
-                    BUILD_DIR "/src/backend/cpu/libafcpu.3" + library_suffix;
+                    BUILD_DIR "/src/backend/cpu/libafcpu" + library_suffix;
                 addBackendLibrary(lib_path.c_str());
                 setBackendLibrary(0);
                 testFunction<float>();
@@ -159,7 +160,7 @@ TEST(BACKEND_TEST, SetCustomCudaLibrary) {
 
             if (backends & AF_BACKEND_CUDA) {
                 string lib_path =
-                    BUILD_DIR "/src/backend/cuda/libafcuda.3" + library_suffix;
+                    BUILD_DIR "/src/backend/cuda/libafcuda" + library_suffix;
                 addBackendLibrary(lib_path.c_str());
                 setBackendLibrary(0);
                 testFunction<float>();
@@ -188,7 +189,7 @@ TEST(BACKEND_TEST, SetCustomOpenclLibrary) {
 
             if (backends & AF_BACKEND_OPENCL) {
                 string lib_path =
-                    BUILD_DIR "/src/backend/opencl/libafopencl.3" + library_suffix;
+                    BUILD_DIR "/src/backend/opencl/libafopencl" + library_suffix;
                 addBackendLibrary(lib_path.c_str());
                 setBackendLibrary(0);
                 testFunction<float>();

--- a/test/backend.cpp
+++ b/test/backend.cpp
@@ -1,5 +1,5 @@
 /*******************************************************
- * Copyright (c) 2014, ArrayFire
+ * Copyright (c) 2019, ArrayFire
  * All rights reserved.
  *
  * This file is distributed under 3-clause BSD license.
@@ -8,15 +8,17 @@
  ********************************************************/
 
 #include <arrayfire.h>
-#include <gtest/gtest.h>
-#include <testHelpers.hpp>
+#include <af/backend.h>
 #include <af/data.h>
+#include <af/device.h>
 #include <af/dim4.hpp>
 #include <af/traits.hpp>
+
+#include <gtest/gtest.h>
+#include <testHelpers.hpp>
+
 #include <string>
 #include <vector>
-
-#include <af/device.h>
 
 using af::array;
 using af::Backend;

--- a/test/backend.cpp
+++ b/test/backend.cpp
@@ -32,6 +32,7 @@ using af::transpose;
 using std::string;
 using std::vector;
 
+// These paths are based on where the CI configuration puts the built libraries
 const string build_dir_str = BUILD_DIR;
 #if defined(_WIN32)
 const string library_suffix = ".dll";
@@ -66,8 +67,6 @@ void testFunction() {
     af_backend activeBackend = (af_backend)0;
     af_get_active_backend(&activeBackend);
     af_info();
-
-    // printf("Active Backend Enum = %s\n", getActiveBackendString(activeBackend));
 
     af_array outArray = 0;
     dim_t dims[]      = {32, 32};

--- a/test/backend.cpp
+++ b/test/backend.cpp
@@ -18,7 +18,6 @@
 
 #include <af/device.h>
 
-using af::addBackendLibrary;
 using af::array;
 using af::Backend;
 using af::dtype_traits;
@@ -27,7 +26,6 @@ using af::getAvailableBackends;
 using af::getBackendCount;
 using af::randu;
 using af::setBackend;
-using af::setBackendLibrary;
 using af::transpose;
 using std::string;
 using std::vector;
@@ -138,8 +136,8 @@ TEST(BACKEND_TEST, SetCustomCpuLibrary) {
             if (backends & AF_BACKEND_CPU) {
                 string lib_path =
                     build_dir_str + library_prefix_cpu + library_suffix;
-                addBackendLibrary(lib_path.c_str());
-                setBackendLibrary(0);
+                af_add_backend_library(lib_path.c_str());
+                af_set_backend_library(0);
                 testFunction<float>();
             }
 
@@ -167,8 +165,8 @@ TEST(BACKEND_TEST, SetCustomCudaLibrary) {
             if (backends & AF_BACKEND_CUDA) {
                 string lib_path =
                     build_dir_str + library_prefix_cuda + library_suffix;
-                addBackendLibrary(lib_path.c_str());
-                setBackendLibrary(0);
+                af_add_backend_library(lib_path.c_str());
+                af_set_backend_library(0);
                 testFunction<float>();
             }
 
@@ -196,8 +194,8 @@ TEST(BACKEND_TEST, SetCustomOpenclLibrary) {
             if (backends & AF_BACKEND_OPENCL) {
                 string lib_path =
                     build_dir_str + library_prefix_opencl + library_suffix;
-                addBackendLibrary(lib_path.c_str());
-                setBackendLibrary(0);
+                af_add_backend_library(lib_path.c_str());
+                af_set_backend_library(0);
                 testFunction<float>();
             }
 
@@ -287,17 +285,17 @@ TEST(BACKEND_TEST, UseArrayAfterSwitchingLibraries) {
                 printf("Using %s and %s\n",
                        lib_path0.c_str(), lib_path1.c_str());
 
-                addBackendLibrary(lib_path0.c_str());
-                addBackendLibrary(lib_path1.c_str());
+                af_add_backend_library(lib_path0.c_str());
+                af_add_backend_library(lib_path1.c_str());
 
-                setBackendLibrary(0);
+                af_set_backend_library(0);
                 array a = randu(3, 2);
                 array at = transpose(a);
 
-                setBackendLibrary(1);
+                af_set_backend_library(1);
                 array b = randu(3, 2);
 
-                setBackendLibrary(0);
+                af_set_backend_library(0);
                 array att = transpose(at);
                 ASSERT_ARRAYS_EQ(a, att);
             }
@@ -321,7 +319,7 @@ TEST(BACKEND_TEST, UseArrayAfterSwitchingLibraries) {
 TEST(BACKEND_TEST, InvalidLibPath) {
     EXPECT_EXIT({
             // START of actual test
-            ASSERT_THROW(addBackendLibrary("qwerty.so"), exception);
+            ASSERT_EQ(af_add_backend_library("qwerty.so"), AF_ERR_LOAD_LIB);
             // END of actual test
 
             if (HasFailure()) {
@@ -338,7 +336,7 @@ TEST(BACKEND_TEST, InvalidLibPath) {
 TEST(BACKEND_TEST, LibIdxPointsToNullHandle) {
     EXPECT_EXIT({
             // START of actual test
-            ASSERT_THROW(setBackendLibrary(0), exception);
+            ASSERT_EQ(af_set_backend_library(0), AF_ERR_LOAD_LIB);
             // END of actual test
 
             if (HasFailure()) {
@@ -355,7 +353,7 @@ TEST(BACKEND_TEST, LibIdxPointsToNullHandle) {
 TEST(BACKEND_TEST, LibIdxExceedsMaxHandles) {
     EXPECT_EXIT({
             // START of actual test
-            ASSERT_THROW(setBackendLibrary(999), exception);
+            ASSERT_EQ(af_set_backend_library(999), AF_ERR_LOAD_LIB);
             // END of actual test
 
             if (HasFailure()) {

--- a/test/backend.cpp
+++ b/test/backend.cpp
@@ -88,7 +88,7 @@ TEST(BACKEND_TEST, DiffBackends) {
 
             int backends = getAvailableBackends();
 
-            ASSERT_NE(backends, 0);
+            EXPECT_NE(backends, 0);
 
             bool cpu    = backends & AF_BACKEND_CPU;
             bool cuda   = backends & AF_BACKEND_CUDA;
@@ -133,7 +133,7 @@ TEST(BACKEND_TEST, SetCustomCpuLibrary) {
             // START of actual test
 
             int backends = getAvailableBackends();
-            ASSERT_NE(backends, 0);
+            EXPECT_NE(backends, 0);
 
             if (backends & AF_BACKEND_CPU) {
                 string lib_path =
@@ -162,7 +162,7 @@ TEST(BACKEND_TEST, SetCustomCudaLibrary) {
             // START of actual test
 
             int backends = getAvailableBackends();
-            ASSERT_NE(backends, 0);
+            EXPECT_NE(backends, 0);
 
             if (backends & AF_BACKEND_CUDA) {
                 string lib_path =
@@ -191,7 +191,7 @@ TEST(BACKEND_TEST, SetCustomOpenclLibrary) {
             // START of actual test
 
             int backends = getAvailableBackends();
-            ASSERT_NE(backends, 0);
+            EXPECT_NE(backends, 0);
 
             if (backends & AF_BACKEND_OPENCL) {
                 string lib_path =
@@ -220,14 +220,14 @@ TEST(BACKEND_TEST, UseArrayAfterSwitchingBackends) {
 
             int backends = getAvailableBackends();
 
-            ASSERT_NE(backends, 0);
+            EXPECT_NE(backends, 0);
 
             bool cpu    = backends & AF_BACKEND_CPU;
             bool cuda   = backends & AF_BACKEND_CUDA;
             bool opencl = backends & AF_BACKEND_OPENCL;
 
             int num_backends = getBackendCount();
-            ASSERT_GT(num_backends, 0);
+            EXPECT_GT(num_backends, 0);
             if (num_backends > 1) {
                 Backend backend0 = cpu ? AF_BACKEND_CPU : AF_BACKEND_OPENCL;
                 Backend backend1 = cuda ? AF_BACKEND_CUDA : AF_BACKEND_OPENCL;
@@ -269,7 +269,7 @@ TEST(BACKEND_TEST, UseArrayAfterSwitchingLibraries) {
 
             int backends = getAvailableBackends();
 
-            ASSERT_NE(backends, 0);
+            EXPECT_NE(backends, 0);
 
             bool cpu    = backends & AF_BACKEND_CPU;
             bool cuda   = backends & AF_BACKEND_CUDA;
@@ -280,7 +280,7 @@ TEST(BACKEND_TEST, UseArrayAfterSwitchingLibraries) {
             string opencl_path = build_dir_str + library_prefix_opencl + library_suffix;
 
             int num_backends = getBackendCount();
-            ASSERT_GT(num_backends, 0);
+            EXPECT_GT(num_backends, 0);
             if (num_backends > 1) {
                 string lib_path0 = cpu ? cpu_path : opencl_path;
                 string lib_path1 = cuda ? cuda_path : opencl_path;
@@ -321,7 +321,7 @@ TEST(BACKEND_TEST, UseArrayAfterSwitchingLibraries) {
 TEST(BACKEND_TEST, InvalidLibPath) {
     EXPECT_EXIT({
             // START of actual test
-            ASSERT_EQ(af_add_backend_library("qwerty.so"), AF_ERR_LOAD_LIB);
+            EXPECT_EQ(AF_ERR_LOAD_LIB, af_add_backend_library("qwerty.so"));
             // END of actual test
 
             if (HasFailure()) {
@@ -338,7 +338,7 @@ TEST(BACKEND_TEST, InvalidLibPath) {
 TEST(BACKEND_TEST, LibIdxPointsToNullHandle) {
     EXPECT_EXIT({
             // START of actual test
-            ASSERT_EQ(af_set_backend_library(0), AF_ERR_LOAD_LIB);
+            EXPECT_EQ(af_set_backend_library(0), AF_ERR_LOAD_LIB);
             // END of actual test
 
             if (HasFailure()) {
@@ -355,7 +355,7 @@ TEST(BACKEND_TEST, LibIdxPointsToNullHandle) {
 TEST(BACKEND_TEST, LibIdxExceedsMaxHandles) {
     EXPECT_EXIT({
             // START of actual test
-            ASSERT_EQ(af_set_backend_library(999), AF_ERR_LOAD_LIB);
+            EXPECT_EQ(AF_ERR_LOAD_LIB, af_set_backend_library(999));
             // END of actual test
 
             if (HasFailure()) {

--- a/test/backend.cpp
+++ b/test/backend.cpp
@@ -177,7 +177,8 @@ TEST(BACKEND_TEST, SetCustomCudaLibrary) {
             if (HasFailure()) {
                 fprintf(stderr, "Test failed");
                 exit(1);
-            } else {
+            }
+            else {
                 fprintf(stderr, "Test succeeded");
                 exit(0);
             }
@@ -206,7 +207,8 @@ TEST(BACKEND_TEST, SetCustomOpenclLibrary) {
             if (HasFailure()) {
                 fprintf(stderr, "Test failed");
                 exit(1);
-            } else {
+            }
+            else {
                 fprintf(stderr, "Test succeeded");
                 exit(0);
             }
@@ -321,7 +323,14 @@ TEST(BACKEND_TEST, UseArrayAfterSwitchingLibraries) {
 TEST(BACKEND_TEST, InvalidLibPath) {
     EXPECT_EXIT({
             // START of actual test
-            EXPECT_EQ(AF_ERR_LOAD_LIB, af_add_backend_library("qwerty.so"));
+            bool is_unified_backend = false;
+            ASSERT_SUCCESS(af_check_unified_backend(&is_unified_backend));
+            if (is_unified_backend) {
+                EXPECT_EQ(AF_ERR_LOAD_LIB, af_add_backend_library("qwerty.so"));
+            }
+            else {
+                ASSERT_SUCCESS(af_add_backend_library("qwerty.so"));
+            }
             // END of actual test
 
             if (HasFailure()) {
@@ -338,14 +347,20 @@ TEST(BACKEND_TEST, InvalidLibPath) {
 TEST(BACKEND_TEST, LibIdxPointsToNullHandle) {
     EXPECT_EXIT({
             // START of actual test
-            EXPECT_EQ(af_set_backend_library(0), AF_ERR_LOAD_LIB);
+            bool is_unified_backend = false;
+            ASSERT_SUCCESS(af_check_unified_backend(&is_unified_backend));
+            if (is_unified_backend) {
+                EXPECT_EQ(AF_ERR_LOAD_LIB, af_set_backend_library(0));
+            }
+            else {
+                ASSERT_SUCCESS(af_set_backend_library(0));
+            }
             // END of actual test
 
             if (HasFailure()) {
                 fprintf(stderr, "Test failed");
                 exit(1);
-            }
-            else {
+            } else {
                 fprintf(stderr, "Test succeeded");
                 exit(0);
             }
@@ -355,7 +370,14 @@ TEST(BACKEND_TEST, LibIdxPointsToNullHandle) {
 TEST(BACKEND_TEST, LibIdxExceedsMaxHandles) {
     EXPECT_EXIT({
             // START of actual test
-            EXPECT_EQ(AF_ERR_LOAD_LIB, af_set_backend_library(999));
+            bool is_unified_backend = false;
+            ASSERT_SUCCESS(af_check_unified_backend(&is_unified_backend));
+            if (is_unified_backend) {
+                EXPECT_EQ(AF_ERR_LOAD_LIB, af_set_backend_library(999));
+            }
+            else {
+                ASSERT_SUCCESS(af_set_backend_library(999));
+            }
             // END of actual test
 
             if (HasFailure()) {

--- a/test/backend.cpp
+++ b/test/backend.cpp
@@ -82,37 +82,96 @@ void testFunction() {
     if (outArray != 0) { ASSERT_SUCCESS(af_release_array(outArray)); }
 }
 
-TEST(BACKEND_TEST, DiffBackends) {
+TEST(BACKEND_TEST, SetBackendDefault) {
+    EXPECT_EXIT({
+            // START of actual test
+            printf("\nRunning Default Backend...\n");
+            testFunction<float>();
+            // END of actual test
+
+            if (HasFailure()) {
+                fprintf(stderr, "Test failed");
+                exit(1);
+            }
+            else {
+                fprintf(stderr, "Test succeeded");
+                exit(0);
+            }
+        }, ::testing::ExitedWithCode(0), "Test succeeded");
+}
+
+TEST(BACKEND_TEST, SetBackendCpu) {
     EXPECT_EXIT({
             // START of actual test
 
             int backends = getAvailableBackends();
-
             EXPECT_NE(backends, 0);
 
-            bool cpu    = backends & AF_BACKEND_CPU;
-            bool cuda   = backends & AF_BACKEND_CUDA;
-            bool opencl = backends & AF_BACKEND_OPENCL;
-
-            printf("\nRunning Default Backend...\n");
-            testFunction<float>();
-
-            if (cpu) {
+            if (backends & AF_BACKEND_CPU) {
                 printf("\nRunning CPU Backend...\n");
                 setBackend(AF_BACKEND_CPU);
                 testFunction<float>();
             }
+            else {
+                printf("CPU backend not available, skipping test\n");
+            }
 
-            if (cuda) {
+            // END of actual test
+
+            if (HasFailure()) {
+                fprintf(stderr, "Test failed");
+                exit(1);
+            }
+            else {
+                fprintf(stderr, "Test succeeded");
+                exit(0);
+            }
+        }, ::testing::ExitedWithCode(0), "Test succeeded");
+}
+
+TEST(BACKEND_TEST, SetBackendCuda) {
+    EXPECT_EXIT({
+            // START of actual test
+
+            int backends = getAvailableBackends();
+            EXPECT_NE(backends, 0);
+
+            if (backends & AF_BACKEND_CUDA) {
                 printf("\nRunning CUDA Backend...\n");
                 setBackend(AF_BACKEND_CUDA);
                 testFunction<float>();
             }
+            else {
+                printf("CUDA backend not available, skipping test\n");
+            }
 
-            if (opencl) {
+            // END of actual test
+
+            if (HasFailure()) {
+                fprintf(stderr, "Test failed");
+                exit(1);
+            }
+            else {
+                fprintf(stderr, "Test succeeded");
+                exit(0);
+            }
+        }, ::testing::ExitedWithCode(0), "Test succeeded");
+}
+
+TEST(BACKEND_TEST, SetBackendOpencl) {
+    EXPECT_EXIT({
+            // START of actual test
+
+            int backends = getAvailableBackends();
+            EXPECT_NE(backends, 0);
+
+            if (backends & AF_BACKEND_OPENCL) {
                 printf("\nRunning OpenCL Backend...\n");
                 setBackend(AF_BACKEND_OPENCL);
                 testFunction<float>();
+            }
+            else {
+                printf("OpenCL backend not available, skipping test\n");
             }
 
             // END of actual test
@@ -141,6 +200,9 @@ TEST(BACKEND_TEST, SetCustomCpuLibrary) {
                 af_add_backend_library(lib_path.c_str());
                 af_set_backend_library(0);
                 testFunction<float>();
+            }
+            else {
+                printf("CPU backend not available, skipping test\n");
             }
 
             // END of actual test
@@ -171,6 +233,9 @@ TEST(BACKEND_TEST, SetCustomCudaLibrary) {
                 af_set_backend_library(0);
                 testFunction<float>();
             }
+            else {
+                printf("CUDA backend not available, skipping test\n");
+            }
 
             // END of actual test
 
@@ -200,6 +265,9 @@ TEST(BACKEND_TEST, SetCustomOpenclLibrary) {
                 af_add_backend_library(lib_path.c_str());
                 af_set_backend_library(0);
                 testFunction<float>();
+            }
+            else {
+                printf("OpenCL backend not available, skipping test\n");
             }
 
             // END of actual test


### PR DESCRIPTION
Useful for comparing results or performance between different versions of ArrayFire.

2 functions are added: ~~`addBackendLibrary`~~  `af_add_backend_library` and ~~`setBackendLibrary`~~ `af_set_backend_library` (see my comment below about removing the C++ API of these functions). The first one gets the handle to the library whose path is specified by the user, and adds it to `AFSymbolManager`'s array of library/backend handles. The second one simply sets `AFSymbolManager`'s active library handle to the one specified by the user. For now, `AFSymbolManager`'s handle array can only hold 10 handles - 3 of those spaces are reserved for the default libraries loaded by the `AFSymbolManager` constructor - which means the user can only add 7 libraries from arbitrary locations.

googletest's Death Tests feature are used in the tests for these changes - specifically `EXPECT_EXIT` calls, since it spawns a separate process. This is needed for each test to emulate `AFSymbolManager` starting in its initial state (with nothing yet in its array of handles).

The tests might fail sometimes on the CPU backend in Linux machines, where `af::info` seems to produce memory leaks (as shown by address sanitizer) and thus segfaults.

Here are the docs:
![image](https://user-images.githubusercontent.com/19368448/57957999-579bca80-78cc-11e9-859f-a5a4d86390e3.png)
![image](https://user-images.githubusercontent.com/19368448/57958062-7dc16a80-78cc-11e9-89a8-157a6b91877b.png)
![image](https://user-images.githubusercontent.com/19368448/57958080-90d43a80-78cc-11e9-91d3-9323f1077982.png)


