### PR TITLE
Address issues with modified inputs for fftC2R functions.

### DIFF
--- a/src/backend/cpu/kernel/fft.hpp
+++ b/src/backend/cpu/kernel/fft.hpp
@@ -121,7 +121,7 @@ void fft_r2c(Param<Tc> out, const af::dim4 oDataDims, CParam<Tr> in,
     plan = transform.create(rank, t_dims, (int)batch, (Tr *)in.get(), in_embed,
                             (int)istrides[0], (int)istrides[rank],
                             (ctype_t *)out.get(), out_embed, (int)ostrides[0],
-                            (int)ostrides[rank], FFTW_ESTIMATE);
+                            (int)ostrides[rank], FFTW_ESTIMATE | FFTW_PRESERVE_INPUT);
 
     transform.execute(plan);
     transform.destroy(plan);


### PR DESCRIPTION
The fftC2R function was modifying the input array when the fftw library
was used. This was happening because the fftw library does not have
and algorithm that can compute the fft without modifying the input array.

This problem does not seem to be happening on the MKL based fft.

Fixes #2518 For the CPU backend. I haven't been able to reproduce this with
the cuda backend.