### PR TITLE
Use Boost_VERSION_STRING to detect v1.71.0 correctly

### DIFF
--- a/CMakeModules/boost_package.cmake
+++ b/CMakeModules/boost_package.cmake
@@ -7,7 +7,7 @@
 
 find_package(Boost)
 
-if("${Boost_VERSION}" VERSION_LESS 107000)
+if("${Boost_VERSION_STRING}" VERSION_LESS 1.70.0)
   set(VER 1.70.0)
   set(MD5 e160ec0ff825fc2850ea4614323b1fb5)
   include(ExternalProject)


### PR DESCRIPTION
- Fixes #2640, earlier similar reference is #1994.