### PR TITLE
Properly include spdlog for AF_TRACE macro usage

### DIFF
--- a/src/backend/common/Logger.hpp
+++ b/src/backend/common/Logger.hpp
@@ -11,10 +11,8 @@
 
 #include <memory>
 #include <string>
+#include <spdlog/spdlog.h>
 
-namespace spdlog {
-class logger;
-}
 namespace common {
 std::shared_ptr<spdlog::logger> loggerFactory(std::string name);
 std::string bytesToString(size_t bytes);


### PR DESCRIPTION
Sometimes, the build fails on Ubuntu 18.04 with gcc 7.3.0. It's tough to repro, but it happens when `spdlog::logger` isn't a complete type and `AF_TRACE` macros are compiled/included in a particular order (https://github.com/arrayfire/arrayfire/issues/2522). May be a weird compiler race when sufficiently-many threads are used where something depends on which translation units are ready.

Fixes #2522 