### PR TITLE
Avoid directly linking to Forge. Set RUNPATH. Improve finding CUDA libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,21 @@ set_target_properties(${built_backends} PROPERTIES
                       VERSION "${ArrayFire_VERSION}"
                       SOVERSION "${ArrayFire_VERSION_MAJOR}")
 
+if(AF_INSTALL_STANDALONE)
+
+  # This flag enables the use of RUNPATH instead of RPATH which is the
+  # preferred method to set the runtime lookup. Only doind this for
+  # standalone builds because we include all libraries with the installers
+  # and they are included in the same directory so the RUNPATH is set to
+  # $ORIGIN. This avoid setting the linker path in ld.so.conf.d
+  check_cxx_compiler_flag("-Wl,--enable-new-dtags" HAS_RUNPATH_FLAG)
+  if(HAS_RUNPATH_FLAG)
+    set_target_properties(${built_backends} PROPERTIES
+      INSTALL_RPATH "$ORIGIN"
+      LINK_OPTIONS "-Wl,--enable-new-dtags")
+  endif()
+endif()
+
 # On some distributions the linker will not add a library to the ELF header if
 # the symbols are not needed when the library was first parsed by the linker.
 # This causes undefined references issues when linking with libraries which have

--- a/CMakeModules/AFconfigure_forge_submodule.cmake
+++ b/CMakeModules/AFconfigure_forge_submodule.cmake
@@ -15,6 +15,7 @@ if(AF_BUILD_FORGE)
   set(FG_WITH_FREEIMAGE OFF CACHE BOOL "Turn on usage of freeimage dependency")
 
   add_subdirectory(extern/forge EXCLUDE_FROM_ALL)
+  set_target_properties(forge PROPERTIES EXCLUDE_FROM_ALL False)
 
   mark_as_advanced(
       FG_BUILD_EXAMPLES

--- a/src/backend/common/CMakeLists.txt
+++ b/src/backend/common/CMakeLists.txt
@@ -74,7 +74,6 @@ target_link_libraries(afcommon_interface
     Boost::boost
     af_glad_interface
     ${CMAKE_DL_LIBS}
-    $<$<BOOL:${AF_BUILD_FORGE}>:forge> #Making it a dependency only so that is built with ALL targets
 )
 
 target_include_directories(afcommon_interface

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -610,7 +610,12 @@ if (WIN32)
   set(dlib_path_prefix "${CUDA_TOOLKIT_ROOT_DIR}/bin")
 endif ()
 
-macro(afcu_collect_libs libname)
+function(afcu_collect_libs libname)
+  set(options "FULL_VERSION")
+  set(single_args "")
+  set(multi_args "")
+
+  cmake_parse_arguments(cuda_args "${options}" "${single_args}" "${multi_args}" ${ARGN})
   if (WIN32)
     find_file(CUDA_${libname}_LIBRARY_DLL
       NAMES
@@ -636,19 +641,25 @@ macro(afcu_collect_libs libname)
         ${dlib_path_prefix})
 
     get_filename_component(outpath "${CUDA_${libname}_LIBRARY}" REALPATH)
+    if(cuda_args_FULL_VERSION)
+      set(library_install_name "${PX}${libname}${SX}.${CUDA_VERSION}")
+    else()
+      set(library_install_name "${PX}${libname}${SX}.${CUDA_VERSION_MAJOR}")
+    endif()
     install(FILES       ${outpath}
             DESTINATION ${AF_INSTALL_LIB_DIR}
-            RENAME      "${PX}${libname}${SX}.${CUDA_VERSION}"
+            RENAME      ${library_install_name}
             COMPONENT   cuda_dependencies)
   endif ()
-endmacro()
+endfunction()
 
 if(AF_INSTALL_STANDALONE)
   afcu_collect_libs(cufft)
+  afcu_collect_libs(cudnn)
   afcu_collect_libs(cublas)
   afcu_collect_libs(cusolver)
   afcu_collect_libs(cusparse)
-  afcu_collect_libs(nvrtc)
+  afcu_collect_libs(nvrtc FULL_VERSION)
 
   if(APPLE)
     afcu_collect_libs(cudart)

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -630,7 +630,12 @@ macro(afcu_collect_libs libname)
             RENAME      "${PX}${libname}.${CUDA_VERSION}${SX}"
             COMPONENT   cuda_dependencies)
   else () #UNIX
-    get_filename_component(outpath "${dlib_path_prefix}/${PX}${libname}${SX}" REALPATH)
+    find_library(CUDA_${libname}_LIBRARY
+      NAME ${libname}
+      PATH
+        ${dlib_path_prefix})
+
+    get_filename_component(outpath "${CUDA_${libname}_LIBRARY}" REALPATH)
     install(FILES       ${outpath}
             DESTINATION ${AF_INSTALL_LIB_DIR}
             RENAME      "${PX}${libname}${SX}.${CUDA_VERSION}"


### PR DESCRIPTION

* Sets the install runpath to $ORIGIN in standalone builds. This allows
the linker to find the libraries in the same directory as the library
and avoids setting the LD_LIBRARY_PATH, and ld.so.conf.d
Fixes #2694 
* On CentOS and Ubuntu all cuda libraries are not located in the
  CUDA toolkit lib directory. They are located in the standard library
  paths
