### PR TITLE
Fix OpenCL compilation error for ROCm sparse

### DIFF
--- a/src/backend/opencl/kernel/csrmv.cl
+++ b/src/backend/opencl/kernel/csrmv.cl
@@ -101,6 +101,9 @@ __kernel void csrmv_block(__global T *output, __global const T *values,
     int rowNext = get_group_id(0);
     __local int s_rowId;
 
+    // Each thread stores part of the output result
+    __local T s_outval[THREADS];
+
     // Each groups performs multiple "dot" operations
     while (true) {
 #if USE_GREEDY
@@ -119,9 +122,6 @@ __kernel void csrmv_block(__global T *output, __global const T *values,
         rowNext += get_num_groups(0);
 #endif
         if (rowId >= M) return;
-
-        // Each thread stores part of the output result
-        __local T s_outval[THREADS];
 
         int colStart = rowidx[rowId];
         int colEnd   = rowidx[rowId + 1];


### PR DESCRIPTION
Fixed the following error when using OpenCL on the ROCm OpenCL implementation:

```
/tmp/AMD_34411_1492/t_34411_1494.cl:162:19: error: variables in the local address space can only be declared in the outermost scope of a kernel function
        __local T s_outval[THREADS];
                  ^
1 error generated.
Error: Failed to compile opencl source (from CL to LLVM IR).
```