### PR TITLE
Fix memory pressure in DefaultMemoryManager

### DIFF
--- a/src/backend/common/DefaultMemoryManager.cpp
+++ b/src/backend/common/DefaultMemoryManager.cpp
@@ -162,7 +162,8 @@ void* DefaultMemoryManager::alloc(bool user_lock, const unsigned ndims,
         if (!this->debug_mode) {
             // FIXME: Add better checks for garbage collection
             // Perhaps look at total memory available as a metric
-            if (getMemoryPressure() > getMemoryPressureThreshold()) {
+            if (current.lock_bytes >= current.max_bytes ||
+                current.total_buffers >= this->max_buffers) {
                 this->signalMemoryCleanup();
             }
 

--- a/src/backend/cpu/queue.hpp
+++ b/src/backend/cpu/queue.hpp
@@ -69,7 +69,7 @@ class queue {
 #ifndef NDEBUG
         sync();
 #else
-        if (getMemoryPressure() > getMemoryPressureThreshold() || count >= 25) {
+        if (getMemoryPressure() >= getMemoryPressureThreshold() || count >= 25) {
             sync();
         }
 #endif

--- a/src/backend/cpu/queue.hpp
+++ b/src/backend/cpu/queue.hpp
@@ -69,7 +69,8 @@ class queue {
 #ifndef NDEBUG
         sync();
 #else
-        if (getMemoryPressure() >= getMemoryPressureThreshold() || count >= 25) {
+        if (getMemoryPressure() >= getMemoryPressureThreshold() ||
+            count >= 25) {
             sync();
         }
 #endif

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -236,7 +236,7 @@ kJITHeuristics passesJitHeuristics(Node *root_node) {
     // A lightweight check based on the height of the node. This is an
     // inexpensive operation and does not traverse the JIT tree.
     if (root_node->getHeight() > 6 ||
-        getMemoryPressure() > getMemoryPressureThreshold()) {
+        getMemoryPressure() >= getMemoryPressureThreshold()) {
         // The size of the parameters without any extra arguments from the
         // JIT tree. This includes one output Param object and 4 integers.
         constexpr size_t base_param_size =

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -256,7 +256,7 @@ kJITHeuristics passesJitHeuristics(Node *root_node) {
         return kJITHeuristics::TreeHeight;
     }
 
-    bool isBufferLimit = getMemoryPressure() > getMemoryPressureThreshold();
+    bool isBufferLimit = getMemoryPressure() >= getMemoryPressureThreshold();
     auto platform      = getActivePlatform();
 
     // The Apple platform can have the nvidia card or the AMD card


### PR DESCRIPTION
Summary: This fixes a bug that caused memory to not be garbage collected until we ran out of memory in v3.7.0. 

When we switched from MemoryManagerImpl to DefaultMemoryManager, we switched the memory pressure check to check for `lock_buffers` instead of `total_buffers` which I'm assuming was unintentional:

https://github.com/arrayfire/arrayfire/blob/v3.6.4/src/backend/common/MemoryManagerImpl.hpp#L379

https://github.com/arrayfire/arrayfire/blob/v3.7.0/src/backend/common/DefaultMemoryManager.cpp#L132

Also, we now check against `getMemoryPressureThreshold()` which default value is 1.0. Since we were returning 1.0 from `getMemoryPressure()`, it would never trigger. 
(https://github.com/padentomasello/arrayfire/blob/v3.7.0/src/backend/common/DefaultMemoryManager.cpp#L165)

I changed it to return to ratio now instead. This should have the intended behavior, plus allow users to adjust the memory_threshold for meaningful changes. 