### PR TITLE
Avoid upcasting in operations involving fp16 and scalars

### DIFF
--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -861,6 +861,11 @@ af::dtype implicit_dtype(af::dtype scalar_type, af::dtype array_type) {
         return array_type;
     }
 
+    // If the array is f16 then avoid upcasting to float or double
+    if ((scalar_type == f64 || scalar_type == f32) && (array_type == f16)) {
+        return f16;
+    }
+
     // Default to single precision by default when multiplying with scalar
     if ((scalar_type == f64 || scalar_type == c64) &&
         (array_type != f64 && array_type != c64)) {

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -10,6 +10,7 @@
 #define GTEST_LINKED_AS_SHARED_LIBRARY 1
 #include <arrayfire.h>
 #include <gtest/gtest.h>
+#include <half.hpp>
 #include <testHelpers.hpp>
 #include <cstddef>
 #include <cstdlib>
@@ -24,7 +25,7 @@ template<typename T>
 using ArrayDeathTest = Array<T>;
 
 typedef ::testing::Types<float, double, cfloat, cdouble, char, unsigned char,
-                         int, uint, intl, uintl, short, ushort>
+                         int, uint, intl, uintl, short, ushort, half_float::half>
     TestTypes;
 
 TYPED_TEST_CASE(Array, TestTypes);
@@ -127,7 +128,7 @@ TYPED_TEST(Array, ConstructorHostPointer1D) {
 
     dtype type    = (dtype)dtype_traits<TypeParam>::af_type;
     size_t nelems = 10;
-    vector<TypeParam> data(nelems, 4);
+    vector<TypeParam> data(nelems, TypeParam(4));
     array a(nelems, &data.front(), afHost);
     EXPECT_EQ(1u, a.numdims());
     EXPECT_EQ(dim_t(nelems), a.dims(0));
@@ -149,7 +150,7 @@ TYPED_TEST(Array, ConstructorHostPointer2D) {
     size_t ndims    = 2;
     size_t dim_size = 10;
     size_t nelems   = dim_size * dim_size;
-    vector<TypeParam> data(nelems, 4);
+    vector<TypeParam> data(nelems, TypeParam(4));
     array a(dim_size, dim_size, &data.front(), afHost);
     EXPECT_EQ(ndims, a.numdims());
     EXPECT_EQ(dim_t(dim_size), a.dims(0));
@@ -171,7 +172,7 @@ TYPED_TEST(Array, ConstructorHostPointer3D) {
     size_t ndims    = 3;
     size_t dim_size = 10;
     size_t nelems   = dim_size * dim_size * dim_size;
-    vector<TypeParam> data(nelems, 4);
+    vector<TypeParam> data(nelems, TypeParam(4));
     array a(dim_size, dim_size, dim_size, &data.front(), afHost);
     EXPECT_EQ(ndims, a.numdims());
     EXPECT_EQ(dim_t(dim_size), a.dims(0));
@@ -193,7 +194,7 @@ TYPED_TEST(Array, ConstructorHostPointer4D) {
     size_t ndims    = 4;
     size_t dim_size = 10;
     size_t nelems   = dim_size * dim_size * dim_size * dim_size;
-    vector<TypeParam> data(nelems, 4);
+    vector<TypeParam> data(nelems, TypeParam(4));
     array a(dim_size, dim_size, dim_size, dim_size, &data.front(), afHost);
     EXPECT_EQ(ndims, a.numdims());
     EXPECT_EQ(dim_t(dim_size), a.dims(0));
@@ -223,6 +224,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_TRUE(one.isreal());
             EXPECT_FALSE(one.iscomplex());
             EXPECT_FALSE(one.isbool());
+            EXPECT_FALSE(one.ishalf());
             break;
 
         case f64:
@@ -234,6 +236,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_TRUE(one.isreal());
             EXPECT_FALSE(one.iscomplex());
             EXPECT_FALSE(one.isbool());
+            EXPECT_FALSE(one.ishalf());
             break;
         case c32:
             EXPECT_TRUE(one.isfloating());
@@ -244,6 +247,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_FALSE(one.isreal());
             EXPECT_TRUE(one.iscomplex());
             EXPECT_FALSE(one.isbool());
+            EXPECT_FALSE(one.ishalf());
             break;
         case c64:
             EXPECT_TRUE(one.isfloating());
@@ -254,6 +258,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_FALSE(one.isreal());
             EXPECT_TRUE(one.iscomplex());
             EXPECT_FALSE(one.isbool());
+            EXPECT_FALSE(one.ishalf());
             break;
         case s32:
             EXPECT_FALSE(one.isfloating());
@@ -264,6 +269,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_TRUE(one.isreal());
             EXPECT_FALSE(one.iscomplex());
             EXPECT_FALSE(one.isbool());
+            EXPECT_FALSE(one.ishalf());
             break;
         case u32:
             EXPECT_FALSE(one.isfloating());
@@ -274,6 +280,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_TRUE(one.isreal());
             EXPECT_FALSE(one.iscomplex());
             EXPECT_FALSE(one.isbool());
+            EXPECT_FALSE(one.ishalf());
             break;
         case s16:
             EXPECT_FALSE(one.isfloating());
@@ -284,6 +291,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_TRUE(one.isreal());
             EXPECT_FALSE(one.iscomplex());
             EXPECT_FALSE(one.isbool());
+            EXPECT_FALSE(one.ishalf());
             break;
         case u16:
             EXPECT_FALSE(one.isfloating());
@@ -294,6 +302,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_TRUE(one.isreal());
             EXPECT_FALSE(one.iscomplex());
             EXPECT_FALSE(one.isbool());
+            EXPECT_FALSE(one.ishalf());
             break;
         case u8:
             EXPECT_FALSE(one.isfloating());
@@ -304,6 +313,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_TRUE(one.isreal());
             EXPECT_FALSE(one.iscomplex());
             EXPECT_FALSE(one.isbool());
+            EXPECT_FALSE(one.ishalf());
             break;
         case b8:
             EXPECT_FALSE(one.isfloating());
@@ -314,6 +324,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_TRUE(one.isreal());
             EXPECT_FALSE(one.iscomplex());
             EXPECT_TRUE(one.isbool());
+            EXPECT_FALSE(one.ishalf());
             break;
         case s64:
             EXPECT_FALSE(one.isfloating());
@@ -324,6 +335,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_TRUE(one.isreal());
             EXPECT_FALSE(one.iscomplex());
             EXPECT_FALSE(one.isbool());
+            EXPECT_FALSE(one.ishalf());
             break;
         case u64:
             EXPECT_FALSE(one.isfloating());
@@ -334,6 +346,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_TRUE(one.isreal());
             EXPECT_FALSE(one.iscomplex());
             EXPECT_FALSE(one.isbool());
+            EXPECT_FALSE(one.ishalf());
             break;
         case f16:
             EXPECT_TRUE(one.isfloating());
@@ -344,7 +357,7 @@ TYPED_TEST(Array, TypeAttributes) {
             EXPECT_TRUE(one.isreal());
             EXPECT_FALSE(one.iscomplex());
             EXPECT_FALSE(one.isbool());
-            EXPECT_FALSE(one.ishalf());
+            EXPECT_TRUE(one.ishalf());
             break;
     }
 }

--- a/test/binary.cpp
+++ b/test/binary.cpp
@@ -9,6 +9,7 @@
 
 #define GTEST_LINKED_AS_SHARED_LIBRARY 1
 #include <gtest/gtest.h>
+#include <half.hpp>
 #include <testHelpers.hpp>
 #include <af/arith.h>
 #include <af/array.h>
@@ -386,3 +387,53 @@ INSTANTIATE_TEST_CASE_P(NegativeValues, PowPrecisionTestInt,
                         testing::Range<int>(-46340, 0, 10e3));
 INSTANTIATE_TEST_CASE_P(NegativeValues, PowPrecisionTestShort,
                         testing::Range<short>(-180, 0, 50));
+
+template<typename T>
+class ResultTypeScalar : public ::testing::Test {
+protected:
+    T scalar;
+    void SetUp() {
+      scalar = T(1);
+    }
+};
+
+typedef ::testing::Types<float, double, unsigned int, int, short,
+                         unsigned short, char, unsigned char, half_float::half>
+    TestTypes;
+TYPED_TEST_CASE(ResultTypeScalar, TestTypes);
+
+TYPED_TEST(ResultTypeScalar, HalfAddition) {
+    SUPPORTED_TYPE_CHECK(half_float::half);
+    ASSERT_EQ(f16, (af::array(10, f16) + this->scalar).type());
+}
+
+TYPED_TEST(ResultTypeScalar, HalfSubtraction) {
+    SUPPORTED_TYPE_CHECK(half_float::half);
+    ASSERT_EQ(f16, (af::array(10, f16) - this->scalar).type());
+}
+
+TYPED_TEST(ResultTypeScalar, HalfMultiplication) {
+    SUPPORTED_TYPE_CHECK(half_float::half);
+    ASSERT_EQ(f16, (af::array(10, f16) * this->scalar).type());
+}
+
+TYPED_TEST(ResultTypeScalar, HalfDivision) {
+    SUPPORTED_TYPE_CHECK(half_float::half);
+    ASSERT_EQ(f16, (af::array(10, f16) / this->scalar).type());
+}
+
+TYPED_TEST(ResultTypeScalar, FloatAddition) {
+    ASSERT_EQ(f32, (af::array(10, f32) + this->scalar).type());
+}
+
+TYPED_TEST(ResultTypeScalar, FloatSubtraction) {
+    ASSERT_EQ(f32, (af::array(10, f32) - this->scalar).type());
+}
+
+TYPED_TEST(ResultTypeScalar, FloatMultiplication) {
+    ASSERT_EQ(f32, (af::array(10, f32) * this->scalar).type());
+}
+
+TYPED_TEST(ResultTypeScalar, FloatDivision) {
+    ASSERT_EQ(f32, (af::array(10, f32) / this->scalar).type());
+}


### PR DESCRIPTION
This commit prevents up-casting in operations that involve the f16
array and a scalar value. Normally you would want upcasts but it
is unlikely that the user expects this to occur with f16 because
there is no native f16 type.