### PR TITLE
Forward generator platform to external projects on windows

### DIFF
--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -37,6 +37,12 @@ index 9446499..786f7db 100644
   set(CLBLAST_PATCH_COMMAND ${GIT} apply ${ArrayFire_BINARY_DIR}/clblast.patch)
 endif()
 
+if(WIN32)
+  set(extproj_gen_opts "-G${CMAKE_GENERATOR}" "-A${CMAKE_GENERATOR_PLATFORM}")
+else(WIN32)
+  set(extproj_gen_opts "-G${CMAKE_GENERATOR}")
+endif(WIN32)
+
 ExternalProject_Add(
     CLBlast-ext
     GIT_REPOSITORY https://github.com/cnugteren/CLBlast.git
@@ -46,7 +52,8 @@ ExternalProject_Add(
     UPDATE_COMMAND ""
     PATCH_COMMAND ${CLBLAST_PATCH_COMMAND}
     BUILD_BYPRODUCTS ${CLBlast_location}
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} "-G${CMAKE_GENERATOR}" -Wno-dev <SOURCE_DIR>/
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} ${extproj_gen_opts}
+      -Wno-dev <SOURCE_DIR>
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
       "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} -w -fPIC"
       -DOVERRIDE_MSVC_FLAGS_TO_MT:BOOL=OFF

--- a/CMakeModules/build_clBLAS.cmake
+++ b/CMakeModules/build_clBLAS.cmake
@@ -12,6 +12,12 @@ set(clBLAS_location ${prefix}/lib/import/${CMAKE_STATIC_LIBRARY_PREFIX}clBLAS${C
 
 find_package(OpenCL)
 
+if(WIN32)
+  set(extproj_gen_opts "-G${CMAKE_GENERATOR}" "-A${CMAKE_GENERATOR_PLATFORM}")
+else(WIN32)
+  set(extproj_gen_opts "-G${CMAKE_GENERATOR}")
+endif(WIN32)
+
 ExternalProject_Add(
     clBLAS-ext
     GIT_REPOSITORY https://github.com/arrayfire/clBLAS.git
@@ -21,7 +27,8 @@ ExternalProject_Add(
     INSTALL_DIR "${prefix}"
     UPDATE_COMMAND ""
     DOWNLOAD_NO_PROGRESS 1
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} "-G${CMAKE_GENERATOR}" -Wno-dev <SOURCE_DIR>/src
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} ${extproj_gen_opts}
+      -Wno-dev <SOURCE_DIR>/src
       -DCMAKE_CXX_FLAGS:STRING="-fPIC"
       -DCMAKE_C_FLAGS:STRING="-fPIC"
       -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}

--- a/CMakeModules/build_clFFT.cmake
+++ b/CMakeModules/build_clFFT.cmake
@@ -18,6 +18,12 @@ ELSE()
     SET(byproducts BUILD_BYPRODUCTS ${clFFT_location})
 ENDIF()
 
+if(WIN32)
+  set(extproj_gen_opts "-G${CMAKE_GENERATOR}" "-A${CMAKE_GENERATOR_PLATFORM}")
+else(WIN32)
+  set(extproj_gen_opts "-G${CMAKE_GENERATOR}")
+endif(WIN32)
+
 ExternalProject_Add(
     clFFT-ext
     GIT_REPOSITORY https://github.com/arrayfire/clFFT.git
@@ -25,7 +31,8 @@ ExternalProject_Add(
     PREFIX "${prefix}"
     INSTALL_DIR "${prefix}"
     UPDATE_COMMAND ""
-    CONFIGURE_COMMAND ${CMAKE_COMMAND} "-G${CMAKE_GENERATOR}" -Wno-dev <SOURCE_DIR>/src
+    CONFIGURE_COMMAND ${CMAKE_COMMAND} ${extproj_gen_opts}
+      -Wno-dev <SOURCE_DIR>/src
       -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
       "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} -w -fPIC"
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}


### PR DESCRIPTION
Resolves #2655 

On windows for multi-platform generators such as Visual Studio, without forwarding the platform string to external projects, cmake is choosing x86 default platform. Hence, the error some times.

I have observed the error especially with latest cmake using Visual Studio 16 2019 latest editions.