### PR TITLE
Add half support for several data functions

### DIFF
--- a/CMakeModules/InternalUtils.cmake
+++ b/CMakeModules/InternalUtils.cmake
@@ -30,7 +30,7 @@ endfunction()
 
 function(arrayfire_get_cuda_cxx_flags cuda_flags)
   if(NOT MSVC)
-    set(flags "-std=c++14 -Xcompiler -fPIC -Xcompiler ${CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY}hidden")
+    set(flags "-std=c++14 --expt-relaxed-constexpr -Xcompiler -fPIC -Xcompiler ${CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY}hidden")
   else()
     set(flags "-Xcompiler /wd4251 -Xcompiler /wd4068 -Xcompiler /wd4275 -Xcompiler /bigobj -Xcompiler /EHsc")
     if(CMAKE_GENERATOR MATCHES "Ninja")

--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -448,6 +448,7 @@ static af_err af_logic(af_array *out, const af_array lhs, const af_array rhs,
             case u64: res = logicOp<uintl, op>(lhs, rhs, odims); break;
             case s16: res = logicOp<short, op>(lhs, rhs, odims); break;
             case u16: res = logicOp<ushort, op>(lhs, rhs, odims); break;
+            case f16: res = logicOp<half, op>(lhs, rhs, odims); break;
             default: TYPE_ERROR(0, type);
         }
 

--- a/src/api/c/data.cpp
+++ b/src/api/c/data.cpp
@@ -186,6 +186,7 @@ af_err af_identity(af_array *out, const unsigned ndims, const dim_t *const dims,
                 // Removed because of bool type. Functions implementations
                 // exist.
             case b8: result = identity_<char>(d); break;
+            case f16: result = identity_<half>(d); break;
             default: TYPE_ERROR(3, type);
         }
         std::swap(*out, result);
@@ -223,6 +224,7 @@ af_err af_range(af_array *result, const unsigned ndims, const dim_t *const dims,
             case s16: out = range_<short>(d, seq_dim); break;
             case u16: out = range_<ushort>(d, seq_dim); break;
             case u8: out = range_<uchar>(d, seq_dim); break;
+            case f16: out = range_<half>(d, seq_dim); break;
             default: TYPE_ERROR(4, type);
         }
         std::swap(*result, out);
@@ -262,6 +264,7 @@ af_err af_iota(af_array *result, const unsigned ndims, const dim_t *const dims,
             case s16: out = iota_<short>(d, t); break;
             case u16: out = iota_<ushort>(d, t); break;
             case u8: out = iota_<uchar>(d, t); break;
+            case f16: out = iota_<half>(d, t); break;
             default: TYPE_ERROR(4, type);
         }
         std::swap(*result, out);
@@ -309,6 +312,7 @@ af_err af_diag_create(af_array *out, const af_array in, const int num) {
                 // Removed because of bool type. Functions implementations
                 // exist.
             case b8: result = diagCreate<char>(in, num); break;
+            case f16: result = diagCreate<half>(in, num); break;
             default: TYPE_ERROR(1, type);
         }
 
@@ -347,6 +351,7 @@ af_err af_diag_extract(af_array *out, const af_array in, const int num) {
                 // Removed because of bool type. Functions implementations
                 // exist.
             case b8: result = diagExtract<char>(in, num); break;
+            case f16: result = diagExtract<half>(in, num); break;
             default: TYPE_ERROR(1, type);
         }
 
@@ -386,6 +391,7 @@ af_err af_lower(af_array *out, const af_array in, bool is_unit_diag) {
             case u16: res = triangle<ushort, false>(in, is_unit_diag); break;
             case u8: res = triangle<uchar, false>(in, is_unit_diag); break;
             case b8: res = triangle<char, false>(in, is_unit_diag); break;
+            case f16: res = triangle<half, false>(in, is_unit_diag); break;
         }
         std::swap(*out, res);
     }
@@ -414,6 +420,7 @@ af_err af_upper(af_array *out, const af_array in, bool is_unit_diag) {
             case u16: res = triangle<ushort, true>(in, is_unit_diag); break;
             case u8: res = triangle<uchar, true>(in, is_unit_diag); break;
             case b8: res = triangle<char, true>(in, is_unit_diag); break;
+            case f16: res = triangle<half, true>(in, is_unit_diag); break;
         }
         std::swap(*out, res);
     }

--- a/src/api/c/ops.hpp
+++ b/src/api/c/ops.hpp
@@ -25,82 +25,51 @@ using namespace detail;
 
 template<typename T, af_op_t op>
 struct Binary {
-    static __DH__ detail::compute_t<T> init();
+    static __DH__ T init();
 
-    __DH__ detail::compute_t<T> operator()(detail::compute_t<T> lhs,
-                                           detail::compute_t<T> rhs);
+    __DH__ T operator()(T lhs, T rhs);
 };
 
 template<typename T>
 struct Binary<T, af_add_t> {
-    static __DH__ detail::compute_t<T> init() {
-        return detail::scalar<detail::compute_t<T>>(0);
-    }
+    static __DH__ T init() { return detail::scalar<T>(0); }
 
-    __DH__ detail::compute_t<T> operator()(detail::compute_t<T> lhs,
-                                           detail::compute_t<T> rhs) {
-        return lhs + rhs;
-    }
+    __DH__ T operator()(T lhs, T rhs) { return lhs + rhs; }
 };
 
 template<typename T>
 struct Binary<T, af_mul_t> {
-    static __DH__ detail::compute_t<T> init() {
-        return detail::scalar<detail::compute_t<T>>(1);
-    }
+    static __DH__ T init() { return detail::scalar<T>(1); }
 
-    __DH__ detail::compute_t<T> operator()(detail::compute_t<T> lhs,
-                                           detail::compute_t<T> rhs) {
-        return lhs * rhs;
-    }
+    __DH__ T operator()(T lhs, T rhs) { return lhs * rhs; }
 };
 
 template<typename T>
 struct Binary<T, af_or_t> {
-    static __DH__ detail::compute_t<T> init() {
-        return detail::scalar<detail::compute_t<T>>(0);
-    }
+    static __DH__ T init() { return detail::scalar<T>(0); }
 
-    __DH__ detail::compute_t<T> operator()(detail::compute_t<T> lhs,
-                                           detail::compute_t<T> rhs) {
-        return lhs || rhs;
-    }
+    __DH__ T operator()(T lhs, T rhs) { return lhs || rhs; }
 };
 
 template<typename T>
 struct Binary<T, af_and_t> {
-    static __DH__ detail::compute_t<T> init() {
-        return detail::scalar<detail::compute_t<T>>(1);
-    }
+    static __DH__ T init() { return detail::scalar<T>(1); }
 
-    __DH__ detail::compute_t<T> operator()(detail::compute_t<T> lhs,
-                                           detail::compute_t<T> rhs) {
-        return lhs && rhs;
-    }
+    __DH__ T operator()(T lhs, T rhs) { return lhs && rhs; }
 };
 
 template<typename T>
 struct Binary<T, af_notzero_t> {
-    static __DH__ detail::compute_t<T> init() {
-        return detail::scalar<detail::compute_t<T>>(0);
-    }
+    static __DH__ T init() { return detail::scalar<T>(0); }
 
-    __DH__ detail::compute_t<T> operator()(detail::compute_t<T> lhs,
-                                           detail::compute_t<T> rhs) {
-        return lhs + rhs;
-    }
+    __DH__ T operator()(T lhs, T rhs) { return lhs + rhs; }
 };
 
 template<typename T>
 struct Binary<T, af_min_t> {
-    static __DH__ detail::compute_t<T> init() {
-        return detail::maxval<detail::compute_t<T>>();
-    }
+    static __DH__ T init() { return detail::maxval<T>(); }
 
-    __DH__ detail::compute_t<T> operator()(detail::compute_t<T> lhs,
-                                           detail::compute_t<T> rhs) {
-        return detail::min(lhs, rhs);
-    }
+    __DH__ T operator()(T lhs, T rhs) { return detail::min(lhs, rhs); }
 };
 
 template<>
@@ -112,17 +81,14 @@ struct Binary<char, af_min_t> {
     }
 };
 
-#define SPECIALIZE_COMPLEX_MIN(T, Tr)                                          \
-    template<>                                                                 \
-    struct Binary<detail::compute_t<T>, af_min_t> {                            \
-        static __DH__ detail::compute_t<T> init() {                            \
-            return detail::scalar<detail::compute_t<T>>(detail::maxval<Tr>()); \
-        }                                                                      \
-                                                                               \
-        __DH__ detail::compute_t<T> operator()(detail::compute_t<T> lhs,       \
-                                               detail::compute_t<T> rhs) {     \
-            return detail::min(lhs, rhs);                                      \
-        }                                                                      \
+#define SPECIALIZE_COMPLEX_MIN(T, Tr)                                       \
+    template<>                                                              \
+    struct Binary<T, af_min_t> {                                            \
+        static __DH__ T init() {                                            \
+            return detail::scalar<T>(detail::maxval<Tr>());                 \
+        }                                                                   \
+                                                                            \
+        __DH__ T operator()(T lhs, T rhs) { return detail::min(lhs, rhs); } \
     };
 
 SPECIALIZE_COMPLEX_MIN(cfloat, float)
@@ -132,14 +98,9 @@ SPECIALIZE_COMPLEX_MIN(cdouble, double)
 
 template<typename T>
 struct Binary<T, af_max_t> {
-    static __DH__ detail::compute_t<T> init() {
-        return detail::minval<detail::compute_t<T>>();
-    }
+    static __DH__ T init() { return detail::minval<T>(); }
 
-    __DH__ detail::compute_t<T> operator()(detail::compute_t<T> lhs,
-                                           detail::compute_t<T> rhs) {
-        return detail::max(lhs, rhs);
-    }
+    __DH__ T operator()(T lhs, T rhs) { return detail::max(lhs, rhs); }
 };
 
 template<>
@@ -151,18 +112,14 @@ struct Binary<char, af_max_t> {
     }
 };
 
-#define SPECIALIZE_COMPLEX_MAX(T, Tr)                                      \
-    template<>                                                             \
-    struct Binary<T, af_max_t> {                                           \
-        static __DH__ detail::compute_t<T> init() {                        \
-            return detail::scalar<detail::compute_t<T>>(                   \
-                detail::scalar<Tr>(0));                                    \
-        }                                                                  \
-                                                                           \
-        __DH__ detail::compute_t<T> operator()(detail::compute_t<T> lhs,   \
-                                               detail::compute_t<T> rhs) { \
-            return detail::max(lhs, rhs);                                  \
-        }                                                                  \
+#define SPECIALIZE_COMPLEX_MAX(T, Tr)                                       \
+    template<>                                                              \
+    struct Binary<T, af_max_t> {                                            \
+        static __DH__ T init() {                                            \
+            return detail::scalar<T>(detail::scalar<Tr>(0));                \
+        }                                                                   \
+                                                                            \
+        __DH__ T operator()(T lhs, T rhs) { return detail::max(lhs, rhs); } \
     };
 
 SPECIALIZE_COMPLEX_MAX(cfloat, float)
@@ -172,42 +129,34 @@ SPECIALIZE_COMPLEX_MAX(cdouble, double)
 
 template<typename Ti, typename To, af_op_t op>
 struct Transform {
-    __DH__ To operator()(detail::compute_t<Ti> in) {
-        return static_cast<To>(in);
-    }
+    __DH__ To operator()(Ti in) { return static_cast<To>(in); }
 };
 
 template<typename Ti, typename To>
 struct Transform<Ti, To, af_min_t> {
-    __DH__ To operator()(detail::compute_t<Ti> in) {
-        return (To)(IS_NAN(in) ? Binary<To, af_min_t>::init() : in);
+    __DH__ To operator()(Ti in) {
+        return IS_NAN(in) ? Binary<To, af_min_t>::init() : To(in);
     }
 };
 
 template<typename Ti, typename To>
 struct Transform<Ti, To, af_max_t> {
-    __DH__ To operator()(detail::compute_t<Ti> in) {
-        return (To)(IS_NAN(in) ? Binary<To, af_max_t>::init() : in);
+    __DH__ To operator()(Ti in) {
+        return IS_NAN(in) ? Binary<To, af_max_t>::init() : To(in);
     }
 };
 
 template<typename Ti, typename To>
 struct Transform<Ti, To, af_or_t> {
-    __DH__ To operator()(detail::compute_t<Ti> in) {
-        return (in != detail::scalar<detail::compute_t<Ti>>(0));
-    }
+    __DH__ To operator()(Ti in) { return (in != detail::scalar<Ti>(0.)); }
 };
 
 template<typename Ti, typename To>
 struct Transform<Ti, To, af_and_t> {
-    __DH__ To operator()(detail::compute_t<Ti> in) {
-        return (in != detail::scalar<detail::compute_t<Ti>>(0));
-    }
+    __DH__ To operator()(Ti in) { return (in != detail::scalar<Ti>(0.)); }
 };
 
 template<typename Ti, typename To>
 struct Transform<Ti, To, af_notzero_t> {
-    __DH__ To operator()(detail::compute_t<Ti> in) {
-        return (in != detail::scalar<detail::compute_t<Ti>>(0));
-    }
+    __DH__ To operator()(Ti in) { return (in != detail::scalar<Ti>(0.)); }
 };

--- a/src/api/c/reduce.cpp
+++ b/src/api/c/reduce.cpp
@@ -247,6 +247,7 @@ static af_err reduce_all_type(double *real, double *imag, const af_array in) {
             case s16: *real = (double)reduce_all<op, short, To>(in); break;
             case b8: *real = (double)reduce_all<op, char, To>(in); break;
             case u8: *real = (double)reduce_all<op, uchar, To>(in); break;
+            case f16: *real = (double)reduce_all<op, half, To>(in); break;
             default: TYPE_ERROR(1, type);
         }
     }
@@ -292,6 +293,9 @@ static af_err reduce_all_common(double *real_val, double *imag_val,
             case b8: *real_val = (double)reduce_all<op, char, char>(in); break;
             case u8:
                 *real_val = (double)reduce_all<op, uchar, uchar>(in);
+                break;
+            case f16:
+                *real_val = (double)reduce_all<op, half, half>(in);
                 break;
 
             case c32:
@@ -391,6 +395,10 @@ static af_err reduce_all_promote(double *real_val, double *imag_val,
                 *real_val = real(cdval);
                 *imag_val = imag(cdval);
                 break;
+            case f16:
+                *real_val = (double)reduce_all<op, half, float>(in, change_nan,
+                                                                nanval);
+                break;
 
             default: TYPE_ERROR(1, type);
         }
@@ -475,7 +483,7 @@ static af_err ireduce_common(af_array *val, af_array *idx, const af_array in,
             case s16: ireduce<op, short>(&res, &loc, in, dim); break;
             case b8: ireduce<op, char>(&res, &loc, in, dim); break;
             case u8: ireduce<op, uchar>(&res, &loc, in, dim); break;
-              //case f16: ireduce<op, half>(&res, &loc, in, dim); break;
+            case f16: ireduce<op, half>(&res, &loc, in, dim); break;
             default: TYPE_ERROR(1, type);
         }
 

--- a/src/api/c/transpose.cpp
+++ b/src/api/c/transpose.cpp
@@ -9,6 +9,7 @@
 
 #include <backend.hpp>
 #include <common/err_common.hpp>
+#include <common/half.hpp>
 #include <handle.hpp>
 #include <transpose.hpp>
 #include <af/arith.h>
@@ -18,6 +19,7 @@
 #include <af/dim4.hpp>
 
 using af::dim4;
+using common::half;
 using namespace detail;
 
 template<typename T>
@@ -63,6 +65,7 @@ af_err af_transpose(af_array* out, af_array in, const bool conjugate) {
             case u64: output = trs<uintl>(in, conjugate); break;
             case s16: output = trs<short>(in, conjugate); break;
             case u16: output = trs<ushort>(in, conjugate); break;
+            case f16: output = trs<half>(in, conjugate); break;
             default: TYPE_ERROR(1, type);
         }
         std::swap(*out, output);
@@ -102,6 +105,7 @@ af_err af_transpose_inplace(af_array in, const bool conjugate) {
             case u64: transpose_inplace<uintl>(in, conjugate); break;
             case s16: transpose_inplace<short>(in, conjugate); break;
             case u16: transpose_inplace<ushort>(in, conjugate); break;
+            case f16: transpose_inplace<half>(in, conjugate); break;
             default: TYPE_ERROR(1, type);
         }
     }

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -949,6 +949,8 @@ INSTANTIATE(long long)
 INSTANTIATE(unsigned long long)
 INSTANTIATE(short)
 INSTANTIATE(unsigned short)
+INSTANTIATE(af_half)
+INSTANTIATE(half_float::half)
 
 template<>
 AFAPI void array::write(const void *ptr, const size_t bytes, af::source src) {
@@ -989,6 +991,8 @@ INSTANTIATE(long long)
 INSTANTIATE(unsigned long long)
 INSTANTIATE(short)
 INSTANTIATE(unsigned short)
+INSTANTIATE(af_half)
+INSTANTIATE(half_float::half)
 
 #undef INSTANTIATE
 #undef TEMPLATE_MEM_FUNC

--- a/src/api/cpp/data.cpp
+++ b/src/api/cpp/data.cpp
@@ -16,6 +16,7 @@
 #include <af/half.h>
 #include <af/traits.hpp>
 #include "error.hpp"
+#include <half.hpp>
 
 #include <type_traits>
 
@@ -135,6 +136,7 @@ CONSTANT(bool);
 CONSTANT(short);
 CONSTANT(unsigned short);
 CONSTANT(half);
+CONSTANT(half_float::half);
 
 #undef CONSTANT
 

--- a/src/backend/common/half.hpp
+++ b/src/backend/common/half.hpp
@@ -1,3 +1,12 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
 #pragma once
 
 #if defined(NVCC) || defined(__CUDACC_RTC__)
@@ -12,6 +21,8 @@
 #include <type_traits>
 
 #include <limits>
+#else
+using uint16_t = unsigned short;
 #endif
 
 #if AF_COMPILER_CXX_RELAXED_CONSTEXPR
@@ -22,7 +33,14 @@
 
 namespace common {
 
+#if defined(__CUDA_ARCH__)
+using native_half_t = __half;
+#else
+using native_half_t = uint16_t;
+#endif
+
 #ifndef __CUDACC_RTC__
+
 /// Convert integer to half-precision floating point.
 ///
 /// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
@@ -34,7 +52,7 @@ namespace common {
 ///
 /// \return binary representation of half-precision value
 template<std::float_round_style R, bool S, typename T>
-CONSTEXPR_DH uint16_t int2half(T value) noexcept {
+CONSTEXPR_DH native_half_t int2half_impl(T value) noexcept {
     static_assert(std::is_integral<T>::value,
                   "int to half conversion only supports builtin integer types");
     if (S) value = -value;
@@ -69,6 +87,18 @@ CONSTEXPR_DH uint16_t int2half(T value) noexcept {
     return bits;
 }
 
+template<typename T, std::float_round_style R = std::round_to_nearest>
+CONSTEXPR_DH native_half_t int2half(T value) noexcept {
+    uint16_t out;
+    if (std::is_signed<T>::value) {
+        out = (value < 0) ? int2half_impl<R, true, T>(value)
+                          : int2half_impl<R, false, T>(value);
+    } else {
+        out = int2half_impl<R, false, T>(value);
+    }
+    return out;
+}
+
 /// Convert IEEE single-precision to half-precision.
 /// Credit for this goes to [Jeroen van der
 /// Zijp](ftp://ftp.fox-toolkit.org/pub/fasthalffloatconversion.pdf).
@@ -77,8 +107,8 @@ CONSTEXPR_DH uint16_t int2half(T value) noexcept {
 ///
 /// \param value single-precision value
 /// \return binary representation of half-precision value
-template<std::float_round_style R = std::numeric_limits<float>::round_style>
-CONSTEXPR_DH uint16_t float2half(float value) noexcept {
+template<std::float_round_style R = std::round_indeterminate>
+CONSTEXPR_DH native_half_t float2half_impl(float value) noexcept {
     uint32_t bits = 0;  // = *reinterpret_cast<uint32*>(&value);
                         // //violating strict aliasing!
     std::memcpy(&bits, &value, sizeof(float));
@@ -205,7 +235,73 @@ CONSTEXPR_DH uint16_t float2half(float value) noexcept {
     return hbits;
 }
 
-__DH__ inline float half2float(uint16_t value) noexcept {
+/// Convert IEEE double-precision to half-precision.
+///
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+///           rounding
+/// \param value double-precision value
+///
+/// \return binary representation of half-precision value
+template<std::float_round_style R>
+CONSTEXPR_DH native_half_t float2half_impl(double value) {
+    uint64_t bits;  // = *reinterpret_cast<uint64*>(&value);		//violating
+                    // strict aliasing!
+    std::memcpy(&bits, &value, sizeof(double));
+    uint32_t hi = bits >> 32, lo = bits & 0xFFFFFFFF;
+    uint16_t hbits = (hi >> 16) & 0x8000;
+    hi &= 0x7FFFFFFF;
+    int exp = hi >> 20;
+    if (exp == 2047)
+        return hbits | 0x7C00 |
+               (0x3FF & -static_cast<unsigned>((bits & 0xFFFFFFFFFFFFF) != 0));
+    if (exp > 1038) {
+        if (R == std::round_toward_infinity)
+            return hbits | 0x7C00 - (hbits >> 15);
+        if (R == std::round_toward_neg_infinity)
+            return hbits | 0x7BFF + (hbits >> 15);
+        return hbits | 0x7BFF + (R != std::round_toward_zero);
+    }
+    int g, s = lo != 0;
+    if (exp > 1008) {
+        g = (hi >> 9) & 1;
+        s |= (hi & 0x1FF) != 0;
+        hbits |= ((exp - 1008) << 10) | ((hi >> 10) & 0x3FF);
+    } else if (exp > 997) {
+        int i = 1018 - exp;
+        hi    = (hi & 0xFFFFF) | 0x100000;
+        g     = (hi >> i) & 1;
+        s |= (hi & ((1L << i) - 1)) != 0;
+        hbits |= hi >> (i + 1);
+    } else {
+        g = 0;
+        s |= hi != 0;
+    }
+    if (R == std::round_to_nearest)
+#if HALF_ROUND_TIES_TO_EVEN
+        hbits += g & (s | hbits);
+#else
+        hbits += g;
+#endif
+    else if (R == std::round_toward_infinity)
+        hbits += ~(hbits >> 15) & (s | g);
+    else if (R == std::round_toward_neg_infinity)
+        hbits += (hbits >> 15) & (g | s);
+    return hbits;
+}
+
+template<typename T, std::float_round_style R = std::round_to_nearest>
+CONSTEXPR_DH native_half_t float2half(T val) {
+#ifdef __CUDA_ARCH__
+    return __float2half(val);
+#else
+    return float2half_impl<R>(val);
+#endif
+}
+
+CONSTEXPR_DH inline float half2float(native_half_t value) noexcept {
+#ifdef __CUDA_ARCH__
+    return __half2float(value);
+#else
     // return _cvtsh_ss(data.data_);
     uint32_t mantissa_table[2048] = {
         0x00000000, 0x33800000, 0x34000000, 0x34400000, 0x34800000, 0x34A00000,
@@ -578,8 +674,103 @@ __DH__ inline float half2float(uint16_t value) noexcept {
     float out = 0.0f;
     std::memcpy(&out, &bits, sizeof(float));
     return out;
+#endif
 }
-#endif  // __CUDACC_RTC__
+
+/// Convert half-precision floating point to integer.
+///
+/// \tparam R rounding mode to use, `std::round_indeterminate` for fastest
+///           rounding
+/// \tparam E `true` for round to even, `false` for round away from
+///           zero
+/// \tparam T type to convert to (buitlin integer type with at least 16
+///           bits precision, excluding any implicit sign bits) \param value
+///           binary representation of half-precision value \return integral
+///           value
+/// \param value The value to convert to integer
+template<std::float_round_style R, bool E, typename T>
+__DH__ T half2int(native_half_t value) {
+    static_assert(std::is_integral<T>::value,
+                  "half to int conversion only supports builtin integer types");
+    unsigned int e = value & 0x7FFF;
+    if (e >= 0x7C00)
+        return (value & 0x8000) ? std::numeric_limits<T>::min()
+                                : std::numeric_limits<T>::max();
+    if (e < 0x3800) {
+        if (R == std::round_toward_infinity)
+            return T(~(value >> 15) & (e != 0));
+        else if (R == std::round_toward_neg_infinity)
+            return -T(value > 0x8000);
+        return T();
+    }
+    unsigned int m = (value & 0x3FF) | 0x400;
+    e >>= 10;
+    if (e < 25) {
+        if (R == std::round_to_nearest)
+            m += (1 << (24 - e)) - (~(m >> (25 - e)) & E);
+        else if (R == std::round_toward_infinity)
+            m += ((value >> 15) - 1) & ((1 << (25 - e)) - 1U);
+        else if (R == std::round_toward_neg_infinity)
+            m += -(value >> 15) & ((1 << (25 - e)) - 1U);
+        m >>= 25 - e;
+    } else
+        m <<= e - 25;
+    return (value & 0x8000) ? -static_cast<T>(m) : static_cast<T>(m);
+}
+
+#else
+
+template<typename T>
+CONSTEXPR_DH native_half_t float2half(T value) {
+    return __float2half(value);
+}
+
+CONSTEXPR_DH inline float half2float(native_half_t value) noexcept {
+    return __half2float(value);
+}
+
+template<typename T>
+CONSTEXPR_DH native_half_t int2half(T value) noexcept;
+
+template<>
+CONSTEXPR_DH native_half_t int2half(int value) noexcept {
+  return __int2half_rn(value);
+}
+
+template<>
+CONSTEXPR_DH native_half_t int2half(unsigned value) noexcept {
+    return __uint2half_rn(value);
+}
+
+template<>
+CONSTEXPR_DH native_half_t int2half(long long value) noexcept {
+    return __ll2half_rn(value);
+}
+
+template<>
+CONSTEXPR_DH native_half_t int2half(unsigned long long value) noexcept {
+    return __ull2half_rn(value);
+}
+
+template<>
+CONSTEXPR_DH native_half_t int2half(short value) noexcept {
+    return __short2half_rn(value);
+}
+template<>
+CONSTEXPR_DH native_half_t int2half(unsigned short value) noexcept {
+    return __ushort2half_rn(value);
+}
+
+template<>
+CONSTEXPR_DH native_half_t int2half(char value) noexcept {
+    return __ull2half_rn(value);
+}
+template<>
+CONSTEXPR_DH native_half_t int2half(unsigned char value) noexcept {
+    return __ull2half_rn(value);
+}
+
+#endif // __CUDACC_RTC__
 
 namespace internal {
 /// Tag type for binary construction.
@@ -589,40 +780,46 @@ struct binary_t {};
 static constexpr binary_t binary;
 }  // namespace internal
 
-class alignas(2) half {
-#if defined(__CUDA_ARCH__)
-    __half data_;
-#else
-    uint16_t data_;
-    /// Constructor.
-    /// \param bits binary representation to set half to
-    CONSTEXPR_DH half(internal::binary_t, uint16_t bits) noexcept
-        : data_(bits) {}
-#endif
+class half;
 
-#if !defined(NVCC) && !defined(__CUDACC_RTC__)
+CONSTEXPR_DH static inline bool operator==(common::half lhs, common::half rhs) noexcept;
+CONSTEXPR_DH static inline bool operator!=(common::half lhs, common::half rhs) noexcept;
+CONSTEXPR_DH static inline bool operator<(common::half lhs, common::half rhs) noexcept;
+CONSTEXPR_DH static inline bool operator<(common::half lhs, float rhs) noexcept;
+CONSTEXPR_DH static inline  bool isinf(half val) noexcept;
+
+/// Classification implementation.
+/// \param arg value to classify
+/// \retval true if not a number
+/// \retval false else
+CONSTEXPR_DH static inline bool isnan(common::half val) noexcept;
+
+class alignas(2) half {
+    native_half_t data_;
+
+    #if !defined(NVCC) && !defined(__CUDACC_RTC__)
     // NVCC on OSX performs a weird transformation where it removes the std::
     // namespace and complains that the std:: namespace is not there
     friend class std::numeric_limits<half>;
     friend struct std::hash<half>;
-#endif
+    #endif
 
    public:
     half() = default;
+
+    /// Constructor.
+    /// \param bits binary representation to set half to
+    CONSTEXPR_DH half(internal::binary_t, uint16_t bits) noexcept
+        : data_() {
+        memcpy(&data_, &bits, sizeof(uint16_t));
+    }
+
     CONSTEXPR_DH explicit half(double value) noexcept
-#ifdef __CUDA_ARCH__
-        : data_(__float2half(value)) {
-#else
-        : data_(float2half<std::round_to_nearest>(value)) {
-#endif
+        : data_(float2half<double>(value)) {
     }
 
     CONSTEXPR_DH explicit half(float value) noexcept
-#ifdef __CUDA_ARCH__
-        : data_(__float2half(value)) {
-#else
-        : data_(float2half<std::round_to_nearest>(value)) {
-#endif
+        : data_(float2half<float>(value)) {
     }
 
 #ifndef __CUDACC_RTC__
@@ -634,11 +831,10 @@ class alignas(2) half {
     template<typename T,
         typename std::enable_if_t<std::is_signed<T>::value>* = nullptr>
     CONSTEXPR_DH explicit half(T value) noexcept
-        : data_((value < 0) ? int2half<std::round_to_nearest, true>(value)
-                            : int2half<std::round_to_nearest, false>(value)) {}
+        : data_(int2half<T>(value)) {}
 
     CONSTEXPR_DH half& operator=(const double& value) noexcept {
-        data_ = float2half<std::round_to_nearest>(value);
+        data_ = float2half<double>(value);
         return *this;
     }
 #endif
@@ -651,26 +847,150 @@ class alignas(2) half {
     }
 #endif
 
-    __DH__ operator float() const noexcept {
-#ifdef __CUDA_ARCH__
-        return __half2float(data_);
-#else
+    CONSTEXPR_DH explicit operator float() const noexcept {
         return half2float(data_);
+    }
+
+    CONSTEXPR_DH explicit operator double() const noexcept {
+        // TODO(umar): convert directly to double
+        return half2float(data_);
+    }
+
+    CONSTEXPR_DH explicit operator short() const noexcept {
+#ifdef __CUDA_ARCH__
+        return __half2short_rn(data_);
+#else
+        return half2int<std::round_indeterminate, true, short>(data_);
 #endif
-    };
+    }
+
+    CONSTEXPR_DH explicit operator long long() const noexcept {
+#ifdef __CUDA_ARCH__
+        return __half2ll_rn(data_);
+#else
+        return half2int<std::round_indeterminate, true, long long int>(data_);
+#endif
+    }
+
+    CONSTEXPR_DH explicit operator int() const noexcept {
+#ifdef __CUDA_ARCH__
+        return __half2int_rn(data_);
+#else
+        return half2int<std::round_indeterminate, true, int>(data_);
+#endif
+    }
+
+    CONSTEXPR_DH explicit operator unsigned() const noexcept {
+#ifdef __CUDA_ARCH__
+        return __half2uint_rn(data_);
+#else
+        return half2int<std::round_indeterminate, true, unsigned>(data_);
+#endif
+    }
+
+    CONSTEXPR_DH explicit operator unsigned short() const noexcept {
+#ifdef __CUDA_ARCH__
+        return __half2ushort_rn(data_);
+#else
+        return half2int<std::round_indeterminate, true, unsigned>(data_);
+#endif
+    }
+
+    CONSTEXPR_DH explicit operator unsigned long long() const noexcept {
+#ifdef __CUDA_ARCH__
+        return __half2ull_rn(data_);
+#else
+        return half2int<std::round_indeterminate, true, unsigned>(data_);
+#endif
+    }
+
+    CONSTEXPR_DH explicit operator char() const noexcept {
+#ifdef __CUDA_ARCH__
+        return __half2short_rn(data_);
+#else
+        return half2int<std::round_indeterminate, true, char>(data_);
+#endif
+    }
+
+    CONSTEXPR_DH explicit operator unsigned char() const noexcept {
+#ifdef __CUDA_ARCH__
+        return __half2short_rn(data_);
+#else
+        return half2int<std::round_indeterminate, true, unsigned char>(data_);
+#endif
+    }
 
 #if defined(__CUDA_ARCH__)
     CONSTEXPR_DH operator __half() const noexcept { return data_; };
 #endif
+
+    friend CONSTEXPR_DH bool operator==(half lhs, half rhs) noexcept;
+    friend CONSTEXPR_DH bool operator!=(half lhs, half rhs) noexcept;
+    friend CONSTEXPR_DH bool operator<(common::half lhs, common::half rhs) noexcept;
+    friend CONSTEXPR_DH bool operator<(common::half lhs, float rhs) noexcept;
+    friend CONSTEXPR_DH bool isinf(half val) noexcept;
+    friend CONSTEXPR_DH inline bool isnan(half val) noexcept;
+
+    CONSTEXPR_DH common::half operator-() const {
+#if defined(__CUDA_ARCH__)
+        return common::half(__hneg(data_));
+#else
+        return common::half(internal::binary, data_ ^ 0x8000);
+#endif
+    }
+
+    CONSTEXPR_DH common::half operator+() const { return *this; }
 };
+
+CONSTEXPR_DH static inline bool operator==(common::half lhs, common::half rhs) noexcept {
+#if defined(__CUDA_ARCH__)
+    return __heq(lhs.data_, rhs.data_);
+#else
+    return (lhs.data_ == rhs.data_ || !((lhs.data_ | rhs.data_) & 0x7FFF)) && !isnan(lhs);
+#endif
+}
+
+CONSTEXPR_DH static inline bool operator!=(common::half lhs, common::half rhs) noexcept {
+#if defined(__CUDA_ARCH__)
+    return __hne(lhs.data_, rhs.data_);
+#else
+    return !(lhs == rhs);
+#endif
+}
+
+CONSTEXPR_DH static inline bool operator<(common::half lhs,
+                                    common::half rhs) noexcept {
+#if defined(__CUDA_ARCH__)
+    return __hle(lhs.data_, rhs.data_);
+#else
+    int xabs = lhs.data_ & 0x7FFF, yabs = rhs.data_ & 0x7FFF;
+    return xabs <= 0x7C00 && yabs <= 0x7C00 &&
+           (((xabs == lhs.data_) ? xabs : -xabs) <
+            ((yabs == rhs.data_) ? yabs : -yabs));
+#endif
+}
+
+CONSTEXPR_DH static inline bool operator<(common::half lhs,
+                                    float rhs) noexcept {
+#if defined(__CUDA_ARCH__)
+    return static_cast<float>(lhs.data_) < rhs;
+#else
+    return static_cast<float>(lhs) < rhs;
+#endif
+}
 
 #ifndef __CUDA_ARCH__
 std::ostream& operator<<(std::ostream& os, const half& val);
+
+static inline std::string to_string(const half &&val) {
+    return std::to_string(static_cast<float>(val));
+}
 #endif
 
 }  // namespace common
 
 #if !defined(NVCC) && !defined(__CUDACC_RTC__)
+//#endif
 /// Extensions to the C++ standard library.
 namespace std {
 /// Numeric limits for half-precision floats.
@@ -801,12 +1121,28 @@ struct hash<common::half>  //: unary_function<common::half,size_t>
             -(*reinterpret_cast<uint16_t*>(&arg.data_) != 0x8000));
     }
 };
+
 }  // namespace std
+#endif
 
 namespace common {
-static bool isinf(::common::half val) noexcept {
-    return val == std::numeric_limits<::common::half>::infinity() ||
-           val == -std::numeric_limits<::common::half>::infinity();
-}
-}  // namespace common
+CONSTEXPR_DH
+static bool isinf(half val) noexcept {
+#ifdef __CUDA_ARCH__
+    return __hisinf(val.data_);
+#else
+    return val == std::numeric_limits<half>::infinity() ||
+           val == -std::numeric_limits<half>::infinity();
 #endif
+}
+
+CONSTEXPR_DH static inline bool isnan(half val) noexcept
+{
+#ifdef __CUDA_ARCH__
+    return __hisnan(val.data_);
+#else
+    return (val.data_ & 0x7FFF) > 0x7C00;
+#endif
+}
+
+}  // namespace common

--- a/src/backend/common/half.hpp
+++ b/src/backend/common/half.hpp
@@ -18,6 +18,7 @@
 #ifndef __CUDACC_RTC__
 #include <cstring>
 #include <ostream>
+#include <string>
 #include <type_traits>
 
 #include <limits>

--- a/src/backend/cpu/cast.hpp
+++ b/src/backend/cpu/cast.hpp
@@ -38,7 +38,7 @@ struct UnOp<To, common::half, af_cast_t> {
 
     void eval(jit::array<To> &out, const jit::array<Ti> &in, int lim) {
         for (int i = 0; i < lim; i++) {
-            float val = in[i];
+            float val = static_cast<float>(in[i]);
             out[i]    = To(val);
         }
     }
@@ -54,7 +54,7 @@ struct UnOp<common::half, Ti, af_cast_t> {
 
     void eval(jit::array<To> &out, const jit::array<Ti> &in, int lim) {
         for (int i = 0; i < lim; i++) {
-            float val = in[i];
+            float val = static_cast<float>(in[i]);
             out[i]    = To(val);
         }
     }

--- a/src/backend/cpu/diagonal.cpp
+++ b/src/backend/cpu/diagonal.cpp
@@ -11,12 +11,15 @@
 #include <kernel/diagonal.hpp>
 
 #include <Array.hpp>
+#include <common/half.hpp>
 #include <platform.hpp>
 #include <af/defines.h>
 #include <af/dim4.hpp>
 
 #include <algorithm>
 #include <cstdlib>
+
+using common::half;
 
 namespace cpu {
 
@@ -58,5 +61,6 @@ INSTANTIATE_DIAGONAL(char)
 INSTANTIATE_DIAGONAL(uchar)
 INSTANTIATE_DIAGONAL(short)
 INSTANTIATE_DIAGONAL(ushort)
+INSTANTIATE_DIAGONAL(half)
 
 }  // namespace cpu

--- a/src/backend/cpu/identity.cpp
+++ b/src/backend/cpu/identity.cpp
@@ -6,13 +6,16 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
-
-#include <Array.hpp>
 #include <identity.hpp>
 #include <kernel/identity.hpp>
+
+#include <Array.hpp>
+#include <common/half.hpp>
 #include <platform.hpp>
 #include <queue.hpp>
 #include <af/dim4.hpp>
+
+using common::half;
 
 namespace cpu {
 
@@ -40,5 +43,6 @@ INSTANTIATE_IDENTITY(char)
 INSTANTIATE_IDENTITY(uchar)
 INSTANTIATE_IDENTITY(short)
 INSTANTIATE_IDENTITY(ushort)
+INSTANTIATE_IDENTITY(half)
 
 }  // namespace cpu

--- a/src/backend/cpu/iota.cpp
+++ b/src/backend/cpu/iota.cpp
@@ -6,13 +6,16 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
-
-#include <Array.hpp>
 #include <iota.hpp>
 #include <kernel/iota.hpp>
+
+#include <Array.hpp>
+#include <common/half.hpp>
 #include <math.hpp>
 #include <platform.hpp>
 #include <queue.hpp>
+
+using common::half;
 
 namespace cpu {
 
@@ -39,5 +42,6 @@ INSTANTIATE(uintl)
 INSTANTIATE(uchar)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
+INSTANTIATE(half)
 
 }  // namespace cpu

--- a/src/backend/cpu/ireduce.cpp
+++ b/src/backend/cpu/ireduce.cpp
@@ -6,16 +6,19 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
-
-#include <Array.hpp>
 #include <ireduce.hpp>
 #include <kernel/ireduce.hpp>
+
+#include <Array.hpp>
+#include <common/half.hpp>
 #include <platform.hpp>
 #include <queue.hpp>
 #include <af/dim4.hpp>
+
 #include <complex>
 
 using af::dim4;
+using common::half;
 
 namespace cpu {
 
@@ -84,6 +87,7 @@ INSTANTIATE(af_min_t, char)
 INSTANTIATE(af_min_t, uchar)
 INSTANTIATE(af_min_t, short)
 INSTANTIATE(af_min_t, ushort)
+INSTANTIATE(af_min_t, half)
 
 // max
 INSTANTIATE(af_max_t, float)
@@ -98,5 +102,6 @@ INSTANTIATE(af_max_t, char)
 INSTANTIATE(af_max_t, uchar)
 INSTANTIATE(af_max_t, short)
 INSTANTIATE(af_max_t, ushort)
+INSTANTIATE(af_max_t, half)
 
 }  // namespace cpu

--- a/src/backend/cpu/jit/BinaryNode.hpp
+++ b/src/backend/cpu/jit/BinaryNode.hpp
@@ -29,17 +29,17 @@ struct BinOp {
 namespace jit {
 
 template<typename To, typename Ti, af_op_t op>
-class BinaryNode : public TNode<To> {
+class BinaryNode : public TNode<compute_t<To>> {
    protected:
-    BinOp<To, Ti, op> m_op;
-    TNode<Ti> *m_lhs, *m_rhs;
+    BinOp<compute_t<To>, compute_t<Ti>, op> m_op;
+    TNode<compute_t<Ti>> *m_lhs, *m_rhs;
 
    public:
     BinaryNode(Node_ptr lhs, Node_ptr rhs)
-        : TNode<To>(To(0), std::max(lhs->getHeight(), rhs->getHeight()) + 1,
+        : TNode<compute_t<To>>(compute_t<To>(0), std::max(lhs->getHeight(), rhs->getHeight()) + 1,
                     {{lhs, rhs}})
-        , m_lhs(reinterpret_cast<TNode<Ti> *>(lhs.get()))
-        , m_rhs(reinterpret_cast<TNode<Ti> *>(rhs.get())) {}
+        , m_lhs(reinterpret_cast<TNode<compute_t<Ti>> *>(lhs.get()))
+        , m_rhs(reinterpret_cast<TNode<compute_t<Ti>> *>(rhs.get())) {}
 
     void calc(int x, int y, int z, int w, int lim) final {
         UNUSED(x);

--- a/src/backend/cpu/jit/BufferNode.hpp
+++ b/src/backend/cpu/jit/BufferNode.hpp
@@ -57,7 +57,7 @@ class BufferNode : public TNode<T> {
         T *in_ptr   = m_ptr + l_off;
         Tc *out_ptr = this->m_val.data();
         for (int i = 0; i < lim; i++) {
-            out_ptr[i] = in_ptr[((x + i) < m_dims[0]) ? (x + i) : 0];
+            out_ptr[i] = static_cast<Tc>(in_ptr[((x + i) < m_dims[0]) ? (x + i) : 0]);
         }
     }
 
@@ -66,7 +66,9 @@ class BufferNode : public TNode<T> {
 
         T *in_ptr   = m_ptr + idx;
         Tc *out_ptr = this->m_val.data();
-        for (int i = 0; i < lim; i++) { out_ptr[i] = in_ptr[i]; }
+        for (int i = 0; i < lim; i++) {
+            out_ptr[i] = static_cast<Tc>(in_ptr[i]);
+        }
     }
 
     void getInfo(unsigned &len, unsigned &buf_count,

--- a/src/backend/cpu/jit/Node.hpp
+++ b/src/backend/cpu/jit/Node.hpp
@@ -105,7 +105,8 @@ class TNode : public Node {
     TNode(T val, const int height,
           const std::array<Node_ptr, kMaxChildren> children)
         : Node(height, children) {
-        m_val.fill(val);
+        using namespace common;
+        m_val.fill(static_cast<compute_t<T>>(val));
     }
 };
 

--- a/src/backend/cpu/kernel/iota.hpp
+++ b/src/backend/cpu/kernel/iota.hpp
@@ -16,18 +16,18 @@ namespace kernel {
 template<typename T>
 void iota(Param<T> output, const af::dim4& sdims) {
     const af::dim4 dims    = output.dims();
-    T* out                 = output.get();
+    data_t<T>* out      = output.get();
     const af::dim4 strides = output.strides();
 
     for (dim_t w = 0; w < dims[3]; w++) {
         dim_t offW = w * strides[3];
-        T valW     = (w % sdims[3]) * sdims[0] * sdims[1] * sdims[2];
+        dim_t valW     = (w % sdims[3]) * sdims[0] * sdims[1] * sdims[2];
         for (dim_t z = 0; z < dims[2]; z++) {
             dim_t offWZ = offW + z * strides[2];
-            T valZ      = valW + (z % sdims[2]) * sdims[0] * sdims[1];
+            dim_t valZ      = valW + (z % sdims[2]) * sdims[0] * sdims[1];
             for (dim_t y = 0; y < dims[1]; y++) {
                 dim_t offWZY = offWZ + y * strides[1];
-                T valY       = valZ + (y % sdims[1]) * sdims[0];
+                dim_t valY       = valZ + (y % sdims[1]) * sdims[0];
                 for (dim_t x = 0; x < dims[0]; x++) {
                     dim_t id = offWZY + x;
                     out[id]  = valY + (x % sdims[0]);

--- a/src/backend/cpu/kernel/random_engine.hpp
+++ b/src/backend/cpu/kernel/random_engine.hpp
@@ -197,13 +197,13 @@ void threefryUniform(T *out, size_t elements, const uintl seed, uintl counter) {
 
 template<typename T>
 void boxMullerTransform(data_t<T> *const out1, data_t<T> *const out2,
-                        const compute_t<T> r1, const compute_t<T> r2) {
+                        const T r1, const T r2) {
     /*
      * The log of a real value x where 0 < x < 1 is negative.
      */
     using Tc = compute_t<T>;
-    Tc r     = sqrt((Tc)(-2.0) * log((Tc)(1.0) - r1));
-    Tc theta = 2 * (Tc)PI_VAL * ((Tc)(1.0) - r2);
+    Tc r     = sqrt((Tc)(-2.0) * log((Tc)(1.0) - static_cast<Tc>(r1)));
+    Tc theta = 2 * (Tc)PI_VAL * ((Tc)(1.0) - static_cast<Tc>(r2));
     *out1    = r * sin(theta);
     *out2    = r * cos(theta);
 }

--- a/src/backend/cpu/kernel/range.hpp
+++ b/src/backend/cpu/kernel/range.hpp
@@ -9,6 +9,9 @@
 
 #pragma once
 #include <Param.hpp>
+#include <af/dim4.hpp>
+
+using af::dim4;
 
 namespace cpu {
 namespace kernel {

--- a/src/backend/cpu/kernel/reduce.hpp
+++ b/src/backend/cpu/kernel/reduce.hpp
@@ -37,7 +37,7 @@ struct reduce_dim {
 
 template<af_op_t op, typename Ti, typename To>
 struct reduce_dim<op, Ti, To, 0> {
-    Transform<Ti, compute_t<To>, op> transform;
+    Transform<data_t<Ti>, compute_t<To>, op> transform;
     Binary<compute_t<To>, op> reduce;
     void operator()(Param<To> out, const dim_t outOffset, CParam<Ti> in,
                     const dim_t inOffset, const int dim, bool change_nan,
@@ -45,8 +45,8 @@ struct reduce_dim<op, Ti, To, 0> {
         const af::dim4 istrides = in.strides();
         const af::dim4 idims    = in.dims();
 
-        To* const outPtr      = out.get() + outOffset;
-        Ti const* const inPtr = in.get() + inOffset;
+        data_t<To> * const outPtr      = out.get() + outOffset;
+        data_t<Ti> const* const inPtr = in.get() + inOffset;
         dim_t stride          = istrides[dim];
 
         compute_t<To> out_val = Binary<compute_t<To>, op>::init();

--- a/src/backend/cpu/kernel/select.hpp
+++ b/src/backend/cpu/kernel/select.hpp
@@ -81,8 +81,8 @@ void select_scalar(Param<T> out, CParam<char> cond, CParam<T> a,
     af::dim4 odims    = out.dims();
     af::dim4 ostrides = out.strides();
 
-    const T *aptr    = a.get();
-    T *optr          = out.get();
+    const data_t<T> *aptr    = a.get();
+    data_t<T> *optr          = out.get();
     const char *cptr = cond.get();
 
     bool is_a_same[] = {adims[0] == odims[0], adims[1] == odims[1],
@@ -108,7 +108,7 @@ void select_scalar(Param<T> out, CParam<char> cond, CParam<T> a,
 
                 for (int i = 0; i < odims[0]; i++) {
                     bool cval = is_c_same[0] ? cptr[c_off1 + i] : cptr[c_off1];
-                    T aval    = is_a_same[0] ? aptr[a_off1 + i] : aptr[a_off1];
+                    compute_t<T> aval    = is_a_same[0] ? aptr[a_off1 + i] : aptr[a_off1];
                     optr[o_off1 + i] = (flip ^ cval) ? aval : b;
                 }
             }

--- a/src/backend/cpu/kernel/select.hpp
+++ b/src/backend/cpu/kernel/select.hpp
@@ -81,9 +81,9 @@ void select_scalar(Param<T> out, CParam<char> cond, CParam<T> a,
     af::dim4 odims    = out.dims();
     af::dim4 ostrides = out.strides();
 
-    const data_t<T> *aptr    = a.get();
-    data_t<T> *optr          = out.get();
-    const char *cptr = cond.get();
+    const data_t<T> *aptr = a.get();
+    data_t<T> *optr       = out.get();
+    const char *cptr      = cond.get();
 
     bool is_a_same[] = {adims[0] == odims[0], adims[1] == odims[1],
                         adims[2] == odims[2], adims[3] == odims[3]};
@@ -108,7 +108,8 @@ void select_scalar(Param<T> out, CParam<char> cond, CParam<T> a,
 
                 for (int i = 0; i < odims[0]; i++) {
                     bool cval = is_c_same[0] ? cptr[c_off1 + i] : cptr[c_off1];
-                    compute_t<T> aval    = is_a_same[0] ? aptr[a_off1 + i] : aptr[a_off1];
+                    compute_t<T> aval = static_cast<compute_t<T>>(
+                        is_a_same[0] ? aptr[a_off1 + i] : aptr[a_off1]);
                     optr[o_off1 + i] = (flip ^ cval) ? aval : b;
                 }
             }

--- a/src/backend/cpu/range.cpp
+++ b/src/backend/cpu/range.cpp
@@ -6,17 +6,20 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#include <kernel/range.hpp>
+#include <range.hpp>
 
 #include <Array.hpp>
 #include <err_cpu.hpp>
-#include <kernel/range.hpp>
 #include <math.hpp>
 #include <platform.hpp>
 #include <queue.hpp>
-#include <range.hpp>
+
 #include <algorithm>
 #include <numeric>
 #include <stdexcept>
+
+using common::half;
 
 namespace cpu {
 
@@ -53,5 +56,6 @@ INSTANTIATE(uintl)
 INSTANTIATE(uchar)
 INSTANTIATE(ushort)
 INSTANTIATE(short)
+INSTANTIATE(half)
 
 }  // namespace cpu

--- a/src/backend/cpu/reduce.cpp
+++ b/src/backend/cpu/reduce.cpp
@@ -61,10 +61,10 @@ To reduce_all(const Array<Ti> &in, bool change_nan, double nanval) {
     in.eval();
     getQueue().sync();
 
-    Transform<Ti, To, op> transform;
-    Binary<To, op> reduce;
+    Transform<Ti, compute_t<To>, op> transform;
+    Binary<compute_t<To>, op> reduce;
 
-    compute_t<To> out = Binary<To, op>::init();
+    compute_t<To> out = Binary<compute_t<To>, op>::init();
 
     // Decrement dimension of select dimension
     af::dim4 dims           = in.dims();
@@ -83,7 +83,8 @@ To reduce_all(const Array<Ti> &in, bool change_nan, double nanval) {
                 for (dim_t i = 0; i < dims[0]; i++) {
                     dim_t idx = i + off1 + off2 + off3;
 
-                    compute_t<To> in_val = transform(inPtr[idx]);
+                    compute_t<To> in_val =
+                        transform(inPtr[idx]);
                     if (change_nan) in_val = IS_NAN(in_val) ? nanval : in_val;
                     out = reduce(in_val, out);
                 }

--- a/src/backend/cpu/triangle.cpp
+++ b/src/backend/cpu/triangle.cpp
@@ -6,13 +6,16 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#include <kernel/triangle.hpp>
+#include <triangle.hpp>
 
 #include <Array.hpp>
-#include <kernel/triangle.hpp>
+#include <common/half.hpp>
 #include <math.hpp>
 #include <platform.hpp>
-#include <triangle.hpp>
 #include <af/dim4.hpp>
+
+using common::half;
 
 namespace cpu {
 
@@ -53,5 +56,6 @@ INSTANTIATE(char)
 INSTANTIATE(uchar)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
+INSTANTIATE(half)
 
 }  // namespace cpu

--- a/src/backend/cuda/copy.cu
+++ b/src/backend/cuda/copy.cu
@@ -8,17 +8,12 @@
  ********************************************************/
 
 #include <Array.hpp>
+#include <common/complex.hpp>
+#include <common/half.hpp>
 #include <copy.hpp>
 #include <cuda_runtime_api.h>
 #include <err_cuda.hpp>
 #include <kernel/memcopy.hpp>
-#include <math.hpp>
-
-#include <Array.hpp>
-#include <common/complex.hpp>
-#include <common/half.hpp>
-#include <cuda_runtime_api.h>
-#include <err_cuda.hpp>
 #include <math.hpp>
 
 using common::half;
@@ -199,7 +194,7 @@ INSTANTIATE(half)
                                          Array<SRC_T> const &src);        \
     template void copyArray<SRC_T, half>(Array<half> & dst,               \
                                          Array<SRC_T> const &src);
-    
+
 INSTANTIATE_PAD_ARRAY(float)
 INSTANTIATE_PAD_ARRAY(double)
 INSTANTIATE_PAD_ARRAY(int)

--- a/src/backend/cuda/diagonal.cu
+++ b/src/backend/cuda/diagonal.cu
@@ -8,11 +8,14 @@
  ********************************************************/
 
 #include <Array.hpp>
+#include <common/half.hpp>
 #include <diagonal.hpp>
 #include <err_cuda.hpp>
 #include <kernel/diagonal.hpp>
 #include <math.hpp>
 #include <af/dim4.hpp>
+
+using common::half;
 
 namespace cuda {
 template<typename T>
@@ -53,5 +56,6 @@ INSTANTIATE_DIAGONAL(char)
 INSTANTIATE_DIAGONAL(uchar)
 INSTANTIATE_DIAGONAL(short)
 INSTANTIATE_DIAGONAL(ushort)
+INSTANTIATE_DIAGONAL(half)
 
 }  // namespace cuda

--- a/src/backend/cuda/identity.cu
+++ b/src/backend/cuda/identity.cu
@@ -6,12 +6,15 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
-
-#include <Array.hpp>
-#include <debug_cuda.hpp>
 #include <identity.hpp>
 #include <kernel/identity.hpp>
+
+#include <Array.hpp>
+#include <common/half.hpp>
+#include <debug_cuda.hpp>
 #include <af/dim4.hpp>
+
+using common::half;
 
 namespace cuda {
 template<typename T>
@@ -36,5 +39,6 @@ INSTANTIATE_IDENTITY(char)
 INSTANTIATE_IDENTITY(uchar)
 INSTANTIATE_IDENTITY(short)
 INSTANTIATE_IDENTITY(ushort)
+INSTANTIATE_IDENTITY(half)
 
 }  // namespace cuda

--- a/src/backend/cuda/iota.cu
+++ b/src/backend/cuda/iota.cu
@@ -8,11 +8,14 @@
  ********************************************************/
 
 #include <Array.hpp>
+#include <common/half.hpp>
 #include <err_cuda.hpp>
 #include <iota.hpp>
 #include <kernel/iota.hpp>
 #include <math.hpp>
 #include <stdexcept>
+
+using common::half;
 
 namespace cuda {
 template<typename T>
@@ -37,4 +40,5 @@ INSTANTIATE(uintl)
 INSTANTIATE(uchar)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
+INSTANTIATE(half)
 }  // namespace cuda

--- a/src/backend/cuda/ireduce.cu
+++ b/src/backend/cuda/ireduce.cu
@@ -6,18 +6,20 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#include <ireduce.hpp>
 
 #include <Array.hpp>
-#include <ireduce.hpp>
+#include <common/half.hpp>
 #include <af/dim4.hpp>
-#include <complex>
 
 #undef _GLIBCXX_USE_INT128
 #include <err_cuda.hpp>
 #include <kernel/ireduce.hpp>
+
 #include <complex>
 
 using af::dim4;
+using common::half;
 
 namespace cuda {
 
@@ -50,6 +52,7 @@ INSTANTIATE(af_min_t, short)
 INSTANTIATE(af_min_t, ushort)
 INSTANTIATE(af_min_t, char)
 INSTANTIATE(af_min_t, uchar)
+INSTANTIATE(af_min_t, half)
 
 // max
 INSTANTIATE(af_max_t, float)
@@ -64,4 +67,5 @@ INSTANTIATE(af_max_t, short)
 INSTANTIATE(af_max_t, ushort)
 INSTANTIATE(af_max_t, char)
 INSTANTIATE(af_max_t, uchar)
+INSTANTIATE(af_max_t, half)
 }  // namespace cuda

--- a/src/backend/cuda/kernel/iota.hpp
+++ b/src/backend/cuda/kernel/iota.hpp
@@ -41,7 +41,7 @@ __global__ void iota_kernel(Param<T> out, const int s0, const int s1,
 
     const int ozw = ow * out.strides[3] + oz * out.strides[2];
 
-    T val = (ow % s3) * s2 * s1 * s0;
+    dim_t val = (ow % s3) * s2 * s1 * s0;
     val += (oz % s2) * s1 * s0;
 
     const int incy = blocksPerMatY * blockDim.y;
@@ -49,7 +49,7 @@ __global__ void iota_kernel(Param<T> out, const int s0, const int s1,
 
     for (int oy = yy; oy < out.dims[1]; oy += incy) {
         int oyzw = ozw + oy * out.strides[1];
-        T valY   = val + (oy % s1) * s0;
+        dim_t valY   = val + (oy % s1) * s0;
         for (int ox = xx; ox < out.dims[0]; ox += incx) {
             int oidx = oyzw + ox;
 

--- a/src/backend/cuda/kernel/lookup.hpp
+++ b/src/backend/cuda/kernel/lookup.hpp
@@ -34,7 +34,7 @@ __global__ void lookup1D(Param<in_t> out, CParam<in_t> in,
     int en = min(out.dims[vDim], idx + THRD_LOAD * THREADS);
 
     for (int oIdx = idx; oIdx < en; oIdx += THREADS) {
-        int iIdx     = trimIndex(idxPtr[oIdx], in.dims[vDim]);
+        int iIdx     = trimIndex(static_cast<int>(idxPtr[oIdx]), in.dims[vDim]);
         outPtr[oIdx] = inPtr[iIdx];
     }
 }

--- a/src/backend/cuda/kernel/memcopy.hpp
+++ b/src/backend/cuda/kernel/memcopy.hpp
@@ -6,6 +6,7 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#pragma once
 
 #include <Param.hpp>
 #include <backend.hpp>
@@ -106,7 +107,7 @@ __inline__ __device__ cdouble scale<cdouble>(cdouble value, double factor) {
 
 template<typename inType, typename outType>
 __inline__ __device__ outType convertType(inType value) {
-    return (outType)value;
+    return static_cast<outType>(value);
 }
 
 template<>
@@ -147,12 +148,12 @@ __inline__ __device__ cfloat convertType<cdouble, cfloat>(cdouble value) {
 #define OTHER_SPECIALIZATIONS(IN_T)                                        \
     template<>                                                             \
     __inline__ __device__ cfloat convertType<IN_T, cfloat>(IN_T value) {   \
-        return make_cuFloatComplex(value, 0.0f);                           \
+        return make_cuFloatComplex(static_cast<float>(value), 0.0f);       \
     }                                                                      \
                                                                            \
     template<>                                                             \
     __inline__ __device__ cdouble convertType<IN_T, cdouble>(IN_T value) { \
-        return make_cuDoubleComplex(value, 0.0);                           \
+        return make_cuDoubleComplex(static_cast<double>(value), 0.0);      \
     }
 
 OTHER_SPECIALIZATIONS(float)

--- a/src/backend/cuda/kernel/range.hpp
+++ b/src/backend/cuda/kernel/range.hpp
@@ -13,6 +13,8 @@
 #include <err_cuda.hpp>
 #include <math.hpp>
 
+#include <type_traits>
+
 namespace cuda {
 namespace kernel {
 // Kernel Launch Config Values
@@ -45,17 +47,17 @@ __global__ void range_kernel(Param<T> out, const int dim,
 
     const int ozw = ow * out.strides[3] + oz * out.strides[2];
 
-    T valZW = (mul3 * ow) + (mul2 * oz);
+    int valZW = (mul3 * ow) + (mul2 * oz);
 
     const int incy = blocksPerMatY * blockDim.y;
     const int incx = blocksPerMatX * blockDim.x;
 
     for (int oy = yy; oy < out.dims[1]; oy += incy) {
-        T valYZW = valZW + (mul1 * oy);
-        int oyzw = ozw + oy * out.strides[1];
+        compute_t<T> valYZW = valZW + (mul1 * oy);
+        int oyzw     = ozw + oy * out.strides[1];
         for (int ox = xx; ox < out.dims[0]; ox += incx) {
-            int oidx = oyzw + ox;
-            T val    = valYZW + (ox * mul0);
+            int oidx         = oyzw + ox;
+            compute_t<T> val = valYZW + static_cast<compute_t<T>>(ox * mul0);
 
             out.ptr[oidx] = val;
         }

--- a/src/backend/cuda/kernel/reduce.hpp
+++ b/src/backend/cuda/kernel/reduce.hpp
@@ -68,13 +68,13 @@ __global__ static void reduce_dim_kernel(Param<To> out, CParam<Ti> in,
     bool is_valid = (ids[0] < in.dims[0]) && (ids[1] < in.dims[1]) &&
                     (ids[2] < in.dims[2]) && (ids[3] < in.dims[3]);
 
-    Transform<Ti, To, op> transform;
+    Transform<Ti, compute_t<To>, op> transform;
     Binary<compute_t<To>, op> reduce;
-    compute_t<To> out_val = Binary<To, op>::init();
+    compute_t<To> out_val = Binary<compute_t<To>, op>::init();
     for (int id = id_dim_in; is_valid && (id < in.dims[dim]);
          id += offset_dim * blockDim.y) {
         compute_t<To> in_val = transform(*iptr);
-        if (change_nan) in_val = !IS_NAN(in_val) ? in_val : nanval;
+        if (change_nan) in_val = !IS_NAN(in_val) ? in_val : compute_t<To>(nanval);
         out_val = reduce(in_val, out_val);
         iptr    = iptr + offset_dim * blockDim.y * istride_dim;
     }
@@ -196,7 +196,7 @@ __global__ static void reduce_first_kernel(Param<To> out, CParam<Ti> in,
     const uint xid        = blockIdx_x * blockDim.x * repeat + tidx;
 
     Binary<compute_t<To>, op> reduce;
-    Transform<Ti, To, op> transform;
+    Transform<Ti, compute_t<To>, op> transform;
 
     __shared__ compute_t<To> s_val[THREADS_PER_BLOCK];
 
@@ -213,10 +213,12 @@ __global__ static void reduce_first_kernel(Param<To> out, CParam<Ti> in,
 
     int lim = min((int)(xid + repeat * DIMX), in.dims[0]);
 
-    compute_t<To> out_val = Binary<To, op>::init();
+    compute_t<To> out_val = Binary<compute_t<To>, op>::init();
     for (int id = xid; id < lim; id += DIMX) {
         compute_t<To> in_val = transform(iptr[id]);
-        if (change_nan) in_val = !IS_NAN(in_val) ? in_val : nanval;
+        if (change_nan)
+            in_val =
+                !IS_NAN(in_val) ? in_val : static_cast<compute_t<To>>(nanval);
         out_val = reduce(in_val, out_val);
     }
 
@@ -388,7 +390,7 @@ To reduce_all(CParam<Ti> in, bool change_nan, double nanval) {
         CUDA_CHECK(cudaStreamSynchronize(cuda::getActiveStream()));
 
         Binary<compute_t<To>, op> reduce;
-        compute_t<To> out = Binary<To, op>::init();
+        compute_t<To> out = Binary<compute_t<To>, op>::init();
         for (int i = 0; i < tmp_elements; i++) {
             out = reduce(out, compute_t<To>(h_data[i]));
         }
@@ -404,7 +406,7 @@ To reduce_all(CParam<Ti> in, bool change_nan, double nanval) {
         Transform<Ti, compute_t<To>, op> transform;
         Binary<compute_t<To>, op> reduce;
         compute_t<To> out       = Binary<compute_t<To>, op>::init();
-        compute_t<To> nanval_to = scalar<To>(nanval);
+        compute_t<To> nanval_to = scalar<compute_t<To>>(nanval);
 
         for (int i = 0; i < in_elements; i++) {
             compute_t<To> in_val = transform(h_data[i]);

--- a/src/backend/cuda/math.hpp
+++ b/src/backend/cuda/math.hpp
@@ -29,6 +29,7 @@
 #include <backend.hpp>
 #include <types.hpp>
 #include <af/defines.h>
+#include <common/half.hpp>
 
 #include <cuda_fp16.h>
 #include <math_constants.h>
@@ -230,6 +231,22 @@ __device__ short minval<short>() {
 template<>
 __device__ ushort maxval<ushort>() {
     return ((ushort)1) << (8 * sizeof(ushort) - 1);
+}
+template<>
+__device__ common::half maxval<common::half>() {
+    return common::half(common::internal::binary, 0x7C00);
+}
+template<>
+__device__ common::half minval<common::half>() {
+    return common::half(common::internal::binary, 0xFC00);
+}
+template<>
+__device__ __half maxval<__half>() {
+    return 0x7C00;
+}
+template<>
+__device__ __half minval<__half>() {
+    return 0xFC00;
 }
 #endif
 

--- a/src/backend/cuda/math.hpp
+++ b/src/backend/cuda/math.hpp
@@ -234,19 +234,19 @@ __device__ ushort maxval<ushort>() {
 }
 template<>
 __device__ common::half maxval<common::half>() {
-    return common::half(common::internal::binary, 0x7C00);
+    return common::half(65537.f);
 }
 template<>
 __device__ common::half minval<common::half>() {
-    return common::half(common::internal::binary, 0xFC00);
+    return common::half(-65537.f);
 }
 template<>
 __device__ __half maxval<__half>() {
-    return 0x7C00;
+    return __float2half(65537.f);
 }
 template<>
 __device__ __half minval<__half>() {
-    return 0xFC00;
+    return __float2half(-65537.f);
 }
 #endif
 

--- a/src/backend/cuda/range.cu
+++ b/src/backend/cuda/range.cu
@@ -6,13 +6,16 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#include <range.hpp>
+#include <kernel/range.hpp>
 
 #include <Array.hpp>
 #include <err_cuda.hpp>
-#include <kernel/range.hpp>
 #include <math.hpp>
-#include <range.hpp>
+
 #include <stdexcept>
+
+using common::half;
 
 namespace cuda {
 template<typename T>
@@ -45,4 +48,5 @@ INSTANTIATE(uintl)
 INSTANTIATE(uchar)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
+INSTANTIATE(half)
 }  // namespace cuda

--- a/src/backend/cuda/transpose_inplace.cpp
+++ b/src/backend/cuda/transpose_inplace.cpp
@@ -8,11 +8,13 @@
  ********************************************************/
 
 #include <Array.hpp>
+#include <common/half.hpp>
 #include <kernel/transpose_inplace.hpp>
 #include <transpose.hpp>
 #include <af/dim4.hpp>
 
 using af::dim4;
+using common::half;
 
 namespace cuda {
 
@@ -39,5 +41,6 @@ INSTANTIATE(intl)
 INSTANTIATE(uintl)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
+INSTANTIATE(half)
 
 }  // namespace cuda

--- a/src/backend/cuda/triangle.cu
+++ b/src/backend/cuda/triangle.cu
@@ -6,13 +6,15 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
-
-#include <Array.hpp>
 #include <kernel/triangle.hpp>
 #include <triangle.hpp>
+
+#include <Array.hpp>
 #include <af/dim4.hpp>
+#include <common/half.hpp>
 
 using af::dim4;
+using common::half;
 
 namespace cuda {
 
@@ -53,4 +55,5 @@ INSTANTIATE(char)
 INSTANTIATE(uchar)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
+INSTANTIATE(half)
 }  // namespace cuda

--- a/src/backend/opencl/diagonal.cpp
+++ b/src/backend/opencl/diagonal.cpp
@@ -8,11 +8,14 @@
  ********************************************************/
 
 #include <Array.hpp>
+#include <common/half.hpp>
 #include <diagonal.hpp>
 #include <err_opencl.hpp>
 #include <kernel/diagonal.hpp>
 #include <math.hpp>
 #include <af/dim4.hpp>
+
+using common::half;
 
 namespace opencl {
 template<typename T>
@@ -53,5 +56,6 @@ INSTANTIATE_DIAGONAL(char)
 INSTANTIATE_DIAGONAL(uchar)
 INSTANTIATE_DIAGONAL(short)
 INSTANTIATE_DIAGONAL(ushort)
+INSTANTIATE_DIAGONAL(half)
 
 }  // namespace opencl

--- a/src/backend/opencl/identity.cpp
+++ b/src/backend/opencl/identity.cpp
@@ -6,12 +6,15 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
-
-#include <Array.hpp>
-#include <debug_opencl.hpp>
 #include <identity.hpp>
 #include <kernel/identity.hpp>
+
+#include <Array.hpp>
+#include <common/half.hpp>
+#include <debug_opencl.hpp>
 #include <af/dim4.hpp>
+
+using common::half;
 
 namespace opencl {
 template<typename T>
@@ -36,5 +39,6 @@ INSTANTIATE_IDENTITY(char)
 INSTANTIATE_IDENTITY(uchar)
 INSTANTIATE_IDENTITY(short)
 INSTANTIATE_IDENTITY(ushort)
+INSTANTIATE_IDENTITY(half)
 
 }  // namespace opencl

--- a/src/backend/opencl/iota.cpp
+++ b/src/backend/opencl/iota.cpp
@@ -6,13 +6,17 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
-
-#include <Array.hpp>
-#include <err_opencl.hpp>
 #include <iota.hpp>
 #include <kernel/iota.hpp>
+
+#include <Array.hpp>
+#include <common/half.hpp>
+#include <err_opencl.hpp>
 #include <math.hpp>
+
 #include <stdexcept>
+
+using common::half;
 
 namespace opencl {
 template<typename T>
@@ -37,4 +41,5 @@ INSTANTIATE(uintl)
 INSTANTIATE(uchar)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
+INSTANTIATE(half)
 }  // namespace opencl

--- a/src/backend/opencl/ireduce.cpp
+++ b/src/backend/opencl/ireduce.cpp
@@ -6,16 +6,18 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
-
-#include <Array.hpp>
-#include <err_opencl.hpp>
 #include <ireduce.hpp>
 #include <kernel/ireduce.hpp>
+
+#include <Array.hpp>
+#include <common/half.hpp>
+#include <err_opencl.hpp>
 #include <ops.hpp>
 #include <af/dim4.hpp>
 #include <complex>
 
 using af::dim4;
+using common::half;
 
 namespace opencl {
 
@@ -48,6 +50,7 @@ INSTANTIATE(af_min_t, char)
 INSTANTIATE(af_min_t, uchar)
 INSTANTIATE(af_min_t, short)
 INSTANTIATE(af_min_t, ushort)
+INSTANTIATE(af_min_t, half)
 
 // max
 INSTANTIATE(af_max_t, float)
@@ -62,4 +65,5 @@ INSTANTIATE(af_max_t, char)
 INSTANTIATE(af_max_t, uchar)
 INSTANTIATE(af_max_t, short)
 INSTANTIATE(af_max_t, ushort)
+INSTANTIATE(af_max_t, half)
 }  // namespace opencl

--- a/src/backend/opencl/magma/magma_blas_clblast.h
+++ b/src/backend/opencl/magma/magma_blas_clblast.h
@@ -58,7 +58,9 @@ template <typename T> typename CLBlastType<T>::Type inline toCLBlastConstant(con
 // Specializations of the above function
 template <> float inline toCLBlastConstant(const float val) { return val; }
 template <> double inline toCLBlastConstant(const double val) { return val; }
-template <> cl_half inline toCLBlastConstant(const common::half val) { return val; }
+template <> cl_half inline toCLBlastConstant(const common::half val) {
+    return static_cast<float>(val);
+}
 template <> std::complex<float> inline toCLBlastConstant(cfloat val) { return {val.s[0], val.s[1]}; }
 template <> std::complex<double> inline toCLBlastConstant(cdouble val) { return {val.s[0], val.s[1]}; }
 

--- a/src/backend/opencl/range.cpp
+++ b/src/backend/opencl/range.cpp
@@ -6,13 +6,16 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#include <kernel/range.hpp>
+#include <range.hpp>
 
 #include <Array.hpp>
+#include <common/half.hpp>
 #include <err_opencl.hpp>
-#include <kernel/range.hpp>
 #include <math.hpp>
-#include <range.hpp>
 #include <stdexcept>
+
+using common::half;
 
 namespace opencl {
 template<typename T>
@@ -45,4 +48,5 @@ INSTANTIATE(uintl)
 INSTANTIATE(uchar)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
+INSTANTIATE(half)
 }  // namespace opencl

--- a/src/backend/opencl/traits.hpp
+++ b/src/backend/opencl/traits.hpp
@@ -46,7 +46,9 @@ STATIC_ bool iscplx<cl_double2>() {
 
 template<typename T>
 STATIC_ std::string scalar_to_option(const T &val) {
-    return std::to_string(+val);
+    using namespace common;
+    using namespace std;
+    return to_string(+val);
 }
 
 template<>

--- a/src/backend/opencl/transpose_inplace.cpp
+++ b/src/backend/opencl/transpose_inplace.cpp
@@ -8,11 +8,13 @@
  ********************************************************/
 
 #include <Array.hpp>
+#include <common/half.hpp>
 #include <kernel/transpose_inplace.hpp>
 #include <transpose.hpp>
 #include <af/dim4.hpp>
 
 using af::dim4;
+using common::half;
 
 namespace opencl {
 
@@ -50,5 +52,6 @@ INSTANTIATE(intl)
 INSTANTIATE(uintl)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
+INSTANTIATE(half)
 
 }  // namespace opencl

--- a/src/backend/opencl/triangle.cpp
+++ b/src/backend/opencl/triangle.cpp
@@ -6,13 +6,15 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
-
-#include <Array.hpp>
 #include <kernel/triangle.hpp>
 #include <triangle.hpp>
+
+#include <Array.hpp>
 #include <af/dim4.hpp>
+#include <common/half.hpp>
 
 using af::dim4;
+using common::half;
 
 namespace opencl {
 
@@ -53,5 +55,6 @@ INSTANTIATE(char)
 INSTANTIATE(uchar)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
+INSTANTIATE(half)
 
 }  // namespace opencl

--- a/src/backend/opencl/types.cpp
+++ b/src/backend/opencl/types.cpp
@@ -30,7 +30,7 @@ template<>
 std::string ToNumStr<float>::operator()(float val) {
     static const char *PINF = "+INFINITY";
     static const char *NINF = "-INFINITY";
-    if (std::isinf(val)) { return val < 0 ? NINF : PINF; }
+    if (std::isinf(val)) { return val < 0.f ? NINF : PINF; }
     return std::to_string(val);
 }
 
@@ -38,7 +38,7 @@ template<>
 std::string ToNumStr<double>::operator()(double val) {
     static const char *PINF = "+INFINITY";
     static const char *NINF = "-INFINITY";
-    if (std::isinf(val)) { return val < 0 ? NINF : PINF; }
+    if (std::isinf(val)) { return val < 0. ? NINF : PINF; }
     return std::to_string(val);
 }
 
@@ -60,10 +60,12 @@ std::string ToNumStr<cdouble>::operator()(cdouble val) {
 
 template<>
 std::string ToNumStr<half>::operator()(half val) {
+    using namespace std;
+    using namespace common;
     static const char *PINF = "+INFINITY";
     static const char *NINF = "-INFINITY";
-    if (common::isinf(val)) { return val < 0 ? NINF : PINF; }
-    return std::to_string(val);
+    if (common::isinf(val)) { return val < 0.f ? NINF : PINF; }
+    return to_string(move(val));
 }
 
 template<>
@@ -71,7 +73,7 @@ template<>
 std::string ToNumStr<half>::operator()<float>(float val) {
     static const char *PINF = "+INFINITY";
     static const char *NINF = "-INFINITY";
-    if (common::isinf(half(val))) { return val < 0 ? NINF : PINF; }
+    if (common::isinf(half(val))) { return val < 0.f ? NINF : PINF; }
     return std::to_string(val);
 }
 

--- a/test/assign.cpp
+++ b/test/assign.cpp
@@ -34,13 +34,6 @@ using std::endl;
 using std::string;
 using std::vector;
 
-namespace half_float {
-std::ostream &operator<<(std::ostream &os, half_float::half val) {
-    os << (float)val;
-    return os;
-}
-}  // namespace half_float
-
 template<typename T>
 class ArrayAssign : public ::testing::Test {
    public:

--- a/test/compare.cpp
+++ b/test/compare.cpp
@@ -9,6 +9,7 @@
 
 #include <gtest/gtest.h>
 #include <testHelpers.hpp>
+#include <half.hpp>
 #include <af/arith.h>
 #include <af/array.h>
 #include <af/data.h>
@@ -22,7 +23,7 @@ template<typename T>
 class Compare : public ::testing::Test {};
 
 typedef ::testing::Types<float, double, uint, int, intl, uintl, uchar, short,
-                         ushort>
+                         ushort, half_float::half>
     TestTypes;
 TYPED_TEST_CASE(Compare, TestTypes);
 

--- a/test/constant.cpp
+++ b/test/constant.cpp
@@ -8,6 +8,7 @@
  ********************************************************/
 
 #include <gtest/gtest.h>
+#include <half.hpp>
 #include <testHelpers.hpp>
 #include <af/arith.h>
 #include <af/array.h>
@@ -28,7 +29,7 @@ template<typename T>
 class Constant : public ::testing::Test {};
 
 typedef ::testing::Types<float, cfloat, double, cdouble, int, unsigned, char,
-                         uchar, uintl, intl, short, ushort>
+                         uchar, uintl, intl, short, ushort, half_float::half>
     TestTypes;
 TYPED_TEST_CASE(Constant, TestTypes);
 
@@ -53,7 +54,7 @@ void ConstantCCheck(T value) {
 
     const int num = 1000;
     typedef typename dtype_traits<T>::base_type BT;
-    BT val    = ::real(value);
+    BT val(::real(value));
     dtype dty = (dtype)dtype_traits<T>::af_type;
     af_array out;
     dim_t dim[] = {(dim_t)num};
@@ -163,9 +164,9 @@ void IdentityCPPError() {
     SUCCEED();
 }
 
-TYPED_TEST(Constant, basicCPP) { ConstantCPPCheck<TypeParam>(5); }
+TYPED_TEST(Constant, basicCPP) { ConstantCPPCheck<TypeParam>(TypeParam(5)); }
 
-TYPED_TEST(Constant, basicC) { ConstantCCheck<TypeParam>(5); }
+TYPED_TEST(Constant, basicC) { ConstantCCheck<TypeParam>(TypeParam(5)); }
 
 TYPED_TEST(Constant, IdentityC) { IdentityCCheck<TypeParam>(); }
 

--- a/test/diagonal.cpp
+++ b/test/diagonal.cpp
@@ -9,7 +9,11 @@
 
 #include <arrayfire.h>
 #include <gtest/gtest.h>
+#include <half.hpp>
 #include <testHelpers.hpp>
+
+#include <cmath>
+#include <vector>
 
 using af::array;
 using af::constant;
@@ -22,13 +26,13 @@ using af::seq;
 using af::span;
 using af::sum;
 using std::abs;
-using std::endl;
 using std::vector;
 
 template<typename T>
 class Diagonal : public ::testing::Test {};
 
-typedef ::testing::Types<float, double, int, uint, char, unsigned char>
+typedef ::testing::Types<float, double, int, uint, char, unsigned char,
+                         half_float::half>
     TestTypes;
 TYPED_TEST_CASE(Diagonal, TestTypes);
 
@@ -54,7 +58,7 @@ TYPED_TEST(Diagonal, Create) {
                 }
             }
         }
-    } catch (const exception& ex) { FAIL() << ex.what() << endl; }
+    } catch (const exception& ex) { FAIL() << ex.what(); }
 }
 
 TYPED_TEST(Diagonal, DISABLED_CreateLargeDim) {
@@ -68,7 +72,7 @@ TYPED_TEST(Diagonal, DISABLED_CreateLargeDim) {
 
             ASSERT_EQ(largeDim, sum<float>(out));
         }
-    } catch (const exception& ex) { FAIL() << ex.what() << endl; }
+    } catch (const exception& ex) { FAIL() << ex.what(); }
 }
 
 TYPED_TEST(Diagonal, Extract) {
@@ -89,7 +93,7 @@ TYPED_TEST(Diagonal, Extract) {
                 ASSERT_EQ(input[i * data.dims(0) + i], h_out[i]);
             }
         }
-    } catch (const exception& ex) { FAIL() << ex.what() << endl; }
+    } catch (const exception& ex) { FAIL() << ex.what(); }
 }
 
 TYPED_TEST(Diagonal, ExtractLargeDim) {
@@ -109,7 +113,7 @@ TYPED_TEST(Diagonal, ExtractLargeDim) {
 
         ASSERT_EQ(n * largeDim, sum<float>(out1));
 
-    } catch (const exception& ex) { FAIL() << ex.what() << endl; }
+    } catch (const exception& ex) { FAIL() << ex.what(); }
 }
 
 TYPED_TEST(Diagonal, ExtractRect) {
@@ -135,7 +139,7 @@ TYPED_TEST(Diagonal, ExtractRect) {
                 }
             }
         }
-    } catch (const exception& ex) { FAIL() << ex.what() << endl; }
+    } catch (const exception& ex) { FAIL() << ex.what(); }
 }
 
 TEST(Diagonal, ExtractGFOR) {

--- a/test/iota.cpp
+++ b/test/iota.cpp
@@ -39,7 +39,7 @@ class Iota : public ::testing::Test {
 
 // create a list of types to be tested
 typedef ::testing::Types<float, double, int, unsigned int, intl, uintl,
-                         unsigned char, short, ushort>
+                         unsigned char, short, ushort, half_float::half>
     TestTypes;
 
 // register the type list

--- a/test/range.cpp
+++ b/test/range.cpp
@@ -10,6 +10,7 @@
 #include <arrayfire.h>
 #include <gtest/gtest.h>
 #include <testHelpers.hpp>
+#include <half.hpp>
 #include <af/defines.h>
 #include <af/dim4.hpp>
 #include <af/traits.hpp>
@@ -40,13 +41,22 @@ class Range : public ::testing::Test {
     vector<af_seq> subMat0;
 };
 
+template<typename T>
+class RangeMax : public Range<T> {};
+
+// create a list of types to be tested
+typedef ::testing::Types<float, double, int, unsigned int, intl, uintl,
+                         unsigned char, short, ushort, half_float::half>
+    AllTypes;
+
 // create a list of types to be tested
 typedef ::testing::Types<float, double, int, unsigned int, intl, uintl,
                          unsigned char, short, ushort>
-    TestTypes;
+    RegularTypes;
 
 // register the type list
-TYPED_TEST_CASE(Range, TestTypes);
+TYPED_TEST_CASE(Range, AllTypes);
+TYPED_TEST_CASE(RangeMax, RegularTypes);
 
 template<typename T>
 void rangeTest(const uint x, const uint y, const uint z, const uint w,
@@ -69,7 +79,7 @@ void rangeTest(const uint x, const uint y, const uint z, const uint w,
         for (int z = 0; z < (int)idims[2]; z++) {
             for (int y = 0; y < (int)idims[1]; y++) {
                 for (int x = 0; x < (int)idims[0]; x++) {
-                    T val = 0;
+                    T val(0);
                     if (dim == 0) {
                         val = x;
                     } else if (dim == 1) {
@@ -82,7 +92,7 @@ void rangeTest(const uint x, const uint y, const uint z, const uint w,
                     dim_t idx = w * idims[0] * idims[1] * idims[2] +
                                 z * idims[0] * idims[1] + y * idims[0] + x;
 
-                    ASSERT_EQ(val, outData[idx]) << "at: " << idx << endl;
+                    ASSERT_EQ(val, outData[idx]) << "at: " << idx;
                 }
             }
         }
@@ -111,10 +121,13 @@ RANGE_INIT(Range4D1, 10, 12, 5, 2, 1);
 RANGE_INIT(Range4D2, 25, 30, 2, 2, 2);
 RANGE_INIT(Range4D3, 25, 30, 2, 2, 3);
 
-RANGE_INIT(Range1DMaxDim0, 65535 * 32 + 1, 1, 1, 1, 0);
-RANGE_INIT(Range1DMaxDim1, 1, 65535 * 32 + 1, 1, 1, 0);
-RANGE_INIT(Range1DMaxDim2, 1, 1, 65535 * 32 + 1, 1, 0);
-RANGE_INIT(Range1DMaxDim3, 1, 1, 1, 65535 * 32 + 1, 0);
+#define RANGE_MAX_INIT(desc, x, y, z, w, rep) \
+    TYPED_TEST(RangeMax, desc) { rangeTest<TypeParam>(x, y, z, w, rep); }
+
+RANGE_MAX_INIT(Range1DMaxDim0, 65535 * 32 + 1, 1, 1, 1, 0);
+RANGE_MAX_INIT(Range1DMaxDim1, 1, 65535 * 32 + 1, 1, 1, 0);
+RANGE_MAX_INIT(Range1DMaxDim2, 1, 1, 65535 * 32 + 1, 1, 0);
+RANGE_MAX_INIT(Range1DMaxDim3, 1, 1, 1, 65535 * 32 + 1, 0);
 
 ///////////////////////////////// CPP ////////////////////////////////////
 //

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -46,6 +46,13 @@ std::ostream &operator<<(std::ostream &os, const af_half &val) {
     return os;
 }
 
+namespace half_float {
+std::ostream &operator<<(std::ostream &os, half_float::half val) {
+    os << (float)val;
+    return os;
+}
+}  // namespace half_float
+
 #define UNUSED(expr) \
     do { (void)(expr); } while (0)
 
@@ -543,7 +550,8 @@ af::array cpu_randu(const af::dim4 dims) {
     bool isTypeCplx = is_same_type<T, af::cfloat>::value ||
                       is_same_type<T, af::cdouble>::value;
     bool isTypeFloat =
-        is_same_type<BT, float>::value || is_same_type<BT, double>::value;
+      is_same_type<BT, float>::value || is_same_type<BT, double>::value ||
+      is_same_type<BT, half_float::half>::value;
 
     size_t elements = (isTypeCplx ? 2 : 1) * dims.elements();
 

--- a/test/transpose.cpp
+++ b/test/transpose.cpp
@@ -9,9 +9,11 @@
 
 #include <arrayfire.h>
 #include <gtest/gtest.h>
+#include <half.hpp>
 #include <testHelpers.hpp>
 #include <af/dim4.hpp>
 #include <af/traits.hpp>
+
 #include <string>
 #include <vector>
 
@@ -43,7 +45,7 @@ class Transpose : public ::testing::Test {
 
 // create a list of types to be tested
 typedef ::testing::Types<float, cfloat, double, cdouble, int, uint, char, uchar,
-                         short, ushort>
+                         short, ushort, half_float::half>
     TestTypes;
 
 // register the type list

--- a/test/triangle.cpp
+++ b/test/triangle.cpp
@@ -10,10 +10,12 @@
 #include <arrayfire.h>
 #include <gtest/gtest.h>
 #include <testHelpers.hpp>
+#include <half.hpp>
 #include <af/data.h>
 #include <af/defines.h>
 #include <af/dim4.hpp>
 #include <af/traits.hpp>
+
 #include <complex>
 #include <iostream>
 #include <string>
@@ -33,7 +35,7 @@ template<typename T>
 class Triangle : public ::testing::Test {};
 
 typedef ::testing::Types<float, cfloat, double, cdouble, int, unsigned, char,
-                         uchar, uintl, intl, short, ushort>
+                         uchar, uintl, intl, short, ushort, half_float::half>
     TestTypes;
 TYPED_TEST_CASE(Triangle, TestTypes);
 


### PR DESCRIPTION
Added half support for

- logical binary operations
- diagonal
- identity
- iota
- ireduce
- range
- triangle
- transpose
- transpose_inplace

Refactored half usage to be explicit.

The OpenCL backend compiles but it is probably broken for f16. I will
be testing that in another PR.