### PR TITLE
Fix half ComputeType for CudaCompute 6.1 GPUs

### DIFF
--- a/src/backend/cuda/blas.cpp
+++ b/src/backend/cuda/blas.cpp
@@ -193,7 +193,16 @@ template<>
 cudaDataType_t getComputeType<half>() {
     auto dev            = getDeviceProp(getActiveDeviceId());
     cudaDataType_t algo = getType<half>();
-    if (dev.major == 6 && dev.minor == 1) { algo = CUDA_R_32F; }
+    // There is probbaly a bug in nvidia cuda docs and/or drivers: According to
+    // https://docs.nvidia.com/cuda/cublas/index.html#cublas-GemmEx computeType
+    // could be 32F even if A/B inputs are 16F. But CudaCompute 6.1 GPUs (for
+    // example GTX10X0) dont seem to be capbale to compute at f32 when the
+    // inputs are f16: results are inf if trying to do so and cublasGemmEx even
+    // returns OK. At the moment let's comment out : the drawback is just that
+    // the speed of f16 computation on these GPUs is very slow:
+    //
+    // if (dev.major == // 6 && dev.minor == 1) { algo = CUDA_R_32F; }
+
     return algo;
 }
 

--- a/test/blas.cpp
+++ b/test/blas.cpp
@@ -397,6 +397,7 @@ TEST(MatrixMultiply, float) {
 }
 
 #ifndef AF_CPU
+
 TEST(MatrixMultiply, half) {
     SUPPORTED_TYPE_CHECK(af_half);
 
@@ -408,7 +409,7 @@ TEST(MatrixMultiply, half) {
         af_array C16 = 0;
         const half_float::half alpha16(1.0f);
         const half_float::half beta16(0.0f);
-        af_gemm(&C16, AF_MAT_NONE, AF_MAT_NONE, &alpha16, A16.get(), B16.get(), &beta16);
+        ASSERT_SUCCESS(af_gemm(&C16, AF_MAT_NONE, AF_MAT_NONE, &alpha16, A16.get(), B16.get(), &beta16));
         af::array C(C16);
         ASSERT_ARRAYS_NEAR(expected16, C, 0.00001);
     }
@@ -417,6 +418,7 @@ TEST(MatrixMultiply, half) {
         ASSERT_ARRAYS_NEAR(expected16, C16, 0.000001);
     }
 }
+
 #endif
 
 struct test_params {


### PR DESCRIPTION
Sadly the AF CI does nt test 6.1 GPUs so jenkins did nt catch that.
At least computation is now correct even if speed is bad.