### PR TITLE
Move Lookup tables in CUDA backend to texture memory to reduce global constant memory usage

### DIFF
--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -375,6 +375,7 @@ cuda_add_library(afcuda
 
     Array.cpp
     Array.hpp
+    LookupTable1D.hpp
     Param.hpp
     anisotropic_diffusion.hpp
     approx.hpp

--- a/src/backend/cuda/LookupTable1D.hpp
+++ b/src/backend/cuda/LookupTable1D.hpp
@@ -1,0 +1,66 @@
+/*******************************************************
+ * Copyright (c) 2020, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Array.hpp>
+#include <err_cuda.hpp>
+
+#include <type_traits>
+
+namespace cuda {
+
+template<typename T>
+class LookupTable1D {
+   public:
+    LookupTable1D()                          = delete;
+    LookupTable1D(const LookupTable1D& arg)  = delete;
+    LookupTable1D(const LookupTable1D&& arg) = delete;
+    LookupTable1D& operator=(const LookupTable1D& arg) = delete;
+    LookupTable1D& operator=(const LookupTable1D&& arg) = delete;
+
+    LookupTable1D(const Array<T>& lutArray) : mTexture(0), mData(lutArray) {
+        cudaResourceDesc resDesc;
+        memset(&resDesc, 0, sizeof(resDesc));
+
+        cudaTextureDesc texDesc;
+        memset(&texDesc, 0, sizeof(texDesc));
+
+        resDesc.resType                = cudaResourceTypeLinear;
+        resDesc.res.linear.devPtr      = mData.get();
+        resDesc.res.linear.desc.x      = sizeof(T) * 8;
+        resDesc.res.linear.sizeInBytes = mData.elements() * sizeof(T);
+
+        if (std::is_signed<T>::value)
+            resDesc.res.linear.desc.f = cudaChannelFormatKindSigned;
+        else if (std::is_unsigned<T>::value)
+            resDesc.res.linear.desc.f = cudaChannelFormatKindUnsigned;
+        else
+            resDesc.res.linear.desc.f = cudaChannelFormatKindFloat;
+
+        texDesc.readMode = cudaReadModeElementType;
+
+        CUDA_CHECK(
+            cudaCreateTextureObject(&mTexture, &resDesc, &texDesc, NULL));
+    }
+
+    ~LookupTable1D() {
+        if (mTexture) { cudaDestroyTextureObject(mTexture); }
+    }
+
+    cudaTextureObject_t get() const noexcept { return mTexture; }
+
+   private:
+    // Keep a copy so that ref count doesn't go down to zero when
+    // original Array<T> goes out of scope before LookupTable1D object does.
+    Array<T> mData;
+    cudaTextureObject_t mTexture;
+};
+
+}  // namespace cuda

--- a/src/backend/cuda/kernel/fast_lut.hpp
+++ b/src/backend/cuda/kernel/fast_lut.hpp
@@ -1,5 +1,5 @@
 /*******************************************************
- * Copyright (c) 2014, ArrayFire
+ * Copyright (c) 2020, ArrayFire
  * All rights reserved.
  *
  * This file is distributed under 3-clause BSD license.
@@ -9,7 +9,7 @@
 
 #pragma once
 
-__constant__ unsigned char FAST_LUT[] = {
+unsigned char FAST_LUT[] = {
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,
     0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,  0,

--- a/src/backend/cuda/kernel/orb_patch.hpp
+++ b/src/backend/cuda/kernel/orb_patch.hpp
@@ -10,19 +10,18 @@
 #pragma once
 
 namespace cuda {
-namespace kernel {
 
 // Reference pattern, generated for a patch size of 31x31, as suggested by
 // original ORB paper
-#define REF_PAT_SIZE 31
-#define REF_PAT_SAMPLES 256
-#define REF_PAT_COORDS 4
-#define REF_PAT_LENGTH (REF_PAT_SAMPLES * REF_PAT_COORDS)
+constexpr unsigned REF_PAT_SIZE    = 31;
+constexpr unsigned REF_PAT_SAMPLES = 256;
+constexpr unsigned REF_PAT_COORDS  = 4;
+constexpr unsigned REF_PAT_LENGTH  = (REF_PAT_SAMPLES * REF_PAT_COORDS);
 
 // Current reference pattern was borrowed from OpenCV, a randomly generated
 // pattern will not achieve same quality as it must be trained like described
 // in sections 4.2 and 4.3 of the original ORB paper.
-__constant__ int d_ref_pat[REF_PAT_LENGTH] = {
+int d_ref_pat[REF_PAT_LENGTH] = {
     8,   -3,  9,   5,   4,   2,   7,   -12, -11, 9,   -8,  2,   7,   -12, 12,
     -13, 2,   -13, 2,   12,  1,   -7,  1,   6,   -2,  -10, -2,  -4,  -13, -13,
     -11, -8,  -13, -3,  -12, -9,  10,  4,   11,  9,   -13, -8,  -8,  -9,  -11,
@@ -93,7 +92,5 @@ __constant__ int d_ref_pat[REF_PAT_LENGTH] = {
     4,   -10, 9,   7,   3,   12,  4,   9,   -7,  10,  -2,  7,   0,   12,  -2,
     -1,  -6,  0,   -11,
 };
-
-}  // namespace kernel
 
 }  // namespace cuda


### PR DESCRIPTION
There is negligible to no difference between texture based look-up table and constant memory look-up table. Hence, shifted to texture memory look-up table to reduce global constant memory usage.
