### PR TITLE
Put print_info in the ArrayFire_BINARY_DIR for all Operating systems

### DIFF
--- a/CMakeModules/CTestCustom.cmake
+++ b/CMakeModules/CTestCustom.cmake
@@ -7,7 +7,11 @@
 
 set(CTEST_CUSTOM_ERROR_POST_CONTEXT 50)
 set(CTEST_CUSTOM_ERROR_PRE_CONTEXT 50)
-set(CTEST_CUSTOM_POST_TEST ./test/print_info)
+if(WIN32)
+  set(CTEST_CUSTOM_POST_TEST ./bin/print_info.exe)
+else()
+  set(CTEST_CUSTOM_POST_TEST ./test/print_info)
+endif()
 
 list(APPEND CTEST_CUSTOM_COVERAGE_EXCLUDE
   "test"


### PR DESCRIPTION
The windows runtime binary directory is different than other operating
systems. This causes issues with the print_info command in the
CTEST_CUSTOM_POST_TEST command because it is located in a different
location on windows. This sets the runtime output directory to the
same location on all OSs for print_info