### PR TITLE
std::initializer_list based constructors for af::array

### DIFF
--- a/CMakeModules/InternalUtils.cmake
+++ b/CMakeModules/InternalUtils.cmake
@@ -172,7 +172,7 @@ macro(arrayfire_set_cmake_default_variables)
   #         PREFIX AF
   #         COMPILERS AppleClang Clang GNU Intel MSVC
   #         # NOTE: cxx_attribute_deprecated does not work well with C
-  #         FEATURES cxx_rvalue_references cxx_noexcept cxx_variadic_templates cxx_alignas cxx_static_assert
+  #         FEATURES cxx_rvalue_references cxx_noexcept cxx_variadic_templates cxx_alignas cxx_static_assert cxx_generalized_initializers
   #         ALLOW_UNKNOWN_COMPILERS
   #         #[VERSION <version>]
   #         #[PROLOG <prolog>]

--- a/CMakeModules/compilers.h
+++ b/CMakeModules/compilers.h
@@ -196,6 +196,12 @@
 #      define AF_COMPILER_CXX_STATIC_ASSERT 0
 #    endif
 
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 400 && __has_feature(cxx_generalized_initializers)
+#      define AF_COMPILER_CXX_GENERALIZED_INITIALIZERS 1
+#    else
+#      define AF_COMPILER_CXX_GENERALIZED_INITIALIZERS 0
+#    endif
+
 #  elif AF_COMPILER_IS_Clang
 
 #    if !(((__clang_major__ * 100) + __clang_minor__) >= 301)
@@ -239,6 +245,12 @@
 #      define AF_COMPILER_CXX_STATIC_ASSERT 1
 #    else
 #      define AF_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#    if ((__clang_major__ * 100) + __clang_minor__) >= 301 && __has_feature(cxx_generalized_initializers)
+#      define AF_COMPILER_CXX_GENERALIZED_INITIALIZERS 1
+#    else
+#      define AF_COMPILER_CXX_GENERALIZED_INITIALIZERS 0
 #    endif
 
 #  elif AF_COMPILER_IS_GNU
@@ -287,6 +299,12 @@
 #      define AF_COMPILER_CXX_STATIC_ASSERT 1
 #    else
 #      define AF_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#    if (__GNUC__ * 100 + __GNUC_MINOR__) >= 404 && (__cplusplus >= 201103L || (defined(__GXX_EXPERIMENTAL_CXX0X__) && __GXX_EXPERIMENTAL_CXX0X__))
+#      define AF_COMPILER_CXX_GENERALIZED_INITIALIZERS 1
+#    else
+#      define AF_COMPILER_CXX_GENERALIZED_INITIALIZERS 0
 #    endif
 
 #  elif AF_COMPILER_IS_Intel
@@ -354,6 +372,12 @@
 #      define AF_COMPILER_CXX_STATIC_ASSERT 0
 #    endif
 
+#    if __INTEL_COMPILER >= 1400 && ((__cplusplus >= 201103L) || defined(__INTEL_CXX11_MODE__) || defined(__GXX_EXPERIMENTAL_CXX0X__))
+#      define AF_COMPILER_CXX_GENERALIZED_INITIALIZERS 1
+#    else
+#      define AF_COMPILER_CXX_GENERALIZED_INITIALIZERS 0
+#    endif
+
 #  elif AF_COMPILER_IS_MSVC
 
 #    if !(_MSC_VER >= 1600)
@@ -404,6 +428,12 @@
 #      define AF_COMPILER_CXX_STATIC_ASSERT 1
 #    else
 #      define AF_COMPILER_CXX_STATIC_ASSERT 0
+#    endif
+
+#    if _MSC_FULL_VER >= 180030723
+#      define AF_COMPILER_CXX_GENERALIZED_INITIALIZERS 1
+#    else
+#      define AF_COMPILER_CXX_GENERALIZED_INITIALIZERS 0
 #    endif
 
 #  endif

--- a/include/af/array.h
+++ b/include/af/array.h
@@ -17,6 +17,12 @@
 #ifdef __cplusplus
 #include <af/traits.hpp>
 
+#if AF_API_VERSION >= 38
+#if AF_COMPILER_CXX_GENERALIZED_INITIALIZERS
+#include <initializer_list>
+#endif
+#endif
+
 namespace af
 {
 
@@ -485,6 +491,15 @@ namespace af
         explicit
         array(const dim4& dims,
               const T *pointer, af::source src=afHost);
+
+#if AF_API_VERSION >= 38
+#if AF_COMPILER_CXX_GENERALIZED_INITIALIZERS
+        template <typename T> array(std::initializer_list<T> list);
+
+        template <typename T>
+        array(const af::dim4 &dims, std::initializer_list<T> list);
+#endif
+#endif
 
         /**
            Adjust the dimensions of an N-D array (fast).

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -219,7 +219,15 @@ struct dtype_traits<half_float::half> {
     AFAPI array::array(dim_t dim0, dim_t dim1, dim_t dim2, dim_t dim3,         \
                        const T *ptr, af::source src)                           \
         : arr(initDataArray(ptr, dtype_traits<T>::af_type, src, dim0, dim1,    \
-                            dim2, dim3)) {}
+                            dim2, dim3)) {}                                    \
+    template<>                                                                 \
+    AFAPI array::array(std::initializer_list<T> list)                          \
+        : arr(initDataArray(list.begin(), dtype_traits<T>::af_type, afHost,    \
+                            list.size(), 1, 1, 1)) {}                          \
+    template<>                                                                 \
+    AFAPI array::array(const af::dim4 &dims, std::initializer_list<T> list)    \
+        : arr(initDataArray(list.begin(), dtype_traits<T>::af_type, afHost,    \
+                            dims[0], dims[1], dims[2], dims[3])) {}
 
 INSTANTIATE(cdouble)
 INSTANTIATE(cfloat)

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -14,6 +14,7 @@
 #include <testHelpers.hpp>
 #include <cstddef>
 #include <cstdlib>
+#include <initializer_list>
 
 using namespace af;
 using std::vector;
@@ -564,4 +565,22 @@ void deathTest() {
 
 TEST(ArrayDeathTest, ProxyMoveAssignmentOperator) {
     EXPECT_EXIT(deathTest(), ::testing::ExitedWithCode(0), "");
+}
+
+TEST(Array, InitializerList) {
+    int h_buffer[] = {23, 34, 18, 99, 34};
+
+    array A(5, h_buffer);
+    array B({23, 34, 18, 99, 34});
+
+    ASSERT_ARRAYS_EQ(A, B);
+}
+
+TEST(Array, InitializerListAndDim4) {
+    int h_buffer[] = {23, 34, 18, 99, 34, 44};
+
+    array A(2, 3, h_buffer);
+    array B(dim4(2, 3), {23, 34, 18, 99, 34, 44});
+
+    ASSERT_ARRAYS_EQ(A, B);
 }


### PR DESCRIPTION
Fixes #2825 