### PR TITLE
Add several workarounds for older CMake versions

### DIFF
--- a/CMakeModules/InternalUtils.cmake
+++ b/CMakeModules/InternalUtils.cmake
@@ -30,20 +30,20 @@ endfunction()
 
 function(arrayfire_get_cuda_cxx_flags cuda_flags)
   if(NOT MSVC)
-    set(flags "-std=c++14 --expt-relaxed-constexpr -Xcompiler -fPIC -Xcompiler ${CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY}hidden")
+    set(flags -std=c++14 --expt-relaxed-constexpr -Xcompiler -fPIC -Xcompiler ${CMAKE_CXX_COMPILE_OPTIONS_VISIBILITY}hidden)
   else()
-    set(flags "-Xcompiler /wd4251 -Xcompiler /wd4068 -Xcompiler /wd4275 -Xcompiler /bigobj -Xcompiler /EHsc")
+    set(flags -Xcompiler /wd4251 -Xcompiler /wd4068 -Xcompiler /wd4275 -Xcompiler /bigobj -Xcompiler /EHsc)
     if(CMAKE_GENERATOR MATCHES "Ninja")
-      set(flags "${flags} -Xcompiler /FS")
+      set(flags ${flags} -Xcompiler /FS)
     endif()
   endif()
 
   if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU" AND
       CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "5.3.0" AND
       ${CUDA_VERSION_MAJOR} LESS 8)
-    set(flags "${flags} -D_FORCE_INLINES -D_MWAITXINTRIN_H_INCLUDED")
+    set(flags ${flags} -D_FORCE_INLINES -D_MWAITXINTRIN_H_INCLUDED)
   endif()
-  set(${cuda_flags} "${flags}" PARENT_SCOPE)
+  set(${cuda_flags} ${flags} PARENT_SCOPE)
 endfunction()
 
 include(CheckCXXCompilerFlag)

--- a/CMakeModules/InternalUtils.cmake
+++ b/CMakeModules/InternalUtils.cmake
@@ -173,18 +173,24 @@ macro(arrayfire_set_cmake_default_variables)
     set(CMAKE_INSTALL_RPATH "/opt/arrayfire/lib")
   endif()
 
-  include(WriteCompilerDetectionHeader)
-  write_compiler_detection_header(
-          FILE ${ArrayFire_BINARY_DIR}/include/af/compilers.h
-          PREFIX AF
-          COMPILERS AppleClang Clang GNU Intel MSVC
-          # NOTE: cxx_attribute_deprecated does not work well with C
-          FEATURES cxx_rvalue_references cxx_noexcept cxx_variadic_templates cxx_alignas cxx_static_assert
-          ALLOW_UNKNOWN_COMPILERS
-          #[VERSION <version>]
-          #[PROLOG <prolog>]
-          #[EPILOG <epilog>]
-          )
+  # This code is used to generate the compilers.h file in CMakeModules. Not all
+  # features of this modules are supported in the versions of CMake we wish to
+  # support so we are directly including the files here
+  # include(WriteCompilerDetectionHeader)
+  # write_compiler_detection_header(
+  #         FILE ${ArrayFire_BINARY_DIR}/include/af/compilers.h
+  #         PREFIX AF
+  #         COMPILERS AppleClang Clang GNU Intel MSVC
+  #         # NOTE: cxx_attribute_deprecated does not work well with C
+  #         FEATURES cxx_rvalue_references cxx_noexcept cxx_variadic_templates cxx_alignas cxx_static_assert
+  #         ALLOW_UNKNOWN_COMPILERS
+  #         #[VERSION <version>]
+  #         #[PROLOG <prolog>]
+  #         #[EPILOG <epilog>]
+  #         )
+  configure_file(
+    ${CMAKE_MODULE_PATH}/compilers.h
+    ${ArrayFire_BINARY_DIR}/include/af/compilers.h)
 endmacro()
 
 macro(set_policies)

--- a/CMakeModules/compilers.h
+++ b/CMakeModules/compilers.h
@@ -1,0 +1,444 @@
+
+// This is a generated file. Do not edit!
+
+#ifndef AF_COMPILER_DETECTION_H
+#define AF_COMPILER_DETECTION_H
+
+#ifdef __cplusplus
+# define AF_COMPILER_IS_Comeau 0
+# define AF_COMPILER_IS_Intel 0
+# define AF_COMPILER_IS_PathScale 0
+# define AF_COMPILER_IS_Embarcadero 0
+# define AF_COMPILER_IS_Borland 0
+# define AF_COMPILER_IS_Watcom 0
+# define AF_COMPILER_IS_OpenWatcom 0
+# define AF_COMPILER_IS_SunPro 0
+# define AF_COMPILER_IS_HP 0
+# define AF_COMPILER_IS_Compaq 0
+# define AF_COMPILER_IS_zOS 0
+# define AF_COMPILER_IS_XLClang 0
+# define AF_COMPILER_IS_XL 0
+# define AF_COMPILER_IS_VisualAge 0
+# define AF_COMPILER_IS_PGI 0
+# define AF_COMPILER_IS_Cray 0
+# define AF_COMPILER_IS_TI 0
+# define AF_COMPILER_IS_Fujitsu 0
+# define AF_COMPILER_IS_GHS 0
+# define AF_COMPILER_IS_SCO 0
+# define AF_COMPILER_IS_ARMCC 0
+# define AF_COMPILER_IS_AppleClang 0
+# define AF_COMPILER_IS_ARMClang 0
+# define AF_COMPILER_IS_Clang 0
+# define AF_COMPILER_IS_GNU 0
+# define AF_COMPILER_IS_MSVC 0
+# define AF_COMPILER_IS_ADSP 0
+# define AF_COMPILER_IS_IAR 0
+# define AF_COMPILER_IS_MIPSpro 0
+
+#if defined(__COMO__)
+# undef AF_COMPILER_IS_Comeau
+# define AF_COMPILER_IS_Comeau 1
+
+#elif defined(__INTEL_COMPILER) || defined(__ICC)
+# undef AF_COMPILER_IS_Intel
+# define AF_COMPILER_IS_Intel 1
+
+#elif defined(__PATHCC__)
+# undef AF_COMPILER_IS_PathScale
+# define AF_COMPILER_IS_PathScale 1
+
+#elif defined(__BORLANDC__) && defined(__CODEGEARC_VERSION__)
+# undef AF_COMPILER_IS_Embarcadero
+# define AF_COMPILER_IS_Embarcadero 1
+
+#elif defined(__BORLANDC__)
+# undef AF_COMPILER_IS_Borland
+# define AF_COMPILER_IS_Borland 1
+
+#elif defined(__WATCOMC__) && __WATCOMC__ < 1200
+# undef AF_COMPILER_IS_Watcom
+# define AF_COMPILER_IS_Watcom 1
+
+#elif defined(__WATCOMC__)
+# undef AF_COMPILER_IS_OpenWatcom
+# define AF_COMPILER_IS_OpenWatcom 1
+
+#elif defined(__SUNPRO_CC)
+# undef AF_COMPILER_IS_SunPro
+# define AF_COMPILER_IS_SunPro 1
+
+#elif defined(__HP_aCC)
+# undef AF_COMPILER_IS_HP
+# define AF_COMPILER_IS_HP 1
+
+#elif defined(__DECCXX)
+# undef AF_COMPILER_IS_Compaq
+# define AF_COMPILER_IS_Compaq 1
+
+#elif defined(__IBMCPP__) && defined(__COMPILER_VER__)
+# undef AF_COMPILER_IS_zOS
+# define AF_COMPILER_IS_zOS 1
+
+#elif defined(__ibmxl__) && defined(__clang__)
+# undef AF_COMPILER_IS_XLClang
+# define AF_COMPILER_IS_XLClang 1
+
+#elif defined(__IBMCPP__) && !defined(__COMPILER_VER__) && __IBMCPP__ >= 800
+# undef AF_COMPILER_IS_XL
+# define AF_COMPILER_IS_XL 1
+
+#elif defined(__IBMCPP__) && !defined(__COMPILER_VER__) && __IBMCPP__ < 800
+# undef AF_COMPILER_IS_VisualAge
+# define AF_COMPILER_IS_VisualAge 1
+
+#elif defined(__PGI)
+# undef AF_COMPILER_IS_PGI
+# define AF_COMPILER_IS_PGI 1
+
+#elif defined(_CRAYC)
+# undef AF_COMPILER_IS_Cray
+# define AF_COMPILER_IS_Cray 1
+
+#elif defined(__TI_COMPILER_VERSION__)
+# undef AF_COMPILER_IS_TI
+# define AF_COMPILER_IS_TI 1
+
+#elif defined(__FUJITSU) || defined(__FCC_VERSION) || defined(__fcc_version)
+# undef AF_COMPILER_IS_Fujitsu
+# define AF_COMPILER_IS_Fujitsu 1
+
+#elif defined(__ghs__)
+# undef AF_COMPILER_IS_GHS
+# define AF_COMPILER_IS_GHS 1
+
+#elif defined(__SCO_VERSION__)
+# undef AF_COMPILER_IS_SCO
+# define AF_COMPILER_IS_SCO 1
+
+#elif defined(__ARMCC_VERSION) && !defined(__clang__)
+# undef AF_COMPILER_IS_ARMCC
+# define AF_COMPILER_IS_ARMCC 1
+
+#elif defined(__clang__) && defined(__apple_build_version__)
+# undef AF_COMPILER_IS_AppleClang
+# define AF_COMPILER_IS_AppleClang 1
+
+#elif defined(__clang__) && defined(__ARMCOMPILER_VERSION)
+# undef AF_COMPILER_IS_ARMClang
+# define AF_COMPILER_IS_ARMClang 1
+
+#elif defined(__clang__)
+# undef AF_COMPILER_IS_Clang
+# define AF_COMPILER_IS_Clang 1
+
+#elif defined(__GNUC__) || defined(__GNUG__)
+# undef AF_COMPILER_IS_GNU
+# define AF_COMPILER_IS_GNU 1
+
+#elif defined(_MSC_VER)
+# undef AF_COMPILER_IS_MSVC
+# define AF_COMPILER_IS_MSVC 1
+
+#elif defined(__VISUALDSPVERSION__) || defined(__ADSPBLACKFIN__) || defined(__ADSPTS__) || defined(__ADSP21000__)
+# undef AF_COMPILER_IS_ADSP
+# define AF_COMPILER_IS_ADSP 1
+
+#elif defined(__IAR_SYSTEMS_ICC__) || defined(__IAR_SYSTEMS_ICC)
+# undef AF_COMPILER_IS_IAR
+# define AF_COMPILER_IS_IAR 1
+
+
+#endif
+
+#  if AF_COMPILER_IS_AppleClang
+
+#    if !(((__clang_major__ * 100) + __clang_minor__) >= 400)
+#      error Unsupported compiler version
+#    endif
+
+# define AF_COMPILER_VERSION_MAJOR (__clang_major__)
+# define AF_COMPILER_VERSION_MINOR (__clang_minor__)
+# define AF_COMPILER_VERSION_PATCH (__clang_patchlevel__)
+# if defined(_MSC_VER)
+   /* _MSC_VER = VVRR */
+#  define AF_SIMULATE_VERSION_MAJOR (_MSC_VER / 100)
+#  define AF_SIMULATE_VERSION_MINOR (_MSC_VER % 100)
+# endif
+# define AF_COMPILER_VERSION_TWEAK (__apple_build_version__)
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_rvalue_references)
+#      define AF_COMPILER_CXX_RVALUE_REFERENCES 1
+#    else
+#      define AF_COMPILER_CXX_RVALUE_REFERENCES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_noexcept)
+#      define AF_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define AF_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_variadic_templates)
+#      define AF_COMPILER_CXX_VARIADIC_TEMPLATES 1
+#    else
+#      define AF_COMPILER_CXX_VARIADIC_TEMPLATES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_alignas)
+#      define AF_COMPILER_CXX_ALIGNAS 1
+#    else
+#      define AF_COMPILER_CXX_ALIGNAS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_static_assert)
+#      define AF_COMPILER_CXX_STATIC_ASSERT 1
+#    else
+#      define AF_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#  elif AF_COMPILER_IS_Clang
+
+#    if !(((__clang_major__ * 100) + __clang_minor__) >= 301)
+#      error Unsupported compiler version
+#    endif
+
+# define AF_COMPILER_VERSION_MAJOR (__clang_major__)
+# define AF_COMPILER_VERSION_MINOR (__clang_minor__)
+# define AF_COMPILER_VERSION_PATCH (__clang_patchlevel__)
+# if defined(_MSC_VER)
+   /* _MSC_VER = VVRR */
+#  define AF_SIMULATE_VERSION_MAJOR (_MSC_VER / 100)
+#  define AF_SIMULATE_VERSION_MINOR (_MSC_VER % 100)
+# endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_rvalue_references)
+#      define AF_COMPILER_CXX_RVALUE_REFERENCES 1
+#    else
+#      define AF_COMPILER_CXX_RVALUE_REFERENCES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_noexcept)
+#      define AF_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define AF_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_variadic_templates)
+#      define AF_COMPILER_CXX_VARIADIC_TEMPLATES 1
+#    else
+#      define AF_COMPILER_CXX_VARIADIC_TEMPLATES 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_alignas)
+#      define AF_COMPILER_CXX_ALIGNAS 1
+#    else
+#      define AF_COMPILER_CXX_ALIGNAS 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_static_assert)
+#      define AF_COMPILER_CXX_STATIC_ASSERT 1
+#    else
+#      define AF_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#  elif AF_COMPILER_IS_GNU
+
+#    if !((__GNUC__ * 100 + __GNUC_MINOR__) >= 404)
+#      error Unsupported compiler version
+#    endif
+
+# if defined(__GNUC__)
+#  define AF_COMPILER_VERSION_MAJOR (__GNUC__)
+# else
+#  define AF_COMPILER_VERSION_MAJOR (__GNUG__)
+# endif
+# if defined(__GNUC_MINOR__)
+#  define AF_COMPILER_VERSION_MINOR (__GNUC_MINOR__)
+# endif
+# if defined(__GNUC_PATCHLEVEL__)
+#  define AF_COMPILER_VERSION_PATCH (__GNUC_PATCHLEVEL__)
+# endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define AF_COMPILER_CXX_RVALUE_REFERENCES 1
+#    else
+#      define AF_COMPILER_CXX_RVALUE_REFERENCES 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 406 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define AF_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define AF_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define AF_COMPILER_CXX_VARIADIC_TEMPLATES 1
+#    else
+#      define AF_COMPILER_CXX_VARIADIC_TEMPLATES 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 408 && __cplusplus >= 201103L
+#      define AF_COMPILER_CXX_ALIGNAS 1
+#    else
+#      define AF_COMPILER_CXX_ALIGNAS 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define AF_COMPILER_CXX_STATIC_ASSERT 1
+#    else
+#      define AF_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#  elif AF_COMPILER_IS_Intel
+
+#    if !(__INTEL_COMPILER >= 1210)
+#      error Unsupported compiler version
+#    endif
+
+  /* __INTEL_COMPILER = VRP */
+# define AF_COMPILER_VERSION_MAJOR (__INTEL_COMPILER/100)
+# define AF_COMPILER_VERSION_MINOR (__INTEL_COMPILER/10 % 10)
+# if defined(__INTEL_COMPILER_UPDATE)
+#  define AF_COMPILER_VERSION_PATCH (__INTEL_COMPILER_UPDATE)
+# else
+#  define AF_COMPILER_VERSION_PATCH (__INTEL_COMPILER   % 10)
+# endif
+# if defined(__INTEL_COMPILER_BUILD_DATE)
+  /* __INTEL_COMPILER_BUILD_DATE = YYYYMMDD */
+#  define AF_COMPILER_VERSION_TWEAK (__INTEL_COMPILER_BUILD_DATE)
+# endif
+# if defined(_MSC_VER)
+   /* _MSC_VER = VVRR */
+#  define AF_SIMULATE_VERSION_MAJOR (_MSC_VER / 100)
+#  define AF_SIMULATE_VERSION_MINOR (_MSC_VER % 100)
+# endif
+# if defined(__GNUC__)
+#  define AF_SIMULATE_VERSION_MAJOR (__GNUC__)
+# elif defined(__GNUG__)
+#  define AF_SIMULATE_VERSION_MAJOR (__GNUG__)
+# endif
+# if defined(__GNUC_MINOR__)
+#  define AF_SIMULATE_VERSION_MINOR (__GNUC_MINOR__)
+# endif
+# if defined(__GNUC_PATCHLEVEL__)
+#  define AF_SIMULATE_VERSION_PATCH (__GNUC_PATCHLEVEL__)
+# endif
+
+#    if (__cpp_rvalue_references >= 200610 || __INTEL_COMPILER >= 1210) && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define AF_COMPILER_CXX_RVALUE_REFERENCES 1
+#    else
+#      define AF_COMPILER_CXX_RVALUE_REFERENCES 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define AF_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define AF_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#    if (__cpp_variadic_templates >= 200704 || __INTEL_COMPILER >= 1210) && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define AF_COMPILER_CXX_VARIADIC_TEMPLATES 1
+#    else
+#      define AF_COMPILER_CXX_VARIADIC_TEMPLATES 0
+#    endif
+
+#    if __INTEL_COMPILER >= 1500 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define AF_COMPILER_CXX_ALIGNAS 1
+#    else
+#      define AF_COMPILER_CXX_ALIGNAS 0
+#    endif
+
+#    if (__cpp_static_assert >= 200410 || __INTEL_COMPILER >= 1210) && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define AF_COMPILER_CXX_STATIC_ASSERT 1
+#    else
+#      define AF_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#  elif AF_COMPILER_IS_MSVC
+
+#    if !(_MSC_VER >= 1600)
+#      error Unsupported compiler version
+#    endif
+
+  /* _MSC_VER = VVRR */
+# define AF_COMPILER_VERSION_MAJOR (_MSC_VER / 100)
+# define AF_COMPILER_VERSION_MINOR (_MSC_VER % 100)
+# if defined(_MSC_FULL_VER)
+#  if _MSC_VER >= 1400
+    /* _MSC_FULL_VER = VVRRPPPPP */
+#   define AF_COMPILER_VERSION_PATCH (_MSC_FULL_VER % 100000)
+#  else
+    /* _MSC_FULL_VER = VVRRPPPP */
+#   define AF_COMPILER_VERSION_PATCH (_MSC_FULL_VER % 10000)
+#  endif
+# endif
+# if defined(_MSC_BUILD)
+#  define AF_COMPILER_VERSION_TWEAK (_MSC_BUILD)
+# endif
+
+#    if _MSC_VER >= 1600
+#      define AF_COMPILER_CXX_RVALUE_REFERENCES 1
+#    else
+#      define AF_COMPILER_CXX_RVALUE_REFERENCES 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define AF_COMPILER_CXX_NOEXCEPT 1
+#    else
+#      define AF_COMPILER_CXX_NOEXCEPT 0
+#    endif
+
+#    if _MSC_VER >= 1800
+#      define AF_COMPILER_CXX_VARIADIC_TEMPLATES 1
+#    else
+#      define AF_COMPILER_CXX_VARIADIC_TEMPLATES 0
+#    endif
+
+#    if _MSC_VER >= 1900
+#      define AF_COMPILER_CXX_ALIGNAS 1
+#    else
+#      define AF_COMPILER_CXX_ALIGNAS 0
+#    endif
+
+#    if _MSC_VER >= 1600
+#      define AF_COMPILER_CXX_STATIC_ASSERT 1
+#    else
+#      define AF_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#  endif
+
+#  if defined(AF_COMPILER_CXX_NOEXCEPT) && AF_COMPILER_CXX_NOEXCEPT
+#    define AF_NOEXCEPT noexcept
+#    define AF_NOEXCEPT_EXPR(X) noexcept(X)
+#  else
+#    define AF_NOEXCEPT
+#    define AF_NOEXCEPT_EXPR(X)
+#  endif
+
+
+#  if defined(AF_COMPILER_CXX_ALIGNAS) && AF_COMPILER_CXX_ALIGNAS
+#    define AF_ALIGNAS(X) alignas(X)
+#  elif AF_COMPILER_IS_GNU || AF_COMPILER_IS_Clang || AF_COMPILER_IS_AppleClang
+#    define AF_ALIGNAS(X) __attribute__ ((__aligned__(X)))
+#  elif AF_COMPILER_IS_MSVC
+#    define AF_ALIGNAS(X) __declspec(align(X))
+#  else
+#    define AF_ALIGNAS(X)
+#  endif
+
+#  if defined(AF_COMPILER_CXX_STATIC_ASSERT) && AF_COMPILER_CXX_STATIC_ASSERT
+#    define AF_STATIC_ASSERT(X) static_assert(X, #X)
+#    define AF_STATIC_ASSERT_MSG(X, MSG) static_assert(X, MSG)
+#  else
+#    define AF_STATIC_ASSERT_JOIN(X, Y) AF_STATIC_ASSERT_JOIN_IMPL(X, Y)
+#    define AF_STATIC_ASSERT_JOIN_IMPL(X, Y) X##Y
+template<bool> struct AFStaticAssert;
+template<> struct AFStaticAssert<true>{};
+#    define AF_STATIC_ASSERT(X) enum { AF_STATIC_ASSERT_JOIN(AFStaticAssertEnum, __LINE__) = sizeof(AFStaticAssert<X>) }
+#    define AF_STATIC_ASSERT_MSG(X, MSG) enum { AF_STATIC_ASSERT_JOIN(AFStaticAssertEnum, __LINE__) = sizeof(AFStaticAssert<X>) }
+#  endif
+
+#endif
+
+#endif

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -172,13 +172,19 @@ endfunction()
 arrayfire_get_cuda_cxx_flags(cuda_cxx_flags)
 arrayfire_get_platform_definitions(platform_flags)
 
-if(AF_WITH_NONFREE AND CMAKE_VERSION VERSION_LESS "3.7")
-  # This definition is required in addition to the definition below because in
-  # an older verion of cmake definitions added using target_compile_definitions
-  # were not added to the nvcc flags. This manually adds these definitions and
-  # pass them to the options parameter in cuda_add_library
-  string(APPEND cuda_cxx_flags " -DAF_WITH_NONFREE_SIFT")
+# This definition is required in addition to the definition below because in
+# an older verion of cmake definitions added using target_compile_definitions
+# were not added to the nvcc flags. This manually adds these definitions and
+# pass them to the options parameter in cuda_add_library
+if(AF_WITH_NONFREE)
+  set(cxx_definitions -DAF_WITH_NONFREE_SIFT)
 endif()
+
+# CUDA_NO_HALF prevents the inclusion of the half class in the global namespace
+# which conflicts with the half class in ArrayFire's common namespace. prefer
+# using __half class instead for CUDA
+list(APPEND cxx_definitions -DAF_CUDA;-DCUDA_NO_HALF)
+list(APPEND cuda_cxx_flags ${cxx_definitions})
 
 include(kernel/scan_by_key/CMakeLists.txt)
 include(kernel/thrust_sort_by_key/CMakeLists.txt)
@@ -475,21 +481,18 @@ cuda_add_library(afcuda
 
     nvrtc/cache.cpp
 
-    OPTIONS "${platform_flags} ${cuda_cxx_flags} -Xcudafe \"--diag_suppress=1427\""
+    OPTIONS ${platform_flags} ${cuda_cxx_flags} -Xcudafe \"--diag_suppress=1427\"
   )
 
 arrayfire_set_default_cxx_flags(afcuda)
 
-# CUDA_NO_HALF prevents the inclusion of the half class in the global namespace
-# which conflicts with the half class in ArrayFire's common namespace. prefer
-# using __half class instead for CUDA
-target_compile_definitions(afcuda PRIVATE AF_CUDA CUDA_NO_HALF)
+# NOTE: Do not add additional CUDA specific definitions here. Add it to the
+# cxx_definitions variable above. cxx_definitions is used to propigate
+# definitions to the scan_by_key and thrust_sort_by_key targets as well as the
+# cuda library above.
+target_compile_options(afcuda PRIVATE ${cxx_definitions})
 
 add_library(ArrayFire::afcuda ALIAS afcuda)
-
-if(AF_WITH_NONFREE)
-  target_compile_definitions(afcuda PRIVATE AF_WITH_NONFREE_SIFT)
-endif()
 
 add_dependencies(afcuda ${jit_kernel_targets} ${nvrtc_kernel_targets})
 add_dependencies(cuda_scan_by_key ${nvrtc_kernel_targets})

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -510,6 +510,12 @@ target_include_directories (afcuda
 
 set_target_properties(afcuda PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
+# Remove cublas_device library which is no longer included with the cuda
+# toolkit. Fixes issues with older CMake versions
+if(DEFINED CUDA_cublas_device_LIBRARY AND NOT CUDA_cublas_device_LIBRARY)
+  list(REMOVE_ITEM CUDA_CUBLAS_LIBRARIES ${CUDA_cublas_device_LIBRARY})
+endif()
+
 target_link_libraries(afcuda
   PRIVATE
     c_api_interface

--- a/src/backend/cuda/kernel/scan_by_key/CMakeLists.txt
+++ b/src/backend/cuda/kernel/scan_by_key/CMakeLists.txt
@@ -16,9 +16,6 @@ endforeach()
 
 cuda_add_cuda_include_once()
 
-arrayfire_get_cuda_cxx_flags(cuda_cxx_flags)
-arrayfire_get_platform_definitions(platform_flags)
-
 foreach(SBK_BINARY_OP ${SBK_BINARY_OPS})
     # When using cuda_compile with older versions of FindCUDA. The generated targets
     # have the same names as the source file. Since we are using the same file for

--- a/src/backend/cuda/kernel/thrust_sort_by_key/CMakeLists.txt
+++ b/src/backend/cuda/kernel/thrust_sort_by_key/CMakeLists.txt
@@ -17,9 +17,6 @@ foreach(STR ${FILESTRINGS})
     endif()
 endforeach()
 
-arrayfire_get_cuda_cxx_flags(cuda_cxx_flags)
-arrayfire_get_platform_definitions(platform_flags)
-
 foreach(SBK_TYPE ${SBK_TYPES})
     foreach(SBK_INST ${SBK_INSTS})
 

--- a/src/backend/opencl/blas.cpp
+++ b/src/backend/opencl/blas.cpp
@@ -24,10 +24,7 @@
 
 // Includes one of the supported OpenCL BLAS back-ends (e.g. clBLAS, CLBlast)
 #include <magma/magma_blas.h>
-
-#if defined(WITH_LINEAR_ALGEBRA)
 #include <cpu/cpu_blas.hpp>
-#endif
 
 using common::half;
 


### PR DESCRIPTION
* Fixes errors with cublas_devices in some versions of CMake
* Remove compiler check header creation to support older CMake
* Workaround for compile definitions in the CUDA backend