### PR TITLE
Fix boost version check from multiple versions of CMake

### DIFF
--- a/CMakeModules/boost_package.cmake
+++ b/CMakeModules/boost_package.cmake
@@ -7,7 +7,9 @@
 
 find_package(Boost)
 
-if("${Boost_VERSION}" VERSION_LESS 107000)
+if(NOT (   Boost_VERSION        VERSION_GREATER_EQUAL 107000
+        OR Boost_VERSION_STRING VERSION_GREATER_EQUAL 1.70
+        OR Boost_VERSION_MACRO  VERSION_GREATER_EQUAL 107000))
   set(VER 1.70.0)
   set(MD5 e160ec0ff825fc2850ea4614323b1fb5)
   include(ExternalProject)


### PR DESCRIPTION
Different versions of FindBoost use different variables and version formats for the version of Boost. Here we are checking all the variables for the version.

Fixes #2640 