### PR TITLE
Clean up tutorials page

### DIFF
--- a/docs/layout.xml
+++ b/docs/layout.xml
@@ -2,23 +2,7 @@
   <!-- Navigation index tabs for HTML output -->
   <navindex>
     <tab type="mainpage" visible="yes" title="" />
-    <tab type="usergroup" visible="yes" title="Tutorials">
-      <tab type="user" url="\ref installing" visible="yes" title="Installation"/>
-      <tab type="user" url="\ref using_on_linux" visible="yes" title="Using on Linux"/>
-      <tab type="user" url="\ref using_on_windows" visible="yes" title="Using on Windows"/>
-      <tab type="user" url="\ref using_on_osx" visible="yes" title="Using on OSX"/>
-      <tab type="user" url="\ref gettingstarted" visible="yes" title="Getting Started"/>
-      <tab type="user" url="\ref vectorization" visible="yes" title="Introduction to Vectorization"/>
-      <tab type="user" url="\ref matrixmanipulation" visible="yes" title="Array and Matrix Manipulation"/>
-      <tab type="user" url="\ref interop_cuda" visible="yes" title="CUDA Interoperability"/>
-      <tab type="user" url="\ref interop_opencl" visible="yes" title="OpenCL Interoperability"/>
-      <tab type="user" url="\ref unifiedbackend" visible="yes" title="Unified Backend"/>
-      <tab type="user" url="\ref forge_visualization" visible="yes" title="Forge Visualization"/>
-      <tab type="user" url="\ref indexing" visible="yes" title="Indexing"/>
-      <tab type="user" url="\ref timing" visible="yes" title="Timing ArrayFire"/>
-      <tab type="user" url="\ref configuring_environment" visible="yes" title="Configuring ArrayFire Environment"/>
-      <tab type="usergroup" url="\ref page_gfor" visible="yes" title="GFOR Usage"/>
-    </tab>
+    <tab type="user" url="\ref tutorials" visible="yes" title="Tutorials"/>
     <tab type="modules" visible="yes" title="Functions" intro="Documentation grouped according to category:"/>
     <tab type="user" url="\ref releasenotes" visible="yes" title="Release Notes"/>
     <tab type="examples" visible="yes" title="" intro=""/>

--- a/docs/pages/tutorials.md
+++ b/docs/pages/tutorials.md
@@ -1,0 +1,17 @@
+# Tutorials {#tutorials}
+
+* [Installation](\ref installing)
+* [Using on Linux](\ref using_on_linux)
+* [Using on Windows](\ref using_on_windows)
+* [Using on OSX](\ref using_on_osx)
+* [Getting Started](\ref gettingstarted)
+* [Introduction to Vectorization](\ref vectorization)
+* [Array and Matrix Manipulation](\ref matrixmanipulation)
+* [CUDA Interoperability](\ref interop_cuda)
+* [OpenCL Interoperability](\ref interop_opencl)
+* [Unified Backend](\ref unifiedbackend)
+* [Forge Visualization](\ref forge_visualization)
+* [Indexing](\ref indexing)
+* [Timing ArrayFire](\ref timing)
+* [Configuring ArrayFire Environment](\ref configuring_environment)
+* [GFOR Usage](\ref page_gfor)


### PR DESCRIPTION
The tutorials page in the docs have unnecessary navigation sub-tabs on the top that (I think) clutters how it looks:
![image](https://user-images.githubusercontent.com/19368448/64201927-dc9bf700-ce5d-11e9-8dcc-2dfe1a54f095.png)

On smaller screens, there are enough sub tabs that make it take up two lines (this is on a 1680x1050 screen from a 2015 macbook pro):
![image](https://user-images.githubusercontent.com/19368448/64202197-92674580-ce5e-11e9-9304-d60c6131cd95.png)

This PR cleans it up by removing those sub-tabs from `layout.xml` (since they're redundant) and adding another markdown page for the tutorials. Here's the result:
![image](https://user-images.githubusercontent.com/19368448/64202019-14a33a00-ce5e-11e9-82dc-a99bcd321013.png)
