### PR TITLE
Relax pinverse tests' max error tolerance if it's too small

### DIFF
--- a/test/pinverse.cpp
+++ b/test/pinverse.cpp
@@ -110,8 +110,12 @@ double eps<cdouble>() {
 template<typename T>
 double relEps(array in) {
     typedef typename af::dtype_traits<T>::base_type InBaseType;
-    return std::numeric_limits<InBaseType>::epsilon() *
-           std::max(in.dims(0), in.dims(1)) * af::max<double>(in);
+    double fixed_eps = eps<T>();
+    double calc_eps = std::numeric_limits<InBaseType>::epsilon() *
+                      std::max(in.dims(0), in.dims(1)) * af::max<double>(in);
+    // Use the fixed values above if calculated error tolerance is unnecessarily
+    // too small
+    return std::max(fixed_eps, calc_eps);
 }
 
 typedef ::testing::Types<float, cfloat, double, cdouble> TestTypes;


### PR DESCRIPTION
Fixes #2740. Added condition on the max error tolerance calculation (`relEps()`) to use the fixed value instead (according to the dtype) if the calculated tolerance is unnecessarily too small.