### PR TITLE
Fix bugs in SIFT and blas

### DIFF
--- a/src/backend/cuda/kernel/sift_nonfree.hpp
+++ b/src/backend/cuda/kernel/sift_nonfree.hpp
@@ -78,6 +78,7 @@
 #include <debug_thrust.hpp>
 #include <memory.hpp>
 #include "shared.hpp"
+#include <af/defines.h>
 
 #include "convolve.hpp"
 #include "resize.hpp"
@@ -1061,7 +1062,7 @@ Array<T> createInitialImage(CParam<T> img, const float init_sigma,
     Array<convAccT> filter = gauss_filter<convAccT>(s);
 
     if (double_input) {
-        resize<T, InterpolationType::Bilinear>(init_img, img);
+        resize<T>(init_img, img, AF_INTERP_BILINEAR);
         convolve2<T, convAccT>(init_tmp, init_img, filter, 0, false);
     } else
         convolve2<T, convAccT>(init_tmp, img, filter, 0, false);
@@ -1108,8 +1109,7 @@ std::vector<Array<T>> buildGaussPyr(Param<T> init_img, const unsigned n_octaves,
                 tmp_pyr.push_back(
                     createEmptyArray<T>({tmp_pyr[src_idx].dims()[0] / 2,
                                          tmp_pyr[src_idx].dims()[1] / 2}));
-                resize<T, InterpolationType::Bilinear>(tmp_pyr[idx],
-                                                       tmp_pyr[src_idx]);
+                resize<T>(tmp_pyr[idx], tmp_pyr[src_idx], AF_INTERP_BILINEAR);
             } else {
                 tmp_pyr.push_back(createEmptyArray<T>(tmp_pyr[src_idx].dims()));
                 Array<T> tmp = createEmptyArray<T>(tmp_pyr[src_idx].dims());

--- a/src/backend/cuda/types.hpp
+++ b/src/backend/cuda/types.hpp
@@ -149,16 +149,13 @@ struct kernel_type<common::half> {
     using data = common::half;
 
 #ifdef __CUDA_ARCH__
-
     // These are the types within a kernel
-
-#if __CUDA_ARCH__ > 530 && __CUDA_ARCH__ != 610
+#if __CUDA_ARCH__ >= 530 && __CUDA_ARCH__ != 610
     using compute = __half;
 #else
     using compute = float;
 #endif
 #else
-
     // outside of a cuda kernel use float
     using compute = float;
 

--- a/test/blas.cpp
+++ b/test/blas.cpp
@@ -406,8 +406,8 @@ TEST(MatrixMultiply, half) {
 
     {
         af_array C16 = 0;
-        const af_half alpha16 = {0x03c00}; // 1.0 : 0 01111 0000000000
-        const af_half beta16 = {0x00000}; //  0.0 : 0 00000 0000000000
+        const half_float::half alpha16(1.0f);
+        const half_float::half beta16(0.0f);
         af_gemm(&C16, AF_MAT_NONE, AF_MAT_NONE, &alpha16, A16.get(), B16.get(), &beta16);
         af::array C(C16);
         ASSERT_ARRAYS_NEAR(expected16, C, 0.00001);
@@ -672,6 +672,13 @@ TEST(Gemm, DocSnippet) {
     af::array c2(c2_copy);
     vector<float> gold2(5*5*2, 3);
     fill(gold2.begin(), gold2.begin() + (5 * 5), 6);
+
+    af_release_array(A);
+    af_release_array(B);
+    af_release_array(C);
+    af_release_array(Asub);
+    af_release_array(Bsub);
+    af_release_array(Csub);
 
     ASSERT_VEC_ARRAY_EQ(gold2, dim4(5, 5, 2), c2);
 }

--- a/test/gen_index.cpp
+++ b/test/gen_index.cpp
@@ -63,22 +63,26 @@ class IndexGeneralizedLegacy : public ::testing::TestWithParam<index_params> {
                                        dims0.get(), f32));
 
         ASSERT_SUCCESS(af_cast(&inArray_, inTmp, get<1>(params)));
+        af_release_array(inTmp);
 
         af_array idxTmp = 0;
         ASSERT_SUCCESS(af_create_array(&idxTmp, &(in[1].front()), dims1.ndims(),
                                        dims1.get(), f32));
         ASSERT_SUCCESS(af_cast(&idxArray_, idxTmp, get<2>(params)));
+        af_release_array(idxTmp);
 
         vector<float> hgold = tests[0];
         af_array goldTmp;
         af_create_array(&goldTmp, &hgold.front(), get<0>(params).dims_.ndims(),
                         get<0>(params).dims_.get(), f32);
         ASSERT_SUCCESS(af_cast(&gold_, goldTmp, get<1>(params)));
+        af_release_array(goldTmp);
     }
 
     void TearDown() {
         if (inArray_) ASSERT_SUCCESS(af_release_array(inArray_));
         if (idxArray_) ASSERT_SUCCESS(af_release_array(idxArray_));
+        if (gold_) ASSERT_SUCCESS(af_release_array(gold_));
     }
 
    public:
@@ -125,6 +129,7 @@ TEST_P(IndexGeneralizedLegacy, SSSA) {
     indexes[3].isSeq   = false;
     ASSERT_SUCCESS(af_index_gen(&outArray, inArray_, 4, indexes));
     ASSERT_ARRAYS_EQ(gold_, outArray);
+    af_release_array(outArray);
 }
 
 void testGeneralIndexOneArray(string pTestFile, const dim_t ndims,

--- a/test/gloh_nonfree.cpp
+++ b/test/gloh_nonfree.cpp
@@ -242,12 +242,8 @@ void glohTest(string pTestFile) {
         ASSERT_SUCCESS(af_release_array(inArray));
         ASSERT_SUCCESS(af_release_array(inArray_f32));
 
-        ASSERT_SUCCESS(af_release_array(x));
-        ASSERT_SUCCESS(af_release_array(y));
-        ASSERT_SUCCESS(af_release_array(score));
-        ASSERT_SUCCESS(af_release_array(orientation));
-        ASSERT_SUCCESS(af_release_array(size));
         ASSERT_SUCCESS(af_release_array(desc));
+        ASSERT_SUCCESS(af_release_features(feat));
 
         delete[] outX;
         delete[] outY;


### PR DESCRIPTION
* Fixes a bug in blas after the type was changed from common::half to compute<T>
* Fix bug in SIFT caused by the change in the resize internal backend API
* Fix several leaks in the blas, gloh, and gen_index tests.