### PR TITLE
FEAT: function to pad array borders

### DIFF
--- a/docs/details/data.dox
+++ b/docs/details/data.dox
@@ -13,6 +13,17 @@ The array created has the same value at all locations
 
 =======================================================================
 
+\defgroup data_func_pad Padding
+
+\brief Pad an array
+
+Pad the input array using a constant or values from input along border
+
+\ingroup data_mat
+\ingroup arrayfire_func
+
+=======================================================================
+
 \defgroup data_func_identity identity
 
 \brief Create an identity array with diagonal values 1

--- a/include/af/data.h
+++ b/include/af/data.h
@@ -416,6 +416,23 @@ namespace af
     AFAPI void replace(array &a, const array  &cond, const double &b);
 #endif
 
+#if AF_API_VERSION >= 37
+    /**
+       \param[in] in is the input array to be padded
+       \param[in] beginPadding informs the number of elements to be
+                  padded at beginning of each dimension
+       \param[in] endPadding informs the number of elements to be
+                  padded at end of each dimension
+       \param[in] padFillType is indicates what values should fill padded region
+
+       \return the padded array
+
+       \ingroup data_func_pad
+    */
+    AFAPI array pad(const array &in, const dim4 &beginPadding,
+                    const dim4 &endPadding, const borderType padFillType);
+#endif
+
     /**
       @}
     */
@@ -707,6 +724,25 @@ extern "C" {
        \ingroup data_func_replace
     */
     AFAPI af_err af_replace_scalar(af_array a, const af_array cond, const double b);
+#endif
+
+#if AF_API_VERSION >= 37
+    /**
+       \param[out] out is the padded array
+       \param[in] in is the input array to be padded
+       \param[in] b_ndims is size of \p l_dims array
+       \param[in] b_dims array contains padding size at beginning of each
+       dimension \param[in] e_ndims is size of \p u_dims array \param[in] e_dims
+       array contains padding sizes at end of each dimension \param[in]
+       pad_fill_type is indicates what values should fill padded region
+
+       \ingroup data_func_pad
+    */
+    AFAPI af_err af_pad(af_array *out, const af_array in,
+                        const unsigned begin_ndims,
+                        const dim_t *const begin_dims, const unsigned end_ndims,
+                        const dim_t *const end_dims,
+                        const af_border_type pad_fill_type);
 #endif
 
 #ifdef __cplusplus

--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -264,25 +264,25 @@ typedef enum {
 } af_interp_type;
 
 typedef enum {
-  ///
-  /// Out of bound values are 0
-  ///
-  AF_PAD_ZERO = 0,
+    ///
+    /// Out of bound values are 0
+    ///
+    AF_PAD_ZERO = 0,
 
-  ///
-  /// Out of bound values are symmetric over the edge
-  ///
-  AF_PAD_SYM,
+    ///
+    /// Out of bound values are symmetric over the edge
+    ///
+    AF_PAD_SYM,
 
-  ///
-  /// Out of bound values are clamped to the edge
-  ///
-  AF_PAD_CLAMP_TO_EDGE,
+    ///
+    /// Out of bound values are clamped to the edge
+    ///
+    AF_PAD_CLAMP_TO_EDGE,
 
-  ///
-  /// Out of bound values are mapped to range of the dimension in cyclic fashion
-  ///
-  AF_PAD_PERIODIC
+    ///
+    /// Out of bound values are mapped to range of the dimension in cyclic fashion
+    ///
+    AF_PAD_PERIODIC
 } af_border_type;
 
 typedef enum {

--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -280,7 +280,7 @@ typedef enum {
   AF_PAD_CLAMP_TO_EDGE,
 
   ///
-  /// Out of bound values are clamped to the edge
+  /// Out of bound values are mapped to range of the dimension in cyclic fashion
   ///
   AF_PAD_PERIODIC
 } af_border_type;

--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -264,20 +264,25 @@ typedef enum {
 } af_interp_type;
 
 typedef enum {
-    ///
-    /// Out of bound values are 0
-    ///
-    AF_PAD_ZERO = 0,
+  ///
+  /// Out of bound values are 0
+  ///
+  AF_PAD_ZERO = 0,
 
-    ///
-    /// Out of bound values are symmetric over the edge
-    ///
-    AF_PAD_SYM,
+  ///
+  /// Out of bound values are symmetric over the edge
+  ///
+  AF_PAD_SYM,
 
-    ///
-    /// Out of bound values are clamped to the edge
-    ///
-    AF_PAD_CLAMP_TO_EDGE
+  ///
+  /// Out of bound values are clamped to the edge
+  ///
+  AF_PAD_CLAMP_TO_EDGE,
+
+  ///
+  /// Out of bound values are clamped to the edge
+  ///
+  AF_PAD_PERIODIC
 } af_border_type;
 
 typedef enum {

--- a/src/api/cpp/data.cpp
+++ b/src/api/cpp/data.cpp
@@ -307,4 +307,16 @@ void replace(array &a, const array &cond, const array &b) {
 void replace(array &a, const array &cond, const double &b) {
     AF_THROW(af_replace_scalar(a.get(), cond.get(), b));
 }
+
+array pad(const array &in, const dim4 &beginPadding, const dim4 &endPadding,
+          const borderType padFillType) {
+    af_array out = 0;
+    // FIXME(pradeep) Cannot use dim4::ndims() since that will
+    //               always return 0 if any one of dimensions
+    //               has no padding completely
+    AF_THROW(af_pad(&out, in.get(), 4, beginPadding.get(), 4, endPadding.get(),
+                    padFillType));
+    return array(out);
+}
+
 }  // namespace af

--- a/src/api/unified/data.cpp
+++ b/src/api/unified/data.cpp
@@ -141,3 +141,10 @@ af_err af_replace_scalar(af_array a, const af_array cond, const double b) {
     CHECK_ARRAYS(a, cond);
       CALL(af_replace_scalar, a, cond, b);
 }
+
+af_err af_pad(af_array *out, const af_array in, const unsigned b_ndims,
+              const dim_t *const b_dims, const unsigned e_ndims,
+              const dim_t *const e_dims, const af_border_type ptype) {
+    CHECK_ARRAYS(in);
+    return CALL(out, in, b_ndims, b_dims, e_ndims, e_dims, ptype);
+}

--- a/src/backend/cpu/kernel/pad_array_borders.hpp
+++ b/src/backend/cpu/kernel/pad_array_borders.hpp
@@ -13,7 +13,6 @@
 #include <utility.hpp>
 
 #include <algorithm>
-#include <cstdlib>
 
 namespace cpu {
 namespace kernel {

--- a/src/backend/cpu/padarray.cpp
+++ b/src/backend/cpu/padarray.cpp
@@ -8,6 +8,7 @@
  ********************************************************/
 
 #include <Array.hpp>
+#include <common/half.hpp>
 #include <copy.hpp>
 #include <err_cpu.hpp>
 #include <kernel/copy.hpp>
@@ -101,6 +102,7 @@ INSTANTIATE_PAD_ARRAY(uchar)
 INSTANTIATE_PAD_ARRAY(char)
 INSTANTIATE_PAD_ARRAY(ushort)
 INSTANTIATE_PAD_ARRAY(short)
+INSTANTIATE_PAD_ARRAY(common::half)
 
 #define INSTANTIATE_PAD_ARRAY_COMPLEX(SRC_T)                              \
     template Array<cfloat> padArray<SRC_T, cfloat>(                       \

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -93,6 +93,7 @@ set(nvrtc_src
   ${CMAKE_CURRENT_SOURCE_DIR}/kernel/interp.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/kernel/shared.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/math.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/utility.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/types.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../common/half.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/../common/kernel_type.hpp

--- a/src/backend/cuda/kernel/pad_array_borders.cuh
+++ b/src/backend/cuda/kernel/pad_array_borders.cuh
@@ -9,6 +9,7 @@
 
 #include <Param.hpp>
 #include <math.hpp>
+#include <utility.hpp>
 
 namespace  cuda {
 
@@ -17,15 +18,14 @@ __device__
 int idxByndEdge(const int i, const int lb, const int len) {
     uint retVal;
     switch (BType) {
-        case AF_PAD_SYM:
-            retVal =
-                ((i < lb || i >= (lb + len)) ? ((len - 1) - ((i - lb) % len))
-                                             : i - lb);
-            break;
+        case AF_PAD_SYM: retVal = trimIndex(i-lb, len); break;
         case AF_PAD_CLAMP_TO_EDGE: retVal = clamp(i - lb, 0, len - 1); break;
-        default:  // AF_PAD_ZERO
-            retVal = 0;
-            break;
+        case AF_PAD_PERIODIC: {
+            int rem   = (i - lb) % len;
+            bool cond = rem < 0;
+            retVal    = cond * (rem + len) + (1 - cond) * rem;
+        } break;
+        default: retVal = 0; break; // AF_PAD_ZERO
     }
     return retVal;
 }

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -27,6 +27,7 @@
 #include <nvrtc_kernel_headers/shared_hpp.hpp>
 #include <nvrtc_kernel_headers/traits_hpp.hpp>
 #include <nvrtc_kernel_headers/types_hpp.hpp>
+#include <nvrtc_kernel_headers/utility_hpp.hpp>
 #include <nvrtc_kernel_headers/version_h.hpp>
 #include <optypes.hpp>
 #include <platform.hpp>
@@ -166,6 +167,7 @@ Kernel buildKernel(const int device, const string &nameExpr,
             "math_constants.h",
             "af/defines.h",
             "af/version.h",
+            "utility.hpp",
         };
 
         constexpr size_t NumHeaders = extent<decltype(includeNames)>::value;
@@ -192,6 +194,7 @@ Kernel buildKernel(const int device, const string &nameExpr,
             string(math_constants_h, math_constants_h_len),
             string(defines_h, defines_h_len),
             string(version_h, version_h_len),
+            string(utility_hpp, utility_hpp_len),
         }};
 
         static const char *headers[] = {
@@ -206,6 +209,7 @@ Kernel buildKernel(const int device, const string &nameExpr,
             sourceStrings[16].c_str(), sourceStrings[17].c_str(),
             sourceStrings[18].c_str(), sourceStrings[19].c_str(),
             sourceStrings[20].c_str(), sourceStrings[21].c_str(),
+            sourceStrings[22].c_str(),
         };
         NVRTC_CHECK(nvrtcCreateProgram(&prog, jit_ker.c_str(), ker_name,
                                        NumHeaders, headers, includeNames));
@@ -448,6 +452,7 @@ string toString(af_border_type p) {
         CASE_STMT(AF_PAD_ZERO);
         CASE_STMT(AF_PAD_SYM);
         CASE_STMT(AF_PAD_CLAMP_TO_EDGE);
+        CASE_STMT(AF_PAD_PERIODIC);
     }
 #undef CASE_STMT
     return retVal;

--- a/src/backend/cuda/pad_array_borders.cpp
+++ b/src/backend/cuda/pad_array_borders.cpp
@@ -10,6 +10,7 @@
 #include <copy.hpp>
 
 #include <Array.hpp>
+#include <common/half.hpp>
 #include <err_cuda.hpp>
 #include <kernel/pad_array_borders.hpp>
 
@@ -48,4 +49,5 @@ INSTANTIATE_PAD_ARRAY_BORDERS(uchar)
 INSTANTIATE_PAD_ARRAY_BORDERS(char)
 INSTANTIATE_PAD_ARRAY_BORDERS(ushort)
 INSTANTIATE_PAD_ARRAY_BORDERS(short)
+INSTANTIATE_PAD_ARRAY_BORDERS(common::half)
 }  // namespace cuda

--- a/src/backend/opencl/copy.hpp
+++ b/src/backend/opencl/copy.hpp
@@ -46,6 +46,9 @@ Array<T> padArrayBorders(Array<T> const &in, dim4 const &lowerBoundPadding,
             kernel::padBorders<T, AF_PAD_CLAMP_TO_EDGE>(ret, in,
                                                         lowerBoundPadding);
             break;
+        case AF_PAD_PERIODIC:
+            kernel::padBorders<T, AF_PAD_PERIODIC>(ret, in, lowerBoundPadding);
+            break;
         default:
             kernel::padBorders<T, AF_PAD_ZERO>(ret, in, lowerBoundPadding);
             break;

--- a/src/backend/opencl/kernel/pad_array_borders.cl
+++ b/src/backend/opencl/kernel/pad_array_borders.cl
@@ -9,17 +9,37 @@
 
 #if AF_BORDER_TYPE == AF_PAD_SYM
 
+int trimIndex(int idx, const int len) {
+    int ret_val = idx;
+    int offset  = abs(ret_val) % len;
+    if (ret_val < 0) {
+        int offset = (abs(ret_val) - 1) % len;
+        ret_val    = offset;
+    } else if (ret_val >= len) {
+        int offset = abs(ret_val) % len;
+        ret_val    = len - offset - 1;
+    }
+    return ret_val;
+}
+
+//TODO(Pradeep) move trimindex from all locations into
+//              a single header after opencl cache is cleaned up
 int idxByndEdge(const int i, const int lb, const int len) {
-    if (i < lb || i >= (lb + len)) {
-        return (len - 1) - ((i - lb) % len);
-    } else
-        return i - lb;
+    return trimIndex(i-lb, len);
 }
 
 #elif AF_BORDER_TYPE == AF_PAD_CLAMP_TO_EDGE
 
 int idxByndEdge(const int i, const int lb, const int len) {
     return clamp(i - lb, 0, len - 1);
+}
+
+#elif AF_BORDER_TYPE == AF_PAD_PERIODIC
+
+int idxByndEdge(const int i, const int lb, const int len) {
+    int rem   = (i - lb) % len;
+    int cond = rem < 0;
+    return cond * (rem + len) + (1 - cond) * rem;
 }
 
 #else

--- a/src/backend/opencl/kernel/pad_array_borders.hpp
+++ b/src/backend/opencl/kernel/pad_array_borders.hpp
@@ -44,6 +44,7 @@ void padBorders(Param out, const Param in, dim4 const& lBPadding) {
         options << " -D T=" << dtype_traits<T>::getName()
                 << " -D AF_BORDER_TYPE=" << BType
                 << " -D AF_PAD_SYM=" << AF_PAD_SYM
+                << " -D AF_PAD_PERIODIC=" << AF_PAD_PERIODIC
                 << " -D AF_PAD_CLAMP_TO_EDGE=" << AF_PAD_CLAMP_TO_EDGE;
         if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
             options << " -D USE_DOUBLE";

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -252,6 +252,7 @@ if(OpenCL_FOUND)
 endif()
 
 make_test(SRC orb.cpp)
+make_test(SRC pad_borders.cpp CXX11)
 make_test(SRC pinverse.cpp)
 make_test(SRC qr_dense.cpp SERIAL)
 make_test(SRC random.cpp)

--- a/test/pad_borders.cpp
+++ b/test/pad_borders.cpp
@@ -1,0 +1,187 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <arrayfire.h>
+#include <gtest/gtest.h>
+#include <half.hpp>
+#include <testHelpers.hpp>
+#include <af/dim4.hpp>
+#include <af/traits.hpp>
+
+#include <vector>
+
+using af::array;
+using af::cdouble;
+using af::cfloat;
+using af::dim4;
+using std::vector;
+
+template<typename T>
+class PadBorders : public ::testing::Test {};
+
+typedef ::testing::Types<float, double, cfloat, cdouble, char, unsigned char,
+                         int, uint, intl, uintl, short,
+                         ushort /*, half_float::half*/>
+    TestTypes;
+
+TYPED_TEST_CASE(PadBorders, TestTypes);
+
+template<typename T>
+void testPad(const vector<T>& input, const dim4& inDims, const dim4& lbPadding,
+             const dim4& ubPadding, const af::borderType btype,
+             const vector<T>& gold, const dim4& outDims) {
+    SUPPORTED_TYPE_CHECK(T);
+    array in(inDims, input.data());
+    array out = af::pad(in, lbPadding, ubPadding, btype);
+    ASSERT_VEC_ARRAY_EQ(gold, outDims, out);
+}
+
+TYPED_TEST(PadBorders, Zero) {
+    testPad(vector<TypeParam>({
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            }),
+            dim4(5, 5), dim4(2, 2, 0, 0), dim4(2, 2, 0, 0), AF_PAD_ZERO,
+            vector<TypeParam>({
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+                1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1,
+                1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            }),
+            dim4(9, 9));
+}
+
+TYPED_TEST(PadBorders, ClampToEdge) {
+    testPad(vector<TypeParam>({
+                1, 1, 1, 1, 1, 1, 2, 2, 2, 1, 1, 2, 2,
+                2, 1, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1,
+            }),
+            dim4(5, 5), dim4(2, 2, 0, 0), dim4(2, 2, 0, 0),
+            AF_PAD_CLAMP_TO_EDGE,
+            vector<TypeParam>({
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 2, 2, 2,
+                1, 1, 1, 1, 1, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            }),
+            dim4(9, 9));
+}
+
+TYPED_TEST(PadBorders, SymmetricOverEdge) {
+    testPad(vector<TypeParam>({
+                1, 1, 1, 1, 0, 2, 3, 2, 2, 0, 3, 5, 2,
+                2, 0, 4, 7, 3, 3, 0, 5, 9, 1, 1, 0,
+            }),
+            dim4(5, 5), dim4(2, 2, 0, 0), dim4(2, 2, 0, 0), AF_PAD_SYM,
+            vector<TypeParam>({
+                3, 2, 2, 3, 2, 2, 0, 0, 2, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1,
+                1, 1, 1, 0, 0, 1, 3, 2, 2, 3, 2, 2, 0, 0, 2, 5, 3, 3, 5, 2, 2,
+                0, 0, 2, 7, 4, 4, 7, 3, 3, 0, 0, 3, 9, 5, 5, 9, 1, 1, 0, 0, 1,
+                9, 5, 5, 9, 1, 1, 0, 0, 1, 7, 4, 4, 7, 3, 3, 0, 0, 3,
+            }),
+            dim4(9, 9));
+}
+
+TYPED_TEST(PadBorders, Periodic) {
+    testPad(vector<TypeParam>({
+                1, 1, 1, 1, 0, 2, 3, 2, 2, 0, 3, 5, 2,
+                2, 0, 4, 7, 3, 3, 0, 5, 9, 1, 1, 0,
+            }),
+            dim4(5, 5), dim4(2, 2, 0, 0), dim4(2, 2, 0, 0), AF_PAD_PERIODIC,
+            vector<TypeParam>({
+                3, 0, 4, 7, 3, 3, 0, 4, 7, 1, 0, 5, 9, 1, 1, 0, 5, 9, 1, 0, 1,
+                1, 1, 1, 0, 1, 1, 2, 0, 2, 3, 2, 2, 0, 2, 3, 2, 0, 3, 5, 2, 2,
+                0, 3, 5, 3, 0, 4, 7, 3, 3, 0, 4, 7, 1, 0, 5, 9, 1, 1, 0, 5, 9,
+                1, 0, 1, 1, 1, 1, 0, 1, 1, 2, 0, 2, 3, 2, 2, 0, 2, 3,
+            }),
+            dim4(9, 9));
+}
+
+TYPED_TEST(PadBorders, BeginOnly) {
+    testPad(vector<TypeParam>({
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            }),
+            dim4(5, 5), dim4(2, 2, 0, 0), dim4(0, 2, 0, 0), AF_PAD_ZERO,
+            vector<TypeParam>({
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1,
+                0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1,
+                0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            }),
+            dim4(7, 9));
+}
+
+TYPED_TEST(PadBorders, EndOnly) {
+    testPad(vector<TypeParam>({
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            }),
+            dim4(5, 5), dim4(0, 2, 0, 0), dim4(2, 2, 0, 0), AF_PAD_ZERO,
+            vector<TypeParam>({
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0,
+                1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 0,
+                1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            }),
+            dim4(7, 9));
+}
+
+TYPED_TEST(PadBorders, BeginCorner) {
+    testPad(vector<TypeParam>({
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            }),
+            dim4(5, 5), dim4(2, 2, 0, 0), dim4(0, 0, 0, 0), AF_PAD_ZERO,
+            vector<TypeParam>({
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+                1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1,
+                1, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1,
+            }),
+            dim4(7, 7));
+}
+
+TYPED_TEST(PadBorders, EndCorner) {
+    testPad(vector<TypeParam>({
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            }),
+            dim4(5, 5), dim4(0, 0, 0, 0), dim4(2, 2, 0, 0), AF_PAD_ZERO,
+            vector<TypeParam>({
+                1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1,
+                1, 1, 0, 0, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 1, 1, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            }),
+            dim4(7, 7));
+}
+
+TEST(PadBorders, NegativePadding) {
+    af_array dummyIn  = 0;
+    af_array dummyOut = 0;
+    dim_t ldims[4]    = {-1, 1, 0, 1};
+    dim_t udims[4]    = {-1, 1, 0, 1};
+    ASSERT_EQ(AF_ERR_SIZE,
+              af_pad(&dummyOut, dummyIn, 4, ldims, 4, udims, AF_PAD_ZERO));
+}
+
+TEST(PadBorders, NegativeNDims) {
+    af_array dummyIn  = 0;
+    af_array dummyOut = 0;
+    dim_t ldims[4]    = {1, 1, 0, 1};
+    dim_t udims[4]    = {1, 1, 0, 1};
+    ASSERT_EQ(AF_ERR_SIZE,
+              af_pad(&dummyOut, dummyIn, -1, ldims, 4, udims, AF_PAD_ZERO));
+}
+
+TEST(PadBorders, InvalidPadType) {
+    af_array dummyIn  = 0;
+    af_array dummyOut = 0;
+    dim_t ldims[4]    = {1, 1, 0, 1};
+    dim_t udims[4]    = {1, 1, 0, 1};
+    ASSERT_EQ(AF_ERR_ARG, af_pad(&dummyOut, dummyIn, 4, ldims, 4, udims,
+                                 (af_border_type)4));
+}


### PR DESCRIPTION
Addresses #2676 partially - allows the user to pad inputs and pass to convolve.

Performance comparison of indexing based padding vs kernel in this PR for a HD image is posted 
https://github.com/arrayfire/arrayfire/issues/2676#issuecomment-561073244