### PR TITLE
Add missing af::meanvar function. Fix bias parameter

### DIFF
--- a/src/api/c/var.cpp
+++ b/src/api/c/var.cpp
@@ -177,7 +177,7 @@ af_err af_var(af_array* out, const af_array in, const bool isbiased,
 
         af_array no_weights = 0;
         af_var_bias bias =
-            (isbiased) ? AF_VARIANCE_POPULATION : AF_VARIANCE_SAMPLE;
+            (isbiased) ? AF_VARIANCE_SAMPLE: AF_VARIANCE_POPULATION;
         switch (type) {
             case f32:
                 output = var_<float, float>(in, no_weights, bias, dim);

--- a/src/api/cpp/CMakeLists.txt
+++ b/src/api/cpp/CMakeLists.txt
@@ -47,6 +47,7 @@ target_sources(cpp_api_interface
     ${CMAKE_CURRENT_SOURCE_DIR}/lapack.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/matchTemplate.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mean.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/meanvar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/meanshift.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/median.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moments.cpp

--- a/src/api/cpp/meanvar.cpp
+++ b/src/api/cpp/meanvar.cpp
@@ -1,0 +1,25 @@
+/*******************************************************
+ * Copyright (c) 2019, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <af/array.h>
+#include <af/statistics.h>
+#include "error.hpp"
+
+using af::array;
+
+namespace af {
+void meanvar(array& mean, array& var, const array& in, const array& weights,
+             const af_var_bias bias, const dim_t dim) {
+    af_array mean_ = mean.get();
+    af_array var_  = var.get();
+    AF_THROW(af_meanvar(&mean_, &var_, in.get(), weights.get(), bias, dim));
+    mean.set(mean_);
+    var.set(var_);
+}
+}  // namespace af

--- a/test/var.cpp
+++ b/test/var.cpp
@@ -116,11 +116,11 @@ TYPED_TEST(Var, DimCPPSmall) {
     for (size_t i = 0; i < in.size(); i++) {
         array input(numDims[i], &in[i].front(), afHost);
 
-        array bout  = var(input, false);
-        array nbout = var(input, true);
+        array bout  = var(input, true);
+        array nbout = var(input, false);
 
-        array bout1  = var(input, false, 1);
-        array nbout1 = var(input, true, 1);
+        array bout1  = var(input, true, 1);
+        array nbout1 = var(input, false, 1);
 
         vector<vector<outType> > h_out(4);
 


### PR DESCRIPTION
* Fixes the bias parameter from the API that accepted the bias parameter as a boolean.
* Adds missing meanvar C++ API function implementation.