### PR TITLE
Dump debug symbols into separate files from binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ include(build_cl2hpp)
 include(platform)
 include(GetPrerequisites)
 include(CheckCXXCompilerFlag)
+include(SplitDebugInfo)
 
 set_policies(
   TYPE NEW

--- a/CMakeModules/CPackConfig.cmake
+++ b/CMakeModules/CPackConfig.cmake
@@ -166,12 +166,37 @@ cpack_add_component(opencl_dependencies
   DESCRIPTION "Libraries required by the OpenCL backend."
   GROUP opencl_backend
   INSTALL_TYPES All Development Runtime)
-  
+if (NOT APPLE) #TODO(pradeep) Remove check after OSX support addition
+  cpack_add_component(afopencl_debug_symbols
+    DISPLAY_NAME "OpenCL Backend Debug Symbols"
+    DESCRIPTION "File containing debug symbols for afopencl dll/so/dylib file"
+    GROUP opencl_backend
+    DISABLED
+    INSTALL_TYPES Development)
+endif ()
+
 cpack_add_component(cuda_dependencies
   DISPLAY_NAME "CUDA Dependencies"
   DESCRIPTION "CUDA runtime and libraries required by the CUDA backend."
   GROUP cuda_backend
   INSTALL_TYPES All Development Runtime)
+if (NOT APPLE) #TODO(pradeep) Remove check after OSX support addition
+  cpack_add_component(afcuda_debug_symbols
+    DISPLAY_NAME "CUDA Backend Debug Symbols"
+    DESCRIPTION "File containing debug symbols for afcuda dll/so/dylib file"
+    GROUP cuda_backend
+    DISABLED
+    INSTALL_TYPES Development)
+endif ()
+
+if (NOT APPLE) #TODO(pradeep) Remove check after OSX support addition
+  cpack_add_component(afcpu_debug_symbols
+    DISPLAY_NAME "CPU Backend Debug Symbols"
+    DESCRIPTION "File containing debug symbols for afcpu dll/so/dylib file"
+    GROUP cpu_backend
+    DISABLED
+    INSTALL_TYPES Development)
+endif ()
 
 cpack_add_component(cuda
   DISPLAY_NAME "CUDA Backend"
@@ -206,11 +231,20 @@ cpack_add_component(opencl
   DEPENDS ${ocl_deps_comps}
   INSTALL_TYPES All Development Runtime)
 
+if (NOT APPLE) #TODO(pradeep) Remove check after OSX support addition
+  cpack_add_component(af_debug_symbols
+    DISPLAY_NAME "Unified Backend Debug Symbols"
+    DESCRIPTION "File containing debug symbols for af dll/so/dylib file"
+    GROUP backends
+    DISABLED
+    INSTALL_TYPES Development)
+endif ()
 cpack_add_component(unified
   DISPLAY_NAME "Unified Backend"
   DESCRIPTION "The Unified backend allows you to choose between any of the installed backends (CUDA, OpenCL, or CPU) at runtime."
   GROUP backends
   INSTALL_TYPES All Development Runtime)
+
 cpack_add_component(headers
   DISPLAY_NAME "C/C++ Headers"
   DESCRIPTION "Headers for the ArrayFire libraries."

--- a/CMakeModules/SplitDebugInfo.cmake
+++ b/CMakeModules/SplitDebugInfo.cmake
@@ -1,0 +1,94 @@
+# Tailored after https://github.com/GerbilSoft/mcrecover/blob/master/cmake/macros/SplitDebugInformation.cmake
+# Minor modifications to original
+
+if (NOT WIN32)
+  include(CMakeFindBinUtils)
+  if (NOT APPLE AND NOT CMAKE_OBJCOPY)
+    message(WARNING "'objcopy' tool not found; debug information will not be split.")
+  elseif (NOT CMAKE_STRIP)
+    message(WARNING "'strip' tool not found; debug information will not be split.")
+  elseif (APPLE)
+    # TODO(pradeep) debug info splits on OSX are disabled
+    # this section of elseif will be removed when Apple support is added
+    message(WARNING "Debug information is not split on OSX")
+  endif ()
+endif (NOT WIN32)
+
+function(af_split_debug_info _target)
+  set(SPLIT_TOOL_EXISTS ON)
+  if (WIN32)
+    set(SPLIT_TOOL_EXISTS OFF)
+    if (MSVC)
+      install(FILES
+        $<TARGET_PDB_FILE:${_target}>
+        DESTINATION ${AF_INSTALL_LIB_DIR}
+        COMPONENT "${_target}_debug_symbols"
+        )
+    endif()
+  elseif (NOT APPLE AND NOT CMAKE_OBJCOPY)
+    set(SPLIT_TOOL_EXISTS OFF)
+  elseif (NOT CMAKE_STRIP)
+    set(SPLIT_TOOL_EXISTS OFF)
+  elseif (APPLE)
+    # TODO(pradeep) debug info splits on OSX are disabled
+    # this section of elseif will be removed when Apple support is added
+    set(SPLIT_TOOL_EXISTS OFF)
+  endif ()
+
+  if (SPLIT_TOOL_EXISTS)
+    get_target_property(TARGET_TYPE ${_target} TYPE)
+    set(PREFIX_EXPR_1
+      "$<$<STREQUAL:$<TARGET_PROPERTY:${_target},PREFIX>,>:${CMAKE_${TARGET_TYPE}_PREFIX}>")
+    set(PREFIX_EXPR_2
+      "$<$<NOT:$<STREQUAL:$<TARGET_PROPERTY:${_target},PREFIX>,>>:$<TARGET_PROPERTY:${_target},PREFIX>>")
+    set(PREFIX_EXPR_FULL "${PREFIX_EXPR_1}${PREFIX_EXPR_2}")
+
+    # If a custom OUTPUT_NAME was specified, use it.
+    set(OUTPUT_NAME_EXPR_1
+        "$<$<STREQUAL:$<TARGET_PROPERTY:${_target},OUTPUT_NAME>,>:${_target}>")
+    set(OUTPUT_NAME_EXPR_2
+        "$<$<NOT:$<STREQUAL:$<TARGET_PROPERTY:${_target},OUTPUT_NAME>,>>:$<TARGET_PROPERTY:${_target},OUTPUT_NAME>>")
+    set(OUTPUT_NAME_EXPR "${OUTPUT_NAME_EXPR_1}${OUTPUT_NAME_EXPR_2}")
+    set(OUTPUT_NAME_FULL "${PREFIX_EXPR_FULL}${OUTPUT_NAME_EXPR}$<TARGET_PROPERTY:${_target},POSTFIX>")
+
+    set(SPLIT_DEBUG_TARGET_EXT ".debug")
+    if(APPLE)
+        set(SPLIT_DEBUG_TARGET_EXT ".dSYM")
+    endif()
+    set(SPLIT_DEBUG_SOURCE "$<TARGET_FILE:${_target}>")
+    set(SPLIT_DEBUG_TARGET_NAME
+        "$<TARGET_FILE_DIR:${_target}>/${OUTPUT_NAME_FULL}")
+    set(SPLIT_DEBUG_TARGET
+        "${SPLIT_DEBUG_TARGET_NAME}${SPLIT_DEBUG_TARGET_EXT}")
+
+    if(APPLE)
+      add_custom_command(TARGET ${_target} POST_BUILD
+          COMMAND dsymutil ${SPLIT_DEBUG_SOURCE} -o ${SPLIT_DEBUG_TARGET}
+          #TODO(pradeep) From initial research stripping debug info from
+          # is removing debug LC_ID_DYLIB command also which is make
+          # shared library unusable. Confirm this from OSX expert
+          # and remove these comments and below command
+          #COMMAND ${CMAKE_STRIP} --strip-debug ${SPLIT_DEBUG_SOURCE}
+        )
+    else(APPLE)
+      add_custom_command(TARGET ${_target} POST_BUILD
+        COMMAND ${CMAKE_OBJCOPY}
+          --only-keep-debug ${SPLIT_DEBUG_SOURCE} ${SPLIT_DEBUG_TARGET}
+        COMMAND ${CMAKE_STRIP}
+          --strip-debug ${SPLIT_DEBUG_SOURCE}
+        COMMAND ${CMAKE_OBJCOPY}
+          --add-gnu-debuglink=${SPLIT_DEBUG_TARGET} ${SPLIT_DEBUG_SOURCE}
+        )
+    endif()
+
+    install(FILES
+      ${SPLIT_DEBUG_TARGET}
+      DESTINATION ${AF_INSTALL_LIB_DIR}
+      COMPONENT "${OUTPUT_NAME_FULL}_debug_symbols"
+      )
+
+    # Make sure the file is deleted on `make clean`.
+    set_property(DIRECTORY APPEND
+      PROPERTY ADDITIONAL_MAKE_CLEAN_FILES ${SPLIT_DEBUG_TARGET})
+  endif(SPLIT_TOOL_EXISTS)
+endfunction(af_split_debug_info)

--- a/CMakeModules/SplitDebugInfo.cmake
+++ b/CMakeModules/SplitDebugInfo.cmake
@@ -4,24 +4,24 @@
 if (NOT WIN32)
   include(CMakeFindBinUtils)
   if (NOT APPLE AND NOT CMAKE_OBJCOPY)
-    message(WARNING "'objcopy' tool not found; debug information will not be split.")
+    message("'objcopy' tool not found; debug information will not be split.")
   elseif (NOT CMAKE_STRIP)
-    message(WARNING "'strip' tool not found; debug information will not be split.")
+    message("'strip' tool not found; debug information will not be split.")
   elseif (APPLE)
     # TODO(pradeep) debug info splits on OSX are disabled
     # this section of elseif will be removed when Apple support is added
-    message(WARNING "Debug information is not split on OSX")
+    message("Debug information is not split on OSX")
   endif ()
 endif (NOT WIN32)
 
-function(af_split_debug_info _target)
+function(af_split_debug_info _target _destination_dir)
   set(SPLIT_TOOL_EXISTS ON)
   if (WIN32)
     set(SPLIT_TOOL_EXISTS OFF)
     if (MSVC)
       install(FILES
         $<TARGET_PDB_FILE:${_target}>
-        DESTINATION ${AF_INSTALL_LIB_DIR}
+        DESTINATION ${_destination_dir}
         COMPONENT "${_target}_debug_symbols"
         )
     endif()
@@ -83,7 +83,7 @@ function(af_split_debug_info _target)
 
     install(FILES
       ${SPLIT_DEBUG_TARGET}
-      DESTINATION ${AF_INSTALL_LIB_DIR}
+      DESTINATION ${_destination_dir}
       COMPONENT "${OUTPUT_NAME_FULL}_debug_symbols"
       )
 

--- a/src/api/unified/CMakeLists.txt
+++ b/src/api/unified/CMakeLists.txt
@@ -101,7 +101,7 @@ install(TARGETS af
   INCLUDES DESTINATION ${AF_INSTALL_INC_DIR}
   )
 
-af_split_debug_info(af)
+af_split_debug_info(af ${AF_INSTALL_LIB_DIR})
 
 # install(TARGETS af EXPORT AF DESTINATION "${AF_INSTALL_LIB_DIR}"
 #   COMPONENT libraries)

--- a/src/api/unified/CMakeLists.txt
+++ b/src/api/unified/CMakeLists.txt
@@ -101,6 +101,8 @@ install(TARGETS af
   INCLUDES DESTINATION ${AF_INSTALL_INC_DIR}
   )
 
+af_split_debug_info(af)
+
 # install(TARGETS af EXPORT AF DESTINATION "${AF_INSTALL_LIB_DIR}"
 #   COMPONENT libraries)
 #

--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -351,6 +351,8 @@ if(LAPACK_FOUND OR MKL_FOUND)
       WITH_LINEAR_ALGEBRA)
 endif()
 
+af_split_debug_info(afcpu)
+
 install(TARGETS afcpu
   EXPORT ArrayFireCPUTargets
   COMPONENT cpu

--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -351,7 +351,7 @@ if(LAPACK_FOUND OR MKL_FOUND)
       WITH_LINEAR_ALGEBRA)
 endif()
 
-af_split_debug_info(afcpu)
+af_split_debug_info(afcpu ${AF_INSTALL_LIB_DIR})
 
 install(TARGETS afcpu
   EXPORT ArrayFireCPUTargets

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -566,6 +566,8 @@ if(APPLE)
   target_link_libraries(afcuda PUBLIC -Wl,-rpath,${CUDA_LIBRARIES_PATH})
 endif()
 
+af_split_debug_info(afcuda)
+
 install(TARGETS afcuda
   EXPORT ArrayFireCUDATargets
   COMPONENT cuda

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -566,7 +566,7 @@ if(APPLE)
   target_link_libraries(afcuda PUBLIC -Wl,-rpath,${CUDA_LIBRARIES_PATH})
 endif()
 
-af_split_debug_info(afcuda)
+af_split_debug_info(afcuda ${AF_INSTALL_LIB_DIR})
 
 install(TARGETS afcuda
   EXPORT ArrayFireCUDATargets

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -516,6 +516,8 @@ if(LAPACK_FOUND OR MKL_FOUND)
       WITH_LINEAR_ALGEBRA)
 endif(LAPACK_FOUND OR MKL_FOUND)
 
+af_split_debug_info(afopencl)
+
 install(TARGETS afopencl
   EXPORT ArrayFireOpenCLTargets
   COMPONENT opencl

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -516,7 +516,7 @@ if(LAPACK_FOUND OR MKL_FOUND)
       WITH_LINEAR_ALGEBRA)
 endif(LAPACK_FOUND OR MKL_FOUND)
 
-af_split_debug_info(afopencl)
+af_split_debug_info(afopencl ${AF_INSTALL_LIB_DIR})
 
 install(TARGETS afopencl
   EXPORT ArrayFireOpenCLTargets


### PR DESCRIPTION
    Dump debug symbols into separate files from binaries
    
    * Linux systems will created separate `lib<target>`.debug
      files with debug symbols of respective backend binaries.
    * Windows by default splits debug symbols into pdb files.
    * OSX debug symbol files are not generated - DISABLED for now
    
    OSX support will be added later.
    
    Component based installers will have *_debug_symbols component(s)
    disabled(not-installed) by default. The user has to explicitly select
    them during installation. The idea is to skip installation on these
    components on deployment systems and have them installed on development
    systems.
