### PR TITLE
Optimize unified backend. Remove exceptions in af_get_backend_id.

### DIFF
--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -27,7 +27,9 @@ using common::half;
 
 af_err af_set_backend(const af_backend bknd) {
     try {
-        ARG_ASSERT(0, bknd == getBackend());
+        if(bknd != getBackend()) {
+            return AF_ERR_ARG;
+        }
     }
     CATCHALL;
 
@@ -49,9 +51,12 @@ af_err af_get_available_backends(int* result) {
 
 af_err af_get_backend_id(af_backend* result, const af_array in) {
     try {
-        ARG_ASSERT(1, in != 0);
-        const ArrayInfo& info = getInfo(in, false, false);
-        *result               = info.getBackendId();
+        if(in) {
+            const ArrayInfo& info = getInfo(in, false, false);
+            *result               = info.getBackendId();
+        } else {
+            return AF_ERR_ARG;
+        }
     }
     CATCHALL;
     return AF_SUCCESS;
@@ -59,9 +64,12 @@ af_err af_get_backend_id(af_backend* result, const af_array in) {
 
 af_err af_get_device_id(int* device, const af_array in) {
     try {
-        ARG_ASSERT(1, in != 0);
-        const ArrayInfo& info = getInfo(in, false, false);
-        *device               = info.getDevId();
+        if(in) {
+            const ArrayInfo& info = getInfo(in, false, false);
+            *device               = info.getDevId();
+        } else {
+            return AF_ERR_ARG;
+        }
     }
     CATCHALL;
     return AF_SUCCESS;

--- a/src/api/unified/CMakeLists.txt
+++ b/src/api/unified/CMakeLists.txt
@@ -57,6 +57,8 @@ else()
       ${ArrayFire_SOURCE_DIR}/src/backend/common/module_loading_unix.cpp)
 endif()
 
+target_compile_definitions(af PRIVATE AF_UNIFIED)
+
 target_include_directories(af
   PUBLIC
     $<BUILD_INTERFACE:${ArrayFire_SOURCE_DIR}/include>
@@ -64,6 +66,7 @@ target_include_directories(af
     $<INSTALL_INTERFACE:${AF_INSTALL_INC_DIR}>
   PRIVATE
     ${ArrayFire_SOURCE_DIR}/src/api/c
+    ${ArrayFire_SOURCE_DIR}/src/api/unified
     $<TARGET_PROPERTY:afcommon_interface,INTERFACE_INCLUDE_DIRECTORIES>
     ${CMAKE_BINARY_DIR}
   )

--- a/src/api/unified/algorithm.cpp
+++ b/src/api/unified/algorithm.cpp
@@ -14,7 +14,7 @@
 #define ALGO_HAPI_DEF(af_func)                                        \
     af_err af_func(af_array *out, const af_array in, const int dim) { \
         CHECK_ARRAYS(in);                                             \
-        return CALL(out, in, dim);                                    \
+        CALL(af_func, out, in, dim);                                  \
     }
 
 ALGO_HAPI_DEF(af_sum)
@@ -34,7 +34,7 @@ ALGO_HAPI_DEF(af_diff2)
     af_err af_func_nan(af_array *out, const af_array in, const int dim, \
                        const double nanval) {                           \
         CHECK_ARRAYS(in);                                               \
-        return CALL(out, in, dim, nanval);                              \
+        CALL(af_func_nan, out, in, dim, nanval);                        \
     }
 
 ALGO_HAPI_DEF(af_sum_nan)
@@ -45,7 +45,7 @@ ALGO_HAPI_DEF(af_product_nan)
 #define ALGO_HAPI_DEF(af_func_all)                                      \
     af_err af_func_all(double *real, double *imag, const af_array in) { \
         CHECK_ARRAYS(in);                                               \
-        return CALL(real, imag, in);                                    \
+        CALL(af_func_all, real, imag, in);                              \
     }
 
 ALGO_HAPI_DEF(af_sum_all)
@@ -62,7 +62,7 @@ ALGO_HAPI_DEF(af_count_all)
     af_err af_func_nan_all(double *real, double *imag, const af_array in, \
                            const double nanval) {                         \
         CHECK_ARRAYS(in);                                                 \
-        return CALL(real, imag, in, nanval);                              \
+        CALL(af_func_nan_all, real, imag, in, nanval);                    \
     }
 
 ALGO_HAPI_DEF(af_sum_nan_all)
@@ -74,7 +74,7 @@ ALGO_HAPI_DEF(af_product_nan_all)
     af_err af_ifunc(af_array *out, af_array *idx, const af_array in, \
                     const int dim) {                                 \
         CHECK_ARRAYS(in);                                            \
-        return CALL(out, idx, in, dim);                              \
+        CALL(af_ifunc, out, idx, in, dim);                           \
     }
 
 ALGO_HAPI_DEF(af_imin)
@@ -86,7 +86,7 @@ ALGO_HAPI_DEF(af_imax)
     af_err af_ifunc_all(double *real, double *imag, unsigned *idx, \
                         const af_array in) {                       \
         CHECK_ARRAYS(in);                                          \
-        return CALL(real, imag, idx, in);                          \
+        CALL(af_ifunc_all, real, imag, idx, in);                   \
     }
 
 ALGO_HAPI_DEF(af_imin_all)
@@ -96,53 +96,53 @@ ALGO_HAPI_DEF(af_imax_all)
 
 af_err af_where(af_array *idx, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(idx, in);
+    CALL(af_where, idx, in);
 }
 
 af_err af_scan(af_array *out, const af_array in, const int dim, af_binary_op op,
                bool inclusive_scan) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, dim, op, inclusive_scan);
+    CALL(af_scan, out, in, dim, op, inclusive_scan);
 }
 
 af_err af_scan_by_key(af_array *out, const af_array key, const af_array in,
                       const int dim, af_binary_op op, bool inclusive_scan) {
     CHECK_ARRAYS(in, key);
-    return CALL(out, key, in, dim, op, inclusive_scan);
+    CALL(af_scan_by_key, out, key, in, dim, op, inclusive_scan);
 }
 
 af_err af_sort(af_array *out, const af_array in, const unsigned dim,
                const bool isAscending) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, dim, isAscending);
+    CALL(af_sort, out, in, dim, isAscending);
 }
 
 af_err af_sort_index(af_array *out, af_array *indices, const af_array in,
                      const unsigned dim, const bool isAscending) {
     CHECK_ARRAYS(in);
-    return CALL(out, indices, in, dim, isAscending);
+    CALL(af_sort_index, out, indices, in, dim, isAscending);
 }
 
 af_err af_sort_by_key(af_array *out_keys, af_array *out_values,
                       const af_array keys, const af_array values,
                       const unsigned dim, const bool isAscending) {
     CHECK_ARRAYS(keys, values);
-    return CALL(out_keys, out_values, keys, values, dim, isAscending);
+    CALL(af_sort_by_key, out_keys, out_values, keys, values, dim, isAscending);
 }
 
 af_err af_set_unique(af_array *out, const af_array in, const bool is_sorted) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, is_sorted);
+    CALL(af_set_unique, out, in, is_sorted);
 }
 
 af_err af_set_union(af_array *out, const af_array first, const af_array second,
                     const bool is_unique) {
     CHECK_ARRAYS(first, second);
-    return CALL(out, first, second, is_unique);
+    CALL(af_set_union, out, first, second, is_unique);
 }
 
 af_err af_set_intersect(af_array *out, const af_array first,
                         const af_array second, const bool is_unique) {
     CHECK_ARRAYS(first, second);
-    return CALL(out, first, second, is_unique);
+    CALL(af_set_intersect, out, first, second, is_unique);
 }

--- a/src/api/unified/arith.cpp
+++ b/src/api/unified/arith.cpp
@@ -15,7 +15,7 @@
     af_err af_func(af_array* out, const af_array lhs, const af_array rhs, \
                    const bool batchMode) {                                \
         CHECK_ARRAYS(lhs, rhs);                                           \
-        return CALL(out, lhs, rhs, batchMode);                            \
+        CALL(af_func, out, lhs, rhs, batchMode);                          \
     }
 
 BINARY_HAPI_DEF(af_add)
@@ -47,13 +47,13 @@ BINARY_HAPI_DEF(af_hypot)
 
 af_err af_cast(af_array* out, const af_array in, const af_dtype type) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, type);
+    CALL(af_cast, out, in, type);
 }
 
 #define UNARY_HAPI_DEF(af_func)                        \
     af_err af_func(af_array* out, const af_array in) { \
         CHECK_ARRAYS(in);                              \
-        return CALL(out, in);                          \
+        CALL(af_func, out, in);                        \
     }
 
 UNARY_HAPI_DEF(af_abs)
@@ -103,5 +103,5 @@ UNARY_HAPI_DEF(af_not)
 af_err af_clamp(af_array* out, const af_array in, const af_array lo,
                 const af_array hi, const bool batch) {
     CHECK_ARRAYS(in, lo, hi);
-    return CALL(out, in, lo, hi, batch);
+    CALL(af_clamp, out, in, lo, hi, batch);
 }

--- a/src/api/unified/array.cpp
+++ b/src/api/unified/array.cpp
@@ -14,84 +14,78 @@
 af_err af_create_array(af_array *arr, const void *const data,
                        const unsigned ndims, const dim_t *const dims,
                        const af_dtype type) {
-    return CALL(arr, data, ndims, dims, type);
+    CALL(af_create_array, arr, data, ndims, dims, type);
 }
 
 af_err af_create_handle(af_array *arr, const unsigned ndims,
                         const dim_t *const dims, const af_dtype type) {
-    return CALL(arr, ndims, dims, type);
+    CALL(af_create_handle, arr, ndims, dims, type);
 }
 
 af_err af_copy_array(af_array *arr, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(arr, in);
+    CALL(af_copy_array, arr, in);
 }
 
 af_err af_write_array(af_array arr, const void *data, const size_t bytes,
                       af_source src) {
     CHECK_ARRAYS(arr);
-    return CALL(arr, data, bytes, src);
+    CALL(af_write_array, arr, data, bytes, src);
 }
 
 af_err af_get_data_ptr(void *data, const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(data, arr);
+    CALL(af_get_data_ptr, data, arr);
 }
 
 af_err af_release_array(af_array arr) {
-    af_backend curr =
-        unified::AFSymbolManager::getInstance().getActiveBackend();
-    af_backend other = curr;
-
-    af_err err = af_get_backend_id(&other, arr);
-    if (err != AF_SUCCESS) return err;
-
-    unified::AFSymbolManager::getInstance().setBackend(other);
-    err = CALL(arr);
-    unified::AFSymbolManager::getInstance().setBackend(curr);
-    return err;
+    if (arr) {
+        CALL(af_release_array, arr);
+    } else {
+        return AF_SUCCESS;
+    }
 }
 
 af_err af_retain_array(af_array *out, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(out, in);
+    CALL(af_retain_array, out, in);
 }
 
 af_err af_get_data_ref_count(int *use_count, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(use_count, in);
+    CALL(af_get_data_ref_count, use_count, in);
 }
 
 af_err af_eval(af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(in);
+    CALL(af_eval, in);
 }
 
 af_err af_get_elements(dim_t *elems, const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(elems, arr);
+    CALL(af_get_elements, elems, arr);
 }
 
 af_err af_get_type(af_dtype *type, const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(type, arr);
+    CALL(af_get_type, type, arr);
 }
 
 af_err af_get_dims(dim_t *d0, dim_t *d1, dim_t *d2, dim_t *d3,
                    const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(d0, d1, d2, d3, arr);
+    CALL(af_get_dims, d0, d1, d2, d3, arr);
 }
 
 af_err af_get_numdims(unsigned *result, const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(result, arr);
+    CALL(af_get_numdims, result, arr);
 }
 
 #define ARRAY_HAPI_DEF(af_func)                        \
     af_err af_func(bool *result, const af_array arr) { \
         CHECK_ARRAYS(arr);                             \
-        return CALL(result, arr);                      \
+        CALL(af_func, result, arr);                    \
     }
 
 ARRAY_HAPI_DEF(af_is_empty)
@@ -112,5 +106,5 @@ ARRAY_HAPI_DEF(af_is_sparse)
 
 af_err af_get_scalar(void *output_value, const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(output_value, arr);
+    CALL(af_get_scalar, output_value, arr);
 }

--- a/src/api/unified/blas.cpp
+++ b/src/api/unified/blas.cpp
@@ -10,39 +10,38 @@
 #include <af/blas.h>
 #include "symbol_manager.hpp"
 
-AFAPI af_err af_gemm(af_array *out,
-                     const af_mat_prop optLhs, const af_mat_prop optRhs,
-                     const void* alpha, const af_array lhs, const af_array rhs,
-                     const void* beta) {
+AFAPI af_err af_gemm(af_array *out, const af_mat_prop optLhs,
+                     const af_mat_prop optRhs, const void *alpha,
+                     const af_array lhs, const af_array rhs, const void *beta) {
     CHECK_ARRAYS(out, lhs, rhs);
-    return CALL(out, optLhs, optRhs, alpha, lhs, rhs, beta);
+    CALL(af_gemm, out, optLhs, optRhs, alpha, lhs, rhs, beta);
 }
 
 af_err af_matmul(af_array *out, const af_array lhs, const af_array rhs,
                  const af_mat_prop optLhs, const af_mat_prop optRhs) {
     CHECK_ARRAYS(lhs, rhs);
-    return CALL(out, lhs, rhs, optLhs, optRhs);
+    CALL(af_matmul, out, lhs, rhs, optLhs, optRhs);
 }
 
 af_err af_dot(af_array *out, const af_array lhs, const af_array rhs,
               const af_mat_prop optLhs, const af_mat_prop optRhs) {
     CHECK_ARRAYS(lhs, rhs);
-    return CALL(out, lhs, rhs, optLhs, optRhs);
+    CALL(af_dot, out, lhs, rhs, optLhs, optRhs);
 }
 
 af_err af_dot_all(double *rval, double *ival, const af_array lhs,
                   const af_array rhs, const af_mat_prop optLhs,
                   const af_mat_prop optRhs) {
     CHECK_ARRAYS(lhs, rhs);
-    return CALL(rval, ival, lhs, rhs, optLhs, optRhs);
+    CALL(af_dot_all, rval, ival, lhs, rhs, optLhs, optRhs);
 }
 
 af_err af_transpose(af_array *out, af_array in, const bool conjugate) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, conjugate);
+    CALL(af_transpose, out, in, conjugate);
 }
 
 af_err af_transpose_inplace(af_array in, const bool conjugate) {
     CHECK_ARRAYS(in);
-    return CALL(in, conjugate);
+    CALL(af_transpose_inplace, in, conjugate);
 }

--- a/src/api/unified/cuda.cpp
+++ b/src/api/unified/cuda.cpp
@@ -7,8 +7,8 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include "symbol_manager.hpp"
 #include <af/backend.h>
+#include "symbol_manager.hpp"
 
 #define AF_DEFINE_CUDA_TYPES
 #include <af/cuda.h>
@@ -16,37 +16,27 @@
 af_err afcu_get_stream(cudaStream_t* stream, int id) {
     af_backend backend;
     af_get_active_backend(&backend);
-    if(backend == AF_BACKEND_CUDA) {
-        return CALL(stream, id);
-    }
+    if (backend == AF_BACKEND_CUDA) { CALL(afcu_get_stream, stream, id); }
     return AF_ERR_NOT_SUPPORTED;
 }
 
 af_err afcu_get_native_id(int* nativeid, int id) {
     af_backend backend;
     af_get_active_backend(&backend);
-    if(backend == AF_BACKEND_CUDA) {
-        return CALL(nativeid, id);
-    }
+    if (backend == AF_BACKEND_CUDA) { CALL(afcu_get_native_id, nativeid, id); }
     return AF_ERR_NOT_SUPPORTED;
 }
-
 
 af_err afcu_set_native_id(int nativeid) {
     af_backend backend;
     af_get_active_backend(&backend);
-    if(backend == AF_BACKEND_CUDA) {
-        return CALL(nativeid);
-    }
+    if (backend == AF_BACKEND_CUDA) { CALL(afcu_set_native_id, nativeid); }
     return AF_ERR_NOT_SUPPORTED;
 }
-
 
 af_err afcu_cublasSetMathMode(cublasMath_t mode) {
     af_backend backend;
     af_get_active_backend(&backend);
-    if(backend == AF_BACKEND_CUDA) {
-        return CALL(mode);
-    }
+    if (backend == AF_BACKEND_CUDA) { CALL(afcu_cublasSetMathMode, mode); }
     return AF_ERR_NOT_SUPPORTED;
 }

--- a/src/api/unified/data.cpp
+++ b/src/api/unified/data.cpp
@@ -13,131 +13,131 @@
 
 af_err af_constant(af_array *result, const double value, const unsigned ndims,
                    const dim_t *const dims, const af_dtype type) {
-    return CALL(result, value, ndims, dims, type);
+    CALL(af_constant, result, value, ndims, dims, type);
 }
 
 af_err af_constant_complex(af_array *arr, const double real, const double imag,
                            const unsigned ndims, const dim_t *const dims,
                            const af_dtype type) {
-    return CALL(arr, real, imag, ndims, dims, type);
+    CALL(af_constant_complex, arr, real, imag, ndims, dims, type);
 }
 
 af_err af_constant_long(af_array *arr, const long long val,
                         const unsigned ndims, const dim_t *const dims) {
-    return CALL(arr, val, ndims, dims);
+    CALL(af_constant_long, arr, val, ndims, dims);
 }
 
 af_err af_constant_ulong(af_array *arr, const unsigned long long val,
                          const unsigned ndims, const dim_t *const dims) {
-    return CALL(arr, val, ndims, dims);
+    CALL(af_constant_ulong, arr, val, ndims, dims);
 }
 
 af_err af_range(af_array *out, const unsigned ndims, const dim_t *const dims,
                 const int seq_dim, const af_dtype type) {
-    return CALL(out, ndims, dims, seq_dim, type);
+    CALL(af_range, out, ndims, dims, seq_dim, type);
 }
 
 af_err af_iota(af_array *out, const unsigned ndims, const dim_t *const dims,
                const unsigned t_ndims, const dim_t *const tdims,
                const af_dtype type) {
-    return CALL(out, ndims, dims, t_ndims, tdims, type);
+    CALL(af_iota, out, ndims, dims, t_ndims, tdims, type);
 }
 
 af_err af_identity(af_array *out, const unsigned ndims, const dim_t *const dims,
                    const af_dtype type) {
-    return CALL(out, ndims, dims, type);
+    CALL(af_identity, out, ndims, dims, type);
 }
 
 af_err af_diag_create(af_array *out, const af_array in, const int num) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, num);
+      CALL(af_diag_create, out, in, num);
 }
 
 af_err af_diag_extract(af_array *out, const af_array in, const int num) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, num);
+      CALL(af_diag_extract, out, in, num);
 }
 
 af_err af_join(af_array *out, const int dim, const af_array first,
                const af_array second) {
     CHECK_ARRAYS(first, second);
-    return CALL(out, dim, first, second);
+      CALL(af_join, out, dim, first, second);
 }
 
 af_err af_join_many(af_array *out, const int dim, const unsigned n_arrays,
                     const af_array *inputs) {
     for (unsigned i = 0; i < n_arrays; i++) CHECK_ARRAYS(inputs[i]);
-    return CALL(out, dim, n_arrays, inputs);
+      CALL(af_join_many, out, dim, n_arrays, inputs);
 }
 
 af_err af_tile(af_array *out, const af_array in, const unsigned x,
                const unsigned y, const unsigned z, const unsigned w) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, x, y, z, w);
+      CALL(af_tile, out, in, x, y, z, w);
 }
 
 af_err af_reorder(af_array *out, const af_array in, const unsigned x,
                   const unsigned y, const unsigned z, const unsigned w) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, x, y, z, w);
+      CALL(af_reorder, out, in, x, y, z, w);
 }
 
 af_err af_shift(af_array *out, const af_array in, const int x, const int y,
                 const int z, const int w) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, x, y, z, w);
+      CALL(af_shift, out, in, x, y, z, w);
 }
 
 af_err af_moddims(af_array *out, const af_array in, const unsigned ndims,
                   const dim_t *const dims) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, ndims, dims);
+      CALL(af_moddims, out, in, ndims, dims);
 }
 
 af_err af_flat(af_array *out, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(out, in);
+      CALL(af_flat, out, in);
 }
 
 af_err af_flip(af_array *out, const af_array in, const unsigned dim) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, dim);
+      CALL(af_flip, out, in, dim);
 }
 
 af_err af_lower(af_array *out, const af_array in, bool is_unit_diag) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, is_unit_diag);
+      CALL(af_lower, out, in, is_unit_diag);
 }
 
 af_err af_upper(af_array *out, const af_array in, bool is_unit_diag) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, is_unit_diag);
+      CALL(af_upper, out, in, is_unit_diag);
 }
 
 af_err af_select(af_array *out, const af_array cond, const af_array a,
                  const af_array b) {
     CHECK_ARRAYS(cond, a, b);
-    return CALL(out, cond, a, b);
+      CALL(af_select, out, cond, a, b);
 }
 
 af_err af_select_scalar_r(af_array *out, const af_array cond, const af_array a,
                           const double b) {
     CHECK_ARRAYS(cond, a);
-    return CALL(out, cond, a, b);
+      CALL(af_select_scalar_r, out, cond, a, b);
 }
 
 af_err af_select_scalar_l(af_array *out, const af_array cond, const double a,
                           const af_array b) {
     CHECK_ARRAYS(cond, b);
-    return CALL(out, cond, a, b);
+      CALL(af_select_scalar_l, out, cond, a, b);
 }
 
 af_err af_replace(af_array a, const af_array cond, const af_array b) {
     CHECK_ARRAYS(a, cond, b);
-    return CALL(a, cond, b);
+      CALL(af_replace, a, cond, b);
 }
 
 af_err af_replace_scalar(af_array a, const af_array cond, const double b) {
     CHECK_ARRAYS(a, cond);
-    return CALL(a, cond, b);
+      CALL(af_replace_scalar, a, cond, b);
 }

--- a/src/api/unified/device.cpp
+++ b/src/api/unified/device.cpp
@@ -29,12 +29,12 @@ af_err af_get_available_backends(int *result) {
 af_err af_get_backend_id(af_backend *result, const af_array in) {
     // DO NOT CALL CHECK_ARRAYS HERE.
     // IT WILL RESULT IN AN INFINITE RECURSION
-    return CALL(result, in);
+    CALL(af_get_backend_id, result, in);
 }
 
 af_err af_get_device_id(int *device, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(device, in);
+    CALL(af_get_device_id, device, in);
 }
 
 af_err af_get_active_backend(af_backend *result) {
@@ -42,46 +42,48 @@ af_err af_get_active_backend(af_backend *result) {
     return AF_SUCCESS;
 }
 
-af_err af_info() { return CALL_NO_PARAMS(); }
+af_err af_info() { CALL_NO_PARAMS(af_info); }
 
-af_err af_init() { return CALL_NO_PARAMS(); }
+af_err af_init() { CALL_NO_PARAMS(af_init); }
 
 af_err af_info_string(char **str, const bool verbose) {
-    return CALL(str, verbose);
+    CALL(af_info_string, str, verbose);
 }
 
 af_err af_device_info(char *d_name, char *d_platform, char *d_toolkit,
                       char *d_compute) {
-    return CALL(d_name, d_platform, d_toolkit, d_compute);
+    CALL(af_device_info, d_name, d_platform, d_toolkit, d_compute);
 }
 
-af_err af_get_device_count(int *num_of_devices) { return CALL(num_of_devices); }
+af_err af_get_device_count(int *num_of_devices) {
+    CALL(af_get_device_count, num_of_devices);
+}
 
 af_err af_get_dbl_support(bool *available, const int device) {
-    return CALL(available, device);
+    CALL(af_get_dbl_support, available, device);
 }
 
 af_err af_get_half_support(bool *available, const int device) {
-    return CALL(available, device);
+    CALL(af_get_half_support, available, device);
 }
 
-af_err af_set_device(const int device) { return CALL(device); }
+af_err af_set_device(const int device) { CALL(af_set_device, device); }
 
-af_err af_get_device(int *device) { return CALL(device); }
+af_err af_get_device(int *device) { CALL(af_get_device, device); }
 
-af_err af_sync(const int device) { return CALL(device); }
+af_err af_sync(const int device) { CALL(af_sync, device); }
 
 af_err af_alloc_device(void **ptr, const dim_t bytes) {
-    return CALL(ptr, bytes);
+    CALL(af_alloc_device, ptr, bytes);
 }
 
 af_err af_alloc_pinned(void **ptr, const dim_t bytes) {
-    return CALL(ptr, bytes);
+    CALL(af_alloc_pinned, ptr, bytes);
 }
 
-af_err af_free_device(void *ptr) { return CALL(ptr); }
+af_err af_free_device(void *ptr) { CALL(af_free_device, ptr); }
 
-af_err af_free_pinned(void *ptr) { return CALL(ptr); }
+af_err af_free_pinned(void *ptr) { CALL(af_free_pinned, ptr); }
 
 af_err af_alloc_host(void **ptr, const dim_t bytes) {
     *ptr = malloc(bytes);
@@ -95,61 +97,74 @@ af_err af_free_host(void *ptr) {
 
 af_err af_device_array(af_array *arr, void *data, const unsigned ndims,
                        const dim_t *const dims, const af_dtype type) {
-    return CALL(arr, data, ndims, dims, type);
+    CALL(af_device_array, arr, data, ndims, dims, type);
 }
 
 af_err af_device_mem_info(size_t *alloc_bytes, size_t *alloc_buffers,
                           size_t *lock_bytes, size_t *lock_buffers) {
-    return CALL(alloc_bytes, alloc_buffers, lock_bytes, lock_buffers);
+    CALL(af_device_mem_info, alloc_bytes, alloc_buffers, lock_bytes,
+         lock_buffers);
 }
 
 af_err af_print_mem_info(const char *msg, const int device_id) {
-    return CALL(msg, device_id);
+    CALL(af_print_mem_info, msg, device_id);
 }
 
-af_err af_device_gc() { return CALL_NO_PARAMS(); }
+af_err af_device_gc() { CALL_NO_PARAMS(af_device_gc); }
 
 af_err af_set_mem_step_size(const size_t step_bytes) {
-    return CALL(step_bytes);
+    CALL(af_set_mem_step_size, step_bytes);
 }
 
-af_err af_get_mem_step_size(size_t *step_bytes) { return CALL(step_bytes); }
+af_err af_get_mem_step_size(size_t *step_bytes) {
+    CALL(af_get_mem_step_size, step_bytes);
+}
 
 af_err af_lock_device_ptr(const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(arr);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    CALL(af_lock_device_ptr, arr);
+#pragma GCC diagnostic pop
 }
 
 af_err af_unlock_device_ptr(const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(arr);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    CALL(af_unlock_device_ptr, arr);
+#pragma GCC diagnostic pop
 }
 
 af_err af_lock_array(const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(arr);
+    CALL(af_lock_array, arr);
 }
 
 af_err af_unlock_array(const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(arr);
+    CALL(af_unlock_array, arr);
 }
 
 af_err af_is_locked_array(bool *res, const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(res, arr);
+    CALL(af_is_locked_array, res, arr);
 }
 
 af_err af_get_device_ptr(void **ptr, const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(ptr, arr);
+    CALL(af_get_device_ptr, ptr, arr);
 }
 
 af_err af_eval_multiple(const int num, af_array *arrays) {
     for (int i = 0; i < num; i++) { CHECK_ARRAYS(arrays[i]); }
-    return CALL(num, arrays);
+    CALL(af_eval_multiple, num, arrays);
 }
 
-af_err af_set_manual_eval_flag(bool flag) { return CALL(flag); }
+af_err af_set_manual_eval_flag(bool flag) {
+    CALL(af_set_manual_eval_flag, flag);
+}
 
-af_err af_get_manual_eval_flag(bool *flag) { return CALL(flag); }
+af_err af_get_manual_eval_flag(bool *flag) {
+    CALL(af_get_manual_eval_flag, flag);
+}

--- a/src/api/unified/event.cpp
+++ b/src/api/unified/event.cpp
@@ -10,16 +10,22 @@
 #include <af/event.h>
 #include "symbol_manager.hpp"
 
-af_err af_create_event(af_event* eventHandle) { return CALL(eventHandle); }
+af_err af_create_event(af_event* eventHandle) {
+    CALL(af_create_event, eventHandle);
+}
 
 af_err af_delete_event(af_event eventHandle) {
-    return CALL(eventHandle);
+    CALL(af_delete_event, eventHandle);
 }
 
-af_err af_mark_event(const af_event eventHandle) { return CALL(eventHandle); }
+af_err af_mark_event(const af_event eventHandle) {
+    CALL(af_mark_event, eventHandle);
+}
 
 af_err af_enqueue_wait_event(const af_event eventHandle) {
-    return CALL(eventHandle);
+    CALL(af_enqueue_wait_event, eventHandle);
 }
 
-af_err af_block_event(const af_event eventHandle) { return CALL(eventHandle); }
+af_err af_block_event(const af_event eventHandle) {
+    CALL(af_block_event, eventHandle);
+}

--- a/src/api/unified/features.cpp
+++ b/src/api/unified/features.cpp
@@ -12,20 +12,20 @@
 #include "symbol_manager.hpp"
 
 af_err af_create_features(af_features *feat, dim_t num) {
-    return CALL(feat, num);
+    CALL(af_create_features, feat, num);
 }
 
 af_err af_retain_features(af_features *out, const af_features feat) {
-    return CALL(out, feat);
+    CALL(af_retain_features, out, feat);
 }
 
 af_err af_get_features_num(dim_t *num, const af_features feat) {
-    return CALL(num, feat);
+    CALL(af_get_features_num, num, feat);
 }
 
 #define FEAT_HAPI_DEF(af_func)                              \
     af_err af_func(af_array *out, const af_features feat) { \
-        return CALL(out, feat);                             \
+        CALL(af_func, out, feat);                           \
     }
 
 FEAT_HAPI_DEF(af_get_features_xpos)
@@ -34,4 +34,6 @@ FEAT_HAPI_DEF(af_get_features_score)
 FEAT_HAPI_DEF(af_get_features_orientation)
 FEAT_HAPI_DEF(af_get_features_size)
 
-af_err af_release_features(af_features feat) { return CALL(feat); }
+af_err af_release_features(af_features feat) {
+    CALL(af_release_features, feat);
+}

--- a/src/api/unified/graphics.cpp
+++ b/src/api/unified/graphics.cpp
@@ -13,84 +13,96 @@
 
 af_err af_create_window(af_window* out, const int width, const int height,
                         const char* const title) {
-    return CALL(out, width, height, title);
+    CALL(af_create_window, out, width, height, title);
 }
 
 af_err af_set_position(const af_window wind, const unsigned x,
                        const unsigned y) {
-    return CALL(wind, x, y);
+    CALL(af_set_position, wind, x, y);
 }
 
 af_err af_set_title(const af_window wind, const char* const title) {
-    return CALL(wind, title);
+    CALL(af_set_title, wind, title);
 }
 
 af_err af_set_size(const af_window wind, const unsigned w, const unsigned h) {
-    return CALL(wind, w, h);
+    CALL(af_set_size, wind, w, h);
 }
 
 af_err af_draw_image(const af_window wind, const af_array in,
                      const af_cell* const props) {
     CHECK_ARRAYS(in);
-    return CALL(wind, in, props);
+    CALL(af_draw_image, wind, in, props);
 }
 
 af_err af_draw_plot(const af_window wind, const af_array X, const af_array Y,
                     const af_cell* const props) {
     CHECK_ARRAYS(X, Y);
-    return CALL(wind, X, Y, props);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    CALL(af_draw_plot, wind, X, Y, props);
+#pragma GCC diagnostic pop
 }
 
 af_err af_draw_plot3(const af_window wind, const af_array P,
                      const af_cell* const props) {
     CHECK_ARRAYS(P);
-    return CALL(wind, P, props);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    CALL(af_draw_plot3, wind, P, props);
+#pragma GCC diagnostic pop
 }
 
 af_err af_draw_plot_nd(const af_window wind, const af_array in,
                        const af_cell* const props) {
     CHECK_ARRAYS(in);
-    return CALL(wind, in, props);
+    CALL(af_draw_plot_nd, wind, in, props);
 }
 
 af_err af_draw_plot_2d(const af_window wind, const af_array X, const af_array Y,
                        const af_cell* const props) {
     CHECK_ARRAYS(X, Y);
-    return CALL(wind, X, Y, props);
+    CALL(af_draw_plot_2d, wind, X, Y, props);
 }
 
 af_err af_draw_plot_3d(const af_window wind, const af_array X, const af_array Y,
                        const af_array Z, const af_cell* const props) {
     CHECK_ARRAYS(X, Y, Z);
-    return CALL(wind, X, Y, Z, props);
+    CALL(af_draw_plot_3d, wind, X, Y, Z, props);
 }
 
 af_err af_draw_scatter(const af_window wind, const af_array X, const af_array Y,
                        const af_marker_type marker,
                        const af_cell* const props) {
     CHECK_ARRAYS(X, Y);
-    return CALL(wind, X, Y, marker, props);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    CALL(af_draw_scatter, wind, X, Y, marker, props);
+#pragma GCC diagnostic pop
 }
 
 af_err af_draw_scatter3(const af_window wind, const af_array P,
                         const af_marker_type marker,
                         const af_cell* const props) {
     CHECK_ARRAYS(P);
-    return CALL(wind, P, marker, props);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    CALL(af_draw_scatter3, wind, P, marker, props);
+#pragma GCC diagnostic pop
 }
 
 af_err af_draw_scatter_nd(const af_window wind, const af_array in,
                           const af_marker_type marker,
                           const af_cell* const props) {
     CHECK_ARRAYS(in);
-    return CALL(wind, in, marker, props);
+    CALL(af_draw_scatter_nd, wind, in, marker, props);
 }
 
 af_err af_draw_scatter_2d(const af_window wind, const af_array X,
                           const af_array Y, const af_marker_type marker,
                           const af_cell* const props) {
     CHECK_ARRAYS(X, Y);
-    return CALL(wind, X, Y, marker, props);
+    CALL(af_draw_scatter_2d, wind, X, Y, marker, props);
 }
 
 af_err af_draw_scatter_3d(const af_window wind, const af_array X,
@@ -98,27 +110,27 @@ af_err af_draw_scatter_3d(const af_window wind, const af_array X,
                           const af_marker_type marker,
                           const af_cell* const props) {
     CHECK_ARRAYS(X, Y, Z);
-    return CALL(wind, X, Y, Z, marker, props);
+    CALL(af_draw_scatter_3d, wind, X, Y, Z, marker, props);
 }
 
 af_err af_draw_hist(const af_window wind, const af_array X, const double minval,
                     const double maxval, const af_cell* const props) {
     CHECK_ARRAYS(X);
-    return CALL(wind, X, minval, maxval, props);
+    CALL(af_draw_hist, wind, X, minval, maxval, props);
 }
 
 af_err af_draw_surface(const af_window wind, const af_array xVals,
                        const af_array yVals, const af_array S,
                        const af_cell* const props) {
     CHECK_ARRAYS(xVals, yVals, S);
-    return CALL(wind, xVals, yVals, S, props);
+    CALL(af_draw_surface, wind, xVals, yVals, S, props);
 }
 
 af_err af_draw_vector_field_nd(const af_window wind, const af_array points,
                                const af_array directions,
                                const af_cell* const props) {
     CHECK_ARRAYS(points, directions);
-    return CALL(wind, points, directions, props);
+    CALL(af_draw_vector_field_nd, wind, points, directions, props);
 }
 
 af_err af_draw_vector_field_3d(const af_window wind, const af_array xPoints,
@@ -127,7 +139,8 @@ af_err af_draw_vector_field_3d(const af_window wind, const af_array xPoints,
                                const af_array zDirs,
                                const af_cell* const props) {
     CHECK_ARRAYS(xPoints, yPoints, zPoints, xDirs, yDirs, zDirs);
-    return CALL(wind, xPoints, yPoints, zPoints, xDirs, yDirs, zDirs, props);
+    CALL(af_draw_vector_field_3d, wind, xPoints, yPoints, zPoints, xDirs, yDirs,
+         zDirs, props);
 }
 
 af_err af_draw_vector_field_2d(const af_window wind, const af_array xPoints,
@@ -135,11 +148,11 @@ af_err af_draw_vector_field_2d(const af_window wind, const af_array xPoints,
                                const af_array yDirs,
                                const af_cell* const props) {
     CHECK_ARRAYS(xPoints, yPoints, xDirs, yDirs);
-    return CALL(wind, xPoints, yPoints, xDirs, yDirs, props);
+    CALL(af_draw_vector_field_2d, wind, xPoints, yPoints, xDirs, yDirs, props);
 }
 
 af_err af_grid(const af_window wind, const int rows, const int cols) {
-    return CALL(wind, rows, cols);
+    CALL(af_grid, wind, rows, cols);
 }
 
 af_err af_set_axes_limits_compute(const af_window wind, const af_array x,
@@ -148,14 +161,14 @@ af_err af_set_axes_limits_compute(const af_window wind, const af_array x,
                                   const af_cell* const props) {
     CHECK_ARRAYS(x, y);
     if (z) CHECK_ARRAYS(z);
-    return CALL(wind, x, y, z, exact, props);
+    CALL(af_set_axes_limits_compute, wind, x, y, z, exact, props);
 }
 
 af_err af_set_axes_limits_2d(const af_window wind, const float xmin,
                              const float xmax, const float ymin,
                              const float ymax, const bool exact,
                              const af_cell* const props) {
-    return CALL(wind, xmin, xmax, ymin, ymax, exact, props);
+    CALL(af_set_axes_limits_2d, wind, xmin, xmax, ymin, ymax, exact, props);
 }
 
 af_err af_set_axes_limits_3d(const af_window wind, const float xmin,
@@ -163,30 +176,33 @@ af_err af_set_axes_limits_3d(const af_window wind, const float xmin,
                              const float ymax, const float zmin,
                              const float zmax, const bool exact,
                              const af_cell* const props) {
-    return CALL(wind, xmin, xmax, ymin, ymax, zmin, zmax, exact, props);
+    CALL(af_set_axes_limits_3d, wind, xmin, xmax, ymin, ymax, zmin, zmax, exact,
+         props);
 }
 
 af_err af_set_axes_titles(const af_window wind, const char* const xtitle,
                           const char* const ytitle, const char* const ztitle,
                           const af_cell* const props) {
-    return CALL(wind, xtitle, ytitle, ztitle, props);
+    CALL(af_set_axes_titles, wind, xtitle, ytitle, ztitle, props);
 }
 
 af_err af_set_axes_label_format(const af_window wind, const char* const xformat,
                                 const char* const yformat,
                                 const char* const zformat,
                                 const af_cell* const props) {
-    return CALL(wind, xformat, yformat, zformat, props);
+    CALL(af_set_axes_label_format, wind, xformat, yformat, zformat, props);
 }
 
-af_err af_show(const af_window wind) { return CALL(wind); }
+af_err af_show(const af_window wind) { CALL(af_show, wind); }
 
 af_err af_is_window_closed(bool* out, const af_window wind) {
-    return CALL(out, wind);
+    CALL(af_is_window_closed, out, wind);
 }
 
 af_err af_set_visibility(const af_window wind, const bool is_visible) {
-    return CALL(wind, is_visible);
+    CALL(af_set_visibility, wind, is_visible);
 }
 
-af_err af_destroy_window(const af_window wind) { return CALL(wind); }
+af_err af_destroy_window(const af_window wind) {
+    CALL(af_destroy_window, wind);
+}

--- a/src/api/unified/image.cpp
+++ b/src/api/unified/image.cpp
@@ -14,224 +14,228 @@
 
 af_err af_gradient(af_array *dx, af_array *dy, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(dx, dy, in);
+      CALL(af_gradient, dx, dy, in);
 }
 
 af_err af_load_image(af_array *out, const char *filename, const bool isColor) {
-    return CALL(out, filename, isColor);
+    CALL(af_load_image, out, filename, isColor);
 }
 
 af_err af_save_image(const char *filename, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(filename, in);
+      CALL(af_save_image, filename, in);
 }
 
 af_err af_load_image_memory(af_array *out, const void *ptr) {
-    return CALL(out, ptr);
+    CALL(af_load_image_memory, out, ptr);
 }
 
 af_err af_save_image_memory(void **ptr, const af_array in,
                             const af_image_format format) {
     CHECK_ARRAYS(in);
-    return CALL(ptr, in, format);
+      CALL(af_save_image_memory, ptr, in, format);
 }
 
-af_err af_delete_image_memory(void *ptr) { return CALL(ptr); }
+af_err af_delete_image_memory(void *ptr) {
+    CALL(af_delete_image_memory, ptr);
+}
 
 af_err af_load_image_native(af_array *out, const char *filename) {
-    return CALL(out, filename);
+    CALL(af_load_image_native, out, filename);
 }
 
 af_err af_save_image_native(const char *filename, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(filename, in);
+      CALL(af_save_image_native, filename, in);
 }
 
-af_err af_is_image_io_available(bool *out) { return CALL(out); }
+af_err af_is_image_io_available(bool *out) {
+    CALL(af_is_image_io_available, out);
+}
 
 af_err af_resize(af_array *out, const af_array in, const dim_t odim0,
                  const dim_t odim1, const af_interp_type method) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, odim0, odim1, method);
+      CALL(af_resize, out, in, odim0, odim1, method);
 }
 
 af_err af_transform(af_array *out, const af_array in, const af_array transform,
                     const dim_t odim0, const dim_t odim1,
                     const af_interp_type method, const bool inverse) {
     CHECK_ARRAYS(in, transform);
-    return CALL(out, in, transform, odim0, odim1, method, inverse);
+      CALL(af_transform, out, in, transform, odim0, odim1, method, inverse);
 }
 
 af_err af_transform_coordinates(af_array *out, const af_array tf,
                                 const float d0, const float d1) {
     CHECK_ARRAYS(tf);
-    return CALL(out, tf, d0, d1);
+      CALL(af_transform_coordinates, out, tf, d0, d1);
 }
 
 af_err af_rotate(af_array *out, const af_array in, const float theta,
                  const bool crop, const af_interp_type method) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, theta, crop, method);
+      CALL(af_rotate, out, in, theta, crop, method);
 }
 
 af_err af_translate(af_array *out, const af_array in, const float trans0,
                     const float trans1, const dim_t odim0, const dim_t odim1,
                     const af_interp_type method) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, trans0, trans1, odim0, odim1, method);
+      CALL(af_translate, out, in, trans0, trans1, odim0, odim1, method);
 }
 
 af_err af_scale(af_array *out, const af_array in, const float scale0,
                 const float scale1, const dim_t odim0, const dim_t odim1,
                 const af_interp_type method) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, scale0, scale1, odim0, odim1, method);
+      CALL(af_scale, out, in, scale0, scale1, odim0, odim1, method);
 }
 
 af_err af_skew(af_array *out, const af_array in, const float skew0,
                const float skew1, const dim_t odim0, const dim_t odim1,
                const af_interp_type method, const bool inverse) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, skew0, skew1, odim0, odim1, method, inverse);
+      CALL(af_skew, out, in, skew0, skew1, odim0, odim1, method, inverse);
 }
 
 af_err af_histogram(af_array *out, const af_array in, const unsigned nbins,
                     const double minval, const double maxval) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, nbins, minval, maxval);
+      CALL(af_histogram, out, in, nbins, minval, maxval);
 }
 
 af_err af_dilate(af_array *out, const af_array in, const af_array mask) {
     CHECK_ARRAYS(in, mask);
-    return CALL(out, in, mask);
+      CALL(af_dilate, out, in, mask);
 }
 
 af_err af_dilate3(af_array *out, const af_array in, const af_array mask) {
     CHECK_ARRAYS(in, mask);
-    return CALL(out, in, mask);
+      CALL(af_dilate3, out, in, mask);
 }
 
 af_err af_erode(af_array *out, const af_array in, const af_array mask) {
     CHECK_ARRAYS(in, mask);
-    return CALL(out, in, mask);
+      CALL(af_erode, out, in, mask);
 }
 
 af_err af_erode3(af_array *out, const af_array in, const af_array mask) {
     CHECK_ARRAYS(in, mask);
-    return CALL(out, in, mask);
+      CALL(af_erode3, out, in, mask);
 }
 
 af_err af_bilateral(af_array *out, const af_array in, const float spatial_sigma,
                     const float chromatic_sigma, const bool isColor) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, spatial_sigma, chromatic_sigma, isColor);
+      CALL(af_bilateral, out, in, spatial_sigma, chromatic_sigma, isColor);
 }
 
 af_err af_mean_shift(af_array *out, const af_array in,
                      const float spatial_sigma, const float chromatic_sigma,
                      const unsigned iter, const bool is_color) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, spatial_sigma, chromatic_sigma, iter, is_color);
+      CALL(af_mean_shift, out, in, spatial_sigma, chromatic_sigma, iter, is_color);
 }
 
 af_err af_minfilt(af_array *out, const af_array in, const dim_t wind_length,
                   const dim_t wind_width, const af_border_type edge_pad) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, wind_length, wind_width, edge_pad);
+      CALL(af_minfilt, out, in, wind_length, wind_width, edge_pad);
 }
 
 af_err af_maxfilt(af_array *out, const af_array in, const dim_t wind_length,
                   const dim_t wind_width, const af_border_type edge_pad) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, wind_length, wind_width, edge_pad);
+      CALL(af_maxfilt, out, in, wind_length, wind_width, edge_pad);
 }
 
 af_err af_regions(af_array *out, const af_array in,
                   const af_connectivity connectivity, const af_dtype ty) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, connectivity, ty);
+      CALL(af_regions, out, in, connectivity, ty);
 }
 
 af_err af_sobel_operator(af_array *dx, af_array *dy, const af_array img,
                          const unsigned ker_size) {
     CHECK_ARRAYS(img);
-    return CALL(dx, dy, img, ker_size);
+      CALL(af_sobel_operator, dx, dy, img, ker_size);
 }
 
 af_err af_rgb2gray(af_array *out, const af_array in, const float rPercent,
                    const float gPercent, const float bPercent) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, rPercent, gPercent, bPercent);
+      CALL(af_rgb2gray, out, in, rPercent, gPercent, bPercent);
 }
 
 af_err af_gray2rgb(af_array *out, const af_array in, const float rFactor,
                    const float gFactor, const float bFactor) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, rFactor, gFactor, bFactor);
+      CALL(af_gray2rgb, out, in, rFactor, gFactor, bFactor);
 }
 
 af_err af_hist_equal(af_array *out, const af_array in, const af_array hist) {
     CHECK_ARRAYS(in, hist);
-    return CALL(out, in, hist);
+      CALL(af_hist_equal, out, in, hist);
 }
 
 af_err af_gaussian_kernel(af_array *out, const int rows, const int cols,
                           const double sigma_r, const double sigma_c) {
-    return CALL(out, rows, cols, sigma_r, sigma_c);
+    CALL(af_gaussian_kernel, out, rows, cols, sigma_r, sigma_c);
 }
 
 af_err af_hsv2rgb(af_array *out, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(out, in);
+      CALL(af_hsv2rgb, out, in);
 }
 
 af_err af_rgb2hsv(af_array *out, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(out, in);
+      CALL(af_rgb2hsv, out, in);
 }
 
 af_err af_color_space(af_array *out, const af_array image, const af_cspace_t to,
                       const af_cspace_t from) {
     CHECK_ARRAYS(image);
-    return CALL(out, image, to, from);
+      CALL(af_color_space, out, image, to, from);
 }
 
 af_err af_unwrap(af_array *out, const af_array in, const dim_t wx,
                  const dim_t wy, const dim_t sx, const dim_t sy, const dim_t px,
                  const dim_t py, const bool is_column) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, wx, wy, sx, sy, px, py, is_column);
+      CALL(af_unwrap, out, in, wx, wy, sx, sy, px, py, is_column);
 }
 
 af_err af_wrap(af_array *out, const af_array in, const dim_t ox, const dim_t oy,
                const dim_t wx, const dim_t wy, const dim_t sx, const dim_t sy,
                const dim_t px, const dim_t py, const bool is_column) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);
+      CALL(af_wrap, out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);
 }
 
 af_err af_sat(af_array *out, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(out, in);
+      CALL(af_sat, out, in);
 }
 
 af_err af_ycbcr2rgb(af_array *out, const af_array in,
                     const af_ycc_std standard) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, standard);
+      CALL(af_ycbcr2rgb, out, in, standard);
 }
 
 af_err af_rgb2ycbcr(af_array *out, const af_array in,
                     const af_ycc_std standard) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, standard);
+      CALL(af_rgb2ycbcr, out, in, standard);
 }
 
 af_err af_canny(af_array *out, const af_array in, const af_canny_threshold ct,
                 const float t1, const float t2, const unsigned sw,
                 const bool isf) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, ct, t1, t2, sw, isf);
+      CALL(af_canny, out, in, ct, t1, t2, sw, isf);
 }
 
 af_err af_anisotropic_diffusion(af_array *out, const af_array in,
@@ -240,18 +244,20 @@ af_err af_anisotropic_diffusion(af_array *out, const af_array in,
                                 const af_flux_function fftype,
                                 const af_diffusion_eq eq) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, dt, K, iterations, fftype, eq);
+      CALL(af_anisotropic_diffusion, out, in, dt, K, iterations, fftype,
+                 eq);
 }
 
 af_err af_iterative_deconv(af_array *out, const af_array in, const af_array ker,
                            const unsigned iterations, const float relax_factor,
                            const af_iterative_deconv_algo algo) {
     CHECK_ARRAYS(in, ker);
-    return CALL(out, in, ker, iterations, relax_factor, algo);
+      CALL(af_iterative_deconv, out, in, ker, iterations, relax_factor,
+                 algo);
 }
 
 af_err af_inverse_deconv(af_array *out, const af_array in, const af_array psf,
                          const float gamma, const af_inverse_deconv_algo algo) {
     CHECK_ARRAYS(in, psf);
-    return CALL(out, in, psf, gamma, algo);
+      CALL(af_inverse_deconv, out, in, psf, gamma, algo);
 }

--- a/src/api/unified/index.cpp
+++ b/src/api/unified/index.cpp
@@ -14,31 +14,31 @@
 af_err af_index(af_array* out, const af_array in, const unsigned ndims,
                 const af_seq* const index) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, ndims, index);
+    CALL(af_index, out, in, ndims, index);
 }
 
 af_err af_lookup(af_array* out, const af_array in, const af_array indices,
                  const unsigned dim) {
     CHECK_ARRAYS(in, indices);
-    return CALL(out, in, indices, dim);
+    CALL(af_lookup, out, in, indices, dim);
 }
 
 af_err af_assign_seq(af_array* out, const af_array lhs, const unsigned ndims,
                      const af_seq* const indices, const af_array rhs) {
     CHECK_ARRAYS(lhs, rhs);
-    return CALL(out, lhs, ndims, indices, rhs);
+    CALL(af_assign_seq, out, lhs, ndims, indices, rhs);
 }
 
 af_err af_index_gen(af_array* out, const af_array in, const dim_t ndims,
                     const af_index_t* indices) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, ndims, indices);
+    CALL(af_index_gen, out, in, ndims, indices);
 }
 
 af_err af_assign_gen(af_array* out, const af_array lhs, const dim_t ndims,
                      const af_index_t* indices, const af_array rhs) {
     CHECK_ARRAYS(lhs, rhs);
-    return CALL(out, lhs, ndims, indices, rhs);
+    CALL(af_assign_gen, out, lhs, ndims, indices, rhs);
 }
 
 af_seq af_make_seq(double begin, double end, double step) {
@@ -46,23 +46,27 @@ af_seq af_make_seq(double begin, double end, double step) {
     return seq;
 }
 
-af_err af_create_indexers(af_index_t** indexers) { return CALL(indexers); }
+af_err af_create_indexers(af_index_t** indexers) {
+    CALL(af_create_indexers, indexers);
+}
 
 af_err af_set_array_indexer(af_index_t* indexer, const af_array idx,
                             const dim_t dim) {
     CHECK_ARRAYS(idx);
-    return CALL(indexer, idx, dim);
+    CALL(af_set_array_indexer, indexer, idx, dim);
 }
 
 af_err af_set_seq_indexer(af_index_t* indexer, const af_seq* idx,
                           const dim_t dim, const bool is_batch) {
-    return CALL(indexer, idx, dim, is_batch);
+    CALL(af_set_seq_indexer, indexer, idx, dim, is_batch);
 }
 
 af_err af_set_seq_param_indexer(af_index_t* indexer, const double begin,
                                 const double end, const double step,
                                 const dim_t dim, const bool is_batch) {
-    return CALL(indexer, begin, end, step, dim, is_batch);
+    CALL(af_set_seq_param_indexer, indexer, begin, end, step, dim, is_batch);
 }
 
-af_err af_release_indexers(af_index_t* indexers) { return CALL(indexers); }
+af_err af_release_indexers(af_index_t* indexers) {
+    CALL(af_release_indexers, indexers);
+}

--- a/src/api/unified/internal.cpp
+++ b/src/api/unified/internal.cpp
@@ -15,36 +15,37 @@ af_err af_create_strided_array(af_array *arr, const void *data,
                                const dim_t *const dims_,
                                const dim_t *const strides_, const af_dtype ty,
                                const af_source location) {
-    return CALL(arr, data, offset, ndims, dims_, strides_, ty, location);
+    CALL(af_create_strided_array, arr, data, offset, ndims, dims_, strides_, ty,
+         location);
 }
 
 af_err af_get_strides(dim_t *s0, dim_t *s1, dim_t *s2, dim_t *s3,
                       const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(s0, s1, s2, s3, in);
+    CALL(af_get_strides, s0, s1, s2, s3, in);
 }
 
 af_err af_get_offset(dim_t *offset, const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(offset, arr);
+    CALL(af_get_offset, offset, arr);
 }
 
 af_err af_get_raw_ptr(void **ptr, const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(ptr, arr);
+    CALL(af_get_raw_ptr, ptr, arr);
 }
 
 af_err af_is_linear(bool *result, const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(result, arr);
+    CALL(af_is_linear, result, arr);
 }
 
 af_err af_is_owner(bool *result, const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(result, arr);
+    CALL(af_is_owner, result, arr);
 }
 
 af_err af_get_allocated_bytes(size_t *bytes, const af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(bytes, arr);
+    CALL(af_get_allocated_bytes, bytes, arr);
 }

--- a/src/api/unified/lapack.cpp
+++ b/src/api/unified/lapack.cpp
@@ -13,83 +13,83 @@
 
 af_err af_svd(af_array *u, af_array *s, af_array *vt, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(u, s, vt, in);
+    CALL(af_svd, u, s, vt, in);
 }
 
 af_err af_svd_inplace(af_array *u, af_array *s, af_array *vt, af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(u, s, vt, in);
+    CALL(af_svd_inplace, u, s, vt, in);
 }
 
 af_err af_lu(af_array *lower, af_array *upper, af_array *pivot,
              const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(lower, upper, pivot, in);
+    CALL(af_lu, lower, upper, pivot, in);
 }
 
 af_err af_lu_inplace(af_array *pivot, af_array in, const bool is_lapack_piv) {
     CHECK_ARRAYS(in);
-    return CALL(pivot, in, is_lapack_piv);
+    CALL(af_lu_inplace, pivot, in, is_lapack_piv);
 }
 
 af_err af_qr(af_array *q, af_array *r, af_array *tau, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(q, r, tau, in);
+    CALL(af_qr, q, r, tau, in);
 }
 
 af_err af_qr_inplace(af_array *tau, af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(tau, in);
+    CALL(af_qr_inplace, tau, in);
 }
 
 af_err af_cholesky(af_array *out, int *info, const af_array in,
                    const bool is_upper) {
     CHECK_ARRAYS(in);
-    return CALL(out, info, in, is_upper);
+    CALL(af_cholesky, out, info, in, is_upper);
 }
 
 af_err af_cholesky_inplace(int *info, af_array in, const bool is_upper) {
     CHECK_ARRAYS(in);
-    return CALL(info, in, is_upper);
+    CALL(af_cholesky_inplace, info, in, is_upper);
 }
 
 af_err af_solve(af_array *x, const af_array a, const af_array b,
                 const af_mat_prop options) {
     CHECK_ARRAYS(a, b);
-    return CALL(x, a, b, options);
+    CALL(af_solve, x, a, b, options);
 }
 
 af_err af_solve_lu(af_array *x, const af_array a, const af_array piv,
                    const af_array b, const af_mat_prop options) {
     CHECK_ARRAYS(a, piv, b);
-    return CALL(x, a, piv, b, options);
+    CALL(af_solve_lu, x, a, piv, b, options);
 }
 
 af_err af_inverse(af_array *out, const af_array in, const af_mat_prop options) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, options);
+    CALL(af_inverse, out, in, options);
 }
 
 af_err af_pinverse(af_array *out, const af_array in, const double tol,
                    const af_mat_prop options) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, tol, options);
+    CALL(af_pinverse, out, in, tol, options);
 }
 
 af_err af_rank(unsigned *rank, const af_array in, const double tol) {
     CHECK_ARRAYS(in);
-    return CALL(rank, in, tol);
+    CALL(af_rank, rank, in, tol);
 }
 
 af_err af_det(double *det_real, double *det_imag, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(det_real, det_imag, in);
+    CALL(af_det, det_real, det_imag, in);
 }
 
 af_err af_norm(double *out, const af_array in, const af_norm_type type,
                const double p, const double q) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, type, p, q);
+    CALL(af_norm, out, in, type, p, q);
 }
 
-af_err af_is_lapack_available(bool *out) { return CALL(out); }
+af_err af_is_lapack_available(bool *out) { CALL(af_is_lapack_available, out); }

--- a/src/api/unified/memory.cpp
+++ b/src/api/unified/memory.cpp
@@ -1,5 +1,5 @@
 /*******************************************************
- * Copyright (c) 2015, ArrayFire
+ * Copyright (c) 2019, ArrayFire
  * All rights reserved.
  *
  * This file is distributed under 3-clause BSD license.
@@ -10,126 +10,133 @@
 #include <af/memory.h>
 #include "symbol_manager.hpp"
 
-af_err af_create_memory_manager(af_memory_manager* out) { return CALL(out); }
+af_err af_create_memory_manager(af_memory_manager* out) {
+    CALL(af_create_memory_manager, out);
+}
 
 af_err af_release_memory_manager(af_memory_manager handle) {
-    return CALL(handle);
+    CALL(af_release_memory_manager, handle);
 }
 
-af_err af_set_memory_manager(af_memory_manager handle) { return CALL(handle); }
+af_err af_set_memory_manager(af_memory_manager handle) {
+    CALL(af_set_memory_manager, handle);
+}
 
 af_err af_set_memory_manager_pinned(af_memory_manager handle) {
-    return CALL(handle);
+    CALL(af_set_memory_manager_pinned, handle);
 }
 
-af_err af_unset_memory_manager() { return CALL_NO_PARAMS(); }
+af_err af_unset_memory_manager() { CALL_NO_PARAMS(af_unset_memory_manager); }
 
-af_err af_unset_memory_manager_pinned() { return CALL_NO_PARAMS(); }
+af_err af_unset_memory_manager_pinned() {
+    CALL_NO_PARAMS(af_unset_memory_manager_pinned);
+}
 
 af_err af_memory_manager_get_payload(af_memory_manager handle, void** payload) {
-    return CALL(handle, payload);
+    CALL(af_memory_manager_get_payload, handle, payload);
 }
 
 af_err af_memory_manager_set_payload(af_memory_manager handle, void* payload) {
-    return CALL(handle, payload);
+    CALL(af_memory_manager_set_payload, handle, payload);
 }
 
 af_err af_memory_manager_set_initialize_fn(af_memory_manager handle,
                                            af_memory_manager_initialize_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_initialize_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_shutdown_fn(af_memory_manager handle,
                                          af_memory_manager_shutdown_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_shutdown_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_alloc_fn(af_memory_manager handle,
                                       af_memory_manager_alloc_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_alloc_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_allocated_fn(af_memory_manager handle,
                                           af_memory_manager_allocated_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_allocated_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_unlock_fn(af_memory_manager handle,
                                        af_memory_manager_unlock_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_unlock_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_signal_memory_cleanup_fn(
     af_memory_manager handle, af_memory_manager_signal_memory_cleanup_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_signal_memory_cleanup_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_print_info_fn(af_memory_manager handle,
                                            af_memory_manager_print_info_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_print_info_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_user_lock_fn(af_memory_manager handle,
                                           af_memory_manager_user_lock_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_user_lock_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_user_unlock_fn(
     af_memory_manager handle, af_memory_manager_user_unlock_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_user_unlock_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_is_user_locked_fn(
     af_memory_manager handle, af_memory_manager_is_user_locked_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_is_user_locked_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_get_memory_pressure_fn(
     af_memory_manager handle, af_memory_manager_get_memory_pressure_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_get_memory_pressure_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_jit_tree_exceeds_memory_pressure_fn(
     af_memory_manager handle,
     af_memory_manager_jit_tree_exceeds_memory_pressure_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_jit_tree_exceeds_memory_pressure_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_add_memory_management_fn(
     af_memory_manager handle, af_memory_manager_add_memory_management_fn fn) {
-    return CALL(handle, fn);
+    CALL(af_memory_manager_set_add_memory_management_fn, handle, fn);
 }
 
 af_err af_memory_manager_set_remove_memory_management_fn(
-    af_memory_manager handle, af_memory_manager_remove_memory_management_fn fn) {
-    return CALL(handle, fn);
+    af_memory_manager handle,
+    af_memory_manager_remove_memory_management_fn fn) {
+    CALL(af_memory_manager_set_remove_memory_management_fn, handle, fn);
 }
 
 af_err af_memory_manager_get_active_device_id(af_memory_manager handle,
                                               int* id) {
-    return CALL(handle, id);
+    CALL(af_memory_manager_get_active_device_id, handle, id);
 }
 
 af_err af_memory_manager_native_alloc(af_memory_manager handle, void** ptr,
                                       size_t size) {
-    return CALL(handle, ptr, size);
+    CALL(af_memory_manager_native_alloc, handle, ptr, size);
 }
 
 af_err af_memory_manager_native_free(af_memory_manager handle, void* ptr) {
-    return CALL(handle, ptr);
+    CALL(af_memory_manager_native_free, handle, ptr);
 }
 
 af_err af_memory_manager_get_max_memory_size(af_memory_manager handle,
                                              size_t* size, int id) {
-    return CALL(handle, size, id);
+    CALL(af_memory_manager_get_max_memory_size, handle, size, id);
 }
 
 af_err af_memory_manager_get_memory_pressure_threshold(af_memory_manager handle,
                                                        float* value) {
-    return CALL(handle, value);
+    CALL(af_memory_manager_get_memory_pressure_threshold, handle, value);
 }
 
 af_err af_memory_manager_set_memory_pressure_threshold(af_memory_manager handle,
                                                        float value) {
-    return CALL(handle, value);
+    CALL(af_memory_manager_set_memory_pressure_threshold, handle, value);
 }

--- a/src/api/unified/ml.cpp
+++ b/src/api/unified/ml.cpp
@@ -6,22 +6,20 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
-#include <af/ml.h>
 #include <af/array.h>
+#include <af/ml.h>
 #include "symbol_manager.hpp"
 
-af_err af_convolve2_gradient_nn(af_array *out, const af_array incoming_gradient,
-                                const af_array original_signal,
-                                const af_array original_filter,
-                                const af_array convolved_output,
-                                const unsigned stride_dims, const dim_t *strides,
-                                const unsigned padding_dims, const dim_t *paddings,
-                                const unsigned dilation_dims,
-                                const dim_t *dilations,
-                                af_conv_gradient_type gradType) {
+af_err af_convolve2_gradient_nn(
+    af_array *out, const af_array incoming_gradient,
+    const af_array original_signal, const af_array original_filter,
+    const af_array convolved_output, const unsigned stride_dims,
+    const dim_t *strides, const unsigned padding_dims, const dim_t *paddings,
+    const unsigned dilation_dims, const dim_t *dilations,
+    af_conv_gradient_type gradType) {
     CHECK_ARRAYS(incoming_gradient, original_signal, original_filter,
                  convolved_output);
-    return CALL(out, incoming_gradient, original_signal, original_filter,
-                convolved_output, stride_dims, strides, padding_dims, paddings,
-                dilation_dims, dilations, gradType);
+    CALL(af_convolve2_gradient_nn, out, incoming_gradient, original_signal,
+         original_filter, convolved_output, stride_dims, strides, padding_dims,
+         paddings, dilation_dims, dilations, gradType);
 }

--- a/src/api/unified/moments.cpp
+++ b/src/api/unified/moments.cpp
@@ -14,11 +14,11 @@
 af_err af_moments(af_array* out, const af_array in,
                   const af_moment_type moment) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, moment);
+    CALL(af_moments, out, in, moment);
 }
 
 af_err af_moments_all(double* out, const af_array in,
                       const af_moment_type moment) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, moment);
+    CALL(af_moments_all, out, in, moment);
 }

--- a/src/api/unified/random.cpp
+++ b/src/api/unified/random.cpp
@@ -11,69 +11,71 @@
 #include <af/random.h>
 #include "symbol_manager.hpp"
 
-af_err af_get_default_random_engine(af_random_engine *r) { return CALL(r); }
+af_err af_get_default_random_engine(af_random_engine *r) {
+    CALL(af_get_default_random_engine, r);
+}
 
 af_err af_create_random_engine(af_random_engine *engineHandle,
                                af_random_engine_type rtype,
                                unsigned long long seed) {
-    return CALL(engineHandle, rtype, seed);
+    CALL(af_create_random_engine, engineHandle, rtype, seed);
 }
 
 af_err af_retain_random_engine(af_random_engine *outHandle,
                                const af_random_engine engineHandle) {
-    return CALL(outHandle, engineHandle);
+    CALL(af_retain_random_engine, outHandle, engineHandle);
 }
 
 af_err af_random_engine_get_type(af_random_engine_type *rtype,
                                  const af_random_engine engine) {
-    return CALL(rtype, engine);
+    CALL(af_random_engine_get_type, rtype, engine);
 }
 
 af_err af_random_engine_set_type(af_random_engine *engine,
                                  const af_random_engine_type rtype) {
-    return CALL(engine, rtype);
+    CALL(af_random_engine_set_type, engine, rtype);
 }
 
 af_err af_set_default_random_engine_type(const af_random_engine_type rtype) {
-    return CALL(rtype);
+    CALL(af_set_default_random_engine_type, rtype);
 }
 
 af_err af_random_uniform(af_array *arr, const unsigned ndims,
                          const dim_t *const dims, const af_dtype type,
                          af_random_engine engine) {
-    return CALL(arr, ndims, dims, type, engine);
+    CALL(af_random_uniform, arr, ndims, dims, type, engine);
 }
 
 af_err af_random_normal(af_array *arr, const unsigned ndims,
                         const dim_t *const dims, const af_dtype type,
                         af_random_engine engine) {
-    return CALL(arr, ndims, dims, type, engine);
+    CALL(af_random_normal, arr, ndims, dims, type, engine);
 }
 
 af_err af_release_random_engine(af_random_engine engineHandle) {
-    return CALL(engineHandle);
+    CALL(af_release_random_engine, engineHandle);
 }
 
 af_err af_random_engine_set_seed(af_random_engine *engine,
                                  const unsigned long long seed) {
-    return CALL(engine, seed);
+    CALL(af_random_engine_set_seed, engine, seed);
 }
 
 af_err af_random_engine_get_seed(unsigned long long *const seed,
                                  af_random_engine engine) {
-    return CALL(seed, engine);
+    CALL(af_random_engine_get_seed, seed, engine);
 }
 
 af_err af_randu(af_array *out, const unsigned ndims, const dim_t *const dims,
                 const af_dtype type) {
-    return CALL(out, ndims, dims, type);
+    CALL(af_randu, out, ndims, dims, type);
 }
 
 af_err af_randn(af_array *out, const unsigned ndims, const dim_t *const dims,
                 const af_dtype type) {
-    return CALL(out, ndims, dims, type);
+    CALL(af_randn, out, ndims, dims, type);
 }
 
-af_err af_set_seed(const unsigned long long seed) { return CALL(seed); }
+af_err af_set_seed(const unsigned long long seed) { CALL(af_set_seed, seed); }
 
-af_err af_get_seed(unsigned long long *seed) { return CALL(seed); }
+af_err af_get_seed(unsigned long long *seed) { CALL(af_get_seed, seed); }

--- a/src/api/unified/signal.cpp
+++ b/src/api/unified/signal.cpp
@@ -15,27 +15,27 @@
 af_err af_approx1(af_array *yo, const af_array yi, const af_array xo,
                   const af_interp_type method, const float offGrid) {
     CHECK_ARRAYS(yo, yi, xo);
-    return CALL(yo, yi, xo, method, offGrid);
+    CALL(af_approx1, yo, yi, xo, method, offGrid);
 }
 
 af_err af_approx1_v2(af_array *yo, const af_array yi, const af_array xo,
                      const af_interp_type method, const float offGrid) {
     CHECK_ARRAYS(yo, yi, xo);
-    return CALL(yo, yi, xo, method, offGrid);
+    CALL(af_approx1_v2, yo, yi, xo, method, offGrid);
 }
 
 af_err af_approx2(af_array *zo, const af_array zi, const af_array xo,
                   const af_array yo, const af_interp_type method,
                   const float offGrid) {
     CHECK_ARRAYS(zo, zi, xo, yo);
-    return CALL(zo, zi, xo, yo, method, offGrid);
+    CALL(af_approx2, zo, zi, xo, yo, method, offGrid);
 }
 
 af_err af_approx2_v2(af_array *zo, const af_array zi, const af_array xo,
                      const af_array yo, const af_interp_type method,
                      const float offGrid) {
     CHECK_ARRAYS(zo, zi, xo, yo);
-    return CALL(zo, zi, xo, yo, method, offGrid);
+    CALL(af_approx2_v2, zo, zi, xo, yo, method, offGrid);
 }
 
 af_err af_approx1_uniform(af_array *yo, const af_array yi, const af_array xo,
@@ -43,7 +43,8 @@ af_err af_approx1_uniform(af_array *yo, const af_array yi, const af_array xo,
                           const double xi_step, const af_interp_type method,
                           const float offGrid) {
     CHECK_ARRAYS(yo, yi, xo);
-    return CALL(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid);
+    CALL(af_approx1_uniform, yo, yi, xo, xdim, xi_beg, xi_step, method,
+         offGrid);
 }
 
 af_err af_approx1_uniform_v2(af_array *yo, const af_array yi, const af_array xo,
@@ -51,7 +52,8 @@ af_err af_approx1_uniform_v2(af_array *yo, const af_array yi, const af_array xo,
                              const double xi_step, const af_interp_type method,
                              const float offGrid) {
     CHECK_ARRAYS(yo, yi, xo);
-    return CALL(yo, yi, xo, xdim, xi_beg, xi_step, method, offGrid);
+    CALL(af_approx1_uniform_v2, yo, yi, xo, xdim, xi_beg, xi_step, method,
+         offGrid);
 }
 
 af_err af_approx2_uniform(af_array *zo, const af_array zi, const af_array xo,
@@ -61,8 +63,8 @@ af_err af_approx2_uniform(af_array *zo, const af_array zi, const af_array xo,
                           const double yi_step, const af_interp_type method,
                           const float offGrid) {
     CHECK_ARRAYS(zo, zi, xo, yo);
-    return CALL(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg, yi_step,
-                method, offGrid);
+    CALL(af_approx2_uniform, zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim,
+         yi_beg, yi_step, method, offGrid);
 }
 
 af_err af_approx2_uniform_v2(af_array *zo, const af_array zi, const af_array xo,
@@ -72,18 +74,18 @@ af_err af_approx2_uniform_v2(af_array *zo, const af_array zi, const af_array xo,
                              const double yi_step, const af_interp_type method,
                              const float offGrid) {
     CHECK_ARRAYS(zo, zi, xo, yo);
-    return CALL(zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg, yi_step,
-                method, offGrid);
+    CALL(af_approx2_uniform_v2, zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim,
+         yi_beg, yi_step, method, offGrid);
 }
 
 af_err af_set_fft_plan_cache_size(size_t cache_size) {
-    return CALL(cache_size);
+    CALL(af_set_fft_plan_cache_size, cache_size);
 }
 
 #define FFT_HAPI_DEF(af_func)                               \
     af_err af_func(af_array in, const double norm_factor) { \
         CHECK_ARRAYS(in);                                   \
-        return CALL(in, norm_factor);                       \
+        CALL(af_func, in, norm_factor);                     \
     }
 
 FFT_HAPI_DEF(af_fft_inplace)
@@ -96,62 +98,62 @@ FFT_HAPI_DEF(af_ifft3_inplace)
 af_err af_fft(af_array *out, const af_array in, const double norm_factor,
               const dim_t odim0) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, norm_factor, odim0);
+    CALL(af_fft, out, in, norm_factor, odim0);
 }
 
 af_err af_fft2(af_array *out, const af_array in, const double norm_factor,
                const dim_t odim0, const dim_t odim1) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, norm_factor, odim0, odim1);
+    CALL(af_fft2, out, in, norm_factor, odim0, odim1);
 }
 
 af_err af_fft3(af_array *out, const af_array in, const double norm_factor,
                const dim_t odim0, const dim_t odim1, const dim_t odim2) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, norm_factor, odim0, odim1, odim2);
+    CALL(af_fft3, out, in, norm_factor, odim0, odim1, odim2);
 }
 
 af_err af_ifft(af_array *out, const af_array in, const double norm_factor,
                const dim_t odim0) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, norm_factor, odim0);
+    CALL(af_ifft, out, in, norm_factor, odim0);
 }
 
 af_err af_ifft2(af_array *out, const af_array in, const double norm_factor,
                 const dim_t odim0, const dim_t odim1) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, norm_factor, odim0, odim1);
+    CALL(af_ifft2, out, in, norm_factor, odim0, odim1);
 }
 
 af_err af_ifft3(af_array *out, const af_array in, const double norm_factor,
                 const dim_t odim0, const dim_t odim1, const dim_t odim2) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, norm_factor, odim0, odim1, odim2);
+    CALL(af_ifft3, out, in, norm_factor, odim0, odim1, odim2);
 }
 
 af_err af_fft_r2c(af_array *out, const af_array in, const double norm_factor,
                   const dim_t pad0) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, norm_factor, pad0);
+    CALL(af_fft_r2c, out, in, norm_factor, pad0);
 }
 
 af_err af_fft2_r2c(af_array *out, const af_array in, const double norm_factor,
                    const dim_t pad0, const dim_t pad1) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, norm_factor, pad0, pad1);
+    CALL(af_fft2_r2c, out, in, norm_factor, pad0, pad1);
 }
 
 af_err af_fft3_r2c(af_array *out, const af_array in, const double norm_factor,
                    const dim_t pad0, const dim_t pad1, const dim_t pad2) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, norm_factor, pad0, pad1, pad2);
+    CALL(af_fft3_r2c, out, in, norm_factor, pad0, pad1, pad2);
 }
 
 #define FFTC2R_HAPI_DEF(af_func)                                               \
     af_err af_func(af_array *out, const af_array in, const double norm_factor, \
                    const bool is_odd) {                                        \
         CHECK_ARRAYS(in);                                                      \
-        return CALL(out, in, norm_factor, is_odd);                             \
+        CALL(af_func, out, in, norm_factor, is_odd);                           \
     }
 
 FFTC2R_HAPI_DEF(af_fft_c2r)
@@ -163,7 +165,7 @@ FFTC2R_HAPI_DEF(af_fft3_c2r)
                    const af_array filter, const af_conv_mode mode, \
                    af_conv_domain domain) {                        \
         CHECK_ARRAYS(signal, filter);                              \
-        return CALL(out, signal, filter, mode, domain);            \
+        CALL(af_func, out, signal, filter, mode, domain);          \
     }
 
 CONV_HAPI_DEF(af_convolve1)
@@ -176,8 +178,8 @@ af_err af_convolve2_nn(af_array *out, const af_array signal,
                        const dim_t *paddings, const unsigned dilation_dims,
                        const dim_t *dilations) {
     CHECK_ARRAYS(signal, filter);
-    return CALL(out, signal, filter, stride_dims, strides, padding_dims,
-                paddings, dilation_dims, dilations);
+    CALL(af_convolve2_nn, out, signal, filter, stride_dims, strides,
+         padding_dims, paddings, dilation_dims, dilations);
 }
 
 af_err af_convolve2_gradient_nn(
@@ -187,18 +189,18 @@ af_err af_convolve2_gradient_nn(
     const dim_t *strides, const unsigned padding_dims, const dim_t *paddings,
     const unsigned dilation_dims, const dim_t *dilations,
     af_conv_gradient_type grad_type) {
-
-    CHECK_ARRAYS(incoming_gradient, original_signal, original_filter, convolved_output);
-    return CALL(out, incoming_gradient, original_signal, original_filter, convolved_output,
-                stride_dims, strides, padding_dims, paddings, dilation_dims, dilations, grad_type);
-
+    CHECK_ARRAYS(incoming_gradient, original_signal, original_filter,
+                 convolved_output);
+    CALL(af_convolve2_gradient_nn, out, incoming_gradient, original_signal,
+         original_filter, convolved_output, stride_dims, strides, padding_dims,
+         paddings, dilation_dims, dilations, grad_type);
 }
 
 #define FFT_CONV_HAPI_DEF(af_func)                                   \
     af_err af_func(af_array *out, const af_array signal,             \
                    const af_array filter, const af_conv_mode mode) { \
         CHECK_ARRAYS(signal, filter);                                \
-        return CALL(out, signal, filter, mode);                      \
+        CALL(af_func, out, signal, filter, mode);                    \
     }
 
 FFT_CONV_HAPI_DEF(af_fft_convolve1)
@@ -209,34 +211,34 @@ af_err af_convolve2_sep(af_array *out, const af_array col_filter,
                         const af_array row_filter, const af_array signal,
                         const af_conv_mode mode) {
     CHECK_ARRAYS(col_filter, row_filter, signal);
-    return CALL(out, col_filter, row_filter, signal, mode);
+    CALL(af_convolve2_sep, out, col_filter, row_filter, signal, mode);
 }
 
 af_err af_fir(af_array *y, const af_array b, const af_array x) {
     CHECK_ARRAYS(b, x);
-    return CALL(y, b, x);
+    CALL(af_fir, y, b, x);
 }
 
 af_err af_iir(af_array *y, const af_array b, const af_array a,
               const af_array x) {
     CHECK_ARRAYS(b, a, x);
-    return CALL(y, b, a, x);
+    CALL(af_iir, y, b, a, x);
 }
 
 af_err af_medfilt(af_array *out, const af_array in, const dim_t wind_length,
                   const dim_t wind_width, const af_border_type edge_pad) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, wind_length, wind_width, edge_pad);
+    CALL(af_medfilt, out, in, wind_length, wind_width, edge_pad);
 }
 
 af_err af_medfilt1(af_array *out, const af_array in, const dim_t wind_width,
                    const af_border_type edge_pad) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, wind_width, edge_pad);
+    CALL(af_medfilt1, out, in, wind_width, edge_pad);
 }
 
 af_err af_medfilt2(af_array *out, const af_array in, const dim_t wind_length,
                    const dim_t wind_width, const af_border_type edge_pad) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, wind_length, wind_width, edge_pad);
+    CALL(af_medfilt2, out, in, wind_length, wind_width, edge_pad);
 }

--- a/src/api/unified/sparse.cpp
+++ b/src/api/unified/sparse.cpp
@@ -15,61 +15,62 @@ af_err af_create_sparse_array(af_array *out, const dim_t nRows,
                               const af_array rowIdx, const af_array colIdx,
                               const af_storage stype) {
     CHECK_ARRAYS(values, rowIdx, colIdx);
-    return CALL(out, nRows, nCols, values, rowIdx, colIdx, stype);
+    CALL(af_create_sparse_array, out, nRows, nCols, values, rowIdx, colIdx,
+         stype);
 }
 
 af_err af_create_sparse_array_from_ptr(
     af_array *out, const dim_t nRows, const dim_t nCols, const dim_t nNZ,
     const void *const values, const int *const rowIdx, const int *const colIdx,
     const af_dtype type, const af_storage stype, const af_source source) {
-    return CALL(out, nRows, nCols, nNZ, values, rowIdx, colIdx, type, stype,
-                source);
+    CALL(af_create_sparse_array_from_ptr, out, nRows, nCols, nNZ, values,
+         rowIdx, colIdx, type, stype, source);
 }
 
 af_err af_create_sparse_array_from_dense(af_array *out, const af_array in,
                                          const af_storage stype) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, stype);
+    CALL(af_create_sparse_array_from_dense, out, in, stype);
 }
 
 af_err af_sparse_convert_to(af_array *out, const af_array in,
                             const af_storage destStorage) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, destStorage);
+    CALL(af_sparse_convert_to, out, in, destStorage);
 }
 
 af_err af_sparse_to_dense(af_array *out, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(out, in);
+    CALL(af_sparse_to_dense, out, in);
 }
 
 af_err af_sparse_get_info(af_array *values, af_array *rowIdx, af_array *colIdx,
                           af_storage *stype, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(values, rowIdx, colIdx, stype, in);
+    CALL(af_sparse_get_info, values, rowIdx, colIdx, stype, in);
 }
 
 af_err af_sparse_get_values(af_array *out, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(out, in);
+    CALL(af_sparse_get_values, out, in);
 }
 
 af_err af_sparse_get_row_idx(af_array *out, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(out, in);
+    CALL(af_sparse_get_row_idx, out, in);
 }
 
 af_err af_sparse_get_col_idx(af_array *out, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(out, in);
+    CALL(af_sparse_get_col_idx, out, in);
 }
 
 af_err af_sparse_get_nnz(dim_t *out, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(out, in);
+    CALL(af_sparse_get_nnz, out, in);
 }
 
 af_err af_sparse_get_storage(af_storage *out, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(out, in);
+    CALL(af_sparse_get_storage, out, in);
 }

--- a/src/api/unified/statistics.cpp
+++ b/src/api/unified/statistics.cpp
@@ -13,91 +13,91 @@
 
 af_err af_mean(af_array *out, const af_array in, const dim_t dim) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, dim);
+    CALL(af_mean, out, in, dim);
 }
 
 af_err af_mean_weighted(af_array *out, const af_array in,
                         const af_array weights, const dim_t dim) {
     CHECK_ARRAYS(in, weights);
-    return CALL(out, in, weights, dim);
+    CALL(af_mean_weighted, out, in, weights, dim);
 }
 
 af_err af_var(af_array *out, const af_array in, const bool isbiased,
               const dim_t dim) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, isbiased, dim);
+    CALL(af_var, out, in, isbiased, dim);
 }
 
 af_err af_var_weighted(af_array *out, const af_array in, const af_array weights,
                        const dim_t dim) {
     CHECK_ARRAYS(in, weights);
-    return CALL(out, in, weights, dim);
+    CALL(af_var_weighted, out, in, weights, dim);
 }
 
 af_err af_meanvar(af_array *mean, af_array *var, const af_array in,
                   const af_array weights, const af_var_bias bias,
                   const dim_t dim) {
     CHECK_ARRAYS(in, weights);
-    return CALL(mean, var, in, weights, bias, dim);
+    CALL(af_meanvar, mean, var, in, weights, bias, dim);
 }
 
 af_err af_stdev(af_array *out, const af_array in, const dim_t dim) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, dim);
+    CALL(af_stdev, out, in, dim);
 }
 
 af_err af_cov(af_array *out, const af_array X, const af_array Y,
               const bool isbiased) {
     CHECK_ARRAYS(X, Y);
-    return CALL(out, X, Y, isbiased);
+    CALL(af_cov, out, X, Y, isbiased);
 }
 
 af_err af_median(af_array *out, const af_array in, const dim_t dim) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, dim);
+    CALL(af_median, out, in, dim);
 }
 
 af_err af_mean_all(double *real, double *imag, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(real, imag, in);
+    CALL(af_mean_all, real, imag, in);
 }
 
 af_err af_mean_all_weighted(double *real, double *imag, const af_array in,
                             const af_array weights) {
     CHECK_ARRAYS(in, weights);
-    return CALL(real, imag, in, weights);
+    CALL(af_mean_all_weighted, real, imag, in, weights);
 }
 
 af_err af_var_all(double *realVal, double *imagVal, const af_array in,
                   const bool isbiased) {
     CHECK_ARRAYS(in);
-    return CALL(realVal, imagVal, in, isbiased);
+    CALL(af_var_all, realVal, imagVal, in, isbiased);
 }
 
 af_err af_var_all_weighted(double *realVal, double *imagVal, const af_array in,
                            const af_array weights) {
     CHECK_ARRAYS(in, weights);
-    return CALL(realVal, imagVal, in, weights);
+    CALL(af_var_all_weighted, realVal, imagVal, in, weights);
 }
 
 af_err af_stdev_all(double *real, double *imag, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(real, imag, in);
+    CALL(af_stdev_all, real, imag, in);
 }
 
 af_err af_median_all(double *realVal, double *imagVal, const af_array in) {
     CHECK_ARRAYS(in);
-    return CALL(realVal, imagVal, in);
+    CALL(af_median_all, realVal, imagVal, in);
 }
 
 af_err af_corrcoef(double *realVal, double *imagVal, const af_array X,
                    const af_array Y) {
     CHECK_ARRAYS(X, Y);
-    return CALL(realVal, imagVal, X, Y);
+    CALL(af_corrcoef, realVal, imagVal, X, Y);
 }
 
 af_err af_topk(af_array *values, af_array *indices, const af_array in,
                const int k, const int dim, const af_topk_function order) {
     CHECK_ARRAYS(in);
-    return CALL(values, indices, in, k, dim, order);
+    CALL(af_topk, values, indices, in, k, dim, order);
 }

--- a/src/api/unified/symbol_manager.cpp
+++ b/src/api/unified/symbol_manager.cpp
@@ -136,7 +136,9 @@ LibHandle openDynLibrary(const af_backend bknd_idx) {
 
     LibHandle retVal = nullptr;
     for (size_t i = 0; i < extent<decltype(pathPrefixes)>::value; i++) {
-        AF_TRACE("Attempting: {}", (pathPrefixes[i].empty() ? "Default System Paths" : pathPrefixes[i]));
+        AF_TRACE("Attempting: {}",
+                 (pathPrefixes[i].empty() ? "Default System Paths"
+                                          : pathPrefixes[i]));
         if ((retVal = loadLibrary(
                  join_path(pathPrefixes[i], bkndLibName).c_str()))) {
             AF_TRACE("Found: {}", join_path(pathPrefixes[i], bkndLibName));
@@ -148,8 +150,7 @@ LibHandle openDynLibrary(const af_backend bknd_idx) {
                 count_func(&count);
                 AF_TRACE("Device Count: {}.", count);
                 if (count == 0) {
-                    AF_TRACE("Skipping: No devices found for {}",
-                             bkndLibName);
+                    AF_TRACE("Skipping: No devices found for {}", bkndLibName);
                     retVal = nullptr;
                     continue;
                 }
@@ -232,36 +233,6 @@ af_err AFSymbolManager::setBackend(af::Backend bknd) {
     } else {
         UNIFIED_ERROR_LOAD_LIB();
     }
-}
-
-bool checkArray(af_backend activeBackend, const af_array a) {
-    // Convert af_array into int to retrieve the backend info.
-    // See ArrayInfo.hpp for more
-    af_backend backend = (af_backend)0;
-
-    // This condition is required so that the invalid args tests for unified
-    // backend return the expected error rather than AF_ERR_ARR_BKND_MISMATCH
-    // Since a = 0, does not have a backend specified, it should be a
-    // AF_ERR_ARG instead of AF_ERR_ARR_BKND_MISMATCH
-    if (a == 0) return true;
-
-    unified::AFSymbolManager::getInstance().call("af_get_backend_id", &backend,
-                                                 a);
-    return backend == activeBackend;
-}
-
-bool checkArray(af_backend activeBackend, const af_array* a) {
-    if (a) {
-        return checkArray(activeBackend, *a);
-    } else {
-        return true;
-    }
-}
-
-bool checkArrays(af_backend activeBackend) {
-    UNUSED(activeBackend);
-    // Dummy
-    return true;
 }
 
 }  // namespace unified

--- a/src/api/unified/symbol_manager.hpp
+++ b/src/api/unified/symbol_manager.hpp
@@ -12,6 +12,7 @@
 #include <common/err_common.hpp>
 #include <common/module_loading.hpp>
 #include <common/util.hpp>
+#include <af/backend.h>
 #include <af/defines.h>
 
 #include <spdlog/spdlog.h>
@@ -54,32 +55,6 @@ class AFSymbolManager {
 
     af::Backend getActiveBackend() { return activeBackend; }
 
-    template<typename... CalleeArgs>
-    af_err call(const char* symbolName, CalleeArgs... args) {
-        typedef af_err (*af_func)(CalleeArgs...);
-        if (!activeHandle) { UNIFIED_ERROR_LOAD_LIB(); }
-        thread_local std::array<std::unordered_map<const char*, af_func>,
-                                NUM_BACKENDS>
-            funcHandles;
-
-        int index           = backend_index(getActiveBackend());
-        af_func& funcHandle = funcHandles[index][symbolName];
-
-        if (!funcHandle) {
-            AF_TRACE("Loading: {}", symbolName);
-            funcHandle =
-                (af_func)common::getFunctionPointer(activeHandle, symbolName);
-        }
-        if (!funcHandle) {
-            AF_TRACE("Failed to load symbol: {}", symbolName);
-            std::string str = "Failed to load symbol: ";
-            str += symbolName;
-            AF_RETURN_ERROR(str.c_str(), AF_ERR_LOAD_SYM);
-        }
-
-        return funcHandle(args...);
-    }
-
     LibHandle getHandle() { return activeHandle; }
     spdlog::logger* getLogger();
 
@@ -105,10 +80,37 @@ class AFSymbolManager {
     std::shared_ptr<spdlog::logger> logger;
 };
 
-// Helper functions to ensure all the input arrays are on the active backend
-bool checkArray(af_backend activeBackend, const af_array a);
-bool checkArray(af_backend activeBackend, const af_array *a);
-bool checkArrays(af_backend activeBackend);
+namespace {
+bool checkArray(af_backend activeBackend, const af_array a) {
+    // Convert af_array into int to retrieve the backend info.
+    // See ArrayInfo.hpp for more
+    af_backend backend = (af_backend)0;
+
+    // This condition is required so that the invalid args tests for unified
+    // backend return the expected error rather than AF_ERR_ARR_BKND_MISMATCH
+    // Since a = 0, does not have a backend specified, it should be a
+    // AF_ERR_ARG instead of AF_ERR_ARR_BKND_MISMATCH
+    if (a == 0) return true;
+
+    af_get_backend_id(&backend, a);
+    return backend == activeBackend;
+}
+
+bool checkArray(af_backend activeBackend, const af_array* a) {
+    if (a) {
+        return checkArray(activeBackend, *a);
+    } else {
+        return true;
+    }
+}
+
+bool checkArrays(af_backend activeBackend) {
+    UNUSED(activeBackend);
+    // Dummy
+    return true;
+}
+
+}  // namespace
 
 template<typename T, typename... Args>
 bool checkArrays(af_backend activeBackend, T a, Args... arg) {
@@ -133,16 +135,20 @@ bool checkArrays(af_backend activeBackend, T a, Args... arg) {
                             AF_ERR_ARR_BKND_MISMATCH);                        \
     } while (0)
 
-#if defined(OS_WIN)
-#define CALL(...) \
-    unified::AFSymbolManager::getInstance().call(__FUNCTION__, __VA_ARGS__)
-#define CALL_NO_PARAMS() \
-    unified::AFSymbolManager::getInstance().call(__FUNCTION__)
-#else
-#define CALL(...) \
-    unified::AFSymbolManager::getInstance().call(__func__, __VA_ARGS__)
-#define CALL_NO_PARAMS() unified::AFSymbolManager::getInstance().call(__func__)
-#endif
+#define CALL(FUNCTION, ...)                                                      \
+    using af_func                  = std::add_pointer<decltype(FUNCTION)>::type; \
+    thread_local auto& instance    = unified::AFSymbolManager::getInstance();    \
+    thread_local af_backend index_ = instance.getActiveBackend();                \
+    thread_local af_func func =                                                  \
+        (af_func)common::getFunctionPointer(instance.getHandle(), __func__);     \
+    if (index_ != instance.getActiveBackend()) {                                 \
+        index_ = instance.getActiveBackend();                                    \
+        func   = (af_func)common::getFunctionPointer(instance.getHandle(),       \
+                                                   __func__);                    \
+    }                                                                            \
+    return func(__VA_ARGS__);
+
+#define CALL_NO_PARAMS(FUNCTION) CALL(FUNCTION)
 
 #define LOAD_SYMBOL()           \
     common::getFunctionPointer( \

--- a/src/api/unified/util.cpp
+++ b/src/api/unified/util.cpp
@@ -13,43 +13,43 @@
 
 af_err af_print_array(af_array arr) {
     CHECK_ARRAYS(arr);
-    return CALL(arr);
+    CALL(af_print_array, arr);
 }
 
 af_err af_print_array_gen(const char *exp, const af_array arr,
                           const int precision) {
     CHECK_ARRAYS(arr);
-    return CALL(exp, arr, precision);
+    CALL(af_print_array_gen, exp, arr, precision);
 }
 
 af_err af_save_array(int *index, const char *key, const af_array arr,
                      const char *filename, const bool append) {
     CHECK_ARRAYS(arr);
-    return CALL(index, key, arr, filename, append);
+    CALL(af_save_array, index, key, arr, filename, append);
 }
 
 af_err af_read_array_index(af_array *out, const char *filename,
                            const unsigned index) {
-    return CALL(out, filename, index);
+    CALL(af_read_array_index, out, filename, index);
 }
 
 af_err af_read_array_key(af_array *out, const char *filename, const char *key) {
-    return CALL(out, filename, key);
+    CALL(af_read_array_key, out, filename, key);
 }
 
 af_err af_read_array_key_check(int *index, const char *filename,
                                const char *key) {
-    return CALL(index, filename, key);
+    CALL(af_read_array_key_check, index, filename, key);
 }
 
 af_err af_array_to_string(char **output, const char *exp, const af_array arr,
                           const int precision, const bool transpose) {
     CHECK_ARRAYS(arr);
-    return CALL(output, exp, arr, precision, transpose);
+    CALL(af_array_to_string, output, exp, arr, precision, transpose);
 }
 
 af_err af_example_function(af_array *out, const af_array a,
                            const af_someenum_t param) {
     CHECK_ARRAYS(a);
-    return CALL(out, a, param);
+    CALL(af_example_function, out, a, param);
 }

--- a/src/api/unified/vision.cpp
+++ b/src/api/unified/vision.cpp
@@ -15,7 +15,7 @@ af_err af_fast(af_features *out, const af_array in, const float thr,
                const unsigned arc_length, const bool non_max,
                const float feature_ratio, const unsigned edge) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, thr, arc_length, non_max, feature_ratio, edge);
+    CALL(af_fast, out, in, thr, arc_length, non_max, feature_ratio, edge);
 }
 
 af_err af_harris(af_features *out, const af_array in,
@@ -23,7 +23,8 @@ af_err af_harris(af_features *out, const af_array in,
                  const float sigma, const unsigned block_size,
                  const float k_thr) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, max_corners, min_response, sigma, block_size, k_thr);
+    CALL(af_harris, out, in, max_corners, min_response, sigma, block_size,
+         k_thr);
 }
 
 af_err af_orb(af_features *feat, af_array *desc, const af_array in,
@@ -31,7 +32,8 @@ af_err af_orb(af_features *feat, af_array *desc, const af_array in,
               const float scl_fctr, const unsigned levels,
               const bool blur_img) {
     CHECK_ARRAYS(in);
-    return CALL(feat, desc, in, fast_thr, max_feat, scl_fctr, levels, blur_img);
+    CALL(af_orb, feat, desc, in, fast_thr, max_feat, scl_fctr, levels,
+         blur_img);
 }
 
 af_err af_sift(af_features *feat, af_array *desc, const af_array in,
@@ -40,8 +42,8 @@ af_err af_sift(af_features *feat, af_array *desc, const af_array in,
                const bool double_input, const float intensity_scale,
                const float feature_ratio) {
     CHECK_ARRAYS(in);
-    return CALL(feat, desc, in, n_layers, contrast_thr, edge_thr, init_sigma,
-                double_input, intensity_scale, feature_ratio);
+    CALL(af_sift, feat, desc, in, n_layers, contrast_thr, edge_thr, init_sigma,
+         double_input, intensity_scale, feature_ratio);
 }
 
 af_err af_gloh(af_features *feat, af_array *desc, const af_array in,
@@ -50,15 +52,15 @@ af_err af_gloh(af_features *feat, af_array *desc, const af_array in,
                const bool double_input, const float intensity_scale,
                const float feature_ratio) {
     CHECK_ARRAYS(in);
-    return CALL(feat, desc, in, n_layers, contrast_thr, edge_thr, init_sigma,
-                double_input, intensity_scale, feature_ratio);
+    CALL(af_gloh, feat, desc, in, n_layers, contrast_thr, edge_thr, init_sigma,
+         double_input, intensity_scale, feature_ratio);
 }
 
 af_err af_hamming_matcher(af_array *idx, af_array *dist, const af_array query,
                           const af_array train, const dim_t dist_dim,
                           const unsigned n_dist) {
     CHECK_ARRAYS(query, train);
-    return CALL(idx, dist, query, train, dist_dim, n_dist);
+    CALL(af_hamming_matcher, idx, dist, query, train, dist_dim, n_dist);
 }
 
 af_err af_nearest_neighbour(af_array *idx, af_array *dist, const af_array query,
@@ -66,27 +68,28 @@ af_err af_nearest_neighbour(af_array *idx, af_array *dist, const af_array query,
                             const unsigned n_dist,
                             const af_match_type dist_type) {
     CHECK_ARRAYS(query, train);
-    return CALL(idx, dist, query, train, dist_dim, n_dist, dist_type);
+    CALL(af_nearest_neighbour, idx, dist, query, train, dist_dim, n_dist,
+         dist_type);
 }
 
 af_err af_match_template(af_array *out, const af_array search_img,
                          const af_array template_img,
                          const af_match_type m_type) {
     CHECK_ARRAYS(search_img, template_img);
-    return CALL(out, search_img, template_img, m_type);
+    CALL(af_match_template, out, search_img, template_img, m_type);
 }
 
 af_err af_susan(af_features *out, const af_array in, const unsigned radius,
                 const float diff_thr, const float geom_thr,
                 const float feature_ratio, const unsigned edge) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, radius, diff_thr, geom_thr, feature_ratio, edge);
+    CALL(af_susan, out, in, radius, diff_thr, geom_thr, feature_ratio, edge);
 }
 
 af_err af_dog(af_array *out, const af_array in, const int radius1,
               const int radius2) {
     CHECK_ARRAYS(in);
-    return CALL(out, in, radius1, radius2);
+    CALL(af_dog, out, in, radius1, radius2);
 }
 
 af_err af_homography(af_array *H, int *inliers, const af_array x_src,
@@ -95,6 +98,6 @@ af_err af_homography(af_array *H, int *inliers, const af_array x_src,
                      const float inlier_thr, const unsigned iterations,
                      const af_dtype type) {
     CHECK_ARRAYS(x_src, y_src, x_dst, y_dst);
-    return CALL(H, inliers, x_src, y_src, x_dst, y_dst, htype, inlier_thr,
-                iterations, type);
+    CALL(af_homography, H, inliers, x_src, y_src, x_dst, y_dst, htype,
+         inlier_thr, iterations, type);
 }


### PR DESCRIPTION
* The unified backend calls af_get_backend_id which throw an exception
  if the af_array passed to it is not an initialized array. This occures
  when you create an af::array with a default constructor or if a move
  is performed. In those cases the af_get_backend_id was throwing an
  exception and catching it then returning the error code. This was
  causing the slowdown in the unified backend.
* Remove ARG_ASSERT calls on simple functions to avoid overhead
* Remove the unordered map from the call function.
* Optimize the CALL macro
* Move the backend handling code from the C API to the C++ API. The
  C API function call will behave like a regular function call.