### PR TITLE
Fix bugs in Sobel operator and Canny's nonMaxSuppression

### DIFF
--- a/src/backend/cpu/kernel/canny.hpp
+++ b/src/backend/cpu/kernel/canny.hpp
@@ -34,9 +34,10 @@ void nonMaxSuppression(Param<T> output, CParam<T> magnitude, CParam<T> dxParam,
 
             for (dim_t j = 1; j < dims[1] - 1; ++j, offset += 2) {
                 for (dim_t i = 1; i < dims[0] - 1; ++i, ++offset) {
-                    if (mag[offset] == 0)
+                    T curr = mag[offset];
+                    if (curr == 0) {
                         out[offset] = (T)0;
-                    else {
+                    } else {
                         const float se = mag[offset + dims[0] + 1];
                         const float nw = mag[offset - dims[0] - 1];
                         const float ea = mag[offset + 1];
@@ -52,47 +53,47 @@ void nonMaxSuppression(Param<T> output, CParam<T> magnitude, CParam<T> dxParam,
 
                         if (dx >= 0) {
                             if (dy >= 0) {
-                                const bool isTrue = (dx - dy) >= 0;
+                                const bool isDxMagGreater = (dx - dy) >= 0;
 
-                                a1    = isTrue ? ea : so;
-                                a2    = isTrue ? we : no;
+                                a1    = isDxMagGreater ? ea : so;
+                                a2    = isDxMagGreater ? we : no;
                                 b1    = se;
                                 b2    = nw;
-                                alpha = isTrue ? dy / dx : dx / dy;
+                                alpha = isDxMagGreater ? dy / dx : dx / dy;
                             } else {
-                                const bool isTrue = (dx + dy) >= 0;
+                                const bool isDyMagGreater = (dx + dy) >= 0;
 
-                                a1    = isTrue ? ea : no;
-                                a2    = isTrue ? we : so;
+                                a1    = isDyMagGreater ? ea : no;
+                                a2    = isDyMagGreater ? we : so;
                                 b1    = ne;
                                 b2    = sw;
-                                alpha = isTrue ? -dy / dx : dx / -dy;
+                                alpha = isDyMagGreater ? -dy / dx : dx / -dy;
                             }
                         } else {
                             if (dy >= 0) {
-                                const bool isTrue = (dx + dy) >= 0;
+                                const bool isDyMagGreater = (dx + dy) >= 0;
 
-                                a1    = isTrue ? so : we;
-                                a2    = isTrue ? no : ea;
+                                a1    = isDyMagGreater ? so : we;
+                                a2    = isDyMagGreater ? no : ea;
                                 b1    = sw;
                                 b2    = ne;
-                                alpha = isTrue ? -dx / dy : dy / -dx;
+                                alpha = isDyMagGreater ? -dx / dy : dy / -dx;
                             } else {
-                                const bool isTrue = (-dx + dy) >= 0;
+                                const bool isDxMagGreater = (-dx + dy) >= 0;
 
-                                a1    = isTrue ? we : no;
-                                a2    = isTrue ? ea : so;
+                                a1    = isDxMagGreater ? we : no;
+                                a2    = isDxMagGreater ? ea : so;
                                 b1    = nw;
                                 b2    = se;
-                                alpha = isTrue ? -dy / dx : dx / -dy;
+                                alpha = isDxMagGreater ? dy / dx : dx / dy;
                             }
                         }
 
                         float mag1 = (1 - alpha) * a1 + alpha * b1;
                         float mag2 = (1 - alpha) * a2 + alpha * b2;
 
-                        if (mag[offset] > mag1 && mag[offset] > mag2) {
-                            out[offset] = mag[offset];
+                        if (curr > mag1 && curr > mag2) {
+                            out[offset] = curr;
                         } else {
                             out[offset] = (T)0;
                         }

--- a/src/backend/cpu/kernel/sobel.hpp
+++ b/src/backend/cpu/kernel/sobel.hpp
@@ -8,7 +8,10 @@
  ********************************************************/
 
 #pragma once
+
 #include <Param.hpp>
+#include <math.hpp>
+
 #include <cassert>
 
 namespace cpu {
@@ -20,64 +23,40 @@ void derivative(Param<To> output, CParam<Ti> input) {
     const af::dim4 istrides = input.strides();
     const af::dim4 ostrides = output.strides();
 
+    auto reflect101 = [](int index, int endIndex) -> int {
+        return std::abs(endIndex - std::abs(endIndex - index));
+    };
+
     for (dim_t b3 = 0; b3 < dims[3]; ++b3) {
         To* optr       = output.get() + b3 * ostrides[3];
         const Ti* iptr = input.get() + b3 * istrides[3];
         for (dim_t b2 = 0; b2 < dims[2]; ++b2) {
             for (dim_t j = 0; j < dims[1]; ++j) {
                 int joff    = j;
-                int _joff   = j - 1;
-                int joff_   = j + 1;
+                int _joff   = reflect101(j - 1, static_cast<int>(dims[1]-1));
+                int joff_   = reflect101(j + 1, static_cast<int>(dims[1]-1));
                 int joffset = j * ostrides[1];
 
                 for (dim_t i = 0; i < dims[0]; ++i) {
                     To accum = To(0);
 
                     int ioff  = i;
-                    int _ioff = i - 1;
-                    int ioff_ = i + 1;
+                    int _ioff = reflect101(i - 1, static_cast<int>(dims[0]-1));
+                    int ioff_ = reflect101(i + 1, static_cast<int>(dims[0]-1));
 
-                    To NW =
-                        (_ioff >= 0 && _joff >= 0)
-                            ? iptr[_joff * istrides[1] + _ioff * istrides[0]]
-                            : 0;
-                    To SW =
-                        (ioff_ < (int)dims[0] && _joff >= 0)
-                            ? iptr[_joff * istrides[1] + ioff_ * istrides[0]]
-                            : 0;
-                    To NE =
-                        (_ioff >= 0 && joff_ < (int)dims[1])
-                            ? iptr[joff_ * istrides[1] + _ioff * istrides[0]]
-                            : 0;
-                    To SE =
-                        (ioff_ < (int)dims[0] && joff_ < (int)dims[1])
-                            ? iptr[joff_ * istrides[1] + ioff_ * istrides[0]]
-                            : 0;
+                    To NW = iptr[_joff * istrides[1] + _ioff * istrides[0]];
+                    To SW = iptr[_joff * istrides[1] + ioff_ * istrides[0]];
+                    To NE = iptr[joff_ * istrides[1] + _ioff * istrides[0]];
+                    To SE = iptr[joff_ * istrides[1] + ioff_ * istrides[0]];
 
                     if (isDX) {
-                        To W =
-                            _joff >= 0
-                                ? iptr[_joff * istrides[1] + ioff * istrides[0]]
-                                : 0;
-
-                        To E =
-                            joff_ < (int)dims[1]
-                                ? iptr[joff_ * istrides[1] + ioff * istrides[0]]
-                                : 0;
-
-                        accum = NW + SW - (NE + SE) + 2 * (W - E);
+                        To N  = iptr[joff * istrides[1] + _ioff * istrides[0]];
+                        To S  = iptr[joff * istrides[1] + ioff_ * istrides[0]];
+                        accum = SW + SE - (NW + NE) + 2 * (S - N);
                     } else {
-                        To N =
-                            _ioff >= 0
-                                ? iptr[joff * istrides[1] + _ioff * istrides[0]]
-                                : 0;
-
-                        To S =
-                            ioff_ < (int)dims[0]
-                                ? iptr[joff * istrides[1] + ioff_ * istrides[0]]
-                                : 0;
-
-                        accum = NW + NE - (SW + SE) + 2 * (N - S);
+                        To W  = iptr[_joff * istrides[1] + ioff * istrides[0]];
+                        To E  = iptr[joff_ * istrides[1] + ioff * istrides[0]];
+                        accum = NE + SE - (NW + SW) + 2 * (E - W);
                     }
 
                     optr[joffset + i * ostrides[0]] = accum;

--- a/src/backend/cuda/kernel/canny.cuh
+++ b/src/backend/cuda/kernel/canny.cuh
@@ -95,39 +95,39 @@ void nonMaxSuppression(Param<float> output, CParam<T> in, CParam<T> dx,
 
             if (dx >= 0) {
                 if (dy >= 0) {
-                    const bool isTrue = (dx - dy) >= 0;
+                    const bool isDxMagGreater = (dx - dy) >= 0;
 
-                    a1    = isTrue ? ea : so;
-                    a2    = isTrue ? we : no;
+                    a1    = isDxMagGreater ? ea : so;
+                    a2    = isDxMagGreater ? we : no;
                     b1    = se;
                     b2    = nw;
-                    alpha = isTrue ? dy / dx : dx / dy;
+                    alpha = isDxMagGreater ? dy / dx : dx / dy;
                 } else {
-                    const bool isTrue = (dx + dy) >= 0;
+                    const bool isDyMagGreater = (dx + dy) >= 0;
 
-                    a1    = isTrue ? ea : no;
-                    a2    = isTrue ? we : so;
+                    a1    = isDyMagGreater ? ea : no;
+                    a2    = isDyMagGreater ? we : so;
                     b1    = ne;
                     b2    = sw;
-                    alpha = isTrue ? -dy / dx : dx / -dy;
+                    alpha = isDyMagGreater ? -dy / dx : dx / -dy;
                 }
             } else {
                 if (dy >= 0) {
-                    const bool isTrue = (dx + dy) >= 0;
+                    const bool isDxMagGreater = (dx + dy) >= 0;
 
-                    a1    = isTrue ? so : we;
-                    a2    = isTrue ? no : ea;
+                    a1    = isDxMagGreater ? so : we;
+                    a2    = isDxMagGreater ? no : ea;
                     b1    = sw;
                     b2    = ne;
-                    alpha = isTrue ? -dx / dy : dy / -dx;
+                    alpha = isDxMagGreater ? -dx / dy : dy / -dx;
                 } else {
-                    const bool isTrue = (-dx + dy) >= 0;
+                    const bool isDyMagGreater = (-dx + dy) >= 0;
 
-                    a1    = isTrue ? we : no;
-                    a2    = isTrue ? ea : so;
+                    a1    = isDyMagGreater ? we : no;
+                    a2    = isDyMagGreater ? ea : so;
                     b1    = nw;
                     b2    = se;
-                    alpha = isTrue ? -dy / dx : dx / -dy;
+                    alpha = isDyMagGreater ? dy / dx : dx / dy;
                 }
             }
 

--- a/src/backend/cuda/kernel/sobel.cuh
+++ b/src/backend/cuda/kernel/sobel.cuh
@@ -12,13 +12,17 @@
 
 namespace cuda {
 
+__device__
+int reflect101(int index, int endIndex) {
+    return abs(endIndex - abs(endIndex - index));
+}
+
 template<typename Ti>
-__device__ Ti load2ShrdMem(const Ti* in, int dim0, int dim1, int gx, int gy,
+__device__ Ti load2ShrdMem(const Ti* in, int d0, int d1, int gx, int gy,
                            int inStride1, int inStride0) {
-    if (gx < 0 || gx >= dim0 || gy < 0 || gy >= dim1)
-        return Ti(0);
-    else
-        return in[gx * inStride0 + gy * inStride1];
+    int idx = reflect101(gx, d0-1) * inStride0 +
+              reflect101(gy, d1-1) * inStride1;
+    return in[idx];
 }
 
 template<typename Ti, typename To>
@@ -73,13 +77,13 @@ __global__ void sobel3x3(Param<To> dx, Param<To> dy, CParam<Ti> in, int nBBS0,
         float NE = shrdMem[_i][j_];
         float SE = shrdMem[i_][j_];
 
-        float t1                       = shrdMem[i][_j];
-        float t2                       = shrdMem[i][j_];
-        dxptr[gy * dx.strides[1] + gx] = (NW + SW - (NE + SE) + 2 * (t1 - t2));
+        float t1  = shrdMem[_i][j];
+        float t2  = shrdMem[i_][j];
+        dxptr[gy * dx.strides[1] + gx] = (SW + SE - (NW + NE) + 2 * (t2 - t1));
 
-        t1                             = shrdMem[_i][j];
-        t2                             = shrdMem[i_][j];
-        dyptr[gy * dy.strides[1] + gx] = (NW + NE - (SW + SE) + 2 * (t1 - t2));
+        t1 = shrdMem[i][_j];
+        t2 = shrdMem[i][j_];
+        dyptr[gy * dy.strides[1] + gx] = (NE + SE - (NW + SW) + 2 * (t2 - t1));
     }
 }
 

--- a/src/backend/opencl/kernel/nonmax_suppression.cl
+++ b/src/backend/opencl/kernel/nonmax_suppression.cl
@@ -75,39 +75,39 @@ __kernel void nonMaxSuppressionKernel(__global T* output, KParam oInfo,
 
             if (dx >= 0) {
                 if (dy >= 0) {
-                    const bool isTrue = (dx - dy) >= 0;
+                    const bool isDxMagGreater = (dx - dy) >= 0;
 
-                    a1    = isTrue ? ea : so;
-                    a2    = isTrue ? we : no;
+                    a1    = isDxMagGreater ? ea : so;
+                    a2    = isDxMagGreater ? we : no;
                     b1    = se;
                     b2    = nw;
-                    alpha = isTrue ? dy / dx : dx / dy;
+                    alpha = isDxMagGreater ? dy / dx : dx / dy;
                 } else {
-                    const bool isTrue = (dx + dy) >= 0;
+                    const bool isDyMagGreater = (dx + dy) >= 0;
 
-                    a1    = isTrue ? ea : no;
-                    a2    = isTrue ? we : so;
+                    a1    = isDyMagGreater ? ea : no;
+                    a2    = isDyMagGreater ? we : so;
                     b1    = ne;
                     b2    = sw;
-                    alpha = isTrue ? -dy / dx : dx / -dy;
+                    alpha = isDyMagGreater ? -dy / dx : dx / -dy;
                 }
             } else {
                 if (dy >= 0) {
-                    const bool isTrue = (dx + dy) >= 0;
+                    const bool isDxMagGreater = (dx + dy) >= 0;
 
-                    a1    = isTrue ? so : we;
-                    a2    = isTrue ? no : ea;
+                    a1    = isDxMagGreater ? so : we;
+                    a2    = isDxMagGreater ? no : ea;
                     b1    = sw;
                     b2    = ne;
-                    alpha = isTrue ? -dx / dy : dy / -dx;
+                    alpha = isDxMagGreater ? -dx / dy : dy / -dx;
                 } else {
-                    const bool isTrue = (-dx + dy) >= 0;
+                    const bool isDyMagGreater = (-dx + dy) >= 0;
 
-                    a1    = isTrue ? we : no;
-                    a2    = isTrue ? ea : so;
+                    a1    = isDyMagGreater ? we : no;
+                    a2    = isDyMagGreater ? ea : so;
                     b1    = nw;
                     b2    = se;
-                    alpha = isTrue ? -dy / dx : dx / -dy;
+                    alpha = isDyMagGreater ? dy / dx : dx / dy;
                 }
             }
 

--- a/test/sobel.cpp
+++ b/test/sobel.cpp
@@ -75,6 +75,10 @@ void testSobelDerivatives(string pTestFile) {
     ASSERT_SUCCESS(af_release_array(dyArray));
 }
 
+
+// rectangle test data is generated using opencv
+// border type is set to cv.BORDER_REFLECT_101 in opencv
+
 TYPED_TEST(Sobel, Rectangle) {
     testSobelDerivatives<TypeParam, TypeParam>(
         string(TEST_DIR "/sobel/rectangle.test"));


### PR DESCRIPTION
Resolves #2588 

@greennbeans , thank you!

Fix gradient factor equation in canny nonmaxsuppression. In the case of negative gradients along both x and y directions, the interpolation factor was incorrectly being calculated.
    
Apart from this, sobel derivaties respective sobel masks were flipped along edge direction (not a transpose, but flip along axes). Terrible bug introduced by me and fixed now in 5e5c022d06979789cff35039b08c42bbc55a253a

Requires https://github.com/arrayfire/arrayfire-data/pull/15