### PR TITLE
Use std::make_tuple instead of explicit tuple constructor

### DIFF
--- a/src/backend/cuda/cudnnModule.hpp
+++ b/src/backend/cuda/cudnnModule.hpp
@@ -67,7 +67,9 @@ class cudnnModule {
     spdlog::logger* getLogger();
 
     /// Returns the version of the cuDNN loaded at runtime
-    std::tuple<int, int, int> getVersion() { return {major, minor, patch}; }
+    std::tuple<int, int, int> getVersion() {
+        return std::make_tuple(major, minor, patch);
+    }
 };
 
 cudnnModule& getCudnnPlugin();


### PR DESCRIPTION
the explicit tuple constructor that is invoked due to the following
statement is throwing error with gcc 5.4.

```c++
std::tuple<int, int> test = {2, 3};
```

However, the code using std::make_tuple is working on gcc 5.4 also.

Resolves #2788 