### PR TITLE
Add log trace support for jit

### DIFF
--- a/docs/pages/configuring_arrayfire_environment.md
+++ b/docs/pages/configuring_arrayfire_environment.md
@@ -164,7 +164,9 @@ list of modules to trace. If enabled, ArrayFire will print relevant information
 to stdout. Currently the following modules are supported:
 
 - all: All trace outputs
+- jit: Logs kernel fetch & respective compile options and any errors.
 - mem: Memory management allocation, free and garbage collection information
+- platform: Device management information
 - unified: Unified backend dynamic loading information
 
 Tracing displays the information that could be useful when debugging or
@@ -175,6 +177,10 @@ optimizing your application. Here is how you would use this variable:
 This will print information about memory operations such as allocations,
 deallocations, and garbage collection.
 
+All trace statements printed to the console have a suffix with the following
+pattern.
+
+**[category][Seconds since Epoch][Thread Id][source file relative path] <Message>**
 
 AF_MAX_BUFFERS {#af_max_buffers}
 -------------------------------------------------------------------------

--- a/src/api/unified/symbol_manager.cpp
+++ b/src/api/unified/symbol_manager.cpp
@@ -135,6 +135,7 @@ LibHandle openDynLibrary(const af_backend bknd_idx) {
     typedef af_err (*func)(int*);
 
     LibHandle retVal = nullptr;
+
     for (size_t i = 0; i < extent<decltype(pathPrefixes)>::value; i++) {
         AF_TRACE("Attempting: {}",
                  (pathPrefixes[i].empty() ? "Default System Paths"

--- a/src/backend/common/Logger.cpp
+++ b/src/backend/common/Logger.cpp
@@ -18,6 +18,7 @@
 #include <array>
 #include <cstdlib>
 #include <memory>
+#include <mutex>
 #include <string>
 
 using std::array;
@@ -29,20 +30,22 @@ using std::to_string;
 using spdlog::get;
 using spdlog::logger;
 using spdlog::stdout_logger_mt;
-using spdlog::level::trace;
 
 namespace common {
+
 shared_ptr<logger> loggerFactory(string name) {
     shared_ptr<logger> logger;
     if (!(logger = get(name))) {
         logger = stdout_logger_mt(name);
-        logger->set_pattern("[%n][%t] %v");
+        logger->set_pattern("[%n][%E][%t] %v");
 
         // Log mode
         string env_var = getEnvVar("AF_TRACE");
         if (env_var.find("all") != string::npos ||
             env_var.find(name) != string::npos) {
-            logger->set_level(trace);
+            logger->set_level(spdlog::level::trace);
+        } else {
+            logger->set_level(spdlog::level::off);
         }
     }
     return logger;

--- a/src/backend/common/Logger.hpp
+++ b/src/backend/common/Logger.hpp
@@ -11,6 +11,8 @@
 
 #include <memory>
 #include <string>
+#include <type_traits>
+
 #include <spdlog/spdlog.h>
 
 namespace common {

--- a/src/backend/opencl/device_manager.hpp
+++ b/src/backend/opencl/device_manager.hpp
@@ -104,6 +104,8 @@ class DeviceManager {
 
     ~DeviceManager();
 
+    spdlog::logger* getLogger();
+
    protected:
     using clfftSetupData = clfftSetupData_;
 
@@ -119,6 +121,7 @@ class DeviceManager {
 
    private:
     // Attributes
+    std::shared_ptr<spdlog::logger> logger;
     std::mutex deviceMutex;
     std::vector<cl::Device*> mDevices;
     std::vector<cl::Context*> mContexts;

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -15,6 +15,7 @@
 #include <blas.hpp>
 #include <cache.hpp>
 #include <clfft.hpp>
+#include <common/Logger.hpp>
 #include <common/host_memory.hpp>
 #include <common/DefaultMemoryManager.hpp>
 #include <common/util.hpp>

--- a/src/backend/opencl/platform.hpp
+++ b/src/backend/opencl/platform.hpp
@@ -30,6 +30,10 @@ class program_cache;
 }
 }  // namespace boost
 
+namespace spdlog {
+class logger;
+}
+
 namespace graphics {
 class ForgeManager;
 }


### PR DESCRIPTION
Add trace support for jit
- [x] CPU Backend - Nothing added as there is compile/link stage.
- [x] CUDA Backend
- [x] OpenCL Backend

Sample output from CUDA backend.

Pure JIT kernels
```
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from JIT
[ RUN      ] JIT.CPP_JIT_HASH
[jit][022615] [ ../src/backend/cuda/nvrtc/cache.cpp:242 ] Fetch kernel: KER15803858198028938426
[jit][022615] [ ../src/backend/cuda/nvrtc/cache.cpp:244 ] 	 Compile option: --gpu-architecture=compute_61
[jit][022615] [ ../src/backend/cuda/nvrtc/cache.cpp:244 ] 	 Compile option: --std=c++14
[jit][022615] [ ../src/backend/cuda/nvrtc/cache.cpp:242 ] Fetch kernel: KER4770152843556411233
[jit][022615] [ ../src/backend/cuda/nvrtc/cache.cpp:244 ] 	 Compile option: --gpu-architecture=compute_61
[jit][022615] [ ../src/backend/cuda/nvrtc/cache.cpp:244 ] 	 Compile option: --std=c++14
[jit][022615] [ ../src/backend/cuda/nvrtc/cache.cpp:242 ] Fetch kernel: KER9160382770965065811
[jit][022615] [ ../src/backend/cuda/nvrtc/cache.cpp:244 ] 	 Compile option: --gpu-architecture=compute_61
[jit][022615] [ ../src/backend/cuda/nvrtc/cache.cpp:244 ] 	 Compile option: --std=c++14
[       OK ] JIT.CPP_JIT_HASH (1036 ms)
[----------] 1 test from JIT (1037 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1037 ms total)
[  PASSED  ] 1 test.
```

NVRTC compilation code path
```
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from Transpose/0, where TypeParam = float
[ RUN      ] Transpose/0.Square512x512
[jit][022725] [ ../src/backend/cuda/nvrtc/cache.cpp:242 ] Fetch kernel: cuda::transpose<float,false,true>
[jit][022725] [ ../src/backend/cuda/nvrtc/cache.cpp:244 ] 	 Compile option: --gpu-architecture=compute_61
[jit][022725] [ ../src/backend/cuda/nvrtc/cache.cpp:244 ] 	 Compile option: --std=c++14
[jit][022725] [ ../src/backend/cuda/nvrtc/cache.cpp:244 ] 	 Compile option: -D TILE_DIM=32
[jit][022725] [ ../src/backend/cuda/nvrtc/cache.cpp:244 ] 	 Compile option: -D THREADS_Y=8
[jit][022725] [ ../src/backend/cuda/nvrtc/cache.cpp:244 ] 	 Compile option: --device-as-default-execution-space
[       OK ] Transpose/0.Square512x512 (800 ms)
[----------] 1 test from Transpose/0 (800 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (800 ms total)
[  PASSED  ] 1 test.
```