### PR TITLE
Ensure query and info functions do not fail if there is no device

### DIFF
--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -21,6 +21,7 @@
 #include <af/version.h>
 
 #include <cstring>
+#include <string>
 
 using namespace detail;
 using common::half;
@@ -158,7 +159,23 @@ af_err af_get_device(int* device) {
 af_err af_set_device(const int device) {
     try {
         ARG_ASSERT(0, device >= 0);
-        ARG_ASSERT(0, setDevice(device) >= 0);
+        if (setDevice(device) < 0) {
+            int ndevices = getDeviceCount();
+            if (ndevices == 0) {
+                AF_ERROR(
+                    "No devices were found on this system. Ensure "
+                    "you have installed the device driver as well as the "
+                    "necessary runtime libraries for your platform.",
+                    AF_ERR_RUNTIME);
+            } else {
+                char buf[512];
+                char err_msg[] =
+                    "The device index of %d is out of range. Use a value "
+                    "between 0 and %d.";
+                snprintf(buf, 512, err_msg, device, ndevices - 1);
+                AF_ERROR(buf, AF_ERR_ARG);
+            }
+        }
     }
     CATCHALL;
 

--- a/src/backend/cpu/platform.cpp
+++ b/src/backend/cpu/platform.cpp
@@ -54,7 +54,7 @@ static inline string& ltrim(string& s) {
 
 int getBackend() { return AF_BACKEND_CPU; }
 
-string getDeviceInfo() {
+string getDeviceInfo() noexcept {
     const CPUInfo cinfo = DeviceManager::getInstance().getCPUInfo();
 
     ostringstream info;

--- a/src/backend/cpu/platform.hpp
+++ b/src/backend/cpu/platform.hpp
@@ -28,7 +28,7 @@ namespace cpu {
 
 int getBackend();
 
-std::string getDeviceInfo();
+std::string getDeviceInfo() noexcept;
 
 bool isDoubleSupported(int device);
 

--- a/src/backend/cuda/device_manager.hpp
+++ b/src/backend/cuda/device_manager.hpp
@@ -70,15 +70,15 @@ class DeviceManager {
 
     friend GraphicsResourceManager& interopManager();
 
-    friend std::string getDeviceInfo(int device);
+    friend std::string getDeviceInfo(int device) noexcept;
 
-    friend std::string getPlatformInfo();
+    friend std::string getPlatformInfo() noexcept;
 
     friend std::string getDriverVersion();
 
-    friend std::string getCUDARuntimeVersion();
+    friend std::string getCUDARuntimeVersion() noexcept;
 
-    friend std::string getDeviceInfo();
+    friend std::string getDeviceInfo() noexcept;
 
     friend int getDeviceCount();
 
@@ -107,6 +107,8 @@ class DeviceManager {
     // Attributes
     enum sort_mode { flops = 0, memory = 1, compute = 2, none = 3 };
 
+    // Checks if the Graphics driver is capable of running the CUDA toolkit
+    // version that ArrayFire was compiled against
     void checkCudaVsDriverVersion();
     void sortDevices(sort_mode mode = flops);
 

--- a/src/backend/cuda/platform.hpp
+++ b/src/backend/cuda/platform.hpp
@@ -54,14 +54,16 @@ class PlanCache;
 
 int getBackend();
 
-std::string getDeviceInfo();
-std::string getDeviceInfo(int device);
+std::string getDeviceInfo() noexcept;
+std::string getDeviceInfo(int device) noexcept;
 
-std::string getPlatformInfo();
+std::string getPlatformInfo() noexcept;
 
 std::string getDriverVersion();
 
-std::string getCUDARuntimeVersion();
+// Returns the cuda runtime version as a string for the current build. If no
+// runtime is found or an error occured, the string "N/A" is returned
+std::string getCUDARuntimeVersion() noexcept;
 
 // Returns true if double is supported by the device
 bool isDoubleSupported(int device);

--- a/src/backend/opencl/device_manager.cpp
+++ b/src/backend/opencl/device_manager.cpp
@@ -170,7 +170,18 @@ DeviceManager::DeviceManager()
     , fgMngr(new graphics::ForgeManager())
     , mFFTSetup(new clfftSetupData) {
     vector<Platform> platforms;
-    Platform::get(&platforms);
+    try {
+        Platform::get(&platforms);
+    } catch (const cl::Error& err) {
+        if (err.err() == CL_PLATFORM_NOT_FOUND_KHR) {
+            AF_ERROR(
+                "No OpenCL platforms found on this system. Ensure you have "
+                "installed the device driver as well as the OpenCL runtime and "
+                "ICD from your device vendor. You can use the clinfo utility "
+                "to debug OpenCL installation issues.",
+                AF_ERR_RUNTIME);
+        }
+    }
 
     // This is all we need because the sort takes care of the order of devices
 #ifdef OS_MAC

--- a/src/backend/opencl/device_manager.hpp
+++ b/src/backend/opencl/device_manager.hpp
@@ -61,9 +61,9 @@ class DeviceManager {
 
     friend kc_entry_t kernelCache(int device, const std::string& key);
 
-    friend std::string getDeviceInfo();
+    friend std::string getDeviceInfo() noexcept;
 
-    friend int getDeviceCount();
+    friend int getDeviceCount() noexcept;
 
     friend int getDeviceIdFromNativeId(cl_device_id id);
 

--- a/src/backend/opencl/platform.hpp
+++ b/src/backend/opencl/platform.hpp
@@ -59,9 +59,9 @@ static inline bool verify_present(std::string pname, const char* ref) {
 
 int getBackend();
 
-std::string getDeviceInfo();
+std::string getDeviceInfo() noexcept;
 
-int getDeviceCount();
+int getDeviceCount() noexcept;
 
 int getActiveDeviceId();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -244,6 +244,7 @@ make_test(SRC moddims.cpp)
 make_test(SRC moments.cpp)
 make_test(SRC morph.cpp)
 make_test(SRC nearest_neighbour.cpp CXX11)
+make_test(SRC nodevice.cpp CXX11)
 
 if(OpenCL_FOUND)
   make_test(SRC ocl_ext_context.cpp

--- a/test/nodevice.cpp
+++ b/test/nodevice.cpp
@@ -1,0 +1,73 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+// Include functions that provide information about the system and shouldn't
+// throw exceptions during runtime.
+
+#include <arrayfire.h>
+#include <gtest/gtest.h>
+#include <testHelpers.hpp>
+
+TEST(NoDevice, Info) {
+    ASSERT_SUCCESS(af_info());
+}
+
+TEST(NoDevice, InfoCxx) {
+    af::info();
+}
+
+TEST(NoDevice, InfoString) {
+    char *str;
+    ASSERT_SUCCESS(af_info_string(&str, true));
+    ASSERT_SUCCESS(af_free_host((void*)str));
+}
+
+TEST(NoDevice, GetDeviceCount) {
+    int device = 0;
+    ASSERT_SUCCESS(af_get_device_count(&device));
+}
+
+TEST(NoDevice, GetDeviceCountCxx) {
+    int device = 0;
+    af::getDeviceCount();
+}
+
+TEST(NoDevice, GetSizeOf) {
+    size_t size;
+    ASSERT_SUCCESS(af_get_size_of(&size, f32));
+    ASSERT_EQ(4, size);
+}
+
+TEST(NoDevice, GetSizeOfCxx) {
+    size_t size = af::getSizeOf(f32);
+    ASSERT_EQ(4, size);
+}
+
+TEST(NoDevice, GetBackendCount) {
+    unsigned int nbackends;
+    ASSERT_SUCCESS(af_get_backend_count(&nbackends));
+}
+
+TEST(NoDevice, GetBackendCountCxx) {
+    unsigned int nbackends = af::getBackendCount();
+}
+
+TEST(NoDevice, GetVersion) {
+    int major = 0, minor = 0, patch = 0;
+
+    ASSERT_SUCCESS(af_get_version(&major, &minor, &patch));
+
+    ASSERT_EQ(AF_VERSION_MAJOR, major);
+    ASSERT_EQ(AF_VERSION_MINOR, minor);
+    ASSERT_EQ(AF_VERSION_PATCH, patch);
+}
+
+TEST(NoDevice, GetRevision) {
+    const char* revision = af_get_revision();
+}


### PR DESCRIPTION
Some of the info and query functions failed when called on a system
with no OpenCL runtime or graphics drivers installed. These functions
should be resilient to these situations and provide feed back to the
user about possible next steps. The following functions are able to
function even if there is not device or driver installed.

af_info
af_info_string
af_get_device_count
af_get_size_of
af_get_backend_count
af_get_version
af_get_revision

This also includes their respective C++ functions.

Added unit tests.