### PR TITLE
Fix byteToString where the byte alue is greater than 1 petabyte

### DIFF
--- a/src/backend/common/Logger.cpp
+++ b/src/backend/common/Logger.cpp
@@ -52,13 +52,15 @@ shared_ptr<logger> loggerFactory(string name) {
 }
 
 string bytesToString(size_t bytes) {
-    static array<const char *, 5> units{{"B", "KB", "MB", "GB", "TB"}};
+    constexpr array<const char *, 7> units{
+        {"B", "KB", "MB", "GB", "TB", "PB", "EB"}};
     size_t count     = 0;
     double fbytes    = static_cast<double>(bytes);
     size_t num_units = units.size();
     for (count = 0; count < num_units && fbytes > 1000.0f; count++) {
         fbytes *= (1.0f / 1024.0f);
     }
+    if (count == units.size()) count--;
     return fmt::format("{:.3g} {}", fbytes, units[count]);
 }
 }  // namespace common

--- a/src/backend/common/err_common.hpp
+++ b/src/backend/common/err_common.hpp
@@ -9,7 +9,10 @@
 
 #pragma once
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
 #include <boost/stacktrace.hpp>
+#pragma GCC diagnostic pop
 #include <common/defines.hpp>
 #include <af/defines.h>
 


### PR DESCRIPTION
The bytesToString failed for values greater than a petabyte for the input byte parameter. This expands the array and addresses the issue in case someone wants to allocate a zettabyte of data.

Also suppresses a warning with newer versions of gcc and boost stacktrace

Fixes #2826 