### PR TITLE
Sets flags to enforce c++ compliance and correct cplusplus definition

### DIFF
--- a/CMakeModules/platform.cmake
+++ b/CMakeModules/platform.cmake
@@ -24,4 +24,19 @@ if(WIN32)
   # C4275: Warnings about using non-exported classes as base class of an
   #        exported class
   add_compile_options(/wd4068 /wd4275)
+
+  # MSVC incorrectly sets the cplusplus to 199711L even if the compiler supports
+  # c++11 features. This flag sets it to the correct standard supported by the
+  # compiler
+  check_cxx_compiler_flag(/Zc:__cplusplus cplusplus_define)
+  if(cplusplus_define)
+    add_compile_options(/Zc:__cplusplus)
+  endif()
+
+  # The "permissive-" option enforces strict(er?) standards compliance by
+  # MSVC
+  check_cxx_compiler_flag(/permissive- cxx_compliance)
+  if(cxx_compliance)
+    add_compile_options(/permissive-)
+  endif()
 endif()


### PR DESCRIPTION
* Sets the "permissive-" flag which instructs the compiler to enforce
  strict compliance to the standard
* Sets the Zc:__cplusplus flag which corrects the __cplusplus defintion
  so that move constructors are enabled in MSVC

Required for #2537