### PR TITLE
Opencl cpu batch matmul fix

### DIFF
--- a/src/backend/opencl/cpu/cpu_blas.cpp
+++ b/src/backend/opencl/cpu/cpu_blas.cpp
@@ -198,6 +198,11 @@ void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
     bool is_r_d2_batched = (oDims[2] == rDims[2]);
     bool is_r_d3_batched = (oDims[3] == rDims[3]);
 
+    // get host pointers from mapped memory
+    mapped_ptr<T> lPtr = lhs.getMappedPtr(CL_MAP_READ);
+    mapped_ptr<T> rPtr = rhs.getMappedPtr(CL_MAP_READ);
+    mapped_ptr<T> oPtr = out.getMappedPtr(CL_MAP_READ | CL_MAP_WRITE);
+
     for (int n = 0; n < batchSize; ++n) {
         int w = n / rDims[2];
         int z = n - w * rDims[2];
@@ -206,11 +211,6 @@ void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
                    w * (is_l_d3_batched * lStrides[3]);
         int roff = z * (is_r_d2_batched * rStrides[2]) +
                    w * (is_r_d3_batched * rStrides[3]);
-
-        // get host pointers from mapped memory
-        auto lPtr = lhs.getMappedPtr();
-        auto rPtr = rhs.getMappedPtr();
-        auto oPtr = out.getMappedPtr();
 
         CBT *lptr = (CBT *)(lPtr.get() + loff);
         CBT *rptr = (CBT *)(rPtr.get() + roff);

--- a/src/backend/opencl/cpu/cpu_blas.cpp
+++ b/src/backend/opencl/cpu/cpu_blas.cpp
@@ -204,8 +204,8 @@ void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
     mapped_ptr<T> oPtr = out.getMappedPtr(CL_MAP_READ | CL_MAP_WRITE);
 
     for (int n = 0; n < batchSize; ++n) {
-        int w = n / rDims[2];
-        int z = n - w * rDims[2];
+        int w = n / oDims[2];
+        int z = n - w * oDims[2];
 
         int loff = z * (is_l_d2_batched * lStrides[2]) +
                    w * (is_l_d3_batched * lStrides[3]);

--- a/src/backend/opencl/cpu/cpu_cholesky.cpp
+++ b/src/backend/opencl/cpu/cpu_cholesky.cpp
@@ -40,7 +40,7 @@ Array<T> cholesky(int *info, const Array<T> &in, const bool is_upper) {
     Array<T> out = copyArray<T>(in);
     *info        = cholesky_inplace(out, is_upper);
 
-    std::shared_ptr<T> oPtr = out.getMappedPtr();
+    mapped_ptr<T> oPtr = out.getMappedPtr();
 
     if (is_upper)
         triangle<T, true, false>(oPtr.get(), oPtr.get(), out.dims(),
@@ -60,7 +60,7 @@ int cholesky_inplace(Array<T> &in, const bool is_upper) {
     char uplo = 'L';
     if (is_upper) uplo = 'U';
 
-    std::shared_ptr<T> inPtr = in.getMappedPtr();
+    mapped_ptr<T> inPtr = in.getMappedPtr();
 
     int info = potrf_func<T>()(AF_LAPACK_COL_MAJOR, uplo, N, inPtr.get(),
                                in.strides()[1]);

--- a/src/backend/opencl/cpu/cpu_inverse.cpp
+++ b/src/backend/opencl/cpu/cpu_inverse.cpp
@@ -50,8 +50,8 @@ Array<T> inverse(const Array<T> &in) {
 
     Array<int> pivot = cpu::lu_inplace<T>(A, false);
 
-    std::shared_ptr<T> aPtr   = A.getMappedPtr();
-    std::shared_ptr<int> pPtr = pivot.getMappedPtr();
+    mapped_ptr<T> aPtr   = A.getMappedPtr();
+    mapped_ptr<int> pPtr = pivot.getMappedPtr();
 
     getri_func<T>()(AF_LAPACK_COL_MAJOR, M, aPtr.get(), A.strides()[1],
                     pPtr.get());

--- a/src/backend/opencl/cpu/cpu_lu.cpp
+++ b/src/backend/opencl/cpu/cpu_lu.cpp
@@ -38,9 +38,9 @@ LU_FUNC(getrf, cdouble, z)
 
 template<typename T>
 void lu_split(Array<T> &lower, Array<T> &upper, const Array<T> &in) {
-    std::shared_ptr<T> ls = lower.getMappedPtr();
-    std::shared_ptr<T> us = upper.getMappedPtr();
-    std::shared_ptr<T> is = in.getMappedPtr();
+    auto ls = lower.getMappedPtr();
+    auto us = upper.getMappedPtr();
+    auto is = in.getMappedPtr(CL_MAP_READ);
 
     T *l = ls.get();
     T *u = us.get();

--- a/src/backend/opencl/cpu/cpu_qr.cpp
+++ b/src/backend/opencl/cpu/cpu_qr.cpp
@@ -69,9 +69,9 @@ void qr(Array<T> &q, Array<T> &r, Array<T> &t, const Array<T> &in) {
     dim4 rdims(M, N);
     r = createEmptyArray<T>(rdims);
 
-    std::shared_ptr<T> qPtr = q.getMappedPtr();
-    std::shared_ptr<T> rPtr = r.getMappedPtr();
-    std::shared_ptr<T> tPtr = t.getMappedPtr();
+    mapped_ptr<T> qPtr = q.getMappedPtr();
+    mapped_ptr<T> rPtr = r.getMappedPtr();
+    mapped_ptr<T> tPtr = t.getMappedPtr();
 
     triangle<T, true, false>(rPtr.get(), qPtr.get(), rdims, r.strides(),
                              q.strides());
@@ -90,8 +90,8 @@ Array<T> qr_inplace(Array<T> &in) {
 
     Array<T> t = createEmptyArray<T>(af::dim4(min(M, N), 1, 1, 1));
 
-    std::shared_ptr<T> iPtr = in.getMappedPtr();
-    std::shared_ptr<T> tPtr = t.getMappedPtr();
+    mapped_ptr<T> iPtr = in.getMappedPtr();
+    mapped_ptr<T> tPtr = t.getMappedPtr();
 
     geqrf_func<T>()(AF_LAPACK_COL_MAJOR, M, N, iPtr.get(), in.strides()[1],
                     tPtr.get());

--- a/src/backend/opencl/cpu/cpu_solve.cpp
+++ b/src/backend/opencl/cpu/cpu_solve.cpp
@@ -74,9 +74,9 @@ Array<T> solveLU(const Array<T> &A, const Array<int> &pivot, const Array<T> &b,
 
     Array<T> B = copyArray<T>(b);
 
-    std::shared_ptr<T> aPtr   = A.getMappedPtr();
-    std::shared_ptr<T> bPtr   = B.getMappedPtr();
-    std::shared_ptr<int> pPtr = pivot.getMappedPtr();
+    mapped_ptr<T> aPtr   = A.getMappedPtr();
+    mapped_ptr<T> bPtr   = B.getMappedPtr();
+    mapped_ptr<int> pPtr = pivot.getMappedPtr();
 
     getrs_func<T>()(AF_LAPACK_COL_MAJOR, 'N', N, NRHS, aPtr.get(),
                     A.strides()[1], pPtr.get(), bPtr.get(), B.strides()[1]);
@@ -91,8 +91,8 @@ Array<T> triangleSolve(const Array<T> &A, const Array<T> &b,
     int N      = B.dims()[0];
     int NRHS   = B.dims()[1];
 
-    std::shared_ptr<T> aPtr = A.getMappedPtr();
-    std::shared_ptr<T> bPtr = B.getMappedPtr();
+    mapped_ptr<T> aPtr = A.getMappedPtr();
+    mapped_ptr<T> bPtr = B.getMappedPtr();
 
     trtrs_func<T>()(AF_LAPACK_COL_MAJOR, options & AF_MAT_UPPER ? 'U' : 'L',
                     'N',  // transpose flag
@@ -116,8 +116,8 @@ Array<T> solve(const Array<T> &a, const Array<T> &b,
     Array<T> A = copyArray<T>(a);
     Array<T> B = padArray<T, T>(b, dim4(max(M, N), K), scalar<T>(0));
 
-    std::shared_ptr<T> aPtr = A.getMappedPtr();
-    std::shared_ptr<T> bPtr = B.getMappedPtr();
+    mapped_ptr<T> aPtr = A.getMappedPtr();
+    mapped_ptr<T> bPtr = B.getMappedPtr();
 
     if (M == N) {
         std::vector<int> pivot(N);

--- a/src/backend/opencl/cpu/cpu_sparse_blas.cpp
+++ b/src/backend/opencl/cpu/cpu_sparse_blas.cpp
@@ -223,18 +223,18 @@ Array<T> matmul(const common::SparseArray<T> lhs, const Array<T> rhs,
     int ldc = out.strides()[1];
 
     // get host pointers from mapped memory
-    auto rhsPtr = rhs.getMappedPtr();
-    auto outPtr = out.getMappedPtr();
+    mapped_ptr<T> rhsPtr = rhs.getMappedPtr(CL_MAP_READ);
+    mapped_ptr<T> outPtr = out.getMappedPtr();
 
     Array<T> values   = lhs.getValues();
     Array<int> rowIdx = lhs.getRowIdx();
     Array<int> colIdx = lhs.getColIdx();
 
-    auto vPtr = values.getMappedPtr();
-    auto rPtr = rowIdx.getMappedPtr();
-    auto cPtr = colIdx.getMappedPtr();
-    int *pB   = rPtr.get();
-    int *pE   = rPtr.get() + 1;
+    mapped_ptr<T> vPtr   = values.getMappedPtr();
+    mapped_ptr<int> rPtr = rowIdx.getMappedPtr();
+    mapped_ptr<int> cPtr = colIdx.getMappedPtr();
+    int *pB              = rPtr.get();
+    int *pE              = rPtr.get() + 1;
 
     sparse_matrix_t csrLhs;
     create_csr_func<T>()(&csrLhs, SPARSE_INDEX_BASE_ZERO, lhs.dims()[0],
@@ -293,11 +293,11 @@ template<typename T, bool conjugate>
 void mv(Array<T> output, const Array<T> values, const Array<int> rowIdx,
         const Array<int> colIdx, const Array<T> right, int M) {
     UNUSED(M);
-    auto oPtr   = output.getMappedPtr();
-    auto rhtPtr = right.getMappedPtr();
-    auto vPtr   = values.getMappedPtr();
-    auto rPtr   = rowIdx.getMappedPtr();
-    auto cPtr   = colIdx.getMappedPtr();
+    mapped_ptr<T> oPtr   = output.getMappedPtr();
+    mapped_ptr<T> rhtPtr = right.getMappedPtr();
+    mapped_ptr<T> vPtr   = values.getMappedPtr();
+    mapped_ptr<int> rPtr = rowIdx.getMappedPtr();
+    mapped_ptr<int> cPtr = colIdx.getMappedPtr();
 
     T const *const valPtr   = vPtr.get();
     int const *const rowPtr = rPtr.get();
@@ -322,11 +322,11 @@ void mv(Array<T> output, const Array<T> values, const Array<int> rowIdx,
 template<typename T, bool conjugate>
 void mtv(Array<T> output, const Array<T> values, const Array<int> rowIdx,
          const Array<int> colIdx, const Array<T> right, int M) {
-    auto oPtr   = output.getMappedPtr();
-    auto rhtPtr = right.getMappedPtr();
-    auto vPtr   = values.getMappedPtr();
-    auto rPtr   = rowIdx.getMappedPtr();
-    auto cPtr   = colIdx.getMappedPtr();
+    mapped_ptr<T> oPtr   = output.getMappedPtr();
+    mapped_ptr<T> rhtPtr = right.getMappedPtr();
+    mapped_ptr<T> vPtr   = values.getMappedPtr();
+    mapped_ptr<int> rPtr = rowIdx.getMappedPtr();
+    mapped_ptr<int> cPtr = colIdx.getMappedPtr();
 
     T const *const valPtr   = vPtr.get();
     int const *const rowPtr = rPtr.get();
@@ -354,11 +354,11 @@ void mm(Array<T> output, const Array<T> values, const Array<int> rowIdx,
         const Array<int> colIdx, const Array<T> right, int M, int N, int ldb,
         int ldc) {
     UNUSED(M);
-    auto oPtr   = output.getMappedPtr();
-    auto rhtPtr = right.getMappedPtr();
-    auto vPtr   = values.getMappedPtr();
-    auto rPtr   = rowIdx.getMappedPtr();
-    auto cPtr   = colIdx.getMappedPtr();
+    mapped_ptr<T> oPtr   = output.getMappedPtr();
+    mapped_ptr<T> rhtPtr = right.getMappedPtr();
+    mapped_ptr<T> vPtr   = values.getMappedPtr();
+    mapped_ptr<int> rPtr = rowIdx.getMappedPtr();
+    mapped_ptr<int> cPtr = colIdx.getMappedPtr();
 
     T const *const valPtr   = vPtr.get();
     int const *const rowPtr = rPtr.get();
@@ -388,11 +388,11 @@ template<typename T, bool conjugate>
 void mtm(Array<T> output, const Array<T> values, const Array<int> rowIdx,
          const Array<int> colIdx, const Array<T> right, int M, int N, int ldb,
          int ldc) {
-    auto oPtr   = output.getMappedPtr();
-    auto rhtPtr = right.getMappedPtr();
-    auto vPtr   = values.getMappedPtr();
-    auto rPtr   = rowIdx.getMappedPtr();
-    auto cPtr   = colIdx.getMappedPtr();
+    mapped_ptr<T> oPtr   = output.getMappedPtr();
+    mapped_ptr<T> rhtPtr = right.getMappedPtr();
+    mapped_ptr<T> vPtr   = values.getMappedPtr();
+    mapped_ptr<int> rPtr = rowIdx.getMappedPtr();
+    mapped_ptr<int> cPtr = colIdx.getMappedPtr();
 
     T const *const valPtr   = vPtr.get();
     int const *const rowPtr = rPtr.get();

--- a/src/backend/opencl/cpu/cpu_svd.cpp
+++ b/src/backend/opencl/cpu/cpu_svd.cpp
@@ -58,10 +58,10 @@ void svdInPlace(Array<Tr> &s, Array<T> &u, Array<T> &vt, Array<T> &in) {
     int M      = iDims[0];
     int N      = iDims[1];
 
-    std::shared_ptr<Tr> sPtr = s.getMappedPtr();
-    std::shared_ptr<T> uPtr  = u.getMappedPtr();
-    std::shared_ptr<T> vPtr  = vt.getMappedPtr();
-    std::shared_ptr<T> iPtr  = in.getMappedPtr();
+    mapped_ptr<Tr> sPtr = s.getMappedPtr();
+    mapped_ptr<T> uPtr  = u.getMappedPtr();
+    mapped_ptr<T> vPtr  = vt.getMappedPtr();
+    mapped_ptr<T> iPtr  = in.getMappedPtr();
 
 #if defined(USE_MKL) || defined(__APPLE__)
     svd_func<T, Tr>()(AF_LAPACK_COL_MAJOR, 'A', M, N, iPtr.get(),

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -1059,7 +1059,7 @@ template<typename T>
 /// \param[in] EXPECTED The expected array of the assertion
 /// \param[in] ACTUAL The actual resulting array from the calculation
 #define ASSERT_ARRAYS_EQ(EXPECTED, ACTUAL) \
-    EXPECT_PRED_FORMAT2(assertArrayEq, EXPECTED, ACTUAL)
+    ASSERT_PRED_FORMAT2(assertArrayEq, EXPECTED, ACTUAL)
 
 /// Same as ASSERT_ARRAYS_EQ, but for cases when a "special" output array is
 /// given to the function.
@@ -1069,7 +1069,7 @@ template<typename T>
 /// \param[in] EXPECTED The expected array of the assertion
 /// \param[in] ACTUAL The actual resulting array from the calculation
 #define ASSERT_SPECIAL_ARRAYS_EQ(EXPECTED, ACTUAL, META) \
-    EXPECT_PRED_FORMAT3(assertArrayEq, EXPECTED, ACTUAL, META)
+    ASSERT_PRED_FORMAT3(assertArrayEq, EXPECTED, ACTUAL, META)
 
 /// Compares a std::vector with an af::/af_array for their types, dims, and
 /// values (strict equality).
@@ -1078,7 +1078,7 @@ template<typename T>
 /// \param[in] EXPECTED_ARR_DIMS The dimensions of the expected array
 /// \param[in] ACTUAL_ARR The actual resulting array from the calculation
 #define ASSERT_VEC_ARRAY_EQ(EXPECTED_VEC, EXPECTED_ARR_DIMS, ACTUAL_ARR) \
-    EXPECT_PRED_FORMAT3(assertArrayEq, EXPECTED_VEC, EXPECTED_ARR_DIMS,  \
+    ASSERT_PRED_FORMAT3(assertArrayEq, EXPECTED_VEC, EXPECTED_ARR_DIMS,  \
                         ACTUAL_ARR)
 
 /// Compares two af::array or af_arrays for their type, dims, and values (with a
@@ -1091,7 +1091,7 @@ template<typename T>
 ///
 /// \NOTE: This macro will deallocate the af_arrays after the call
 #define ASSERT_ARRAYS_NEAR(EXPECTED, ACTUAL, MAX_ABSDIFF) \
-    EXPECT_PRED_FORMAT3(assertArrayNear, EXPECTED, ACTUAL, MAX_ABSDIFF)
+    ASSERT_PRED_FORMAT3(assertArrayNear, EXPECTED, ACTUAL, MAX_ABSDIFF)
 
 /// Compares a std::vector with an af::array for their dims and values (with a
 /// given tolerance).
@@ -1103,7 +1103,7 @@ template<typename T>
 ///            elements of EXPECTED and ACTUAL
 #define ASSERT_VEC_ARRAY_NEAR(EXPECTED_VEC, EXPECTED_ARR_DIMS, ACTUAL_ARR, \
                               MAX_ABSDIFF)                                 \
-    EXPECT_PRED_FORMAT4(assertArrayNear, EXPECTED_VEC, EXPECTED_ARR_DIMS,  \
+    ASSERT_PRED_FORMAT4(assertArrayNear, EXPECTED_VEC, EXPECTED_ARR_DIMS,  \
                         ACTUAL_ARR, MAX_ABSDIFF)
 
 #if defined(USE_MTX)


### PR DESCRIPTION
Fixes a couple of issues with the CPU OpenCL blas functions. The batching functionality was not working correctly for righ hand side batches. The matmul function was throwing errors in case the same input was passed in. This was caused only on the Intel GPU OpenCL implementation because mapping the same buffer as a READ and WRITE mapped pointer caused an error. These issues have been fixed and the getMappedPtr is refactored to return unique_ptr instead of shared_ptr.

Fixes #1711 