### PR TITLE
Fix mDeviceType pushback in addDeviceContext. Fix NodeIterator condition

### DIFF
--- a/src/backend/common/jit/NodeIterator.hpp
+++ b/src/backend/common/jit/NodeIterator.hpp
@@ -31,7 +31,7 @@ class NodeIterator : public std::iterator<std::input_iterator_tag, Node> {
 
     /// Copies the children of the \p n Node to the end of the tree vector
     void copy_children_to_end(Node* n) {
-        for (int i = 0; n->m_children[i] != nullptr && i < Node::kMaxChildren;
+        for (int i = 0; i < Node::kMaxChildren && n->m_children[i] != nullptr;
              i++) {
             auto ptr = n->m_children[i].get();
             if (find(begin(tree), end(tree), ptr) == end(tree)) {

--- a/src/backend/opencl/device_manager.cpp
+++ b/src/backend/opencl/device_manager.cpp
@@ -159,7 +159,7 @@ static inline bool compare_default(const Device* ldev, const Device* rdev) {
     // Sort based on memory
     auto l_mem = ldev->getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>();
     auto r_mem = rdev->getInfo<CL_DEVICE_GLOBAL_MEM_SIZE>();
-    return l_mem >= r_mem;
+    return l_mem > r_mem;
 }
 
 DeviceManager::DeviceManager()

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -434,6 +434,7 @@ void addDeviceContext(cl_device_id dev, cl_context ctx, cl_command_queue que) {
         devMngr.mPlatforms.push_back(getPlatformEnum(*tDevice));
         // FIXME: add OpenGL Interop for user provided contexts later
         devMngr.mIsGLSharingOn.push_back(false);
+        devMngr.mDeviceTypes.push_back(tDevice->getInfo<CL_DEVICE_TYPE>());
         nDevices = devMngr.mDevices.size() - 1;
 
         // cache the boost program_cache object, clean up done on program exit


### PR DESCRIPTION
* Fix the compare_default comparitor to confom to the strict weak ordering
  requirement for the less than operator of the sort
* Fix the order of the condition in the NodeIterator that allowed access
  to a staticly allocated array
* Fix a missing push_back to the mDeviceType vector in the
  addDeviceContext function