### PR TITLE
Add af_approx2*_v2 functions

### DIFF
--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -753,19 +753,21 @@ extern "C" {
 /**
    C Interface for signals interpolation on one dimensional signals.
 
-   \param[out]    out      is the interpolated array.
-   \param[in]     in       is the multidimensional input array. Values assumed to
-                           lie uniformly spaced indices in the range of `[0, n)`,
-                           where `n` is the number of elements in the array.
-   \param[in]     pos      positions of the interpolation points along the first
-                           dimension.
-   \param[in]     method   is the interpolation method to be used. The following
-                           types (defined in enum \ref af_interp_type)
-                           are supported: nearest neighbor, linear, and cubic.
-   \param[in]     off_grid is the default value for any indices outside the
+   \param[out] out      is the interpolated array.
+   \param[in]  in       is the multidimensional input array. Values assumed
+                        to lie uniformly spaced indices in the range of
+                        `[0, n)`, where `n` is the number of elements in the
+                        array.
+   \param[in]  pos      positions of the interpolation points along the first
+                        dimension.
+   \param[in]  method   is the interpolation method to be used. The following
+                        types (defined in enum \ref af_interp_type)
+                        are supported: nearest neighbor, linear, and cubic.
+   \param[in]  off_grid is the default value for any indices outside the
                            valid range of indices.
-   \return        \ref AF_SUCCESS if the interpolation operation is successful,
-                  otherwise an appropriate error code is returned.
+
+   \return \ref AF_SUCCESS if the interpolation operation is successful,
+           otherwise an appropriate error code is returned.
 
    \ingroup signal_func_approx1
  */
@@ -778,9 +780,10 @@ AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
    output array
 
    \param[in,out] out      is the interpolated array (can be preallocated).
-   \param[in]     in       is the multidimensional input array. Values assumed to
-                           lie uniformly spaced indices in the range of `[0, n)`,
-                           where `n` is the number of elements in the array.
+   \param[in]     in       is the multidimensional input array. Values assumed
+                           to lie uniformly spaced indices in the range of
+                           `[0, n)`, where `n` is the number of elements in the
+                           array.
    \param[in]     pos      positions of the interpolation points along the first
                            dimension.
    \param[in]     method   is the interpolation method to be used. The following
@@ -788,14 +791,15 @@ AFAPI af_err af_approx1(af_array *out, const af_array in, const af_array pos,
                            are supported: nearest neighbor, linear, and cubic.
    \param[in]     off_grid is the default value for any indices outside the
                            valid range of indices.
-   \return        \ref AF_SUCCESS if the interpolation operation is successful,
-                  otherwise an appropriate error code is returned.
+
+   \return \ref AF_SUCCESS if the interpolation operation is successful,
+           otherwise an appropriate error code is returned.
 
    \note \p out can either be a null or existing `af_array` object. If it is a
          sub-array of an existing `af_array`, only the corresponding portion of
          the `af_array` will be overwritten
-   \note Passing an `af_array` that has not been initialized to \p out will cause
-         undefined behavior.
+   \note Passing an `af_array` that has not been initialized to \p out will
+         cause undefined behavior.
 
    \ingroup signal_func_approx1
  */
@@ -806,18 +810,28 @@ AFAPI af_err af_approx1_v2(af_array *out, const af_array in, const af_array pos,
 /**
    C Interface for signals interpolation on two dimensional signals.
 
-   \param[out] out the interpolated array.
-   \param[in]  in is the multidimensional input array. Values assumed to lie uniformly spaced indices in the range of `[0, n)` along both interpolation dimensions. `n` is the number of elements in the array.
-   \param[in]  pos0 positions of the interpolation points along the first dimension.
-   \param[in]  pos1 positions of the interpolation points along the second dimension.
-   \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
-   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
-   \return     \ref AF_SUCCESS if the interpolation operation is successful,
-               otherwise an appropriate error code is returned.
+   \param[out] out      the interpolated array.
+   \param[in]  in       is the multidimensional input array. Values assumed to
+                        lie uniformly spaced indices in the range of `[0, n)`
+                        along both interpolation dimensions. `n` is the number
+                        of elements in the array.
+   \param[in]  pos0     positions of the interpolation points along the first
+                        dimension.
+   \param[in]  pos1     positions of the interpolation points along the second
+                        dimension.
+   \param[in]  method   is the interpolation method to be used. All
+                        interpolation types defined in \ref af_interp_type are
+                        supported.
+   \param[in]  off_grid is the default value for any indices outside the valid
+                        range of indices.
+
+   \return \ref AF_SUCCESS if the interpolation operation is successful,
+           otherwise an appropriate error code is returned.
 
    \ingroup signal_func_approx2
  */
-AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, const af_array pos1,
+AFAPI af_err af_approx2(af_array *out, const af_array in,
+                        const af_array pos0, const af_array pos1,
                         const af_interp_type method, const float off_grid);
 
 #if AF_API_VERSION >= 37
@@ -825,64 +839,83 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
    C Interface for the version of \ref af_approx2 that accepts a preallocated
    output array
 
-   \param[out] out the interpolated array.
-   \param[in]  in is the multidimensional input array. Values assumed to lie uniformly spaced indices in the range of `[0, n)` along both interpolation dimensions. `n` is the number of elements in the array.
-   \param[in]  pos0 positions of the interpolation points along the first dimension.
-   \param[in]  pos1 positions of the interpolation points along the second dimension.
-   \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
-   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
-   \return     \ref AF_SUCCESS if the interpolation operation is successful,
-               otherwise an appropriate error code is returned.
+   \param[in,out] out      the interpolated array (can be preallocated).
+   \param[in]     in       is the multidimensional input array. Values assumed
+                           to lie uniformly spaced indices in the range of
+                           `[0, n)` along both interpolation dimensions. `n` is
+                           the number of elements in the array.
+   \param[in]     pos0     positions of the interpolation points along the first
+                           dimension.
+   \param[in]     pos1     positions of the interpolation points along the
+                           second dimension.
+   \param[in]     method   is the interpolation method to be used. All
+                           interpolation types defined in \ref af_interp_type
+                           are supported.
+   \param[in]     off_grid is the default value for any indices outside the
+                           valid range of indices.
+
+   \return \ref AF_SUCCESS if the interpolation operation is successful,
+           otherwise an appropriate error code is returned.
+
+   \note \p out can either be a null or existing `af_array` object. If it is a
+         sub-array of an existing `af_array`, only the corresponding portion of
+         the `af_array` will be overwritten
+   \note Passing an `af_array` to \p out that has not been initialized will
+         cause undefined behavior.
 
    \ingroup signal_func_approx2
  */
-AFAPI af_err af_approx2_v2(af_array *out, const af_array in, const af_array pos0, const af_array pos1,
+AFAPI af_err af_approx2_v2(af_array *out, const af_array in,
+                           const af_array pos0, const af_array pos1,
                            const af_interp_type method, const float off_grid);
 #endif
 
 
 #if AF_API_VERSION >= 37
 /**
-   C Interface for signals interpolation on one dimensional signals along specified dimension.
+   C Interface for signals interpolation on one dimensional signals along
+   specified dimension.
 
-   af_approx1_uniform() accepts the dimension to perform the
-   interpolation along the input. It also accepts start and step
-   values which define the uniform range of corresponding indices.
+   af_approx1_uniform() accepts the dimension to perform the interpolation along
+   the input. It also accepts start and step values which define the uniform
+   range of corresponding indices.
 
-   The following image illustrates what the range of indices
-   corresponding to the input values look like if `idx_start` and
-   `idx_step` are set to an arbitrary value of 10,
+   The following image illustrates what the range of indices corresponding to
+   the input values look like if `idx_start` and `idx_step` are set to an
+   arbitrary value of 10,
 
    \image html approx1_arbitrary_idx.png "approx1() using idx_start=10.0, idx_step=10.0"
 
    The blue dots represent indices whose values are known. The red dots
    represent indices whose values are unknown.
 
-   \param[out]    out        the interpolated array.
-   \param[in]     in         is the multidimensional input array. Values lie on
-                             uniformly spaced indices determined by `idx_start`
-                             and `idx_step`.
-   \param[in]     pos        positions of the interpolation points along
-                             `interp_dim`.
-   \param[in]     interp_dim is the dimension to perform interpolation across.
-   \param[in]     idx_start  is the first index value along `interp_dim`.
-   \param[in]     idx_step   is the uniform spacing value between subsequent
-                             indices along `interp_dim`.
-   \param[in]     method     is the interpolation method to be used. The
-                             following types (defined in enum
-                             \ref af_interp_type) are supported: nearest
-                             neighbor, linear, and cubic.
-   \param[in]     off_grid   is the default value for any indices outside the
-                             valid range of indices.
-   \return        \ref AF_SUCCESS if the interpolation operation is successful,
-                  otherwise an appropriate error code is returned.
+   \param[out] out        the interpolated array.
+   \param[in]  in         is the multidimensional input array. Values lie on
+                          uniformly spaced indices determined by `idx_start`
+                          and `idx_step`.
+   \param[in]  pos        positions of the interpolation points along
+                          `interp_dim`.
+   \param[in]  interp_dim is the dimension to perform interpolation across.
+   \param[in]  idx_start  is the first index value along `interp_dim`.
+   \param[in]  idx_step   is the uniform spacing value between subsequent
+                          indices along `interp_dim`.
+   \param[in]  method     is the interpolation method to be used. The
+                          following types (defined in enum
+                          \ref af_interp_type) are supported: nearest
+                          neighbor, linear, and cubic.
+   \param[in]  off_grid   is the default value for any indices outside the
+                          valid range of indices.
+
+   \return \ref AF_SUCCESS if the interpolation operation is successful,
+           otherwise an appropriate error code is returned.
 
    \ingroup signal_func_approx1
  */
 AFAPI af_err af_approx1_uniform(af_array *out, const af_array in,
                                 const af_array pos, const int interp_dim,
                                 const double idx_start, const double idx_step,
-                                const af_interp_type method, const float off_grid);
+                                const af_interp_type method,
+                                const float off_grid);
 
 /**
    C Interface for the version of \ref af_approx1_uniform that accepts a
@@ -904,80 +937,116 @@ AFAPI af_err af_approx1_uniform(af_array *out, const af_array in,
                              neighbor, linear, and cubic.
    \param[in]     off_grid   is the default value for any indices outside the
                              valid range of indices.
-   \return        \ref AF_SUCCESS if the interpolation operation is successful,
-                  otherwise an appropriate error code is returned.
+
+   \return \ref AF_SUCCESS if the interpolation operation is successful,
+           otherwise an appropriate error code is returned.
 
    \note \p out can either be a null or existing `af_array` object. If it is a
          sub-array of an existing `af_array`, only the corresponding portion of
          the `af_array` will be overwritten
-   \note Passing an `af_array` to \p out that has not been initialized will cause
-         undefined behavior.
+   \note Passing an `af_array` to \p out that has not been initialized will
+         cause undefined behavior.
 
    \ingroup signal_func_approx1
  */
 AFAPI af_err af_approx1_uniform_v2(af_array *out, const af_array in,
                                    const af_array pos, const int interp_dim,
-                                   const double idx_start, const double idx_step,
-                                   const af_interp_type method, const float off_grid);
+                                   const double idx_start,
+                                   const double idx_step,
+                                   const af_interp_type method,
+                                   const float off_grid);
 
 /**
-   C Interface for signals interpolation on two dimensional signals alog specified dimensions.
+   C Interface for signals interpolation on two dimensional signals along
+   specified dimensions.
 
-   af_approx2_uniform() accepts two dimensions to perform the
-   interpolation along the input. It also accepts start and step
-   values which define the uniform range of corresponding indices.
+   af_approx2_uniform() accepts two dimensions to perform the interpolation
+   along the input. It also accepts start and step values which define the
+   uniform range of corresponding indices.
 
-   \param[out] out the interpolated array.
-   \param[in]  in is the multidimensional input array.
-   \param[in]  pos0 positions of the interpolation points along `interp_dim0`.
-   \param[in]  interp_dim0 is the first dimension to perform interpolation across.
+   \param[out] out            the interpolated array.
+   \param[in]  in             is the multidimensional input array.
+   \param[in]  pos0           positions of the interpolation points along
+                              `interp_dim0`.
+   \param[in]  interp_dim0    is the first dimension to perform interpolation
+                              across.
    \param[in]  idx_start_dim0 is the first index value along `interp_dim0`.
-   \param[in]  idx_step_dim0 is the uniform spacing value between subsequent indices along `interp_dim0`.
-   \param[in]  pos1 positions of the interpolation points along `interp_dim1`.
-   \param[in]  interp_dim1 is the second dimension to perform interpolation across.
+   \param[in]  idx_step_dim0  is the uniform spacing value between subsequent
+                              indices along `interp_dim0`.
+   \param[in]  pos1           positions of the interpolation points along
+                              `interp_dim1`.
+   \param[in]  interp_dim1    is the second dimension to perform interpolation
+                              across.
    \param[in]  idx_start_dim1 is the first index value along `interp_dim1`.
-   \param[in]  idx_step_dim1 is the uniform spacing value between subsequent indices along `interp_dim1`.
-   \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
-   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
-   \return     \ref AF_SUCCESS if the interpolation operation is successful,
-               otherwise an appropriate error code is returned.
+   \param[in]  idx_step_dim1  is the uniform spacing value between subsequent
+                              indices along `interp_dim1`.
+   \param[in]  method         is the interpolation method to be used. All
+                              interpolation types defined in \ref af_interp_type
+                              are supported.
+   \param[in]  off_grid       is the default value for any indices outside the
+                              valid range of indices.
+
+   \return \ref AF_SUCCESS if the interpolation operation is successful,
+           otherwise an appropriate error code is returned.
 
    \ingroup signal_func_approx2
  */
 AFAPI af_err af_approx2_uniform(af_array *out, const af_array in,
-                                const af_array pos0, const int interp_dim0, const double idx_start_dim0, const double idx_step_dim0,
-                                const af_array pos1, const int interp_dim1, const double idx_start_dim1, const double idx_step_dim1,
-                                const af_interp_type method, const float off_grid);
+                                const af_array pos0, const int interp_dim0,
+                                const double idx_start_dim0,
+                                const double idx_step_dim0,
+                                const af_array pos1, const int interp_dim1,
+                                const double idx_start_dim1,
+                                const double idx_step_dim1,
+                                const af_interp_type method,
+                                const float off_grid);
 
 /**
    C Interface for the version of \ref af_approx2_uniform that accepts a
    preallocated output array
 
-   af_approx2_uniform() accepts two dimensions to perform the
-   interpolation along the input. It also accepts start and step
-   values which define the uniform range of corresponding indices.
+   \param[in,out] out            the interpolated array.
+   \param[in]     in             is the multidimensional input array.
+   \param[in]     pos0           positions of the interpolation points along
+                                 `interp_dim0`.
+   \param[in]     interp_dim0    is the first dimension to perform interpolation
+                                 across.
+   \param[in]     idx_start_dim0 is the first index value along `interp_dim0`.
+   \param[in]     idx_step_dim0  is the uniform spacing value between subsequent
+                                 indices along `interp_dim0`.
+   \param[in]     pos1           positions of the interpolation points along
+                                 `interp_dim1`.
+   \param[in]     interp_dim1    is the second dimension to perform
+                                 interpolation across.
+   \param[in]     idx_start_dim1 is the first index value along `interp_dim1`.
+   \param[in]     idx_step_dim1  is the uniform spacing value between subsequent
+                                 indices along `interp_dim1`.
+   \param[in]     method         is the interpolation method to be used. All
+                                 interpolation types defined in
+                                 \ref af_interp_type are supported.
+   \param[in]     off_grid       is the default value for any indices outside
+                                 the valid range of indices.
 
-   \param[out] out the interpolated array.
-   \param[in]  in is the multidimensional input array.
-   \param[in]  pos0 positions of the interpolation points along `interp_dim0`.
-   \param[in]  interp_dim0 is the first dimension to perform interpolation across.
-   \param[in]  idx_start_dim0 is the first index value along `interp_dim0`.
-   \param[in]  idx_step_dim0 is the uniform spacing value between subsequent indices along `interp_dim0`.
-   \param[in]  pos1 positions of the interpolation points along `interp_dim1`.
-   \param[in]  interp_dim1 is the second dimension to perform interpolation across.
-   \param[in]  idx_start_dim1 is the first index value along `interp_dim1`.
-   \param[in]  idx_step_dim1 is the uniform spacing value between subsequent indices along `interp_dim1`.
-   \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
-   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
-   \return     \ref AF_SUCCESS if the interpolation operation is successful,
-               otherwise an appropriate error code is returned.
+   \return \ref AF_SUCCESS if the interpolation operation is successful,
+           otherwise an appropriate error code is returned.
+
+   \note \p out can either be a null or existing `af_array` object. If it is a
+         sub-array of an existing `af_array`, only the corresponding portion of
+         the `af_array` will be overwritten
+   \note Passing an `af_array` to \p out that has not been initialized will
+         cause undefined behavior.
 
    \ingroup signal_func_approx2
  */
 AFAPI af_err af_approx2_uniform_v2(af_array *out, const af_array in,
-                                   const af_array pos0, const int interp_dim0, const double idx_start_dim0, const double idx_step_dim0,
-                                   const af_array pos1, const int interp_dim1, const double idx_start_dim1, const double idx_step_dim1,
-                                   const af_interp_type method, const float off_grid);
+                                   const af_array pos0, const int interp_dim0,
+                                   const double idx_start_dim0,
+                                   const double idx_step_dim0,
+                                   const af_array pos1, const int interp_dim1,
+                                   const double idx_start_dim1,
+                                   const double idx_step_dim1,
+                                   const af_interp_type method,
+                                   const float off_grid);
 #endif
 
 /**

--- a/include/af/signal.h
+++ b/include/af/signal.h
@@ -822,6 +822,27 @@ AFAPI af_err af_approx2(af_array *out, const af_array in, const af_array pos0, c
 
 #if AF_API_VERSION >= 37
 /**
+   C Interface for the version of \ref af_approx2 that accepts a preallocated
+   output array
+
+   \param[out] out the interpolated array.
+   \param[in]  in is the multidimensional input array. Values assumed to lie uniformly spaced indices in the range of `[0, n)` along both interpolation dimensions. `n` is the number of elements in the array.
+   \param[in]  pos0 positions of the interpolation points along the first dimension.
+   \param[in]  pos1 positions of the interpolation points along the second dimension.
+   \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
+   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
+   \return     \ref AF_SUCCESS if the interpolation operation is successful,
+               otherwise an appropriate error code is returned.
+
+   \ingroup signal_func_approx2
+ */
+AFAPI af_err af_approx2_v2(af_array *out, const af_array in, const af_array pos0, const af_array pos1,
+                           const af_interp_type method, const float off_grid);
+#endif
+
+
+#if AF_API_VERSION >= 37
+/**
    C Interface for signals interpolation on one dimensional signals along specified dimension.
 
    af_approx1_uniform() accepts the dimension to perform the
@@ -927,6 +948,36 @@ AFAPI af_err af_approx2_uniform(af_array *out, const af_array in,
                                 const af_array pos0, const int interp_dim0, const double idx_start_dim0, const double idx_step_dim0,
                                 const af_array pos1, const int interp_dim1, const double idx_start_dim1, const double idx_step_dim1,
                                 const af_interp_type method, const float off_grid);
+
+/**
+   C Interface for the version of \ref af_approx2_uniform that accepts a
+   preallocated output array
+
+   af_approx2_uniform() accepts two dimensions to perform the
+   interpolation along the input. It also accepts start and step
+   values which define the uniform range of corresponding indices.
+
+   \param[out] out the interpolated array.
+   \param[in]  in is the multidimensional input array.
+   \param[in]  pos0 positions of the interpolation points along `interp_dim0`.
+   \param[in]  interp_dim0 is the first dimension to perform interpolation across.
+   \param[in]  idx_start_dim0 is the first index value along `interp_dim0`.
+   \param[in]  idx_step_dim0 is the uniform spacing value between subsequent indices along `interp_dim0`.
+   \param[in]  pos1 positions of the interpolation points along `interp_dim1`.
+   \param[in]  interp_dim1 is the second dimension to perform interpolation across.
+   \param[in]  idx_start_dim1 is the first index value along `interp_dim1`.
+   \param[in]  idx_step_dim1 is the uniform spacing value between subsequent indices along `interp_dim1`.
+   \param[in]  method is the interpolation method to be used. All interpolation types defined in \ref af_interp_type are supported.
+   \param[in]  off_grid is the default value for any indices outside the valid range of indices.
+   \return     \ref AF_SUCCESS if the interpolation operation is successful,
+               otherwise an appropriate error code is returned.
+
+   \ingroup signal_func_approx2
+ */
+AFAPI af_err af_approx2_uniform_v2(af_array *out, const af_array in,
+                                   const af_array pos0, const int interp_dim0, const double idx_start_dim0, const double idx_step_dim0,
+                                   const af_array pos1, const int interp_dim1, const double idx_start_dim1, const double idx_step_dim1,
+                                   const af_interp_type method, const float off_grid);
 #endif
 
 /**

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -33,14 +33,13 @@ inline void approx1(af_array *yo, const af_array yi, const af_array xo,
 
 template<typename Ty, typename Tp>
 inline void approx2(af_array *zo, const af_array zi, const af_array xo,
-                          const int xdim, const Tp &xi_beg,
-                          const Tp &xi_step, const af_array yo,
-                          const int ydim, const Tp &yi_beg,
-                          const Tp &yi_step, const af_interp_type method,
-                          const float offGrid) {
+                    const int xdim, const Tp &xi_beg, const Tp &xi_step,
+                    const af_array yo, const int ydim, const Tp &yi_beg,
+                    const Tp &yi_step, const af_interp_type method,
+                    const float offGrid) {
     approx2<Ty>(getArray<Ty>(*zo), getArray<Ty>(zi), getArray<Tp>(xo), xdim,
-                xi_beg, xi_step, getArray<Tp>(yo), ydim,
-                yi_beg, yi_step, method, offGrid);
+                xi_beg, xi_step, getArray<Tp>(yo), ydim, yi_beg, yi_step,
+                method, offGrid);
 }
 
 af_err af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
@@ -57,8 +56,8 @@ af_err af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
 
         const dim4 yi_dims = yi_info.dims();
         const dim4 xo_dims = xo_info.dims();
-        dim4 yo_dims  = yi_dims;
-        yo_dims[xdim] = xo_dims[xdim];
+        dim4 yo_dims       = yi_dims;
+        yo_dims[xdim]      = xo_dims[xdim];
 
         ARG_ASSERT(1, yi_info.isFloating());                        // Only floating and complex types
         ARG_ASSERT(2, xo_info.isRealFloating()) ;                   // Only floating types
@@ -85,9 +84,7 @@ af_err af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
             return af_create_handle(yo, 0, nullptr, yi_info.getType());
         }
 
-        if (allocate_yo) {
-            *yo = createHandle(yo_dims, yi_info.getType());
-        }
+        if (allocate_yo) { *yo = createHandle(yo_dims, yi_info.getType()); }
 
         DIM_ASSERT(0, getInfo(*yo).dims() == yo_dims);
 
@@ -202,32 +199,27 @@ af_err af_approx2_common(af_array *zo, const af_array zi, const af_array xo,
         zo_dims[xdim] = xo_info.dims()[xdim];
         zo_dims[ydim] = xo_info.dims()[ydim];
 
-        if (allocate_zo) {
-            *zo = createHandle(zo_dims, zi_info.getType());
-        }
+        if (allocate_zo) { *zo = createHandle(zo_dims, zi_info.getType()); }
 
         DIM_ASSERT(0, getInfo(*zo).dims() == zo_dims);
 
         switch (zi_info.getType()) {
             case f32:
-                approx2<float, float>(zo, zi, xo, xdim, xi_beg, xi_step,
-                                      yo, ydim, yi_beg, yi_step,
-                                      method, offGrid);
+                approx2<float, float>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
+                                      ydim, yi_beg, yi_step, method, offGrid);
                 break;
             case f64:
-                approx2<double, double>(zo, zi, xo, xdim, xi_beg, xi_step,
-                                        yo, ydim, yi_beg, yi_step,
-                                        method, offGrid);
+                approx2<double, double>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
+                                        ydim, yi_beg, yi_step, method, offGrid);
                 break;
             case c32:
-                approx2<cfloat, float>(zo, zi, xo, xdim, xi_beg, xi_step,
-                                       yo, ydim, yi_beg, yi_step,
-                                       method, offGrid);
+                approx2<cfloat, float>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
+                                       ydim, yi_beg, yi_step, method, offGrid);
                 break;
             case c64:
-                approx2<cdouble, double>(zo, zi, xo, xdim, xi_beg, xi_step,
-                                         yo, ydim, yi_beg, yi_step,
-                                         method, offGrid);
+                approx2<cdouble, double>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
+                                         ydim, yi_beg, yi_step, method,
+                                         offGrid);
                 break;
             default: TYPE_ERROR(1, zi_info.getType());
         }
@@ -243,21 +235,21 @@ af_err af_approx2_uniform(af_array *zo, const af_array zi, const af_array xo,
                           const int ydim, const double yi_beg,
                           const double yi_step, const af_interp_type method,
                           const float offGrid) {
-    return af_approx2_common(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg,
-                             yi_step, method, offGrid, true);
+    return af_approx2_common(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim,
+                             yi_beg, yi_step, method, offGrid, true);
 }
 
 af_err af_approx2_uniform_v2(af_array *zo, const af_array zi, const af_array xo,
-                          const int xdim, const double xi_beg,
-                          const double xi_step, const af_array yo,
-                          const int ydim, const double yi_beg,
-                          const double yi_step, const af_interp_type method,
-                          const float offGrid) {
+                             const int xdim, const double xi_beg,
+                             const double xi_step, const af_array yo,
+                             const int ydim, const double yi_beg,
+                             const double yi_step, const af_interp_type method,
+                             const float offGrid) {
     if (zo == 0) return AF_ERR_ARG;
     // Since this v2, assume that the output has already been initialized
     // either to null or an existing af_array
-    return af_approx2_common(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg,
-                             yi_step, method, offGrid, *zo == 0);
+    return af_approx2_common(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim,
+                             yi_beg, yi_step, method, offGrid, *zo == 0);
 }
 
 af_err af_approx2(af_array *zo, const af_array zi, const af_array xo,
@@ -268,8 +260,8 @@ af_err af_approx2(af_array *zo, const af_array zi, const af_array xo,
 }
 
 af_err af_approx2_v2(af_array *zo, const af_array zi, const af_array xo,
-                  const af_array yo, const af_interp_type method,
-                  const float offGrid) {
+                     const af_array yo, const af_interp_type method,
+                     const float offGrid) {
     if (zo == 0) return AF_ERR_ARG;
     // Since this v2, assume that the output has already been initialized
     // either to null or an existing af_array

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -46,7 +46,7 @@ void af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
                        const int xdim, const double xi_beg,
                        const double xi_step, const af_interp_type method,
                        const float offGrid, const bool allocate_yo) {
-    ARG_ASSERT(0, yo != 0); // *yo (the af_array) can be null, but not yo
+    ARG_ASSERT(0, yo != 0);  // *yo (the af_array) can be null, but not yo
     ARG_ASSERT(1, yi != 0);
     ARG_ASSERT(2, xo != 0);
 
@@ -94,16 +94,16 @@ void af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
                                   offGrid);
             break;
         case f64:
-            approx1<double, double>(yo, yi, xo, xdim, xi_beg, xi_step,
-                                    method, offGrid);
+            approx1<double, double>(yo, yi, xo, xdim, xi_beg, xi_step, method,
+                                    offGrid);
             break;
         case c32:
-            approx1<cfloat, float>(yo, yi, xo, xdim, xi_beg, xi_step,
-                                   method, offGrid);
+            approx1<cfloat, float>(yo, yi, xo, xdim, xi_beg, xi_step, method,
+                                   offGrid);
             break;
         case c64:
-            approx1<cdouble, double>(yo, yi, xo, xdim, xi_beg, xi_step,
-                                     method, offGrid);
+            approx1<cdouble, double>(yo, yi, xo, xdim, xi_beg, xi_step, method,
+                                     offGrid);
             break;
         default: TYPE_ERROR(1, yi_info.getType());
     }
@@ -116,7 +116,8 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi, const af_array xo,
     try {
         af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid,
                           true);
-    } CATCHALL;
+    }
+    CATCHALL;
 
     return AF_SUCCESS;
 }
@@ -126,10 +127,11 @@ af_err af_approx1_uniform_v2(af_array *yo, const af_array yi, const af_array xo,
                              const double xi_step, const af_interp_type method,
                              const float offGrid) {
     try {
-        ARG_ASSERT(0, yo != 0); // need to dereference yo in next call
+        ARG_ASSERT(0, yo != 0);  // need to dereference yo in next call
         af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid,
                           *yo == 0);
-    } CATCHALL;
+    }
+    CATCHALL;
 
     return AF_SUCCESS;
 }
@@ -138,7 +140,8 @@ af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
                   const af_interp_type method, const float offGrid) {
     try {
         af_approx1_common(yo, yi, xo, 0, 0.0, 1.0, method, offGrid, true);
-    } CATCHALL;
+    }
+    CATCHALL;
 
     return AF_SUCCESS;
 }
@@ -146,20 +149,21 @@ af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
 af_err af_approx1_v2(af_array *yo, const af_array yi, const af_array xo,
                      const af_interp_type method, const float offGrid) {
     try {
-        ARG_ASSERT(0, yo != 0); // need to dereference yo in next call
+        ARG_ASSERT(0, yo != 0);  // need to dereference yo in next call
         af_approx1_common(yo, yi, xo, 0, 0.0, 1.0, method, offGrid, *yo == 0);
-    } CATCHALL;
+    }
+    CATCHALL;
 
     return AF_SUCCESS;
 }
 
 void af_approx2_common(af_array *zo, const af_array zi, const af_array xo,
                        const int xdim, const double xi_beg,
-                       const double xi_step, const af_array yo,
-                       const int ydim, const double yi_beg,
-                       const double yi_step, const af_interp_type method,
-                       const float offGrid, bool allocate_zo) {
-    ARG_ASSERT(0, zo != 0); // *zo (the af_array) can be null, but not zo
+                       const double xi_step, const af_array yo, const int ydim,
+                       const double yi_beg, const double yi_step,
+                       const af_interp_type method, const float offGrid,
+                       bool allocate_zo) {
+    ARG_ASSERT(0, zo != 0);  // *zo (the af_array) can be null, but not zo
     ARG_ASSERT(1, zi != 0);
     ARG_ASSERT(2, xo != 0);
     ARG_ASSERT(6, yo != 0);
@@ -188,13 +192,11 @@ void af_approx2_common(af_array *zo, const af_array zi, const af_array xo,
     // POS should either be (x, y, 1, 1) or (x, y, zi_dims[2], zi_dims[3])
     if (xo_dims[xdim] * xo_dims[ydim] != xo_dims.elements()) {
         for (int i = 0; i < 4; i++) {
-            if (xdim != i && ydim != i)
-                DIM_ASSERT(2, xo_dims[i] == zi_dims[i]);
+            if (xdim != i && ydim != i) DIM_ASSERT(2, xo_dims[i] == zi_dims[i]);
         }
     }
 
-    if (zi_dims.ndims() == 0 || xo_dims.ndims() == 0 ||
-        yo_dims.ndims() == 0) {
+    if (zi_dims.ndims() == 0 || xo_dims.ndims() == 0 || yo_dims.ndims() == 0) {
         af_create_handle(zo, 0, nullptr, zi_info.getType());
         return;
     }
@@ -209,21 +211,20 @@ void af_approx2_common(af_array *zo, const af_array zi, const af_array xo,
 
     switch (zi_info.getType()) {
         case f32:
-            approx2<float, float>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
-                                  ydim, yi_beg, yi_step, method, offGrid);
+            approx2<float, float>(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim,
+                                  yi_beg, yi_step, method, offGrid);
             break;
         case f64:
-            approx2<double, double>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
-                                    ydim, yi_beg, yi_step, method, offGrid);
+            approx2<double, double>(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim,
+                                    yi_beg, yi_step, method, offGrid);
             break;
         case c32:
-            approx2<cfloat, float>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
-                                   ydim, yi_beg, yi_step, method, offGrid);
+            approx2<cfloat, float>(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim,
+                                   yi_beg, yi_step, method, offGrid);
             break;
         case c64:
             approx2<cdouble, double>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
-                                     ydim, yi_beg, yi_step, method,
-                                     offGrid);
+                                     ydim, yi_beg, yi_step, method, offGrid);
             break;
         default: TYPE_ERROR(1, zi_info.getType());
     }
@@ -238,7 +239,8 @@ af_err af_approx2_uniform(af_array *zo, const af_array zi, const af_array xo,
     try {
         af_approx2_common(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg,
                           yi_step, method, offGrid, true);
-    } CATCHALL;
+    }
+    CATCHALL;
 
     return AF_SUCCESS;
 }
@@ -250,10 +252,11 @@ af_err af_approx2_uniform_v2(af_array *zo, const af_array zi, const af_array xo,
                              const double yi_step, const af_interp_type method,
                              const float offGrid) {
     try {
-        ARG_ASSERT(0, zo != 0); // need to dereference zo in next call
+        ARG_ASSERT(0, zo != 0);  // need to dereference zo in next call
         af_approx2_common(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg,
                           yi_step, method, offGrid, *zo == 0);
-    } CATCHALL;
+    }
+    CATCHALL;
 
     return AF_SUCCESS;
 }
@@ -264,7 +267,8 @@ af_err af_approx2(af_array *zo, const af_array zi, const af_array xo,
     try {
         af_approx2_common(zo, zi, xo, 0, 0.0, 1.0, yo, 1, 0.0, 1.0, method,
                           offGrid, true);
-    } CATCHALL;
+    }
+    CATCHALL;
 
     return AF_SUCCESS;
 }
@@ -273,10 +277,11 @@ af_err af_approx2_v2(af_array *zo, const af_array zi, const af_array xo,
                      const af_array yo, const af_interp_type method,
                      const float offGrid) {
     try {
-        ARG_ASSERT(0, zo != 0); // need to dereference zo in next call
+        ARG_ASSERT(0, zo != 0);  // need to dereference zo in next call
         af_approx2_common(zo, zi, xo, 0, 0.0, 1.0, yo, 1, 0.0, 1.0, method,
                           offGrid, *zo == 0);
-    } CATCHALL;
+    }
+    CATCHALL;
 
     return AF_SUCCESS;
 }

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -42,191 +42,191 @@ inline void approx2(af_array *zo, const af_array zi, const af_array xo,
                 method, offGrid);
 }
 
-af_err af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
-                         const int xdim, const double xi_beg,
-                         const double xi_step, const af_interp_type method,
-                         const float offGrid, const bool allocate_yo) {
-    try {
-        ARG_ASSERT(0, yo != 0);
-        ARG_ASSERT(1, yi != 0);
-        ARG_ASSERT(2, xo != 0);
+void af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
+                       const int xdim, const double xi_beg,
+                       const double xi_step, const af_interp_type method,
+                       const float offGrid, const bool allocate_yo) {
+    ARG_ASSERT(0, yo != 0); // *yo (the af_array) can be null, but not yo
+    ARG_ASSERT(1, yi != 0);
+    ARG_ASSERT(2, xo != 0);
 
-        const ArrayInfo &yi_info = getInfo(yi);
-        const ArrayInfo &xo_info = getInfo(xo);
+    const ArrayInfo &yi_info = getInfo(yi);
+    const ArrayInfo &xo_info = getInfo(xo);
 
-        const dim4 yi_dims = yi_info.dims();
-        const dim4 xo_dims = xo_info.dims();
-        dim4 yo_dims       = yi_dims;
-        yo_dims[xdim]      = xo_dims[xdim];
+    const dim4 yi_dims = yi_info.dims();
+    const dim4 xo_dims = xo_info.dims();
+    dim4 yo_dims       = yi_dims;
+    yo_dims[xdim]      = xo_dims[xdim];
 
-        ARG_ASSERT(1, yi_info.isFloating());                        // Only floating and complex types
-        ARG_ASSERT(2, xo_info.isRealFloating()) ;                   // Only floating types
-        ARG_ASSERT(1, yi_info.isSingle() == xo_info.isSingle());    // Must have same precision
-        ARG_ASSERT(1, yi_info.isDouble() == xo_info.isDouble());    // Must have same precision
-        ARG_ASSERT(3, xdim >= 0 && xdim < 4);
+    ARG_ASSERT(1, yi_info.isFloating());                        // Only floating and complex types
+    ARG_ASSERT(2, xo_info.isRealFloating()) ;                   // Only floating types
+    ARG_ASSERT(1, yi_info.isSingle() == xo_info.isSingle());    // Must have same precision
+    ARG_ASSERT(1, yi_info.isDouble() == xo_info.isDouble());    // Must have same precision
+    ARG_ASSERT(3, xdim >= 0 && xdim < 4);
 
-        // POS should either be (x, 1, 1, 1) or (1, yi_dims[1], yi_dims[2], yi_dims[3])
-        if (xo_dims[xdim] != xo_dims.elements()) {
-            for (int i = 0; i < 4; i++) {
-                if (xdim != i) DIM_ASSERT(2, xo_dims[i] == yi_dims[i]);
-            }
-        }
-
-        ARG_ASSERT(5, xi_step != 0);
-        ARG_ASSERT(6, (method == AF_INTERP_CUBIC         ||
-                       method == AF_INTERP_CUBIC_SPLINE  ||
-                       method == AF_INTERP_LINEAR        ||
-                       method == AF_INTERP_LINEAR_COSINE ||
-                       method == AF_INTERP_LOWER         ||
-                       method == AF_INTERP_NEAREST));
-
-        if (yi_dims.ndims() == 0 || xo_dims.ndims() == 0) {
-            return af_create_handle(yo, 0, nullptr, yi_info.getType());
-        }
-
-        if (allocate_yo) { *yo = createHandle(yo_dims, yi_info.getType()); }
-
-        DIM_ASSERT(0, getInfo(*yo).dims() == yo_dims);
-
-        switch (yi_info.getType()) {
-            case f32:
-                approx1<float, float>(yo, yi, xo, xdim, xi_beg, xi_step, method,
-                                      offGrid);
-                break;
-            case f64:
-                approx1<double, double>(yo, yi, xo, xdim, xi_beg, xi_step,
-                                        method, offGrid);
-                break;
-            case c32:
-                approx1<cfloat, float>(yo, yi, xo, xdim, xi_beg, xi_step,
-                                       method, offGrid);
-                break;
-            case c64:
-                approx1<cdouble, double>(yo, yi, xo, xdim, xi_beg, xi_step,
-                                         method, offGrid);
-                break;
-            default: TYPE_ERROR(1, yi_info.getType());
+    // POS should either be (x, 1, 1, 1) or (1, yi_dims[1], yi_dims[2], yi_dims[3])
+    if (xo_dims[xdim] != xo_dims.elements()) {
+        for (int i = 0; i < 4; i++) {
+            if (xdim != i) DIM_ASSERT(2, xo_dims[i] == yi_dims[i]);
         }
     }
-    CATCHALL;
 
-    return AF_SUCCESS;
+    ARG_ASSERT(5, xi_step != 0);
+    ARG_ASSERT(6, (method == AF_INTERP_CUBIC         ||
+                   method == AF_INTERP_CUBIC_SPLINE  ||
+                   method == AF_INTERP_LINEAR        ||
+                   method == AF_INTERP_LINEAR_COSINE ||
+                   method == AF_INTERP_LOWER         ||
+                   method == AF_INTERP_NEAREST));
+
+    if (yi_dims.ndims() == 0 || xo_dims.ndims() == 0) {
+        af_create_handle(yo, 0, nullptr, yi_info.getType());
+        return;
+    }
+
+    if (allocate_yo) { *yo = createHandle(yo_dims, yi_info.getType()); }
+
+    DIM_ASSERT(0, getInfo(*yo).dims() == yo_dims);
+
+    switch (yi_info.getType()) {
+        case f32:
+            approx1<float, float>(yo, yi, xo, xdim, xi_beg, xi_step, method,
+                                  offGrid);
+            break;
+        case f64:
+            approx1<double, double>(yo, yi, xo, xdim, xi_beg, xi_step,
+                                    method, offGrid);
+            break;
+        case c32:
+            approx1<cfloat, float>(yo, yi, xo, xdim, xi_beg, xi_step,
+                                   method, offGrid);
+            break;
+        case c64:
+            approx1<cdouble, double>(yo, yi, xo, xdim, xi_beg, xi_step,
+                                     method, offGrid);
+            break;
+        default: TYPE_ERROR(1, yi_info.getType());
+    }
 }
 
 af_err af_approx1_uniform(af_array *yo, const af_array yi, const af_array xo,
                           const int xdim, const double xi_beg,
                           const double xi_step, const af_interp_type method,
                           const float offGrid) {
-    return af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid,
-                             true);
+    try {
+        af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid,
+                          true);
+    } CATCHALL;
+
+    return AF_SUCCESS;
 }
 
 af_err af_approx1_uniform_v2(af_array *yo, const af_array yi, const af_array xo,
                              const int xdim, const double xi_beg,
                              const double xi_step, const af_interp_type method,
                              const float offGrid) {
-    if (yo == 0) return AF_ERR_ARG;
-    // Since this v2, assume that the output has already been initialized
-    // either to null or an existing af_array
-    return af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid,
-                             *yo == 0);
+    try {
+        ARG_ASSERT(0, yo != 0); // need to dereference yo in next call
+        af_approx1_common(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid,
+                          *yo == 0);
+    } CATCHALL;
+
+    return AF_SUCCESS;
 }
 
 af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
                   const af_interp_type method, const float offGrid) {
-    return af_approx1_common(yo, yi, xo, 0, 0.0, 1.0, method, offGrid, true);
+    try {
+        af_approx1_common(yo, yi, xo, 0, 0.0, 1.0, method, offGrid, true);
+    } CATCHALL;
+
+    return AF_SUCCESS;
 }
 
 af_err af_approx1_v2(af_array *yo, const af_array yi, const af_array xo,
                      const af_interp_type method, const float offGrid) {
-    if (yo == 0) return AF_ERR_ARG;
-    // Since this is v2, assume that the output has already been initialized
-    // either to null or an existing af_array
-    return af_approx1_common(yo, yi, xo, 0, 0.0, 1.0, method, offGrid,
-                             *yo == 0);
-}
-
-af_err af_approx2_common(af_array *zo, const af_array zi, const af_array xo,
-                         const int xdim, const double xi_beg,
-                         const double xi_step, const af_array yo,
-                         const int ydim, const double yi_beg,
-                         const double yi_step, const af_interp_type method,
-                         const float offGrid, bool allocate_zo) {
     try {
-        ARG_ASSERT(0, zo != 0);
-        ARG_ASSERT(1, zi != 0);
-        ARG_ASSERT(2, xo != 0);
-        ARG_ASSERT(6, yo != 0);
-
-        const ArrayInfo &zi_info = getInfo(zi);
-        const ArrayInfo &xo_info = getInfo(xo);
-        const ArrayInfo &yo_info = getInfo(yo);
-
-        dim4 zi_dims = zi_info.dims();
-        dim4 xo_dims = xo_info.dims();
-        dim4 yo_dims = yo_info.dims();
-
-        ARG_ASSERT(1, zi_info.isFloating());  // Only floating and complex types
-        ARG_ASSERT(2, xo_info.isRealFloating());  // Only floating types
-        ARG_ASSERT(4, yo_info.isRealFloating());  // Only floating types
-        ARG_ASSERT(
-            2, xo_info.getType() == yo_info.getType());  // Must have same type
-        ARG_ASSERT(1, zi_info.isSingle() ==
-                          xo_info.isSingle());  // Must have same precision
-        ARG_ASSERT(1, zi_info.isDouble() ==
-                          xo_info.isDouble());  // Must have same precision
-        DIM_ASSERT(2, xo_dims == yo_dims);  // POS0 and POS1 must have same dims
-
-        ARG_ASSERT(3, xdim >= 0 && xdim < 4);
-        ARG_ASSERT(5, ydim >= 0 && ydim < 4);
-        ARG_ASSERT(7, xi_step != 0);
-        ARG_ASSERT(9, yi_step != 0);
-
-        // POS should either be (x, y, 1, 1) or (x, y, zi_dims[2], zi_dims[3])
-        if (xo_dims[xdim] * xo_dims[ydim] != xo_dims.elements()) {
-            for (int i = 0; i < 4; i++) {
-                if (xdim != i && ydim != i)
-                    DIM_ASSERT(2, xo_dims[i] == zi_dims[i]);
-            }
-        }
-
-        if (zi_dims.ndims() == 0 || xo_dims.ndims() == 0 ||
-            yo_dims.ndims() == 0) {
-            return af_create_handle(zo, 0, nullptr, zi_info.getType());
-        }
-
-        dim4 zo_dims  = zi_info.dims();
-        zo_dims[xdim] = xo_info.dims()[xdim];
-        zo_dims[ydim] = xo_info.dims()[ydim];
-
-        if (allocate_zo) { *zo = createHandle(zo_dims, zi_info.getType()); }
-
-        DIM_ASSERT(0, getInfo(*zo).dims() == zo_dims);
-
-        switch (zi_info.getType()) {
-            case f32:
-                approx2<float, float>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
-                                      ydim, yi_beg, yi_step, method, offGrid);
-                break;
-            case f64:
-                approx2<double, double>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
-                                        ydim, yi_beg, yi_step, method, offGrid);
-                break;
-            case c32:
-                approx2<cfloat, float>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
-                                       ydim, yi_beg, yi_step, method, offGrid);
-                break;
-            case c64:
-                approx2<cdouble, double>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
-                                         ydim, yi_beg, yi_step, method,
-                                         offGrid);
-                break;
-            default: TYPE_ERROR(1, zi_info.getType());
-        }
-    }
-    CATCHALL;
+        ARG_ASSERT(0, yo != 0); // need to dereference yo in next call
+        af_approx1_common(yo, yi, xo, 0, 0.0, 1.0, method, offGrid, *yo == 0);
+    } CATCHALL;
 
     return AF_SUCCESS;
+}
+
+void af_approx2_common(af_array *zo, const af_array zi, const af_array xo,
+                       const int xdim, const double xi_beg,
+                       const double xi_step, const af_array yo,
+                       const int ydim, const double yi_beg,
+                       const double yi_step, const af_interp_type method,
+                       const float offGrid, bool allocate_zo) {
+    ARG_ASSERT(0, zo != 0); // *zo (the af_array) can be null, but not zo
+    ARG_ASSERT(1, zi != 0);
+    ARG_ASSERT(2, xo != 0);
+    ARG_ASSERT(6, yo != 0);
+
+    const ArrayInfo &zi_info = getInfo(zi);
+    const ArrayInfo &xo_info = getInfo(xo);
+    const ArrayInfo &yo_info = getInfo(yo);
+
+    dim4 zi_dims = zi_info.dims();
+    dim4 xo_dims = xo_info.dims();
+    dim4 yo_dims = yo_info.dims();
+
+    ARG_ASSERT(1, zi_info.isFloating());                      // Only floating and complex types
+    ARG_ASSERT(2, xo_info.isRealFloating());                  // Only floating types
+    ARG_ASSERT(4, yo_info.isRealFloating());                  // Only floating types
+    ARG_ASSERT(2, xo_info.getType() == yo_info.getType());    // Must have same type
+    ARG_ASSERT(1, zi_info.isSingle() == xo_info.isSingle());  // Must have same precision
+    ARG_ASSERT(1, zi_info.isDouble() == xo_info.isDouble());  // Must have same precision
+    DIM_ASSERT(2, xo_dims == yo_dims);                        // POS0 and POS1 must have same dims
+
+    ARG_ASSERT(3, xdim >= 0 && xdim < 4);
+    ARG_ASSERT(5, ydim >= 0 && ydim < 4);
+    ARG_ASSERT(7, xi_step != 0);
+    ARG_ASSERT(9, yi_step != 0);
+
+    // POS should either be (x, y, 1, 1) or (x, y, zi_dims[2], zi_dims[3])
+    if (xo_dims[xdim] * xo_dims[ydim] != xo_dims.elements()) {
+        for (int i = 0; i < 4; i++) {
+            if (xdim != i && ydim != i)
+                DIM_ASSERT(2, xo_dims[i] == zi_dims[i]);
+        }
+    }
+
+    if (zi_dims.ndims() == 0 || xo_dims.ndims() == 0 ||
+        yo_dims.ndims() == 0) {
+        af_create_handle(zo, 0, nullptr, zi_info.getType());
+        return;
+    }
+
+    dim4 zo_dims  = zi_info.dims();
+    zo_dims[xdim] = xo_info.dims()[xdim];
+    zo_dims[ydim] = xo_info.dims()[ydim];
+
+    if (allocate_zo) { *zo = createHandle(zo_dims, zi_info.getType()); }
+
+    DIM_ASSERT(0, getInfo(*zo).dims() == zo_dims);
+
+    switch (zi_info.getType()) {
+        case f32:
+            approx2<float, float>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
+                                  ydim, yi_beg, yi_step, method, offGrid);
+            break;
+        case f64:
+            approx2<double, double>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
+                                    ydim, yi_beg, yi_step, method, offGrid);
+            break;
+        case c32:
+            approx2<cfloat, float>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
+                                   ydim, yi_beg, yi_step, method, offGrid);
+            break;
+        case c64:
+            approx2<cdouble, double>(zo, zi, xo, xdim, xi_beg, xi_step, yo,
+                                     ydim, yi_beg, yi_step, method,
+                                     offGrid);
+            break;
+        default: TYPE_ERROR(1, zi_info.getType());
+    }
 }
 
 af_err af_approx2_uniform(af_array *zo, const af_array zi, const af_array xo,
@@ -235,8 +235,12 @@ af_err af_approx2_uniform(af_array *zo, const af_array zi, const af_array xo,
                           const int ydim, const double yi_beg,
                           const double yi_step, const af_interp_type method,
                           const float offGrid) {
-    return af_approx2_common(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim,
-                             yi_beg, yi_step, method, offGrid, true);
+    try {
+        af_approx2_common(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg,
+                          yi_step, method, offGrid, true);
+    } CATCHALL;
+
+    return AF_SUCCESS;
 }
 
 af_err af_approx2_uniform_v2(af_array *zo, const af_array zi, const af_array xo,
@@ -245,26 +249,34 @@ af_err af_approx2_uniform_v2(af_array *zo, const af_array zi, const af_array xo,
                              const int ydim, const double yi_beg,
                              const double yi_step, const af_interp_type method,
                              const float offGrid) {
-    if (zo == 0) return AF_ERR_ARG;
-    // Since this v2, assume that the output has already been initialized
-    // either to null or an existing af_array
-    return af_approx2_common(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim,
-                             yi_beg, yi_step, method, offGrid, *zo == 0);
+    try {
+        ARG_ASSERT(0, zo != 0); // need to dereference zo in next call
+        af_approx2_common(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg,
+                          yi_step, method, offGrid, *zo == 0);
+    } CATCHALL;
+
+    return AF_SUCCESS;
 }
 
 af_err af_approx2(af_array *zo, const af_array zi, const af_array xo,
                   const af_array yo, const af_interp_type method,
                   const float offGrid) {
-    return af_approx2_common(zo, zi, xo, 0, 0.0, 1.0, yo, 1, 0.0, 1.0, method,
-                             offGrid, true);
+    try {
+        af_approx2_common(zo, zi, xo, 0, 0.0, 1.0, yo, 1, 0.0, 1.0, method,
+                          offGrid, true);
+    } CATCHALL;
+
+    return AF_SUCCESS;
 }
 
 af_err af_approx2_v2(af_array *zo, const af_array zi, const af_array xo,
                      const af_array yo, const af_interp_type method,
                      const float offGrid) {
-    if (zo == 0) return AF_ERR_ARG;
-    // Since this v2, assume that the output has already been initialized
-    // either to null or an existing af_array
-    return af_approx2_common(zo, zi, xo, 0, 0.0, 1.0, yo, 1, 0.0, 1.0, method,
-                             offGrid, *zo == 0);
+    try {
+        ARG_ASSERT(0, zo != 0); // need to dereference zo in next call
+        af_approx2_common(zo, zi, xo, 0, 0.0, 1.0, yo, 1, 0.0, 1.0, method,
+                          offGrid, *zo == 0);
+    } CATCHALL;
+
+    return AF_SUCCESS;
 }

--- a/src/api/unified/signal.cpp
+++ b/src/api/unified/signal.cpp
@@ -31,8 +31,8 @@ af_err af_approx2(af_array *zo, const af_array zi, const af_array xo,
 }
 
 af_err af_approx2_v2(af_array *zo, const af_array zi, const af_array xo,
-                  const af_array yo, const af_interp_type method,
-                  const float offGrid) {
+                     const af_array yo, const af_interp_type method,
+                     const float offGrid) {
     CHECK_ARRAYS(zo, zi, xo, yo);
     return CALL(zo, zi, xo, yo, method, offGrid);
 }
@@ -65,11 +65,11 @@ af_err af_approx2_uniform(af_array *zo, const af_array zi, const af_array xo,
 }
 
 af_err af_approx2_uniform_v2(af_array *zo, const af_array zi, const af_array xo,
-                          const int xdim, const double xi_beg,
-                          const double xi_step, const af_array yo,
-                          const int ydim, const double yi_beg,
-                          const double yi_step, const af_interp_type method,
-                          const float offGrid) {
+                             const int xdim, const double xi_beg,
+                             const double xi_step, const af_array yo,
+                             const int ydim, const double yi_beg,
+                             const double yi_step, const af_interp_type method,
+                             const float offGrid) {
     CHECK_ARRAYS(zo, zi, xo, yo);
     return CALL(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg, yi_step,
                 method, offGrid);

--- a/src/api/unified/signal.cpp
+++ b/src/api/unified/signal.cpp
@@ -30,6 +30,13 @@ af_err af_approx2(af_array *zo, const af_array zi, const af_array xo,
     return CALL(zo, zi, xo, yo, method, offGrid);
 }
 
+af_err af_approx2_v2(af_array *zo, const af_array zi, const af_array xo,
+                  const af_array yo, const af_interp_type method,
+                  const float offGrid) {
+    CHECK_ARRAYS(zo, zi, xo, yo);
+    return CALL(zo, zi, xo, yo, method, offGrid);
+}
+
 af_err af_approx1_uniform(af_array *yo, const af_array yi, const af_array xo,
                           const int xdim, const double xi_beg,
                           const double xi_step, const af_interp_type method,
@@ -52,7 +59,18 @@ af_err af_approx2_uniform(af_array *zo, const af_array zi, const af_array xo,
                           const int ydim, const double yi_beg,
                           const double yi_step, const af_interp_type method,
                           const float offGrid) {
-    CHECK_ARRAYS(zi, xo, yo);
+    CHECK_ARRAYS(zo, zi, xo, yo);
+    return CALL(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg, yi_step,
+                method, offGrid);
+}
+
+af_err af_approx2_uniform_v2(af_array *zo, const af_array zi, const af_array xo,
+                          const int xdim, const double xi_beg,
+                          const double xi_step, const af_array yo,
+                          const int ydim, const double yi_beg,
+                          const double yi_step, const af_interp_type method,
+                          const float offGrid) {
+    CHECK_ARRAYS(zo, zi, xo, yo);
     return CALL(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg, yi_step,
                 method, offGrid);
 }

--- a/src/backend/cpu/approx.cpp
+++ b/src/backend/cpu/approx.cpp
@@ -39,16 +39,10 @@ void approx1(Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,
 }
 
 template<typename Ty, typename Tp>
-Array<Ty> approx2(const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
-                  const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
-                  const int ydim, const Tp &yi_beg, const Tp &yi_step,
-                  const af_interp_type method, const float offGrid) {
-    dim4 odims  = zi.dims();
-    odims[xdim] = xo.dims()[xdim];
-    odims[ydim] = xo.dims()[ydim];
-
-    Array<Ty> zo = createEmptyArray<Ty>(odims);
-
+void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
+             const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
+             const int ydim, const Tp &yi_beg, const Tp &yi_step,
+             const af_interp_type method, const float offGrid) {
     switch (method) {
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
@@ -74,18 +68,17 @@ Array<Ty> approx2(const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
             break;
         default: break;
     }
-    return zo;
 }
 
-#define INSTANTIATE(Ty, Tp)                                       \
-    template void approx1<Ty, Tp>(                                \
-        Array<Ty> & yo, const Array<Ty> &yi, const Array<Tp> &xo, \
-        const int xdim, const Tp &xi_beg, const Tp &xi_step,      \
-        const af_interp_type method, const float offGrid);        \
-    template Array<Ty> approx2<Ty, Tp>(                           \
-        const Array<Ty> &zi, const Array<Tp> &xo, const int xdim, \
-        const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo, \
-        const int ydim, const Tp &yi_beg, const Tp &yi_step,      \
+#define INSTANTIATE(Ty, Tp)                                             \
+    template void approx1<Ty, Tp>(                                      \
+        Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,        \
+        const int xdim, const Tp &xi_beg, const Tp &xi_step,            \
+        const af_interp_type method, const float offGrid);              \
+    template void approx2<Ty, Tp>(                                      \
+        Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim, \
+        const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,       \
+        const int ydim, const Tp &yi_beg, const Tp &yi_step,            \
         const af_interp_type method, const float offGrid);
 
 INSTANTIATE(float, float)

--- a/src/backend/cpu/approx.cpp
+++ b/src/backend/cpu/approx.cpp
@@ -39,10 +39,11 @@ void approx1(Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,
 }
 
 template<typename Ty, typename Tp>
-void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
-             const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
-             const int ydim, const Tp &yi_beg, const Tp &yi_step,
-             const af_interp_type method, const float offGrid) {
+void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo,
+             const int xdim, const Tp &xi_beg, const Tp &xi_step,
+             const Array<Tp> &yo, const int ydim, const Tp &yi_beg,
+             const Tp &yi_step, const af_interp_type method,
+             const float offGrid) {
     switch (method) {
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
@@ -70,16 +71,16 @@ void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int 
     }
 }
 
-#define INSTANTIATE(Ty, Tp)                                             \
-    template void approx1<Ty, Tp>(                                      \
-        Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,        \
-        const int xdim, const Tp &xi_beg, const Tp &xi_step,            \
-        const af_interp_type method, const float offGrid);              \
-    template void approx2<Ty, Tp>(                                      \
-        Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim, \
-        const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,       \
-        const int ydim, const Tp &yi_beg, const Tp &yi_step,            \
-        const af_interp_type method, const float offGrid);
+#define INSTANTIATE(Ty, Tp)                                       \
+    template void approx1<Ty, Tp>(                                \
+        Array<Ty> & yo, const Array<Ty> &yi, const Array<Tp> &xo, \
+        const int xdim, const Tp &xi_beg, const Tp &xi_step,      \
+        const af_interp_type method, const float offGrid);        \
+    template void approx2<Ty, Tp>(                                \
+        Array<Ty> & zo, const Array<Ty> &zi, const Array<Tp> &xo, \
+        const int xdim, const Tp &xi_beg, const Tp &xi_step,      \
+        const Array<Tp> &yo, const int ydim, const Tp &yi_beg,    \
+        const Tp &yi_step, const af_interp_type method, const float offGrid);
 
 INSTANTIATE(float, float)
 INSTANTIATE(double, double)

--- a/src/backend/cpu/approx.hpp
+++ b/src/backend/cpu/approx.hpp
@@ -17,8 +17,8 @@ void approx1(Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,
              const af_interp_type method, const float offGrid);
 
 template<typename Ty, typename Tp>
-Array<Ty> approx2(const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
-                  const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
-                  const int ydim, const Tp &yi_beg, const Tp &yi_step,
-                  const af_interp_type method, const float offGrid);
+void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
+             const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
+             const int ydim, const Tp &yi_beg, const Tp &yi_step,
+             const af_interp_type method, const float offGrid);
 }  // namespace cpu

--- a/src/backend/cpu/approx.hpp
+++ b/src/backend/cpu/approx.hpp
@@ -17,8 +17,9 @@ void approx1(Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,
              const af_interp_type method, const float offGrid);
 
 template<typename Ty, typename Tp>
-void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
-             const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
-             const int ydim, const Tp &yi_beg, const Tp &yi_step,
-             const af_interp_type method, const float offGrid);
+void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo,
+             const int xdim, const Tp &xi_beg, const Tp &xi_step,
+             const Array<Tp> &yo, const int ydim, const Tp &yi_beg,
+             const Tp &yi_step, const af_interp_type method,
+             const float offGrid);
 }  // namespace cpu

--- a/src/backend/cuda/approx.cpp
+++ b/src/backend/cuda/approx.cpp
@@ -23,24 +23,25 @@ void approx1(Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,
 }
 
 template<typename Ty, typename Tp>
-void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
-             const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
-             const int ydim, const Tp &yi_beg, const Tp &yi_step,
-             const af_interp_type method, const float offGrid) {
+void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo,
+             const int xdim, const Tp &xi_beg, const Tp &xi_step,
+             const Array<Tp> &yo, const int ydim, const Tp &yi_beg,
+             const Tp &yi_step, const af_interp_type method,
+             const float offGrid) {
     kernel::approx2<Ty, Tp>(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg,
                             yi_step, offGrid, method, interpOrder(method));
 }
 
-#define INSTANTIATE(Ty, Tp)                                             \
-    template void approx1<Ty, Tp>(                                      \
-        Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,        \
-        const int xdim, const Tp &xi_beg, const Tp &xi_step,            \
-        const af_interp_type method, const float offGrid);              \
-    template void approx2<Ty, Tp>(                                      \
-        Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim, \
-        const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,       \
-        const int ydim, const Tp &yi_beg, const Tp &yi_step,            \
-        const af_interp_type method, const float offGrid);
+#define INSTANTIATE(Ty, Tp)                                       \
+    template void approx1<Ty, Tp>(                                \
+        Array<Ty> & yo, const Array<Ty> &yi, const Array<Tp> &xo, \
+        const int xdim, const Tp &xi_beg, const Tp &xi_step,      \
+        const af_interp_type method, const float offGrid);        \
+    template void approx2<Ty, Tp>(                                \
+        Array<Ty> & zo, const Array<Ty> &zi, const Array<Tp> &xo, \
+        const int xdim, const Tp &xi_beg, const Tp &xi_step,      \
+        const Array<Tp> &yo, const int ydim, const Tp &yi_beg,    \
+        const Tp &yi_step, const af_interp_type method, const float offGrid);
 
 INSTANTIATE(float, float)
 INSTANTIATE(double, double)

--- a/src/backend/cuda/approx.cpp
+++ b/src/backend/cuda/approx.cpp
@@ -23,31 +23,23 @@ void approx1(Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,
 }
 
 template<typename Ty, typename Tp>
-Array<Ty> approx2(const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
-                  const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
-                  const int ydim, const Tp &yi_beg, const Tp &yi_step,
-                  const af_interp_type method, const float offGrid) {
-    af::dim4 odims = zi.dims();
-    odims[xdim]    = xo.dims()[xdim];
-    odims[ydim]    = xo.dims()[ydim];
-
-    // Create output placeholder
-    Array<Ty> zo = createEmptyArray<Ty>(odims);
-
+void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
+             const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
+             const int ydim, const Tp &yi_beg, const Tp &yi_step,
+             const af_interp_type method, const float offGrid) {
     kernel::approx2<Ty, Tp>(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg,
                             yi_step, offGrid, method, interpOrder(method));
-    return zo;
 }
 
-#define INSTANTIATE(Ty, Tp)                                       \
-    template void approx1<Ty, Tp>(                                \
-        Array<Ty> & yo, const Array<Ty> &yi, const Array<Tp> &xo, \
-        const int xdim, const Tp &xi_beg, const Tp &xi_step,      \
-        const af_interp_type method, const float offGrid);        \
-    template Array<Ty> approx2<Ty, Tp>(                           \
-        const Array<Ty> &zi, const Array<Tp> &xo, const int xdim, \
-        const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo, \
-        const int ydim, const Tp &yi_beg, const Tp &yi_step,      \
+#define INSTANTIATE(Ty, Tp)                                             \
+    template void approx1<Ty, Tp>(                                      \
+        Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,        \
+        const int xdim, const Tp &xi_beg, const Tp &xi_step,            \
+        const af_interp_type method, const float offGrid);              \
+    template void approx2<Ty, Tp>(                                      \
+        Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim, \
+        const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,       \
+        const int ydim, const Tp &yi_beg, const Tp &yi_step,            \
         const af_interp_type method, const float offGrid);
 
 INSTANTIATE(float, float)

--- a/src/backend/cuda/approx.hpp
+++ b/src/backend/cuda/approx.hpp
@@ -16,8 +16,9 @@ void approx1(Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,
              const af_interp_type method, const float offGrid);
 
 template<typename Ty, typename Tp>
-void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
-             const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
-             const int ydim, const Tp &yi_beg, const Tp &yi_step,
-             const af_interp_type method, const float offGrid);
+void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo,
+             const int xdim, const Tp &xi_beg, const Tp &xi_step,
+             const Array<Tp> &yo, const int ydim, const Tp &yi_beg,
+             const Tp &yi_step, const af_interp_type method,
+             const float offGrid);
 }  // namespace cuda

--- a/src/backend/cuda/approx.hpp
+++ b/src/backend/cuda/approx.hpp
@@ -16,8 +16,8 @@ void approx1(Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,
              const af_interp_type method, const float offGrid);
 
 template<typename Ty, typename Tp>
-Array<Ty> approx2(const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
-                  const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
-                  const int ydim, const Tp &yi_beg, const Tp &yi_step,
-                  const af_interp_type method, const float offGrid);
+void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
+             const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
+             const int ydim, const Tp &yi_beg, const Tp &yi_step,
+             const af_interp_type method, const float offGrid);
 }  // namespace cuda

--- a/src/backend/opencl/approx.cpp
+++ b/src/backend/opencl/approx.cpp
@@ -39,10 +39,11 @@ void approx1(Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,
 }
 
 template<typename Ty, typename Tp>
-void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
-             const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
-             const int ydim, const Tp &yi_beg, const Tp &yi_step,
-             const af_interp_type method, const float offGrid) {
+void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo,
+             const int xdim, const Tp &xi_beg, const Tp &xi_step,
+             const Array<Tp> &yo, const int ydim, const Tp &yi_beg,
+             const Tp &yi_step, const af_interp_type method,
+             const float offGrid) {
     switch (method) {
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
@@ -67,16 +68,16 @@ void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int 
     }
 }
 
-#define INSTANTIATE(Ty, Tp)                                             \
-    template void approx1<Ty, Tp>(                                      \
-        Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,        \
-        const int xdim, const Tp &xi_beg, const Tp &xi_step,            \
-        const af_interp_type method, const float offGrid);              \
-    template void approx2<Ty, Tp>(                                      \
-        Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim, \
-        const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,       \
-        const int ydim, const Tp &yi_beg, const Tp &yi_step,            \
-        const af_interp_type method, const float offGrid);
+#define INSTANTIATE(Ty, Tp)                                       \
+    template void approx1<Ty, Tp>(                                \
+        Array<Ty> & yo, const Array<Ty> &yi, const Array<Tp> &xo, \
+        const int xdim, const Tp &xi_beg, const Tp &xi_step,      \
+        const af_interp_type method, const float offGrid);        \
+    template void approx2<Ty, Tp>(                                \
+        Array<Ty> & zo, const Array<Ty> &zi, const Array<Tp> &xo, \
+        const int xdim, const Tp &xi_beg, const Tp &xi_step,      \
+        const Array<Tp> &yo, const int ydim, const Tp &yi_beg,    \
+        const Tp &yi_step, const af_interp_type method, const float offGrid);
 
 INSTANTIATE(float, float)
 INSTANTIATE(double, double)

--- a/src/backend/opencl/approx.cpp
+++ b/src/backend/opencl/approx.cpp
@@ -39,17 +39,10 @@ void approx1(Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,
 }
 
 template<typename Ty, typename Tp>
-Array<Ty> approx2(const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
-                  const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
-                  const int ydim, const Tp &yi_beg, const Tp &yi_step,
-                  const af_interp_type method, const float offGrid) {
-    af::dim4 odims = zi.dims();
-    odims[xdim]    = xo.dims()[xdim];
-    odims[ydim]    = xo.dims()[ydim];
-
-    // Create output placeholder
-    Array<Ty> zo = createEmptyArray<Ty>(odims);
-
+void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
+             const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
+             const int ydim, const Tp &yi_beg, const Tp &yi_step,
+             const af_interp_type method, const float offGrid) {
     switch (method) {
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
@@ -72,19 +65,17 @@ Array<Ty> approx2(const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
             break;
         default: break;
     }
-
-    return zo;
 }
 
-#define INSTANTIATE(Ty, Tp)                                       \
-    template void approx1<Ty, Tp>(                                \
-        Array<Ty> & yo, const Array<Ty> &yi, const Array<Tp> &xo, \
-        const int xdim, const Tp &xi_beg, const Tp &xi_step,      \
-        const af_interp_type method, const float offGrid);        \
-    template Array<Ty> approx2<Ty, Tp>(                           \
-        const Array<Ty> &zi, const Array<Tp> &xo, const int xdim, \
-        const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo, \
-        const int ydim, const Tp &yi_beg, const Tp &yi_step,      \
+#define INSTANTIATE(Ty, Tp)                                             \
+    template void approx1<Ty, Tp>(                                      \
+        Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,        \
+        const int xdim, const Tp &xi_beg, const Tp &xi_step,            \
+        const af_interp_type method, const float offGrid);              \
+    template void approx2<Ty, Tp>(                                      \
+        Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim, \
+        const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,       \
+        const int ydim, const Tp &yi_beg, const Tp &yi_step,            \
         const af_interp_type method, const float offGrid);
 
 INSTANTIATE(float, float)

--- a/src/backend/opencl/approx.hpp
+++ b/src/backend/opencl/approx.hpp
@@ -16,8 +16,8 @@ void approx1(Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,
              const af_interp_type method, const float offGrid);
 
 template<typename Ty, typename Tp>
-Array<Ty> approx2(const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
-                  const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
-                  const int ydim, const Tp &yi_beg, const Tp &yi_step,
-                  const af_interp_type method, const float offGrid);
+void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
+             const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
+             const int ydim, const Tp &yi_beg, const Tp &yi_step,
+             const af_interp_type method, const float offGrid);
 }  // namespace opencl

--- a/src/backend/opencl/approx.hpp
+++ b/src/backend/opencl/approx.hpp
@@ -16,8 +16,9 @@ void approx1(Array<Ty> &yo, const Array<Ty> &yi, const Array<Tp> &xo,
              const af_interp_type method, const float offGrid);
 
 template<typename Ty, typename Tp>
-void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo, const int xdim,
-             const Tp &xi_beg, const Tp &xi_step, const Array<Tp> &yo,
-             const int ydim, const Tp &yi_beg, const Tp &yi_step,
-             const af_interp_type method, const float offGrid);
+void approx2(Array<Ty> &zo, const Array<Ty> &zi, const Array<Tp> &xo,
+             const int xdim, const Tp &xi_beg, const Tp &xi_step,
+             const Array<Tp> &yo, const int ydim, const Tp &yi_beg,
+             const Tp &yi_step, const af_interp_type method,
+             const float offGrid);
 }  // namespace opencl

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -932,25 +932,26 @@ class Approx1V2 : public ::testing::Test {
 TYPED_TEST_CASE(Approx1V2, TestTypes);
 
 class SimpleTestData : public TestData {
+    static const int h_gold_size = 15;
+    static const int h_in_size   = 9;
+    static const int h_pos_size = 5;
+
     vector<float> h_pos;
     dim4 pos_dims;
 
    public:
     SimpleTestData() {
         gold_dims = dim4(5, 3);
-        int h_gold_size = gold_dims.elements();
         float gold_arr[h_gold_size] = {10.0f, 15.0f, 20.0f, 25.0f, 30.0f,
                                        40.0f, 45.0f, 50.0f, 55.0f, 60.0f,
                                        70.0f, 75.0f, 80.0f, 85.0f, 90.0f};
 
         in_dims = dim4(3, 3);
-        int h_in_size = in_dims.elements();
         float in_arr[h_in_size]     = {10.0f, 20.0f, 30.0f,
                                        40.0f, 50.0f, 60.0f,
                                        70.0f, 80.0f, 90.0f};
 
         pos_dims = dim4(5);
-        int h_pos_size = pos_dims.elements();
         float pos_arr[h_pos_size]   = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
 
         h_gold.assign(gold_arr, gold_arr + h_gold_size);

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -863,9 +863,9 @@ class Approx1V2 : public ::testing::Test {
         ReleaseArrays();
     }
 
-    void UploadTestData(float *h_gold, dim4 gold_dims,
-                        float *h_in, dim4 in_dims,
-                        float *h_pos, dim4 pos_dims) {
+    void setTestData(float *h_gold, dim4 gold_dims,
+                     float *h_in, dim4 in_dims,
+                     float *h_pos, dim4 pos_dims) {
         ReleaseArrays();
 
         gold = 0;
@@ -897,6 +897,12 @@ class Approx1V2 : public ::testing::Test {
                                        (af_dtype)dtype_traits<BT>::af_type));
     }
 
+    void setTestData(TestData *data) {
+        setTestData(data->getGoldArr(), data->getGoldDims(),
+                    data->getInArr(), data->getInDims(),
+                    data->getMiscArrs(0), data->getMiscDims(0));
+    }
+
     void testSpclOutArray(TestOutputArrayType out_array_type) {
         SUPPORTED_TYPE_CHECK(T);
 
@@ -925,103 +931,82 @@ class Approx1V2 : public ::testing::Test {
 
 TYPED_TEST_CASE(Approx1V2, TestTypes);
 
-struct SimpleTestData {
-    static const int h_gold_size = 15;
-    static const int h_in_size   = 9;
-    static const int h_pos_size  = 5;
-
-    vector<float> h_gold;
-    vector<float> h_in;
+class SimpleTestData : public TestData {
     vector<float> h_pos;
-
-    dim4 gold_dims;
-    dim4 in_dims;
     dim4 pos_dims;
 
-    SimpleTestData()
-        : h_gold(h_gold_size)
-        , h_in(h_in_size)
-        , h_pos(h_pos_size)
-        , gold_dims(5, 3)
-        , in_dims(3, 3)
-        , pos_dims(5) {
+   public:
+    SimpleTestData() {
+        gold_dims = dim4(5, 3);
+        int h_gold_size = gold_dims.elements();
         float gold_arr[h_gold_size] = {10.0f, 15.0f, 20.0f, 25.0f, 30.0f,
                                        40.0f, 45.0f, 50.0f, 55.0f, 60.0f,
                                        70.0f, 75.0f, 80.0f, 85.0f, 90.0f};
 
+        in_dims = dim4(3, 3);
+        int h_in_size = in_dims.elements();
         float in_arr[h_in_size]     = {10.0f, 20.0f, 30.0f,
                                        40.0f, 50.0f, 60.0f,
                                        70.0f, 80.0f, 90.0f};
 
+        pos_dims = dim4(5);
+        int h_pos_size = pos_dims.elements();
         float pos_arr[h_pos_size]   = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
 
         h_gold.assign(gold_arr, gold_arr + h_gold_size);
         h_in.assign(in_arr, in_arr + h_in_size);
         h_pos.assign(pos_arr, pos_arr + h_pos_size);
+
+        h_misc_arrs.push_back(&h_pos.front());
+        misc_dims.push_back(pos_dims);
     }
 };
 
 TYPED_TEST(Approx1V2, UseNullOutputArray) {
     SimpleTestData data;
-    this->UploadTestData(&data.h_gold.front(), data.gold_dims,
-                         &data.h_in.front(), data.in_dims,
-                         &data.h_pos.front(), data.pos_dims);
+    this->setTestData(&data);
     this->testSpclOutArray(NULL_ARRAY);
 }
 
 TYPED_TEST(Approx1V2, UseFullExistingOutputArray) {
     SimpleTestData data;
-    this->UploadTestData(&data.h_gold.front(), data.gold_dims,
-                         &data.h_in.front(), data.in_dims,
-                         &data.h_pos.front(), data.pos_dims);
+    this->setTestData(&data);
     this->testSpclOutArray(FULL_ARRAY);
 }
 
 TYPED_TEST(Approx1V2, UseExistingOutputSubArray) {
     SimpleTestData data;
-    this->UploadTestData(&data.h_gold.front(), data.gold_dims,
-                         &data.h_in.front(), data.in_dims,
-                         &data.h_pos.front(), data.pos_dims);
+    this->setTestData(&data);
     this->testSpclOutArray(SUB_ARRAY);
 }
 
 TYPED_TEST(Approx1V2, UseReorderedOutputArray) {
     SimpleTestData data;
-    this->UploadTestData(&data.h_gold.front(), data.gold_dims,
-                         &data.h_in.front(), data.in_dims,
-                         &data.h_pos.front(), data.pos_dims);
+    this->setTestData(&data);
     this->testSpclOutArray(REORDERED_ARRAY);
 }
 
 TYPED_TEST(Approx1V2, UniformUseNullOutputArray) {
     SimpleTestData data;
-    this->UploadTestData(&data.h_gold.front(), data.gold_dims,
-                         &data.h_in.front(), data.in_dims,
-                         &data.h_pos.front(), data.pos_dims);
+    this->setTestData(&data);
     this->testSpclOutArrayUniform(NULL_ARRAY);
 }
 
 TYPED_TEST(Approx1V2, UniformUseFullExistingOutputArray) {
     SimpleTestData data;
-    this->UploadTestData(&data.h_gold.front(), data.gold_dims,
-                         &data.h_in.front(), data.in_dims,
-                         &data.h_pos.front(), data.pos_dims);
+    this->setTestData(&data);
     this->testSpclOutArrayUniform(FULL_ARRAY);
 }
 
 TYPED_TEST(Approx1V2, UniformUseExistingOutputSubArray) {
     SimpleTestData data;
-    this->UploadTestData(&data.h_gold.front(), data.gold_dims,
-                         &data.h_in.front(), data.in_dims,
-                         &data.h_pos.front(), data.pos_dims);
+    this->setTestData(&data);
     this->testSpclOutArrayUniform(SUB_ARRAY);
 }
 
 TYPED_TEST(Approx1V2, UniformUseReorderedOutputArray) {
     SimpleTestData data;
-    this->UploadTestData(&data.h_gold.front(), data.gold_dims,
-                         &data.h_in.front(), data.in_dims,
-                         &data.h_pos.front(), data.pos_dims);
+    this->setTestData(&data);
     this->testSpclOutArrayUniform(REORDERED_ARRAY);
 }
 
@@ -1039,13 +1024,13 @@ class Approx1NullArgs : public ::testing::Test {
     void SetUp() {
         SimpleTestData data;
 
-        ASSERT_SUCCESS(af_create_array(&in, &data.h_in.front(),
-                                       data.in_dims.ndims(),
-                                       data.in_dims.get(),
+        ASSERT_SUCCESS(af_create_array(&in, data.getInArr(),
+                                       data.getInDims().ndims(),
+                                       data.getInDims().get(),
                                        f32));
-        ASSERT_SUCCESS(af_create_array(&pos, &data.h_pos.front(),
-                                       data.pos_dims.ndims(),
-                                       data.pos_dims.get(),
+        ASSERT_SUCCESS(af_create_array(&pos, data.getMiscArrs(0),
+                                       data.getMiscDims(0).ndims(),
+                                       data.getMiscDims(0).get(),
                                        f32));
     }
 

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -835,8 +835,8 @@ class Approx1V2 : public ::testing::Test {
     typedef typename dtype_traits<T>::base_type BT;
 
     static const int h_gold_size = 15;
-    static const int h_in_size = 9;
-    static const int h_pos_size = 5;
+    static const int h_in_size   = 9;
+    static const int h_pos_size  = 5;
 
     vector<T> h_gold_cast;
     vector<T> h_in_cast;
@@ -851,19 +851,24 @@ class Approx1V2 : public ::testing::Test {
     af_array pos;
 
     Approx1V2()
-        : h_gold_cast(h_gold_size), h_in_cast(h_in_size), h_pos_cast(h_pos_size)
-        , gold_dims(5, 3), in_dims(3, 3), pos_dims(5)
-        , gold(0), in(0), pos(0)
-    {
+        : h_gold_cast(h_gold_size)
+        , h_in_cast(h_in_size)
+        , h_pos_cast(h_pos_size)
+        , gold_dims(5, 3)
+        , in_dims(3, 3)
+        , pos_dims(5)
+        , gold(0)
+        , in(0)
+        , pos(0) {
         float h_gold[h_gold_size] = {10.0f, 15.0f, 20.0f, 25.0f, 30.0f,
                                      40.0f, 45.0f, 50.0f, 55.0f, 60.0f,
                                      70.0f, 75.0f, 80.0f, 85.0f, 90.0f};
 
-        float h_in[h_in_size] = {10.0f, 20.0f, 30.0f,
-                                 40.0f, 50.0f, 60.0f,
-                                 70.0f, 80.0f, 90.0f};
+        float h_in[h_in_size]     = {10.0f, 20.0f, 30.0f,
+                                     40.0f, 50.0f, 60.0f,
+                                     70.0f, 80.0f, 90.0f};
 
-        float h_pos[h_pos_size] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
+        float h_pos[h_pos_size]   = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
 
         for (int i = 0; i < gold_dims.elements(); ++i) {
             h_gold_cast[i] = static_cast<T>(h_gold[i]);
@@ -883,14 +888,14 @@ class Approx1V2 : public ::testing::Test {
         ASSERT_SUCCESS(af_create_array(&in, &h_in_cast.front(), in_dims.ndims(),
                                        in_dims.get(),
                                        (af_dtype)dtype_traits<T>::af_type));
-        ASSERT_SUCCESS(af_create_array(&pos, &h_pos_cast.front(), pos_dims.ndims(),
-                                       pos_dims.get(),
+        ASSERT_SUCCESS(af_create_array(&pos, &h_pos_cast.front(),
+                                       pos_dims.ndims(), pos_dims.get(),
                                        (af_dtype)dtype_traits<BT>::af_type));
     }
 
     void TearDown() {
-        if (pos != 0) { ASSERT_SUCCESS(af_release_array(pos)); }
-        if (in != 0) { ASSERT_SUCCESS(af_release_array(in)); }
+        if (pos != 0)  { ASSERT_SUCCESS(af_release_array(pos)); }
+        if (in != 0)   { ASSERT_SUCCESS(af_release_array(in)); }
         if (gold != 0) { ASSERT_SUCCESS(af_release_array(gold)); }
     }
 
@@ -978,32 +983,39 @@ TYPED_TEST_CASE(Approx1NullArgs, float);
 
 TYPED_TEST(Approx1NullArgs, NullOutputPtr) {
     af_array* out_ptr = 0;
-    ASSERT_EQ(af_approx1(out_ptr, this->in, this->pos, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(af_approx1(out_ptr, this->in, this->pos, AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx1NullArgs, NullInputArray) {
-    ASSERT_EQ(af_approx1(&this->out, 0, this->pos, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(af_approx1(&this->out, 0, this->pos, AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx1NullArgs, NullPosArray) {
-    ASSERT_EQ(af_approx1(&this->out, this->in, 0, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(af_approx1(&this->out, this->in, 0, AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx1NullArgs, V2NullOutputPtr) {
     af_array* out_ptr = 0;
-    ASSERT_EQ(af_approx1_v2(out_ptr, this->in, this->pos, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(
+        af_approx1_v2(out_ptr, this->in, this->pos, AF_INTERP_LINEAR, 0.f),
+        AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx1NullArgs, V2NullInputArray) {
-    ASSERT_EQ(af_approx1_v2(&this->out, 0, this->pos, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(af_approx1_v2(&this->out, 0, this->pos, AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx1NullArgs, V2NullPosArray) {
-    ASSERT_EQ(af_approx1_v2(&this->out, this->in, 0, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(af_approx1_v2(&this->out, this->in, 0, AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx1NullArgs, UniformNullOutputPtr) {
-    af_array* out_ptr  = 0;
+    af_array* out_ptr = 0;
     ASSERT_EQ(af_approx1_uniform(out_ptr, this->in, this->pos, 0, 0.0, 1.0,
                                  AF_INTERP_LINEAR, 0.f),
               AF_ERR_ARG);
@@ -1022,7 +1034,7 @@ TYPED_TEST(Approx1NullArgs, UniformNullPosArray) {
 }
 
 TYPED_TEST(Approx1NullArgs, V2UniformNullOutputPtr) {
-    af_array* out_ptr  = 0;
+    af_array* out_ptr = 0;
     ASSERT_EQ(af_approx1_uniform_v2(out_ptr, this->in, this->pos, 0, 0.0, 1.0,
                                     AF_INTERP_LINEAR, 0.f),
               AF_ERR_ARG);

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -846,35 +846,29 @@ class Approx1V2 : public ::testing::Test {
     af_array in;
     af_array pos;
 
-    Approx1V2()
-        : gold(0)
-        , in(0)
-        , pos(0) {}
+    Approx1V2() : gold(0), in(0), pos(0) {}
 
     void SetUp() {}
 
-    void ReleaseArrays() {
+    void releaseArrays() {
         if (pos != 0)  { ASSERT_SUCCESS(af_release_array(pos)); }
         if (in != 0)   { ASSERT_SUCCESS(af_release_array(in)); }
         if (gold != 0) { ASSERT_SUCCESS(af_release_array(gold)); }
     }
 
-    void TearDown() {
-        ReleaseArrays();
-    }
+    void TearDown() { releaseArrays(); }
 
-    void setTestData(float *h_gold, dim4 gold_dims,
-                     float *h_in, dim4 in_dims,
-                     float *h_pos, dim4 pos_dims) {
-        ReleaseArrays();
+    void setTestData(float* h_gold, dim4 gold_dims, float* h_in, dim4 in_dims,
+                     float* h_pos, dim4 pos_dims) {
+        releaseArrays();
 
         gold = 0;
-        in = 0;
-        pos = 0;
+        in   = 0;
+        pos  = 0;
 
         this->gold_dims = gold_dims;
-        this->in_dims = in_dims;
-        this->pos_dims = pos_dims;
+        this->in_dims   = in_dims;
+        this->pos_dims  = pos_dims;
 
         for (int i = 0; i < gold_dims.elements(); ++i) {
             h_gold_cast.push_back(static_cast<T>(h_gold[i]));
@@ -939,10 +933,7 @@ class SimpleTestData {
     dim4 in_dims;
     dim4 pos_dims;
 
-    SimpleTestData()
-        : gold_dims(5, 3)
-        , in_dims(3, 3)
-        , pos_dims(5) {
+    SimpleTestData() : gold_dims(5, 3), in_dims(3, 3), pos_dims(5) {
         float gold_arr[h_gold_size] = {10.0f, 15.0f, 20.0f, 25.0f, 30.0f,
                                        40.0f, 45.0f, 50.0f, 55.0f, 60.0f,
                                        70.0f, 75.0f, 80.0f, 85.0f, 90.0f};
@@ -961,12 +952,12 @@ class SimpleTestData {
 
 template<typename T>
 class Approx1V2Simple : public Approx1V2<T> {
-protected:
+   protected:
     void SetUp() {
         SimpleTestData data;
         this->setTestData(&data.h_gold.front(), data.gold_dims,
-                          &data.h_in.front(), data.in_dims,
-                          &data.h_pos.front(), data.pos_dims);
+                          &data.h_in.front(), data.in_dims, &data.h_pos.front(),
+                          data.pos_dims);
     }
 };
 
@@ -1010,22 +1001,17 @@ class Approx1NullArgs : public ::testing::Test {
     af_array in;
     af_array pos;
 
-    Approx1NullArgs()
-        : out(0)
-        , in(0)
-        , pos(0) {}
+    Approx1NullArgs() : out(0), in(0), pos(0) {}
 
     void SetUp() {
         SimpleTestData data;
 
         ASSERT_SUCCESS(af_create_array(&in, &data.h_in.front(),
-                                       data.in_dims.ndims(),
-                                       data.in_dims.get(),
+                                       data.in_dims.ndims(), data.in_dims.get(),
                                        f32));
         ASSERT_SUCCESS(af_create_array(&pos, &data.h_pos.front(),
                                        data.pos_dims.ndims(),
-                                       data.pos_dims.get(),
-                                       f32));
+                                       data.pos_dims.get(), f32));
     }
 
     void TearDown() {
@@ -1036,71 +1022,66 @@ class Approx1NullArgs : public ::testing::Test {
 
 TEST_F(Approx1NullArgs, NullOutputPtr) {
     af_array* out_ptr = 0;
-    ASSERT_EQ(af_approx1(out_ptr, this->in, this->pos, AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG,
+              af_approx1(out_ptr, this->in, this->pos, AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx1NullArgs, NullInputArray) {
-    ASSERT_EQ(af_approx1(&this->out, 0, this->pos, AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG,
+              af_approx1(&this->out, 0, this->pos, AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx1NullArgs, NullPosArray) {
-    ASSERT_EQ(af_approx1(&this->out, this->in, 0, AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG,
+              af_approx1(&this->out, this->in, 0, AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx1NullArgs, V2NullOutputPtr) {
     af_array* out_ptr = 0;
-    ASSERT_EQ(
-        af_approx1_v2(out_ptr, this->in, this->pos, AF_INTERP_LINEAR, 0.f),
-        AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx1_v2(out_ptr, this->in, this->pos,
+                                        AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx1NullArgs, V2NullInputArray) {
-    ASSERT_EQ(af_approx1_v2(&this->out, 0, this->pos, AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG,
+              af_approx1_v2(&this->out, 0, this->pos, AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx1NullArgs, V2NullPosArray) {
-    ASSERT_EQ(af_approx1_v2(&this->out, this->in, 0, AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG,
+              af_approx1_v2(&this->out, this->in, 0, AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx1NullArgs, UniformNullOutputPtr) {
     af_array* out_ptr = 0;
-    ASSERT_EQ(af_approx1_uniform(out_ptr, this->in, this->pos, 0, 0.0, 1.0,
-                                 AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx1_uniform(out_ptr, this->in, this->pos, 0,
+                                             0.0, 1.0, AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx1NullArgs, UniformNullInputArray) {
-    ASSERT_EQ(af_approx1_uniform(&this->out, 0, this->pos, 0, 0.0, 1.0,
-                                 AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx1_uniform(&this->out, 0, this->pos, 0, 0.0,
+                                             1.0, AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx1NullArgs, UniformNullPosArray) {
-    ASSERT_EQ(af_approx1_uniform(&this->out, this->in, 0, 0, 0.0, 1.0,
-                                 AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx1_uniform(&this->out, this->in, 0, 0, 0.0,
+                                             1.0, AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx1NullArgs, V2UniformNullOutputPtr) {
     af_array* out_ptr = 0;
-    ASSERT_EQ(af_approx1_uniform_v2(out_ptr, this->in, this->pos, 0, 0.0, 1.0,
-                                    AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG,
+              af_approx1_uniform_v2(out_ptr, this->in, this->pos, 0, 0.0, 1.0,
+                                    AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx1NullArgs, V2UniformNullInputArray) {
-    ASSERT_EQ(af_approx1_uniform_v2(&this->out, 0, this->pos, 0, 0.0, 1.0,
-                                    AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG,
+              af_approx1_uniform_v2(&this->out, 0, this->pos, 0, 0.0, 1.0,
+                                    AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx1NullArgs, V2UniformNullPosArray) {
-    ASSERT_EQ(af_approx1_uniform_v2(&this->out, this->in, 0, 0, 0.0, 1.0,
-                                    AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx1_uniform_v2(&this->out, this->in, 0, 0, 0.0,
+                                                1.0, AF_INTERP_LINEAR, 0.f));
 }

--- a/test/approx1.cpp
+++ b/test/approx1.cpp
@@ -897,12 +897,6 @@ class Approx1V2 : public ::testing::Test {
                                        (af_dtype)dtype_traits<BT>::af_type));
     }
 
-    void setTestData(TestData *data) {
-        setTestData(data->getGoldArr(), data->getGoldDims(),
-                    data->getInArr(), data->getInDims(),
-                    data->getMiscArrs(0), data->getMiscDims(0));
-    }
-
     void testSpclOutArray(TestOutputArrayType out_array_type) {
         SUPPORTED_TYPE_CHECK(T);
 
@@ -931,83 +925,82 @@ class Approx1V2 : public ::testing::Test {
 
 TYPED_TEST_CASE(Approx1V2, TestTypes);
 
-class SimpleTestData : public TestData {
+class SimpleTestData {
+   public:
     static const int h_gold_size = 15;
     static const int h_in_size   = 9;
-    static const int h_pos_size = 5;
+    static const int h_pos_size  = 5;
 
+    vector<float> h_gold;
+    vector<float> h_in;
     vector<float> h_pos;
+
+    dim4 gold_dims;
+    dim4 in_dims;
     dim4 pos_dims;
 
-   public:
-    SimpleTestData() {
-        gold_dims = dim4(5, 3);
+    SimpleTestData()
+        : gold_dims(5, 3)
+        , in_dims(3, 3)
+        , pos_dims(5) {
         float gold_arr[h_gold_size] = {10.0f, 15.0f, 20.0f, 25.0f, 30.0f,
                                        40.0f, 45.0f, 50.0f, 55.0f, 60.0f,
                                        70.0f, 75.0f, 80.0f, 85.0f, 90.0f};
 
-        in_dims = dim4(3, 3);
-        float in_arr[h_in_size]     = {10.0f, 20.0f, 30.0f,
-                                       40.0f, 50.0f, 60.0f,
-                                       70.0f, 80.0f, 90.0f};
+        float in_arr[h_in_size] = {10.0f, 20.0f, 30.0f,
+                                   40.0f, 50.0f, 60.0f,
+                                   70.0f, 80.0f, 90.0f};
 
-        pos_dims = dim4(5);
-        float pos_arr[h_pos_size]   = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
+        float pos_arr[h_pos_size] = {0.0f, 0.5f, 1.0f, 1.5f, 2.0f};
 
         h_gold.assign(gold_arr, gold_arr + h_gold_size);
         h_in.assign(in_arr, in_arr + h_in_size);
         h_pos.assign(pos_arr, pos_arr + h_pos_size);
-
-        h_misc_arrs.push_back(&h_pos.front());
-        misc_dims.push_back(pos_dims);
     }
 };
 
-TYPED_TEST(Approx1V2, UseNullOutputArray) {
-    SimpleTestData data;
-    this->setTestData(&data);
+template<typename T>
+class Approx1V2Simple : public Approx1V2<T> {
+protected:
+    void SetUp() {
+        SimpleTestData data;
+        this->setTestData(&data.h_gold.front(), data.gold_dims,
+                          &data.h_in.front(), data.in_dims,
+                          &data.h_pos.front(), data.pos_dims);
+    }
+};
+
+TYPED_TEST_CASE(Approx1V2Simple, TestTypes);
+
+TYPED_TEST(Approx1V2Simple, UseNullOutputArray) {
     this->testSpclOutArray(NULL_ARRAY);
 }
 
-TYPED_TEST(Approx1V2, UseFullExistingOutputArray) {
-    SimpleTestData data;
-    this->setTestData(&data);
+TYPED_TEST(Approx1V2Simple, UseFullExistingOutputArray) {
     this->testSpclOutArray(FULL_ARRAY);
 }
 
-TYPED_TEST(Approx1V2, UseExistingOutputSubArray) {
-    SimpleTestData data;
-    this->setTestData(&data);
+TYPED_TEST(Approx1V2Simple, UseExistingOutputSubArray) {
     this->testSpclOutArray(SUB_ARRAY);
 }
 
-TYPED_TEST(Approx1V2, UseReorderedOutputArray) {
-    SimpleTestData data;
-    this->setTestData(&data);
+TYPED_TEST(Approx1V2Simple, UseReorderedOutputArray) {
     this->testSpclOutArray(REORDERED_ARRAY);
 }
 
-TYPED_TEST(Approx1V2, UniformUseNullOutputArray) {
-    SimpleTestData data;
-    this->setTestData(&data);
+TYPED_TEST(Approx1V2Simple, UniformUseNullOutputArray) {
     this->testSpclOutArrayUniform(NULL_ARRAY);
 }
 
-TYPED_TEST(Approx1V2, UniformUseFullExistingOutputArray) {
-    SimpleTestData data;
-    this->setTestData(&data);
+TYPED_TEST(Approx1V2Simple, UniformUseFullExistingOutputArray) {
     this->testSpclOutArrayUniform(FULL_ARRAY);
 }
 
-TYPED_TEST(Approx1V2, UniformUseExistingOutputSubArray) {
-    SimpleTestData data;
-    this->setTestData(&data);
+TYPED_TEST(Approx1V2Simple, UniformUseExistingOutputSubArray) {
     this->testSpclOutArrayUniform(SUB_ARRAY);
 }
 
-TYPED_TEST(Approx1V2, UniformUseReorderedOutputArray) {
-    SimpleTestData data;
-    this->setTestData(&data);
+TYPED_TEST(Approx1V2Simple, UniformUseReorderedOutputArray) {
     this->testSpclOutArrayUniform(REORDERED_ARRAY);
 }
 
@@ -1025,19 +1018,19 @@ class Approx1NullArgs : public ::testing::Test {
     void SetUp() {
         SimpleTestData data;
 
-        ASSERT_SUCCESS(af_create_array(&in, data.getInArr(),
-                                       data.getInDims().ndims(),
-                                       data.getInDims().get(),
+        ASSERT_SUCCESS(af_create_array(&in, &data.h_in.front(),
+                                       data.in_dims.ndims(),
+                                       data.in_dims.get(),
                                        f32));
-        ASSERT_SUCCESS(af_create_array(&pos, data.getMiscArrs(0),
-                                       data.getMiscDims(0).ndims(),
-                                       data.getMiscDims(0).get(),
+        ASSERT_SUCCESS(af_create_array(&pos, &data.h_pos.front(),
+                                       data.pos_dims.ndims(),
+                                       data.pos_dims.get(),
                                        f32));
     }
 
     void TearDown() {
-        if (pos != 0)  { ASSERT_SUCCESS(af_release_array(pos)); }
-        if (in != 0)   { ASSERT_SUCCESS(af_release_array(in)); }
+        if (pos != 0) { ASSERT_SUCCESS(af_release_array(pos)); }
+        if (in != 0)  { ASSERT_SUCCESS(af_release_array(in)); }
     }
 };
 

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -760,7 +760,7 @@ class Approx2V2 : public ::testing::Test {
     typedef typename dtype_traits<T>::base_type BT;
 
     static const int h_gold_size = 4;
-    static const int h_in_size = 9;
+    static const int h_in_size   = 9;
     static const int h_pos1_size = 4;
     static const int h_pos2_size = 4;
 
@@ -780,15 +780,30 @@ class Approx2V2 : public ::testing::Test {
     af_array pos2;
 
     Approx2V2()
-        : h_gold_cast(h_gold_size), h_in_cast(h_in_size)
-        , h_pos1_cast(h_pos1_size), h_pos2_cast(h_pos2_size)
-        , gold_dims(2, 2), in_dims(3, 3), pos1_dims(2, 2), pos2_dims(2, 2)
-        , gold(0), in(0), pos1(0), pos2(0)
-    {
-        float h_gold[h_gold_size] = {1.5, 1.5, 2.5, 2.5};
-        float h_in[h_in_size] = {1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0};
-        float h_pos1[h_pos1_size] = {0.5, 1.5, 0.5, 1.5};
-        float h_pos2[h_pos2_size] = {0.5, 0.5, 1.5, 1.5};
+        : h_gold_cast(h_gold_size)
+        , h_in_cast(h_in_size)
+        , h_pos1_cast(h_pos1_size)
+        , h_pos2_cast(h_pos2_size)
+        , gold_dims(2, 2)
+        , in_dims(3, 3)
+        , pos1_dims(2, 2)
+        , pos2_dims(2, 2)
+        , gold(0)
+        , in(0)
+        , pos1(0)
+        , pos2(0) {
+        float h_gold[h_gold_size] = {1.5, 1.5,
+                                     2.5, 2.5};
+
+        float h_in[h_in_size]     = {1.0, 1.0, 1.0,
+                                     2.0, 2.0, 2.0,
+                                     3.0, 3.0, 3.0};
+
+        float h_pos1[h_pos1_size] = {0.5, 1.5,
+                                     0.5, 1.5};
+
+        float h_pos2[h_pos2_size] = {0.5, 0.5,
+                                     1.5, 1.5};
 
         for (int i = 0; i < gold_dims.elements(); ++i) {
             h_gold_cast[i] = static_cast<T>(h_gold[i]);
@@ -811,18 +826,18 @@ class Approx2V2 : public ::testing::Test {
         ASSERT_SUCCESS(af_create_array(&in, &h_in_cast.front(), in_dims.ndims(),
                                        in_dims.get(),
                                        (af_dtype)dtype_traits<T>::af_type));
-        ASSERT_SUCCESS(af_create_array(&pos1, &h_pos1_cast.front(), pos1_dims.ndims(),
-                                       pos1_dims.get(),
+        ASSERT_SUCCESS(af_create_array(&pos1, &h_pos1_cast.front(),
+                                       pos1_dims.ndims(), pos1_dims.get(),
                                        (af_dtype)dtype_traits<BT>::af_type));
-        ASSERT_SUCCESS(af_create_array(&pos2, &h_pos2_cast.front(), pos2_dims.ndims(),
-                                       pos2_dims.get(),
+        ASSERT_SUCCESS(af_create_array(&pos2, &h_pos2_cast.front(),
+                                       pos2_dims.ndims(), pos2_dims.get(),
                                        (af_dtype)dtype_traits<BT>::af_type));
     }
 
     void TearDown() {
         if (pos2 != 0) { ASSERT_SUCCESS(af_release_array(pos2)); }
         if (pos1 != 0) { ASSERT_SUCCESS(af_release_array(pos1)); }
-        if (in != 0) { ASSERT_SUCCESS(af_release_array(in)); }
+        if (in != 0)   { ASSERT_SUCCESS(af_release_array(in)); }
         if (gold != 0) { ASSERT_SUCCESS(af_release_array(gold)); }
     }
 
@@ -834,7 +849,8 @@ class Approx2V2 : public ::testing::Test {
         genTestOutputArray(&out, gold_dims.ndims(), gold_dims.get(),
                            (af_dtype)dtype_traits<T>::af_type, &metadata);
 
-        ASSERT_SUCCESS(af_approx2_v2(&out, in, pos1, pos2, AF_INTERP_LINEAR, 0));
+        ASSERT_SUCCESS(
+            af_approx2_v2(&out, in, pos1, pos2, AF_INTERP_LINEAR, 0));
         ASSERT_SPECIAL_ARRAYS_EQ(gold, out, &metadata);
     }
 
@@ -846,8 +862,8 @@ class Approx2V2 : public ::testing::Test {
         genTestOutputArray(&out, gold_dims.ndims(), gold_dims.get(),
                            (af_dtype)dtype_traits<T>::af_type, &metadata);
 
-        ASSERT_SUCCESS(af_approx2_uniform_v2(&out, in, pos1, 0, 0.0, 1.0,
-                                             pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0));
+        ASSERT_SUCCESS(af_approx2_uniform_v2(&out, in, pos1, 0, 0.0, 1.0, pos2,
+                                             1, 0.0, 1.0, AF_INTERP_LINEAR, 0));
         ASSERT_SPECIAL_ARRAYS_EQ(gold, out, &metadata);
     }
 };
@@ -910,40 +926,56 @@ TYPED_TEST_CASE(Approx2NullArgs, float);
 
 TYPED_TEST(Approx2NullArgs, NullOutputPtr) {
     af_array* out_ptr = 0;
-    ASSERT_EQ(af_approx2(out_ptr, this->in, this->pos1, this->pos2, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(af_approx2(out_ptr, this->in, this->pos1, this->pos2,
+                         AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, NullInputArray) {
-    ASSERT_EQ(af_approx2(&this->out, 0, this->pos1, this->pos2, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(af_approx2(&this->out, 0, this->pos1, this->pos2,
+                         AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, NullPos1Array) {
-    ASSERT_EQ(af_approx2(&this->out, this->in, 0, this->pos2, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(
+        af_approx2(&this->out, this->in, 0, this->pos2, AF_INTERP_LINEAR, 0.f),
+        AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, NullPos2Array) {
-    ASSERT_EQ(af_approx2(&this->out, this->in, this->pos1, 0, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(
+        af_approx2(&this->out, this->in, this->pos1, 0, AF_INTERP_LINEAR, 0.f),
+        AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, V2NullOutputPtr) {
     af_array* out_ptr = 0;
-    ASSERT_EQ(af_approx2_v2(out_ptr, this->in, this->pos1, this->pos2, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(af_approx2_v2(out_ptr, this->in, this->pos1, this->pos2,
+                            AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, V2NullInputArray) {
-    ASSERT_EQ(af_approx2_v2(&this->out, 0, this->pos1, this->pos2, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(af_approx2_v2(&this->out, 0, this->pos1, this->pos2,
+                            AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, V2NullPos1Array) {
-    ASSERT_EQ(af_approx2_v2(&this->out, this->in, 0, this->pos2, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(af_approx2_v2(&this->out, this->in, 0, this->pos2,
+                            AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, V2NullPos2Array) {
-    ASSERT_EQ(af_approx2_v2(&this->out, this->in, this->pos1, 0, AF_INTERP_LINEAR, 0.f), AF_ERR_ARG);
+    ASSERT_EQ(af_approx2_v2(&this->out, this->in, this->pos1, 0,
+                            AF_INTERP_LINEAR, 0.f),
+              AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, UniformNullOutputPtr) {
-    af_array* out_ptr  = 0;
+    af_array* out_ptr = 0;
     ASSERT_EQ(af_approx2_uniform(out_ptr, this->in, this->pos1, 0, 0.0, 1.0,
                                  this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
               AF_ERR_ARG);
@@ -968,26 +1000,29 @@ TYPED_TEST(Approx2NullArgs, UniformNullPos2Array) {
 }
 
 TYPED_TEST(Approx2NullArgs, V2UniformNullOutputPtr) {
-    af_array* out_ptr  = 0;
-    ASSERT_EQ(af_approx2_uniform_v2(out_ptr, this->in, this->pos1, 0, 0.0, 1.0,
-                                    this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
-              AF_ERR_ARG);
+    af_array* out_ptr = 0;
+    ASSERT_EQ(
+        af_approx2_uniform_v2(out_ptr, this->in, this->pos1, 0, 0.0, 1.0,
+                              this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
+        AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, V2UniformNullInputArray) {
-    ASSERT_EQ(af_approx2_uniform_v2(&this->out, 0, this->pos1, 0, 0.0, 1.0,
-                                    this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
-              AF_ERR_ARG);
+    ASSERT_EQ(
+        af_approx2_uniform_v2(&this->out, 0, this->pos1, 0, 0.0, 1.0,
+                              this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
+        AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, V2UniformNullPos1Array) {
-    ASSERT_EQ(af_approx2_uniform_v2(&this->out, this->in, 0, 0, 0.0, 1.0,
-                                    this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
-              AF_ERR_ARG);
+    ASSERT_EQ(
+        af_approx2_uniform_v2(&this->out, this->in, 0, 0, 0.0, 1.0, this->pos2,
+                              1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
+        AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, V2UniformNullPos2Array) {
-    ASSERT_EQ(af_approx2_uniform_v2(&this->out, this->in, this->pos1, 0, 0.0, 1.0,
-                                    0, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
+    ASSERT_EQ(af_approx2_uniform_v2(&this->out, this->in, this->pos1, 0, 0.0,
+                                    1.0, 0, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
               AF_ERR_ARG);
 }

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -939,25 +939,25 @@ TYPED_TEST(Approx2NullArgs, V2NullPos2Array) {
 TYPED_TEST(Approx2NullArgs, UniformNullOutputPtr) {
     af_array* out_ptr  = 0;
     ASSERT_EQ(af_approx2_uniform(out_ptr, this->in, this->pos1, 0, 0.0, 1.0,
-                                    this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
+                                 this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
               AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, UniformNullInputArray) {
     ASSERT_EQ(af_approx2_uniform(&this->out, 0, this->pos1, 0, 0.0, 1.0,
-                                    this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
+                                 this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
               AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, UniformNullPos1Array) {
-    ASSERT_EQ(af_approx2_uniform(&this->out, 0, 0, 0, 0.0, 1.0,
-                                    this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
+    ASSERT_EQ(af_approx2_uniform(&this->out, this->in, 0, 0, 0.0, 1.0,
+                                 this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
               AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, UniformNullPos2Array) {
-    ASSERT_EQ(af_approx2_uniform(&this->out, 0, 0, 0, 0.0, 1.0,
-                                    0, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
+    ASSERT_EQ(af_approx2_uniform(&this->out, this->in, this->pos1, 0, 0.0, 1.0,
+                                 0, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
               AF_ERR_ARG);
 }
 
@@ -975,13 +975,13 @@ TYPED_TEST(Approx2NullArgs, V2UniformNullInputArray) {
 }
 
 TYPED_TEST(Approx2NullArgs, V2UniformNullPos1Array) {
-    ASSERT_EQ(af_approx2_uniform_v2(&this->out, 0, 0, 0, 0.0, 1.0,
+    ASSERT_EQ(af_approx2_uniform_v2(&this->out, this->in, 0, 0, 0.0, 1.0,
                                     this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
               AF_ERR_ARG);
 }
 
 TYPED_TEST(Approx2NullArgs, V2UniformNullPos2Array) {
-    ASSERT_EQ(af_approx2_uniform_v2(&this->out, 0, 0, 0, 0.0, 1.0,
+    ASSERT_EQ(af_approx2_uniform_v2(&this->out, this->in, this->pos1, 0, 0.0, 1.0,
                                     0, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
               AF_ERR_ARG);
 }

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -830,8 +830,6 @@ class Approx2V2 : public ::testing::Test {
 
         ASSERT_SUCCESS(af_approx2_v2(&out, in, pos1, pos2, AF_INTERP_LINEAR, 0));
         ASSERT_SPECIAL_ARRAYS_EQ(gold, out, &metadata);
-
-        if (out != 0) { ASSERT_SUCCESS(af_release_array(out)); }
     }
 
     void testSpclOutArrayUniform(TestOutputArrayType out_array_type) {
@@ -845,8 +843,6 @@ class Approx2V2 : public ::testing::Test {
         ASSERT_SUCCESS(af_approx2_uniform_v2(&out, in, pos1, 0, 0.0, 1.0,
                                              pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0));
         ASSERT_SPECIAL_ARRAYS_EQ(gold, out, &metadata);
-
-        if (out != 0) { ASSERT_SUCCESS(af_release_array(out)); }
     }
 };
 

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -759,6 +759,11 @@ class Approx2V2 : public ::testing::Test {
    protected:
     typedef typename dtype_traits<T>::base_type BT;
 
+    static const int h_gold_size = 4;
+    static const int h_in_size = 9;
+    static const int h_pos1_size = 4;
+    static const int h_pos2_size = 4;
+
     vector<T> h_gold_cast;
     vector<T> h_in_cast;
     vector<BT> h_pos1_cast;
@@ -775,14 +780,15 @@ class Approx2V2 : public ::testing::Test {
     af_array pos2;
 
     Approx2V2()
-        : h_gold_cast(4), h_in_cast(9), h_pos1_cast(4), h_pos2_cast(4),
-          gold_dims(2, 2), in_dims(3, 3), pos1_dims(2, 2), pos2_dims(2, 2),
-          gold(0), in(0), pos1(0), pos2(0)
+        : h_gold_cast(h_gold_size), h_in_cast(h_in_size)
+        , h_pos1_cast(h_pos1_size), h_pos2_cast(h_pos2_size)
+        , gold_dims(2, 2), in_dims(3, 3), pos1_dims(2, 2), pos2_dims(2, 2)
+        , gold(0), in(0), pos1(0), pos2(0)
     {
-        float h_gold[4] = {1.5, 1.5, 2.5, 2.5};
-        float h_in[9] = {1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0};
-        float h_pos1[4] = {0.5, 1.5, 0.5, 1.5};
-        float h_pos2[4] = {0.5, 0.5, 1.5, 1.5};
+        float h_gold[h_gold_size] = {1.5, 1.5, 2.5, 2.5};
+        float h_in[h_in_size] = {1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0};
+        float h_pos1[h_pos1_size] = {0.5, 1.5, 0.5, 1.5};
+        float h_pos2[h_pos2_size] = {0.5, 0.5, 1.5, 1.5};
 
         for (int i = 0; i < gold_dims.elements(); ++i) {
             h_gold_cast[i] = static_cast<T>(h_gold[i]);

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -874,6 +874,11 @@ class Approx2V2 : public ::testing::Test {
 TYPED_TEST_CASE(Approx2V2, TestTypes);
 
 class SimpleTestData : public TestData {
+    static const int h_gold_size = 4;
+    static const int h_in_size = 9;
+    static const int h_pos1_size = 4;
+    static const int h_pos2_size = 4;
+
     vector<float> h_pos1;
     vector<float> h_pos2;
 
@@ -883,23 +888,19 @@ class SimpleTestData : public TestData {
    public:
     SimpleTestData() {
         gold_dims = dim4(2, 2);
-        int h_gold_size = gold_dims.elements();
         float gold_arr[h_gold_size] = {1.5, 1.5,
                                        2.5, 2.5};
 
         in_dims = dim4(3, 3);
-        int h_in_size = in_dims.elements();
         float in_arr[h_in_size]     = {1.0, 1.0, 1.0,
                                        2.0, 2.0, 2.0,
                                        3.0, 3.0, 3.0};
 
         pos1_dims = dim4(2, 2);
-        int h_pos1_size = pos1_dims.elements();
         float pos1_arr[h_pos1_size] = {0.5, 1.5,
                                        0.5, 1.5};
 
         pos2_dims = dim4(2, 2);
-        int h_pos2_size = pos2_dims.elements();
         float pos2_arr[h_pos2_size] = {0.5, 0.5,
                                        1.5, 1.5};
 

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -774,38 +774,31 @@ class Approx2V2 : public ::testing::Test {
     af_array pos1;
     af_array pos2;
 
-    Approx2V2()
-        : gold(0)
-        , in(0)
-        , pos1(0)
-        , pos2(0) {}
+    Approx2V2() : gold(0), in(0), pos1(0), pos2(0) {}
 
     void SetUp() {}
 
-    void ReleaseArrays() {
+    void releaseArrays() {
         if (pos2 != 0) { ASSERT_SUCCESS(af_release_array(pos2)); }
         if (pos1 != 0) { ASSERT_SUCCESS(af_release_array(pos1)); }
         if (in != 0)   { ASSERT_SUCCESS(af_release_array(in)); }
         if (gold != 0) { ASSERT_SUCCESS(af_release_array(gold)); }
     }
 
-    void TearDown() {
-        ReleaseArrays();
-    }
+    void TearDown() { releaseArrays(); }
 
-    void setTestData(float *h_gold, dim4 gold_dims,
-                     float *h_in, dim4 in_dims,
-                     float *h_pos1, dim4 pos1_dims,
-                     float *h_pos2, dim4 pos2_dims) {
-        ReleaseArrays();
+    void setTestData(float* h_gold, dim4 gold_dims, float* h_in, dim4 in_dims,
+                     float* h_pos1, dim4 pos1_dims, float* h_pos2,
+                     dim4 pos2_dims) {
+        releaseArrays();
 
         gold = 0;
-        in = 0;
+        in   = 0;
         pos1 = 0;
         pos2 = 0;
 
         this->gold_dims = gold_dims;
-        this->in_dims = in_dims;
+        this->in_dims   = in_dims;
         this->pos1_dims = pos1_dims;
         this->pos2_dims = pos2_dims;
 
@@ -868,7 +861,7 @@ TYPED_TEST_CASE(Approx2V2, TestTypes);
 class SimpleTestData {
    public:
     static const int h_gold_size = 4;
-    static const int h_in_size = 9;
+    static const int h_in_size   = 9;
     static const int h_pos1_size = 4;
     static const int h_pos2_size = 4;
 
@@ -884,22 +877,14 @@ class SimpleTestData {
 
    public:
     SimpleTestData()
-        : gold_dims(2, 2)
-        , in_dims(3, 3)
-        , pos1_dims(2, 2)
-        , pos2_dims(2, 2) {
-        float gold_arr[h_gold_size] = {1.5, 1.5,
-                                       2.5, 2.5};
+        : gold_dims(2, 2), in_dims(3, 3), pos1_dims(2, 2), pos2_dims(2, 2) {
+        float gold_arr[h_gold_size] = {1.5, 1.5, 2.5, 2.5};
 
-        float in_arr[h_in_size]     = {1.0, 1.0, 1.0,
-                                       2.0, 2.0, 2.0,
-                                       3.0, 3.0, 3.0};
+        float in_arr[h_in_size] = {1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0};
 
-        float pos1_arr[h_pos1_size] = {0.5, 1.5,
-                                       0.5, 1.5};
+        float pos1_arr[h_pos1_size] = {0.5, 1.5, 0.5, 1.5};
 
-        float pos2_arr[h_pos2_size] = {0.5, 0.5,
-                                       1.5, 1.5};
+        float pos2_arr[h_pos2_size] = {0.5, 0.5, 1.5, 1.5};
 
         h_gold.assign(gold_arr, gold_arr + h_gold_size);
         h_in.assign(in_arr, in_arr + h_in_size);
@@ -961,134 +946,116 @@ class Approx2NullArgs : public ::testing::Test {
     af_array pos1;
     af_array pos2;
 
-    Approx2NullArgs()
-        : out(0)
-        , in(0)
-        , pos1(0)
-        , pos2(0) {}
+    Approx2NullArgs() : out(0), in(0), pos1(0), pos2(0) {}
 
     void SetUp() {
         SimpleTestData data;
         ASSERT_SUCCESS(af_create_array(&in, &data.h_in.front(),
-                                       data.in_dims.ndims(),
-                                       data.in_dims.get(),
+                                       data.in_dims.ndims(), data.in_dims.get(),
                                        f32));
         ASSERT_SUCCESS(af_create_array(&pos1, &data.h_pos1.front(),
                                        data.pos1_dims.ndims(),
-                                       data.pos1_dims.get(),
-                                       f32));
+                                       data.pos1_dims.get(), f32));
         ASSERT_SUCCESS(af_create_array(&pos2, &data.h_pos2.front(),
                                        data.pos2_dims.ndims(),
-                                       data.pos2_dims.get(),
-                                       f32));
+                                       data.pos2_dims.get(), f32));
     }
 
     void TearDown() {
-        if (pos2 != 0)  { ASSERT_SUCCESS(af_release_array(pos2)); }
-        if (pos1 != 0)  { ASSERT_SUCCESS(af_release_array(pos1)); }
-        if (in != 0)    { ASSERT_SUCCESS(af_release_array(in)); }
+        if (pos2 != 0) { ASSERT_SUCCESS(af_release_array(pos2)); }
+        if (pos1 != 0) { ASSERT_SUCCESS(af_release_array(pos1)); }
+        if (in != 0) { ASSERT_SUCCESS(af_release_array(in)); }
     }
 };
 
 TEST_F(Approx2NullArgs, NullOutputPtr) {
     af_array* out_ptr = 0;
-    ASSERT_EQ(af_approx2(out_ptr, this->in, this->pos1, this->pos2,
-                         AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx2(out_ptr, this->in, this->pos1, this->pos2,
+                                     AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx2NullArgs, NullInputArray) {
-    ASSERT_EQ(af_approx2(&this->out, 0, this->pos1, this->pos2,
-                         AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx2(&this->out, 0, this->pos1, this->pos2,
+                                     AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx2NullArgs, NullPos1Array) {
-    ASSERT_EQ(
-        af_approx2(&this->out, this->in, 0, this->pos2, AF_INTERP_LINEAR, 0.f),
-        AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx2(&this->out, this->in, 0, this->pos2,
+                                     AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx2NullArgs, NullPos2Array) {
-    ASSERT_EQ(
-        af_approx2(&this->out, this->in, this->pos1, 0, AF_INTERP_LINEAR, 0.f),
-        AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx2(&this->out, this->in, this->pos1, 0,
+                                     AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx2NullArgs, V2NullOutputPtr) {
     af_array* out_ptr = 0;
-    ASSERT_EQ(af_approx2_v2(out_ptr, this->in, this->pos1, this->pos2,
-                            AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx2_v2(out_ptr, this->in, this->pos1,
+                                        this->pos2, AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx2NullArgs, V2NullInputArray) {
-    ASSERT_EQ(af_approx2_v2(&this->out, 0, this->pos1, this->pos2,
-                            AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx2_v2(&this->out, 0, this->pos1, this->pos2,
+                                        AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx2NullArgs, V2NullPos1Array) {
-    ASSERT_EQ(af_approx2_v2(&this->out, this->in, 0, this->pos2,
-                            AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx2_v2(&this->out, this->in, 0, this->pos2,
+                                        AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx2NullArgs, V2NullPos2Array) {
-    ASSERT_EQ(af_approx2_v2(&this->out, this->in, this->pos1, 0,
-                            AF_INTERP_LINEAR, 0.f),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx2_v2(&this->out, this->in, this->pos1, 0,
+                                        AF_INTERP_LINEAR, 0.f));
 }
 
 TEST_F(Approx2NullArgs, UniformNullOutputPtr) {
     af_array* out_ptr = 0;
-    ASSERT_EQ(af_approx2_uniform(out_ptr, this->in, this->pos1, 0, 0.0, 1.0,
-                                 this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG,
+              af_approx2_uniform(out_ptr, this->in, this->pos1, 0, 0.0, 1.0,
+                                 this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0));
 }
 
 TEST_F(Approx2NullArgs, UniformNullInputArray) {
-    ASSERT_EQ(af_approx2_uniform(&this->out, 0, this->pos1, 0, 0.0, 1.0,
-                                 this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG,
+              af_approx2_uniform(&this->out, 0, this->pos1, 0, 0.0, 1.0,
+                                 this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0));
 }
 
 TEST_F(Approx2NullArgs, UniformNullPos1Array) {
-    ASSERT_EQ(af_approx2_uniform(&this->out, this->in, 0, 0, 0.0, 1.0,
-                                 this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG,
+              af_approx2_uniform(&this->out, this->in, 0, 0, 0.0, 1.0,
+                                 this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0));
 }
 
 TEST_F(Approx2NullArgs, UniformNullPos2Array) {
-    ASSERT_EQ(af_approx2_uniform(&this->out, this->in, this->pos1, 0, 0.0, 1.0,
-                                 0, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG,
+              af_approx2_uniform(&this->out, this->in, this->pos1, 0, 0.0, 1.0,
+                                 0, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0));
 }
 
 TEST_F(Approx2NullArgs, V2UniformNullOutputPtr) {
     af_array* out_ptr = 0;
-    ASSERT_EQ(
-        af_approx2_uniform_v2(out_ptr, this->in, this->pos1, 0, 0.0, 1.0,
-                              this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
-        AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx2_uniform_v2(out_ptr, this->in, this->pos1,
+                                                0, 0.0, 1.0, this->pos2, 1, 0.0,
+                                                1.0, AF_INTERP_LINEAR, 0));
 }
 
 TEST_F(Approx2NullArgs, V2UniformNullInputArray) {
-    ASSERT_EQ(
-        af_approx2_uniform_v2(&this->out, 0, this->pos1, 0, 0.0, 1.0,
-                              this->pos2, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
-        AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx2_uniform_v2(&this->out, 0, this->pos1, 0,
+                                                0.0, 1.0, this->pos2, 1, 0.0,
+                                                1.0, AF_INTERP_LINEAR, 0));
 }
 
 TEST_F(Approx2NullArgs, V2UniformNullPos1Array) {
-    ASSERT_EQ(
-        af_approx2_uniform_v2(&this->out, this->in, 0, 0, 0.0, 1.0, this->pos2,
-                              1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
-        AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG, af_approx2_uniform_v2(&this->out, this->in, 0, 0, 0.0,
+                                                1.0, this->pos2, 1, 0.0, 1.0,
+                                                AF_INTERP_LINEAR, 0));
 }
 
 TEST_F(Approx2NullArgs, V2UniformNullPos2Array) {
-    ASSERT_EQ(af_approx2_uniform_v2(&this->out, this->in, this->pos1, 0, 0.0,
-                                    1.0, 0, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0),
-              AF_ERR_ARG);
+    ASSERT_EQ(AF_ERR_ARG,
+              af_approx2_uniform_v2(&this->out, this->in, this->pos1, 0, 0.0,
+                                    1.0, 0, 1, 0.0, 1.0, AF_INTERP_LINEAR, 0));
 }

--- a/test/approx2.cpp
+++ b/test/approx2.cpp
@@ -820,8 +820,8 @@ class Approx2V2 : public ::testing::Test {
     }
 
     void TearDown() {
-        if (pos2 != 0) { ASSERT_SUCCESS(af_release_array(pos1)); }
-        if (pos1 != 0) { ASSERT_SUCCESS(af_release_array(pos2)); }
+        if (pos2 != 0) { ASSERT_SUCCESS(af_release_array(pos2)); }
+        if (pos1 != 0) { ASSERT_SUCCESS(af_release_array(pos1)); }
         if (in != 0) { ASSERT_SUCCESS(af_release_array(in)); }
         if (gold != 0) { ASSERT_SUCCESS(af_release_array(gold)); }
     }

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -1417,4 +1417,40 @@ void genTestOutputArray(af_array *out_ptr, const unsigned ndims,
     return testWriteToOutputArray(aName, bName, a, b, metadata);
 }
 
+class TestData {
+   protected:
+    std::vector<float> h_gold;
+    std::vector<float> h_in;
+    std::vector<float*> h_misc_arrs;
+
+    af::dim4 gold_dims;
+    af::dim4 in_dims;
+    std::vector<af::dim4> misc_dims;
+
+   public:
+    float *getGoldArr() {
+        return &h_gold.front();
+    }
+    float *getInArr() {
+        return &h_in.front();
+    }
+    float *getMiscArrs(int i) {
+        return h_misc_arrs.at(i);
+    }
+    af::dim4 getGoldDims() {
+        return gold_dims;
+    }
+    af::dim4 getInDims() {
+        return in_dims;
+    }
+    af::dim4 getMiscDims(int i) {
+        return misc_dims.at(i);
+    }
+
+    // Make TestData an abstract class to prevent it from being used directly
+    virtual ~TestData() = 0;
+};
+
+TestData::~TestData() {}
+
 #pragma GCC diagnostic pop

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -1417,40 +1417,4 @@ void genTestOutputArray(af_array *out_ptr, const unsigned ndims,
     return testWriteToOutputArray(aName, bName, a, b, metadata);
 }
 
-class TestData {
-   protected:
-    std::vector<float> h_gold;
-    std::vector<float> h_in;
-    std::vector<float*> h_misc_arrs;
-
-    af::dim4 gold_dims;
-    af::dim4 in_dims;
-    std::vector<af::dim4> misc_dims;
-
-   public:
-    float *getGoldArr() {
-        return &h_gold.front();
-    }
-    float *getInArr() {
-        return &h_in.front();
-    }
-    float *getMiscArrs(int i) {
-        return h_misc_arrs.at(i);
-    }
-    af::dim4 getGoldDims() {
-        return gold_dims;
-    }
-    af::dim4 getInDims() {
-        return in_dims;
-    }
-    af::dim4 getMiscDims(int i) {
-        return misc_dims.at(i);
-    }
-
-    // Make TestData an abstract class to prevent it from being used directly
-    virtual ~TestData() = 0;
-};
-
-TestData::~TestData() {}
-
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Similar to #2324 / #2599, but for `af_approx2*_v2` functions.

This also modifies `af_approx1*_v2` tests so that they use test fixtures instead of repeating defining the host C arrays over and over again.