### PR TITLE
Fix build configs of mutli-config cmake generators

### DIFF
--- a/.github/workflows/cpu_build.yml
+++ b/.github/workflows/cpu_build.yml
@@ -88,7 +88,6 @@ jobs:
                   mkdir build && cd build
                   cmake -G Ninja \
                       -DCMAKE_MAKE_PROGRAM:FILEPATH=${GITHUB_WORKSPACE}/ninja \
-                      -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
                       -DAF_BUILD_CUDA:BOOL=OFF -DAF_BUILD_OPENCL:BOOL=OFF \
                       -DAF_BUILD_UNIFIED:BOOL=OFF -DAF_BUILD_EXAMPLES:BOOL=ON \
                       -DAF_BUILD_FORGE:BOOL=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,12 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 cmake_minimum_required(VERSION 3.5)
-project(ArrayFire
-  VERSION 3.7.0
-  LANGUAGES C CXX )
+
+project(ArrayFire VERSION 3.7.0 LANGUAGES C CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
+
+include(AFBuildConfigurations)
 include(AFInstallDirs)
 include(CMakeDependentOption)
 include(InternalUtils)

--- a/CMakeModules/AFBuildConfigurations.cmake
+++ b/CMakeModules/AFBuildConfigurations.cmake
@@ -1,0 +1,24 @@
+# CMake 3.9 or later provides a global property to whether we are multi-config
+# or single-config generator. Before 3.9, the defintion of CMAKE_CONFIGURATION_TYPES
+# variable indicated multi-config, but developers might modify.
+if(NOT CMAKE_VERSION VERSION_LESS 3.9)
+  get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+elseif(CMAKE_CONFIGURATION_TYPES)
+  # CMAKE_CONFIGURATION_TYPES is set by project() call for multi-config generators
+  set(_isMultiConfig True)
+else()
+  set(_isMultiConfig False)
+endif()
+
+if(_isMultiConfig)
+  set(CMAKE_CONFIGURATION_TYPES
+    "Coverage;Debug;MinSizeRel;Release;RelWithDebInfo"
+    CACHE STRING "Configurations for Multi-Config CMake Generator" FORCE)
+else()
+  if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build Type" FORCE)
+  endif()
+  set_property(CACHE CMAKE_BUILD_TYPE
+    PROPERTY
+      STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo" "Coverage")
+endif()

--- a/CMakeModules/InternalUtils.cmake
+++ b/CMakeModules/InternalUtils.cmake
@@ -108,16 +108,6 @@ macro(arrayfire_set_cmake_default_variables)
   set(CMAKE_CXX_EXTENSIONS OFF)
   set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
-  # Set a default build type if none was specified
-  if(NOT CMAKE_BUILD_TYPE)
-      set(CMAKE_BUILD_TYPE Release CACHE STRING "The type of the build")
-  endif()
-
-  # Set the possible values of build type for cmake-gui
-  set_property(CACHE CMAKE_BUILD_TYPE
-    PROPERTY
-      STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo" "Coverage")
-
   set(CMAKE_CXX_FLAGS_COVERAGE
       "-g -O0"
       CACHE STRING "Flags used by the C++ compiler during coverage builds.")

--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -43,6 +43,12 @@ else()
   set(extproj_gen_opts "-G${CMAKE_GENERATOR}")
 endif()
 
+if("${CMAKE_BUILD_TYPE}" MATCHES "Release|RelWithDebInfo")
+  set(extproj_build_type "Release")
+else()
+  set(extproj_build_type ${CMAKE_BUILD_TYPE})
+endif()
+
 ExternalProject_Add(
     CLBlast-ext
     GIT_REPOSITORY https://github.com/cnugteren/CLBlast.git
@@ -59,7 +65,7 @@ ExternalProject_Add(
       -DOVERRIDE_MSVC_FLAGS_TO_MT:BOOL=OFF
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
       "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} -w -fPIC"
-      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      -DCMAKE_BUILD_TYPE:STRING=${extproj_build_type}
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
       -DCMAKE_INSTALL_LIBDIR:PATH=lib
       -DBUILD_SHARED_LIBS:BOOL=OFF

--- a/CMakeModules/build_clBLAS.cmake
+++ b/CMakeModules/build_clBLAS.cmake
@@ -18,6 +18,12 @@ else()
   set(extproj_gen_opts "-G${CMAKE_GENERATOR}")
 endif()
 
+if("${CMAKE_BUILD_TYPE}" MATCHES "Release|RelWithDebInfo")
+  set(extproj_build_type "Release")
+else()
+  set(extproj_build_type ${CMAKE_BUILD_TYPE})
+endif()
+
 ExternalProject_Add(
     clBLAS-ext
     GIT_REPOSITORY https://github.com/arrayfire/clBLAS.git
@@ -31,7 +37,7 @@ ExternalProject_Add(
       -Wno-dev <SOURCE_DIR>/src
       -DCMAKE_CXX_FLAGS:STRING="-fPIC"
       -DCMAKE_C_FLAGS:STRING="-fPIC"
-      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      -DCMAKE_BUILD_TYPE:STRING=${extproj_build_type}
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
       -DBUILD_SHARED_LIBS:BOOL=OFF
       -DBUILD_CLIENT:BOOL=OFF

--- a/CMakeModules/build_clFFT.cmake
+++ b/CMakeModules/build_clFFT.cmake
@@ -24,6 +24,12 @@ else()
   set(extproj_gen_opts "-G${CMAKE_GENERATOR}")
 endif()
 
+if("${CMAKE_BUILD_TYPE}" MATCHES "Release|RelWithDebInfo")
+  set(extproj_build_type "Release")
+else()
+  set(extproj_build_type ${CMAKE_BUILD_TYPE})
+endif()
+
 ExternalProject_Add(
     clFFT-ext
     GIT_REPOSITORY https://github.com/arrayfire/clFFT.git
@@ -37,7 +43,7 @@ ExternalProject_Add(
       "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS} -w -fPIC"
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
       "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} -w -fPIC"
-      -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+      -DCMAKE_BUILD_TYPE:STRING=${extproj_build_type}
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
       -DBUILD_SHARED_LIBS:BOOL=OFF
       -DBUILD_EXAMPLES:BOOL=OFF


### PR DESCRIPTION
All upstream projects will use `Release` config on single config
cmake generators if the value of CMAKE_BUILD_TYPE is either Release
or RelWithDebInfo. In every other scenario, it will just use the
existing value of CMAKE_BUILD_TYPE variable.

Note: With current cmake min version as 3.5, which doesn't have ternary
generator expression, setting the build type using generator expressions
turned out to be too clumsy and cumbersone set of lines. Hence, used
simple if-else code-block.