### PR TITLE
Fix several OpenCL fp16 kernels.

### DIFF
--- a/src/backend/opencl/jit.cpp
+++ b/src/backend/opencl/jit.cpp
@@ -183,7 +183,9 @@ static Kernel getKernel(const vector<Node *> &output_nodes,
         Program prog;
         buildProgram(
             prog, 2, ker_strs, ker_lens,
-            isDoubleSupported(device) ? string(" -D USE_DOUBLE") : string(""));
+            (isDoubleSupported(device) ? string(" -D USE_DOUBLE") : string("")) +
+            (isHalfSupported(device) ? string(" -D USE_HALF") : string(""))
+                     );
 
         entry.prog = new Program(prog);
         entry.ker  = new Kernel(*entry.prog, funcName.c_str());

--- a/src/backend/opencl/kernel/identity.hpp
+++ b/src/backend/opencl/kernel/identity.hpp
@@ -10,6 +10,7 @@
 #include <Param.hpp>
 #include <cache.hpp>
 #include <common/dispatch.hpp>
+#include <common/half.hpp>
 #include <debug_opencl.hpp>
 #include <kernel_headers/identity.hpp>
 #include <math.hpp>
@@ -17,33 +18,40 @@
 #include <traits.hpp>
 #include "config.hpp"
 
-using af::scalar_to_option;
-using cl::Buffer;
-using cl::EnqueueArgs;
-using cl::Kernel;
-using cl::KernelFunctor;
-using cl::NDRange;
-using cl::Program;
-using std::ostringstream;
-using std::string;
-
 namespace opencl {
 namespace kernel {
 template<typename T>
 static void identity(Param out) {
-    std::string refName = std::string("identity_kernel") +
+
+    using af::scalar_to_option;
+    using cl::Buffer;
+    using cl::EnqueueArgs;
+    using cl::Kernel;
+    using cl::KernelFunctor;
+    using cl::NDRange;
+    using cl::Program;
+    using common::half;
+    using std::ostringstream;
+    using std::string;
+    using std::is_same;
+
+    string refName = std::string("identity_kernel") +
                           std::string(dtype_traits<T>::getName());
 
     int device       = getActiveDeviceId();
     kc_entry_t entry = kernelCache(device, refName);
 
     if (entry.prog == 0 && entry.ker == 0) {
-        std::ostringstream options;
+        ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName() << " -D ONE=(T)("
                 << scalar_to_option(scalar<T>(1)) << ")"
                 << " -D ZERO=(T)(" << scalar_to_option(scalar<T>(0)) << ")";
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
+        if (is_same<T, double>::value || is_same<T, cdouble>::value) {
             options << " -D USE_DOUBLE";
+        }
+
+        if (is_same<T, half>::value) {
+          options << " -D USE_HALF";
         }
 
         const char* ker_strs[] = {identity_cl};

--- a/src/backend/opencl/kernel/iota.hpp
+++ b/src/backend/opencl/kernel/iota.hpp
@@ -11,20 +11,13 @@
 #include <Param.hpp>
 #include <cache.hpp>
 #include <common/dispatch.hpp>
+#include <common/half.hpp>
 #include <debug_opencl.hpp>
 #include <kernel_headers/iota.hpp>
 #include <program.hpp>
 #include <traits.hpp>
 #include <af/dim4.hpp>
 #include <string>
-
-using cl::Buffer;
-using cl::EnqueueArgs;
-using cl::Kernel;
-using cl::KernelFunctor;
-using cl::NDRange;
-using cl::Program;
-using std::string;
 
 namespace opencl {
 namespace kernel {
@@ -36,6 +29,14 @@ static const int TILEY   = 32;
 
 template<typename T>
 void iota(Param out, const af::dim4& sdims) {
+    using cl::Buffer;
+    using cl::EnqueueArgs;
+    using cl::Kernel;
+    using cl::KernelFunctor;
+    using cl::NDRange;
+    using cl::Program;
+    using std::string;
+
     std::string refName =
         std::string("iota_kernel_") + std::string(dtype_traits<T>::getName());
 
@@ -48,6 +49,8 @@ void iota(Param out, const af::dim4& sdims) {
         options << " -D T=" << dtype_traits<T>::getName();
         if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
             options << " -D USE_DOUBLE";
+
+        if (std::is_same<T, common::half>::value) options << " -D USE_HALF";
 
         const char* ker_strs[] = {iota_cl};
         const int ker_lens[]   = {iota_cl_len};

--- a/src/backend/opencl/kernel/jit.cl
+++ b/src/backend/opencl/kernel/jit.cl
@@ -7,12 +7,6 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#pragma OPENCL EXTENSION all : enable
-#ifdef cl_khr_fp16
-#else
-#define half short
-#endif
-
 #define __select(cond, a, b) (cond) ? (a) : (b)
 #define __not_select(cond, a, b) (cond) ? (b) : (a)
 #define __circular_mod(a, b) ((a) < (b)) ? (a) : (a - b)

--- a/src/backend/opencl/kernel/ops.cl
+++ b/src/backend/opencl/kernel/ops.cl
@@ -63,6 +63,7 @@ uint transform(Ti in) { return (in != 0); }
 #ifdef MIN_OP
 
 #if CPLX
+#undef IS_NAN
 #define IS_NAN(in) !((in.x) == (in.x)) || !((in.y) == (in.y))
 #endif
 
@@ -83,6 +84,7 @@ T binOp(T lhs, T rhs) { return sabs(lhs) < sabs(rhs) ? lhs : rhs; }
 #ifdef MAX_OP
 
 #if CPLX
+#undef IS_NAN
 #define IS_NAN(in) !((in.x) == (in.x)) || !((in.y) == (in.y))
 #endif
 

--- a/src/backend/opencl/kernel/range.hpp
+++ b/src/backend/opencl/kernel/range.hpp
@@ -11,19 +11,12 @@
 #include <Param.hpp>
 #include <cache.hpp>
 #include <common/dispatch.hpp>
+#include <common/half.hpp>
 #include <debug_opencl.hpp>
 #include <kernel_headers/range.hpp>
 #include <program.hpp>
 #include <traits.hpp>
 #include <string>
-
-using cl::Buffer;
-using cl::EnqueueArgs;
-using cl::Kernel;
-using cl::KernelFunctor;
-using cl::NDRange;
-using cl::Program;
-using std::string;
 
 namespace opencl {
 namespace kernel {
@@ -35,6 +28,14 @@ static const int RANGE_TILEY = 32;
 
 template<typename T>
 void range(Param out, const int dim) {
+    using cl::Buffer;
+    using cl::EnqueueArgs;
+    using cl::Kernel;
+    using cl::KernelFunctor;
+    using cl::NDRange;
+    using cl::Program;
+    using std::string;
+
     std::string refName =
         std::string("range_kernel_") + std::string(dtype_traits<T>::getName());
 
@@ -46,6 +47,9 @@ void range(Param out, const int dim) {
         options << " -D T=" << dtype_traits<T>::getName();
         if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
             options << " -D USE_DOUBLE";
+
+        if (std::is_same<T, common::half>::value)
+          options << " -D USE_HALF";
 
         const char* ker_strs[] = {range_cl};
         const int ker_lens[]   = {range_cl_len};

--- a/src/backend/opencl/kernel/reduce.hpp
+++ b/src/backend/opencl/kernel/reduce.hpp
@@ -28,6 +28,12 @@
 #include "config.hpp"
 #include "names.hpp"
 
+#include <iostream>
+
+namespace opencl {
+
+namespace kernel {
+
 using cl::Buffer;
 using cl::EnqueueArgs;
 using cl::Kernel;
@@ -37,10 +43,6 @@ using cl::Program;
 using common::half;
 using std::string;
 using std::unique_ptr;
-
-namespace opencl {
-
-namespace kernel {
 
 template<typename Ti, typename To, af_op_t op>
 void reduce_dim_launcher(Param out, Param in, const int dim,
@@ -69,6 +71,11 @@ void reduce_dim_launcher(Param out, Param in, const int dim,
             std::is_same<Ti, cdouble>::value) {
             options << " -D USE_DOUBLE";
         }
+
+        if (std::is_same<Ti, half>::value) {
+          options << " -D USE_HALF";
+        }
+        std::cout << options.str() << "\n";
 
         const char *ker_strs[] = {ops_cl, reduce_dim_cl};
         const int ker_lens[]   = {ops_cl_len, reduce_dim_cl_len};

--- a/src/backend/opencl/kernel/reduce.hpp
+++ b/src/backend/opencl/kernel/reduce.hpp
@@ -28,10 +28,7 @@
 #include "config.hpp"
 #include "names.hpp"
 
-#include <iostream>
-
 namespace opencl {
-
 namespace kernel {
 
 using cl::Buffer;

--- a/src/backend/opencl/kernel/reduce.hpp
+++ b/src/backend/opencl/kernel/reduce.hpp
@@ -72,10 +72,9 @@ void reduce_dim_launcher(Param out, Param in, const int dim,
             options << " -D USE_DOUBLE";
         }
 
-        if (std::is_same<Ti, half>::value) {
-          options << " -D USE_HALF";
+        if (std::is_same<Ti, half>::value || std::is_same<To, half>::value) {
+            options << " -D USE_HALF";
         }
-        std::cout << options.str() << "\n";
 
         const char *ker_strs[] = {ops_cl, reduce_dim_cl};
         const int ker_lens[]   = {ops_cl_len, reduce_dim_cl_len};
@@ -171,6 +170,10 @@ void reduce_first_launcher(Param out, Param in, const uint groups_x,
         if (std::is_same<Ti, double>::value ||
             std::is_same<Ti, cdouble>::value) {
             options << " -D USE_DOUBLE";
+        }
+
+        if (std::is_same<Ti, half>::value || std::is_same<To, half>::value) {
+            options << " -D USE_HALF";
         }
 
         const char *ker_strs[] = {ops_cl, reduce_first_cl};

--- a/src/backend/opencl/kernel/transpose.cl
+++ b/src/backend/opencl/kernel/transpose.cl
@@ -15,12 +15,6 @@ T doOp(T in) {
 #define doOp(in) in
 #endif
 
-#pragma OPENCL EXTENSION all : enable
-#ifdef cl_khr_fp16
-#else
-#define half short
-#endif
-
 __kernel void transpose(__global T *oData, const KParam out,
                         const __global T *iData, const KParam in,
                         const int blocksPerMatX, const int blocksPerMatY) {

--- a/src/backend/opencl/kernel/transpose.hpp
+++ b/src/backend/opencl/kernel/transpose.hpp
@@ -18,14 +18,6 @@
 #include <types.hpp>
 #include <string>
 
-using cl::Buffer;
-using cl::EnqueueArgs;
-using cl::Kernel;
-using cl::KernelFunctor;
-using cl::NDRange;
-using cl::Program;
-using std::string;
-
 namespace opencl {
 namespace kernel {
 static const int TILE_DIM  = 32;
@@ -34,7 +26,15 @@ static const int THREADS_Y = 256 / TILE_DIM;
 
 template<typename T, bool conjugate, bool IS32MULTIPLE>
 void transpose(Param out, const Param in, cl::CommandQueue queue) {
-    std::string refName =
+    using cl::Buffer;
+    using cl::EnqueueArgs;
+    using cl::Kernel;
+    using cl::KernelFunctor;
+    using cl::NDRange;
+    using cl::Program;
+    using std::string;
+
+    string refName =
         std::string("transpose_") + std::string(dtype_traits<T>::getName()) +
         std::to_string(conjugate) + std::to_string(IS32MULTIPLE);
 
@@ -50,6 +50,8 @@ void transpose(Param out, const Param in, cl::CommandQueue queue) {
 
         if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
             options << " -D USE_DOUBLE";
+
+        if (std::is_same<T, common::half>::value) options << " -D USE_HALF";
 
         const char* ker_strs[] = {transpose_cl};
         const int ker_lens[]   = {transpose_cl_len};

--- a/src/backend/opencl/kernel/triangle.hpp
+++ b/src/backend/opencl/kernel/triangle.hpp
@@ -11,6 +11,7 @@
 #include <Param.hpp>
 #include <cache.hpp>
 #include <common/dispatch.hpp>
+#include <common/half.hpp>
 #include <debug_opencl.hpp>
 #include <kernel_headers/triangle.hpp>
 #include <math.hpp>
@@ -18,15 +19,6 @@
 #include <traits.hpp>
 #include <types.hpp>
 #include <string>
-
-using af::scalar_to_option;
-using cl::Buffer;
-using cl::EnqueueArgs;
-using cl::Kernel;
-using cl::KernelFunctor;
-using cl::NDRange;
-using cl::Program;
-using std::string;
 
 namespace opencl {
 namespace kernel {
@@ -42,6 +34,14 @@ void triangle(Param out, const Param in) {
                           std::string(dtype_traits<T>::getName()) +
                           std::to_string(is_upper) +
                           std::to_string(is_unit_diag);
+    using af::scalar_to_option;
+    using cl::Buffer;
+    using cl::EnqueueArgs;
+    using cl::Kernel;
+    using cl::KernelFunctor;
+    using cl::NDRange;
+    using cl::Program;
+    using std::string;
 
     int device       = getActiveDeviceId();
     kc_entry_t entry = kernelCache(device, refName);
@@ -55,6 +55,8 @@ void triangle(Param out, const Param in) {
                 << " -D ONE=(T)(" << scalar_to_option(scalar<T>(1)) << ")";
         if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
             options << " -D USE_DOUBLE";
+
+        if (std::is_same<T, common::half>::value) options << " -D USE_HALF";
 
         const char* ker_strs[] = {triangle_cl};
         const int ker_lens[]   = {triangle_cl_len};

--- a/src/backend/opencl/magma/magma_blas_clblast.h
+++ b/src/backend/opencl/magma/magma_blas_clblast.h
@@ -59,13 +59,14 @@ template <typename T> typename CLBlastType<T>::Type inline toCLBlastConstant(con
 template <> float inline toCLBlastConstant(const float val) { return val; }
 template <> double inline toCLBlastConstant(const double val) { return val; }
 template <> cl_half inline toCLBlastConstant(const common::half val) {
-    return static_cast<float>(val);
+    return static_cast<cl_half>(static_cast<float>(val));
 }
 template <> std::complex<float> inline toCLBlastConstant(cfloat val) { return {val.s[0], val.s[1]}; }
 template <> std::complex<double> inline toCLBlastConstant(cdouble val) { return {val.s[0], val.s[1]}; }
 
 // Conversions to CLBlast basic types
 template <typename T> struct CLBlastBasicType { using Type = T; };
+template <> struct CLBlastBasicType<common::half> { using Type = cl_half; };
 template <> struct CLBlastBasicType<cfloat> { using Type = float; };
 template <> struct CLBlastBasicType<cdouble> { using Type = double; };
 

--- a/src/backend/opencl/program.cpp
+++ b/src/backend/opencl/program.cpp
@@ -25,6 +25,11 @@ const static std::string DEFAULT_MACROS_STR(
                                            #ifdef USE_DOUBLE\n\
                                            #pragma OPENCL EXTENSION cl_khr_fp64 : enable\n\
                                            #endif\n                     \
+                                           #ifdef USE_HALF\n\
+                                           #pragma OPENCL EXTENSION cl_khr_fp16 : enable\n\
+                                           #else\n                     \
+                                           #define half short\n          \
+                                           #endif\n                      \
                                            #ifndef M_PI\n               \
                                            #define M_PI 3.1415926535897932384626433832795028841971693993751058209749445923078164\n \
                                            #endif\n                     \

--- a/test/math.cpp
+++ b/test/math.cpp
@@ -24,7 +24,7 @@ using std::abs;
 using std::endl;
 using std::vector;
 
-const int num        = 10000;
+const int num        = 300;
 const float hlf_err  = 1e-2;
 const float flt_err  = 1e-3;
 const double dbl_err = 1e-10;

--- a/test/math.cpp
+++ b/test/math.cpp
@@ -24,7 +24,7 @@ using std::abs;
 using std::endl;
 using std::vector;
 
-const int num        = 300;
+const int num        = 10000;
 const float hlf_err  = 1e-2;
 const float flt_err  = 1e-3;
 const double dbl_err = 1e-10;


### PR DESCRIPTION
Fixes the following kernels on the AMD Vega card with fp16 kernels.

- rotate
- triangle
- reduce
- JIT
- identity
- lookup
- random
- range
- transpose
- iota

Not addressed in this PR:

- matmul(half test is failing on clblast)
- JIT LargeTree kernel is still failing
- rotate is still failing for the short datatype
- iota is failing because of rounding issues between the two fp16 types