### PR TITLE
Fix buffer-overflow write in scan by key cuda kernel

### DIFF
--- a/src/backend/cuda/kernel/scan_first_by_key_impl.hpp
+++ b/src/backend/cuda/kernel/scan_first_by_key_impl.hpp
@@ -99,24 +99,20 @@ void scan_first_by_key(Param<To> out, CParam<Ti> in, CParam<Tk> key,
     if (blocks_x == 1) {
         scan_final_launcher<Ti, Tk, To, op>(out, in, key, blocks_x, blocks_y,
                                             threads_x, true, inclusive_scan);
-
     } else {
-        Param<To> tmp = out;
         Param<char> tmpflg;
         Param<int> tmpid;
-
-        tmp.dims[0]       = blocks_x;
-        tmpflg.dims[0]    = blocks_x;
-        tmpid.dims[0]     = blocks_x;
-        tmp.strides[0]    = 1;
-        tmpflg.strides[0] = 1;
-        tmpid.strides[0]  = 1;
-        for (int k = 1; k < 4; k++) {
-            tmpflg.dims[k]    = out.dims[k];
-            tmpid.dims[k]     = out.dims[k];
-            tmp.strides[k]    = tmp.strides[k - 1] * tmp.dims[k - 1];
-            tmpflg.strides[k] = tmpflg.strides[k - 1] * tmpflg.dims[k - 1];
-            tmpid.strides[k]  = tmpid.strides[k - 1] * tmpid.dims[k - 1];
+        Param<To> tmp  = out;
+        tmp.dims[0]    = blocks_x;
+        tmp.strides[0] = 1;
+        for (int k = 1; k < AF_MAX_DIMS; k++) {
+            tmp.strides[k] = tmp.strides[k - 1] * tmp.dims[k - 1];
+        }
+        for (int k = 0; k < AF_MAX_DIMS; k++) {
+            tmpflg.dims[k]    = tmp.dims[k];
+            tmpflg.strides[k] = tmp.strides[k];
+            tmpid.dims[k]     = tmp.dims[k];
+            tmpid.strides[k]  = tmp.strides[k];
         }
 
         int tmp_elements  = tmp.strides[3] * tmp.dims[3];

--- a/src/backend/opencl/kernel/scan_first_by_key.cl
+++ b/src/backend/opencl/kernel/scan_first_by_key.cl
@@ -269,7 +269,6 @@ __kernel void bcast_first_kernel(__global To *oData, KParam oInfo,
                                  uint groups_x, uint groups_y, uint lim) {
     const int lidx = get_local_id(0);
     const int lidy = get_local_id(1);
-    const int lid  = lidy * get_local_size(0) + lidx;
 
     const int zid       = get_group_id(0) / groups_x;
     const int wid       = get_group_id(1) / groups_y;
@@ -295,7 +294,8 @@ __kernel void bcast_first_kernel(__global To *oData, KParam oInfo,
             int boundary = tiData[groupId_x];
             To accum     = tData[groupId_x - 1];
 
-            for (int k = 0, id = xid; k < lim && id < boundary;
+            for (int k = 0, id = xid;
+                 k < lim && id < oInfo.dims[0] && id < boundary;
                  k++, id += DIMX) {
                 oData[id] = binOp(accum, oData[id]);
             }

--- a/test/scan_by_key.cpp
+++ b/test/scan_by_key.cpp
@@ -218,3 +218,21 @@ TEST(ScanByKey, Test_Scan_By_key_Simple_1) {
     scanByKeyTest<int, int, AF_BINARY_ADD, false>(
         dims, scanDim, nodeLengths, keyStart, keyEnd, dataStart, dataEnd, 1e-5);
 }
+
+TEST(ScanByKey, FixOverflowWrite) {
+    const int SIZE = 41000;
+    vector<int> keys(SIZE, 0);
+    vector<float> vals(SIZE, 1.0f);
+
+    array someVals = array(SIZE, vals.data());
+    array keysAF = array(SIZE, s32);
+    array valsAF = array(SIZE, vals.data());
+
+    keysAF = array(SIZE, keys.data());
+
+    float prior = valsAF(0).scalar<float>();
+
+    array result = af::scanByKey(keysAF, someVals, 0, AF_BINARY_ADD, true);
+
+    ASSERT_EQ(prior, valsAF(0).scalar<float>());
+}


### PR DESCRIPTION
I did some code refactoring, please bare with that. The main fix is in `scanbykey_first_bcast` kernel during the final output write.

` k < lim && id < out.dims[0] && id < boundary`

Fixes #2680 