### PR TITLE
Enforce dependencies between allocs and frees using events

### DIFF
--- a/src/api/c/random.cpp
+++ b/src/api/c/random.cpp
@@ -27,9 +27,7 @@ using namespace common;
 using af::dim4;
 
 Array<uint> emptyArray() {
-    static const Array<uint> EMPTY_ARRAY = createEmptyArray<uint>(af::dim4(0));
-
-    return EMPTY_ARRAY;
+    return createEmptyArray<uint>(af::dim4(0));
 }
 
 struct RandomEngine {
@@ -46,18 +44,15 @@ struct RandomEngine {
 
     RandomEngine(void)
         : type(AF_RANDOM_ENGINE_DEFAULT)
-        , seed(new uintl)
-        , counter(new uintl)
+        , seed(new uintl())
+        , counter(new uintl())
         , pos(emptyArray())
         , sh1(emptyArray())
         , sh2(emptyArray())
         , mask(0)
         , recursion_table(emptyArray())
         , temper_table(emptyArray())
-        , state(emptyArray()) {
-        *seed    = 0;
-        *counter = 0;
-    }
+        , state(emptyArray()) {}
 };
 
 af_random_engine getRandomEngineHandle(const RandomEngine engine) {
@@ -73,8 +68,9 @@ RandomEngine *getRandomEngine(const af_random_engine engineHandle) {
     return (RandomEngine *)engineHandle;
 }
 
+namespace {
 template<typename T>
-static inline af_array uniformDistribution_(const af::dim4 &dims,
+inline af_array uniformDistribution_(const af::dim4 &dims,
                                             RandomEngine *e) {
     if (e->type == AF_RANDOM_ENGINE_MERSENNE_GP11213) {
         return getHandle(uniformDistribution<T>(dims, e->pos, e->sh1, e->sh2,
@@ -87,7 +83,7 @@ static inline af_array uniformDistribution_(const af::dim4 &dims,
 }
 
 template<typename T>
-static inline af_array normalDistribution_(const af::dim4 &dims,
+inline af_array normalDistribution_(const af::dim4 &dims,
                                            RandomEngine *e) {
     if (e->type == AF_RANDOM_ENGINE_MERSENNE_GP11213) {
         return getHandle(normalDistribution<T>(dims, e->pos, e->sh1, e->sh2,
@@ -99,7 +95,7 @@ static inline af_array normalDistribution_(const af::dim4 &dims,
     }
 }
 
-static void validateRandomType(const af_random_engine_type type) {
+void validateRandomType(const af_random_engine_type type) {
     if ((type != AF_RANDOM_ENGINE_PHILOX_4X32_10) &&
         (type != AF_RANDOM_ENGINE_THREEFRY_2X32_16) &&
         (type != AF_RANDOM_ENGINE_MERSENNE_GP11213) &&
@@ -110,13 +106,14 @@ static void validateRandomType(const af_random_engine_type type) {
         AF_ERROR("Invalid random type", AF_ERR_ARG);
     }
 }
+}
 
 af_err af_get_default_random_engine(af_random_engine *r) {
     try {
         AF_CHECK(af_init());
 
-        thread_local RandomEngine re;
-        *r = static_cast<af_random_engine>(&re);
+        thread_local RandomEngine *re = new RandomEngine;
+        *r = static_cast<af_random_engine>(re);
         return AF_SUCCESS;
     }
     CATCHALL;

--- a/src/backend/common/EventBase.hpp
+++ b/src/backend/common/EventBase.hpp
@@ -1,0 +1,81 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+#pragma once
+#include <utility>
+
+namespace common {
+template<typename NativeEventPolicy>
+class EventBase {
+    using QueueType = typename NativeEventPolicy::QueueType;
+    using EventType = typename NativeEventPolicy::EventType;
+    using ErrorType = typename NativeEventPolicy::ErrorType;
+    EventType e_;
+
+   public:
+    /// Default constructor of the Event object. Does not create the event.
+    constexpr EventBase() noexcept : e_() {}
+
+    /// Deleted copy constructor
+    ///
+    /// The event object can only be moved.
+    EventBase(EventBase &other) = delete;
+
+    /// \brief Move constructor of the Event object. Resets the moved object to
+    ///        an invalid event.
+    EventBase(EventBase &&other) noexcept
+        : e_(std::forward<EventType>(other.e_)) {
+        other.e_ = 0;
+    }
+
+    /// \brief Event destructor. Calls the destroy event call on the native API
+    ~EventBase() noexcept {
+        if (e_) NativeEventPolicy::destroyEvent(&e_);
+    }
+
+    /// \brief Creates the event object by calling the native create API
+    ErrorType create() noexcept { return NativeEventPolicy::createEvent(&e_); }
+
+    /// \brief Adds the event on the queue. Once this point on the program
+    ///        is executed, the event is marked complete.
+    ///
+    /// \returns the error code for the mark call
+    ErrorType mark(QueueType &queue) noexcept {
+        return NativeEventPolicy::markEvent(&e_, queue);
+    }
+
+    /// \brief This is an asynchronous function which will block the
+    ///        queue/stream from progressing before continuing forward. It will
+    ///        not block the calling thread.
+    ///
+    /// \param queue The queue that will wait for the previous tasks to complete
+    ///
+    /// \returns the error code for the wait call
+    ErrorType enqueueWait(QueueType &queue) noexcept {
+        return NativeEventPolicy::waitForEvent(&e_, queue);
+    }
+
+    /// \brief This function will block the calling thread until the event has
+    ///        completed
+    ErrorType block() const noexcept {
+        return NativeEventPolicy::syncForEvent();
+    }
+
+    /// \brief Returns true if the event is a valid event.
+    constexpr operator bool() const { return e_; }
+
+    EventBase &operator=(EventBase &other) = delete;
+
+    EventBase &operator=(EventBase &&other) noexcept {
+        e_       = std::move(other.e_);
+        other.e_ = 0;
+        return *this;
+    }
+};
+
+}  // namespace common

--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -44,6 +44,8 @@ target_sources(afcpu
     diff.cpp
     diff.hpp
     err_cpu.hpp
+    Event.cpp
+    Event.hpp
     exampleFunction.cpp
     exampleFunction.hpp
     fast.cpp
@@ -263,6 +265,7 @@ endif(AF_WITH_CPUID)
 target_sources(afcpu
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/threads/async_queue.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/threads/event.hpp
   )
 
 arrayfire_set_default_cxx_flags(afcpu)

--- a/src/backend/cpu/Event.cpp
+++ b/src/backend/cpu/Event.cpp
@@ -1,0 +1,20 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Event.hpp>
+#include <queue.hpp>
+
+namespace cpu {
+/// \brief Creates a new event and marks it in the queue
+Event make_event(cpu::queue &queue) {
+    Event e;
+    if (0 == e.create()) { e.mark(queue); }
+    return e;
+}
+}  // namespace cpu

--- a/src/backend/cpu/Event.hpp
+++ b/src/backend/cpu/Event.hpp
@@ -1,0 +1,49 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+#pragma once
+
+#include <queue.hpp>
+
+#include <common/EventBase.hpp>
+
+#include <atomic>
+#include <thread>
+
+namespace cpu {
+
+class CPUEventPolicy {
+   public:
+    using EventType = queue_event;
+    using QueueType = queue;
+    using ErrorType = int;
+
+    static int createEvent(queue_event *e) noexcept { return e->create(); }
+
+    static int markEvent(queue_event *e, cpu::queue &stream) noexcept {
+        return e->mark(stream);
+    }
+
+    static int waitForEvent(queue_event *e, cpu::queue &stream) noexcept {
+        return e->wait(stream);
+    }
+
+    static int syncForEvent(queue_event *e) noexcept {
+        e->sync();
+        return 0;
+    }
+
+    static int destroyEvent(queue_event *e) noexcept { return 0; }
+};
+
+using Event = common::EventBase<CPUEventPolicy>;
+
+/// \brief Creates a new event and marks it in the queue
+Event make_event(cpu::queue &queue);
+
+}  // namespace cpu

--- a/src/backend/cpu/device_manager.cpp
+++ b/src/backend/cpu/device_manager.cpp
@@ -10,6 +10,7 @@
 #include <common/graphics_common.hpp>
 #include <device_manager.hpp>
 #include <af/version.h>
+#include <memory.hpp>
 
 #include <cctype>
 #include <sstream>

--- a/src/backend/cpu/platform.cpp
+++ b/src/backend/cpu/platform.cpp
@@ -7,6 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <common/defines.hpp>
 #include <common/host_memory.hpp>
 #include <device_manager.hpp>
 #include <platform.hpp>

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -174,6 +174,8 @@ cuda_add_library(afcuda
     dilate3d.cu
     erode.cu
     erode3d.cu
+    Event.cpp
+    Event.hpp
     exampleFunction.cu
     fast.cu
     fast_pyramid.cu

--- a/src/backend/cuda/Event.cpp
+++ b/src/backend/cuda/Event.cpp
@@ -1,0 +1,20 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <cuda_runtime_api.h>
+#include <Event.hpp>
+
+namespace cuda {
+/// \brief Creates a new event and marks it in the queue
+Event make_event(cudaStream_t queue) {
+    Event e;
+    if (e.create() == CUDA_SUCCESS) { e.mark(queue); }
+    return e;
+}
+}  // namespace cuda

--- a/src/backend/cuda/Event.hpp
+++ b/src/backend/cuda/Event.hpp
@@ -1,0 +1,59 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+#pragma once
+
+#include <common/EventBase.hpp>
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+
+namespace cuda {
+
+class CUDARuntimeEventPolicy {
+   public:
+    using EventType = CUevent;
+    using QueueType = CUstream;
+    using ErrorType = CUresult;
+
+    static ErrorType createEvent(CUevent *e) noexcept {
+      auto err = cuEventCreate(e, CU_EVENT_DISABLE_TIMING | CU_EVENT_BLOCKING_SYNC);
+        // printf("create %p: error: %s\n", *e, cudaGetErrorName(err));
+        return err;
+    }
+
+    static ErrorType markEvent(CUevent *e,
+                               QueueType &stream) noexcept {
+        auto err = cuEventRecord(*e, stream);
+        // printf("mark   %p: error: %s\n", *e, cudaGetErrorName(err));
+        return err;
+    }
+
+    static ErrorType waitForEvent(CUevent *e,
+                                  QueueType &stream) noexcept {
+      auto err = cuStreamWaitEvent(stream, *e, 0);
+        // printf("wait   %p: error: %s\n", *e, cudaGetErrorName(err));
+        return err;
+    }
+
+    static ErrorType syncForEvent(CUevent *e) noexcept {
+        return cuEventSynchronize(*e);
+    }
+
+    static ErrorType destroyEvent(CUevent *e) noexcept {
+        auto err = cuEventDestroy(*e);
+        // printf("destroy %p: error: %s\n", *e, cudaGetErrorName(err));
+        return err;
+    }
+};
+
+using Event = common::EventBase<CUDARuntimeEventPolicy>;
+
+/// \brief Creates a new event and marks it in the stream
+Event make_event(cudaStream_t stream);
+
+}  // namespace cuda

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -96,6 +96,8 @@ target_sources(afopencl
     err_opencl.hpp
     errorcodes.cpp
     errorcodes.hpp
+    Event.hpp
+    Event.cpp
     exampleFunction.cpp
     exampleFunction.hpp
     fast.cpp

--- a/src/backend/opencl/Event.cpp
+++ b/src/backend/opencl/Event.cpp
@@ -1,0 +1,19 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Event.hpp>
+
+namespace opencl {
+/// \brief Creates a new event and marks it in the queue
+Event make_event(cl::CommandQueue &queue) {
+    Event e;
+    if (e.create() == CL_SUCCESS) { e.mark(queue()); }
+    return e;
+}
+}  // namespace opencl

--- a/src/backend/opencl/Event.hpp
+++ b/src/backend/opencl/Event.hpp
@@ -1,0 +1,48 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+#pragma once
+
+#include <common/EventBase.hpp>
+#include <platform.hpp>
+
+namespace opencl {
+class OpenCLEventPolicy {
+   public:
+    using EventType = cl_event;
+    using QueueType = cl_command_queue;
+    using ErrorType = cl_int;
+
+    static cl_int createEvent(cl_event *e) noexcept {
+        // Events are created when you mark them
+        return CL_SUCCESS;
+    }
+
+    static cl_int markEvent(cl_event *e, cl_command_queue stream) noexcept {
+        return clEnqueueMarkerWithWaitList(stream, 0, nullptr, e);
+    }
+
+    static cl_int waitForEvent(cl_event *e, cl_command_queue stream) noexcept {
+        return clEnqueueMarkerWithWaitList(stream, 1, e, nullptr);
+    }
+
+    static cl_int syncForEvent(cl_event *e) noexcept {
+        return clWaitForEvents(1, e);
+    }
+
+    static cl_int destroyEvent(cl_event *e) noexcept {
+        return clReleaseEvent(*e);
+    }
+};
+
+using Event = common::EventBase<OpenCLEventPolicy>;
+
+/// \brief Creates a new event and marks it in the queue
+Event make_event(cl::CommandQueue &queue);
+
+}  // namespace opencl

--- a/src/backend/opencl/topk.cpp
+++ b/src/backend/opencl/topk.cpp
@@ -69,7 +69,7 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
         Buffer* ibuf         = indices.get();
         Buffer* vbuf         = values.get();
 
-        Event ev_in, ev_val, ev_ind;
+        cl::Event ev_in, ev_val, ev_ind;
 
         T* ptr     = static_cast<T*>(getQueue().enqueueMapBuffer(
             *in_buf, CL_FALSE, CL_MAP_READ, 0, in.elements() * sizeof(T),
@@ -84,7 +84,7 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
 
         // Create a linear index
         iota(begin(idx), end(idx), 0);
-        Event::waitForEvents({ev_in, ev_ind});
+        cl::Event::waitForEvents({ev_in, ev_ind});
 
         int iter = in.dims()[1] * in.dims()[2] * in.dims()[3];
         for (int i = 0; i < iter; i++) {


### PR DESCRIPTION
* Creates an event class which is based on cudaEvent_t and OpenCL
  Events
* Use these events to enforce dependencies between frees and allocs
  to make sure that the data is not overwritten in later operations.
  This is not really an issue now because we are only running ops on
  one stream, but this will be an issue when we move to multiple streams
* Track MemoryEvent pairs in the memory manager.