### PR TITLE
Fix constant mem declaration in CUDA morph kernel

### DIFF
--- a/src/backend/cuda/kernel/morph.hpp
+++ b/src/backend/cuda/kernel/morph.hpp
@@ -19,7 +19,7 @@
 namespace cuda {
 namespace kernel {
 
-static const int MAX_MORPH_FILTER_LEN = 17;
+static const int MAX_MORPH_FILTER_LEN = 19;
 static const int THREADS_X            = 16;
 static const int THREADS_Y            = 16;
 static const int CUBE_X               = 8;

--- a/src/backend/cuda/morph_impl.hpp
+++ b/src/backend/cuda/morph_impl.hpp
@@ -22,7 +22,7 @@ Array<T> morph(const Array<T> &in, const Array<T> &mask) {
     if (mdims[0] != mdims[1]) {
         CUDA_NOT_SUPPORTED("Rectangular masks are not supported");
     }
-    if (mdims[0] > 19) {
+    if (mdims[0] > MAX_MORPH_FILTER_LEN) {
         CUDA_NOT_SUPPORTED("Kernels > 19x19 are not supported");
     }
     Array<T> out = createEmptyArray<T>(in.dims());

--- a/src/backend/cuda/morph_impl.hpp
+++ b/src/backend/cuda/morph_impl.hpp
@@ -22,7 +22,7 @@ Array<T> morph(const Array<T> &in, const Array<T> &mask) {
     if (mdims[0] != mdims[1]) {
         CUDA_NOT_SUPPORTED("Rectangular masks are not supported");
     }
-    if (mdims[0] > MAX_MORPH_FILTER_LEN) {
+    if (mdims[0] > kernel::MAX_MORPH_FILTER_LEN) {
         CUDA_NOT_SUPPORTED("Kernels > 19x19 are not supported");
     }
     Array<T> out = createEmptyArray<T>(in.dims());


### PR DESCRIPTION
Global constant value of max filter length was not modified
after increasing filter support to 19 from 17 back originally.