### PR TITLE
Let af_approx1 allocate the output array, have af_approx1_v2 accept preallocated outputs

### DIFF
--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -776,6 +776,9 @@ extern "C" {
 AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
                         const af_interp_type method, const float off_grid);
 
+AFAPI af_err af_approx1_v2(af_array *out, const af_array in, const af_array pos,
+                           const af_interp_type method, const float off_grid);
+
 /**
    C Interface for signals interpolation on two dimensional signals.
 
@@ -839,6 +842,11 @@ AFAPI af_err af_approx1_uniform(af_array *out, const af_array in,
                                 const af_array pos, const int interp_dim,
                                 const double idx_start, const double idx_step,
                                 const af_interp_type method, const float off_grid);
+
+AFAPI af_err af_approx1_uniform_v2(af_array *out, const af_array in,
+                                   const af_array pos, const int interp_dim,
+                                   const double idx_start, const double idx_step,
+                                   const af_interp_type method, const float off_grid);
 
 /**
    C Interface for signals interpolation on two dimensional signals alog specified dimensions.

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -767,10 +767,6 @@ extern "C" {
    \return        \ref AF_SUCCESS if the interpolation operation is successful,
                   otherwise an appropriate error code is returned.
 
-   \note \p out can either be a null or existing `af_array` object. If it is a
-         sub-array of an existing `af_array`, only the corresponding portion of
-         the `af_array` will be overwritten
-
    \ingroup signal_func_approx1
  */
 AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
@@ -855,10 +851,6 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
                              valid range of indices.
    \return        \ref AF_SUCCESS if the interpolation operation is successful,
                   otherwise an appropriate error code is returned.
-
-   \note \p out can either be a null or existing `af_array` object. If it is a
-         sub-array of an existing `af_array`, only the corresponding portion of
-         the `af_array` will be overwritten
 
    \ingroup signal_func_approx1
  */

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -772,6 +772,7 @@ extern "C" {
 AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
                         const af_interp_type method, const float off_grid);
 
+#if AF_API_VERSION >= 37
 /**
    C Interface for the version of \ref af_approx1 that accepts a preallocated
    output array
@@ -793,11 +794,14 @@ AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
    \note \p out can either be a null or existing `af_array` object. If it is a
          sub-array of an existing `af_array`, only the corresponding portion of
          the `af_array` will be overwritten
+   \note Passing an `af_array` that has not been initialized to \p out will cause
+         undefined behavior.
 
    \ingroup signal_func_approx1
  */
 AFAPI af_err af_approx1_v2(af_array *out, const af_array in, const af_array pos,
                            const af_interp_type method, const float off_grid);
+#endif
 
 /**
    C Interface for signals interpolation on two dimensional signals.
@@ -885,6 +889,8 @@ AFAPI af_err af_approx1_uniform(af_array *out, const af_array in,
    \note \p out can either be a null or existing `af_array` object. If it is a
          sub-array of an existing `af_array`, only the corresponding portion of
          the `af_array` will be overwritten
+   \note Passing an `af_array` to \p out that has not been initialized will cause
+         undefined behavior.
 
    \ingroup signal_func_approx1
  */

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -753,7 +753,7 @@ extern "C" {
 /**
    C Interface for signals interpolation on one dimensional signals.
 
-   \param[in,out] out      is the interpolated array.
+   \param[out]    out      is the interpolated array.
    \param[in]     in       is the multidimensional input array. Values assumed to
                            lie uniformly spaced indices in the range of `[0, n)`,
                            where `n` is the number of elements in the array.
@@ -776,6 +776,30 @@ extern "C" {
 AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
                         const af_interp_type method, const float off_grid);
 
+/**
+   C Interface for the version of \ref af_approx1 that accepts a preallocated
+   output array
+
+   \param[in,out] out      is the interpolated array (can be preallocated).
+   \param[in]     in       is the multidimensional input array. Values assumed to
+                           lie uniformly spaced indices in the range of `[0, n)`,
+                           where `n` is the number of elements in the array.
+   \param[in]     pos      positions of the interpolation points along the first
+                           dimension.
+   \param[in]     method   is the interpolation method to be used. The following
+                           types (defined in enum \ref af_interp_type)
+                           are supported: nearest neighbor, linear, and cubic.
+   \param[in]     off_grid is the default value for any indices outside the
+                           valid range of indices.
+   \return        \ref AF_SUCCESS if the interpolation operation is successful,
+                  otherwise an appropriate error code is returned.
+
+   \note \p out can either be a null or existing `af_array` object. If it is a
+         sub-array of an existing `af_array`, only the corresponding portion of
+         the `af_array` will be overwritten
+
+   \ingroup signal_func_approx1
+ */
 AFAPI af_err af_approx1_v2(af_array *out, const af_array in, const af_array pos,
                            const af_interp_type method, const float off_grid);
 
@@ -813,7 +837,7 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
    The blue dots represent indices whose values are known. The red dots
    represent indices whose values are unknown.
 
-   \param[in,out] out        the interpolated array.
+   \param[out]    out        the interpolated array.
    \param[in]     in         is the multidimensional input array. Values lie on
                              uniformly spaced indices determined by `idx_start`
                              and `idx_step`.
@@ -843,6 +867,35 @@ AFAPI af_err af_approx1_uniform(af_array *out, const af_array in,
                                 const double idx_start, const double idx_step,
                                 const af_interp_type method, const float off_grid);
 
+/**
+   C Interface for the version of \ref af_approx1_uniform that accepts a
+   preallocated output array
+
+   \param[in,out] out        the interpolated array (can be preallocated).
+   \param[in]     in         is the multidimensional input array. Values lie on
+                             uniformly spaced indices determined by `idx_start`
+                             and `idx_step`.
+   \param[in]     pos        positions of the interpolation points along
+                             `interp_dim`.
+   \param[in]     interp_dim is the dimension to perform interpolation across.
+   \param[in]     idx_start  is the first index value along `interp_dim`.
+   \param[in]     idx_step   is the uniform spacing value between subsequent
+                             indices along `interp_dim`.
+   \param[in]     method     is the interpolation method to be used. The
+                             following types (defined in enum
+                             \ref af_interp_type) are supported: nearest
+                             neighbor, linear, and cubic.
+   \param[in]     off_grid   is the default value for any indices outside the
+                             valid range of indices.
+   \return        \ref AF_SUCCESS if the interpolation operation is successful,
+                  otherwise an appropriate error code is returned.
+
+   \note \p out can either be a null or existing `af_array` object. If it is a
+         sub-array of an existing `af_array`, only the corresponding portion of
+         the `af_array` will be overwritten
+
+   \ingroup signal_func_approx1
+ */
 AFAPI af_err af_approx1_uniform_v2(af_array *out, const af_array in,
                                    const af_array pos, const int interp_dim,
                                    const double idx_start, const double idx_step,

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -43,11 +43,10 @@ static inline af_array approx2(const af_array zi, const af_array xo,
                                  yi_beg, yi_step, method, offGrid));
 }
 
-af_err af_approx1_common(af_array *yo, const af_array yi,
-                         const af_array xo, const int xdim,
-                         const double xi_beg, const double xi_step,
-                         const af_interp_type method, const float offGrid,
-                         const bool allocate_yo) {
+af_err af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
+                         const int xdim, const double xi_beg,
+                         const double xi_step, const af_interp_type method,
+                         const float offGrid, const bool allocate_yo) {
     try {
         const ArrayInfo &yi_info = getInfo(yi);
         const ArrayInfo &xo_info = getInfo(xo);
@@ -76,7 +75,7 @@ af_err af_approx1_common(af_array *yo, const af_array yi,
                        method == AF_INTERP_LOWER         ||
                        method == AF_INTERP_NEAREST));
 
-        if (yi_dims.ndims() == 0 || xo_dims.ndims() ==  0) {
+        if (yi_dims.ndims() == 0 || xo_dims.ndims() == 0) {
             return af_create_handle(yo, 0, nullptr, yi_info.getType());
         }
 
@@ -113,18 +112,20 @@ af_err af_approx1_common(af_array *yo, const af_array yi,
     return AF_SUCCESS;
 }
 
-af_err af_approx1_uniform(af_array *yo, const af_array yi,
-                          const af_array xo, const int xdim,
-                          const double xi_beg, const double xi_step,
-                          const af_interp_type method, const float offGrid) {
-    return af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid, true);
+af_err af_approx1_uniform(af_array *yo, const af_array yi, const af_array xo,
+                          const int xdim, const double xi_beg,
+                          const double xi_step, const af_interp_type method,
+                          const float offGrid) {
+    return af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid,
+                             true);
 }
 
 af_err af_approx1_uniform_v2(af_array *yo, const af_array yi, const af_array xo,
                              const int xdim, const double xi_beg,
                              const double xi_step, const af_interp_type method,
                              const float offGrid) {
-    return af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid, *yo == 0);
+    return af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid,
+                             *yo == 0);
 }
 
 af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
@@ -134,7 +135,8 @@ af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
 
 af_err af_approx1_v2(af_array *yo, const af_array yi, const af_array xo,
                      const af_interp_type method, const float offGrid) {
-    return af_approx1_common(yo, yi, xo, 0, 0.0, 1.0, method, offGrid, *yo == 0);
+    return af_approx1_common(yo, yi, xo, 0, 0.0, 1.0, method, offGrid,
+                             *yo == 0);
 }
 
 af_err af_approx2_uniform(af_array *zo, const af_array zi, const af_array xo,

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -124,6 +124,8 @@ af_err af_approx1_uniform_v2(af_array *yo, const af_array yi, const af_array xo,
                              const int xdim, const double xi_beg,
                              const double xi_step, const af_interp_type method,
                              const float offGrid) {
+    // For a "v2" function, assume that the output has already been initialized
+    // either to null or an existing af_array
     return af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid,
                              *yo == 0);
 }
@@ -135,6 +137,8 @@ af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
 
 af_err af_approx1_v2(af_array *yo, const af_array yi, const af_array xo,
                      const af_interp_type method, const float offGrid) {
+    // For a "v2" function, assume that the output has already been initialized
+    // either to null or an existing af_array
     return af_approx1_common(yo, yi, xo, 0, 0.0, 1.0, method, offGrid,
                              *yo == 0);
 }

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -125,19 +125,7 @@ af_err af_approx1_uniform_v2(af_array *yo, const af_array yi, const af_array xo,
                              const int xdim, const double xi_beg,
                              const double xi_step, const af_interp_type method,
                              const float offGrid) {
-    const ArrayInfo &yi_info = getInfo(yi);
-    const ArrayInfo &xo_info = getInfo(xo);
-
-    const dim4 yi_dims = yi_info.dims();
-    const dim4 xo_dims = xo_info.dims();
-
-    dim4 yo_dims  = yi_dims;
-    yo_dims[xdim] = xo_dims[xdim];
-    if (*yo == 0) { *yo = createHandle(yo_dims, yi_info.getType()); }
-
-    DIM_ASSERT(1, getInfo(*yo).dims() == yo_dims);
-
-    return af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid, false);
+    return af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid, *yo == 0);
 }
 
 af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
@@ -147,20 +135,7 @@ af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
 
 af_err af_approx1_v2(af_array *yo, const af_array yi, const af_array xo,
                      const af_interp_type method, const float offGrid) {
-    const ArrayInfo &yi_info = getInfo(yi);
-    const ArrayInfo &xo_info = getInfo(xo);
-
-    const dim4 yi_dims = yi_info.dims();
-    const dim4 xo_dims = xo_info.dims();
-    const int xdim = 0;
-
-    dim4 yo_dims  = yi_dims;
-    yo_dims[xdim] = xo_dims[xdim];
-    if (*yo == 0) { *yo = createHandle(yo_dims, yi_info.getType()); }
-
-    DIM_ASSERT(1, getInfo(*yo).dims() == yo_dims);
-
-    return af_approx1_common(yo, yi, xo, xdim, 0.0, 1.0, method, offGrid, false);
+    return af_approx1_common(yo, yi, xo, 0, 0.0, 1.0, method, offGrid, *yo == 0);
 }
 
 af_err af_approx2_uniform(af_array *zo, const af_array zi, const af_array xo,

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -122,9 +122,21 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi,
 }
 
 af_err af_approx1_uniform_v2(af_array *yo, const af_array yi, const af_array xo,
-                          const int xdim, const double xi_beg,
-                          const double xi_step, const af_interp_type method,
-                          const float offGrid) {
+                             const int xdim, const double xi_beg,
+                             const double xi_step, const af_interp_type method,
+                             const float offGrid) {
+    const ArrayInfo &yi_info = getInfo(yi);
+    const ArrayInfo &xo_info = getInfo(xo);
+
+    const dim4 yi_dims = yi_info.dims();
+    const dim4 xo_dims = xo_info.dims();
+
+    dim4 yo_dims  = yi_dims;
+    yo_dims[xdim] = xo_dims[xdim];
+    if (*yo == 0) { *yo = createHandle(yo_dims, yi_info.getType()); }
+
+    DIM_ASSERT(1, getInfo(*yo).dims() == yo_dims);
+
     return af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid, false);
 }
 
@@ -134,7 +146,7 @@ af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
 }
 
 af_err af_approx1_v2(af_array *yo, const af_array yi, const af_array xo,
-                  const af_interp_type method, const float offGrid) {
+                     const af_interp_type method, const float offGrid) {
     const ArrayInfo &yi_info = getInfo(yi);
     const ArrayInfo &xo_info = getInfo(xo);
 

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -52,8 +52,8 @@ af_err af_approx1_common(af_array *yo, const af_array yi,
         const ArrayInfo &yi_info = getInfo(yi);
         const ArrayInfo &xo_info = getInfo(xo);
 
-        dim4 yi_dims = yi_info.dims();
-        dim4 xo_dims = xo_info.dims();
+        const dim4 yi_dims = yi_info.dims();
+        const dim4 xo_dims = xo_info.dims();
 
         ARG_ASSERT(1, yi_info.isFloating());                        // Only floating and complex types
         ARG_ASSERT(2, xo_info.isRealFloating()) ;                   // Only floating types

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -47,11 +47,10 @@ af_err af_approx1_common(af_array *yo, const af_array yi,
                          const af_array xo, const int xdim,
                          const double xi_beg, const double xi_step,
                          const af_interp_type method, const float offGrid,
-                         const bool allocate_yo)
-{
+                         const bool allocate_yo) {
     try {
-        const ArrayInfo& yi_info = getInfo(yi);
-        const ArrayInfo& xo_info = getInfo(xo);
+        const ArrayInfo &yi_info = getInfo(yi);
+        const ArrayInfo &xo_info = getInfo(xo);
 
         dim4 yi_dims = yi_info.dims();
         dim4 xo_dims = xo_info.dims();

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -57,6 +57,8 @@ af_err af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
 
         const dim4 yi_dims = yi_info.dims();
         const dim4 xo_dims = xo_info.dims();
+        dim4 yo_dims  = yi_dims;
+        yo_dims[xdim] = xo_dims[xdim];
 
         ARG_ASSERT(1, yi_info.isFloating());                        // Only floating and complex types
         ARG_ASSERT(2, xo_info.isRealFloating()) ;                   // Only floating types
@@ -84,12 +86,10 @@ af_err af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
         }
 
         if (allocate_yo) {
-            dim4 yo_dims  = yi_dims;
-            yo_dims[xdim] = xo_dims[xdim];
             *yo = createHandle(yo_dims, yi_info.getType());
-
-            DIM_ASSERT(1, getInfo(*yo).dims() == yo_dims);
         }
+
+        DIM_ASSERT(1, getInfo(*yo).dims() == yo_dims);
 
         switch (yi_info.getType()) {
             case f32:

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -43,7 +43,75 @@ static inline af_array approx2(const af_array zi, const af_array xo,
                                  yi_beg, yi_step, method, offGrid));
 }
 
-af_err af_approx1_uniform(af_array *yo, const af_array yi, const af_array xo,
+af_err af_approx1_uniform(af_array *yo, const af_array yi,
+                          const af_array xo, const int xdim,
+                          const double xi_beg, const double xi_step,
+                          const af_interp_type method, const float offGrid)
+{
+    try {
+        const ArrayInfo& yi_info = getInfo(yi);
+        const ArrayInfo& xo_info = getInfo(xo);
+
+        dim4 yi_dims = yi_info.dims();
+        dim4 xo_dims = xo_info.dims();
+
+        ARG_ASSERT(1, yi_info.isFloating());                        // Only floating and complex types
+        ARG_ASSERT(2, xo_info.isRealFloating()) ;                   // Only floating types
+        ARG_ASSERT(1, yi_info.isSingle() == xo_info.isSingle());    // Must have same precision
+        ARG_ASSERT(1, yi_info.isDouble() == xo_info.isDouble());    // Must have same precision
+        ARG_ASSERT(3, xdim >= 0 && xdim < 4);
+
+        // POS should either be (x, 1, 1, 1) or (1, yi_dims[1], yi_dims[2], yi_dims[3])
+        if (xo_dims[xdim] != xo_dims.elements()) {
+            for (int i = 0; i < 4; i++) {
+                if (xdim != i) DIM_ASSERT(2, xo_dims[i] == yi_dims[i]);
+            }
+        }
+
+        ARG_ASSERT(5, xi_step != 0);
+        ARG_ASSERT(6, (method == AF_INTERP_CUBIC         ||
+                       method == AF_INTERP_CUBIC_SPLINE  ||
+                       method == AF_INTERP_LINEAR        ||
+                       method == AF_INTERP_LINEAR_COSINE ||
+                       method == AF_INTERP_LOWER         ||
+                       method == AF_INTERP_NEAREST));
+
+        if (yi_dims.ndims() == 0 || xo_dims.ndims() ==  0) {
+            return af_create_handle(yo, 0, nullptr, yi_info.getType());
+        }
+
+        dim4 yo_dims  = yi_dims;
+        yo_dims[xdim] = xo_dims[xdim];
+        *yo = createHandle(yo_dims, yi_info.getType());
+
+        DIM_ASSERT(1, getInfo(*yo).dims() == yo_dims);
+
+        switch (yi_info.getType()) {
+            case f32:
+                approx1<float, float>(yo, yi, xo, xdim, xi_beg, xi_step, method,
+                                      offGrid);
+                break;
+            case f64:
+                approx1<double, double>(yo, yi, xo, xdim, xi_beg, xi_step,
+                                        method, offGrid);
+                break;
+            case c32:
+                approx1<cfloat, float>(yo, yi, xo, xdim, xi_beg, xi_step,
+                                       method, offGrid);
+                break;
+            case c64:
+                approx1<cdouble, double>(yo, yi, xo, xdim, xi_beg, xi_step,
+                                         method, offGrid);
+                break;
+            default: TYPE_ERROR(1, yi_info.getType());
+        }
+    }
+    CATCHALL;
+
+    return AF_SUCCESS;
+}
+
+af_err af_approx1_uniform_v2(af_array *yo, const af_array yi, const af_array xo,
                           const int xdim, const double xi_beg,
                           const double xi_step, const af_interp_type method,
                           const float offGrid) {
@@ -82,12 +150,6 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi, const af_array xo,
             return AF_SUCCESS;
         }
 
-        dim4 yo_dims  = yi_dims;
-        yo_dims[xdim] = xo_dims[xdim];
-        if (*yo == 0) { *yo = createHandle(yo_dims, yi_info.getType()); }
-
-        DIM_ASSERT(1, getInfo(*yo).dims() == yo_dims);
-
         switch (yi_info.getType()) {
             case f32:
                 approx1<float, float>(yo, yi, xo, xdim, xi_beg, xi_step, method,
@@ -116,6 +178,25 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi, const af_array xo,
 af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
                   const af_interp_type method, const float offGrid) {
     return af_approx1_uniform(yo, yi, xo, 0, 0.0, 1.0, method, offGrid);
+}
+
+af_err af_approx1_v2(af_array *yo, const af_array yi, const af_array xo,
+                  const af_interp_type method, const float offGrid) {
+
+    const ArrayInfo &yi_info = getInfo(yi);
+    const ArrayInfo &xo_info = getInfo(xo);
+
+    const dim4 yi_dims = yi_info.dims();
+    const dim4 xo_dims = xo_info.dims();
+    const int xdim = 0;
+
+    dim4 yo_dims  = yi_dims;
+    yo_dims[xdim] = xo_dims[xdim];
+    if (*yo == 0) { *yo = createHandle(yo_dims, yi_info.getType()); }
+
+    DIM_ASSERT(1, getInfo(*yo).dims() == yo_dims);
+
+    return af_approx1_uniform_v2(yo, yi, xo, xdim, 0.0, 1.0, method, offGrid);
 }
 
 af_err af_approx2_uniform(af_array *zo, const af_array zi, const af_array xo,

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -48,6 +48,10 @@ af_err af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
                          const double xi_step, const af_interp_type method,
                          const float offGrid, const bool allocate_yo) {
     try {
+        ARG_ASSERT(0, yo != 0);
+        ARG_ASSERT(1, yi != 0);
+        ARG_ASSERT(2, xo != 0);
+
         const ArrayInfo &yi_info = getInfo(yi);
         const ArrayInfo &xo_info = getInfo(xo);
 
@@ -124,7 +128,8 @@ af_err af_approx1_uniform_v2(af_array *yo, const af_array yi, const af_array xo,
                              const int xdim, const double xi_beg,
                              const double xi_step, const af_interp_type method,
                              const float offGrid) {
-    // For a "v2" function, assume that the output has already been initialized
+    if (yo == 0) return AF_ERR_ARG;
+    // Since this v2, assume that the output has already been initialized
     // either to null or an existing af_array
     return af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid,
                              *yo == 0);
@@ -137,7 +142,8 @@ af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
 
 af_err af_approx1_v2(af_array *yo, const af_array yi, const af_array xo,
                      const af_interp_type method, const float offGrid) {
-    // For a "v2" function, assume that the output has already been initialized
+    if (yo == 0) return AF_ERR_ARG;
+    // Since this is v2, assume that the output has already been initialized
     // either to null or an existing af_array
     return af_approx1_common(yo, yi, xo, 0, 0.0, 1.0, method, offGrid,
                              *yo == 0);

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -1043,33 +1043,33 @@ TYPED_TEST(Approx1, UseReorderedOutputArrayUniform) {
 }
 
 TEST(Approx1, NullOutputPtrApprox1) {
-    af_array *out_ptr = 0;
-    af_array in = 0;
-    af_array pos = 0;
+    af_array* out_ptr = 0;
+    af_array in       = 0;
+    af_array pos      = 0;
     ASSERT_EQ(af_approx1(out_ptr, in, pos, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
 }
 
 TEST(Approx1, NullOutputPtrApprox1Uniform) {
-    af_array *out_ptr = 0;
-    af_array in = 0;
-    af_array pos = 0;
+    af_array* out_ptr = 0;
+    af_array in       = 0;
+    af_array pos      = 0;
     ASSERT_EQ(af_approx1_uniform(out_ptr, in, pos, 0, 0.0, 1.0,
                                  AF_INTERP_LINEAR, 0.f),
               AF_ERR_ARG);
 }
 
 TEST(Approx1, NullOutputPtrApprox1V2) {
-    af_array *out_ptr = 0;
-    af_array in = 0;
-    af_array pos = 0;
+    af_array* out_ptr = 0;
+    af_array in       = 0;
+    af_array pos      = 0;
     ASSERT_EQ(af_approx1_v2(out_ptr, in, pos, AF_INTERP_LINEAR, 0.f),
               AF_ERR_ARG);
 }
 
 TEST(Approx1, NullOutputPtrApprox1UniformV2) {
-    af_array *out_ptr = 0;
-    af_array in = 0;
-    af_array pos = 0;
+    af_array* out_ptr = 0;
+    af_array in       = 0;
+    af_array pos      = 0;
     ASSERT_EQ(af_approx1_uniform_v2(out_ptr, in, pos, 0, 0.0, 1.0,
                                     AF_INTERP_LINEAR, 0.f),
               AF_ERR_ARG);
@@ -1077,26 +1077,26 @@ TEST(Approx1, NullOutputPtrApprox1UniformV2) {
 
 TEST(Approx1, NullInputArray) {
     af_array out = 0;
-    af_array in = 0;
+    af_array in  = 0;
     af_array pos = 0;
 
     float h_pos[5] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
     dim4 pos_dims(5);
-    ASSERT_SUCCESS(af_create_array(&pos, h_pos, pos_dims.ndims(),
-                                   pos_dims.get(), f32));
+    ASSERT_SUCCESS(
+        af_create_array(&pos, h_pos, pos_dims.ndims(), pos_dims.get(), f32));
 
     ASSERT_EQ(af_approx1(&out, in, pos, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
 }
 
 TEST(Approx1, NullPosArray) {
     af_array out = 0;
-    af_array in = 0;
+    af_array in  = 0;
     af_array pos = 0;
 
     float h_in[3] = {10.0f, 20.0f, 30.0f};
     dim4 in_dims(3);
-    ASSERT_SUCCESS(af_create_array(&in, h_in, in_dims.ndims(),
-                                   in_dims.get(), f32));
+    ASSERT_SUCCESS(
+        af_create_array(&in, h_in, in_dims.ndims(), in_dims.get(), f32));
 
     ASSERT_EQ(af_approx1(&out, in, pos, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
 }

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -1041,3 +1041,62 @@ TYPED_TEST(Approx1, UseReorderedOutputArrayUniform) {
     testSpclOutArrayUniform<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos,
                                        pos_dims, REORDERED_ARRAY);
 }
+
+TEST(Approx1, NullOutputPtrApprox1) {
+    af_array *out_ptr = 0;
+    af_array in = 0;
+    af_array pos = 0;
+    ASSERT_EQ(af_approx1(out_ptr, in, pos, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+}
+
+TEST(Approx1, NullOutputPtrApprox1Uniform) {
+    af_array *out_ptr = 0;
+    af_array in = 0;
+    af_array pos = 0;
+    ASSERT_EQ(af_approx1_uniform(out_ptr, in, pos, 0, 0.0, 1.0,
+                                 AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
+}
+
+TEST(Approx1, NullOutputPtrApprox1V2) {
+    af_array *out_ptr = 0;
+    af_array in = 0;
+    af_array pos = 0;
+    ASSERT_EQ(af_approx1_v2(out_ptr, in, pos, AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
+}
+
+TEST(Approx1, NullOutputPtrApprox1UniformV2) {
+    af_array *out_ptr = 0;
+    af_array in = 0;
+    af_array pos = 0;
+    ASSERT_EQ(af_approx1_uniform_v2(out_ptr, in, pos, 0, 0.0, 1.0,
+                                    AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
+}
+
+TEST(Approx1, NullInputArray) {
+    af_array out = 0;
+    af_array in = 0;
+    af_array pos = 0;
+
+    float h_pos[5] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
+    dim4 pos_dims(5);
+    ASSERT_SUCCESS(af_create_array(&pos, h_pos, pos_dims.ndims(),
+                                   pos_dims.get(), f32));
+
+    ASSERT_EQ(af_approx1(&out, in, pos, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+}
+
+TEST(Approx1, NullPosArray) {
+    af_array out = 0;
+    af_array in = 0;
+    af_array pos = 0;
+
+    float h_in[3] = {10.0f, 20.0f, 30.0f};
+    dim4 in_dims(3);
+    ASSERT_SUCCESS(af_create_array(&in, h_in, in_dims.ndims(),
+                                   in_dims.get(), f32));
+
+    ASSERT_EQ(af_approx1(&out, in, pos, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+}

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -940,25 +940,37 @@ TYPED_TEST(Approx1, UseReorderedOutputArray) {
                                 pos_dims, REORDERED_ARRAY);
 }
 
+template<typename T>
 void testSpclOutArrayUniform(float* h_gold, dim4 gold_dims, float* h_in, dim4 in_dims,
                              float* h_pos, dim4 pos_dims,
                              TestOutputArrayType out_array_type) {
+    SUPPORTED_TYPE_CHECK(T);
+    typedef typename dtype_traits<T>::base_type BT;
+
+    vector<T> h_gold_cast(gold_dims.elements());
+    vector<T> h_in_cast(in_dims.elements());
+    vector<BT> h_pos_cast(pos_dims.elements());
+
     af_array in  = 0;
     af_array pos = 0;
+
     ASSERT_SUCCESS(
-        af_create_array(&in, h_in, in_dims.ndims(), in_dims.get(), f32));
+        af_create_array(&in, &h_in_cast.front(), in_dims.ndims(), in_dims.get(),
+                        (af_dtype)dtype_traits<T>::af_type));
     ASSERT_SUCCESS(
-        af_create_array(&pos, h_pos, pos_dims.ndims(), pos_dims.get(), f32));
+        af_create_array(&pos, &h_pos_cast.front(), pos_dims.ndims(), pos_dims.get(),
+                        (af_dtype)dtype_traits<BT>::af_type));
 
     af_array out = 0;
     TestOutputArrayInfo metadata(out_array_type);
-    genTestOutputArray(&out, gold_dims.ndims(), gold_dims.get(), f32,
-                       &metadata);
+    genTestOutputArray(&out, gold_dims.ndims(), gold_dims.get(),
+                       (af_dtype)dtype_traits<T>::af_type, &metadata);
     ASSERT_SUCCESS(af_approx1_uniform_v2(&out, in, pos, 0, 0.0, 1.0, AF_INTERP_LINEAR, 0.f));
 
     af_array gold = 0;
-    ASSERT_SUCCESS(af_create_array(&gold, h_gold, gold_dims.ndims(),
-                                   gold_dims.get(), f32));
+    ASSERT_SUCCESS(af_create_array(&gold, &h_gold_cast.front(),
+                                   gold_dims.ndims(), gold_dims.get(),
+                                   (af_dtype)dtype_traits<T>::af_type));
 
     ASSERT_SPECIAL_ARRAYS_EQ(gold, out, &metadata);
 
@@ -967,7 +979,7 @@ void testSpclOutArrayUniform(float* h_gold, dim4 gold_dims, float* h_in, dim4 in
     if (in != 0) { ASSERT_SUCCESS(af_release_array(in)); }
 }
 
-TEST(Approx1, UseNullOutputArrayUniform) {
+TYPED_TEST(Approx1, UseNullOutputArrayUniform) {
     float h_in[3] = {10.0f, 20.0f, 30.0f};
     dim4 in_dims(3);
 
@@ -978,11 +990,11 @@ TEST(Approx1, UseNullOutputArrayUniform) {
     dim4 gold_dims(5);
 
     SCOPED_TRACE("UseNullOutputArray");
-    testSpclOutArrayUniform(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
-                            NULL_ARRAY);
+    testSpclOutArrayUniform<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
+                                       NULL_ARRAY);
 }
 
-TEST(Approx1, UseFullExistingOutputArrayUniform) {
+TYPED_TEST(Approx1, UseFullExistingOutputArrayUniform) {
     float h_in[3] = {10.0f, 20.0f, 30.0f};
     dim4 in_dims(3);
 
@@ -993,11 +1005,11 @@ TEST(Approx1, UseFullExistingOutputArrayUniform) {
     dim4 gold_dims(5);
 
     SCOPED_TRACE("UseFullExistingOutputArray");
-    testSpclOutArrayUniform(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
-                            FULL_ARRAY);
+    testSpclOutArrayUniform<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
+                                       FULL_ARRAY);
 }
 
-TEST(Approx1, UseExistingOutputSubArrayUniform) {
+TYPED_TEST(Approx1, UseExistingOutputSubArrayUniform) {
     float h_in[3] = {10.0f, 20.0f, 30.0f};
     dim4 in_dims(3);
 
@@ -1008,11 +1020,11 @@ TEST(Approx1, UseExistingOutputSubArrayUniform) {
     dim4 gold_subarr_dims(5);
 
     SCOPED_TRACE("UseExistingOutputSubArray");
-    testSpclOutArrayUniform(h_gold_subarr, gold_subarr_dims, h_in, in_dims, h_pos,
-                            pos_dims, SUB_ARRAY);
+    testSpclOutArrayUniform<TypeParam>(h_gold_subarr, gold_subarr_dims, h_in, in_dims, h_pos,
+                                       pos_dims, SUB_ARRAY);
 }
 
-TEST(Approx1, UseReorderedOutputArrayUniform) {
+TYPED_TEST(Approx1, UseReorderedOutputArrayUniform) {
     float h_in[9] = {10.0f, 20.0f, 30.0f, 40.0f, 50.0f,
                      60.0f, 70.0f, 80.0f, 90.0f};
     dim4 in_dims(3, 3);
@@ -1025,6 +1037,6 @@ TEST(Approx1, UseReorderedOutputArrayUniform) {
     dim4 gold_dims(5, 3);
 
     SCOPED_TRACE("UseReorderedOutputArray");
-    testSpclOutArrayUniform(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
-                            REORDERED_ARRAY);
+    testSpclOutArrayUniform<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
+                                       REORDERED_ARRAY);
 }

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -853,12 +853,12 @@ void testSpclOutArray(float* h_gold, dim4 gold_dims, float* h_in, dim4 in_dims,
     af_array in  = 0;
     af_array pos = 0;
 
-    ASSERT_SUCCESS(
-        af_create_array(&in, &h_in_cast.front(), in_dims.ndims(), in_dims.get(),
-                        (af_dtype)dtype_traits<T>::af_type));
-    ASSERT_SUCCESS(
-        af_create_array(&pos, &h_pos_cast.front(), pos_dims.ndims(), pos_dims.get(),
-                        (af_dtype)dtype_traits<BT>::af_type));
+    ASSERT_SUCCESS(af_create_array(&in, &h_in_cast.front(), in_dims.ndims(),
+                                   in_dims.get(),
+                                   (af_dtype)dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&pos, &h_pos_cast.front(), pos_dims.ndims(),
+                                   pos_dims.get(),
+                                   (af_dtype)dtype_traits<BT>::af_type));
 
     af_array out = 0;
     TestOutputArrayInfo metadata(out_array_type);
@@ -941,8 +941,8 @@ TYPED_TEST(Approx1, UseReorderedOutputArray) {
 }
 
 template<typename T>
-void testSpclOutArrayUniform(float* h_gold, dim4 gold_dims, float* h_in, dim4 in_dims,
-                             float* h_pos, dim4 pos_dims,
+void testSpclOutArrayUniform(float* h_gold, dim4 gold_dims, float* h_in,
+                             dim4 in_dims, float* h_pos, dim4 pos_dims,
                              TestOutputArrayType out_array_type) {
     SUPPORTED_TYPE_CHECK(T);
     typedef typename dtype_traits<T>::base_type BT;
@@ -954,18 +954,19 @@ void testSpclOutArrayUniform(float* h_gold, dim4 gold_dims, float* h_in, dim4 in
     af_array in  = 0;
     af_array pos = 0;
 
-    ASSERT_SUCCESS(
-        af_create_array(&in, &h_in_cast.front(), in_dims.ndims(), in_dims.get(),
-                        (af_dtype)dtype_traits<T>::af_type));
-    ASSERT_SUCCESS(
-        af_create_array(&pos, &h_pos_cast.front(), pos_dims.ndims(), pos_dims.get(),
-                        (af_dtype)dtype_traits<BT>::af_type));
+    ASSERT_SUCCESS(af_create_array(&in, &h_in_cast.front(), in_dims.ndims(),
+                                   in_dims.get(),
+                                   (af_dtype)dtype_traits<T>::af_type));
+    ASSERT_SUCCESS(af_create_array(&pos, &h_pos_cast.front(), pos_dims.ndims(),
+                                   pos_dims.get(),
+                                   (af_dtype)dtype_traits<BT>::af_type));
 
     af_array out = 0;
     TestOutputArrayInfo metadata(out_array_type);
     genTestOutputArray(&out, gold_dims.ndims(), gold_dims.get(),
                        (af_dtype)dtype_traits<T>::af_type, &metadata);
-    ASSERT_SUCCESS(af_approx1_uniform_v2(&out, in, pos, 0, 0.0, 1.0, AF_INTERP_LINEAR, 0.f));
+    ASSERT_SUCCESS(af_approx1_uniform_v2(&out, in, pos, 0, 0.0, 1.0,
+                                         AF_INTERP_LINEAR, 0.f));
 
     af_array gold = 0;
     ASSERT_SUCCESS(af_create_array(&gold, &h_gold_cast.front(),
@@ -990,8 +991,8 @@ TYPED_TEST(Approx1, UseNullOutputArrayUniform) {
     dim4 gold_dims(5);
 
     SCOPED_TRACE("UseNullOutputArray");
-    testSpclOutArrayUniform<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
-                                       NULL_ARRAY);
+    testSpclOutArrayUniform<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos,
+                                       pos_dims, NULL_ARRAY);
 }
 
 TYPED_TEST(Approx1, UseFullExistingOutputArrayUniform) {
@@ -1005,8 +1006,8 @@ TYPED_TEST(Approx1, UseFullExistingOutputArrayUniform) {
     dim4 gold_dims(5);
 
     SCOPED_TRACE("UseFullExistingOutputArray");
-    testSpclOutArrayUniform<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
-                                       FULL_ARRAY);
+    testSpclOutArrayUniform<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos,
+                                       pos_dims, FULL_ARRAY);
 }
 
 TYPED_TEST(Approx1, UseExistingOutputSubArrayUniform) {
@@ -1020,8 +1021,8 @@ TYPED_TEST(Approx1, UseExistingOutputSubArrayUniform) {
     dim4 gold_subarr_dims(5);
 
     SCOPED_TRACE("UseExistingOutputSubArray");
-    testSpclOutArrayUniform<TypeParam>(h_gold_subarr, gold_subarr_dims, h_in, in_dims, h_pos,
-                                       pos_dims, SUB_ARRAY);
+    testSpclOutArrayUniform<TypeParam>(h_gold_subarr, gold_subarr_dims, h_in,
+                                       in_dims, h_pos, pos_dims, SUB_ARRAY);
 }
 
 TYPED_TEST(Approx1, UseReorderedOutputArrayUniform) {
@@ -1037,6 +1038,6 @@ TYPED_TEST(Approx1, UseReorderedOutputArrayUniform) {
     dim4 gold_dims(5, 3);
 
     SCOPED_TRACE("UseReorderedOutputArray");
-    testSpclOutArrayUniform<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
-                                       REORDERED_ARRAY);
+    testSpclOutArrayUniform<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos,
+                                       pos_dims, REORDERED_ARRAY);
 }

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -951,6 +951,16 @@ void testSpclOutArrayUniform(float* h_gold, dim4 gold_dims, float* h_in,
     vector<T> h_in_cast(in_dims.elements());
     vector<BT> h_pos_cast(pos_dims.elements());
 
+    for (int i = 0; i < gold_dims.elements(); ++i) {
+        h_gold_cast[i] = static_cast<T>(h_gold[i]);
+    }
+    for (int i = 0; i < in_dims.elements(); ++i) {
+        h_in_cast[i] = static_cast<T>(h_in[i]);
+    }
+    for (int i = 0; i < pos_dims.elements(); ++i) {
+        h_pos_cast[i] = static_cast<BT>(h_pos[i]);
+    }
+
     af_array in  = 0;
     af_array pos = 0;
 

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -829,25 +829,47 @@ TEST(Approx1, CPPEmptyPosAndInput) {
     ASSERT_TRUE(interp.isempty());
 }
 
+template<typename T>
 void testSpclOutArray(float* h_gold, dim4 gold_dims, float* h_in, dim4 in_dims,
                       float* h_pos, dim4 pos_dims,
                       TestOutputArrayType out_array_type) {
+    SUPPORTED_TYPE_CHECK(T);
+    typedef typename dtype_traits<T>::base_type BT;
+
+    vector<T> h_gold_cast(gold_dims.elements());
+    vector<T> h_in_cast(in_dims.elements());
+    vector<BT> h_pos_cast(pos_dims.elements());
+
+    for (int i = 0; i < gold_dims.elements(); ++i) {
+        h_gold_cast[i] = static_cast<T>(h_gold[i]);
+    }
+    for (int i = 0; i < in_dims.elements(); ++i) {
+        h_in_cast[i] = static_cast<T>(h_in[i]);
+    }
+    for (int i = 0; i < pos_dims.elements(); ++i) {
+        h_pos_cast[i] = static_cast<BT>(h_pos[i]);
+    }
+
     af_array in  = 0;
     af_array pos = 0;
+
     ASSERT_SUCCESS(
-        af_create_array(&in, h_in, in_dims.ndims(), in_dims.get(), f32));
+        af_create_array(&in, &h_in_cast.front(), in_dims.ndims(), in_dims.get(),
+                        (af_dtype)dtype_traits<T>::af_type));
     ASSERT_SUCCESS(
-        af_create_array(&pos, h_pos, pos_dims.ndims(), pos_dims.get(), f32));
+        af_create_array(&pos, &h_pos_cast.front(), pos_dims.ndims(), pos_dims.get(),
+                        (af_dtype)dtype_traits<BT>::af_type));
 
     af_array out = 0;
     TestOutputArrayInfo metadata(out_array_type);
-    genTestOutputArray(&out, gold_dims.ndims(), gold_dims.get(), f32,
-                       &metadata);
+    genTestOutputArray(&out, gold_dims.ndims(), gold_dims.get(),
+                       (af_dtype)dtype_traits<T>::af_type, &metadata);
     ASSERT_SUCCESS(af_approx1_v2(&out, in, pos, AF_INTERP_LINEAR, 0));
 
     af_array gold = 0;
-    ASSERT_SUCCESS(af_create_array(&gold, h_gold, gold_dims.ndims(),
-                                   gold_dims.get(), f32));
+    ASSERT_SUCCESS(af_create_array(&gold, &h_gold_cast.front(),
+                                   gold_dims.ndims(), gold_dims.get(),
+                                   (af_dtype)dtype_traits<T>::af_type));
 
     ASSERT_SPECIAL_ARRAYS_EQ(gold, out, &metadata);
 
@@ -856,7 +878,7 @@ void testSpclOutArray(float* h_gold, dim4 gold_dims, float* h_in, dim4 in_dims,
     if (in != 0) { ASSERT_SUCCESS(af_release_array(in)); }
 }
 
-TEST(Approx1, UseNullOutputArray) {
+TYPED_TEST(Approx1, UseNullOutputArray) {
     float h_in[3] = {10.0f, 20.0f, 30.0f};
     dim4 in_dims(3);
 
@@ -867,11 +889,11 @@ TEST(Approx1, UseNullOutputArray) {
     dim4 gold_dims(5);
 
     SCOPED_TRACE("UseNullOutputArray");
-    testSpclOutArray(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
-                     NULL_ARRAY);
+    testSpclOutArray<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos,
+                                pos_dims, NULL_ARRAY);
 }
 
-TEST(Approx1, UseFullExistingOutputArray) {
+TYPED_TEST(Approx1, UseFullExistingOutputArray) {
     float h_in[3] = {10.0f, 20.0f, 30.0f};
     dim4 in_dims(3);
 
@@ -882,11 +904,11 @@ TEST(Approx1, UseFullExistingOutputArray) {
     dim4 gold_dims(5);
 
     SCOPED_TRACE("UseFullExistingOutputArray");
-    testSpclOutArray(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
-                     FULL_ARRAY);
+    testSpclOutArray<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos,
+                                pos_dims, FULL_ARRAY);
 }
 
-TEST(Approx1, UseExistingOutputSubArray) {
+TYPED_TEST(Approx1, UseExistingOutputSubArray) {
     float h_in[3] = {10.0f, 20.0f, 30.0f};
     dim4 in_dims(3);
 
@@ -897,11 +919,11 @@ TEST(Approx1, UseExistingOutputSubArray) {
     dim4 gold_subarr_dims(5);
 
     SCOPED_TRACE("UseExistingOutputSubArray");
-    testSpclOutArray(h_gold_subarr, gold_subarr_dims, h_in, in_dims, h_pos,
-                     pos_dims, SUB_ARRAY);
+    testSpclOutArray<TypeParam>(h_gold_subarr, gold_subarr_dims, h_in, in_dims,
+                                h_pos, pos_dims, SUB_ARRAY);
 }
 
-TEST(Approx1, UseReorderedOutputArray) {
+TYPED_TEST(Approx1, UseReorderedOutputArray) {
     float h_in[9] = {10.0f, 20.0f, 30.0f, 40.0f, 50.0f,
                      60.0f, 70.0f, 80.0f, 90.0f};
     dim4 in_dims(3, 3);
@@ -914,8 +936,8 @@ TEST(Approx1, UseReorderedOutputArray) {
     dim4 gold_dims(5, 3);
 
     SCOPED_TRACE("UseReorderedOutputArray");
-    testSpclOutArray(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
-                     REORDERED_ARRAY);
+    testSpclOutArray<TypeParam>(h_gold, gold_dims, h_in, in_dims, h_pos,
+                                pos_dims, REORDERED_ARRAY);
 }
 
 void testSpclOutArrayUniform(float* h_gold, dim4 gold_dims, float* h_in, dim4 in_dims,

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -917,3 +917,92 @@ TEST(Approx1, UseReorderedOutputArray) {
     testSpclOutArray(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
                      REORDERED_ARRAY);
 }
+
+void testSpclOutArrayUniform(float* h_gold, dim4 gold_dims, float* h_in, dim4 in_dims,
+                             float* h_pos, dim4 pos_dims,
+                             TestOutputArrayType out_array_type) {
+    af_array in  = 0;
+    af_array pos = 0;
+    ASSERT_SUCCESS(
+        af_create_array(&in, h_in, in_dims.ndims(), in_dims.get(), f32));
+    ASSERT_SUCCESS(
+        af_create_array(&pos, h_pos, pos_dims.ndims(), pos_dims.get(), f32));
+
+    af_array out = 0;
+    TestOutputArrayInfo metadata(out_array_type);
+    genTestOutputArray(&out, gold_dims.ndims(), gold_dims.get(), f32,
+                       &metadata);
+    ASSERT_SUCCESS(af_approx1_uniform_v2(&out, in, pos, 0, 0.0, 1.0, AF_INTERP_LINEAR, 0.f));
+
+    af_array gold = 0;
+    ASSERT_SUCCESS(af_create_array(&gold, h_gold, gold_dims.ndims(),
+                                   gold_dims.get(), f32));
+
+    ASSERT_SPECIAL_ARRAYS_EQ(gold, out, &metadata);
+
+    if (gold != 0) { ASSERT_SUCCESS(af_release_array(gold)); }
+    if (pos != 0) { ASSERT_SUCCESS(af_release_array(pos)); }
+    if (in != 0) { ASSERT_SUCCESS(af_release_array(in)); }
+}
+
+TEST(Approx1, UseNullOutputArrayUniform) {
+    float h_in[3] = {10.0f, 20.0f, 30.0f};
+    dim4 in_dims(3);
+
+    float h_pos[5] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
+    dim4 pos_dims(5);
+
+    float h_gold[5] = {10.0f, 15.0f, 20.0f, 25.0f, 30.0f};
+    dim4 gold_dims(5);
+
+    SCOPED_TRACE("UseNullOutputArray");
+    testSpclOutArrayUniform(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
+                            NULL_ARRAY);
+}
+
+TEST(Approx1, UseFullExistingOutputArrayUniform) {
+    float h_in[3] = {10.0f, 20.0f, 30.0f};
+    dim4 in_dims(3);
+
+    float h_pos[5] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
+    dim4 pos_dims(5);
+
+    float h_gold[5] = {10.0f, 15.0f, 20.0f, 25.0f, 30.0f};
+    dim4 gold_dims(5);
+
+    SCOPED_TRACE("UseFullExistingOutputArray");
+    testSpclOutArrayUniform(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
+                            FULL_ARRAY);
+}
+
+TEST(Approx1, UseExistingOutputSubArrayUniform) {
+    float h_in[3] = {10.0f, 20.0f, 30.0f};
+    dim4 in_dims(3);
+
+    float h_pos[5] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
+    dim4 pos_dims(5);
+
+    float h_gold_subarr[5] = {10.0f, 15.0f, 20.0f, 25.0f, 30.0f};
+    dim4 gold_subarr_dims(5);
+
+    SCOPED_TRACE("UseExistingOutputSubArray");
+    testSpclOutArrayUniform(h_gold_subarr, gold_subarr_dims, h_in, in_dims, h_pos,
+                            pos_dims, SUB_ARRAY);
+}
+
+TEST(Approx1, UseReorderedOutputArrayUniform) {
+    float h_in[9] = {10.0f, 20.0f, 30.0f, 40.0f, 50.0f,
+                     60.0f, 70.0f, 80.0f, 90.0f};
+    dim4 in_dims(3, 3);
+
+    float h_pos[5] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
+    dim4 pos_dims(5);
+
+    float h_gold[15] = {10.0f, 15.0f, 20.0f, 25.0f, 30.0f, 40.0f, 45.0f, 50.0f,
+                        55.0f, 60.0f, 70.0f, 75.0f, 80.0f, 85.0f, 90.0f};
+    dim4 gold_dims(5, 3);
+
+    SCOPED_TRACE("UseReorderedOutputArray");
+    testSpclOutArrayUniform(h_gold, gold_dims, h_in, in_dims, h_pos, pos_dims,
+                            REORDERED_ARRAY);
+}

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -843,7 +843,7 @@ void testSpclOutArray(float* h_gold, dim4 gold_dims, float* h_in, dim4 in_dims,
     TestOutputArrayInfo metadata(out_array_type);
     genTestOutputArray(&out, gold_dims.ndims(), gold_dims.get(), f32,
                        &metadata);
-    ASSERT_SUCCESS(af_approx1(&out, in, pos, AF_INTERP_LINEAR, 0));
+    ASSERT_SUCCESS(af_approx1_v2(&out, in, pos, AF_INTERP_LINEAR, 0));
 
     af_array gold = 0;
     ASSERT_SUCCESS(af_create_array(&gold, h_gold, gold_dims.ndims(),

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -924,15 +924,17 @@ TYPED_TEST(Approx1, UseExistingOutputSubArray) {
 }
 
 TYPED_TEST(Approx1, UseReorderedOutputArray) {
-    float h_in[9] = {10.0f, 20.0f, 30.0f, 40.0f, 50.0f,
-                     60.0f, 70.0f, 80.0f, 90.0f};
+    float h_in[9] = {10.0f, 20.0f, 30.0f,
+                     40.0f, 50.0f, 60.0f,
+                     70.0f, 80.0f, 90.0f};
     dim4 in_dims(3, 3);
 
     float h_pos[5] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
     dim4 pos_dims(5);
 
-    float h_gold[15] = {10.0f, 15.0f, 20.0f, 25.0f, 30.0f, 40.0f, 45.0f, 50.0f,
-                        55.0f, 60.0f, 70.0f, 75.0f, 80.0f, 85.0f, 90.0f};
+    float h_gold[15] = {10.0f, 15.0f, 20.0f, 25.0f, 30.0f,
+                        40.0f, 45.0f, 50.0f, 55.0f, 60.0f,
+                        70.0f, 75.0f, 80.0f, 85.0f, 90.0f};
     dim4 gold_dims(5, 3);
 
     SCOPED_TRACE("UseReorderedOutputArray");


### PR DESCRIPTION
This extends #2324 in order to address the concern raised in https://github.com/arrayfire/arrayfire/pull/2481#discussion_r273752946. Here, `af_approx1`'s behavior towards allocating output arrays is reverted to the original (before #2324), where it simply creates a new `af_array` each time. However, a new function is added: `af_approx1_v2`, which implements the same behavior as in #2324 (uses the existing array passed as the `out` argument and only allocate if it is null).

Here are some screenshots of the added documentation as well:
![image](https://user-images.githubusercontent.com/19368448/61666592-e8649d00-aca5-11e9-9133-ead321ed39ef.png)
![image](https://user-images.githubusercontent.com/19368448/61666626-fc100380-aca5-11e9-8fc8-0211993cbf4e.png)
