### PR TITLE
Fix empty array handling in lu, rank, and qr. Other minor refactoring

### DIFF
--- a/src/api/c/lu.cpp
+++ b/src/api/c/lu.cpp
@@ -49,6 +49,9 @@ af_err af_lu(af_array *lower, af_array *upper, af_array *pivot,
 
         af_dtype type = i_info.getType();
 
+        ARG_ASSERT(0, lower != nullptr);
+        ARG_ASSERT(1, upper != nullptr);
+        ARG_ASSERT(2, pivot != nullptr);
         ARG_ASSERT(3, i_info.isFloating());  // Only floating and complex types
 
         if (i_info.ndims() == 0) {
@@ -81,13 +84,13 @@ af_err af_lu_inplace(af_array *pivot, af_array in, const bool is_lapack_piv) {
         }
 
         ARG_ASSERT(1, i_info.isFloating());  // Only floating and complex types
+        ARG_ASSERT(0, pivot != nullptr);
 
         if (i_info.ndims() == 0) {
             return af_create_handle(pivot, 0, nullptr, type);
         }
 
         af_array out;
-
         switch (type) {
             case f32: out = lu_inplace<float>(in, is_lapack_piv); break;
             case f64: out = lu_inplace<double>(in, is_lapack_piv); break;
@@ -95,7 +98,7 @@ af_err af_lu_inplace(af_array *pivot, af_array in, const bool is_lapack_piv) {
             case c64: out = lu_inplace<cdouble>(in, is_lapack_piv); break;
             default: TYPE_ERROR(1, type);
         }
-        if (pivot != NULL) std::swap(*pivot, out);
+        std::swap(*pivot, out);
     }
     CATCHALL;
 

--- a/src/api/c/median.cpp
+++ b/src/api/c/median.cpp
@@ -41,14 +41,12 @@ static double median(const af_array& in) {
     } else if (nElems == 2) {
         T result[2];
         AF_CHECK(af_get_data_ptr((void*)&result, in));
-        if (input.isFloating()) {
-            return division(result[0] + result[1], 2.0);
-        } else {
-            return division((float)result[0] + (float)result[1], 2.0);
-        }
+        return division(
+            (static_cast<double>(result[0]) + static_cast<double>(result[1])),
+            2.0);
     }
 
-    double mid       = (nElems + 1) / 2;
+    double mid       = static_cast<double>(nElems + 1) / 2.0;
     af_seq mdSpan[1] = {af_make_seq(mid - 1, mid, 1)};
 
     Array<T> sortedArr = sort<T>(input, 0, true);
@@ -68,11 +66,9 @@ static double median(const af_array& in) {
     if (nElems % 2 == 1) {
         result = resPtr[0];
     } else {
-        if (input.isFloating()) {
-            result = division(resPtr[0] + resPtr[1], 2);
-        } else {
-            result = division((float)resPtr[0] + (float)resPtr[1], 2);
-        }
+        result = division(
+            static_cast<double>(resPtr[0]) + static_cast<double>(resPtr[1]),
+            2.0);
     }
 
     return result;
@@ -90,9 +86,9 @@ static af_array median(const af_array& in, const dim_t dim) {
 
     Array<T> sortedIn = sort<T>(input, dim, true);
 
-    int dimLength = input.dims()[dim];
-    double mid    = (dimLength + 1) / 2;
-    af_array left = 0;
+    size_t dimLength = input.dims()[dim];
+    double mid       = static_cast<double>(dimLength + 1) / 2.0;
+    af_array left    = 0;
 
     af_seq slices[4] = {af_span, af_span, af_span, af_span};
     slices[dim]      = af_make_seq(mid - 1.0, mid - 1.0, 1.0);

--- a/src/api/c/qr.cpp
+++ b/src/api/c/qr.cpp
@@ -55,6 +55,9 @@ af_err af_qr(af_array *q, af_array *r, af_array *tau, const af_array in) {
             return AF_SUCCESS;
         }
 
+        ARG_ASSERT(0, q != nullptr);
+        ARG_ASSERT(1, r != nullptr);
+        ARG_ASSERT(2, tau != nullptr);
         ARG_ASSERT(3, i_info.isFloating());  // Only floating and complex types
 
         switch (type) {
@@ -81,13 +84,13 @@ af_err af_qr_inplace(af_array *tau, af_array in) {
         af_dtype type = i_info.getType();
 
         ARG_ASSERT(1, i_info.isFloating());  // Only floating and complex types
+        ARG_ASSERT(0, tau != nullptr);
 
         if (i_info.ndims() == 0) {
             return af_create_handle(tau, 0, nullptr, type);
         }
 
         af_array out;
-
         switch (type) {
             case f32: out = qr_inplace<float>(in); break;
             case f64: out = qr_inplace<double>(in); break;
@@ -95,7 +98,7 @@ af_err af_qr_inplace(af_array *tau, af_array in) {
             case c64: out = qr_inplace<cdouble>(in); break;
             default: TYPE_ERROR(1, type);
         }
-        if (tau != NULL) std::swap(*tau, out);
+        std::swap(*tau, out);
     }
     CATCHALL;
 

--- a/src/api/c/rank.cpp
+++ b/src/api/c/rank.cpp
@@ -56,19 +56,17 @@ af_err af_rank(uint* out, const af_array in, const double tol) {
         af_dtype type = i_info.getType();
 
         ARG_ASSERT(1, i_info.isFloating());  // Only floating and complex types
+        ARG_ASSERT(0, out != nullptr);
 
-        uint output;
-        if (i_info.ndims() == 0) {
-            output = 0;
-            return AF_SUCCESS;
-        }
-
-        switch (type) {
-            case f32: output = rank<float>(in, tol); break;
-            case f64: output = rank<double>(in, tol); break;
-            case c32: output = rank<cfloat>(in, tol); break;
-            case c64: output = rank<cdouble>(in, tol); break;
-            default: TYPE_ERROR(1, type);
+        uint output = 0;
+        if (i_info.ndims() != 0) {
+            switch (type) {
+                case f32: output = rank<float>(in, tol); break;
+                case f64: output = rank<double>(in, tol); break;
+                case c32: output = rank<cfloat>(in, tol); break;
+                case c64: output = rank<cdouble>(in, tol); break;
+                default: TYPE_ERROR(1, type);
+            }
         }
         std::swap(*out, output);
     }

--- a/src/backend/common/DefaultMemoryManager.hpp
+++ b/src/backend/common/DefaultMemoryManager.hpp
@@ -35,11 +35,8 @@ class DefaultMemoryManager final : public common::memory::MemoryManagerBase {
         size_t bytes;
     };
 
-    using locked_t    = typename std::unordered_map<void *, locked_info>;
-    using locked_iter = typename locked_t::iterator;
-
-    using free_t    = std::unordered_map<size_t, std::vector<void *>>;
-    using free_iter = typename free_t::iterator;
+    using locked_t = typename std::unordered_map<void *, locked_info>;
+    using free_t   = std::unordered_map<size_t, std::vector<void *>>;
 
     struct memory_info {
         locked_t locked_map;

--- a/test/lu_dense.cpp
+++ b/test/lu_dense.cpp
@@ -235,3 +235,46 @@ TYPED_TEST(LU, RectangularLarge1) {
 TYPED_TEST(LU, RectangularMultipleOfTwoLarge1) {
     luTester<TypeParam>(512, 1024, eps<TypeParam>());
 }
+
+TEST(LU, NullLowerOutput) {
+    if (noLAPACKTests()) return;
+    dim4 dims(3, 3);
+    af_array in = 0;
+    ASSERT_SUCCESS(af_randu(&in, dims.ndims(), dims.get(), f32));
+
+    af_array upper, pivot;
+    ASSERT_EQ(AF_ERR_ARG, af_lu(NULL, &upper, &pivot, in));
+    ASSERT_SUCCESS(af_release_array(in));
+}
+
+TEST(LU, NullUpperOutput) {
+    if (noLAPACKTests()) return;
+    dim4 dims(3, 3);
+    af_array in = 0;
+    ASSERT_SUCCESS(af_randu(&in, dims.ndims(), dims.get(), f32));
+
+    af_array lower, pivot;
+    ASSERT_EQ(AF_ERR_ARG, af_lu(&lower, NULL, &pivot, in));
+    ASSERT_SUCCESS(af_release_array(in));
+}
+
+TEST(LU, NullPivotOutput) {
+    if (noLAPACKTests()) return;
+    dim4 dims(3, 3);
+    af_array in = 0;
+    ASSERT_SUCCESS(af_randu(&in, dims.ndims(), dims.get(), f32));
+
+    af_array lower, upper;
+    ASSERT_EQ(AF_ERR_ARG, af_lu(&lower, &upper, NULL, in));
+    ASSERT_SUCCESS(af_release_array(in));
+}
+
+TEST(LU, InPlaceNullOutput) {
+    if (noLAPACKTests()) return;
+    dim4 dims(3, 3);
+    af_array in = 0;
+    ASSERT_SUCCESS(af_randu(&in, dims.ndims(), dims.get(), f32));
+
+    ASSERT_EQ(AF_ERR_ARG, af_lu_inplace(NULL, in, true));
+    ASSERT_SUCCESS(af_release_array(in));
+}

--- a/test/median.cpp
+++ b/test/median.cpp
@@ -150,3 +150,18 @@ MEDIAN(float, uchar)
 MEDIAN(float, short)
 MEDIAN(float, ushort)
 MEDIAN(double, double)
+
+TEST(Median, OneElement) {
+    af::array in = randu(1, f32);
+
+    af::array out = median(in);
+    ASSERT_ARRAYS_EQ(in, out);
+}
+
+TEST(Median, TwoElements) {
+    af::array in = randu(2, f32);
+
+    af::array out  = median(in);
+    af::array gold = mean(in);
+    ASSERT_ARRAYS_EQ(gold, out);
+}

--- a/test/memory.cpp
+++ b/test/memory.cpp
@@ -710,7 +710,7 @@ af_err unlock_fn(af_memory_manager manager, void *ptr, int userLock) {
 
 af_err user_unlock_fn(af_memory_manager manager, void *ptr) {
     auto *payload = getMemoryManagerPayload<E2ETestPayload>(manager);
-    af_err err = unlock_fn(manager, ptr, /* user */ 1);
+    af_err err    = unlock_fn(manager, ptr, /* user */ 1);
     payload->lockedBytes -= payload->table[ptr];
     return err;
 }

--- a/test/qr_dense.cpp
+++ b/test/qr_dense.cpp
@@ -179,3 +179,13 @@ TYPED_TEST(QR, RectangularLarge1) {
 TYPED_TEST(QR, RectangularMultipleOfTwoLarge1) {
     qrTester<TypeParam>(512, 1024, eps<TypeParam>());
 }
+
+TEST(QR, InPlaceNullOutput) {
+    if (noLAPACKTests()) return;
+    dim4 dims(3, 3);
+    af_array in = 0;
+    ASSERT_SUCCESS(af_randu(&in, dims.ndims(), dims.get(), f32));
+
+    ASSERT_EQ(AF_ERR_ARG, af_qr_inplace(NULL, in));
+    ASSERT_SUCCESS(af_release_array(in));
+}

--- a/test/rank_dense.cpp
+++ b/test/rank_dense.cpp
@@ -112,3 +112,13 @@ void detTest() {
 }
 
 TYPED_TEST(Det, Small) { detTest<TypeParam>(); }
+
+TEST(Rank, NullOutput) {
+    if (noLAPACKTests()) return;
+    dim4 dims(3, 3);
+    af_array in = 0;
+    af_randu(&in, dims.ndims(), dims.get(), f32);
+
+    ASSERT_EQ(AF_ERR_ARG, af_rank(NULL, in, 1e-6));
+    ASSERT_SUCCESS(af_release_array(in));
+}


### PR DESCRIPTION
* some linear algebra functions could have leaked memory in case the input was null. This PR addresses that potential leak and handles the empty or null array case.
* Minor refactor in median
* Minor refactor in DefaultMemoryManager. Just changed names of the variables.