### PR TITLE
Disable events by default. Add enable events flag

### DIFF
--- a/include/af/internal.h
+++ b/include/af/internal.h
@@ -187,6 +187,23 @@ extern "C"
     AFAPI af_err af_get_allocated_bytes(size_t *bytes, const af_array arr);
 #endif
 
+#if AF_API_VERSION >= 37
+    /**
+       Enables and disables(default) the use of events in the memory manager
+       for synchronization. Enabling events incurrs a performance penilty
+       but allows you to use streams(not currently supported).
+
+       \note The default for this variable may change in future versions of
+             ArrayFire
+
+       \param[in] enabled If true, events will be used in the memory manager
+       \returns AF_SUCCESS
+
+       \ingroup internal_func_eventsbasedmemorymanager
+    */
+    AFAPI af_err af_set_use_events_based_memory_manager(int enable);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/api/c/internal.cpp
+++ b/src/api/c/internal.cpp
@@ -9,6 +9,7 @@
 
 #include <Array.hpp>
 #include <backend.hpp>
+#include <common/defaults.hpp>
 #include <common/err_common.hpp>
 #include <handle.hpp>
 #include <platform.hpp>
@@ -22,6 +23,7 @@ using af::dim4;
 using detail::cdouble;
 using detail::cfloat;
 using detail::createStridedArray;
+using common::getEventsEnabledFlag;
 using detail::intl;
 using detail::uchar;
 using detail::uint;
@@ -223,5 +225,13 @@ af_err af_get_allocated_bytes(size_t *bytes, const af_array arr) {
         std::swap(*bytes, res);
     }
     CATCHALL;
+    return AF_SUCCESS;
+}
+
+af_err af_set_use_events_based_memory_manager(int enable) {
+    if (enable == 0)
+        getEventsEnabledFlag() = 0;
+    else
+        getEventsEnabledFlag() = 1;
     return AF_SUCCESS;
 }

--- a/src/api/unified/internal.cpp
+++ b/src/api/unified/internal.cpp
@@ -48,3 +48,7 @@ af_err af_get_allocated_bytes(size_t *bytes, const af_array arr) {
     CHECK_ARRAYS(arr);
     return CALL(bytes, arr);
 }
+
+af_err af_set_use_events_based_memory_manager(int enable) {
+    return CALL(enable);
+}

--- a/src/backend/common/CMakeLists.txt
+++ b/src/backend/common/CMakeLists.txt
@@ -37,6 +37,8 @@ target_sources(afcommon_interface
     ${CMAKE_CURRENT_SOURCE_DIR}/cblas.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/complex.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/constants.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/defaults.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/defaults.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/defines.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dim4.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dispatch.cpp

--- a/src/backend/common/defaults.cpp
+++ b/src/backend/common/defaults.cpp
@@ -1,0 +1,19 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <common/defaults.hpp>
+
+namespace common {
+
+int& getEventsEnabledFlag() {
+    static int events_enabled = false;
+    return events_enabled;
+}
+
+}  // namespace common

--- a/src/backend/common/defaults.hpp
+++ b/src/backend/common/defaults.hpp
@@ -1,0 +1,26 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+namespace common {
+
+// Returns the reference to the Events Enabled flag which determine if the
+// events should be used by the memory manager when memory is allocated or
+// freed.
+//
+// This is flag is necessary because events incure a small performance penilty
+// which can be significant in the case where you are performing many smaller
+// operations. Event based allocation and frees are required to support streams
+// in ArrayFire which may be added in the future.
+//
+// \returns 0 if events are disabled(default). Nonzero otherwise
+int& getEventsEnabledFlag();
+
+}  // namespace common

--- a/src/backend/cpu/memory.cpp
+++ b/src/backend/cpu/memory.cpp
@@ -9,6 +9,7 @@
 
 #include <memory.hpp>
 
+#include <common/defaults.hpp>
 #include <common/Logger.hpp>
 #include <common/MemoryManagerImpl.hpp>
 #include <common/half.hpp>
@@ -31,6 +32,7 @@ template class common::MemoryManager<cpu::MemoryManager>;
 #endif
 
 using common::bytesToString;
+using common::getEventsEnabledFlag;
 using common::half;
 using std::function;
 using std::move;
@@ -72,12 +74,14 @@ void *memAllocUser(const size_t &bytes) {
 
 template<typename T>
 void memFree(T *ptr) {
-    Event e = make_event(getQueue());
+    Event e;
+    if (getEventsEnabledFlag()) { e = make_event(getQueue()); }
     return memoryManager().unlock((void *)ptr, move(e), false);
 }
 
 void memFreeUser(void *ptr) {
-    Event e = make_event(getQueue());
+    Event e;
+    if (getEventsEnabledFlag()) { e = make_event(getQueue()); }
     memoryManager().unlock((void *)ptr, move(e), true);
 }
 
@@ -104,7 +108,8 @@ T *pinnedAlloc(const size_t &elements) {
 
 template<typename T>
 void pinnedFree(T *ptr) {
-    Event e = make_event(getQueue());
+    Event e;
+    if (getEventsEnabledFlag()) { e = make_event(getQueue()); }
     return memoryManager().unlock((void *)ptr, move(e), false);
 }
 

--- a/src/backend/cuda/Event.hpp
+++ b/src/backend/cuda/Event.hpp
@@ -21,7 +21,7 @@ class CUDARuntimeEventPolicy {
     using ErrorType = CUresult;
 
     static ErrorType createEvent(CUevent *e) noexcept {
-        // Creating events with the CU_EVENT_BLOCKING_SYNC flag 
+        // Creating events with the CU_EVENT_BLOCKING_SYNC flag
         // severly impacts the speed if/when creating many arrays
         auto err = cuEventCreate(e, CU_EVENT_DISABLE_TIMING);
         return err;

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -12,6 +12,7 @@
 #include <Event.hpp>
 #include <common/Logger.hpp>
 #include <common/MemoryManagerImpl.hpp>
+#include <common/defaults.hpp>
 #include <common/dispatch.hpp>
 #include <common/half.hpp>
 #include <common/util.hpp>
@@ -37,8 +38,9 @@ template class common::MemoryManager<cuda::MemoryManagerPinned>;
 #endif
 
 using common::bytesToString;
-using common::MemoryEventPair;
+using common::getEventsEnabledFlag;
 using common::half;
+using common::MemoryEventPair;
 
 using std::move;
 
@@ -77,12 +79,14 @@ void *memAllocUser(const size_t &bytes) {
 
 template<typename T>
 void memFree(T *ptr) {
-    Event e = make_event(getActiveStream());
+    Event e;
+    if (getEventsEnabledFlag()) { e = make_event(getActiveStream()); }
     memoryManager().unlock((void *)ptr, move(e), false);
 }
 
 void memFreeUser(void *ptr) {
-    Event e = make_event(getActiveStream());
+    Event e;
+    if (getEventsEnabledFlag()) { e = make_event(getActiveStream()); }
     memoryManager().unlock((void *)ptr, move(e), true);
 }
 
@@ -111,7 +115,8 @@ T *pinnedAlloc(const size_t &elements) {
 
 template<typename T>
 void pinnedFree(T *ptr) {
-    Event e = make_event(getActiveStream());
+    Event e;
+    if (getEventsEnabledFlag()) { e = make_event(getActiveStream()); }
     return pinnedMemoryManager().unlock((void *)ptr, move(e), false);
 }
 

--- a/src/backend/opencl/memory.cpp
+++ b/src/backend/opencl/memory.cpp
@@ -13,9 +13,10 @@
 #include <types.hpp>
 
 #include <common/Logger.hpp>
+#include <common/MemoryManagerImpl.hpp>
+#include <common/defaults.hpp>
 #include <spdlog/spdlog.h>
 
-#include <common/MemoryManagerImpl.hpp>
 template class common::MemoryManager<opencl::MemoryManager>;
 template class common::MemoryManager<opencl::MemoryManagerPinned>;
 
@@ -28,6 +29,7 @@ template class common::MemoryManager<opencl::MemoryManagerPinned>;
 #endif
 
 using common::bytesToString;
+using common::getEventsEnabledFlag;
 using common::MemoryEventPair;
 
 using std::function;
@@ -68,12 +70,14 @@ void *memAllocUser(const size_t &bytes) {
 }
 template<typename T>
 void memFree(T *ptr) {
-    Event e = make_event(getQueue());
+    Event e;
+    if (getEventsEnabledFlag()) { e = make_event(getQueue()); }
     return memoryManager().unlock((void *)ptr, move(e), false);
 }
 
 void memFreeUser(void *ptr) {
-    Event e = make_event(getQueue());
+    Event e;
+    if (getEventsEnabledFlag()) { e = make_event(getQueue()); }
     memoryManager().unlock((void *)ptr, move(e), true);
 }
 
@@ -112,7 +116,8 @@ T *pinnedAlloc(const size_t &elements) {
 
 template<typename T>
 void pinnedFree(T *ptr) {
-    Event e = make_event(getQueue());
+    Event e;
+    if (getEventsEnabledFlag()) { e = make_event(getQueue()); }
     return pinnedMemoryManager().unlock((void *)ptr, move(e), false);
 }
 

--- a/test/internal.cpp
+++ b/test/internal.cpp
@@ -144,3 +144,8 @@ TEST(Internal, Allocated) {
 
     ASSERT_EQ(d.allocated(), a_allocated);
 }
+
+TEST(Internal, DisableEvents) {
+    ASSERT_SUCCESS(af_set_use_events_based_memory_manager(1));
+    ASSERT_SUCCESS(af_set_use_events_based_memory_manager(0));
+}


### PR DESCRIPTION
This commit disables the use of events but does not remove the
events based code from the memory manager. This is required because
it is not necessary as of now and there is a performance penalty
for using events. This may be enabled in the future once we begin
using streams where events will be necessary.

Fixes #2673 