### PR TITLE
Remove openmp flag for cuda backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,6 @@ set(MKL_THREAD_LAYER "Intel OpenMP" CACHE STRING "The thread layer to choose for
 find_package(CUDA 7.0)
 find_package(OpenCL 1.2)
 find_package(OpenGL)
-find_package(OpenMP)
 find_package(FreeImage)
 find_package(Threads)
 find_package(FFTW)

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -472,15 +472,6 @@ target_include_directories (afcuda
     ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-if(OpenMP_CXX_FOUND)
-  target_link_libraries(afcuda
-    PRIVATE
-      OpenMP::OpenMP_CXX
-    )
-elseif(NOT APPLE)
-  message(FATAL_ERROR "OpenMP is required to compile CUDA Backend")
-endif()
-
 set_target_properties(afcuda PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_link_libraries(afcuda


### PR DESCRIPTION
/permissive flag does not work with two-phase-lookup enabled
for projects with openmp support enabled. Hence, it has been
removed for afcuda target.