### PR TITLE
Log dynamic lib loading failures from unified API

### DIFF
--- a/src/api/unified/symbol_manager.cpp
+++ b/src/api/unified/symbol_manager.cpp
@@ -148,6 +148,8 @@ LibHandle openDynLibrary(const af_backend bknd_idx) {
                 count_func(&count);
                 AF_TRACE("Device Count: {}.", count);
                 if (count == 0) {
+                    AF_TRACE("Skipping: No devices found for {}",
+                             bkndLibName);
                     retVal = nullptr;
                     continue;
                 }

--- a/src/api/unified/symbol_manager.cpp
+++ b/src/api/unified/symbol_manager.cpp
@@ -136,7 +136,7 @@ LibHandle openDynLibrary(const af_backend bknd_idx) {
 
     LibHandle retVal = nullptr;
     for (size_t i = 0; i < extent<decltype(pathPrefixes)>::value; i++) {
-        AF_TRACE("Attempting: {}", pathPrefixes[i]);
+        AF_TRACE("Attempting: {}", (pathPrefixes[i].empty() ? "Default System Paths" : pathPrefixes[i]));
         if ((retVal = loadLibrary(
                  join_path(pathPrefixes[i], bkndLibName).c_str()))) {
             AF_TRACE("Found: {}", join_path(pathPrefixes[i], bkndLibName));

--- a/src/backend/common/module_loading_unix.cpp
+++ b/src/backend/common/module_loading_unix.cpp
@@ -27,8 +27,14 @@ LibHandle loadLibrary(const char* library_name) {
 void unloadLibrary(LibHandle handle) { dlclose(handle); }
 
 string getErrorMessage() {
-    string error_message(dlerror());
-    return error_message;
+    char* errMsg = dlerror();
+    if (errMsg) {
+        return string(errMsg);
+    } else {
+        // constructing std::basic_string from NULL/0 address is
+        // invalid and has undefined behavior
+        return string("No Error");
+    }
 }
 
 }  // namespace common


### PR DESCRIPTION
Help resolves #2634 

Added `AF_TRACE` commands when load library fails. Until now, only success is being reported in trace logs.

Cleaned up a unnecessary redirection in symbol_manage.cpp.

I tried to put trace command in `UNIFIED_ERROR_LOAD_LIB` macro but the dlerror call by that point is returning NULL because of earlier reads. I am still trying to figure out why/where this is happening.

