### PR TITLE
Apply clang-tidy suggestions to all backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ GPATH
 docs/details/examples.dox
 /TAGS
 external/
+extern/
 compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ docs/details/examples.dox
 external/
 extern/
 compile_commands.json
+venv
+test/gtest
+src/backend/cuda/cub

--- a/include/af/features.h
+++ b/include/af/features.h
@@ -38,7 +38,7 @@ namespace af
         ~features();
 
         /// Copy assignment operator
-        features& operator= (const features& f);
+        features& operator= (const features& other);
 
         /// Returns  the number of features represented by this object
         size_t getNumFeatures() const;

--- a/include/af/graphics.h
+++ b/include/af/graphics.h
@@ -83,12 +83,13 @@ class AFAPI Window {
            Creates a window object with default width
            and height with title set to "ArrayFire"
 
-           \param[in] wnd is an \ref af_window handle which can be retrieved by
+           \param[in] window is an \ref af_window handle which can be retrieved
+                             by
            doing a get call on any \ref Window object
 
            \ingroup gfx_func_window
          */
-        Window(const af_window wnd);
+        Window(const af_window window);
 
         /**
            Destroys the window handle

--- a/include/af/random.h
+++ b/include/af/random.h
@@ -53,9 +53,9 @@ namespace af
       /**
           Copy constructor for \ref af::randomEngine.
 
-          \param[in] in The input random engine object
+          \param[in] other The input random engine object
       */
-      randomEngine(const randomEngine &in);
+      randomEngine(const randomEngine &other);
 
       /**
           Creates a copy of the random engine object from a \ref
@@ -73,11 +73,11 @@ namespace af
       /**
           \brief Assigns the internal state of randome engine
 
-          \param[in] in The object to be assigned to the random engine
+          \param[in] other The object to be assigned to the random engine
 
           \returns the reference to this
       */
-      randomEngine &operator=(const randomEngine &in);
+      randomEngine &operator=(const randomEngine &other);
 
       /**
           \brief Sets the random type of the random engine

--- a/include/af/seq.h
+++ b/include/af/seq.h
@@ -111,10 +111,10 @@ public:
 
         Creates a copy seq from another sequence.
 
-        \param[in] afs seqence to be copies
+        \param[in] other seqence to be copies
         \param[in] is_gfor is the gfor flag
     */
-    seq(seq afs, bool is_gfor);
+    seq(seq other, bool is_gfor);
 
     /**
         \brief Create a seq object from an \ref af_seq struct

--- a/src/.clang-tidy
+++ b/src/.clang-tidy
@@ -1,0 +1,391 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,*,-fuchsia-*,-cppcoreguidelines-*,-misc-misplaced-const,-hicpp-no-array-decay,-readability-implicit-bool-conversion,bugprone-*,performance-*,modernize-*,-llvm-header-guard,-hicpp-use-auto,-modernize-use-trailing-return-type,-hicpp-uppercase-literal-suffix,-hicpp-use-nullptr,-modernize-use-nullptr,-google-runtime-int,-llvm-include-order,-google-runtime-references,-readability-magic-numbers,-readability-isolate-declaration,-hicpp-vararg,-google-readability-todo,-bugprone-macro-parentheses,-misc-unused-using-decls,-readability-else-after-return,-hicpp-avoid-c-arrays,-modernize-avoid-c-arrays'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: true
+FormatStyle:     file
+User:            arrayfire
+CheckOptions:
+  - key:             abseil-string-find-startswith.AbseilStringsMatchHeader
+    value:           'absl/strings/match.h'
+  - key:             abseil-string-find-startswith.IncludeStyle
+    value:           llvm
+  - key:             abseil-string-find-startswith.StringLikeClasses
+    value:           '::std::basic_string'
+  - key:             bugprone-argument-comment.CommentBoolLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentCharacterLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentFloatLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentIntegerLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentNullPtrs
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentStringLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.CommentUserDefinedLiterals
+    value:           '0'
+  - key:             bugprone-argument-comment.StrictMode
+    value:           '0'
+  - key:             bugprone-assert-side-effect.AssertMacros
+    value:           assert
+  - key:             bugprone-assert-side-effect.CheckFunctionCalls
+    value:           '0'
+  - key:             bugprone-dangling-handle.HandleClasses
+    value:           'std::basic_string_view;std::experimental::basic_string_view'
+  - key:             bugprone-exception-escape.FunctionsThatShouldNotThrow
+    value:           ''
+  - key:             bugprone-exception-escape.IgnoredExceptions
+    value:           ''
+  - key:             bugprone-misplaced-widening-cast.CheckImplicitCasts
+    value:           '0'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfCompareToConstant
+    value:           '1'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfConstant
+    value:           '1'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfIntegerExpression
+    value:           '0'
+  - key:             bugprone-sizeof-expression.WarnOnSizeOfThis
+    value:           '1'
+  - key:             bugprone-string-constructor.LargeLengthThreshold
+    value:           '8388608'
+  - key:             bugprone-string-constructor.WarnOnLargeLength
+    value:           '1'
+  - key:             bugprone-suspicious-enum-usage.StrictMode
+    value:           '0'
+  - key:             bugprone-suspicious-missing-comma.MaxConcatenatedTokens
+    value:           '5'
+  - key:             bugprone-suspicious-missing-comma.RatioThreshold
+    value:           '0.200000'
+  - key:             bugprone-suspicious-missing-comma.SizeThreshold
+    value:           '5'
+  - key:             bugprone-suspicious-string-compare.StringCompareLikeFunctions
+    value:           ''
+  - key:             bugprone-suspicious-string-compare.WarnOnImplicitComparison
+    value:           '1'
+  - key:             bugprone-suspicious-string-compare.WarnOnLogicalNotComparison
+    value:           '0'
+  - key:             bugprone-too-small-loop-variable.MagnitudeBitsUpperLimit
+    value:           '16'
+  - key:             bugprone-unhandled-self-assignment.WarnOnlyIfThisHasSuspiciousField
+    value:           '1'
+  - key:             bugprone-unused-return-value.CheckedFunctions
+    value:           '::std::async;::std::launder;::std::remove;::std::remove_if;::std::unique;::std::unique_ptr::release;::std::basic_string::empty;::std::vector::empty'
+  - key:             cert-dcl16-c.IgnoreMacros
+    value:           '1'
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-dcl59-cpp.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             cert-err09-cpp.CheckThrowTemporaries
+    value:           '1'
+  - key:             cert-err61-cpp.CheckThrowTemporaries
+    value:           '1'
+  - key:             cert-msc32-c.DisallowedSeedTypes
+    value:           'time_t,std::time_t'
+  - key:             cert-msc51-cpp.DisallowedSeedTypes
+    value:           'time_t,std::time_t'
+  - key:             cert-oop11-cpp.IncludeStyle
+    value:           llvm
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoredFloatingPointValues
+    value:           '1.0;100.0;'
+  - key:             cppcoreguidelines-avoid-magic-numbers.IgnoredIntegerValues
+    value:           '1;2;3;4;'
+  - key:             cppcoreguidelines-explicit-virtual-functions.FinalSpelling
+    value:           final
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-explicit-virtual-functions.OverrideSpelling
+    value:           override
+  - key:             cppcoreguidelines-macro-usage.AllowedRegexp
+    value:           '^DEBUG_*'
+  - key:             cppcoreguidelines-macro-usage.CheckCapsOnly
+    value:           '0'
+  - key:             cppcoreguidelines-macro-usage.IgnoreCommandLineMacros
+    value:           '1'
+  - key:             cppcoreguidelines-no-malloc.Allocations
+    value:           '::malloc;::calloc'
+  - key:             cppcoreguidelines-no-malloc.Deallocations
+    value:           '::free'
+  - key:             cppcoreguidelines-no-malloc.Reallocations
+    value:           '::realloc'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             cppcoreguidelines-owning-memory.LegacyResourceConsumers
+    value:           '::free;::realloc;::freopen;::fclose'
+  - key:             cppcoreguidelines-owning-memory.LegacyResourceProducers
+    value:           '::malloc;::aligned_alloc;::realloc;::calloc;::fopen;::freopen;::tmpfile'
+  - key:             cppcoreguidelines-pro-bounds-constant-array-index.GslHeader
+    value:           ''
+  - key:             cppcoreguidelines-pro-bounds-constant-array-index.IncludeStyle
+    value:           '0'
+  - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
+    value:           '0'
+  - key:             cppcoreguidelines-pro-type-member-init.UseAssignment
+    value:           '0'
+  - key:             cppcoreguidelines-special-member-functions.AllowMissingMoveFunctions
+    value:           '0'
+  - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value:           '0'
+  - key:             fuchsia-header-anon-namespaces.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             fuchsia-restrict-system-includes.Includes
+    value:           '*'
+  - key:             google-build-namespaces.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             google-global-names-in-headers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-function-size.VariableThreshold
+    value:           '4294967295'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             google-runtime-int.SignedTypePrefix
+    value:           int
+  - key:             google-runtime-int.TypeSuffix
+    value:           ''
+  - key:             google-runtime-int.UnsignedTypePrefix
+    value:           uint
+  - key:             google-runtime-references.WhiteListTypes
+    value:           ''
+  - key:             hicpp-braces-around-statements.ShortStatementLines
+    value:           '0'
+  - key:             hicpp-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             hicpp-function-size.StatementThreshold
+    value:           '800'
+  - key:             hicpp-function-size.VariableThreshold
+    value:           '4294967295'
+  - key:             hicpp-member-init.IgnoreArrays
+    value:           '0'
+  - key:             hicpp-member-init.UseAssignment
+    value:           '0'
+  - key:             hicpp-move-const-arg.CheckTriviallyCopyableMove
+    value:           '1'
+  - key:             hicpp-multiway-paths-covered.WarnOnMissingElse
+    value:           '0'
+  - key:             hicpp-named-parameter.IgnoreFailedSplit
+    value:           '0'
+  - key:             hicpp-no-malloc.Allocations
+    value:           '::malloc;::calloc'
+  - key:             hicpp-no-malloc.Deallocations
+    value:           '::free'
+  - key:             hicpp-no-malloc.Reallocations
+    value:           '::realloc'
+  - key:             hicpp-signed-bitwise.IgnorePositiveIntegerLiterals
+    value:           'true'
+  - key:             hicpp-special-member-functions.AllowMissingMoveFunctions
+    value:           '0'
+  - key:             hicpp-special-member-functions.AllowSoleDefaultDtor
+    value:           '0'
+  - key:             hicpp-uppercase-literal-suffix.IgnoreMacros
+    value:           '1'
+  - key:             hicpp-uppercase-literal-suffix.NewSuffixes
+    value:           ''
+  - key:             hicpp-use-auto.MinTypeNameLength
+    value:           '5'
+  - key:             hicpp-use-auto.RemoveStars
+    value:           '0'
+  - key:             hicpp-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             hicpp-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             hicpp-use-emplace.TupleMakeFunctions
+    value:           '::std::make_pair;::std::make_tuple'
+  - key:             hicpp-use-emplace.TupleTypes
+    value:           '::std::pair;::std::tuple'
+  - key:             hicpp-use-equals-default.IgnoreMacros
+    value:           '1'
+  - key:             hicpp-use-equals-delete.IgnoreMacros
+    value:           '1'
+  - key:             hicpp-use-noexcept.ReplacementString
+    value:           ''
+  - key:             hicpp-use-noexcept.UseNoexceptFalse
+    value:           '1'
+  - key:             hicpp-use-nullptr.NullMacros
+    value:           ''
+  - key:             hicpp-use-override.FinalSpelling
+    value:           final
+  - key:             hicpp-use-override.IgnoreDestructors
+    value:           '0'
+  - key:             hicpp-use-override.OverrideSpelling
+    value:           override
+  - key:             llvm-namespace-comment.ShortNamespaceLines
+    value:           '1'
+  - key:             llvm-namespace-comment.SpacesBeforeComments
+    value:           '1'
+  - key:             misc-definitions-in-headers.HeaderFileExtensions
+    value:           ',h,hh,hpp,hxx'
+  - key:             misc-definitions-in-headers.UseHeaderFileExtension
+    value:           '1'
+  - key:             misc-throw-by-value-catch-by-reference.CheckThrowTemporaries
+    value:           '1'
+  - key:             misc-unused-parameters.StrictMode
+    value:           '0'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-make-shared.IgnoreMacros
+    value:           '1'
+  - key:             modernize-make-shared.IncludeStyle
+    value:           '0'
+  - key:             modernize-make-shared.MakeSmartPtrFunction
+    value:           'std::make_shared'
+  - key:             modernize-make-shared.MakeSmartPtrFunctionHeader
+    value:           memory
+  - key:             modernize-make-unique.IgnoreMacros
+    value:           '1'
+  - key:             modernize-make-unique.IncludeStyle
+    value:           '0'
+  - key:             modernize-make-unique.MakeSmartPtrFunction
+    value:           'std::make_unique'
+  - key:             modernize-make-unique.MakeSmartPtrFunctionHeader
+    value:           memory
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-pass-by-value.ValuesOnly
+    value:           '0'
+  - key:             modernize-raw-string-literal.ReplaceShorterLiterals
+    value:           '0'
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-random-shuffle.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-auto.MinTypeNameLength
+    value:           '5'
+  - key:             modernize-use-auto.RemoveStars
+    value:           '0'
+  - key:             modernize-use-default-member-init.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-default-member-init.UseAssignment
+    value:           '0'
+  - key:             modernize-use-emplace.ContainersWithPushBack
+    value:           '::std::vector;::std::list;::std::deque'
+  - key:             modernize-use-emplace.SmartPointers
+    value:           '::std::shared_ptr;::std::unique_ptr;::std::auto_ptr;::std::weak_ptr'
+  - key:             modernize-use-emplace.TupleMakeFunctions
+    value:           '::std::make_pair;::std::make_tuple'
+  - key:             modernize-use-emplace.TupleTypes
+    value:           '::std::pair;::std::tuple'
+  - key:             modernize-use-equals-default.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-equals-delete.IgnoreMacros
+    value:           '1'
+  - key:             modernize-use-nodiscard.ReplacementString
+    value:           '[[nodiscard]]'
+  - key:             modernize-use-noexcept.ReplacementString
+    value:           ''
+  - key:             modernize-use-noexcept.UseNoexceptFalse
+    value:           '1'
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+  - key:             modernize-use-override.FinalSpelling
+    value:           final
+  - key:             modernize-use-override.IgnoreDestructors
+    value:           '0'
+  - key:             modernize-use-override.OverrideSpelling
+    value:           override
+  - key:             modernize-use-transparent-functors.SafeMode
+    value:           '0'
+  - key:             modernize-use-using.IgnoreMacros
+    value:           '1'
+  - key:             objc-forbidden-subclassing.ForbiddenSuperClassNames
+    value:           'ABNewPersonViewController;ABPeoplePickerNavigationController;ABPersonViewController;ABUnknownPersonViewController;NSHashTable;NSMapTable;NSPointerArray;NSPointerFunctions;NSTimer;UIActionSheet;UIAlertView;UIImagePickerController;UITextInputMode;UIWebView'
+  - key:             openmp-exception-escape.IgnoredExceptions
+    value:           ''
+  - key:             performance-faster-string-find.StringLikeClasses
+    value:           'std::basic_string'
+  - key:             performance-for-range-copy.AllowedTypes
+    value:           ''
+  - key:             performance-for-range-copy.WarnOnAllAutoCopies
+    value:           '0'
+  - key:             performance-inefficient-string-concatenation.StrictMode
+    value:           '0'
+  - key:             performance-inefficient-vector-operation.VectorLikeClasses
+    value:           '::std::vector'
+  - key:             performance-move-const-arg.CheckTriviallyCopyableMove
+    value:           '1'
+  - key:             performance-move-constructor-init.IncludeStyle
+    value:           llvm
+  - key:             performance-type-promotion-in-math-fn.IncludeStyle
+    value:           llvm
+  - key:             performance-unnecessary-copy-initialization.AllowedTypes
+    value:           'Array$;SparseArray*'
+  - key:             performance-unnecessary-value-param.AllowedTypes
+    value:           'CParam'
+  - key:             performance-unnecessary-value-param.IncludeStyle
+    value:           llvm
+  - key:             portability-simd-intrinsics.Std
+    value:           ''
+  - key:             portability-simd-intrinsics.Suggest
+    value:           '0'
+  - key:             readability-braces-around-statements.ShortStatementLines
+    value:           '0'
+  - key:             readability-function-size.BranchThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.LineThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.NestingThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.ParameterThreshold
+    value:           '4294967295'
+  - key:             readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             readability-function-size.VariableThreshold
+    value:           '4294967295'
+  - key:             readability-identifier-naming.IgnoreFailedSplit
+    value:           '0'
+  - key:             readability-implicit-bool-conversion.AllowIntegerConditions
+    value:           '0'
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           '0'
+  - key:             readability-inconsistent-declaration-parameter-name.IgnoreMacros
+    value:           '1'
+  - key:             readability-inconsistent-declaration-parameter-name.Strict
+    value:           '0'
+  - key:             readability-magic-numbers.IgnoredFloatingPointValues
+    value:           '1.0;100.0;'
+  - key:             readability-magic-numbers.IgnoredIntegerValues
+    value:           '1;2;3;4;'
+  - key:             readability-redundant-smartptr-get.IgnoreMacros
+    value:           '1'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalAssignment
+    value:           '0'
+  - key:             readability-simplify-boolean-expr.ChainedConditionalReturn
+    value:           '0'
+  - key:             readability-simplify-subscript-expr.Types
+    value:           '::std::basic_string;::std::basic_string_view;::std::vector;::std::array'
+  - key:             readability-static-accessed-through-instance.NameSpecifierNestingThreshold
+    value:           '3'
+  - key:             readability-uppercase-literal-suffix.IgnoreMacros
+    value:           '1'
+  - key:             readability-uppercase-literal-suffix.NewSuffixes
+    value:           'f,U,L,UL,LL,ULL'
+  - key:             zircon-temporary-objects.Names
+    value:           ''
+...

--- a/src/api/c/anisotropic_diffusion.cpp
+++ b/src/api/c/anisotropic_diffusion.cpp
@@ -17,23 +17,24 @@
 #include <gradient.hpp>
 #include <handle.hpp>
 #include <reduce.hpp>
+
 #include <af/dim4.hpp>
 #include <af/image.h>
 
 #include <type_traits>
 
 using af::dim4;
-using namespace detail;
 
 template<typename T>
-af_array diffusion(const Array<float> in, const float dt, const float K,
+af_array diffusion(const Array<float>& in, const float dt, const float K,
                    const unsigned iterations, const af_flux_function fftype,
                    const af::diffusionEq eq) {
-    auto out   = copyArray(in);
-    auto dims  = out.dims();
-    auto g0    = createEmptyArray<float>(dims);
-    auto g1    = createEmptyArray<float>(dims);
-    float cnst = -2.0f * K * K / dims.elements();
+    auto out  = copyArray(in);
+    auto dims = out.dims();
+    auto g0   = createEmptyArray<float>(dims);
+    auto g1   = createEmptyArray<float>(dims);
+    float cnst =
+        -2.0f * K * K / dims.elements();  // NOLINT(readability-magic-numbers)
 
     for (unsigned i = 0; i < iterations; ++i) {
         gradient<float>(g0, g1, out);
@@ -71,7 +72,7 @@ af_err af_anisotropic_diffusion(af_array* out, const af_array in,
 
         auto input = castArray<float>(in);
 
-        af_array output = 0;
+        af_array output = nullptr;
         switch (inputType) {
             case f64:
                 output = diffusion<double>(input, dt, K, iterations, F, eq);

--- a/src/api/c/approx.cpp
+++ b/src/api/c/approx.cpp
@@ -19,7 +19,10 @@
 #include <af/signal.h>
 
 using af::dim4;
-using namespace detail;
+using detail::approx1;
+using detail::approx2;
+using detail::cdouble;
+using detail::cfloat;
 
 namespace {
 template<typename Ty, typename Tp>
@@ -53,10 +56,10 @@ void af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
     const ArrayInfo &yi_info = getInfo(yi);
     const ArrayInfo &xo_info = getInfo(xo);
 
-    const dim4 yi_dims = yi_info.dims();
-    const dim4 xo_dims = xo_info.dims();
-    dim4 yo_dims       = yi_dims;
-    yo_dims[xdim]      = xo_dims[xdim];
+    const dim4 &yi_dims = yi_info.dims();
+    const dim4 &xo_dims = xo_info.dims();
+    dim4 yo_dims        = yi_dims;
+    yo_dims[xdim]       = xo_dims[xdim];
 
     ARG_ASSERT(1, yi_info.isFloating());      // Only floating and complex types
     ARG_ASSERT(2, xo_info.isRealFloating());  // Only floating types
@@ -70,7 +73,7 @@ void af_approx1_common(af_array *yo, const af_array yi, const af_array xo,
     // yi_dims[3])
     if (xo_dims[xdim] != xo_dims.elements()) {
         for (int i = 0; i < 4; i++) {
-            if (xdim != i) DIM_ASSERT(2, xo_dims[i] == yi_dims[i]);
+            if (xdim != i) { DIM_ASSERT(2, xo_dims[i] == yi_dims[i]); }
         }
     }
 
@@ -196,7 +199,9 @@ void af_approx2_common(af_array *zo, const af_array zi, const af_array xo,
     // POS should either be (x, y, 1, 1) or (x, y, zi_dims[2], zi_dims[3])
     if (xo_dims[xdim] * xo_dims[ydim] != xo_dims.elements()) {
         for (int i = 0; i < 4; i++) {
-            if (xdim != i && ydim != i) DIM_ASSERT(2, xo_dims[i] == zi_dims[i]);
+            if (xdim != i && ydim != i) {
+                DIM_ASSERT(2, xo_dims[i] == zi_dims[i]);
+            }
         }
     }
 

--- a/src/api/c/array.cpp
+++ b/src/api/c/array.cpp
@@ -23,6 +23,7 @@ using detail::cdouble;
 using detail::cfloat;
 using detail::intl;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
 using detail::ushort;
 

--- a/src/api/c/array.cpp
+++ b/src/api/c/array.cpp
@@ -16,14 +16,17 @@
 #include <sparse_handle.hpp>
 #include <af/sparse.h>
 
-using namespace detail;
-
+using af::dim4;
 using common::half;
 using common::SparseArrayBase;
+using detail::cdouble;
+using detail::cfloat;
+using detail::intl;
+using detail::uchar;
+using detail::uintl;
+using detail::ushort;
 
-af_array createHandle(const af::dim4 &d, af_dtype dtype) {
-    using namespace detail;
-
+af_array createHandle(const dim4 &d, af_dtype dtype) {
     // clang-format off
     switch (dtype) {
         case f32: return createHandle<float  >(d);
@@ -44,9 +47,7 @@ af_array createHandle(const af::dim4 &d, af_dtype dtype) {
     // clang-format on
 }
 
-af_array createHandleFromValue(const af::dim4 &d, double val, af_dtype dtype) {
-    using namespace detail;
-
+af_array createHandleFromValue(const dim4 &d, double val, af_dtype dtype) {
     // clang-format off
     switch (dtype) {
         case f32: return createHandleFromValue<float  >(d, val);
@@ -161,7 +162,7 @@ af_err af_create_handle(af_array *result, const unsigned ndims,
     try {
         AF_CHECK(af_init());
 
-        if (ndims > 0) ARG_ASSERT(2, ndims > 0 && dims != NULL);
+        if (ndims > 0) { ARG_ASSERT(2, ndims > 0 && dims != NULL); }
 
         dim4 d(0);
         for (unsigned i = 0; i < ndims; i++) { d[i] = dims[i]; }
@@ -181,40 +182,39 @@ af_err af_copy_array(af_array *out, const af_array in) {
 
         af_array res = 0;
         if (info.isSparse()) {
-            SparseArrayBase sbase = getSparseArrayBase(in);
+            const SparseArrayBase sbase = getSparseArrayBase(in);
             if (info.ndims() == 0) {
                 return af_create_sparse_array_from_ptr(
                     out, info.dims()[0], info.dims()[1], 0, nullptr, nullptr,
                     nullptr, type, sbase.getStorage(), afDevice);
-            } else {
-                switch (type) {
-                    case f32: res = copySparseArray<float>(in); break;
-                    case f64: res = copySparseArray<double>(in); break;
-                    case c32: res = copySparseArray<cfloat>(in); break;
-                    case c64: res = copySparseArray<cdouble>(in); break;
-                    default: TYPE_ERROR(0, type);
-                }
             }
+            switch (type) {
+                case f32: res = copySparseArray<float>(in); break;
+                case f64: res = copySparseArray<double>(in); break;
+                case c32: res = copySparseArray<cfloat>(in); break;
+                case c64: res = copySparseArray<cdouble>(in); break;
+                default: TYPE_ERROR(0, type);
+            }
+
         } else {
             if (info.ndims() == 0) {
                 return af_create_handle(out, 0, nullptr, type);
-            } else {
-                switch (type) {
-                    case f32: res = copyArray<float>(in); break;
-                    case c32: res = copyArray<cfloat>(in); break;
-                    case f64: res = copyArray<double>(in); break;
-                    case c64: res = copyArray<cdouble>(in); break;
-                    case b8: res = copyArray<char>(in); break;
-                    case s32: res = copyArray<int>(in); break;
-                    case u32: res = copyArray<uint>(in); break;
-                    case u8: res = copyArray<uchar>(in); break;
-                    case s64: res = copyArray<intl>(in); break;
-                    case u64: res = copyArray<uintl>(in); break;
-                    case s16: res = copyArray<short>(in); break;
-                    case u16: res = copyArray<ushort>(in); break;
-                    case f16: res = copyArray<half>(in); break;
-                    default: TYPE_ERROR(1, type);
-                }
+            }
+            switch (type) {
+                case f32: res = copyArray<float>(in); break;
+                case c32: res = copyArray<cfloat>(in); break;
+                case f64: res = copyArray<double>(in); break;
+                case c64: res = copyArray<cdouble>(in); break;
+                case b8: res = copyArray<char>(in); break;
+                case s32: res = copyArray<int>(in); break;
+                case u32: res = copyArray<uint>(in); break;
+                case u8: res = copyArray<uchar>(in); break;
+                case s64: res = copyArray<intl>(in); break;
+                case u64: res = copyArray<uintl>(in); break;
+                case s16: res = copyArray<short>(in); break;
+                case u16: res = copyArray<ushort>(in); break;
+                case f16: res = copyArray<half>(in); break;
+                default: TYPE_ERROR(1, type);
             }
         }
         std::swap(*out, res);
@@ -254,7 +254,7 @@ af_err af_get_data_ref_count(int *use_count, const af_array in) {
 
 af_err af_release_array(af_array arr) {
     try {
-        if (arr == 0) return AF_SUCCESS;
+        if (arr == 0) { return AF_SUCCESS; }
         const ArrayInfo &info = getInfo(arr, false, false);
         af_dtype type         = info.getType();
 
@@ -338,7 +338,6 @@ void write_array(af_array arr, const T *const data, const size_t bytes,
     } else {
         writeDeviceDataArray(getArray<T>(arr), data, bytes);
     }
-    return;
 }
 
 af_err af_write_array(af_array arr, const void *data, const size_t bytes,

--- a/src/api/c/assign.cpp
+++ b/src/api/c/assign.cpp
@@ -40,6 +40,7 @@ using detail::cfloat;
 using detail::createSubArray;
 using detail::intl;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
 using detail::ushort;
 

--- a/src/api/c/assign.cpp
+++ b/src/api/c/assign.cpp
@@ -24,18 +24,24 @@
 #include <af/dim4.hpp>
 #include <af/index.h>
 
-using namespace detail;
-
-using std::enable_if;
 using std::signbit;
 using std::swap;
 using std::vector;
 
+using af::dim4;
 using common::convert2Canonical;
 using common::createSpanIndex;
 using common::half;
 using common::if_complex;
 using common::if_real;
+using detail::Array;
+using detail::cdouble;
+using detail::cfloat;
+using detail::createSubArray;
+using detail::intl;
+using detail::uchar;
+using detail::uintl;
+using detail::ushort;
 
 template<typename Tout, typename Tin>
 static void assign(Array<Tout>& out, const vector<af_seq> seqs,
@@ -44,23 +50,23 @@ static void assign(Array<Tout>& out, const vector<af_seq> seqs,
     const dim4& outDs = out.dims();
     const dim4& iDims = in.dims();
 
-    if (iDims.elements() == 0) return;
+    if (iDims.elements() == 0) { return; }
 
     out.eval();
 
     dim4 oDims = toDims(seqs, outDs);
 
     bool isVec = true;
-    for (int i = 0; isVec && i < (int)oDims.ndims() - 1; i++) {
+    for (int i = 0; isVec && i < static_cast<int>(oDims.ndims()) - 1; i++) {
         isVec &= oDims[i] == 1;
     }
 
     isVec &= in.isVector() || in.isScalar();
 
-    for (dim_t i = ndims; i < (int)in.ndims(); i++) { oDims[i] = 1; }
+    for (dim_t i = ndims; i < in.ndims(); i++) { oDims[i] = 1; }
 
     if (isVec) {
-        if (oDims.elements() != (dim_t)in.elements() && in.elements() != 1) {
+        if (oDims.elements() != in.elements() && in.elements() != 1) {
             AF_ERROR("Size mismatch between input and output", AF_ERR_SIZE);
         }
 
@@ -73,8 +79,9 @@ static void assign(Array<Tout>& out, const vector<af_seq> seqs,
         copyArray<Tin, Tout>(dst, in_);
     } else {
         for (int i = 0; i < AF_MAX_DIMS; i++) {
-            if (oDims[i] != iDims[i])
+            if (oDims[i] != iDims[i]) {
                 AF_ERROR("Size mismatch between input and output", AF_ERR_SIZE);
+            }
         }
         Array<Tout> dst = createSubArray<Tout>(out, seqs, false);
 
@@ -126,7 +133,8 @@ af_err af_assign_seq(af_array* out, const af_array lhs, const unsigned ndims,
         const ArrayInfo& lInfo = getInfo(lhs);
 
         if (ndims == 1 && ndims != lInfo.ndims()) {
-            af_array tmp_in, tmp_out;
+            af_array tmp_in;
+            af_array tmp_out;
             AF_CHECK(af_flat(&tmp_in, lhs));
             AF_CHECK(af_assign_seq(&tmp_out, tmp_in, ndims, index, rhs));
             AF_CHECK(
@@ -135,7 +143,7 @@ af_err af_assign_seq(af_array* out, const af_array lhs, const unsigned ndims,
             // This can run into a double free issue if tmp_in == tmp_out
             // The condition ensures release only if both are different
             // Issue found on Tegra X1
-            if (tmp_in != tmp_out) AF_CHECK(af_release_array(tmp_out));
+            if (tmp_in != tmp_out) { AF_CHECK(af_release_array(tmp_out)); }
             return AF_SUCCESS;
         }
 
@@ -144,10 +152,11 @@ af_err af_assign_seq(af_array* out, const af_array lhs, const unsigned ndims,
         if (*out != lhs) {
             int count = 0;
             AF_CHECK(af_get_data_ref_count(&count, lhs));
-            if (count > 1)
+            if (count > 1) {
                 AF_CHECK(af_copy_array(&res, lhs));
-            else
+            } else {
                 res = retain(lhs);
+            }
         } else {
             res = lhs;
         }
@@ -223,7 +232,7 @@ af_err af_assign_gen(af_array* out, const af_array lhs, const dim_t ndims,
         }
 
         af_array rhs = rhs_;
-        if (track == (int)ndims) {
+        if (track == static_cast<int>(ndims)) {
             // all indexs are sequences, redirecting to af_assign
             return af_assign_seq(out, lhs, ndims, seqs.data(), rhs);
         }
@@ -238,15 +247,17 @@ af_err af_assign_gen(af_array* out, const af_array lhs, const dim_t ndims,
         af_dtype lhsType       = lInfo.getType();
         af_dtype rhsType       = rInfo.getType();
 
-        if (rhsDims.ndims() == 0) return af_retain_array(out, lhs);
+        if (rhsDims.ndims() == 0) { return af_retain_array(out, lhs); }
 
-        if (lhsDims.ndims() == 0)
+        if (lhsDims.ndims() == 0) {
             return af_create_handle(out, 0, nullptr, lhsType);
+        }
 
         ARG_ASSERT(2, (ndims == 1) || (ndims == (dim_t)lInfo.ndims()));
 
-        if (ndims == 1 && ndims != (dim_t)lInfo.ndims()) {
-            af_array tmp_in = 0, tmp_out = 0;
+        if (ndims == 1 && ndims != static_cast<dim_t>(lInfo.ndims())) {
+            af_array tmp_in  = 0;
+            af_array tmp_out = 0;
             AF_CHECK(af_flat(&tmp_in, lhs));
             AF_CHECK(af_assign_gen(&tmp_out, tmp_in, ndims, indexs, rhs_));
             AF_CHECK(
@@ -255,7 +266,7 @@ af_err af_assign_gen(af_array* out, const af_array lhs, const dim_t ndims,
             // This can run into a double free issue if tmp_in == tmp_out
             // The condition ensures release only if both are different
             // Issue found on Tegra X1
-            if (tmp_in != tmp_out) AF_CHECK(af_release_array(tmp_out));
+            if (tmp_in != tmp_out) { AF_CHECK(af_release_array(tmp_out)); }
             return AF_SUCCESS;
         }
 
@@ -269,8 +280,9 @@ af_err af_assign_gen(af_array* out, const af_array lhs, const dim_t ndims,
             AF_CHECK(af_get_data_ref_count(&count, lhs));
             if (count > 1) {
                 AF_CHECK(af_copy_array(&output, lhs));
-            } else
+            } else {
                 output = retain(lhs);
+            }
         } else {
             output = lhs;
         }
@@ -280,21 +292,24 @@ af_err af_assign_gen(af_array* out, const af_array lhs, const dim_t ndims,
         // particular dimension, set the length of
         // that dimension accordingly before any checks
         for (dim_t i = 0; i < ndims; i++) {
-            if (!indexs[i].isSeq)
+            if (!indexs[i].isSeq) {
                 oDims[i] = getInfo(indexs[i].idx.arr).elements();
+            }
         }
 
-        for (dim_t i = ndims; i < (dim_t)lInfo.ndims(); i++) oDims[i] = 1;
+        for (dim_t i = ndims; i < static_cast<dim_t>(lInfo.ndims()); i++) {
+            oDims[i] = 1;
+        }
 
         bool isVec = true;
         for (int i = 0; isVec && i < oDims.ndims() - 1; i++) {
             isVec &= oDims[i] == 1;
         }
 
-        // TODO: Move logic out of this
+        // TODO(umar): Move logic out of this
         isVec &= rInfo.isVector() || rInfo.isScalar();
         if (isVec) {
-            if (oDims.elements() != (dim_t)rInfo.elements() &&
+            if (oDims.elements() != static_cast<dim_t>(rInfo.elements()) &&
                 rInfo.elements() != 1) {
                 AF_ERROR("Size mismatch between input and output", AF_ERR_SIZE);
             }
@@ -308,13 +323,14 @@ af_err af_assign_gen(af_array* out, const af_array lhs, const dim_t ndims,
             }
         } else {
             for (int i = 0; i < AF_MAX_DIMS; i++) {
-                if (oDims[i] != rhsDims[i])
+                if (oDims[i] != rhsDims[i]) {
                     AF_ERROR("Size mismatch between input and output",
                              AF_ERR_SIZE);
+                }
             }
         }
 
-        std::array<af_index_t, AF_MAX_DIMS> idxrs;
+        std::array<af_index_t, AF_MAX_DIMS> idxrs{};
         for (dim_t i = 0; i < AF_MAX_DIMS; ++i) {
             if (i < ndims) {
                 bool isSeq = indexs[i].isSeq;
@@ -370,11 +386,11 @@ af_err af_assign_gen(af_array* out, const af_array lhs, const dim_t ndims,
         } catch (...) {
             if (*out != lhs) {
                 AF_CHECK(af_release_array(output));
-                if (isVec) AF_CHECK(af_release_array(rhs));
+                if (isVec) { AF_CHECK(af_release_array(rhs)); }
             }
             throw;
         }
-        if (isVec) AF_CHECK(af_release_array(rhs));
+        if (isVec) { AF_CHECK(af_release_array(rhs)); }
         swap(*out, output);
     }
     CATCHALL;

--- a/src/api/c/bilateral.cpp
+++ b/src/api/c/bilateral.cpp
@@ -16,7 +16,9 @@
 #include <af/image.h>
 
 using af::dim4;
-using namespace detail;
+using detail::bilateral;
+using detail::uchar;
+using detail::uint;
 
 template<typename inType, typename outType, bool isColor>
 static inline af_array bilateral(const af_array &in, const float &sp_sig,
@@ -74,8 +76,11 @@ static af_err bilateral(af_array *out, const af_array &in, const float &s_sigma,
 
 af_err af_bilateral(af_array *out, const af_array in, const float spatial_sigma,
                     const float chromatic_sigma, const bool isColor) {
-    if (isColor)
-        return bilateral<true>(out, in, spatial_sigma, chromatic_sigma);
-    else
-        return bilateral<false>(out, in, spatial_sigma, chromatic_sigma);
+    af_err err = AF_ERR_UNKNOWN;
+    if (isColor) {
+        err = bilateral<true>(out, in, spatial_sigma, chromatic_sigma);
+    } else {
+        err = bilateral<false>(out, in, spatial_sigma, chromatic_sigma);
+    }
+    return err;
 }

--- a/src/api/c/bilateral.cpp
+++ b/src/api/c/bilateral.cpp
@@ -19,6 +19,7 @@ using af::dim4;
 using detail::bilateral;
 using detail::uchar;
 using detail::uint;
+using detail::ushort;
 
 template<typename inType, typename outType, bool isColor>
 static inline af_array bilateral(const af_array &in, const float &sp_sig,

--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -34,6 +34,7 @@ using detail::cdouble;
 using detail::cfloat;
 using detail::intl;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
 using detail::ushort;
 

--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -32,8 +32,8 @@ using detail::arithOp;
 using detail::arithOpD;
 using detail::cdouble;
 using detail::cfloat;
-using detail::uchar;
 using detail::intl;
+using detail::uchar;
 using detail::uintl;
 using detail::ushort;
 

--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -26,9 +26,16 @@
 
 #include <common/half.hpp>
 
-using namespace detail;
 using af::dim4;
 using common::half;
+using detail::arithOp;
+using detail::arithOpD;
+using detail::cdouble;
+using detail::cfloat;
+using detail::uchar;
+using detail::intl;
+using detail::uintl;
+using detail::ushort;
 
 template<typename T, af_op_t op>
 static inline af_array arithOp(const af_array lhs, const af_array rhs,
@@ -48,12 +55,14 @@ template<typename T, af_op_t op>
 static inline af_array arithSparseDenseOp(const af_array lhs,
                                           const af_array rhs,
                                           const bool reverse) {
-    if (op == af_add_t || op == af_sub_t)
+    if (op == af_add_t || op == af_sub_t) {
         return getHandle(
             arithOpD<T, op>(castSparse<T>(lhs), castArray<T>(rhs), reverse));
-    else if (op == af_mul_t || op == af_div_t)
+    }
+    if (op == af_mul_t || op == af_div_t) {
         return getHandle(
             arithOp<T, op>(castSparse<T>(lhs), castArray<T>(rhs), reverse));
+    }
 }
 
 template<af_op_t op>
@@ -115,7 +124,6 @@ static af_err af_arith_real(af_array *out, const af_array lhs,
             case f16: res = arithOp<half, op>(lhs, rhs, odims); break;
             default: TYPE_ERROR(0, otype);
         }
-
         std::swap(*out, res);
     }
     CATCHALL;
@@ -126,8 +134,8 @@ template<af_op_t op>
 static af_err af_arith_sparse(af_array *out, const af_array lhs,
                               const af_array rhs) {
     try {
-        common::SparseArrayBase linfo = getSparseArrayBase(lhs);
-        common::SparseArrayBase rinfo = getSparseArrayBase(rhs);
+        const common::SparseArrayBase linfo = getSparseArrayBase(lhs);
+        const common::SparseArrayBase rinfo = getSparseArrayBase(rhs);
 
         ARG_ASSERT(1, (linfo.getStorage() == rinfo.getStorage()));
         ARG_ASSERT(1, (linfo.dims() == rinfo.dims()));
@@ -153,10 +161,9 @@ template<af_op_t op>
 static af_err af_arith_sparse_dense(af_array *out, const af_array lhs,
                                     const af_array rhs,
                                     const bool reverse = false) {
-    using namespace common;
     try {
-        common::SparseArrayBase linfo = getSparseArrayBase(lhs);
-        ArrayInfo rinfo               = getInfo(rhs);
+        const common::SparseArrayBase linfo = getSparseArrayBase(lhs);
+        const ArrayInfo &rinfo              = getInfo(rhs);
 
         const af_dtype otype = implicit(linfo.getType(), rinfo.getType());
         af_array res;
@@ -185,82 +192,86 @@ static af_err af_arith_sparse_dense(af_array *out, const af_array lhs,
 af_err af_add(af_array *out, const af_array lhs, const af_array rhs,
               const bool batchMode) {
     // Check if inputs are sparse
-    ArrayInfo linfo = getInfo(lhs, false, true);
-    ArrayInfo rinfo = getInfo(rhs, false, true);
+    const ArrayInfo &linfo = getInfo(lhs, false, true);
+    const ArrayInfo &rinfo = getInfo(rhs, false, true);
 
     if (linfo.isSparse() && rinfo.isSparse()) {
         return af_arith_sparse<af_add_t>(out, lhs, rhs);
-    } else if (linfo.isSparse() && !rinfo.isSparse()) {
+    }
+    if (linfo.isSparse() && !rinfo.isSparse()) {
         return af_arith_sparse_dense<af_add_t>(out, lhs, rhs);
-    } else if (!linfo.isSparse() && rinfo.isSparse()) {
+    }
+    if (!linfo.isSparse() && rinfo.isSparse()) {
         // second operand(Array) of af_arith call should be dense
         return af_arith_sparse_dense<af_add_t>(out, rhs, lhs, true);
-    } else {
-        return af_arith<af_add_t>(out, lhs, rhs, batchMode);
     }
+    return af_arith<af_add_t>(out, lhs, rhs, batchMode);
 }
 
 af_err af_mul(af_array *out, const af_array lhs, const af_array rhs,
               const bool batchMode) {
     // Check if inputs are sparse
-    ArrayInfo linfo = getInfo(lhs, false, true);
-    ArrayInfo rinfo = getInfo(rhs, false, true);
+    const ArrayInfo &linfo = getInfo(lhs, false, true);
+    const ArrayInfo &rinfo = getInfo(rhs, false, true);
 
     if (linfo.isSparse() && rinfo.isSparse()) {
         // return af_arith_sparse<af_mul_t>(out, lhs, rhs);
         // MKL doesn't have mul or div support yet, hence
         // this is commented out although alternative cpu code exists
         return AF_ERR_NOT_SUPPORTED;
-    } else if (linfo.isSparse() && !rinfo.isSparse()) {
+    }
+    if (linfo.isSparse() && !rinfo.isSparse()) {
         return af_arith_sparse_dense<af_mul_t>(out, lhs, rhs);
-    } else if (!linfo.isSparse() && rinfo.isSparse()) {
+    }
+    if (!linfo.isSparse() && rinfo.isSparse()) {
         return af_arith_sparse_dense<af_mul_t>(out, rhs, lhs,
                                                true);  // dense should be rhs
-    } else {
-        return af_arith<af_mul_t>(out, lhs, rhs, batchMode);
     }
+    return af_arith<af_mul_t>(out, lhs, rhs, batchMode);
 }
 
 af_err af_sub(af_array *out, const af_array lhs, const af_array rhs,
               const bool batchMode) {
     // Check if inputs are sparse
-    ArrayInfo linfo = getInfo(lhs, false, true);
-    ArrayInfo rinfo = getInfo(rhs, false, true);
+    const ArrayInfo &linfo = getInfo(lhs, false, true);
+    const ArrayInfo &rinfo = getInfo(rhs, false, true);
 
     if (linfo.isSparse() && rinfo.isSparse()) {
         return af_arith_sparse<af_sub_t>(out, lhs, rhs);
-    } else if (linfo.isSparse() && !rinfo.isSparse()) {
+    }
+    if (linfo.isSparse() && !rinfo.isSparse()) {
         return af_arith_sparse_dense<af_sub_t>(out, lhs, rhs);
-    } else if (!linfo.isSparse() && rinfo.isSparse()) {
+    }
+    if (!linfo.isSparse() && rinfo.isSparse()) {
         return af_arith_sparse_dense<af_sub_t>(out, rhs, lhs,
                                                true);  // dense should be rhs
-    } else {
-        return af_arith<af_sub_t>(out, lhs, rhs, batchMode);
     }
+    return af_arith<af_sub_t>(out, lhs, rhs, batchMode);
 }
 
 af_err af_div(af_array *out, const af_array lhs, const af_array rhs,
               const bool batchMode) {
     // Check if inputs are sparse
-    ArrayInfo linfo = getInfo(lhs, false, true);
-    ArrayInfo rinfo = getInfo(rhs, false, true);
+    const ArrayInfo &linfo = getInfo(lhs, false, true);
+    const ArrayInfo &rinfo = getInfo(rhs, false, true);
 
     if (linfo.isSparse() && rinfo.isSparse()) {
         // return af_arith_sparse<af_div_t>(out, lhs, rhs);
         // MKL doesn't have mul or div support yet, hence
         // this is commented out although alternative cpu code exists
         return AF_ERR_NOT_SUPPORTED;
-    } else if (linfo.isSparse() && !rinfo.isSparse()) {
+    }
+    if (linfo.isSparse() && !rinfo.isSparse()) {
         return af_arith_sparse_dense<af_div_t>(out, lhs, rhs);
-    } else if (!linfo.isSparse() && rinfo.isSparse()) {
+    }
+    if (!linfo.isSparse() && rinfo.isSparse()) {
         // Division by sparse is currently not allowed - for convinence of
         // dealing with division by 0
         // return af_arith_sparse_dense<af_div_t>(out, rhs, lhs, true); // dense
         // should be rhs
         return AF_ERR_NOT_SUPPORTED;
-    } else {
-        return af_arith<af_div_t>(out, lhs, rhs, batchMode);
     }
+    return af_arith<af_div_t>(out, lhs, rhs, batchMode);
 }
 
 af_err af_maxof(af_array *out, const af_array lhs, const af_array rhs,
@@ -298,7 +309,8 @@ af_err af_pow(af_array *out, const af_array lhs, const af_array rhs,
             AF_CHECK(af_release_array(log_res));
             std::swap(*out, res);
             return AF_SUCCESS;
-        } else if (linfo.isComplex()) {
+        }
+        if (linfo.isComplex()) {
             af_array mag, angle;
             af_array mag_res, angle_res;
             af_array real_res, imag_res, cplx_res;

--- a/src/api/c/cast.cpp
+++ b/src/api/c/cast.cpp
@@ -27,7 +27,9 @@ using detail::cdouble;
 using detail::cfloat;
 using detail::intl;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
+using detail::ushort;
 
 static af_array cast(const af_array in, const af_dtype type) {
     const ArrayInfo& info = getInfo(in, false, true);

--- a/src/api/c/cast.cpp
+++ b/src/api/c/cast.cpp
@@ -7,22 +7,27 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <backend.hpp>
+#include <cast.hpp>
 #include <common/ArrayInfo.hpp>
+#include <common/err_common.hpp>
+#include <common/half.hpp>
+#include <handle.hpp>
 #include <optypes.hpp>
 #include <sparse.hpp>
 #include <sparse_handle.hpp>
 #include <af/arith.h>
 #include <af/array.h>
 #include <af/defines.h>
+#include <af/dim4.hpp>
 
-#include <backend.hpp>
-#include <cast.hpp>
-#include <common/err_common.hpp>
-#include <common/half.hpp>
-#include <handle.hpp>
-
-using namespace detail;
+using af::dim4;
 using common::half;
+using detail::cdouble;
+using detail::cfloat;
+using detail::intl;
+using detail::uchar;
+using detail::uintl;
 
 static af_array cast(const af_array in, const af_dtype type) {
     const ArrayInfo& info = getInfo(in, false, true);

--- a/src/api/c/cholesky.cpp
+++ b/src/api/c/cholesky.cpp
@@ -7,8 +7,9 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include <backend.hpp>
 #include <cholesky.hpp>
+
+#include <backend.hpp>
 #include <common/ArrayInfo.hpp>
 #include <common/err_common.hpp>
 #include <handle.hpp>
@@ -16,8 +17,8 @@
 #include <af/defines.h>
 #include <af/lapack.h>
 
-using af::dim4;
-using namespace detail;
+using detail::cdouble;
+using detail::cfloat;
 
 template<typename T>
 static inline af_array cholesky(int *info, const af_array in,

--- a/src/api/c/clamp.cpp
+++ b/src/api/c/clamp.cpp
@@ -7,24 +7,29 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <arith.hpp>
 #include <backend.hpp>
 #include <common/ArrayInfo.hpp>
 #include <common/err_common.hpp>
 #include <common/half.hpp>
 #include <handle.hpp>
 #include <implicit.hpp>
+#include <logic.hpp>
 #include <optypes.hpp>
 #include <af/arith.h>
 #include <af/array.h>
 #include <af/data.h>
 #include <af/defines.h>
 
-#include <arith.hpp>
-#include <logic.hpp>
-
-using namespace detail;
 using af::dim4;
 using common::half;
+using detail::arithOp;
+using detail::Array;
+using detail::cdouble;
+using detail::cfloat;
+using detail::intl;
+using detail::uchar;
+using detail::uintl;
 
 template<typename T>
 static inline af_array clampOp(const af_array in, const af_array lo,

--- a/src/api/c/clamp.cpp
+++ b/src/api/c/clamp.cpp
@@ -29,7 +29,9 @@ using detail::cdouble;
 using detail::cfloat;
 using detail::intl;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
+using detail::ushort;
 
 template<typename T>
 static inline af_array clampOp(const af_array in, const af_array lo,

--- a/src/api/c/complex.cpp
+++ b/src/api/c/complex.cpp
@@ -21,9 +21,13 @@
 
 #include <complex.hpp>
 
-using namespace detail;
 using af::dim4;
 using common::half;
+using detail::cdouble;
+using detail::cfloat;
+using detail::conj;
+using detail::imag;
+using detail::real;
 
 template<typename To, typename Ti>
 static inline af_array cplx(const af_array lhs, const af_array rhs,
@@ -42,7 +46,7 @@ af_err af_cplx2(af_array *out, const af_array lhs, const af_array rhs,
             AF_ERROR("Inputs to cplx2 can not be of complex type", AF_ERR_ARG);
         }
 
-        if (type != f64) type = f32;
+        if (type != f64) { type = f32; }
 
         dim4 odims =
             getOutDims(getInfo(lhs).dims(), getInfo(rhs).dims(), batchMode);
@@ -176,21 +180,13 @@ af_err af_abs(af_array *out, const af_array in) {
         if (in_type == f16) { type = f16; }
 
         switch (type) {
-            case f32:
-                res = getHandle(abs<float, float>(castArray<float>(in)));
-                break;
-            case f64:
-                res = getHandle(abs<double, double>(castArray<double>(in)));
-                break;
-            case c32:
-                res = getHandle(abs<float, cfloat>(castArray<cfloat>(in)));
-                break;
-            case c64:
-                res = getHandle(abs<double, cdouble>(castArray<cdouble>(in)));
-                break;
-            case f16:
-                res = getHandle(abs<half, half>(getArray<half>(in)));
-                break;
+            // clang-format off
+            case f32: res = getHandle(detail::abs<float, float>(castArray<float>(in))); break;
+            case f64: res = getHandle(detail::abs<double, double>(castArray<double>(in))); break;
+            case c32: res = getHandle(detail::abs<float, cfloat>(castArray<cfloat>(in))); break;
+            case c64: res = getHandle(detail::abs<double, cdouble>(castArray<cdouble>(in))); break;
+            case f16: res = getHandle(detail::abs<half, half>(getArray<half>(in))); break;
+            // clang-format on
             default: TYPE_ERROR(1, in_type); break;
         }
 

--- a/src/api/c/confidence_connected.cpp
+++ b/src/api/c/confidence_connected.cpp
@@ -24,7 +24,6 @@
 #include <type_traits>
 
 using af::dim4;
-using std::abs;
 using std::array;
 using std::conditional;
 using std::is_same;
@@ -138,7 +137,7 @@ af_array ccHelper(const Array<T>& img, const Array<uint>& seedx,
 
     Array<CT> segmented = floodFill(in, seedx, seedy, CT(1), lower, upper);
 
-    if (abs<CT>(s1var) < epsilon) {
+    if (std::abs<CT>(s1var) < epsilon) {
         // If variance is close to zero, stop after initial segmentation
         return getHandle(labelSegmented(segmented));
     }
@@ -167,7 +166,7 @@ af_array ccHelper(const Array<T>& img, const Array<uint>& seedx,
         if (newLow > minSeedIntensity) { newLow = minSeedIntensity; }
         if (newHigh < maxSeedIntensity) { newHigh = maxSeedIntensity; }
 
-        if (abs<CT>(validsVar) < epsilon) {
+        if (std::abs<CT>(validsVar) < epsilon) {
             // If variance is close to zero, discontinue iterating.
             continueLoop = false;
         }

--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -6,16 +6,16 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#include <convolve.hpp>
+
 #include <arith.hpp>
 #include <backend.hpp>
 #include <cast.hpp>
 #include <common/err_common.hpp>
 #include <common/half.hpp>
-#include <convolve.hpp>
 #include <fftconvolve.hpp>
 #include <handle.hpp>
 #include <tile.hpp>
-
 #include <af/data.h>
 #include <af/defines.h>
 #include <af/dim4.hpp>
@@ -26,7 +26,15 @@
 
 using af::dim4;
 using common::half;
-using namespace detail;
+using detail::arithOp;
+using detail::Array;
+using detail::cast;
+using detail::cdouble;
+using detail::cfloat;
+using detail::convolve;
+using detail::intl;
+using detail::uchar;
+using detail::uintl;
 
 template<typename T, typename accT, dim_t baseDim, bool expand>
 inline static af_array convolve(const af_array &s, const af_array &f,
@@ -65,14 +73,15 @@ AF_BATCH_KIND identifyBatchKind(const dim4 &sDims, const dim4 &fDims) {
     dim_t sn = sDims.ndims();
     dim_t fn = fDims.ndims();
 
-    if (sn == baseDim && fn == baseDim)
-        return AF_BATCH_NONE;
-    else if (sn == baseDim && (fn > baseDim && fn <= AF_MAX_DIMS))
+    if (sn == baseDim && fn == baseDim) { return AF_BATCH_NONE; }
+    if (sn == baseDim && (fn > baseDim && fn <= AF_MAX_DIMS)) {
         return AF_BATCH_RHS;
-    else if ((sn > baseDim && sn <= AF_MAX_DIMS) && fn == baseDim)
+    }
+    if ((sn > baseDim && sn <= AF_MAX_DIMS) && fn == baseDim) {
         return AF_BATCH_LHS;
-    else if ((sn > baseDim && sn <= AF_MAX_DIMS) &&
-             (fn > baseDim && fn <= AF_MAX_DIMS)) {
+    }
+    if ((sn > baseDim && sn <= AF_MAX_DIMS) &&
+        (fn > baseDim && fn <= AF_MAX_DIMS)) {
         bool doesDimensionsMatch = true;
         bool isInterleaved       = true;
         for (dim_t i = baseDim; i < AF_MAX_DIMS; i++) {
@@ -80,10 +89,10 @@ AF_BATCH_KIND identifyBatchKind(const dim4 &sDims, const dim4 &fDims) {
             isInterleaved &=
                 (sDims[i] == 1 || fDims[i] == 1 || sDims[i] == fDims[i]);
         }
-        if (doesDimensionsMatch) return AF_BATCH_SAME;
+        if (doesDimensionsMatch) { return AF_BATCH_SAME; }
         return (isInterleaved ? AF_BATCH_DIFF : AF_BATCH_UNSUPPORTED);
-    } else
-        return AF_BATCH_UNSUPPORTED;
+    }
+    return AF_BATCH_UNSUPPORTED;
 }
 
 template<dim_t baseDim, bool expand>
@@ -240,36 +249,38 @@ af_err convolve2_sep(af_array *out, af_array col_filter, af_array row_filter,
 template<int baseDim>
 bool isFreqDomain(const af_array &signal, const af_array filter,
                   af_conv_domain domain) {
-    if (domain == AF_CONV_FREQ) return true;
-    if (domain != AF_CONV_AUTO) return false;
+    if (domain == AF_CONV_FREQ) { return true; }
+    if (domain != AF_CONV_AUTO) { return false; }
 
     const ArrayInfo &sInfo = getInfo(signal);
     const ArrayInfo &fInfo = getInfo(filter);
 
-    dim4 sdims = sInfo.dims();
-    dim4 fdims = fInfo.dims();
+    const dim4 &sdims = sInfo.dims();
+    dim4 fdims        = fInfo.dims();
 
-    if (identifyBatchKind<baseDim>(sdims, fdims) == AF_BATCH_DIFF) return true;
+    if (identifyBatchKind<baseDim>(sdims, fdims) == AF_BATCH_DIFF) {
+        return true;
+    }
 
     int kbatch = 1;
     for (int i = 3; i >= baseDim; i--) { kbatch *= fdims[i]; }
 
-    if (kbatch >= 10) return true;
+    if (kbatch >= 10) { return true; }
 
     if (baseDim == 1) {
-        if (fdims[0] > 128) return true;
+        if (fdims[0] > 128) { return true; }
     }
 
     if (baseDim == 2) {
         // maximum supported size in 2D domain
-        if (fdims[0] > 17 || fdims[1] > 17) return true;
+        if (fdims[0] > 17 || fdims[1] > 17) { return true; }
 
         // Maximum supported non square size
-        if (fdims[0] != fdims[1] && fdims[0] > 5) return true;
+        if (fdims[0] != fdims[1] && fdims[0] > 5) { return true; }
     }
 
     if (baseDim == 3) {
-        if (fdims[0] > 5 || fdims[1] > 5 || fdims[2] > 5) return true;
+        if (fdims[0] > 5 || fdims[1] > 5 || fdims[2] > 5) { return true; }
     }
 
     return false;
@@ -278,13 +289,14 @@ bool isFreqDomain(const af_array &signal, const af_array filter,
 af_err af_convolve1(af_array *out, const af_array signal, const af_array filter,
                     const af_conv_mode mode, af_conv_domain domain) {
     try {
-        if (isFreqDomain<1>(signal, filter, domain))
+        if (isFreqDomain<1>(signal, filter, domain)) {
             return af_fft_convolve1(out, signal, filter, mode);
+        }
 
-        if (mode == AF_CONV_EXPAND)
+        if (mode == AF_CONV_EXPAND) {
             return convolve<1, true>(out, signal, filter);
-        else
-            return convolve<1, false>(out, signal, filter);
+        }
+        { return convolve<1, false>(out, signal, filter); }
     }
     CATCHALL;
 }
@@ -297,13 +309,15 @@ af_err af_convolve2(af_array *out, const af_array signal, const af_array filter,
             return af_convolve1(out, signal, filter, mode, domain);
         }
 
-        if (isFreqDomain<2>(signal, filter, domain))
+        if (isFreqDomain<2>(signal, filter, domain)) {
             return af_fft_convolve2(out, signal, filter, mode);
+        }
 
-        if (mode == AF_CONV_EXPAND)
+        if (mode == AF_CONV_EXPAND) {
             return convolve<2, true>(out, signal, filter);
-        else
+        } else {
             return convolve<2, false>(out, signal, filter);
+        }
     }
     CATCHALL;
 }
@@ -371,13 +385,15 @@ af_err af_convolve3(af_array *out, const af_array signal, const af_array filter,
             return af_convolve2(out, signal, filter, mode, domain);
         }
 
-        if (isFreqDomain<3>(signal, filter, domain))
+        if (isFreqDomain<3>(signal, filter, domain)) {
             return af_fft_convolve3(out, signal, filter, mode);
+        }
 
-        if (mode == AF_CONV_EXPAND)
+        if (mode == AF_CONV_EXPAND) {
             return convolve<3, true>(out, signal, filter);
-        else
+        } else {
             return convolve<3, false>(out, signal, filter);
+        }
     }
     CATCHALL;
 }
@@ -386,10 +402,11 @@ af_err af_convolve2_sep(af_array *out, const af_array signal,
                         const af_array col_filter, const af_array row_filter,
                         const af_conv_mode mode) {
     try {
-        if (mode == AF_CONV_EXPAND)
+        if (mode == AF_CONV_EXPAND) {
             return convolve2_sep<true>(out, signal, col_filter, row_filter);
-        else
+        } else {
             return convolve2_sep<false>(out, signal, col_filter, row_filter);
+        }
     }
     CATCHALL;
 }
@@ -398,8 +415,8 @@ template<typename T>
 af_array conv2GradCall(const af_array incoming_gradient,
                        const af_array original_signal,
                        const af_array original_filter,
-                       const af_array convolved_output, af::dim4 stride,
-                       af::dim4 padding, af::dim4 dilation,
+                       const af_array convolved_output, const dim4 &stride,
+                       const dim4 &padding, const dim4 &dilation,
                        af_conv_gradient_type grad_type) {
     if (grad_type == AF_CONV_GRADIENT_FILTER) {
         return getHandle(detail::conv2FilterGradient<T>(
@@ -423,7 +440,7 @@ af_err af_convolve2_gradient_nn(
     af_conv_gradient_type grad_type) {
     try {
         const ArrayInfo &iinfo = getInfo(incoming_gradient);
-        af::dim4 iDims         = iinfo.dims();
+        const af::dim4 &iDims  = iinfo.dims();
 
         const ArrayInfo &sinfo = getInfo(original_signal);
         af::dim4 sDims         = sinfo.dims();

--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -34,7 +34,9 @@ using detail::cfloat;
 using detail::convolve;
 using detail::intl;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
+using detail::ushort;
 
 template<typename T, typename accT, dim_t baseDim, bool expand>
 inline static af_array convolve(const af_array &s, const af_array &f,

--- a/src/api/c/corrcoef.cpp
+++ b/src/api/c/corrcoef.cpp
@@ -32,8 +32,8 @@ static To corrcoef(const af_array& X, const af_array& Y) {
     Array<To> xIn = cast<To>(getArray<Ti>(X));
     Array<To> yIn = cast<To>(getArray<Ti>(Y));
 
-    dim4 dims = xIn.dims();
-    dim_t n   = xIn.elements();
+    const dim4& dims = xIn.dims();
+    dim_t n          = xIn.elements();
 
     To xSum = detail::reduce_all<af_add_t, To, To>(xIn);
     To ySum = detail::reduce_all<af_add_t, To, To>(yIn);
@@ -46,15 +46,17 @@ static To corrcoef(const af_array& X, const af_array& Y) {
     To ySqSum = detail::reduce_all<af_add_t, To, To>(ySq);
     To xySum  = detail::reduce_all<af_add_t, To, To>(xy);
 
-    To result = (n * xySum - xSum * ySum) / (sqrt(n * xSqSum - xSum * xSum) *
-                                             sqrt(n * ySqSum - ySum * ySum));
+    To result =
+        (n * xySum - xSum * ySum) / (std::sqrt(n * xSqSum - xSum * xSum) *
+                                     std::sqrt(n * ySqSum - ySum * ySum));
 
     return result;
 }
 
+// NOLINTNEXTLINE
 af_err af_corrcoef(double* realVal, double* imagVal, const af_array X,
                    const af_array Y) {
-    UNUSED(imagVal);  // TODO: implement for complex types
+    UNUSED(imagVal);  // TODO(umar): implement for complex types
     try {
         const ArrayInfo& xInfo = getInfo(X);
         const ArrayInfo& yInfo = getInfo(Y);
@@ -66,8 +68,9 @@ af_err af_corrcoef(double* realVal, double* imagVal, const af_array X,
         ARG_ASSERT(2, (xType == yType));
         ARG_ASSERT(2, (xDims.ndims() == yDims.ndims()));
 
-        for (dim_t i = 0; i < xDims.ndims(); ++i)
+        for (dim_t i = 0; i < xDims.ndims(); ++i) {
             ARG_ASSERT(2, (xDims[i] == yDims[i]));
+        }
 
         switch (xType) {
             case f64: *realVal = corrcoef<double, double>(X, Y); break;

--- a/src/api/c/covariance.cpp
+++ b/src/api/c/covariance.cpp
@@ -23,13 +23,13 @@
 #include "stats.h"
 
 using af::dim4;
-using namespace detail;
+using detail::Array;
 
 template<typename T, typename cType>
-static af_array cov(const af_array& X, const af_array& Y, const bool isbiased) {
-    typedef typename baseOutType<cType>::type weightType;
-    Array<T> _x       = getArray<T>(X);
-    Array<T> _y       = getArray<T>(Y);
+static af_array cov(const af_array& X, const af_array& Y, bool isbiased) {
+    using weightType  = typename baseOutType<cType>::type;
+    const Array<T> _x = getArray<T>(X);
+    const Array<T> _y = getArray<T>(Y);
     Array<cType> xArr = cast<cType>(_x);
     Array<cType> yArr = cast<cType>(_y);
 

--- a/src/api/c/data.cpp
+++ b/src/api/c/data.cpp
@@ -27,7 +27,16 @@
 
 using af::dim4;
 using common::half;
-using namespace detail;
+using detail::cdouble;
+using detail::cfloat;
+using detail::createValueArray;
+using detail::intl;
+using detail::iota;
+using detail::padArrayBorders;
+using detail::range;
+using detail::scalar;
+using detail::uchar;
+using detail::uintl;
 
 dim4 verifyDims(const unsigned ndims, const dim_t *const dims) {
     DIM_ASSERT(1, ndims >= 1);
@@ -49,12 +58,8 @@ af_err af_constant(af_array *result, const double value, const unsigned ndims,
         af_array out;
         AF_CHECK(af_init());
 
-        dim4 d(1, 1, 1, 1);
-        if (ndims <= 0) {
-            return af_create_handle(result, 0, nullptr, type);
-        } else {
-            d = verifyDims(ndims, dims);
-        }
+        if (ndims <= 0) { return af_create_handle(result, 0, nullptr, type); }
+        dim4 d = verifyDims(ndims, dims);
 
         switch (type) {
             case f32: out = createHandleFromValue<float>(d, value); break;
@@ -92,12 +97,8 @@ af_err af_constant_complex(af_array *result, const double real,
         af_array out;
         AF_CHECK(af_init());
 
-        dim4 d(1, 1, 1, 1);
-        if (ndims <= 0) {
-            return af_create_handle(result, 0, nullptr, type);
-        } else {
-            d = verifyDims(ndims, dims);
-        }
+        if (ndims <= 0) { return af_create_handle(result, 0, nullptr, type); }
+        dim4 d = verifyDims(ndims, dims);
 
         switch (type) {
             case c32: out = createCplx<cfloat, float>(d, real, imag); break;
@@ -117,12 +118,8 @@ af_err af_constant_long(af_array *result, const intl val, const unsigned ndims,
         af_array out;
         AF_CHECK(af_init());
 
-        dim4 d(1, 1, 1, 1);
-        if (ndims <= 0) {
-            return af_create_handle(result, 0, nullptr, s64);
-        } else {
-            d = verifyDims(ndims, dims);
-        }
+        if (ndims <= 0) { return af_create_handle(result, 0, nullptr, s64); }
+        dim4 d = verifyDims(ndims, dims);
 
         out = getHandle(createValueArray<intl>(d, val));
 
@@ -139,12 +136,9 @@ af_err af_constant_ulong(af_array *result, const uintl val,
         af_array out;
         AF_CHECK(af_init());
 
-        dim4 d(1, 1, 1, 1);
-        if (ndims <= 0) {
-            return af_create_handle(result, 0, nullptr, u64);
-        } else {
-            d = verifyDims(ndims, dims);
-        }
+        if (ndims <= 0) { return af_create_handle(result, 0, nullptr, u64); }
+        dim4 d = verifyDims(ndims, dims);
+
         out = getHandle(createValueArray<uintl>(d, val));
 
         std::swap(*result, out);
@@ -207,12 +201,8 @@ af_err af_range(af_array *result, const unsigned ndims, const dim_t *const dims,
         af_array out;
         AF_CHECK(af_init());
 
-        dim4 d(0);
-        if (ndims <= 0) {
-            return af_create_handle(result, 0, nullptr, type);
-        } else {
-            d = verifyDims(ndims, dims);
-        }
+        if (ndims <= 0) { return af_create_handle(result, 0, nullptr, type); }
+        dim4 d = verifyDims(ndims, dims);
 
         switch (type) {
             case f32: out = range_<float>(d, seq_dim); break;
@@ -364,10 +354,11 @@ af_err af_diag_extract(af_array *out, const af_array in, const int num) {
 
 template<typename T, bool is_upper>
 af_array triangle(const af_array in, bool is_unit_diag) {
-    if (is_unit_diag)
+    if (is_unit_diag) {
         return getHandle(triangle<T, is_upper, true>(getArray<T>(in)));
-    else
+    } else {
         return getHandle(triangle<T, is_upper, false>(getArray<T>(in)));
+    }
 }
 
 af_err af_lower(af_array *out, const af_array in, bool is_unit_diag) {

--- a/src/api/c/data.cpp
+++ b/src/api/c/data.cpp
@@ -36,7 +36,9 @@ using detail::padArrayBorders;
 using detail::range;
 using detail::scalar;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
+using detail::ushort;
 
 dim4 verifyDims(const unsigned ndims, const dim_t *const dims) {
     DIM_ASSERT(1, ndims >= 1);

--- a/src/api/c/det.cpp
+++ b/src/api/c/det.cpp
@@ -20,7 +20,11 @@
 #include <af/lapack.h>
 
 using af::dim4;
-using namespace detail;
+using detail::Array;
+using detail::cdouble;
+using detail::cfloat;
+using detail::createEmptyArray;
+using detail::scalar;
 
 template<typename T>
 T det(const af_array a) {
@@ -57,7 +61,7 @@ T det(const af_array a) {
         is_neg ^= (hP[i] != (i + 1));
     }
 
-    if (is_neg) res = res * scalar<T>(-1);
+    if (is_neg) { res = res * scalar<T>(-1); }
 
     return res;
 }
@@ -72,9 +76,10 @@ af_err af_det(double *real_val, double *imag_val, const af_array in) {
 
         af_dtype type = i_info.getType();
 
-        if (i_info.dims()[0])
+        if (i_info.dims()[0]) {
             DIM_ASSERT(1, i_info.dims()[0] ==
                               i_info.dims()[1]);  // Only square matrices
+        }
         ARG_ASSERT(1, i_info.isFloating());  // Only floating and complex types
 
         *real_val = 0;

--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -39,7 +39,9 @@ using detail::isDoubleSupported;
 using detail::isHalfSupported;
 using detail::setDevice;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
+using detail::ushort;
 
 af_err af_set_backend(const af_backend bknd) {
     try {

--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -14,7 +14,6 @@
 #include <handle.hpp>
 #include <platform.hpp>
 #include <sparse_handle.hpp>
-
 #include <af/backend.h>
 #include <af/device.h>
 #include <af/dim4.hpp>
@@ -23,8 +22,24 @@
 #include <cstring>
 #include <string>
 
-using namespace detail;
+using af::dim4;
 using common::half;
+using detail::Array;
+using detail::cdouble;
+using detail::cfloat;
+using detail::createEmptyArray;
+using detail::devprop;
+using detail::evalFlag;
+using detail::getActiveDeviceId;
+using detail::getBackend;
+using detail::getDeviceCount;
+using detail::getDeviceInfo;
+using detail::intl;
+using detail::isDoubleSupported;
+using detail::isHalfSupported;
+using detail::setDevice;
+using detail::uchar;
+using detail::uintl;
 
 af_err af_set_backend(const af_backend bknd) {
     try {
@@ -77,7 +92,7 @@ af_err af_get_device_id(int* device, const af_array in) {
 }
 
 af_err af_get_active_backend(af_backend* result) {
-    *result = (af_backend)getBackend();
+    *result = static_cast<af_backend>(getBackend());
     return AF_SUCCESS;
 }
 
@@ -92,7 +107,7 @@ af_err af_init() {
 
 af_err af_info() {
     try {
-        printf("%s", getDeviceInfo().c_str());
+        printf("%s", getDeviceInfo().c_str());  // NOLINT
     }
     CATCHALL;
     return AF_SUCCESS;
@@ -102,7 +117,8 @@ af_err af_info_string(char** str, const bool verbose) {
     UNUSED(verbose);  // TODO(umar): Add something useful
     try {
         std::string infoStr = getDeviceInfo();
-        af_alloc_host((void**)str, sizeof(char) * (infoStr.size() + 1));
+        af_alloc_host(reinterpret_cast<void**>(str),
+                      sizeof(char) * (infoStr.size() + 1));
 
         // Need to do a deep copy
         // str.c_str wont cut it
@@ -172,7 +188,7 @@ af_err af_set_device(const int device) {
                 char err_msg[] =
                     "The device index of %d is out of range. Use a value "
                     "between 0 and %d.";
-                snprintf(buf, 512, err_msg, device, ndevices - 1);
+                snprintf(buf, 512, err_msg, device, ndevices - 1);  // NOLINT
                 AF_ERROR(buf, AF_ERR_ARG);
             }
         }
@@ -194,13 +210,11 @@ af_err af_sync(const int device) {
 template<typename T>
 static inline void eval(af_array arr) {
     getArray<T>(arr).eval();
-    return;
 }
 
 template<typename T>
 static inline void sparseEval(af_array arr) {
     getSparseArray<T>(arr).eval();
-    return;
 }
 
 af_err af_eval(af_array arr) {
@@ -250,14 +264,13 @@ static inline void evalMultiple(int num, af_array* arrayPtrs) {
     }
 
     evalMultiple<T>(arrays);
-    return;
 }
 
 af_err af_eval_multiple(int num, af_array* arrays) {
     try {
         const ArrayInfo& info = getInfo(arrays[0]);
         af_dtype type         = info.getType();
-        dim4 dims             = info.dims();
+        const dim4& dims      = info.dims();
 
         for (int i = 1; i < num; i++) {
             const ArrayInfo& currInfo = getInfo(arrays[i]);

--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -82,7 +82,7 @@ af_err af_get_device_id(int* device, const af_array in) {
     try {
         if (in) {
             const ArrayInfo& info = getInfo(in, false, false);
-            *device               = info.getDevId();
+            *device               = static_cast<int>(info.getDevId());
         } else {
             return AF_ERR_ARG;
         }

--- a/src/api/c/diff.cpp
+++ b/src/api/c/diff.cpp
@@ -16,7 +16,13 @@
 #include <af/defines.h>
 
 using af::dim4;
-using namespace detail;
+using detail::cdouble;
+using detail::cfloat;
+using detail::intl;
+using detail::uchar;
+using detail::uint;
+using detail::uintl;
+using detail::ushort;
 
 template<typename T>
 static inline af_array diff1(const af_array in, const int dim) {

--- a/src/api/c/dog.cpp
+++ b/src/api/c/dog.cpp
@@ -7,6 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <Array.hpp>
 #include <arith.hpp>
 #include <backend.hpp>
 #include <common/err_common.hpp>
@@ -18,7 +19,10 @@
 #include <af/vision.h>
 
 using af::dim4;
-using namespace detail;
+using detail::arithOp;
+using detail::Array;
+using detail::convolve;
+using detail::uchar;
 
 template<typename T, typename accT>
 static af_array dog(const af_array& in, const int radius1, const int radius2) {

--- a/src/api/c/dog.cpp
+++ b/src/api/c/dog.cpp
@@ -23,6 +23,8 @@ using detail::arithOp;
 using detail::Array;
 using detail::convolve;
 using detail::uchar;
+using detail::uint;
+using detail::ushort;
 
 template<typename T, typename accT>
 static af_array dog(const af_array& in, const int radius1, const int radius2) {

--- a/src/api/c/error.cpp
+++ b/src/api/c/error.cpp
@@ -10,12 +10,14 @@
 #include <common/err_common.hpp>
 #include <af/device.h>
 #include <af/exception.h>
+
 #include <algorithm>
 #include <string>
 
 void af_get_last_error(char **str, dim_t *len) {
     std::string &global_error_string = get_global_error_string();
-    dim_t slen = std::min(MAX_ERR_SIZE, (int)global_error_string.size());
+    dim_t slen =
+        std::min(MAX_ERR_SIZE, static_cast<int>(global_error_string.size()));
 
     if (len && slen == 0) {
         *len = 0;
@@ -23,13 +25,13 @@ void af_get_last_error(char **str, dim_t *len) {
         return;
     }
 
-    af_alloc_host((void **)str, sizeof(char) * (slen + 1));
+    af_alloc_host(reinterpret_cast<void **>(str), sizeof(char) * (slen + 1));
     global_error_string.copy(*str, slen);
 
     (*str)[slen]        = '\0';
     global_error_string = std::string("");
 
-    if (len) *len = slen;
+    if (len) { *len = slen; }
 }
 
 af_err af_set_enable_stacktrace(int is_enabled) {

--- a/src/api/c/events.cpp
+++ b/src/api/c/events.cpp
@@ -14,7 +14,11 @@
 #include <af/device.h>
 #include <af/event.h>
 
-using namespace detail;
+using detail::block;
+using detail::createEvent;
+using detail::enqueueWaitOnActiveQueue;
+using detail::Event;
+using detail::markEventOnActiveQueue;
 
 Event &getEvent(af_event &handle) {
     Event &event = *static_cast<Event *>(handle);

--- a/src/api/c/fast.cpp
+++ b/src/api/c/fast.cpp
@@ -7,6 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <Array.hpp>
 #include <backend.hpp>
 #include <common/err_common.hpp>
 #include <fast.hpp>
@@ -18,7 +19,10 @@
 #include <af/vision.h>
 
 using af::dim4;
-using namespace detail;
+using detail::Array;
+using detail::createEmptyArray;
+using detail::createValueArray;
+using detail::uchar;
 
 template<typename T>
 static af_features fast(af_array const &in, const float thr,

--- a/src/api/c/fast.cpp
+++ b/src/api/c/fast.cpp
@@ -23,6 +23,8 @@ using detail::Array;
 using detail::createEmptyArray;
 using detail::createValueArray;
 using detail::uchar;
+using detail::uint;
+using detail::ushort;
 
 template<typename T>
 static af_features fast(af_array const &in, const float thr,

--- a/src/api/c/features.cpp
+++ b/src/api/c/features.cpp
@@ -14,26 +14,27 @@
 
 af_err af_release_features(af_features featHandle) {
     try {
-        af_features_t feat = *(af_features_t *)featHandle;
+        af_features_t feat = *static_cast<af_features_t *>(featHandle);
         if (feat.n > 0) {
-            if (feat.x != 0) AF_CHECK(af_release_array(feat.x));
-            if (feat.y != 0) AF_CHECK(af_release_array(feat.y));
-            if (feat.score != 0) AF_CHECK(af_release_array(feat.score));
-            if (feat.orientation != 0)
+            if (feat.x != 0) { AF_CHECK(af_release_array(feat.x)); }
+            if (feat.y != 0) { AF_CHECK(af_release_array(feat.y)); }
+            if (feat.score != 0) { AF_CHECK(af_release_array(feat.score)); }
+            if (feat.orientation != 0) {
                 AF_CHECK(af_release_array(feat.orientation));
-            if (feat.size != 0) AF_CHECK(af_release_array(feat.size));
+            }
+            if (feat.size != 0) { AF_CHECK(af_release_array(feat.size)); }
             feat.n = 0;
         }
-        delete (af_features_t *)featHandle;
+        delete static_cast<af_features_t *>(featHandle);
     }
     CATCHALL;
     return AF_SUCCESS;
 }
 
 af_features getFeaturesHandle(const af_features_t feat) {
-    af_features_t *featHandle = new af_features_t;
-    *featHandle               = feat;
-    return (af_features)featHandle;
+    auto *featHandle = new af_features_t;
+    *featHandle      = feat;
+    return static_cast<af_features>(featHandle);
 }
 
 af_err af_create_features(af_features *featHandle, dim_t num) {
@@ -58,7 +59,7 @@ af_err af_create_features(af_features *featHandle, dim_t num) {
 }
 
 af_features_t getFeatures(const af_features featHandle) {
-    return *(af_features_t *)featHandle;
+    return *static_cast<af_features_t *>(featHandle);
 }
 
 af_err af_retain_features(af_features *outHandle,

--- a/src/api/c/fft.cpp
+++ b/src/api/c/fft.cpp
@@ -15,12 +15,15 @@
 #include <af/signal.h>
 
 using af::dim4;
-using namespace detail;
+using detail::Array;
+using detail::cdouble;
+using detail::cfloat;
+using detail::multiply_inplace;
 
 void computePaddedDims(dim4 &pdims, const dim4 &idims, const dim_t npad,
                        dim_t const *const pad) {
     for (int i = 0; i < 4; i++) {
-        pdims[i] = (i < (int)npad) ? pad[i] : idims[i];
+        pdims[i] = (i < static_cast<int>(npad)) ? pad[i] : idims[i];
     }
 }
 
@@ -37,7 +40,7 @@ static af_err fft(af_array *out, const af_array in, const double norm_factor,
     try {
         const ArrayInfo &info = getInfo(in);
         af_dtype type         = info.getType();
-        af::dim4 dims         = info.dims();
+        const dim4 &dims      = info.dims();
 
         if (dims.ndims() == 0) { return af_retain_array(out, in); }
 

--- a/src/api/c/fft_common.hpp
+++ b/src/api/c/fft_common.hpp
@@ -10,38 +10,38 @@
 #include <fft.hpp>
 #include <handle.hpp>
 
-using namespace detail;
-
-void computePaddedDims(dim4 &pdims, const dim4 &idims, const dim_t npad,
+void computePaddedDims(af::dim4 &pdims, const af::dim4 &idims, const dim_t npad,
                        dim_t const *const pad);
 
 template<typename inType, typename outType, int rank, bool direction>
-Array<outType> fft(const Array<inType> input, const double norm_factor,
-                   const dim_t npad, const dim_t *const pad) {
-    dim4 pdims(1);
+detail::Array<outType> fft(const detail::Array<inType> input,
+                           const double norm_factor, const dim_t npad,
+                           const dim_t *const pad) {
+    af::dim4 pdims(1);
     computePaddedDims(pdims, input.dims(), npad, pad);
-    auto res = padArray(input, pdims, scalar<outType>(0));
+    auto res = padArray(input, pdims, detail::scalar<outType>(0));
 
-    fft_inplace<outType, rank, direction>(res);
+    detail::fft_inplace<outType, rank, direction>(res);
     if (norm_factor != 1.0) multiply_inplace(res, norm_factor);
 
     return res;
 }
 
 template<typename inType, typename outType, int rank>
-Array<outType> fft_r2c(const Array<inType> input, const double norm_factor,
-                       const dim_t npad, const dim_t *const pad) {
-    dim4 idims = input.dims();
+detail::Array<outType> fft_r2c(const detail::Array<inType> input,
+                               const double norm_factor, const dim_t npad,
+                               const dim_t *const pad) {
+    af::dim4 idims = input.dims();
 
     bool is_pad = false;
     for (int i = 0; i < npad; i++) { is_pad |= (pad[i] != idims[i]); }
 
-    Array<inType> tmp = input;
+    detail::Array<inType> tmp = input;
 
     if (is_pad) {
-        dim4 pdims(1);
+        af::dim4 pdims(1);
         computePaddedDims(pdims, input.dims(), npad, pad);
-        tmp = padArray(input, pdims, scalar<inType>(0));
+        tmp = padArray(input, pdims, detail::scalar<inType>(0));
     }
 
     auto res = fft_r2c<outType, inType, rank>(tmp);
@@ -51,9 +51,11 @@ Array<outType> fft_r2c(const Array<inType> input, const double norm_factor,
 }
 
 template<typename inType, typename outType, int rank>
-Array<outType> fft_c2r(const Array<inType> input, const double norm_factor,
-                       const dim4 &odims) {
-    Array<outType> output = fft_c2r<outType, inType, rank>(input, odims);
+detail::Array<outType> fft_c2r(const detail::Array<inType> input,
+                               const double norm_factor,
+                               const af::dim4 &odims) {
+    detail::Array<outType> output =
+        fft_c2r<outType, inType, rank>(input, odims);
 
     if (norm_factor != 1) {
         // Normalize input because tmp was not normalized

--- a/src/api/c/fftconvolve.cpp
+++ b/src/api/c/fftconvolve.cpp
@@ -29,6 +29,7 @@ using detail::fftconvolve;
 using detail::intl;
 using detail::real;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
 using detail::ushort;
 using std::max;

--- a/src/api/c/filters.cpp
+++ b/src/api/c/filters.cpp
@@ -18,7 +18,9 @@
 #include <af/signal.h>
 
 using af::dim4;
-using namespace detail;
+using detail::uchar;
+using detail::uint;
+using detail::ushort;
 
 af_err af_medfilt(af_array *out, const af_array in, const dim_t wind_length,
                   const dim_t wind_width, const af_border_type edge_pad) {

--- a/src/api/c/flip.cpp
+++ b/src/api/c/flip.cpp
@@ -33,6 +33,7 @@ using detail::cfloat;
 using detail::intl;
 using detail::uchar;
 using detail::uintl;
+using detail::ushort;
 using std::swap;
 using std::vector;
 

--- a/src/api/c/flip.cpp
+++ b/src/api/c/flip.cpp
@@ -25,21 +25,27 @@
 #include <af/index.h>
 #include <af/seq.h>
 
-using namespace detail;
+using af::dim4;
 using common::half;
+using detail::Array;
+using detail::cdouble;
+using detail::cfloat;
+using detail::intl;
+using detail::uchar;
+using detail::uintl;
 using std::swap;
 using std::vector;
 
 template<typename T>
 static af_array flipArray(const af_array in, const unsigned dim) {
-    const Array<T> &input = getArray<T>(in);
+    const Array<T> input = getArray<T>(in);
     vector<af_seq> index(4);
 
     for (int i = 0; i < 4; i++) { index[i] = af_span; }
 
     // Reverse "dim"
     dim4 in_dims = input.dims();
-    af_seq s     = {(double)(in_dims[dim] - 1), 0, -1};
+    af_seq s     = {static_cast<double>(in_dims[dim] - 1), 0, -1};
 
     index[dim] = s;
 

--- a/src/api/c/gaussian_kernel.cpp
+++ b/src/api/c/gaussian_kernel.cpp
@@ -20,9 +20,9 @@
 #include <af/dim4.hpp>
 #include <af/image.h>
 
+using detail::arithOp;
 using detail::Array;
 using detail::createValueArray;
-using detail::arithOp;
 
 template<typename T>
 Array<T> gaussianKernel(const int rows, const int cols, const double sigma_r,

--- a/src/api/c/gaussian_kernel.cpp
+++ b/src/api/c/gaussian_kernel.cpp
@@ -20,7 +20,9 @@
 #include <af/dim4.hpp>
 #include <af/image.h>
 
-using namespace detail;
+using detail::Array;
+using detail::createValueArray;
+using detail::arithOp;
 
 template<typename T>
 Array<T> gaussianKernel(const int rows, const int cols, const double sigma_r,
@@ -36,8 +38,8 @@ Array<T> gaussianKernel(const int rows, const int cols, const double sigma_r,
         Array<T> wt = range<T>(dim4(cols, rows), 0);
         Array<T> w  = transpose<T>(wt, false);
 
-        Array<T> c =
-            createValueArray<T>(odims, scalar<T>((double)(cols - 1) / 2.0));
+        Array<T> c = createValueArray<T>(
+            odims, scalar<T>(static_cast<double>(cols - 1) / 2.0));
         w = arithOp<T, af_sub_t>(w, c, odims);
 
         sigma        = sigma_c > 0 ? sigma_c : 0.25 * cols;
@@ -51,8 +53,8 @@ Array<T> gaussianKernel(const int rows, const int cols, const double sigma_r,
     if (rows > 1) {
         Array<T> w = range<T>(dim4(rows, cols), 0);
 
-        Array<T> r =
-            createValueArray<T>(odims, scalar<T>((double)(rows - 1) / 2.0));
+        Array<T> r = createValueArray<T>(
+            odims, scalar<T>(static_cast<double>(rows - 1) / 2.0));
         w = arithOp<T, af_sub_t>(w, r, odims);
 
         sigma        = sigma_r > 0 ? sigma_r : 0.25 * rows;

--- a/src/api/c/gradient.cpp
+++ b/src/api/c/gradient.cpp
@@ -16,7 +16,8 @@
 #include <af/image.h>
 
 using af::dim4;
-using namespace detail;
+using detail::cdouble;
+using detail::cfloat;
 
 template<typename T>
 static inline void gradient(af_array *grad0, af_array *grad1,

--- a/src/api/c/harris.cpp
+++ b/src/api/c/harris.cpp
@@ -17,8 +17,13 @@
 #include <af/features.h>
 #include <af/vision.h>
 
+#include <cmath>
+
 using af::dim4;
-using namespace detail;
+using detail::Array;
+using detail::createEmptyArray;
+using detail::createValueArray;
+using std::floor;
 
 template<typename T, typename convAccT>
 static af_features harris(af_array const &in, const unsigned max_corners,
@@ -50,12 +55,13 @@ af_err af_harris(af_features *out, const af_array in,
                  const float k_thr) {
     try {
         const ArrayInfo &info = getInfo(in);
-        af::dim4 dims         = info.dims();
+        dim4 dims             = info.dims();
         dim_t in_ndims        = dims.ndims();
 
-        unsigned filter_len =
-            (block_size == 0) ? floor(6.f * sigma) : block_size;
-        if (block_size == 0 && filter_len % 2 == 0) filter_len--;
+        unsigned filter_len = (block_size == 0)
+                                  ? static_cast<unsigned>(floor(6.f * sigma))
+                                  : block_size;
+        if (block_size == 0 && filter_len % 2 == 0) { filter_len--; }
 
         const unsigned edge =
             (block_size > 0) ? block_size / 2 : filter_len / 2;

--- a/src/api/c/hist.cpp
+++ b/src/api/c/hist.cpp
@@ -17,9 +17,8 @@
 #include <reduce.hpp>
 #include <af/graphics.h>
 
-using af::dim4;
-using namespace detail;
-using namespace graphics;
+using detail::Array;
+using graphics::ForgeManager;
 
 template<typename T>
 fg_chart setup_histogram(fg_window const window, const af_array in,
@@ -27,18 +26,19 @@ fg_chart setup_histogram(fg_window const window, const af_array in,
                          const af_cell* const props) {
     ForgeModule& _ = graphics::forgePlugin();
 
-    Array<T> histogramInput = getArray<T>(in);
-    dim_t nBins             = histogramInput.elements();
+    const Array<T> histogramInput = getArray<T>(in);
+    dim_t nBins                   = histogramInput.elements();
 
     // Retrieve Forge Histogram with nBins and array type
     ForgeManager& fgMngr = forgeManager();
 
     // Get the chart for the current grid position (if any)
     fg_chart chart = NULL;
-    if (props->col > -1 && props->row > -1)
+    if (props->col > -1 && props->row > -1) {
         chart = fgMngr.getChart(window, props->row, props->col, FG_CHART_2D);
-    else
+    } else {
         chart = fgMngr.getChart(window, 0, 0, FG_CHART_2D);
+    }
 
     // Create a histogram for the chart
     fg_histogram hist = fgMngr.getHistogram(chart, nBins, getGLType<T>());
@@ -56,15 +56,21 @@ fg_chart setup_histogram(fg_window const window, const af_array in,
 
         if (xMin == 0 && xMax == 0 && yMin == 0 && yMax == 0) {
             // No previous limits. Set without checking
-            xMin = step_round(minval, false);
-            xMax = step_round(maxval, true);
-            yMax = step_round(freqMax, true);
+            xMin = static_cast<float>(step_round(minval, false));
+            xMax = static_cast<float>(step_round(maxval, true));
+            yMax = static_cast<float>(step_round(freqMax, true));
             // For histogram, always set yMin to 0.
             yMin = 0;
         } else {
-            if (xMin > minval) xMin = step_round(minval, false);
-            if (xMax < maxval) xMax = step_round(maxval, true);
-            if (yMax < freqMax) yMax = step_round(freqMax, true);
+            if (xMin > minval) {
+                xMin = static_cast<float>(step_round(minval, false));
+            }
+            if (xMax < maxval) {
+                xMax = static_cast<float>(step_round(maxval, true));
+            }
+            if (yMax < freqMax) {
+                yMax = static_cast<float>(step_round(freqMax, true));
+            }
             // For histogram, always set yMin to 0.
             yMin = 0;
         }

--- a/src/api/c/histeq.cpp
+++ b/src/api/c/histeq.cpp
@@ -20,7 +20,7 @@
 #include <af/image.h>
 #include <af/index.h>
 
-using namespace detail;
+using detail::Array;
 
 template<typename T, typename hType>
 static af_array hist_equal(const af_array& in, const af_array& hist) {
@@ -31,14 +31,14 @@ static af_array hist_equal(const af_array& in, const af_array& hist) {
 
     Array<float> fHist = cast<float>(getArray<hType>(hist));
 
-    dim4 hDims       = fHist.dims();
-    dim_t grayLevels = fHist.elements();
+    const dim4& hDims = fHist.dims();
+    dim_t grayLevels  = fHist.elements();
 
     Array<float> cdf = scan<af_add_t, float, float>(fHist, 0);
 
     float minCdf = reduce_all<af_min_t, float, float>(cdf);
     float maxCdf = reduce_all<af_max_t, float, float>(cdf);
-    float factor = (float)(grayLevels - 1) / (maxCdf - minCdf);
+    float factor = static_cast<float>(grayLevels - 1) / (maxCdf - minCdf);
 
     // constant array of min value from cdf
     Array<float> minCnst = createValueArray<float>(hDims, minCdf);

--- a/src/api/c/histogram.cpp
+++ b/src/api/c/histogram.cpp
@@ -14,19 +14,23 @@
 #include <af/dim4.hpp>
 #include <af/image.h>
 
-using af::dim4;
-using namespace detail;
+using detail::intl;
+using detail::uchar;
+using detail::uintl;
 
 template<typename inType, typename outType>
 static inline af_array histogram(const af_array in, const unsigned &nbins,
                                  const double &minval, const double &maxval,
                                  const bool islinear) {
-    if (islinear)
-        return getHandle(histogram<inType, outType, true>(
+    af_array out = nullptr;
+    if (islinear) {
+        out = getHandle(histogram<inType, outType, true>(
             getArray<inType>(in), nbins, minval, maxval));
-    else
-        return getHandle(histogram<inType, outType, false>(
+    } else {
+        out = getHandle(histogram<inType, outType, false>(
             getArray<inType>(in), nbins, minval, maxval));
+    }
+    return out;
 }
 
 af_err af_histogram(af_array *out, const af_array in, const unsigned nbins,

--- a/src/api/c/histogram.cpp
+++ b/src/api/c/histogram.cpp
@@ -16,7 +16,9 @@
 
 using detail::intl;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
+using detail::ushort;
 
 template<typename inType, typename outType>
 static inline af_array histogram(const af_array in, const unsigned &nbins,

--- a/src/api/c/homography.cpp
+++ b/src/api/c/homography.cpp
@@ -17,8 +17,12 @@
 #include <af/random.h>
 #include <af/vision.h>
 
+#include <utility>
+
 using af::dim4;
-using namespace detail;
+using detail::Array;
+using detail::createEmptyArray;
+using std::swap;
 
 template<typename T>
 static inline void homography(af_array& H, int& inliers, const af_array x_src,
@@ -89,8 +93,8 @@ af_err af_homography(af_array* H, int* inliers, const af_array x_src,
                 break;
             default: TYPE_ERROR(1, otype);
         }
-        std::swap(*H, outH);
-        std::swap(*inliers, outInl);
+        swap(*H, outH);
+        swap(*inliers, outInl);
     }
     CATCHALL;
 

--- a/src/api/c/hsv_rgb.cpp
+++ b/src/api/c/hsv_rgb.cpp
@@ -16,7 +16,9 @@
 #include <af/image.h>
 
 using af::dim4;
-using namespace detail;
+using detail::Array;
+using detail::hsv2rgb;
+using detail::rgb2hsv;
 
 template<typename T, bool isHSV2RGB>
 static af_array convert(const af_array& in) {

--- a/src/api/c/iir.cpp
+++ b/src/api/c/iir.cpp
@@ -19,7 +19,8 @@
 #include <cstdio>
 
 using af::dim4;
-using namespace detail;
+using detail::cdouble;
+using detail::cfloat;
 
 af_err af_fir(af_array* y, const af_array b, const af_array x) {
     try {
@@ -28,9 +29,9 @@ af_err af_fir(af_array* y, const af_array b, const af_array x) {
 
         dim4 xdims    = getInfo(x).dims();
         af_seq seqs[] = {af_span, af_span, af_span, af_span};
-        seqs[0].begin = 0;
-        seqs[0].end   = xdims[0] - 1;
-        seqs[0].step  = 1;
+        seqs[0].begin = 0.;
+        seqs[0].end   = static_cast<double>(xdims[0]) - 1.;
+        seqs[0].step  = 1.;
         af_array res;
         AF_CHECK(af_index(&res, out, 4, seqs));
         AF_CHECK(af_release_array(out));

--- a/src/api/c/image.cpp
+++ b/src/api/c/image.cpp
@@ -34,6 +34,8 @@ using detail::copy_image;
 using detail::createValueArray;
 using detail::forgeManager;
 using detail::uchar;
+using detail::uint;
+using detail::ushort;
 using graphics::ForgeManager;
 
 template<typename T>

--- a/src/api/c/image.cpp
+++ b/src/api/c/image.cpp
@@ -27,8 +27,14 @@
 #include <limits>
 
 using af::dim4;
-using namespace detail;
-using namespace graphics;
+using detail::arithOp;
+using detail::Array;
+using detail::cast;
+using detail::copy_image;
+using detail::createValueArray;
+using detail::forgeManager;
+using detail::uchar;
+using graphics::ForgeManager;
 
 template<typename T>
 Array<T> normalizePerType(const Array<T>& in) {
@@ -58,10 +64,10 @@ static fg_image convert_and_copy_image(const af_array in) {
     ForgeManager& fgMngr = forgeManager();
 
     // The inDims[2] * 100 is a hack to convert to fg_channel_format
-    // TODO Write a proper conversion function
-    fg_image ret_val =
-        fgMngr.getImage(inDims[1], inDims[0],
-                        (fg_channel_format)(inDims[2] * 100), getGLType<T>());
+    // TODO(pradeep): Write a proper conversion function
+    fg_image ret_val = fgMngr.getImage(
+        inDims[1], inDims[0], static_cast<fg_channel_format>(inDims[2] * 100),
+        getGLType<T>());
     copy_image<T>(normalizePerType<T>(imgData), ret_val);
 
     return ret_val;

--- a/src/api/c/imageio.cpp
+++ b/src/api/c/imageio.cpp
@@ -38,6 +38,7 @@ using af::dim4;
 using detail::pinnedAlloc;
 using detail::pinnedFree;
 using detail::uchar;
+using detail::uint;
 using detail::ushort;
 using std::string;
 using std::swap;

--- a/src/api/c/imageio.cpp
+++ b/src/api/c/imageio.cpp
@@ -38,14 +38,13 @@ using af::dim4;
 using namespace detail;
 using std::string;
 using std::swap;
-using std::unique_ptr;
 
 template<typename T, FI_CHANNELS fi_color, FI_CHANNELS fo_color>
 static af_err readImage(af_array* rImage, const uchar* pSrcLine,
                         const int nSrcPitch, const uint fi_w, const uint fi_h) {
     // create an array to receive the loaded image data.
     AF_CHECK(af_init());
-    float* pDst  = pinnedAlloc<float>(fi_w * fi_h * 4);  // 4 channels is max
+    auto* pDst   = pinnedAlloc<float>(fi_w * fi_h * 4);  // 4 channels is max
     float* pDst0 = pDst;
     float* pDst1 = pDst + (fi_w * fi_h * 1);
     float* pDst2 = pDst + (fi_w * fi_h * 2);
@@ -56,32 +55,37 @@ static af_err readImage(af_array* rImage, const uchar* pSrcLine,
 
     for (uint x = 0; x < fi_w; ++x) {
         for (uint y = 0; y < fi_h; ++y) {
-            const T* src = (T*)(pSrcLine - y * nSrcPitch);
+            const T* src = reinterpret_cast<const T*>(pSrcLine - y * nSrcPitch);
             if (fo_color == 1) {
-                pDst0[indx] = (T) * (src + (x * step));
+                pDst0[indx] = static_cast<T>(*(src + (x * step)));
             } else if (fo_color >= 3) {
-                if ((af_dtype)af::dtype_traits<T>::af_type == u8) {
-                    pDst0[indx] = (float)*(src + (x * step + FI_RGBA_RED));
-                    pDst1[indx] = (float)*(src + (x * step + FI_RGBA_GREEN));
-                    pDst2[indx] = (float)*(src + (x * step + FI_RGBA_BLUE));
-                    if (fo_color == 4)
+                if (static_cast<af_dtype>(af::dtype_traits<T>::af_type) == u8) {
+                    pDst0[indx] =
+                        static_cast<float>(*(src + (x * step + FI_RGBA_RED)));
+                    pDst1[indx] =
+                        static_cast<float>(*(src + (x * step + FI_RGBA_GREEN)));
+                    pDst2[indx] =
+                        static_cast<float>(*(src + (x * step + FI_RGBA_BLUE)));
+                    if (fo_color == 4) {
                         pDst3[indx] =
                             (float)*(src + (x * step + FI_RGBA_ALPHA));
+                    }
                 } else {
                     // Non 8-bit types do not use ordering
                     // See Pixel Access Functions Chapter in FreeImage Doc
-                    pDst0[indx] = (float)*(src + (x * step + 0));
-                    pDst1[indx] = (float)*(src + (x * step + 1));
-                    pDst2[indx] = (float)*(src + (x * step + 2));
-                    if (fo_color == 4)
-                        pDst3[indx] = (float)*(src + (x * step + 3));
+                    pDst0[indx] = static_cast<float>(*(src + (x * step + 0)));
+                    pDst1[indx] = static_cast<float>(*(src + (x * step + 1)));
+                    pDst2[indx] = static_cast<float>(*(src + (x * step + 2)));
+                    if (fo_color == 4) {
+                        pDst3[indx] =
+                            static_cast<float>(*(src + (x * step + 3)));
+                    }
                 }
             }
             indx++;
         }
     }
 
-    // TODO
     af::dim4 dims(fi_h, fi_w, fo_color, 1);
     af_err err = af_create_array(rImage, pDst, dims.ndims(), dims.get(),
                                  (af_dtype)af::dtype_traits<float>::af_type);
@@ -104,7 +108,8 @@ FreeImage_Module::FreeImage_Module() : module(nullptr, nullptr) {
 FreeImage_Module::FreeImage_Module() : module("freeimage", nullptr) {
     if (!module.isLoaded()) {
         string error_message =
-            "Error loading FreeImage: " + module.getErrorMessage() +
+            "Error loading FreeImage: " +
+            common::DependencyModule::getErrorMessage() +
             "\nFreeImage or one of it's dependencies failed to "
             "load. Try installing FreeImage or check if FreeImage is in the "
             "search path.";
@@ -139,7 +144,8 @@ FreeImage_Module::FreeImage_Module() : module("freeimage", nullptr) {
 #ifndef FREEIMAGE_STATIC
     if (!module.symbolsLoaded()) {
         string error_message =
-            "Error loading FreeImage: " + module.getErrorMessage() +
+            "Error loading FreeImage: " +
+            common::DependencyModule::getErrorMessage() +
             "\nThe installed version of FreeImage is not compatible with "
             "ArrayFire. Please create an issue on which this error message";
         AF_ERROR(error_message.c_str(), AF_ERR_LOAD_LIB);
@@ -154,7 +160,7 @@ FreeImage_Module::~FreeImage_Module() {
 }
 
 FreeImage_Module& getFreeImagePlugin() {
-    static FreeImage_Module* plugin = new FreeImage_Module();
+    static auto* plugin = new FreeImage_Module();
     return *plugin;
 }
 
@@ -167,7 +173,7 @@ static af_err readImage(af_array* rImage, const uchar* pSrcLine,
                         const int nSrcPitch, const uint fi_w, const uint fi_h) {
     // create an array to receive the loaded image data.
     AF_CHECK(af_init());
-    float* pDst = pinnedAlloc<float>(fi_w * fi_h);
+    auto* pDst = pinnedAlloc<float>(fi_w * fi_h);
 
     uint indx = 0;
     uint step = nSrcPitch / (fi_w * sizeof(T));
@@ -176,18 +182,18 @@ static af_err readImage(af_array* rImage, const uchar* pSrcLine,
         for (uint y = 0; y < fi_h; ++y) {
             const T* src = (T*)(pSrcLine - y * nSrcPitch);
             if (fo_color == 1) {
-                pDst[indx] = (T) * (src + (x * step));
+                pDst[indx] = static_cast<T>(*(src + (x * step)));
             } else if (fo_color >= 3) {
-                if ((af_dtype)af::dtype_traits<T>::af_type == u8) {
-                    r = (T) * (src + (x * step + FI_RGBA_RED));
-                    g = (T) * (src + (x * step + FI_RGBA_GREEN));
-                    b = (T) * (src + (x * step + FI_RGBA_BLUE));
+                if (static_cast<af_dtype>(af::dtype_traits<T>::af_type) == u8) {
+                    r = *(src + (x * step + FI_RGBA_RED));
+                    g = *(src + (x * step + FI_RGBA_GREEN));
+                    b = *(src + (x * step + FI_RGBA_BLUE));
                 } else {
                     // Non 8-bit types do not use ordering
                     // See Pixel Access Functions Chapter in FreeImage Doc
-                    r = (T) * (src + (x * step + 0));
-                    g = (T) * (src + (x * step + 1));
-                    b = (T) * (src + (x * step + 2));
+                    r = *(src + (x * step + 0));
+                    g = *(src + (x * step + 1));
+                    b = *(src + (x * step + 2));
                 }
                 pDst[indx] = r * 0.2989f + g * 0.5870f + b * 0.1140f;
             }
@@ -226,10 +232,10 @@ af_err af_load_image(af_array* out, const char* filename, const bool isColor) {
                      AF_ERR_NOT_SUPPORTED);
         }
 
-        int flags = 0;
-        if (fif == FIF_JPEG) flags = flags | JPEG_ACCURATE;
+        unsigned flags = 0;
+        if (fif == FIF_JPEG) { flags = flags | JPEG_ACCURATE; }
 #ifdef JPEG_GREYSCALE
-        if (fif == FIF_JPEG && !isColor) flags = flags | JPEG_GREYSCALE;
+        if (fif == FIF_JPEG && !isColor) { flags = flags | JPEG_GREYSCALE; }
 #endif
 
         // check that the plugin has reading capabilities ...
@@ -289,19 +295,19 @@ af_err af_load_image(af_array* out, const char* filename, const bool isColor) {
         af_array rImage;
         if (isColor) {
             if (fi_color == 4) {  // 4 channel image
-                if (fi_bpc == 8)
+                if (fi_bpc == 8) {
                     AF_CHECK((readImage<uchar, AFFI_RGBA, AFFI_RGBA>)(&rImage,
                                                                       pSrcLine,
                                                                       nSrcPitch,
                                                                       fi_w,
                                                                       fi_h));
-                else if (fi_bpc == 16)
+                } else if (fi_bpc == 16) {
                     AF_CHECK(
                         (readImage<ushort, AFFI_RGBA, AFFI_RGBA>)(&rImage,
                                                                   pSrcLine,
                                                                   nSrcPitch,
                                                                   fi_w, fi_h));
-                else if (fi_bpc == 32)
+                } else if (fi_bpc == 32) {
                     switch (image_type) {
                         case FIT_UINT32:
                             AF_CHECK((readImage<uint, AFFI_RGBA,
@@ -328,20 +334,21 @@ af_err af_load_image(af_array* out, const char* filename, const bool isColor) {
                                      AF_ERR_NOT_SUPPORTED);
                             break;
                     }
+                }
             } else if (fi_color == 1) {
-                if (fi_bpc == 8)
+                if (fi_bpc == 8) {
                     AF_CHECK((readImage<uchar, AFFI_GRAY, AFFI_RGB>)(&rImage,
                                                                      pSrcLine,
                                                                      nSrcPitch,
                                                                      fi_w,
                                                                      fi_h));
-                else if (fi_bpc == 16)
+                } else if (fi_bpc == 16) {
                     AF_CHECK((readImage<ushort, AFFI_GRAY, AFFI_RGB>)(&rImage,
                                                                       pSrcLine,
                                                                       nSrcPitch,
                                                                       fi_w,
                                                                       fi_h));
-                else if (fi_bpc == 32)
+                } else if (fi_bpc == 32) {
                     switch (image_type) {
                         case FIT_UINT32:
                             AF_CHECK((
@@ -370,19 +377,20 @@ af_err af_load_image(af_array* out, const char* filename, const bool isColor) {
                                      AF_ERR_NOT_SUPPORTED);
                             break;
                     }
+                }
             } else {  // 3 channel image
-                if (fi_bpc == 8)
+                if (fi_bpc == 8) {
                     AF_CHECK((
                         readImage<uchar, AFFI_RGB, AFFI_RGB>)(&rImage, pSrcLine,
                                                               nSrcPitch, fi_w,
                                                               fi_h));
-                else if (fi_bpc == 16)
+                } else if (fi_bpc == 16) {
                     AF_CHECK((readImage<ushort, AFFI_RGB, AFFI_RGB>)(&rImage,
                                                                      pSrcLine,
                                                                      nSrcPitch,
                                                                      fi_w,
                                                                      fi_h));
-                else if (fi_bpc == 32)
+                } else if (fi_bpc == 32) {
                     switch (image_type) {
                         case FIT_UINT32:
                             AF_CHECK(
@@ -413,18 +421,19 @@ af_err af_load_image(af_array* out, const char* filename, const bool isColor) {
                                      AF_ERR_NOT_SUPPORTED);
                             break;
                     }
+                }
             }
         } else {                  // output gray irrespective
             if (fi_color == 1) {  // 4 channel image
-                if (fi_bpc == 8)
+                if (fi_bpc == 8) {
                     AF_CHECK((readImage<uchar, AFFI_GRAY>)(&rImage, pSrcLine,
                                                            nSrcPitch, fi_w,
                                                            fi_h));
-                else if (fi_bpc == 16)
+                } else if (fi_bpc == 16) {
                     AF_CHECK((readImage<ushort, AFFI_GRAY>)(&rImage, pSrcLine,
                                                             nSrcPitch, fi_w,
                                                             fi_h));
-                else if (fi_bpc == 32)
+                } else if (fi_bpc == 32) {
                     switch (image_type) {
                         case FIT_UINT32:
                             AF_CHECK((readImage<uint, AFFI_GRAY>)(&rImage,
@@ -449,16 +458,17 @@ af_err af_load_image(af_array* out, const char* filename, const bool isColor) {
                                      AF_ERR_NOT_SUPPORTED);
                             break;
                     }
+                }
             } else if (fi_color == 3 || fi_color == 4) {
-                if (fi_bpc == 8)
+                if (fi_bpc == 8) {
                     AF_CHECK((readImage<uchar, AFFI_RGB>)(&rImage, pSrcLine,
                                                           nSrcPitch, fi_w,
                                                           fi_h));
-                else if (fi_bpc == 16)
+                } else if (fi_bpc == 16) {
                     AF_CHECK((readImage<ushort, AFFI_RGB>)(&rImage, pSrcLine,
                                                            nSrcPitch, fi_w,
                                                            fi_h));
-                else if (fi_bpc == 32)
+                } else if (fi_bpc == 32) {
                     switch (image_type) {
                         case FIT_UINT32:
                             AF_CHECK((readImage<uint, AFFI_RGB>)(&rImage,
@@ -483,6 +493,7 @@ af_err af_load_image(af_array* out, const char* filename, const bool isColor) {
                                      AF_ERR_NOT_SUPPORTED);
                             break;
                     }
+                }
             }
         }
 
@@ -578,10 +589,11 @@ af_err af_save_image(const char* filename, const af_array in_) {
             AF_CHECK(af_transpose(&aaT, aa, false));
 
             const ArrayInfo& cinfo = getInfo(rrT);
-            float* pSrc0           = pinnedAlloc<float>(cinfo.elements());
-            float* pSrc1           = pinnedAlloc<float>(cinfo.elements());
-            float* pSrc2           = pinnedAlloc<float>(cinfo.elements());
-            float* pSrc3           = pinnedAlloc<float>(cinfo.elements());
+
+            auto* pSrc0 = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc1 = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc2 = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc3 = pinnedAlloc<float>(cinfo.elements());
 
             AF_CHECK(af_get_data_ptr((void*)pSrc0, rrT));
             AF_CHECK(af_get_data_ptr((void*)pSrc1, ggT));
@@ -592,13 +604,13 @@ af_err af_save_image(const char* filename, const af_array in_) {
             for (uint y = 0; y < fi_h; ++y) {
                 for (uint x = 0; x < fi_w; ++x) {
                     *(pDstLine + x * step + FI_RGBA_RED) =
-                        (uchar)pSrc0[indx];  // r
+                        static_cast<uchar>(pSrc0[indx]);  // r
                     *(pDstLine + x * step + FI_RGBA_GREEN) =
-                        (uchar)pSrc1[indx];  // g
+                        static_cast<uchar>(pSrc1[indx]);  // g
                     *(pDstLine + x * step + FI_RGBA_BLUE) =
-                        (uchar)pSrc2[indx];  // b
+                        static_cast<uchar>(pSrc2[indx]);  // b
                     *(pDstLine + x * step + FI_RGBA_ALPHA) =
-                        (uchar)pSrc3[indx];  // a
+                        static_cast<uchar>(pSrc3[indx]);  // a
                     ++indx;
                 }
                 pDstLine -= nDstPitch;
@@ -613,9 +625,10 @@ af_err af_save_image(const char* filename, const af_array in_) {
             AF_CHECK(af_transpose(&bbT, bb, false));
 
             const ArrayInfo& cinfo = getInfo(rrT);
-            float* pSrc0           = pinnedAlloc<float>(cinfo.elements());
-            float* pSrc1           = pinnedAlloc<float>(cinfo.elements());
-            float* pSrc2           = pinnedAlloc<float>(cinfo.elements());
+
+            auto* pSrc0 = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc1 = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc2 = pinnedAlloc<float>(cinfo.elements());
 
             AF_CHECK(af_get_data_ptr((void*)pSrc0, rrT));
             AF_CHECK(af_get_data_ptr((void*)pSrc1, ggT));
@@ -625,11 +638,11 @@ af_err af_save_image(const char* filename, const af_array in_) {
             for (uint y = 0; y < fi_h; ++y) {
                 for (uint x = 0; x < fi_w; ++x) {
                     *(pDstLine + x * step + FI_RGBA_RED) =
-                        (uchar)pSrc0[indx];  // r
+                        static_cast<uchar>(pSrc0[indx]);  // r
                     *(pDstLine + x * step + FI_RGBA_GREEN) =
-                        (uchar)pSrc1[indx];  // g
+                        static_cast<uchar>(pSrc1[indx]);  // g
                     *(pDstLine + x * step + FI_RGBA_BLUE) =
-                        (uchar)pSrc2[indx];  // b
+                        static_cast<uchar>(pSrc2[indx]);  // b
                     ++indx;
                 }
                 pDstLine -= nDstPitch;
@@ -640,12 +653,12 @@ af_err af_save_image(const char* filename, const af_array in_) {
         } else {
             AF_CHECK(af_transpose(&rrT, rr, false));
             const ArrayInfo& cinfo = getInfo(rrT);
-            float* pSrc0           = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc0            = pinnedAlloc<float>(cinfo.elements());
             AF_CHECK(af_get_data_ptr((void*)pSrc0, rrT));
 
             for (uint y = 0; y < fi_h; ++y) {
                 for (uint x = 0; x < fi_w; ++x) {
-                    *(pDstLine + x * step) = (uchar)pSrc0[indx];
+                    *(pDstLine + x * step) = static_cast<uchar>(pSrc0[indx]);
                     ++indx;
                 }
                 pDstLine -= nDstPitch;
@@ -654,7 +667,7 @@ af_err af_save_image(const char* filename, const af_array in_) {
         }
 
         int flags = 0;
-        if (fif == FIF_JPEG) flags = flags | JPEG_QUALITYSUPERB;
+        if (fif == FIF_JPEG) { flags = flags | JPEG_QUALITYSUPERB; }
 
         // now save the result image
         if (!(_.FreeImage_Save(fif, pResultBitmap.get(), filename, flags) ==
@@ -662,15 +675,15 @@ af_err af_save_image(const char* filename, const af_array in_) {
             AF_ERROR("FreeImage Error: Failed to save image", AF_ERR_RUNTIME);
         }
 
-        if (free_in) AF_CHECK(af_release_array(in));
-        if (rr != 0) AF_CHECK(af_release_array(rr));
-        if (gg != 0) AF_CHECK(af_release_array(gg));
-        if (bb != 0) AF_CHECK(af_release_array(bb));
-        if (aa != 0) AF_CHECK(af_release_array(aa));
-        if (rrT != 0) AF_CHECK(af_release_array(rrT));
-        if (ggT != 0) AF_CHECK(af_release_array(ggT));
-        if (bbT != 0) AF_CHECK(af_release_array(bbT));
-        if (aaT != 0) AF_CHECK(af_release_array(aaT));
+        if (free_in) { AF_CHECK(af_release_array(in)); }
+        if (rr != 0) { AF_CHECK(af_release_array(rr)); }
+        if (gg != 0) { AF_CHECK(af_release_array(gg)); }
+        if (bb != 0) { AF_CHECK(af_release_array(bb)); }
+        if (aa != 0) { AF_CHECK(af_release_array(aa)); }
+        if (rrT != 0) { AF_CHECK(af_release_array(rrT)); }
+        if (ggT != 0) { AF_CHECK(af_release_array(ggT)); }
+        if (bbT != 0) { AF_CHECK(af_release_array(bbT)); }
+        if (aaT != 0) { AF_CHECK(af_release_array(aaT)); }
     }
     CATCHALL
 
@@ -690,7 +703,7 @@ af_err af_load_image_memory(af_array* out, const void* ptr) {
         // set your own FreeImage error handler
         _.FreeImage_SetOutputMessage(FreeImageErrorHandler);
 
-        FIMEMORY* stream = (FIMEMORY*)ptr;
+        auto* stream = static_cast<FIMEMORY*>(const_cast<void*>(ptr));
         _.FreeImage_SeekMemory(stream, 0L, SEEK_SET);
 
         // try to guess the file format from the file extension
@@ -704,8 +717,8 @@ af_err af_load_image_memory(af_array* out, const void* ptr) {
                      AF_ERR_NOT_SUPPORTED);
         }
 
-        int flags = 0;
-        if (fif == FIF_JPEG) flags = flags | JPEG_ACCURATE;
+        unsigned flags = 0;
+        if (fif == FIF_JPEG) { flags = flags | JPEG_ACCURATE; }
 
         // check that the plugin has reading capabilities ...
         bitmap_ptr pBitmap = make_bitmap_ptr(NULL);
@@ -759,47 +772,50 @@ af_err af_load_image_memory(af_array* out, const void* ptr) {
         // result image
         af_array rImage;
         if (fi_color == 4) {  // 4 channel image
-            if (fi_bpc == 8)
+            if (fi_bpc == 8) {
                 AF_CHECK((readImage<uchar, AFFI_RGBA, AFFI_RGBA>)(&rImage,
                                                                   pSrcLine,
                                                                   nSrcPitch,
                                                                   fi_w, fi_h));
-            else if (fi_bpc == 16)
+            } else if (fi_bpc == 16) {
                 AF_CHECK((readImage<ushort, AFFI_RGBA, AFFI_RGBA>)(&rImage,
                                                                    pSrcLine,
                                                                    nSrcPitch,
                                                                    fi_w, fi_h));
-            else if (fi_bpc == 32)
+            } else if (fi_bpc == 32) {
                 AF_CHECK((readImage<float, AFFI_RGBA, AFFI_RGBA>)(&rImage,
                                                                   pSrcLine,
                                                                   nSrcPitch,
                                                                   fi_w, fi_h));
+            }
         } else if (fi_color == 1) {  // 1 channel image
-            if (fi_bpc == 8)
+            if (fi_bpc == 8) {
                 AF_CHECK((readImage<uchar, AFFI_GRAY>)(&rImage, pSrcLine,
                                                        nSrcPitch, fi_w, fi_h));
-            else if (fi_bpc == 16)
+            } else if (fi_bpc == 16) {
                 AF_CHECK((readImage<ushort, AFFI_GRAY>)(&rImage, pSrcLine,
                                                         nSrcPitch, fi_w, fi_h));
-            else if (fi_bpc == 32)
+            } else if (fi_bpc == 32) {
                 AF_CHECK((readImage<float, AFFI_GRAY>)(&rImage, pSrcLine,
                                                        nSrcPitch, fi_w, fi_h));
+            }
         } else {  // 3 channel image
-            if (fi_bpc == 8)
+            if (fi_bpc == 8) {
                 AF_CHECK((readImage<uchar, AFFI_RGB, AFFI_RGB>)(&rImage,
                                                                 pSrcLine,
                                                                 nSrcPitch, fi_w,
                                                                 fi_h));
-            else if (fi_bpc == 16)
+            } else if (fi_bpc == 16) {
                 AF_CHECK((readImage<ushort, AFFI_RGB, AFFI_RGB>)(&rImage,
                                                                  pSrcLine,
                                                                  nSrcPitch,
                                                                  fi_w, fi_h));
-            else if (fi_bpc == 32)
+            } else if (fi_bpc == 32) {
                 AF_CHECK((readImage<float, AFFI_RGB, AFFI_RGB>)(&rImage,
                                                                 pSrcLine,
                                                                 nSrcPitch, fi_w,
                                                                 fi_h));
+            }
         }
 
         swap(*out, rImage);
@@ -819,7 +835,7 @@ af_err af_save_image_memory(void** ptr, const af_array in_,
         _.FreeImage_SetOutputMessage(FreeImageErrorHandler);
 
         // try to guess the file format from the file extension
-        FREE_IMAGE_FORMAT fif = (FREE_IMAGE_FORMAT)format;
+        auto fif = static_cast<FREE_IMAGE_FORMAT>(format);
 
         if (fif == FIF_UNKNOWN || fif > 34) {  // FreeImage FREE_IMAGE_FORMAT
                                                // has upto 34 enums as of 3.17
@@ -882,10 +898,10 @@ af_err af_save_image_memory(void** ptr, const af_array in_,
             AF_CHECK(af_transpose(&aaT, aa, false));
 
             const ArrayInfo& cinfo = getInfo(rrT);
-            float* pSrc0           = pinnedAlloc<float>(cinfo.elements());
-            float* pSrc1           = pinnedAlloc<float>(cinfo.elements());
-            float* pSrc2           = pinnedAlloc<float>(cinfo.elements());
-            float* pSrc3           = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc0            = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc1            = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc2            = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc3            = pinnedAlloc<float>(cinfo.elements());
 
             AF_CHECK(af_get_data_ptr((void*)pSrc0, rrT));
             AF_CHECK(af_get_data_ptr((void*)pSrc1, ggT));
@@ -896,13 +912,13 @@ af_err af_save_image_memory(void** ptr, const af_array in_,
             for (uint y = 0; y < fi_h; ++y) {
                 for (uint x = 0; x < fi_w; ++x) {
                     *(pDstLine + x * step + FI_RGBA_RED) =
-                        (uchar)pSrc0[indx];  // r
+                        static_cast<uchar>(pSrc0[indx]);  // r
                     *(pDstLine + x * step + FI_RGBA_GREEN) =
-                        (uchar)pSrc1[indx];  // g
+                        static_cast<uchar>(pSrc1[indx]);  // g
                     *(pDstLine + x * step + FI_RGBA_BLUE) =
-                        (uchar)pSrc2[indx];  // b
+                        static_cast<uchar>(pSrc2[indx]);  // b
                     *(pDstLine + x * step + FI_RGBA_ALPHA) =
-                        (uchar)pSrc3[indx];  // a
+                        static_cast<uchar>(pSrc3[indx]);  // a
                     ++indx;
                 }
                 pDstLine -= nDstPitch;
@@ -917,9 +933,9 @@ af_err af_save_image_memory(void** ptr, const af_array in_,
             AF_CHECK(af_transpose(&bbT, bb, false));
 
             const ArrayInfo& cinfo = getInfo(rrT);
-            float* pSrc0           = pinnedAlloc<float>(cinfo.elements());
-            float* pSrc1           = pinnedAlloc<float>(cinfo.elements());
-            float* pSrc2           = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc0            = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc1            = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc2            = pinnedAlloc<float>(cinfo.elements());
 
             AF_CHECK(af_get_data_ptr((void*)pSrc0, rrT));
             AF_CHECK(af_get_data_ptr((void*)pSrc1, ggT));
@@ -929,11 +945,11 @@ af_err af_save_image_memory(void** ptr, const af_array in_,
             for (uint y = 0; y < fi_h; ++y) {
                 for (uint x = 0; x < fi_w; ++x) {
                     *(pDstLine + x * step + FI_RGBA_RED) =
-                        (uchar)pSrc0[indx];  // r
+                        static_cast<uchar>(pSrc0[indx]);  // r
                     *(pDstLine + x * step + FI_RGBA_GREEN) =
-                        (uchar)pSrc1[indx];  // g
+                        static_cast<uchar>(pSrc1[indx]);  // g
                     *(pDstLine + x * step + FI_RGBA_BLUE) =
-                        (uchar)pSrc2[indx];  // b
+                        static_cast<uchar>(pSrc2[indx]);  // b
                     ++indx;
                 }
                 pDstLine -= nDstPitch;
@@ -944,12 +960,12 @@ af_err af_save_image_memory(void** ptr, const af_array in_,
         } else {
             AF_CHECK(af_transpose(&rrT, rr, false));
             const ArrayInfo& cinfo = getInfo(rrT);
-            float* pSrc0           = pinnedAlloc<float>(cinfo.elements());
+            auto* pSrc0            = pinnedAlloc<float>(cinfo.elements());
             AF_CHECK(af_get_data_ptr((void*)pSrc0, rrT));
 
             for (uint y = 0; y < fi_h; ++y) {
                 for (uint x = 0; x < fi_w; ++x) {
-                    *(pDstLine + x * step) = (uchar)pSrc0[indx];
+                    *(pDstLine + x * step) = static_cast<uchar>(pSrc0[indx]);
                     ++indx;
                 }
                 pDstLine -= nDstPitch;
@@ -962,7 +978,7 @@ af_err af_save_image_memory(void** ptr, const af_array in_,
         FIMEMORY* stream       = _.FreeImage_OpenMemory(data, size_in_bytes);
 
         int flags = 0;
-        if (fif == FIF_JPEG) flags = flags | JPEG_QUALITYSUPERB;
+        if (fif == FIF_JPEG) { flags = flags | JPEG_QUALITYSUPERB; }
 
         // now save the result image
         if (!(_.FreeImage_SaveToMemory(fif, pResultBitmap.get(), stream,
@@ -972,15 +988,15 @@ af_err af_save_image_memory(void** ptr, const af_array in_,
 
         *ptr = stream;
 
-        if (free_in) AF_CHECK(af_release_array(in));
-        if (rr != 0) AF_CHECK(af_release_array(rr));
-        if (gg != 0) AF_CHECK(af_release_array(gg));
-        if (bb != 0) AF_CHECK(af_release_array(bb));
-        if (aa != 0) AF_CHECK(af_release_array(aa));
-        if (rrT != 0) AF_CHECK(af_release_array(rrT));
-        if (ggT != 0) AF_CHECK(af_release_array(ggT));
-        if (bbT != 0) AF_CHECK(af_release_array(bbT));
-        if (aaT != 0) AF_CHECK(af_release_array(aaT));
+        if (free_in) { AF_CHECK(af_release_array(in)); }
+        if (rr != 0) { AF_CHECK(af_release_array(rr)); }
+        if (gg != 0) { AF_CHECK(af_release_array(gg)); }
+        if (bb != 0) { AF_CHECK(af_release_array(bb)); }
+        if (aa != 0) { AF_CHECK(af_release_array(aa)); }
+        if (rrT != 0) { AF_CHECK(af_release_array(rrT)); }
+        if (ggT != 0) { AF_CHECK(af_release_array(ggT)); }
+        if (bbT != 0) { AF_CHECK(af_release_array(bbT)); }
+        if (aaT != 0) { AF_CHECK(af_release_array(aaT)); }
     }
     CATCHALL
 
@@ -996,17 +1012,17 @@ af_err af_delete_image_memory(void* ptr) {
         // set your own FreeImage error handler
         _.FreeImage_SetOutputMessage(FreeImageErrorHandler);
 
-        FIMEMORY* stream = (FIMEMORY*)ptr;
+        auto* stream = static_cast<FIMEMORY*>(ptr);
         _.FreeImage_SeekMemory(stream, 0L, SEEK_SET);
 
         // Ensure data is freeimage compatible
         FREE_IMAGE_FORMAT fif =
-            _.FreeImage_GetFileTypeFromMemory((FIMEMORY*)ptr, 0);
+            _.FreeImage_GetFileTypeFromMemory(static_cast<FIMEMORY*>(ptr), 0);
         if (fif == FIF_UNKNOWN) {
             AF_ERROR("FreeImage Error: Unknown Filetype", AF_ERR_NOT_SUPPORTED);
         }
 
-        _.FreeImage_CloseMemory((FIMEMORY*)ptr);
+        _.FreeImage_CloseMemory(static_cast<FIMEMORY*>(ptr));
     }
     CATCHALL
 

--- a/src/api/c/imageio2.cpp
+++ b/src/api/c/imageio2.cpp
@@ -32,7 +32,9 @@
 #include <string>
 
 using af::dim4;
-using namespace detail;
+using detail::pinnedAlloc;
+using detail::pinnedFree;
+using detail::uchar;
 
 template<typename T, FI_CHANNELS fi_color>
 static af_err readImage_t(af_array* rImage, const uchar* pSrcLine,
@@ -51,60 +53,63 @@ static af_err readImage_t(af_array* rImage, const uchar* pSrcLine,
 
     for (uint x = 0; x < fi_w; ++x) {
         for (uint y = 0; y < fi_h; ++y) {
-            const T* src = (T*)((uchar*)pSrcLine - y * nSrcPitch);
+            const T* src = reinterpret_cast<T*>(const_cast<uchar*>(pSrcLine) -
+                                                y * nSrcPitch);
             if (fi_color == 1) {
-                pDst0[indx] = (T) * (src + (x * step));
+                pDst0[indx] = *(src + (x * step));
             } else if (fi_color >= 3) {
-                if ((af_dtype)af::dtype_traits<T>::af_type == u8) {
-                    pDst0[indx] = (T) * (src + (x * step + FI_RGBA_RED));
-                    pDst1[indx] = (T) * (src + (x * step + FI_RGBA_GREEN));
-                    pDst2[indx] = (T) * (src + (x * step + FI_RGBA_BLUE));
-                    if (fi_color == 4)
+                if (static_cast<af_dtype>(af::dtype_traits<T>::af_type) == u8) {
+                    pDst0[indx] = *(src + (x * step + FI_RGBA_RED));
+                    pDst1[indx] = *(src + (x * step + FI_RGBA_GREEN));
+                    pDst2[indx] = *(src + (x * step + FI_RGBA_BLUE));
+                    if (fi_color == 4) {
                         pDst3[indx] = (T) * (src + (x * step + FI_RGBA_ALPHA));
+                    }
                 } else {
                     // Non 8-bit types do not use ordering
                     // See Pixel Access Functions Chapter in FreeImage Doc
-                    pDst0[indx] = (T) * (src + (x * step + 0));
-                    pDst1[indx] = (T) * (src + (x * step + 1));
-                    pDst2[indx] = (T) * (src + (x * step + 2));
-                    if (fi_color == 4)
-                        pDst3[indx] = (T) * (src + (x * step + 3));
+                    pDst0[indx] = *(src + (x * step + 0));
+                    pDst1[indx] = *(src + (x * step + 1));
+                    pDst2[indx] = *(src + (x * step + 2));
+                    if (fi_color == 4) {
+                        pDst3[indx] = *(src + (x * step + 3));
+                    }
                 }
             }
             indx++;
         }
     }
 
-    // TODO
     af::dim4 dims(fi_h, fi_w, fi_color, 1);
-    af_err err = af_create_array(rImage, pDst, dims.ndims(), dims.get(),
-                                 (af_dtype)af::dtype_traits<T>::af_type);
+    af_err err =
+        af_create_array(rImage, pDst, dims.ndims(), dims.get(),
+                        static_cast<af_dtype>(af::dtype_traits<T>::af_type));
     pinnedFree(pDst);
     return err;
 }
 
 FREE_IMAGE_TYPE getFIT(FI_CHANNELS channels, af_dtype type) {
     if (channels == AFFI_GRAY) {
-        if (type == u8)
-            return FIT_BITMAP;
-        else if (type == u16)
+        if (type == u8) { return FIT_BITMAP; }
+        if (type == u16) {
             return FIT_UINT16;
-        else if (type == f32)
+        } else if (type == f32) {
             return FIT_FLOAT;
+        }
     } else if (channels == AFFI_RGB) {
-        if (type == u8)
-            return FIT_BITMAP;
-        else if (type == u16)
+        if (type == u8) { return FIT_BITMAP; }
+        if (type == u16) {
             return FIT_RGB16;
-        else if (type == f32)
+        } else if (type == f32) {
             return FIT_RGBF;
+        }
     } else if (channels == AFFI_RGBA) {
-        if (type == u8)
-            return FIT_BITMAP;
-        else if (type == u16)
+        if (type == u8) { return FIT_BITMAP; }
+        if (type == u16) {
             return FIT_RGBA16;
-        else if (type == f32)
+        } else if (type == f32) {
             return FIT_RGBAF;
+        }
     }
     return FIT_BITMAP;
 }
@@ -133,8 +138,8 @@ af_err af_load_image_native(af_array* out, const char* filename) {
                      AF_ERR_NOT_SUPPORTED);
         }
 
-        int flags = 0;
-        if (fif == FIF_JPEG) flags = flags | JPEG_ACCURATE;
+        unsigned flags = 0;
+        if (fif == FIF_JPEG) { flags = flags | JPEG_ACCURATE; }
 
         // check that the plugin has reading capabilities ...
         bitmap_ptr pBitmap = make_bitmap_ptr(nullptr);
@@ -192,15 +197,15 @@ af_err af_load_image_native(af_array* out, const char* filename) {
         // result image
         af_array rImage;
         if (fi_color == 4) {  // 4 channel image
-            if (fi_bpc == 8)
+            if (fi_bpc == 8) {
                 AF_CHECK((readImage_t<uchar, AFFI_RGBA>)(&rImage, pSrcLine,
                                                          nSrcPitch, fi_w,
                                                          fi_h));
-            else if (fi_bpc == 16)
+            } else if (fi_bpc == 16) {
                 AF_CHECK((readImage_t<ushort, AFFI_RGBA>)(&rImage, pSrcLine,
                                                           nSrcPitch, fi_w,
                                                           fi_h));
-            else if (fi_bpc == 32)
+            } else if (fi_bpc == 32) {
                 switch (image_type) {
                     case FIT_UINT32:
                         AF_CHECK((readImage_t<uint, AFFI_RGBA>)(&rImage,
@@ -225,16 +230,17 @@ af_err af_load_image_native(af_array* out, const char* filename) {
                                  AF_ERR_NOT_SUPPORTED);
                         break;
                 }
+            }
         } else if (fi_color == 1) {
-            if (fi_bpc == 8)
+            if (fi_bpc == 8) {
                 AF_CHECK((readImage_t<uchar, AFFI_GRAY>)(&rImage, pSrcLine,
                                                          nSrcPitch, fi_w,
                                                          fi_h));
-            else if (fi_bpc == 16)
+            } else if (fi_bpc == 16) {
                 AF_CHECK((readImage_t<ushort, AFFI_GRAY>)(&rImage, pSrcLine,
                                                           nSrcPitch, fi_w,
                                                           fi_h));
-            else if (fi_bpc == 32)
+            } else if (fi_bpc == 32) {
                 switch (image_type) {
                     case FIT_UINT32:
                         AF_CHECK((readImage_t<uint, AFFI_GRAY>)(&rImage,
@@ -259,15 +265,16 @@ af_err af_load_image_native(af_array* out, const char* filename) {
                                  AF_ERR_NOT_SUPPORTED);
                         break;
                 }
+            }
         } else {  // 3 channel imag
-            if (fi_bpc == 8)
+            if (fi_bpc == 8) {
                 AF_CHECK((readImage_t<uchar, AFFI_RGB>)(&rImage, pSrcLine,
                                                         nSrcPitch, fi_w, fi_h));
-            else if (fi_bpc == 16)
+            } else if (fi_bpc == 16) {
                 AF_CHECK((readImage_t<ushort, AFFI_RGB>)(&rImage, pSrcLine,
                                                          nSrcPitch, fi_w,
                                                          fi_h));
-            else if (fi_bpc == 32)
+            } else if (fi_bpc == 32) {
                 switch (image_type) {
                     case FIT_UINT32:
                         AF_CHECK((readImage_t<uint, AFFI_RGB>)(&rImage,
@@ -291,6 +298,7 @@ af_err af_load_image_native(af_array* out, const char* filename) {
                                  AF_ERR_NOT_SUPPORTED);
                         break;
                 }
+            }
         }
 
         std::swap(*out, rImage);
@@ -301,7 +309,7 @@ af_err af_load_image_native(af_array* out, const char* filename) {
 }
 
 template<typename T, FI_CHANNELS channels>
-static void save_t(T* pDstLine, const af_array in, const dim4 dims,
+static void save_t(T* pDstLine, const af_array in, const dim4& dims,
                    uint nDstPitch) {
     af_array rr = 0, gg = 0, bb = 0, aa = 0;
     AF_CHECK(channel_split(in, dims, &rr, &gg, &bb,
@@ -314,20 +322,20 @@ static void save_t(T* pDstLine, const af_array in, const dim4 dims,
     uint indx = 0;
 
     AF_CHECK(af_transpose(&rrT, rr, false));
-    if (channels >= 3) AF_CHECK(af_transpose(&ggT, gg, false));
-    if (channels >= 3) AF_CHECK(af_transpose(&bbT, bb, false));
-    if (channels >= 4) AF_CHECK(af_transpose(&aaT, aa, false));
+    if (channels >= 3) { AF_CHECK(af_transpose(&ggT, gg, false)); }
+    if (channels >= 3) { AF_CHECK(af_transpose(&bbT, bb, false)); }
+    if (channels >= 4) { AF_CHECK(af_transpose(&aaT, aa, false)); }
 
     const ArrayInfo& cinfo = getInfo(rrT);
     pSrc0                  = pinnedAlloc<T>(cinfo.elements());
-    if (channels >= 3) pSrc1 = pinnedAlloc<T>(cinfo.elements());
-    if (channels >= 3) pSrc2 = pinnedAlloc<T>(cinfo.elements());
-    if (channels >= 4) pSrc3 = pinnedAlloc<T>(cinfo.elements());
+    if (channels >= 3) { pSrc1 = pinnedAlloc<T>(cinfo.elements()); }
+    if (channels >= 3) { pSrc2 = pinnedAlloc<T>(cinfo.elements()); }
+    if (channels >= 4) { pSrc3 = pinnedAlloc<T>(cinfo.elements()); }
 
     AF_CHECK(af_get_data_ptr((void*)pSrc0, rrT));
-    if (channels >= 3) AF_CHECK(af_get_data_ptr((void*)pSrc1, ggT));
-    if (channels >= 3) AF_CHECK(af_get_data_ptr((void*)pSrc2, bbT));
-    if (channels >= 4) AF_CHECK(af_get_data_ptr((void*)pSrc3, aaT));
+    if (channels >= 3) { AF_CHECK(af_get_data_ptr((void*)pSrc1, ggT)); }
+    if (channels >= 3) { AF_CHECK(af_get_data_ptr((void*)pSrc2, bbT)); }
+    if (channels >= 4) { AF_CHECK(af_get_data_ptr((void*)pSrc3, aaT)); }
 
     const uint fi_w = dims[1];
     const uint fi_h = dims[0];
@@ -336,45 +344,48 @@ static void save_t(T* pDstLine, const af_array in, const dim4 dims,
     for (uint y = 0; y < fi_h; ++y) {
         for (uint x = 0; x < fi_w; ++x) {
             if (channels == 1) {
-                *(pDstLine + x * step) = (T)pSrc0[indx];  // r -> 0
+                *(pDstLine + x * step) = pSrc0[indx];  // r -> 0
             } else if (channels >= 3) {
                 if ((af_dtype)af::dtype_traits<T>::af_type == u8) {
                     *(pDstLine + x * step + FI_RGBA_RED) =
-                        (T)pSrc0[indx];  // r -> 0
+                        pSrc0[indx];  // r -> 0
                     *(pDstLine + x * step + FI_RGBA_GREEN) =
-                        (T)pSrc1[indx];  // g -> 1
+                        pSrc1[indx];  // g -> 1
                     *(pDstLine + x * step + FI_RGBA_BLUE) =
-                        (T)pSrc2[indx];  // b -> 2
-                    if (channels >= 4)
+                        pSrc2[indx];  // b -> 2
+                    if (channels >= 4) {
                         *(pDstLine + x * step + FI_RGBA_ALPHA) =
-                            (T)pSrc3[indx];  // a
+                            pSrc3[indx];  // a
+                    }
                 } else {
                     // Non 8-bit types do not use ordering
                     // See Pixel Access Functions Chapter in FreeImage Doc
-                    *(pDstLine + x * step + 0) = (T)pSrc0[indx];  // r -> 0
-                    *(pDstLine + x * step + 1) = (T)pSrc1[indx];  // g -> 1
-                    *(pDstLine + x * step + 2) = (T)pSrc2[indx];  // b -> 2
-                    if (channels >= 4)
-                        *(pDstLine + x * step + 3) = (T)pSrc3[indx];  // a
+                    *(pDstLine + x * step + 0) = pSrc0[indx];  // r -> 0
+                    *(pDstLine + x * step + 1) = pSrc1[indx];  // g -> 1
+                    *(pDstLine + x * step + 2) = pSrc2[indx];  // b -> 2
+                    if (channels >= 4) {
+                        *(pDstLine + x * step + 3) = pSrc3[indx];  // a
+                    }
                 }
             }
             ++indx;
         }
-        pDstLine = (T*)(((uchar*)pDstLine) - nDstPitch);
+        pDstLine = reinterpret_cast<T*>(reinterpret_cast<uchar*>(pDstLine) -
+                                        nDstPitch);
     }
     pinnedFree(pSrc0);
-    if (channels >= 3) pinnedFree(pSrc1);
-    if (channels >= 3) pinnedFree(pSrc2);
-    if (channels >= 4) pinnedFree(pSrc3);
+    if (channels >= 3) { pinnedFree(pSrc1); }
+    if (channels >= 3) { pinnedFree(pSrc2); }
+    if (channels >= 4) { pinnedFree(pSrc3); }
 
-    if (rr != 0) AF_CHECK(af_release_array(rr));
-    if (gg != 0) AF_CHECK(af_release_array(gg));
-    if (bb != 0) AF_CHECK(af_release_array(bb));
-    if (aa != 0) AF_CHECK(af_release_array(aa));
-    if (rrT != 0) AF_CHECK(af_release_array(rrT));
-    if (ggT != 0) AF_CHECK(af_release_array(ggT));
-    if (bbT != 0) AF_CHECK(af_release_array(bbT));
-    if (aaT != 0) AF_CHECK(af_release_array(aaT));
+    if (rr != 0) { AF_CHECK(af_release_array(rr)); }
+    if (gg != 0) { AF_CHECK(af_release_array(gg)); }
+    if (bb != 0) { AF_CHECK(af_release_array(bb)); }
+    if (aa != 0) { AF_CHECK(af_release_array(aa)); }
+    if (rrT != 0) { AF_CHECK(af_release_array(rrT)); }
+    if (ggT != 0) { AF_CHECK(af_release_array(ggT)); }
+    if (bbT != 0) { AF_CHECK(af_release_array(bbT)); }
+    if (aaT != 0) { AF_CHECK(af_release_array(aaT)); }
 }
 
 // Save an image to disk.
@@ -399,7 +410,7 @@ af_err af_save_image_native(const char* filename, const af_array in) {
 
         const ArrayInfo& info = getInfo(in);
         // check image color type
-        FI_CHANNELS channels = (FI_CHANNELS)info.dims()[2];
+        auto channels = static_cast<FI_CHANNELS>(info.dims()[2]);
         DIM_ASSERT(1, channels <= 4);
         DIM_ASSERT(1, channels != 2);
 
@@ -426,13 +437,7 @@ af_err af_save_image_native(const char* filename, const af_array in) {
         bitmap_ptr pResultBitmap = make_bitmap_ptr(nullptr);
         switch (type) {
             case u8:
-                pResultBitmap.reset(_.FreeImage_AllocateT(fit_type, fi_w, fi_h,
-                                                          fi_bpp, 0, 0, 0));
-                break;
             case u16:
-                pResultBitmap.reset(_.FreeImage_AllocateT(fit_type, fi_w, fi_h,
-                                                          fi_bpp, 0, 0, 0));
-                break;
             case f32:
                 pResultBitmap.reset(_.FreeImage_AllocateT(fit_type, fi_w, fi_h,
                                                           fi_bpp, 0, 0, 0));
@@ -453,55 +458,55 @@ af_err af_save_image_native(const char* filename, const af_array in) {
         if (channels == AFFI_GRAY) {
             switch (type) {
                 case u8:
-                    save_t<uchar, AFFI_GRAY>((uchar*)pDstLine, in, info.dims(),
-                                             nDstPitch);
+                    save_t<uchar, AFFI_GRAY>(static_cast<uchar*>(pDstLine), in,
+                                             info.dims(), nDstPitch);
                     break;
                 case u16:
-                    save_t<ushort, AFFI_GRAY>((ushort*)pDstLine, in,
-                                              info.dims(), nDstPitch);
+                    save_t<ushort, AFFI_GRAY>(static_cast<ushort*>(pDstLine),
+                                              in, info.dims(), nDstPitch);
                     break;
                 case f32:
-                    save_t<float, AFFI_GRAY>((float*)pDstLine, in, info.dims(),
-                                             nDstPitch);
+                    save_t<float, AFFI_GRAY>(static_cast<float*>(pDstLine), in,
+                                             info.dims(), nDstPitch);
                     break;
                 default: TYPE_ERROR(1, type);
             }
         } else if (channels == AFFI_RGB) {
             switch (type) {
                 case u8:
-                    save_t<uchar, AFFI_RGB>((uchar*)pDstLine, in, info.dims(),
-                                            nDstPitch);
+                    save_t<uchar, AFFI_RGB>(static_cast<uchar*>(pDstLine), in,
+                                            info.dims(), nDstPitch);
                     break;
                 case u16:
-                    save_t<ushort, AFFI_RGB>((ushort*)pDstLine, in, info.dims(),
-                                             nDstPitch);
+                    save_t<ushort, AFFI_RGB>(static_cast<ushort*>(pDstLine), in,
+                                             info.dims(), nDstPitch);
                     break;
                 case f32:
-                    save_t<float, AFFI_RGB>((float*)pDstLine, in, info.dims(),
-                                            nDstPitch);
+                    save_t<float, AFFI_RGB>(static_cast<float*>(pDstLine), in,
+                                            info.dims(), nDstPitch);
                     break;
                 default: TYPE_ERROR(1, type);
             }
         } else {
             switch (type) {
                 case u8:
-                    save_t<uchar, AFFI_RGBA>((uchar*)pDstLine, in, info.dims(),
-                                             nDstPitch);
+                    save_t<uchar, AFFI_RGBA>(static_cast<uchar*>(pDstLine), in,
+                                             info.dims(), nDstPitch);
                     break;
                 case u16:
-                    save_t<ushort, AFFI_RGBA>((ushort*)pDstLine, in,
-                                              info.dims(), nDstPitch);
+                    save_t<ushort, AFFI_RGBA>(static_cast<ushort*>(pDstLine),
+                                              in, info.dims(), nDstPitch);
                     break;
                 case f32:
-                    save_t<float, AFFI_RGBA>((float*)pDstLine, in, info.dims(),
-                                             nDstPitch);
+                    save_t<float, AFFI_RGBA>(static_cast<float*>(pDstLine), in,
+                                             info.dims(), nDstPitch);
                     break;
                 default: TYPE_ERROR(1, type);
             }
         }
 
-        int flags = 0;
-        if (fif == FIF_JPEG) flags = flags | JPEG_QUALITYSUPERB;
+        unsigned flags = 0;
+        if (fif == FIF_JPEG) { flags = flags | JPEG_QUALITYSUPERB; }
 
         // now save the result image
         if (!(_.FreeImage_Save(fif, pResultBitmap.get(), filename, flags) ==

--- a/src/api/c/imageio2.cpp
+++ b/src/api/c/imageio2.cpp
@@ -35,6 +35,8 @@ using af::dim4;
 using detail::pinnedAlloc;
 using detail::pinnedFree;
 using detail::uchar;
+using detail::uint;
+using detail::ushort;
 
 template<typename T, FI_CHANNELS fi_color>
 static af_err readImage_t(af_array* rImage, const uchar* pSrcLine,

--- a/src/api/c/implicit.cpp
+++ b/src/api/c/implicit.cpp
@@ -23,22 +23,22 @@ af_dtype implicit(const af_dtype lty, const af_dtype rty) {
     if (lty == c64 || rty == c64) { return c64; }
 
     if (lty == c32 || rty == c32) {
-        if (lty == f64 || rty == f64) return c64;
+        if (lty == f64 || rty == f64) { return c64; }
         return c32;
     }
 
-    if (lty == f64 || rty == f64) return f64;
-    if (lty == f32 || rty == f32) return f32;
-    if ((lty == f16) || (rty == f16)) return f16;
+    if (lty == f64 || rty == f64) { return f64; }
+    if (lty == f32 || rty == f32) { return f32; }
+    if ((lty == f16) || (rty == f16)) { return f16; }
 
-    if ((lty == u64) || (rty == u64)) return u64;
-    if ((lty == s64) || (rty == s64)) return s64;
-    if ((lty == u32) || (rty == u32)) return u32;
-    if ((lty == s32) || (rty == s32)) return s32;
-    if ((lty == u16) || (rty == u16)) return u16;
-    if ((lty == s16) || (rty == s16)) return s16;
-    if ((lty == u8) || (rty == u8)) return u8;
-    if ((lty == b8) && (rty == b8)) return b8;
+    if ((lty == u64) || (rty == u64)) { return u64; }
+    if ((lty == s64) || (rty == s64)) { return s64; }
+    if ((lty == u32) || (rty == u32)) { return u32; }
+    if ((lty == s32) || (rty == s32)) { return s32; }
+    if ((lty == u16) || (rty == u16)) { return u16; }
+    if ((lty == s16) || (rty == s16)) { return s16; }
+    if ((lty == u8) || (rty == u8)) { return u8; }
+    if ((lty == b8) && (rty == b8)) { return b8; }
 
     return f32;
 }

--- a/src/api/c/implicit.hpp
+++ b/src/api/c/implicit.hpp
@@ -17,7 +17,5 @@
 #include <af/array.h>
 #include <af/defines.h>
 
-using namespace detail;
-
 af_dtype implicit(const af_array lhs, const af_array rhs);
 af_dtype implicit(const af_dtype lty, const af_dtype rty);

--- a/src/api/c/index.cpp
+++ b/src/api/c/index.cpp
@@ -58,13 +58,14 @@ af_seq convert2Canonical(const af_seq s, const dim_t len) {
 template<typename T>
 static af_array indexBySeqs(const af_array& src,
                             const vector<af_seq> indicesV) {
-    size_t ndims = indicesV.size();
-    auto input   = getArray<T>(src);
+    size_t ndims      = indicesV.size();
+    const auto& input = getArray<T>(src);
 
-    if (ndims == 1 && ndims != input.ndims())
+    if (ndims == 1 && ndims != input.ndims()) {
         return getHandle(createSubArray(::flat(input), indicesV));
-    else
+    } else {
         return getHandle(createSubArray(input, indicesV));
+    }
 }
 
 af_err af_index(af_array* result, const af_array in, const unsigned ndims,
@@ -203,7 +204,7 @@ af_err af_index_gen(af_array* out, const af_array in, const dim_t ndims,
             return AF_SUCCESS;
         }
 
-        if (ndims == 1 && ndims != (dim_t)iInfo.ndims()) {
+        if (ndims == 1 && ndims != static_cast<dim_t>(iInfo.ndims())) {
             af_array in_ = 0;
             AF_CHECK(af_flat(&in_, in));
             AF_CHECK(af_index_gen(out, in_, ndims, indexs));
@@ -212,7 +213,7 @@ af_err af_index_gen(af_array* out, const af_array in, const dim_t ndims,
         }
 
         int track = 0;
-        std::array<af_seq, AF_MAX_DIMS> seqs;
+        std::array<af_seq, AF_MAX_DIMS> seqs{};
         seqs.fill(af_span);
         for (dim_t i = 0; i < ndims; i++) {
             if (indexs[i].isSeq) {
@@ -221,9 +222,11 @@ af_err af_index_gen(af_array* out, const af_array in, const dim_t ndims,
             }
         }
 
-        if (track == (int)ndims) return af_index(out, in, ndims, seqs.data());
+        if (track == static_cast<int>(ndims)) {
+            return af_index(out, in, ndims, seqs.data());
+        }
 
-        std::array<af_index_t, AF_MAX_DIMS> idxrs;
+        std::array<af_index_t, AF_MAX_DIMS> idxrs{};
 
         for (dim_t i = 0; i < AF_MAX_DIMS; ++i) {
             if (i < ndims) {
@@ -289,7 +292,7 @@ af_seq af_make_seq(double begin, double end, double step) {
 
 af_err af_create_indexers(af_index_t** indexers) {
     try {
-        af_index_t* out = new af_index_t[AF_MAX_DIMS];
+        auto* out = new af_index_t[AF_MAX_DIMS];
         for (int i = 0; i < AF_MAX_DIMS; ++i) {
             out[i].idx.seq = af_span;
             out[i].isSeq   = true;

--- a/src/api/c/internal.cpp
+++ b/src/api/c/internal.cpp
@@ -42,12 +42,14 @@ af_err af_create_strided_array(af_array *arr, const void *data,
         ARG_ASSERT(5, strides_ != NULL);
         ARG_ASSERT(5, strides_[0] == 1);
 
-        for (int i = 1; i < (int)ndims; i++) { ARG_ASSERT(5, strides_[i] > 0); }
+        for (int i = 1; i < static_cast<int>(ndims); i++) {
+            ARG_ASSERT(5, strides_[i] > 0);
+        }
 
         dim4 dims(ndims, dims_);
         dim4 strides(ndims, strides_);
 
-        for (int i = ndims; i < 4; i++) {
+        for (int i = static_cast<int>(ndims); i < 4; i++) {
             strides[i] = strides[i - 1] * dims[i - 1];
         }
 
@@ -56,58 +58,60 @@ af_err af_create_strided_array(af_array *arr, const void *data,
         af_array res;
         AF_CHECK(af_init());
 
+        void *in_data = const_cast<void *>(data); // const cast because the api cannot change
         switch (ty) {
             case f32:
                 res = getHandle(createStridedArray<float>(
-                    dims, strides, offset, (float *)data, isdev));
+                    dims, strides, offset, static_cast<float *>(in_data), isdev));
                 break;
             case f64:
                 res = getHandle(createStridedArray<double>(
-                    dims, strides, offset, (double *)data, isdev));
+                    dims, strides, offset, static_cast<double *>(in_data), isdev));
                 break;
             case c32:
                 res = getHandle(createStridedArray<cfloat>(
-                    dims, strides, offset, (cfloat *)data, isdev));
+                    dims, strides, offset, static_cast<cfloat *>(in_data), isdev));
                 break;
             case c64:
                 res = getHandle(createStridedArray<cdouble>(
-                    dims, strides, offset, (cdouble *)data, isdev));
+                    dims, strides, offset, static_cast<cdouble *>(in_data),
+                    isdev));
                 break;
             case u32:
-                res = getHandle(createStridedArray<uint>(dims, strides, offset,
-                                                         (uint *)data, isdev));
+                res = getHandle(createStridedArray<uint>(
+                    dims, strides, offset, static_cast<uint *>(in_data), isdev));
                 break;
             case s32:
-                res = getHandle(createStridedArray<int>(dims, strides, offset,
-                                                        (int *)data, isdev));
+                res = getHandle(createStridedArray<int>(
+                    dims, strides, offset, static_cast<int *>(in_data), isdev));
                 break;
             case u64:
                 res = getHandle(createStridedArray<uintl>(
-                    dims, strides, offset, (uintl *)data, isdev));
+                    dims, strides, offset, static_cast<uintl *>(in_data), isdev));
                 break;
             case s64:
-                res = getHandle(createStridedArray<intl>(dims, strides, offset,
-                                                         (intl *)data, isdev));
+                res = getHandle(createStridedArray<intl>(
+                    dims, strides, offset, static_cast<intl *>(in_data), isdev));
                 break;
             case u16:
                 res = getHandle(createStridedArray<ushort>(
-                    dims, strides, offset, (ushort *)data, isdev));
+                    dims, strides, offset, static_cast<ushort *>(in_data), isdev));
                 break;
             case s16:
                 res = getHandle(createStridedArray<short>(
-                    dims, strides, offset, (short *)data, isdev));
+                    dims, strides, offset, static_cast<short *>(in_data), isdev));
                 break;
             case b8:
-                res = getHandle(createStridedArray<char>(dims, strides, offset,
-                                                         (char *)data, isdev));
+                res = getHandle(createStridedArray<char>(
+                    dims, strides, offset, static_cast<char *>(in_data), isdev));
                 break;
             case u8:
                 res = getHandle(createStridedArray<uchar>(
-                    dims, strides, offset, (uchar *)data, isdev));
+                    dims, strides, offset, static_cast<uchar *>(in_data), isdev));
                 break;
             case f16:
-                res = getHandle(createStridedArray<half>(dims, strides, offset,
-                                                         (half *)data, isdev));
+                res = getHandle(createStridedArray<half>(
+                    dims, strides, offset, static_cast<half *>(in_data), isdev));
                 break;
             default: TYPE_ERROR(6, ty);
         }
@@ -147,19 +151,19 @@ af_err af_get_raw_ptr(void **ptr, const af_array arr) {
         af_dtype ty = getInfo(arr).getType();
 
         switch (ty) {
-            case f32: res = (void *)getRawPtr(getArray<float>(arr)); break;
-            case f64: res = (void *)getRawPtr(getArray<double>(arr)); break;
-            case c32: res = (void *)getRawPtr(getArray<cfloat>(arr)); break;
-            case c64: res = (void *)getRawPtr(getArray<cdouble>(arr)); break;
-            case u32: res = (void *)getRawPtr(getArray<uint>(arr)); break;
-            case s32: res = (void *)getRawPtr(getArray<int>(arr)); break;
-            case u64: res = (void *)getRawPtr(getArray<uintl>(arr)); break;
-            case s64: res = (void *)getRawPtr(getArray<intl>(arr)); break;
-            case u16: res = (void *)getRawPtr(getArray<ushort>(arr)); break;
-            case s16: res = (void *)getRawPtr(getArray<short>(arr)); break;
-            case b8: res = (void *)getRawPtr(getArray<char>(arr)); break;
-            case u8: res = (void *)getRawPtr(getArray<uchar>(arr)); break;
-            case f16: res = (void *)getRawPtr(getArray<half>(arr)); break;
+            case f32: res = getRawPtr(getArray<float>(arr)); break;
+            case f64: res = getRawPtr(getArray<double>(arr)); break;
+            case c32: res = getRawPtr(getArray<cfloat>(arr)); break;
+            case c64: res = getRawPtr(getArray<cdouble>(arr)); break;
+            case u32: res = getRawPtr(getArray<uint>(arr)); break;
+            case s32: res = getRawPtr(getArray<int>(arr)); break;
+            case u64: res = getRawPtr(getArray<uintl>(arr)); break;
+            case s64: res = getRawPtr(getArray<intl>(arr)); break;
+            case u16: res = getRawPtr(getArray<ushort>(arr)); break;
+            case s16: res = getRawPtr(getArray<short>(arr)); break;
+            case b8: res = getRawPtr(getArray<char>(arr)); break;
+            case u8: res = getRawPtr(getArray<uchar>(arr)); break;
+            case f16: res = getRawPtr(getArray<half>(arr)); break;
             default: TYPE_ERROR(6, ty);
         }
 
@@ -184,19 +188,19 @@ af_err af_is_owner(bool *result, const af_array arr) {
         af_dtype ty = getInfo(arr).getType();
 
         switch (ty) {
-            case f32: res = (void *)getArray<float>(arr).isOwner(); break;
-            case f64: res = (void *)getArray<double>(arr).isOwner(); break;
-            case c32: res = (void *)getArray<cfloat>(arr).isOwner(); break;
-            case c64: res = (void *)getArray<cdouble>(arr).isOwner(); break;
-            case u32: res = (void *)getArray<uint>(arr).isOwner(); break;
-            case s32: res = (void *)getArray<int>(arr).isOwner(); break;
-            case u64: res = (void *)getArray<uintl>(arr).isOwner(); break;
-            case s64: res = (void *)getArray<intl>(arr).isOwner(); break;
-            case u16: res = (void *)getArray<ushort>(arr).isOwner(); break;
-            case s16: res = (void *)getArray<short>(arr).isOwner(); break;
-            case b8: res = (void *)getArray<char>(arr).isOwner(); break;
-            case u8: res = (void *)getArray<uchar>(arr).isOwner(); break;
-            case f16: res = (void *)getArray<half>(arr).isOwner(); break;
+            case f32: res = getArray<float>(arr).isOwner(); break;
+            case f64: res = getArray<double>(arr).isOwner(); break;
+            case c32: res = getArray<cfloat>(arr).isOwner(); break;
+            case c64: res = getArray<cdouble>(arr).isOwner(); break;
+            case u32: res = getArray<uint>(arr).isOwner(); break;
+            case s32: res = getArray<int>(arr).isOwner(); break;
+            case u64: res = getArray<uintl>(arr).isOwner(); break;
+            case s64: res = getArray<intl>(arr).isOwner(); break;
+            case u16: res = getArray<ushort>(arr).isOwner(); break;
+            case s16: res = getArray<short>(arr).isOwner(); break;
+            case b8: res = getArray<char>(arr).isOwner(); break;
+            case u8: res = getArray<uchar>(arr).isOwner(); break;
+            case f16: res = getArray<half>(arr).isOwner(); break;
             default: TYPE_ERROR(6, ty);
         }
 

--- a/src/api/c/internal.cpp
+++ b/src/api/c/internal.cpp
@@ -58,19 +58,23 @@ af_err af_create_strided_array(af_array *arr, const void *data,
         af_array res;
         AF_CHECK(af_init());
 
-        void *in_data = const_cast<void *>(data); // const cast because the api cannot change
+        void *in_data = const_cast<void *>(
+            data);  // const cast because the api cannot change
         switch (ty) {
             case f32:
                 res = getHandle(createStridedArray<float>(
-                    dims, strides, offset, static_cast<float *>(in_data), isdev));
+                    dims, strides, offset, static_cast<float *>(in_data),
+                    isdev));
                 break;
             case f64:
                 res = getHandle(createStridedArray<double>(
-                    dims, strides, offset, static_cast<double *>(in_data), isdev));
+                    dims, strides, offset, static_cast<double *>(in_data),
+                    isdev));
                 break;
             case c32:
                 res = getHandle(createStridedArray<cfloat>(
-                    dims, strides, offset, static_cast<cfloat *>(in_data), isdev));
+                    dims, strides, offset, static_cast<cfloat *>(in_data),
+                    isdev));
                 break;
             case c64:
                 res = getHandle(createStridedArray<cdouble>(
@@ -79,7 +83,8 @@ af_err af_create_strided_array(af_array *arr, const void *data,
                 break;
             case u32:
                 res = getHandle(createStridedArray<uint>(
-                    dims, strides, offset, static_cast<uint *>(in_data), isdev));
+                    dims, strides, offset, static_cast<uint *>(in_data),
+                    isdev));
                 break;
             case s32:
                 res = getHandle(createStridedArray<int>(
@@ -87,31 +92,38 @@ af_err af_create_strided_array(af_array *arr, const void *data,
                 break;
             case u64:
                 res = getHandle(createStridedArray<uintl>(
-                    dims, strides, offset, static_cast<uintl *>(in_data), isdev));
+                    dims, strides, offset, static_cast<uintl *>(in_data),
+                    isdev));
                 break;
             case s64:
                 res = getHandle(createStridedArray<intl>(
-                    dims, strides, offset, static_cast<intl *>(in_data), isdev));
+                    dims, strides, offset, static_cast<intl *>(in_data),
+                    isdev));
                 break;
             case u16:
                 res = getHandle(createStridedArray<ushort>(
-                    dims, strides, offset, static_cast<ushort *>(in_data), isdev));
+                    dims, strides, offset, static_cast<ushort *>(in_data),
+                    isdev));
                 break;
             case s16:
                 res = getHandle(createStridedArray<short>(
-                    dims, strides, offset, static_cast<short *>(in_data), isdev));
+                    dims, strides, offset, static_cast<short *>(in_data),
+                    isdev));
                 break;
             case b8:
                 res = getHandle(createStridedArray<char>(
-                    dims, strides, offset, static_cast<char *>(in_data), isdev));
+                    dims, strides, offset, static_cast<char *>(in_data),
+                    isdev));
                 break;
             case u8:
                 res = getHandle(createStridedArray<uchar>(
-                    dims, strides, offset, static_cast<uchar *>(in_data), isdev));
+                    dims, strides, offset, static_cast<uchar *>(in_data),
+                    isdev));
                 break;
             case f16:
                 res = getHandle(createStridedArray<half>(
-                    dims, strides, offset, static_cast<half *>(in_data), isdev));
+                    dims, strides, offset, static_cast<half *>(in_data),
+                    isdev));
                 break;
             default: TYPE_ERROR(6, ty);
         }

--- a/src/api/c/inverse.cpp
+++ b/src/api/c/inverse.cpp
@@ -16,7 +16,6 @@
 #include <af/defines.h>
 #include <af/lapack.h>
 
-using af::dim4;
 using namespace detail;
 
 template<typename T>

--- a/src/api/c/join.cpp
+++ b/src/api/c/join.cpp
@@ -33,7 +33,7 @@ static inline af_array join_many(const int dim, const unsigned n_arrays,
     std::vector<Array<T>> inputs_;
     inputs_.reserve(n_arrays);
 
-    for (int i = 0; i < (int)n_arrays; i++) {
+    for (unsigned i = 0; i < n_arrays; i++) {
         inputs_.push_back(getArray<T>(inputs[i]));
     }
     return getHandle(join<T>(dim, inputs_));
@@ -59,7 +59,7 @@ af_err af_join(af_array *out, const int dim, const af_array first,
         // All dimensions except join dimension must be equal
         // Compute output dims
         for (int i = 0; i < 4; i++) {
-            if (i != dim) DIM_ASSERT(2, fdims[i] == sdims[i]);
+            if (i != dim) { DIM_ASSERT(2, fdims[i] == sdims[i]); }
         }
 
         af_array output;
@@ -97,14 +97,14 @@ af_err af_join_many(af_array *out, const int dim, const unsigned n_arrays,
         std::vector<ArrayInfo> info;
         info.reserve(n_arrays);
         std::vector<af::dim4> dims(n_arrays);
-        for (int i = 0; i < (int)n_arrays; i++) {
+        for (unsigned i = 0; i < n_arrays; i++) {
             info.push_back(getInfo(inputs[i]));
             dims[i] = info[i].dims();
         }
 
         ARG_ASSERT(1, dim >= 0 && dim < 4);
 
-        for (int i = 1; i < (int)n_arrays; i++) {
+        for (unsigned i = 1; i < n_arrays; i++) {
             ARG_ASSERT(3, info[0].getType() == info[i].getType());
             DIM_ASSERT(3, info[i].elements() > 0);
         }
@@ -113,7 +113,7 @@ af_err af_join_many(af_array *out, const int dim, const unsigned n_arrays,
         // Compute output dims
         for (int i = 0; i < 4; i++) {
             if (i != dim) {
-                for (int j = 1; j < (int)n_arrays; j++) {
+                for (unsigned j = 1; j < n_arrays; j++) {
                     DIM_ASSERT(3, dims[0][i] == dims[j][i]);
                 }
             }

--- a/src/api/c/match_template.cpp
+++ b/src/api/c/match_template.cpp
@@ -15,11 +15,11 @@
 #include <af/vision.h>
 
 using af::dim4;
+using detail::intl;
 using detail::uchar;
-using detail::ushort;
 using detail::uint;
 using detail::uintl;
-using detail::intl;
+using detail::ushort;
 
 template<typename inType, typename outType>
 static af_array match_template(const af_array& sImg, const af_array tImg,

--- a/src/api/c/match_template.cpp
+++ b/src/api/c/match_template.cpp
@@ -15,7 +15,11 @@
 #include <af/vision.h>
 
 using af::dim4;
-using namespace detail;
+using detail::uchar;
+using detail::ushort;
+using detail::uint;
+using detail::uintl;
+using detail::intl;
 
 template<typename inType, typename outType>
 static af_array match_template(const af_array& sImg, const af_array tImg,
@@ -63,8 +67,8 @@ af_err af_match_template(af_array* out, const af_array search_img,
         const ArrayInfo& sInfo = getInfo(search_img);
         const ArrayInfo& tInfo = getInfo(template_img);
 
-        dim4 const sDims = sInfo.dims();
-        dim4 const tDims = tInfo.dims();
+        dim4 const& sDims = sInfo.dims();
+        dim4 const& tDims = tInfo.dims();
 
         dim_t sNumDims = sDims.ndims();
         dim_t tNumDims = tDims.ndims();

--- a/src/api/c/mean.cpp
+++ b/src/api/c/mean.cpp
@@ -23,10 +23,10 @@
 #include "stats.h"
 
 using common::half;
-using detail::mean;
 using detail::Array;
-using detail::cfloat;
 using detail::cdouble;
+using detail::cfloat;
+using detail::mean;
 
 template<typename Ti, typename To>
 static To mean(const af_array &in) {

--- a/src/api/c/mean.cpp
+++ b/src/api/c/mean.cpp
@@ -23,31 +23,33 @@
 #include "stats.h"
 
 using common::half;
-
-using namespace detail;
+using detail::mean;
+using detail::Array;
+using detail::cfloat;
+using detail::cdouble;
 
 template<typename Ti, typename To>
 static To mean(const af_array &in) {
-    typedef typename baseOutType<To>::type Tw;
+    using Tw = typename baseOutType<To>::type;
     return mean<Ti, Tw, To>(getArray<Ti>(in));
 }
 
 template<typename T>
 static T mean(const af_array &in, const af_array &weights) {
-    typedef typename baseOutType<T>::type Tw;
+    using Tw = typename baseOutType<T>::type;
     return mean<T, Tw>(castArray<T>(in), castArray<Tw>(weights));
 }
 
 template<typename Ti, typename To>
 static af_array mean(const af_array &in, const dim_t dim) {
-    typedef typename baseOutType<To>::type Tw;
+    using Tw = typename baseOutType<To>::type;
     return getHandle<To>(mean<Ti, Tw, To>(getArray<Ti>(in), dim));
 }
 
 template<typename T>
 static af_array mean(const af_array &in, const af_array &weights,
                      const dim_t dim) {
-    typedef typename baseOutType<T>::type Tw;
+    using Tw = typename baseOutType<T>::type;
     return getHandle<T>(
         mean<T, Tw>(castArray<T>(in), castArray<Tw>(weights), dim));
 }
@@ -113,16 +115,16 @@ af_err af_mean_weighted(af_array *out, const af_array in,
         }
 
         switch (iType) {
-            case f64: output = mean<double>(in, w, dim); break;
-            case f32: output = mean<float>(in, w, dim); break;
-            case s32: output = mean<float>(in, w, dim); break;
-            case u32: output = mean<float>(in, w, dim); break;
-            case s64: output = mean<double>(in, w, dim); break;
-            case u64: output = mean<double>(in, w, dim); break;
-            case s16: output = mean<float>(in, w, dim); break;
-            case u16: output = mean<float>(in, w, dim); break;
-            case u8: output = mean<float>(in, w, dim); break;
+            case f32:
+            case s32:
+            case u32:
+            case s16:
+            case u16:
+            case u8:
             case b8: output = mean<float>(in, w, dim); break;
+            case f64:
+            case s64:
+            case u64: output = mean<double>(in, w, dim); break;
             case c32: output = mean<cfloat>(in, w, dim); break;
             case c64: output = mean<cdouble>(in, w, dim); break;
             case f16: output = mean<half>(in, w, dim); break;
@@ -184,17 +186,17 @@ af_err af_mean_all_weighted(double *realVal, double *imagVal, const af_array in,
                  f64)); /* verify that weights are non-complex real numbers */
 
         switch (iType) {
-            case f64: *realVal = mean<double>(in, weights); break;
-            case f32: *realVal = mean<float>(in, weights); break;
-            case s32: *realVal = mean<float>(in, weights); break;
-            case u32: *realVal = mean<float>(in, weights); break;
-            case s64: *realVal = mean<double>(in, weights); break;
-            case u64: *realVal = mean<double>(in, weights); break;
-            case s16: *realVal = mean<float>(in, weights); break;
-            case u16: *realVal = mean<float>(in, weights); break;
-            case u8: *realVal = mean<float>(in, weights); break;
-            case b8: *realVal = mean<float>(in, weights); break;
+            case f32:
+            case s32:
+            case u32:
+            case s16:
+            case u16:
+            case u8:
+            case b8:
             case f16: *realVal = mean<float>(in, weights); break;
+            case f64:
+            case s64:
+            case u64: *realVal = mean<double>(in, weights); break;
             case c32: {
                 cfloat tmp = mean<cfloat>(in, weights);
                 *realVal   = real(tmp);

--- a/src/api/c/meanshift.cpp
+++ b/src/api/c/meanshift.cpp
@@ -39,7 +39,7 @@ af_err af_mean_shift(af_array *out, const af_array in,
         af::dim4 dims         = info.dims();
 
         DIM_ASSERT(1, (dims.ndims() >= 2));
-        if (is_color) DIM_ASSERT(1, (dims[2] == 3));
+        if (is_color) { DIM_ASSERT(1, (dims[2] == 3)); }
 
         af_array output;
         switch (type) {

--- a/src/api/c/median.cpp
+++ b/src/api/c/median.cpp
@@ -24,6 +24,8 @@ using af::dim4;
 using detail::Array;
 using detail::division;
 using detail::uchar;
+using detail::uint;
+using detail::ushort;
 using std::sort;
 
 template<typename T>

--- a/src/api/c/memory.cpp
+++ b/src/api/c/memory.cpp
@@ -44,6 +44,7 @@ using detail::pinnedFree;
 using detail::printMemInfo;
 using detail::signalMemoryCleanup;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
 using detail::ushort;
 using std::move;

--- a/src/api/c/memoryapi.hpp
+++ b/src/api/c/memoryapi.hpp
@@ -76,6 +76,6 @@ struct MemoryManager {
     MemoryManagerFunctionWrapper *wrapper;
 };
 
-MemoryManager &getMemoryManager(const af_memory_manager manager);
+MemoryManager &getMemoryManager(const af_memory_manager handle);
 
 af_memory_manager getHandle(MemoryManager &manager);

--- a/src/api/c/moddims.cpp
+++ b/src/api/c/moddims.cpp
@@ -18,7 +18,12 @@
 
 using af::dim4;
 using common::half;
-using namespace detail;
+using detail::cdouble;
+using detail::cfloat;
+using detail::intl;
+using detail::uchar;
+using detail::uintl;
+using detail::ushort;
 
 namespace {
 template<typename T>

--- a/src/api/c/moddims.cpp
+++ b/src/api/c/moddims.cpp
@@ -22,6 +22,7 @@ using detail::cdouble;
 using detail::cfloat;
 using detail::intl;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
 using detail::ushort;
 

--- a/src/api/c/moments.cpp
+++ b/src/api/c/moments.cpp
@@ -62,7 +62,7 @@ af_err af_moments(af_array* out, const af_array in,
 
 template<typename T>
 static inline void moment_copy(double* out, const af_array moments) {
-    auto info = getInfo(moments);
+    const auto& info = getInfo(moments);
     vector<T> h_moments(info.elements());
     copyData(h_moments.data(), moments);
 

--- a/src/api/c/morph.cpp
+++ b/src/api/c/morph.cpp
@@ -20,8 +20,8 @@ using detail::Array;
 using detail::cdouble;
 using detail::cfloat;
 using detail::createEmptyArray;
-using detail::uint;
 using detail::uchar;
+using detail::uint;
 using detail::ushort;
 
 template<typename T, bool isDilation>

--- a/src/api/c/morph.cpp
+++ b/src/api/c/morph.cpp
@@ -16,11 +16,17 @@
 #include <af/image.h>
 
 using af::dim4;
-using namespace detail;
+using detail::Array;
+using detail::cdouble;
+using detail::cfloat;
+using detail::createEmptyArray;
+using detail::uint;
+using detail::uchar;
+using detail::ushort;
 
 template<typename T, bool isDilation>
 static inline af_array morph(const af_array &in, const af_array &mask) {
-    const Array<T> &input  = getArray<T>(in);
+    const Array<T> input   = getArray<T>(in);
     const Array<T> &filter = castArray<T>(mask);
     Array<T> out           = morph<T, isDilation>(input, filter);
     return getHandle(out);
@@ -28,7 +34,7 @@ static inline af_array morph(const af_array &in, const af_array &mask) {
 
 template<typename T, bool isDilation>
 static inline af_array morph3d(const af_array &in, const af_array &mask) {
-    const Array<T> &input  = getArray<T>(in);
+    const Array<T> input   = getArray<T>(in);
     const Array<T> &filter = castArray<T>(mask);
     Array<T> out           = morph3d<T, isDilation>(input, filter);
     return getHandle(out);

--- a/src/api/c/nearest_neighbour.cpp
+++ b/src/api/c/nearest_neighbour.cpp
@@ -22,6 +22,7 @@ using detail::cfloat;
 using detail::createEmptyArray;
 using detail::intl;
 using detail::uchar;
+using detail::uint;
 using detail::uintl;
 using detail::ushort;
 

--- a/src/api/c/nearest_neighbour.cpp
+++ b/src/api/c/nearest_neighbour.cpp
@@ -16,7 +16,14 @@
 #include <af/vision.h>
 
 using af::dim4;
-using namespace detail;
+using detail::Array;
+using detail::cdouble;
+using detail::cfloat;
+using detail::createEmptyArray;
+using detail::intl;
+using detail::uchar;
+using detail::uintl;
+using detail::ushort;
 
 template<typename Ti, typename To>
 static void nearest_neighbour(af_array* idx, af_array* dist,

--- a/src/api/c/norm.cpp
+++ b/src/api/c/norm.cpp
@@ -30,7 +30,8 @@ double matrixNorm(const Array<T> &A, double p) {
     if (p == 1) {
         Array<T> colSum = reduce<af_add_t, T, T>(A, 0);
         return reduce_all<af_max_t, T, T>(colSum);
-    } else if (p == af::Inf) {
+    }
+    if (p == af::Inf) {
         Array<T> rowSum = reduce<af_add_t, T, T>(A, 1);
         return reduce_all<af_max_t, T, T>(rowSum);
     }
@@ -41,9 +42,8 @@ double matrixNorm(const Array<T> &A, double p) {
 
 template<typename T>
 double vectorNorm(const Array<T> &A, double p) {
-    if (p == 1) {
-        return reduce_all<af_add_t, T, T>(A);
-    } else if (p == af::Inf) {
+    if (p == 1) { return reduce_all<af_add_t, T, T>(A); }
+    if (p == af::Inf) {
         return reduce_all<af_max_t, T, T>(A);
     } else if (p == 2) {
         Array<T> A_sq = arithOp<T, af_mul_t>(A, A, A.dims());
@@ -81,7 +81,7 @@ double LPQNorm(const Array<T> &A, double p, double q) {
 template<typename T>
 double norm(const af_array a, const af_norm_type type, const double p,
             const double q) {
-    typedef typename af::dtype_traits<T>::base_type BT;
+    using BT = typename af::dtype_traits<T>::base_type;
 
     const Array<BT> A = abs<BT, T>(getArray<T>(a));
 

--- a/src/api/c/pinverse.cpp
+++ b/src/api/c/pinverse.cpp
@@ -59,7 +59,7 @@ Array<T> pinverseSvd(const Array<T> &in, const double tol) {
     dim_t Q = in.dims()[3];
 
     // Compute SVD
-    typedef typename dtype_traits<T>::base_type Tr;
+    using Tr = typename dtype_traits<T>::base_type;
     // Ideally, these initializations should use createEmptyArray(), but for
     // some reason, linux-opencl-k80 will produce wrong results for large arrays
     Array<T> u  = createValueArray<T>(dim4(M, M, P, Q), scalar<T>(0));

--- a/src/api/c/plot.cpp
+++ b/src/api/c/plot.cpp
@@ -51,10 +51,11 @@ fg_chart setup_plot(fg_window window, const af_array in_,
     fg_chart chart      = NULL;
     fg_chart_type ctype = order == 2 ? FG_CHART_2D : FG_CHART_3D;
 
-    if (props->col > -1 && props->row > -1)
+    if (props->col > -1 && props->row > -1) {
         chart = fgMngr.getChart(window, props->row, props->col, ctype);
-    else
+    } else {
         chart = fgMngr.getChart(window, 0, 0, ctype);
+    }
 
     fg_plot plot =
         fgMngr.getPlot(chart, tdims[1], getGLType<T>(), ptype, mtype);
@@ -79,16 +80,16 @@ fg_chart setup_plot(fg_window window, const af_array in_,
             cmax[0] = step_round(dmax[0], true);
             cmin[1] = step_round(dmin[1], false);
             cmax[1] = step_round(dmax[1], true);
-            if (order == 3) cmin[2] = step_round(dmin[2], false);
-            if (order == 3) cmax[2] = step_round(dmax[2], true);
+            if (order == 3) { cmin[2] = step_round(dmin[2], false); }
+            if (order == 3) { cmax[2] = step_round(dmax[2], true); }
         } else {
-            if (cmin[0] > dmin[0]) cmin[0] = step_round(dmin[0], false);
-            if (cmax[0] < dmax[0]) cmax[0] = step_round(dmax[0], true);
-            if (cmin[1] > dmin[1]) cmin[1] = step_round(dmin[1], false);
-            if (cmax[1] < dmax[1]) cmax[1] = step_round(dmax[1], true);
+            if (cmin[0] > dmin[0]) { cmin[0] = step_round(dmin[0], false); }
+            if (cmax[0] < dmax[0]) { cmax[0] = step_round(dmax[0], true); }
+            if (cmin[1] > dmin[1]) { cmin[1] = step_round(dmin[1], false); }
+            if (cmax[1] < dmax[1]) { cmax[1] = step_round(dmax[1], true); }
             if (order == 3) {
-                if (cmin[2] > dmin[2]) cmin[2] = step_round(dmin[2], false);
-                if (cmax[2] < dmax[2]) cmax[2] = step_round(dmax[2], true);
+                if (cmin[2] > dmin[2]) { cmin[2] = step_round(dmin[2], false); }
+                if (cmax[2] < dmax[2]) { cmax[2] = step_round(dmax[2], true); }
             }
         }
         FG_CHECK(_.fg_set_chart_axes_limits(chart, cmin[0], cmax[0], cmin[1],
@@ -103,10 +104,12 @@ template<typename T>
 fg_chart setup_plot(fg_window window, const af_array in_, const int order,
                     const af_cell* const props, fg_plot_type ptype,
                     fg_marker_type mtype) {
-    if (order == 2)
+    if (order == 2) {
         return setup_plot<T, 2>(window, in_, props, ptype, mtype);
-    else if (order == 3)
+    }
+    if (order == 3) {
         return setup_plot<T, 3>(window, in_, props, ptype, mtype);
+    }
     // Dummy to avoid warnings
     return NULL;
 }
@@ -181,15 +184,15 @@ af_err plotWrapper(const af_window window, const af_array X, const af_array Y,
         if (window == 0) { AF_ERROR("Not a valid window", AF_ERR_INTERNAL); }
 
         const ArrayInfo& xInfo = getInfo(X);
-        af::dim4 xDims         = xInfo.dims();
+        const af::dim4& xDims  = xInfo.dims();
         af_dtype xType         = xInfo.getType();
 
         const ArrayInfo& yInfo = getInfo(Y);
-        af::dim4 yDims         = yInfo.dims();
+        const af::dim4& yDims  = yInfo.dims();
         af_dtype yType         = yInfo.getType();
 
         const ArrayInfo& zInfo = getInfo(Z);
-        af::dim4 zDims         = zInfo.dims();
+        const af::dim4& zDims  = zInfo.dims();
         af_dtype zType         = zInfo.getType();
 
         DIM_ASSERT(0, xDims == yDims);
@@ -255,11 +258,11 @@ af_err plotWrapper(const af_window window, const af_array X, const af_array Y,
         if (window == 0) { AF_ERROR("Not a valid window", AF_ERR_INTERNAL); }
 
         const ArrayInfo& xInfo = getInfo(X);
-        af::dim4 xDims         = xInfo.dims();
+        const af::dim4& xDims  = xInfo.dims();
         af_dtype xType         = xInfo.getType();
 
         const ArrayInfo& yInfo = getInfo(Y);
-        af::dim4 yDims         = yInfo.dims();
+        const af::dim4& yDims  = yInfo.dims();
         af_dtype yType         = yInfo.getType();
 
         DIM_ASSERT(0, xDims == yDims);
@@ -344,7 +347,8 @@ af_err af_draw_plot3(const af_window wind, const af_array P,
 
         if (dims.ndims() == 2 && dims[1] == 3) {
             return plotWrapper(wind, P, 1, props);
-        } else if (dims.ndims() == 2 && dims[0] == 3) {
+        }
+        if (dims.ndims() == 2 && dims[0] == 3) {
             return plotWrapper(wind, P, 0, props);
         } else if (dims.ndims() == 1 && dims[0] % 3 == 0) {
             dim4 rdims(dims.elements() / 3, 3, 1, 1);
@@ -405,7 +409,8 @@ af_err af_draw_scatter3(const af_window wind, const af_array P,
 
         if (dims.ndims() == 2 && dims[1] == 3) {
             return plotWrapper(wind, P, 1, props, FG_PLOT_SCATTER, fg_marker);
-        } else if (dims.ndims() == 2 && dims[0] == 3) {
+        }
+        if (dims.ndims() == 2 && dims[0] == 3) {
             return plotWrapper(wind, P, 0, props, FG_PLOT_SCATTER, fg_marker);
         } else if (dims.ndims() == 1 && dims[0] % 3 == 0) {
             dim4 rdims(dims.elements() / 3, 3, 1, 1);

--- a/src/api/c/print.cpp
+++ b/src/api/c/print.cpp
@@ -273,7 +273,8 @@ af_err af_array_to_string(char **output, const char *exp, const af_array arr,
             }
         }
         std::string str = ss.str();
-        af_alloc_host((void **)output, sizeof(char) * (str.size() + 1));
+        af_alloc_host(reinterpret_cast<void **>(output),
+                      sizeof(char) * (str.size() + 1));
         str.copy(*output, str.size());
         (*output)[str.size()] = '\0';  // don't forget the terminating 0
     }

--- a/src/api/c/random.cpp
+++ b/src/api/c/random.cpp
@@ -30,33 +30,33 @@ using af::dim4;
 Array<uint> emptyArray() { return createEmptyArray<uint>(af::dim4(0)); }
 
 struct RandomEngine {
-    af_random_engine_type type;
-    std::shared_ptr<uintl> seed;
-    std::shared_ptr<uintl> counter;
-    Array<uint> pos;
-    Array<uint> sh1;
-    Array<uint> sh2;
-    uint mask;
-    Array<uint> recursion_table;
-    Array<uint> temper_table;
-    Array<uint> state;
+    // clang-format off
+    af_random_engine_type type{AF_RANDOM_ENGINE_DEFAULT}; // NOLINT(misc-non-private-member-variables-in-classes)
+    std::shared_ptr<uintl> seed;                          // NOLINT(misc-non-private-member-variables-in-classes)
+    std::shared_ptr<uintl> counter;                       // NOLINT(misc-non-private-member-variables-in-classes)
+    Array<uint> pos;                                      // NOLINT(misc-non-private-member-variables-in-classes)
+    Array<uint> sh1;                                      // NOLINT(misc-non-private-member-variables-in-classes)
+    Array<uint> sh2;                                      // NOLINT(misc-non-private-member-variables-in-classes)
+    uint mask{0};                                         // NOLINT(misc-non-private-member-variables-in-classes)
+    Array<uint> recursion_table;                          // NOLINT(misc-non-private-member-variables-in-classes)
+    Array<uint> temper_table;                             // NOLINT(misc-non-private-member-variables-in-classes)
+    Array<uint> state;                                    // NOLINT(misc-non-private-member-variables-in-classes)
+    // clang-format on
 
-    RandomEngine(void)
-        : type(AF_RANDOM_ENGINE_DEFAULT)
-        , seed(new uintl())
+    RandomEngine()
+        : seed(new uintl())
         , counter(new uintl())
         , pos(emptyArray())
         , sh1(emptyArray())
         , sh2(emptyArray())
-        , mask(0)
         , recursion_table(emptyArray())
         , temper_table(emptyArray())
         , state(emptyArray()) {}
 };
 
-af_random_engine getRandomEngineHandle(const RandomEngine engine) {
-    RandomEngine *engineHandle = new RandomEngine;
-    *engineHandle              = engine;
+af_random_engine getRandomEngineHandle(const RandomEngine &engine) {
+    auto *engineHandle = new RandomEngine;
+    *engineHandle      = engine;
     return static_cast<af_random_engine>(engineHandle);
 }
 
@@ -64,7 +64,7 @@ RandomEngine *getRandomEngine(const af_random_engine engineHandle) {
     if (engineHandle == 0) {
         AF_ERROR("Uninitialized random engine", AF_ERR_ARG);
     }
-    return (RandomEngine *)engineHandle;
+    return static_cast<RandomEngine *>(engineHandle);
 }
 
 namespace {
@@ -109,8 +109,8 @@ af_err af_get_default_random_engine(af_random_engine *r) {
     try {
         AF_CHECK(af_init());
 
-        thread_local RandomEngine *re = new RandomEngine;
-        *r                            = static_cast<af_random_engine>(re);
+        thread_local auto *re = new RandomEngine;
+        *r                    = static_cast<af_random_engine>(re);
         return AF_SUCCESS;
     }
     CATCHALL;

--- a/src/api/c/rank.cpp
+++ b/src/api/c/rank.cpp
@@ -24,8 +24,8 @@ using namespace detail;
 
 template<typename T>
 static inline uint rank(const af_array in, double tol) {
-    typedef typename af::dtype_traits<T>::base_type BT;
-    Array<T> In = getArray<T>(in);
+    using BT          = typename af::dtype_traits<T>::base_type;
+    const Array<T> In = getArray<T>(in);
 
     Array<BT> R = createEmptyArray<BT>(dim4());
 

--- a/src/api/c/reduce.cpp
+++ b/src/api/c/reduce.cpp
@@ -75,7 +75,7 @@ static af_err reduce_type(af_array *out, const af_array in, const int dim) {
 
         const ArrayInfo &in_info = getInfo(in);
 
-        if (dim >= (int)in_info.ndims()) {
+        if (dim >= static_cast<int>(in_info.ndims())) {
             *out = retain(in);
             return AF_SUCCESS;
         }
@@ -179,7 +179,9 @@ static af_err reduce_common(af_array *out, const af_array in, const int dim) {
 
         const ArrayInfo &in_info = getInfo(in);
 
-        if (dim >= (int)in_info.ndims()) { return af_retain_array(out, in); }
+        if (dim >= static_cast<int>(in_info.ndims())) {
+            return af_retain_array(out, in);
+        }
 
         af_dtype type = in_info.getType();
         af_array res;
@@ -287,7 +289,7 @@ static af_err reduce_promote(af_array *out, const af_array in, const int dim,
 
         const ArrayInfo &in_info = getInfo(in);
 
-        if (dim >= (int)in_info.ndims()) {
+        if (dim >= static_cast<int>(in_info.ndims())) {
             *out = retain(in);
             return AF_SUCCESS;
         }
@@ -522,10 +524,11 @@ af_err af_any_true_by_key(af_array *keys_out, af_array *vals_out,
                                              dim);
 }
 
-template<af_op_t op, typename Ti, typename To>
-static inline To reduce_all(const af_array in, bool change_nan = false,
-                            double nanval = 0) {
-    return reduce_all<op, Ti, To>(getArray<Ti>(in), change_nan, nanval);
+template<af_op_t op, typename Ti, typename Tacc, typename Tret = double>
+static inline Tret reduce_all(const af_array in, bool change_nan = false,
+                              double nanval = 0) {
+    return static_cast<Tret>(
+        reduce_all<op, Ti, Tacc>(getArray<Ti>(in), change_nan, nanval));
 }
 
 template<af_op_t op, typename To>
@@ -534,24 +537,26 @@ static af_err reduce_all_type(double *real, double *imag, const af_array in) {
         const ArrayInfo &in_info = getInfo(in);
         af_dtype type            = in_info.getType();
 
-        ARG_ASSERT(0, real != NULL);
+        ARG_ASSERT(0, real != nullptr);
         *real = 0;
-        if (imag) *imag = 0;
+        if (imag) { *imag = 0; }
 
         switch (type) {
-            case f32: *real = (double)reduce_all<op, float, To>(in); break;
-            case f64: *real = (double)reduce_all<op, double, To>(in); break;
-            case c32: *real = (double)reduce_all<op, cfloat, To>(in); break;
-            case c64: *real = (double)reduce_all<op, cdouble, To>(in); break;
-            case u32: *real = (double)reduce_all<op, uint, To>(in); break;
-            case s32: *real = (double)reduce_all<op, int, To>(in); break;
-            case u64: *real = (double)reduce_all<op, uintl, To>(in); break;
-            case s64: *real = (double)reduce_all<op, intl, To>(in); break;
-            case u16: *real = (double)reduce_all<op, ushort, To>(in); break;
-            case s16: *real = (double)reduce_all<op, short, To>(in); break;
-            case b8: *real = (double)reduce_all<op, char, To>(in); break;
-            case u8: *real = (double)reduce_all<op, uchar, To>(in); break;
-            case f16: *real = (double)reduce_all<op, half, To>(in); break;
+            // clang-format off
+            case f32: *real = reduce_all<op, float,   To>(in); break;
+            case f64: *real = reduce_all<op, double,  To>(in); break;
+            case c32: *real = reduce_all<op, cfloat,  To>(in); break;
+            case c64: *real = reduce_all<op, cdouble, To>(in); break;
+            case u32: *real = reduce_all<op, uint,    To>(in); break;
+            case s32: *real = reduce_all<op, int,     To>(in); break;
+            case u64: *real = reduce_all<op, uintl,   To>(in); break;
+            case s64: *real = reduce_all<op, intl,    To>(in); break;
+            case u16: *real = reduce_all<op, ushort,  To>(in); break;
+            case s16: *real = reduce_all<op, short,   To>(in); break;
+            case b8:  *real = reduce_all<op, char,    To>(in); break;
+            case u8:  *real = reduce_all<op, uchar,   To>(in); break;
+            case f16: *real = reduce_all<op, half,    To>(in); break;
+            // clang-format on
             default: TYPE_ERROR(1, type);
         }
     }
@@ -568,48 +573,37 @@ static af_err reduce_all_common(double *real_val, double *imag_val,
         af_dtype type            = in_info.getType();
 
         ARG_ASSERT(2, in_info.ndims() > 0);
-        ARG_ASSERT(0, real_val != NULL);
+        ARG_ASSERT(0, real_val != nullptr);
         *real_val = 0;
-        if (imag_val != NULL) *imag_val = 0;
+        if (imag_val != nullptr) { *imag_val = 0; }
 
         cfloat cfval;
         cdouble cdval;
 
         switch (type) {
-            case f32:
-                *real_val = (double)reduce_all<op, float, float>(in);
-                break;
-            case f64:
-                *real_val = (double)reduce_all<op, double, double>(in);
-                break;
-            case u32: *real_val = (double)reduce_all<op, uint, uint>(in); break;
-            case s32: *real_val = (double)reduce_all<op, int, int>(in); break;
-            case u64:
-                *real_val = (double)reduce_all<op, uintl, uintl>(in);
-                break;
-            case s64: *real_val = (double)reduce_all<op, intl, intl>(in); break;
-            case u16:
-                *real_val = (double)reduce_all<op, ushort, ushort>(in);
-                break;
-            case s16:
-                *real_val = (double)reduce_all<op, short, short>(in);
-                break;
-            case b8: *real_val = (double)reduce_all<op, char, char>(in); break;
-            case u8:
-                *real_val = (double)reduce_all<op, uchar, uchar>(in);
-                break;
-            case f16: *real_val = (double)reduce_all<op, half, half>(in); break;
-
+            // clang-format off
+            case f32: *real_val = reduce_all<op, float,  float>(in); break;
+            case f64: *real_val = reduce_all<op, double, double>(in); break;
+            case u32: *real_val = reduce_all<op, uint,   uint>(in); break;
+            case s32: *real_val = reduce_all<op, int,    int>(in); break;
+            case u64: *real_val = reduce_all<op, uintl,  uintl>(in); break;
+            case s64: *real_val = reduce_all<op, intl,   intl>(in); break;
+            case u16: *real_val = reduce_all<op, ushort, ushort>(in); break;
+            case s16: *real_val = reduce_all<op, short,  short>(in); break;
+            case b8:  *real_val = reduce_all<op, char,   char>(in); break;
+            case u8:  *real_val = reduce_all<op, uchar,  uchar>(in); break;
+            case f16: *real_val = reduce_all<op, half,   half>(in); break;
+            // clang-format on
             case c32:
-                cfval = reduce_all<op, cfloat, cfloat>(in);
-                ARG_ASSERT(1, imag_val != NULL);
+                cfval = reduce_all<op, cfloat, cfloat, cfloat>(in);
+                ARG_ASSERT(1, imag_val != nullptr);
                 *real_val = real(cfval);
                 *imag_val = imag(cfval);
                 break;
 
             case c64:
-                cdval = reduce_all<op, cdouble, cdouble>(in);
-                ARG_ASSERT(1, imag_val != NULL);
+                cdval = reduce_all<op, cdouble, cdouble, cdouble>(in);
+                ARG_ASSERT(1, imag_val != nullptr);
                 *real_val = real(cdval);
                 *imag_val = imag(cdval);
                 break;
@@ -630,75 +624,49 @@ static af_err reduce_all_promote(double *real_val, double *imag_val,
         const ArrayInfo &in_info = getInfo(in);
         af_dtype type            = in_info.getType();
 
-        ARG_ASSERT(0, real_val != NULL);
+        ARG_ASSERT(0, real_val != nullptr);
         *real_val = 0;
-        if (imag_val) *imag_val = 0;
+        if (imag_val) { *imag_val = 0; }
 
         cfloat cfval;
         cdouble cdval;
 
         switch (type) {
-            case f32:
-                *real_val = (double)reduce_all<op, float, float>(in, change_nan,
-                                                                 nanval);
-                break;
-            case f64:
-                *real_val = (double)reduce_all<op, double, double>(
-                    in, change_nan, nanval);
-                break;
-            case u32:
-                *real_val =
-                    (double)reduce_all<op, uint, uint>(in, change_nan, nanval);
-                break;
-            case s32:
-                *real_val =
-                    (double)reduce_all<op, int, int>(in, change_nan, nanval);
-                break;
-            case u64:
-                *real_val = (double)reduce_all<op, uintl, uintl>(in, change_nan,
-                                                                 nanval);
-                break;
-            case s64:
-                *real_val =
-                    (double)reduce_all<op, intl, intl>(in, change_nan, nanval);
-                break;
-            case u16:
-                *real_val = (double)reduce_all<op, ushort, uint>(in, change_nan,
-                                                                 nanval);
-                break;
-            case s16:
-                *real_val =
-                    (double)reduce_all<op, short, int>(in, change_nan, nanval);
-                break;
-            case u8:
-                *real_val =
-                    (double)reduce_all<op, uchar, uint>(in, change_nan, nanval);
-                break;
+            // clang-format off
+            case f32: *real_val = reduce_all<op, float,   float>(in, change_nan, nanval); break;
+            case f64: *real_val = reduce_all<op, double, double>(in, change_nan, nanval); break;
+            case u32: *real_val = reduce_all<op, uint,     uint>(in, change_nan, nanval); break;
+            case s32: *real_val = reduce_all<op, int,       int>(in, change_nan, nanval); break;
+            case u64: *real_val = reduce_all<op, uintl,   uintl>(in, change_nan, nanval); break;
+            case s64: *real_val = reduce_all<op, intl,     intl>(in, change_nan, nanval); break;
+            case u16: *real_val = reduce_all<op, ushort,   uint>(in, change_nan, nanval); break;
+            case s16: *real_val = reduce_all<op, short,     int>(in, change_nan, nanval); break;
+            case u8:  *real_val = reduce_all<op, uchar,    uint>(in, change_nan, nanval); break;
+            // clang-format on
             case b8: {
                 if (op == af_mul_t) {
-                    *real_val = (double)reduce_all<af_and_t, char, char>(
-                        in, change_nan, nanval);
+                    *real_val = reduce_all<af_and_t, char, char>(in, change_nan,
+                                                                 nanval);
                 } else {
-                    *real_val = (double)reduce_all<af_notzero_t, char, uint>(
+                    *real_val = reduce_all<af_notzero_t, char, uint>(
                         in, change_nan, nanval);
                 }
             } break;
             case c32:
-                cfval = reduce_all<op, cfloat, cfloat>(in);
-                ARG_ASSERT(1, imag_val != NULL);
+                cfval = reduce_all<op, cfloat, cfloat, cfloat>(in);
+                ARG_ASSERT(1, imag_val != nullptr);
                 *real_val = real(cfval);
                 *imag_val = imag(cfval);
                 break;
 
             case c64:
-                cdval = reduce_all<op, cdouble, cdouble>(in);
-                ARG_ASSERT(1, imag_val != NULL);
+                cdval = reduce_all<op, cdouble, cdouble, cdouble>(in);
+                ARG_ASSERT(1, imag_val != nullptr);
                 *real_val = real(cdval);
                 *imag_val = imag(cdval);
                 break;
             case f16:
-                *real_val =
-                    (double)reduce_all<op, half, float>(in, change_nan, nanval);
+                *real_val = reduce_all<op, half, float>(in, change_nan, nanval);
                 break;
 
             default: TYPE_ERROR(1, type);
@@ -778,7 +746,7 @@ static af_err ireduce_common(af_array *val, af_array *idx, const af_array in,
         const ArrayInfo &in_info = getInfo(in);
         ARG_ASSERT(2, in_info.ndims() > 0);
 
-        if (dim >= (int)in_info.ndims()) {
+        if (dim >= static_cast<int>(in_info.ndims())) {
             *val = retain(in);
             *idx = createHandleFromValue<uint>(in_info.dims(), 0);
             return AF_SUCCESS;
@@ -830,13 +798,13 @@ static af_err rreduce_common(af_array *val, af_array *idx, const af_array in,
         const ArrayInfo &in_info = getInfo(in);
         ARG_ASSERT(2, in_info.ndims() > 0);
 
-        if (dim >= (int)in_info.ndims()) {
+        if (dim >= static_cast<int>(in_info.ndims())) {
             *val = retain(in);
             *idx = createHandleFromValue<uint>(in_info.dims(), 0);
             return AF_SUCCESS;
         }
 
-        // TODO: make sure ragged_len.dims == in.dims(), except on reduced dim
+        // Make sure ragged_len.dims == in.dims(), except on reduced dim
         const ArrayInfo &ragged_info = getInfo(ragged_len);
         dim4 test_dim                = in_info.dims();
         test_dim[dim]                = 1;
@@ -892,9 +860,9 @@ af_err af_max_ragged(af_array *val, af_array *idx, const af_array in,
     return rreduce_common<af_max_t>(val, idx, in, ragged_len, dim);
 }
 
-template<af_op_t op, typename T>
-static inline T ireduce_all(unsigned *loc, const af_array in) {
-    return ireduce_all<op, T>(loc, getArray<T>(in));
+template<af_op_t op, typename T, typename Tret = T>
+static inline Tret ireduce_all(unsigned *loc, const af_array in) {
+    return static_cast<Tret>(ireduce_all<op, T>(loc, getArray<T>(in)));
 }
 
 template<af_op_t op>
@@ -905,45 +873,45 @@ static af_err ireduce_all_common(double *real_val, double *imag_val,
         af_dtype type            = in_info.getType();
 
         ARG_ASSERT(3, in_info.ndims() > 0);
-        ARG_ASSERT(0, real_val != NULL);
+        ARG_ASSERT(0, real_val != nullptr);
         *real_val = 0;
-        if (imag_val) *imag_val = 0;
+        if (imag_val) { *imag_val = 0; }
 
         cfloat cfval;
         cdouble cdval;
 
         switch (type) {
             case f32:
-                *real_val = (double)ireduce_all<op, float>(loc, in);
+                *real_val = ireduce_all<op, float, double>(loc, in);
                 break;
             case f64:
-                *real_val = (double)ireduce_all<op, double>(loc, in);
+                *real_val = ireduce_all<op, double, double>(loc, in);
                 break;
-            case u32: *real_val = (double)ireduce_all<op, uint>(loc, in); break;
-            case s32: *real_val = (double)ireduce_all<op, int>(loc, in); break;
+            case u32: *real_val = ireduce_all<op, uint, double>(loc, in); break;
+            case s32: *real_val = ireduce_all<op, int, double>(loc, in); break;
             case u64:
-                *real_val = (double)ireduce_all<op, uintl>(loc, in);
+                *real_val = ireduce_all<op, uintl, double>(loc, in);
                 break;
-            case s64: *real_val = (double)ireduce_all<op, intl>(loc, in); break;
+            case s64: *real_val = ireduce_all<op, intl, double>(loc, in); break;
             case u16:
-                *real_val = (double)ireduce_all<op, ushort>(loc, in);
+                *real_val = ireduce_all<op, ushort, double>(loc, in);
                 break;
             case s16:
-                *real_val = (double)ireduce_all<op, short>(loc, in);
+                *real_val = ireduce_all<op, short, double>(loc, in);
                 break;
-            case b8: *real_val = (double)ireduce_all<op, char>(loc, in); break;
-            case u8: *real_val = (double)ireduce_all<op, uchar>(loc, in); break;
+            case b8: *real_val = ireduce_all<op, char, double>(loc, in); break;
+            case u8: *real_val = ireduce_all<op, uchar, double>(loc, in); break;
 
             case c32:
                 cfval = ireduce_all<op, cfloat>(loc, in);
-                ARG_ASSERT(1, imag_val != NULL);
+                ARG_ASSERT(1, imag_val != nullptr);
                 *real_val = real(cfval);
                 *imag_val = imag(cfval);
                 break;
 
             case c64:
                 cdval = ireduce_all<op, cdouble>(loc, in);
-                ARG_ASSERT(1, imag_val != NULL);
+                ARG_ASSERT(1, imag_val != nullptr);
                 *real_val = real(cdval);
                 *imag_val = imag(cdval);
                 break;

--- a/src/api/c/reorder.cpp
+++ b/src/api/c/reorder.cpp
@@ -40,8 +40,8 @@ static inline af_array reorder(const af_array in, const af::dim4 &rdims0) {
 
     af_array out;
     if (rdims[0] == 0 && rdims[1] == 1 && rdims[2] == 2 && rdims[3] == 3) {
-        Array<T> Out = In;
-        out          = getHandle(Out);
+        const Array<T> &Out = In;
+        out                 = getHandle(Out);
     } else if (rdims[0] == 0) {
         dim4 odims    = dim4(1, 1, 1, 1);
         dim4 ostrides = dim4(1, 1, 1, 1);

--- a/src/api/c/resize.cpp
+++ b/src/api/c/resize.cpp
@@ -16,7 +16,6 @@
 #include <af/defines.h>
 #include <af/image.h>
 
-using af::dim4;
 using namespace detail;
 
 template<typename T>

--- a/src/api/c/rgb_gray.cpp
+++ b/src/api/c/rgb_gray.cpp
@@ -117,10 +117,11 @@ af_err convert(af_array* out, const af_array in, const float r, const float g,
 
         // If RGB is input, then assert 3 channels
         // else 1 channel
-        if (isRGB2GRAY)
+        if (isRGB2GRAY) {
             ARG_ASSERT(1, (inputDims[2] == 3));
-        else
+        } else {
             ARG_ASSERT(1, (inputDims[2] == 1));
+        }
 
         af_array output = 0;
         switch (iType) {

--- a/src/api/c/rotate.cpp
+++ b/src/api/c/rotate.cpp
@@ -13,8 +13,12 @@
 #include <handle.hpp>
 #include <rotate.hpp>
 #include <af/image.h>
+#include <cmath>
 
 using af::dim4;
+using std::cos;
+using std::fabs;
+using std::sin;
 using namespace detail;
 
 template<typename T>
@@ -27,16 +31,14 @@ static inline af_array rotate(const af_array in, const float theta,
 af_err af_rotate(af_array *out, const af_array in, const float theta,
                  const bool crop, const af_interp_type method) {
     try {
-        unsigned odims0 = 0, odims1 = 0;
+        dim_t odims0 = 0, odims1 = 0;
 
         const ArrayInfo &info = getInfo(in);
         af::dim4 idims        = info.dims();
 
         if (!crop) {
-            odims0 = idims[0] * fabs(std::cos(theta)) +
-                     idims[1] * fabs(std::sin(theta));
-            odims1 = idims[1] * fabs(std::cos(theta)) +
-                     idims[0] * fabs(std::sin(theta));
+            odims0 = idims[0] * fabs(cos(theta)) + idims[1] * fabs(sin(theta));
+            odims1 = idims[1] * fabs(cos(theta)) + idims[0] * fabs(sin(theta));
         } else {
             odims0 = idims[0];
             odims1 = idims[1];
@@ -68,7 +70,7 @@ af_err af_rotate(af_array *out, const af_array in, const float theta,
             case u64: output = rotate<uintl>(in, theta, odims, method); break;
             case s16: output = rotate<short>(in, theta, odims, method); break;
             case u16: output = rotate<ushort>(in, theta, odims, method); break;
-            case u8: output = rotate<uchar>(in, theta, odims, method); break;
+            case u8:
             case b8: output = rotate<uchar>(in, theta, odims, method); break;
             default: TYPE_ERROR(1, itype);
         }

--- a/src/api/c/sat.cpp
+++ b/src/api/c/sat.cpp
@@ -24,7 +24,7 @@ inline af_array sat(const af_array& in) {
 af_err af_sat(af_array* out, const af_array in) {
     try {
         const ArrayInfo& info = getInfo(in);
-        const dim4 dims       = info.dims();
+        const dim4& dims      = info.dims();
 
         ARG_ASSERT(1, (dims.ndims() >= 2));
 

--- a/src/api/c/scan.cpp
+++ b/src/api/c/scan.cpp
@@ -18,7 +18,6 @@
 #include <af/dim4.hpp>
 #include <complex>
 
-using af::dim4;
 using namespace detail;
 
 template<af_op_t op, typename Ti, typename To>
@@ -116,7 +115,7 @@ af_err af_accum(af_array* out, const af_array in, const int dim) {
 
         const ArrayInfo& in_info = getInfo(in);
 
-        if (dim >= (int)in_info.ndims()) {
+        if (dim >= static_cast<int>(in_info.ndims())) {
             *out = retain(in);
             return AF_SUCCESS;
         }
@@ -157,7 +156,7 @@ af_err af_scan(af_array* out, const af_array in, const int dim, af_binary_op op,
 
         const ArrayInfo& in_info = getInfo(in);
 
-        if (dim >= (int)in_info.ndims()) {
+        if (dim >= static_cast<int>(in_info.ndims())) {
             *out = retain(in);
             return AF_SUCCESS;
         }
@@ -221,7 +220,7 @@ af_err af_scan_by_key(af_array* out, const af_array key, const af_array in,
         const ArrayInfo& in_info  = getInfo(in);
         const ArrayInfo& key_info = getInfo(key);
 
-        if (dim >= (int)in_info.ndims()) {
+        if (dim >= static_cast<int>(in_info.ndims())) {
             *out = retain(in);
             return AF_SUCCESS;
         }
@@ -245,9 +244,7 @@ af_err af_scan_by_key(af_array* out, const af_array key, const af_array in,
                 res =
                     scan_op<cdouble, cdouble>(key, in, dim, op, inclusive_scan);
                 break;
-            case u32:
-                res = scan_op<uint, uint>(key, in, dim, op, inclusive_scan);
-                break;
+            case s16:
             case s32:
                 res = scan_op<int, int>(key, in, dim, op, inclusive_scan);
                 break;
@@ -258,14 +255,8 @@ af_err af_scan_by_key(af_array* out, const af_array key, const af_array in,
                 res = scan_op<intl, intl>(key, in, dim, op, inclusive_scan);
                 break;
             case u16:
-                res = scan_op<uint, uint>(key, in, dim, op, inclusive_scan);
-                break;
-            case s16:
-                res = scan_op<int, int>(key, in, dim, op, inclusive_scan);
-                break;
+            case u32:
             case u8:
-                res = scan_op<uint, uint>(key, in, dim, op, inclusive_scan);
-                break;
             case b8:
                 res = scan_op<uint, uint>(key, in, dim, op, inclusive_scan);
                 break;

--- a/src/api/c/set.cpp
+++ b/src/api/c/set.cpp
@@ -15,7 +15,6 @@
 #include <af/defines.h>
 #include <complex>
 
-using af::dim4;
 using namespace detail;
 
 template<typename T>
@@ -117,7 +116,7 @@ af_err af_set_intersect(af_array* out, const af_array first,
         const ArrayInfo& first_info  = getInfo(first);
         const ArrayInfo& second_info = getInfo(second);
 
-        // TODO: fix for set intersect from union
+        // TODO(umar): fix for set intersect from union
         if (first_info.isEmpty()) { return af_retain_array(out, first); }
 
         if (second_info.isEmpty()) { return af_retain_array(out, second); }

--- a/src/api/c/shift.cpp
+++ b/src/api/c/shift.cpp
@@ -14,7 +14,6 @@
 #include <shift.hpp>
 #include <af/data.h>
 
-using af::dim4;
 using namespace detail;
 
 template<typename T>

--- a/src/api/c/sobel.cpp
+++ b/src/api/c/sobel.cpp
@@ -19,10 +19,10 @@
 using af::dim4;
 using namespace detail;
 
-typedef std::pair<af_array, af_array> ArrayPair;
+using ArrayPair = std::pair<af_array, af_array>;
 template<typename Ti, typename To>
 ArrayPair sobelDerivatives(const af_array &in, const unsigned &ker_size) {
-    typedef std::pair<Array<To>, Array<To>> BAPair;
+    using BAPair = std::pair<Array<To>, Array<To>>;
     BAPair out = sobelDerivatives<Ti, To>(getArray<Ti>(in), ker_size);
     return std::make_pair(getHandle<To>(out.first), getHandle<To>(out.second));
 }

--- a/src/api/c/sobel.cpp
+++ b/src/api/c/sobel.cpp
@@ -23,7 +23,7 @@ using ArrayPair = std::pair<af_array, af_array>;
 template<typename Ti, typename To>
 ArrayPair sobelDerivatives(const af_array &in, const unsigned &ker_size) {
     using BAPair = std::pair<Array<To>, Array<To>>;
-    BAPair out = sobelDerivatives<Ti, To>(getArray<Ti>(in), ker_size);
+    BAPair out   = sobelDerivatives<Ti, To>(getArray<Ti>(in), ker_size);
     return std::make_pair(getHandle<To>(out.first), getHandle<To>(out.second));
 }
 

--- a/src/api/c/sort.cpp
+++ b/src/api/c/sort.cpp
@@ -185,8 +185,6 @@ void sort_by_key_tmplt(af_array *okey, af_array *oval, const af_array ikey,
             break;
         default: TYPE_ERROR(1, vtype);
     }
-
-    return;
 }
 
 af_err af_sort_by_key(af_array *out_keys, af_array *out_values,

--- a/src/api/c/sparse.cpp
+++ b/src/api/c/sparse.cpp
@@ -133,19 +133,22 @@ af_array createSparseArrayFromPtr(const af::dim4 &dims, const dim_t nNZ,
                                   const int *const colIdx,
                                   const af::storage stype,
                                   const af::source source) {
-    SparseArray<T> sparse = createEmptySparseArray<T>(dims, nNZ, stype);
-
     if (nNZ) {
-        if (source == afHost)
-            sparse = common::createHostDataSparseArray(dims, nNZ, values,
-                                                       rowIdx, colIdx, stype);
-        else if (source == afDevice)
-            sparse = common::createDeviceDataSparseArray(
-                dims, nNZ, const_cast<T *>(values), const_cast<int *>(rowIdx),
-                const_cast<int *>(colIdx), stype);
+        switch (source) {
+            case afHost:
+                return getHandle(common::createHostDataSparseArray(
+                    dims, nNZ, values, rowIdx, colIdx, stype));
+                break;
+            case afDevice:
+                return getHandle(common::createDeviceDataSparseArray(
+                    dims, nNZ, const_cast<T *>(values),
+                    const_cast<int *>(rowIdx), const_cast<int *>(colIdx),
+                    stype));
+                break;
+        }
     }
 
-    return getHandle(sparse);
+    return getHandle(createEmptySparseArray<T>(dims, nNZ, stype));
 }
 
 af_err af_create_sparse_array_from_ptr(
@@ -400,10 +403,10 @@ af_array getSparseValues(const af_array in) {
 af_err af_sparse_get_info(af_array *values, af_array *rows, af_array *cols,
                           af_storage *stype, const af_array in) {
     try {
-        if (values != NULL) AF_CHECK(af_sparse_get_values(values, in));
-        if (rows != NULL) AF_CHECK(af_sparse_get_row_idx(rows, in));
-        if (cols != NULL) AF_CHECK(af_sparse_get_col_idx(cols, in));
-        if (stype != NULL) AF_CHECK(af_sparse_get_storage(stype, in));
+        if (values != NULL) { AF_CHECK(af_sparse_get_values(values, in)); }
+        if (rows != NULL) { AF_CHECK(af_sparse_get_row_idx(rows, in)); }
+        if (cols != NULL) { AF_CHECK(af_sparse_get_col_idx(cols, in)); }
+        if (stype != NULL) { AF_CHECK(af_sparse_get_storage(stype, in)); }
     }
     CATCHALL;
 

--- a/src/api/c/sparse_handle.hpp
+++ b/src/api/c/sparse_handle.hpp
@@ -20,7 +20,7 @@
 
 #include <common/SparseArray.hpp>
 
-const common::SparseArrayBase &getSparseArrayBase(const af_array arr,
+const common::SparseArrayBase &getSparseArrayBase(const af_array in,
                                                   bool device_check = true);
 
 template<typename T>

--- a/src/api/c/stdev.cpp
+++ b/src/api/c/stdev.cpp
@@ -28,8 +28,8 @@ using namespace detail;
 
 template<typename inType, typename outType>
 static outType stdev(const af_array& in) {
-    typedef typename baseOutType<outType>::type weightType;
-    Array<inType> _in       = getArray<inType>(in);
+    using weightType        = typename baseOutType<outType>::type;
+    const Array<inType> _in = getArray<inType>(in);
     Array<outType> input    = cast<outType>(_in);
     Array<outType> meanCnst = createValueArray<outType>(
         input.dims(), mean<inType, weightType, outType>(_in));
@@ -45,10 +45,10 @@ static outType stdev(const af_array& in) {
 
 template<typename inType, typename outType>
 static af_array stdev(const af_array& in, int dim) {
-    typedef typename baseOutType<outType>::type weightType;
-    Array<inType> _in    = getArray<inType>(in);
-    Array<outType> input = cast<outType>(_in);
-    dim4 iDims           = input.dims();
+    using weightType        = typename baseOutType<outType>::type;
+    const Array<inType> _in = getArray<inType>(in);
+    Array<outType> input    = cast<outType>(_in);
+    dim4 iDims              = input.dims();
 
     Array<outType> meanArr = mean<inType, weightType, outType>(_in, dim);
 
@@ -63,7 +63,7 @@ static af_array stdev(const af_array& in, int dim) {
     Array<outType> diffSq =
         detail::arithOp<outType, af_mul_t>(diff, diff, diff.dims());
     Array<outType> redDiff = reduce<af_add_t, outType, outType>(diffSq, dim);
-    dim4 oDims             = redDiff.dims();
+    const dim4& oDims      = redDiff.dims();
 
     Array<outType> divArr =
         createValueArray<outType>(oDims, scalar<outType>(iDims[dim]));
@@ -74,6 +74,7 @@ static af_array stdev(const af_array& in, int dim) {
     return getHandle<outType>(result);
 }
 
+// NOLINTNEXTLINE(readability-non-const-parameter)
 af_err af_stdev_all(double* realVal, double* imagVal, const af_array in) {
     UNUSED(imagVal);  // TODO implement for complex values
     try {
@@ -90,8 +91,8 @@ af_err af_stdev_all(double* realVal, double* imagVal, const af_array in) {
             case u64: *realVal = stdev<uintl, double>(in); break;
             case u8: *realVal = stdev<uchar, float>(in); break;
             case b8: *realVal = stdev<char, float>(in); break;
-            // TODO: FIXME: sqrt(complex) is not present in cuda/opencl backend
-            // case c32: {
+            // TODO(umar): FIXME: sqrt(complex) is not present in cuda/opencl
+            // backend case c32: {
             //    cfloat tmp = stdev<cfloat,cfloat>(in);
             //    *realVal = real(tmp);
             //    *imagVal = imag(tmp);
@@ -126,9 +127,9 @@ af_err af_stdev(af_array* out, const af_array in, const dim_t dim) {
             case u64: output = stdev<uintl, double>(in, dim); break;
             case u8: output = stdev<uchar, float>(in, dim); break;
             case b8: output = stdev<char, float>(in, dim); break;
-            // TODO: FIXME: sqrt(complex) is not present in cuda/opencl backend
-            // case c32: output = stdev<cfloat,  cfloat>(in, dim); break;
-            // case c64: output = stdev<cdouble,cdouble>(in, dim); break;
+            // TODO(umar): FIXME: sqrt(complex) is not present in cuda/opencl
+            // backend case c32: output = stdev<cfloat,  cfloat>(in, dim);
+            // break; case c64: output = stdev<cdouble,cdouble>(in, dim); break;
             default: TYPE_ERROR(1, type);
         }
         std::swap(*out, output);

--- a/src/api/c/surface.cpp
+++ b/src/api/c/surface.cpp
@@ -70,10 +70,11 @@ fg_chart setup_surface(fg_window window, const af_array xVals,
 
     // Get the chart for the current grid position (if any)
     fg_chart chart = NULL;
-    if (props->col > -1 && props->row > -1)
+    if (props->col > -1 && props->row > -1) {
         chart = fgMngr.getChart(window, props->row, props->col, FG_CHART_3D);
-    else
+    } else {
         chart = fgMngr.getChart(window, 0, 0, FG_CHART_3D);
+    }
 
     fg_surface surface =
         fgMngr.getSurface(chart, Z_dims[0], Z_dims[1], getGLType<T>());
@@ -104,12 +105,12 @@ fg_chart setup_surface(fg_window window, const af_array xVals,
             cmin[2] = step_round(dmin[2], false);
             cmax[2] = step_round(dmax[2], true);
         } else {
-            if (cmin[0] > dmin[0]) cmin[0] = step_round(dmin[0], false);
-            if (cmax[0] < dmax[0]) cmax[0] = step_round(dmax[0], true);
-            if (cmin[1] > dmin[1]) cmin[1] = step_round(dmin[1], false);
-            if (cmax[1] < dmax[1]) cmax[1] = step_round(dmax[1], true);
-            if (cmin[2] > dmin[2]) cmin[2] = step_round(dmin[2], false);
-            if (cmax[2] < dmax[2]) cmax[2] = step_round(dmax[2], true);
+            if (cmin[0] > dmin[0]) { cmin[0] = step_round(dmin[0], false); }
+            if (cmax[0] < dmax[0]) { cmax[0] = step_round(dmax[0], true); }
+            if (cmin[1] > dmin[1]) { cmin[1] = step_round(dmin[1], false); }
+            if (cmax[1] < dmax[1]) { cmax[1] = step_round(dmax[1], true); }
+            if (cmin[2] > dmin[2]) { cmin[2] = step_round(dmin[2], false); }
+            if (cmax[2] < dmax[2]) { cmax[2] = step_round(dmax[2], true); }
         }
 
         FG_CHECK(_.fg_set_chart_axes_limits(chart, cmin[0], cmax[0], cmin[1],
@@ -135,7 +136,7 @@ af_err af_draw_surface(const af_window window, const af_array xVals,
         af_dtype Ytype         = Yinfo.getType();
 
         const ArrayInfo& Sinfo = getInfo(S);
-        af::dim4 S_dims        = Sinfo.dims();
+        const af::dim4& S_dims = Sinfo.dims();
         af_dtype Stype         = Sinfo.getType();
 
         TYPE_ASSERT(Xtype == Ytype);

--- a/src/api/c/svd.cpp
+++ b/src/api/c/svd.cpp
@@ -28,7 +28,7 @@ static inline void svd(af_array *s, af_array *u, af_array *vt,
     int M                 = dims[0];
     int N                 = dims[1];
 
-    typedef typename af::dtype_traits<T>::base_type Tr;
+    using Tr = typename af::dtype_traits<T>::base_type;
 
     // Allocate output arrays
     Array<Tr> sA = createEmptyArray<Tr>(af::dim4(min(M, N)));
@@ -50,7 +50,7 @@ static inline void svdInPlace(af_array *s, af_array *u, af_array *vt,
     int M                 = dims[0];
     int N                 = dims[1];
 
-    typedef typename af::dtype_traits<T>::base_type Tr;
+    using Tr = typename af::dtype_traits<T>::base_type;
 
     // Allocate output arrays
     Array<Tr> sA = createEmptyArray<Tr>(af::dim4(min(M, N)));

--- a/src/api/c/tile.cpp
+++ b/src/api/c/tile.cpp
@@ -26,7 +26,7 @@ using namespace detail;
 template<typename T>
 static inline af_array tile(const af_array in, const af::dim4 &tileDims) {
     const Array<T> inArray = getArray<T>(in);
-    const dim4 inDims      = inArray.dims();
+    const dim4 &inDims     = inArray.dims();
 
     // FIXME: Always use JIT instead of checking for the condition.
     // The current limitation exists for performance reasons. it should change
@@ -42,11 +42,13 @@ static inline af_array tile(const af_array in, const af::dim4 &tileDims) {
         outDims[i] = inDims[i] * tileDims[i];
     }
 
+    af_array out = nullptr;
     if (take_jit_path) {
-        return getHandle(unaryOp<T, af_noop_t>(inArray, outDims));
+        out = getHandle(unaryOp<T, af_noop_t>(inArray, outDims));
     } else {
-        return getHandle(tile<T>(inArray, tileDims));
+        out = getHandle(tile<T>(inArray, tileDims));
     }
+    return out;
 }
 
 af_err af_tile(af_array *out, const af_array in, const af::dim4 &tileDims) {

--- a/src/api/c/topk.cpp
+++ b/src/api/c/topk.cpp
@@ -41,7 +41,7 @@ af_err af_topk(af_array *values, af_array *indices, const af_array in,
     try {
         af::topkFunction ord = (order == AF_TOPK_DEFAULT ? AF_TOPK_MAX : order);
 
-        ArrayInfo inInfo = getInfo(in);
+        const ArrayInfo &inInfo = getInfo(in);
 
         ARG_ASSERT(2, (inInfo.ndims() > 0));
 
@@ -67,9 +67,10 @@ af_err af_topk(af_array *values, af_array *indices, const af_array in,
         ARG_ASSERT(2, (inInfo.dims()[rdim] >= k));
         ARG_ASSERT(4, (k <= 256));  // TODO(umar): Remove this limitation
 
-        if (rdim != 0)
+        if (rdim != 0) {
             AF_ERROR("topk is supported along dimenion 0 only.",
                      AF_ERR_NOT_SUPPORTED);
+        }
 
         af_dtype type = inInfo.getType();
 

--- a/src/api/c/transform.cpp
+++ b/src/api/c/transform.cpp
@@ -20,10 +20,9 @@ using namespace detail;
 
 template<typename T>
 static inline void transform(af_array *out, const af_array in,
-                             const af_array tf, const dim4 &odims,
-                             const af_interp_type method, const bool inverse,
-                             const bool perspective) {
-    transform<T>(getArray<T>(*out), getArray<T>(in), getArray<float>(tf), odims,
+                             const af_array tf, const af_interp_type method,
+                             const bool inverse, const bool perspective) {
+    transform<T>(getArray<T>(*out), getArray<T>(in), getArray<float>(tf),
                  method, inverse, perspective);
 }
 
@@ -143,18 +142,18 @@ void af_transform_common(af_array *out, const af_array in, const af_array tf,
 
     // clang-format off
     switch(itype) {
-    case f32: transform<float  >(out, in, tf, odims, method, inverse, perspective);  break;
-    case f64: transform<double >(out, in, tf, odims, method, inverse, perspective);  break;
-    case c32: transform<cfloat >(out, in, tf, odims, method, inverse, perspective);  break;
-    case c64: transform<cdouble>(out, in, tf, odims, method, inverse, perspective);  break;
-    case s32: transform<int    >(out, in, tf, odims, method, inverse, perspective);  break;
-    case u32: transform<uint   >(out, in, tf, odims, method, inverse, perspective);  break;
-    case s64: transform<intl   >(out, in, tf, odims, method, inverse, perspective);  break;
-    case u64: transform<uintl  >(out, in, tf, odims, method, inverse, perspective);  break;
-    case s16: transform<short  >(out, in, tf, odims, method, inverse, perspective);  break;
-    case u16: transform<ushort >(out, in, tf, odims, method, inverse, perspective);  break;
-    case u8:  transform<uchar  >(out, in, tf, odims, method, inverse, perspective);  break;
-    case b8:  transform<char   >(out, in, tf, odims, method, inverse, perspective);  break;
+    case f32: transform<float  >(out, in, tf, method, inverse, perspective);  break;
+    case f64: transform<double >(out, in, tf, method, inverse, perspective);  break;
+    case c32: transform<cfloat >(out, in, tf, method, inverse, perspective);  break;
+    case c64: transform<cdouble>(out, in, tf, method, inverse, perspective);  break;
+    case s32: transform<int    >(out, in, tf, method, inverse, perspective);  break;
+    case u32: transform<uint   >(out, in, tf, method, inverse, perspective);  break;
+    case s64: transform<intl   >(out, in, tf, method, inverse, perspective);  break;
+    case u64: transform<uintl  >(out, in, tf, method, inverse, perspective);  break;
+    case s16: transform<short  >(out, in, tf, method, inverse, perspective);  break;
+    case u16: transform<ushort >(out, in, tf, method, inverse, perspective);  break;
+    case u8:  transform<uchar  >(out, in, tf, method, inverse, perspective);  break;
+    case b8:  transform<char   >(out, in, tf, method, inverse, perspective);  break;
     default:  TYPE_ERROR(1, itype);
     }
     // clang-format on

--- a/src/api/c/transform.cpp
+++ b/src/api/c/transform.cpp
@@ -33,13 +33,12 @@ AF_BATCH_KIND getTransformBatchKind(const dim4 &iDims, const dim4 &tDims) {
     dim_t iNd = iDims.ndims();
     dim_t tNd = tDims.ndims();
 
-    if (iNd == baseDim && tNd == baseDim)
-        return AF_BATCH_NONE;
-    else if (iNd == baseDim && tNd <= 4)
+    if (iNd == baseDim && tNd == baseDim) { return AF_BATCH_NONE; }
+    if (iNd == baseDim && tNd <= 4) {
         return AF_BATCH_RHS;
-    else if (iNd <= 4 && tNd == baseDim)
+    } else if (iNd <= 4 && tNd == baseDim) {
         return AF_BATCH_LHS;
-    else if (iNd <= 4 && tNd <= 4) {
+    } else if (iNd <= 4 && tNd <= 4) {
         bool dimsMatch     = true;
         bool isInterleaved = true;
         for (dim_t i = baseDim; i < 4; i++) {
@@ -47,10 +46,11 @@ AF_BATCH_KIND getTransformBatchKind(const dim4 &iDims, const dim4 &tDims) {
             isInterleaved &=
                 (iDims[i] == 1 || tDims[i] == 1 || iDims[i] == tDims[i]);
         }
-        if (dimsMatch) return AF_BATCH_SAME;
+        if (dimsMatch) { return AF_BATCH_SAME; }
         return (isInterleaved ? AF_BATCH_DIFF : AF_BATCH_UNSUPPORTED);
-    } else
+    } else {
         return AF_BATCH_UNSUPPORTED;
+    }
 }
 
 void af_transform_common(af_array *out, const af_array in, const af_array tf,
@@ -64,8 +64,8 @@ void af_transform_common(af_array *out, const af_array in, const af_array tf,
     const ArrayInfo &t_info = getInfo(tf);
     const ArrayInfo &i_info = getInfo(in);
 
-    const dim4 idims     = i_info.dims();
-    const dim4 tdims     = t_info.dims();
+    const dim4 &idims    = i_info.dims();
+    const dim4 &tdims    = t_info.dims();
     const af_dtype itype = i_info.getType();
 
     // Assert type and interpolation
@@ -93,17 +93,19 @@ void af_transform_common(af_array *out, const af_array in, const af_array tf,
 
     // If idims[2] > 1 and tdims[2] > 1, then both must be equal
     // else at least one of them must be 1
-    if (tdims[2] != 1 && idims[2] != 1)
+    if (tdims[2] != 1 && idims[2] != 1) {
         DIM_ASSERT(2, idims[2] == tdims[2]);
-    else
+    } else {
         DIM_ASSERT(2, idims[2] == 1 || tdims[2] == 1);
+    }
 
     // If idims[3] > 1 and tdims[3] > 1, then both must be equal
     // else at least one of them must be 1
-    if (tdims[3] != 1 && idims[3] != 1)
+    if (tdims[3] != 1 && idims[3] != 1) {
         DIM_ASSERT(2, idims[3] == tdims[3]);
-    else
+    } else {
         DIM_ASSERT(2, idims[3] == 1 || tdims[3] == 1);
+    }
 
     const bool perspective = (tdims[1] == 3);
     dim_t o0 = odim0, o1 = odim1, o2 = 0, o3 = 0;
@@ -225,8 +227,8 @@ af_err af_scale(af_array *out, const af_array in, const float scale0,
             DIM_ASSERT(4, odim0 != 0);
             DIM_ASSERT(5, odim1 != 0);
 
-            sx = idims[0] / (float)_odim0;
-            sy = idims[1] / (float)_odim1;
+            sx = idims[0] / static_cast<float>(_odim0);
+            sy = idims[1] / static_cast<float>(_odim1);
 
         } else {
             sx = 1.f / scale0, sy = 1.f / scale1;

--- a/src/api/c/transform_coordinates.cpp
+++ b/src/api/c/transform_coordinates.cpp
@@ -38,8 +38,15 @@ template<typename T>
 static af_array transform_coordinates(const af_array &tf_, const float d0_,
                                       const float d1_) {
     af::dim4 h_dims(4, 3);
-    T h_in[4 * 3] = {(T)0,   (T)0, (T)d1_, (T)d1_, (T)0, (T)d0_,
-                     (T)d0_, (T)0, (T)1,   (T)1,   (T)1, (T)1};
+    T zero = 0;
+    T one = 1;
+    T d0 = static_cast<T>(d0_);
+    T d1   = static_cast<T>(d1_);
+    // clang-format off
+    T h_in[4 * 3] = {zero, zero,  d1,   d1,
+                     zero,   d0,  d0, zero,
+                      one,  one, one,  one};
+    // clang-format on
 
     const Array<T> tf = getArray<T>(tf_);
     Array<T> in       = createHostDataArray<T>(h_dims, h_in);

--- a/src/api/c/transform_coordinates.cpp
+++ b/src/api/c/transform_coordinates.cpp
@@ -39,8 +39,8 @@ static af_array transform_coordinates(const af_array &tf_, const float d0_,
                                       const float d1_) {
     af::dim4 h_dims(4, 3);
     T zero = 0;
-    T one = 1;
-    T d0 = static_cast<T>(d0_);
+    T one  = 1;
+    T d0   = static_cast<T>(d0_);
     T d1   = static_cast<T>(d1_);
     // clang-format off
     T h_in[4 * 3] = {zero, zero,  d1,   d1,

--- a/src/api/c/transpose.cpp
+++ b/src/api/c/transpose.cpp
@@ -90,7 +90,7 @@ af_err af_transpose_inplace(af_array in, const bool conjugate) {
         DIM_ASSERT(0, dims[0] == dims[1]);
 
         // If singleton element
-        if (dims[0] == 1) return AF_SUCCESS;
+        if (dims[0] == 1) { return AF_SUCCESS; }
 
         switch (type) {
             case f32: transpose_inplace<float>(in, conjugate); break;

--- a/src/api/c/unary.cpp
+++ b/src/api/c/unary.cpp
@@ -201,7 +201,7 @@ struct unaryOpCplxFun<Tc, Tr, af_log_t> {
         // log(r)
         Array<Tr> a_out = unaryOp<Tr, af_log_t>(r);
         // phi
-        Array<Tr> b_out = phi;
+        const Array<Tr> &b_out = phi;
 
         // log(r) + i * phi
         return cplx<Tc, Tr>(a_out, b_out, a_out.dims());
@@ -631,14 +631,16 @@ static inline af_array checkOp(const af_array in) {
 
 template<af_op_t op>
 struct cplxLogicOp {
-    af_array operator()(Array<char> resR, Array<char> resI, dim4 dims) {
+    af_array operator()(const Array<char> &resR, const Array<char> &resI,
+                        const dim4 &dims) {
         return getHandle(logicOp<char, af_or_t>(resR, resI, dims));
     }
 };
 
 template<>
 struct cplxLogicOp<af_iszero_t> {
-    af_array operator()(Array<char> resR, Array<char> resI, dim4 dims) {
+    af_array operator()(const Array<char> &resR, const Array<char> &resI,
+                        const dim4 &dims) {
         return getHandle(logicOp<char, af_and_t>(resR, resI, dims));
     }
 };
@@ -652,7 +654,7 @@ static inline af_array checkOpCplx(const af_array in) {
     Array<char> resI = checkOp<BT, op>(I);
 
     const ArrayInfo &in_info = getInfo(in);
-    dim4 dims                = in_info.dims();
+    const dim4 &dims         = in_info.dims();
     cplxLogicOp<op> cplxLogic;
     af_array res = cplxLogic(resR, resI, dims);
 
@@ -669,7 +671,7 @@ static af_err af_check(af_array *out, const af_array in) {
 
         // Convert all inputs to floats / doubles / complex
         af_dtype type = implicit(in_type, f32);
-        if (in_type == f16) type = f16;
+        if (in_type == f16) { type = f16; }
 
         switch (type) {
             case f32: res = checkOp<float, op>(in); break;

--- a/src/api/c/var.cpp
+++ b/src/api/c/var.cpp
@@ -35,9 +35,9 @@ using std::tuple;
 
 template<typename inType, typename outType>
 static outType varAll(const af_array& in, const bool isbiased) {
-    typedef typename baseOutType<outType>::type weightType;
-    Array<inType> inArr  = getArray<inType>(in);
-    Array<outType> input = cast<outType>(inArr);
+    using weightType          = typename baseOutType<outType>::type;
+    const Array<inType> inArr = getArray<inType>(in);
+    Array<outType> input      = cast<outType>(inArr);
 
     Array<outType> meanCnst = createValueArray<outType>(
         input.dims(), mean<inType, weightType, outType>(inArr));
@@ -56,13 +56,13 @@ static outType varAll(const af_array& in, const bool isbiased) {
 
 template<typename inType, typename outType>
 static outType varAll(const af_array& in, const af_array weights) {
-    typedef typename baseOutType<outType>::type bType;
+    using bType = typename baseOutType<outType>::type;
 
     Array<outType> input = cast<outType>(getArray<inType>(in));
     Array<outType> wts   = cast<outType>(getArray<bType>(weights));
 
     bType wtsSum = reduce_all<af_add_t, bType, bType>(getArray<bType>(weights));
-    outType wtdMean = mean<outType, bType>(input, getArray<bType>(weights));
+    auto wtdMean = mean<outType, bType>(input, getArray<bType>(weights));
 
     Array<outType> meanArr = createValueArray<outType>(input.dims(), wtdMean);
     Array<outType> diff =
@@ -83,7 +83,7 @@ static tuple<Array<outType>, Array<outType>> meanvar(
     const Array<inType>& in,
     const Array<typename baseOutType<outType>::type>& weights,
     const af_var_bias bias, const dim_t dim) {
-    typedef typename baseOutType<outType>::type weightType;
+    using weightType     = typename baseOutType<outType>::type;
     Array<outType> input = cast<outType>(in);
     dim4 iDims           = input.dims();
 
@@ -129,7 +129,7 @@ static tuple<af_array, af_array> meanvar(const af_array& in,
                                          const af_array& weights,
                                          const af_var_bias bias,
                                          const dim_t dim) {
-    typedef typename baseOutType<outType>::type weightType;
+    using weightType    = typename baseOutType<outType>::type;
     Array<outType> mean = createEmptyArray<outType>({0}),
                    var  = createEmptyArray<outType>({0});
 
@@ -162,10 +162,9 @@ static af_array var_(const af_array& in, const af_array& weights,
         Array<bType> empty = createEmptyArray<bType>({0});
         return getHandle(
             var<inType, outType>(getArray<inType>(in), empty, bias, dim));
-    } else {
-        return getHandle(var<inType, outType>(
-            getArray<inType>(in), getArray<bType>(weights), bias, dim));
     }
+    return getHandle(var<inType, outType>(getArray<inType>(in),
+                                          getArray<bType>(weights), bias, dim));
 }
 
 af_err af_var(af_array* out, const af_array in, const bool isbiased,

--- a/src/api/c/vector_field.cpp
+++ b/src/api/c/vector_field.cpp
@@ -57,17 +57,19 @@ fg_chart setup_vector_field(fg_window window, const vector<af_array>& points,
     fg_chart chart = NULL;
 
     if (pIn.dims()[0] == 2) {
-        if (props->col > -1 && props->row > -1)
+        if (props->col > -1 && props->row > -1) {
             chart =
                 fgMngr.getChart(window, props->row, props->col, FG_CHART_2D);
-        else
+        } else {
             chart = fgMngr.getChart(window, 0, 0, FG_CHART_2D);
+        }
     } else {
-        if (props->col > -1 && props->row > -1)
+        if (props->col > -1 && props->row > -1) {
             chart =
                 fgMngr.getChart(window, props->row, props->col, FG_CHART_3D);
-        else
+        } else {
             chart = fgMngr.getChart(window, 0, 0, FG_CHART_3D);
+        }
     }
 
     fg_vector_field vfield =
@@ -93,16 +95,16 @@ fg_chart setup_vector_field(fg_window window, const vector<af_array>& points,
             cmax[0] = step_round(dmax[0], true);
             cmin[1] = step_round(dmin[1], false);
             cmax[1] = step_round(dmax[1], true);
-            if (pIn.dims()[0] == 3) cmin[2] = step_round(dmin[2], false);
-            if (pIn.dims()[0] == 3) cmax[2] = step_round(dmax[2], true);
+            if (pIn.dims()[0] == 3) { cmin[2] = step_round(dmin[2], false); }
+            if (pIn.dims()[0] == 3) { cmax[2] = step_round(dmax[2], true); }
         } else {
-            if (cmin[0] > dmin[0]) cmin[0] = step_round(dmin[0], false);
-            if (cmax[0] < dmax[0]) cmax[0] = step_round(dmax[0], true);
-            if (cmin[1] > dmin[1]) cmin[1] = step_round(dmin[1], false);
-            if (cmax[1] < dmax[1]) cmax[1] = step_round(dmax[1], true);
+            if (cmin[0] > dmin[0]) { cmin[0] = step_round(dmin[0], false); }
+            if (cmax[0] < dmax[0]) { cmax[0] = step_round(dmax[0], true); }
+            if (cmin[1] > dmin[1]) { cmin[1] = step_round(dmin[1], false); }
+            if (cmax[1] < dmax[1]) { cmax[1] = step_round(dmax[1], true); }
             if (pIn.dims()[0] == 3) {
-                if (cmin[2] > dmin[2]) cmin[2] = step_round(dmin[2], false);
-                if (cmax[2] < dmax[2]) cmax[2] = step_round(dmax[2], true);
+                if (cmin[2] > dmin[2]) { cmin[2] = step_round(dmin[2], false); }
+                if (cmax[2] < dmax[2]) { cmax[2] = step_round(dmax[2], true); }
             }
         }
         FG_CHECK(_.fg_set_chart_axes_limits(chart, cmin[0], cmax[0], cmin[1],
@@ -124,7 +126,7 @@ af_err vectorFieldWrapper(const af_window window, const af_array points,
         af_dtype pType         = pInfo.getType();
 
         const ArrayInfo& dInfo = getInfo(directions);
-        af::dim4 dDims         = dInfo.dims();
+        const af::dim4& dDims  = dInfo.dims();
         af_dtype dType         = dInfo.getType();
 
         DIM_ASSERT(0, pDims == dDims);
@@ -193,9 +195,9 @@ af_err vectorFieldWrapper(const af_window window, const af_array xPoints,
         const ArrayInfo& ypInfo = getInfo(yPoints);
         const ArrayInfo& zpInfo = getInfo(zPoints);
 
-        af::dim4 xpDims = xpInfo.dims();
-        af::dim4 ypDims = ypInfo.dims();
-        af::dim4 zpDims = zpInfo.dims();
+        af::dim4 xpDims        = xpInfo.dims();
+        const af::dim4& ypDims = ypInfo.dims();
+        const af::dim4& zpDims = zpInfo.dims();
 
         af_dtype xpType = xpInfo.getType();
         af_dtype ypType = ypInfo.getType();
@@ -205,9 +207,9 @@ af_err vectorFieldWrapper(const af_window window, const af_array xPoints,
         const ArrayInfo& ydInfo = getInfo(yDirs);
         const ArrayInfo& zdInfo = getInfo(zDirs);
 
-        af::dim4 xdDims = xdInfo.dims();
-        af::dim4 ydDims = ydInfo.dims();
-        af::dim4 zdDims = zdInfo.dims();
+        const af::dim4& xdDims = xdInfo.dims();
+        const af::dim4& ydDims = ydInfo.dims();
+        const af::dim4& zdDims = zdInfo.dims();
 
         af_dtype xdType = xdInfo.getType();
         af_dtype ydType = ydInfo.getType();
@@ -298,8 +300,8 @@ af_err vectorFieldWrapper(const af_window window, const af_array xPoints,
         const ArrayInfo& xpInfo = getInfo(xPoints);
         const ArrayInfo& ypInfo = getInfo(yPoints);
 
-        af::dim4 xpDims = xpInfo.dims();
-        af::dim4 ypDims = ypInfo.dims();
+        af::dim4 xpDims        = xpInfo.dims();
+        const af::dim4& ypDims = ypInfo.dims();
 
         af_dtype xpType = xpInfo.getType();
         af_dtype ypType = ypInfo.getType();
@@ -307,8 +309,8 @@ af_err vectorFieldWrapper(const af_window window, const af_array xPoints,
         const ArrayInfo& xdInfo = getInfo(xDirs);
         const ArrayInfo& ydInfo = getInfo(yDirs);
 
-        af::dim4 xdDims = xdInfo.dims();
-        af::dim4 ydDims = ydInfo.dims();
+        const af::dim4& xdDims = xdInfo.dims();
+        const af::dim4& ydDims = ydInfo.dims();
 
         af_dtype xdType = xdInfo.getType();
         af_dtype ydType = ydInfo.getType();

--- a/src/api/c/where.cpp
+++ b/src/api/c/where.cpp
@@ -16,7 +16,6 @@
 #include <af/dim4.hpp>
 #include <complex>
 
-using af::dim4;
 using namespace detail;
 
 template<typename T>

--- a/src/api/c/window.cpp
+++ b/src/api/c/window.cpp
@@ -15,7 +15,6 @@
 #include <common/graphics_common.hpp>
 #include <platform.hpp>
 
-using af::dim4;
 using namespace detail;
 using namespace graphics;
 
@@ -75,26 +74,27 @@ af_err af_set_axes_limits_compute(const af_window window, const af_array x,
 
         ForgeManager& fgMngr = forgeManager();
 
-        fg_chart chart = NULL;
+        fg_chart chart = nullptr;
 
         fg_chart_type ctype = (z ? FG_CHART_3D : FG_CHART_2D);
 
-        if (props->col > -1 && props->row > -1)
+        if (props->col > -1 && props->row > -1) {
             chart = fgMngr.getChart(window, props->row, props->col, ctype);
-        else
+        } else {
             chart = fgMngr.getChart(window, 0, 0, ctype);
+        }
 
-        double xmin = -1, xmax = 1;
-        double ymin = -1, ymax = 1;
-        double zmin = -1, zmax = 1;
-        AF_CHECK(af_min_all(&xmin, NULL, x));
-        AF_CHECK(af_max_all(&xmax, NULL, x));
-        AF_CHECK(af_min_all(&ymin, NULL, y));
-        AF_CHECK(af_max_all(&ymax, NULL, y));
+        double xmin = -1., xmax = 1.;
+        double ymin = -1., ymax = 1.;
+        double zmin = -1., zmax = 1.;
+        AF_CHECK(af_min_all(&xmin, nullptr, x));
+        AF_CHECK(af_max_all(&xmax, nullptr, x));
+        AF_CHECK(af_min_all(&ymin, nullptr, y));
+        AF_CHECK(af_max_all(&ymax, nullptr, y));
 
         if (ctype == FG_CHART_3D) {
-            AF_CHECK(af_min_all(&zmin, NULL, z));
-            AF_CHECK(af_max_all(&zmax, NULL, z));
+            AF_CHECK(af_min_all(&zmin, nullptr, z));
+            AF_CHECK(af_max_all(&zmax, nullptr, z));
         }
 
         if (!exact) {
@@ -123,21 +123,22 @@ af_err af_set_axes_limits_2d(const af_window window, const float xmin,
 
         ForgeManager& fgMngr = forgeManager();
 
-        fg_chart chart = NULL;
+        fg_chart chart = nullptr;
         // The ctype here below doesn't really matter as it is only fetching
         // the chart. It will not set it.
         // If this is actually being done, then it is extremely bad.
         fg_chart_type ctype = FG_CHART_2D;
 
-        if (props->col > -1 && props->row > -1)
+        if (props->col > -1 && props->row > -1) {
             chart = fgMngr.getChart(window, props->row, props->col, ctype);
-        else
+        } else {
             chart = fgMngr.getChart(window, 0, 0, ctype);
+        }
 
-        float _xmin = xmin;
-        float _xmax = xmax;
-        float _ymin = ymin;
-        float _ymax = ymax;
+        double _xmin = xmin;
+        double _xmax = xmax;
+        double _ymin = ymin;
+        double _ymax = ymax;
         if (!exact) {
             _xmin = step_round(_xmin, false);
             _xmax = step_round(_xmax, true);
@@ -163,23 +164,24 @@ af_err af_set_axes_limits_3d(const af_window window, const float xmin,
 
         ForgeManager& fgMngr = forgeManager();
 
-        fg_chart chart = NULL;
+        fg_chart chart = nullptr;
         // The ctype here below doesn't really matter as it is only fetching
         // the chart. It will not set it.
         // If this is actually being done, then it is extremely bad.
         fg_chart_type ctype = FG_CHART_3D;
 
-        if (props->col > -1 && props->row > -1)
+        if (props->col > -1 && props->row > -1) {
             chart = fgMngr.getChart(window, props->row, props->col, ctype);
-        else
+        } else {
             chart = fgMngr.getChart(window, 0, 0, ctype);
+        }
 
-        float _xmin = xmin;
-        float _xmax = xmax;
-        float _ymin = ymin;
-        float _ymax = ymax;
-        float _zmin = zmin;
-        float _zmax = zmax;
+        double _xmin = xmin;
+        double _xmax = xmax;
+        double _ymin = ymin;
+        double _ymax = ymax;
+        double _zmin = zmin;
+        double _zmax = zmax;
         if (!exact) {
             _xmin = step_round(_xmin, false);
             _xmax = step_round(_xmax, true);
@@ -205,14 +207,15 @@ af_err af_set_axes_titles(const af_window window, const char* const xtitle,
 
         ForgeManager& fgMngr = forgeManager();
 
-        fg_chart chart = NULL;
+        fg_chart chart = nullptr;
 
         fg_chart_type ctype = (ztitle ? FG_CHART_3D : FG_CHART_2D);
 
-        if (props->col > -1 && props->row > -1)
+        if (props->col > -1 && props->row > -1) {
             chart = fgMngr.getChart(window, props->row, props->col, ctype);
-        else
+        } else {
             chart = fgMngr.getChart(window, 0, 0, ctype);
+        }
 
         FG_CHECK(forgePlugin().fg_set_chart_axes_titles(chart, xtitle, ytitle,
                                                         ztitle));
@@ -238,10 +241,11 @@ af_err af_set_axes_label_format(const af_window window,
 
         fg_chart_type ctype = (zformat ? FG_CHART_3D : FG_CHART_2D);
 
-        if (props->col > -1 && props->row > -1)
+        if (props->col > -1 && props->row > -1) {
             chart = fgMngr.getChart(window, props->row, props->col, ctype);
-        else
+        } else {
             chart = fgMngr.getChart(window, 0, 0, ctype);
+        }
 
         if (ctype == FG_CHART_2D) {
             FG_CHECK(forgePlugin().fg_set_chart_label_format(chart, xformat,

--- a/src/api/c/wrap.cpp
+++ b/src/api/c/wrap.cpp
@@ -19,11 +19,10 @@ using af::dim4;
 using namespace detail;
 
 template<typename T>
-static inline void wrap(af_array* out, const af_array in, const dim_t ox,
-                        const dim_t oy, const dim_t wx, const dim_t wy,
-                        const dim_t sx, const dim_t sy, const dim_t px,
-                        const dim_t py, const bool is_column) {
-    wrap<T>(getArray<T>(*out), getArray<T>(in), ox, oy, wx, wy, sx, sy, px, py,
+static inline void wrap(af_array* out, const af_array in, const dim_t wx,
+                        const dim_t wy, const dim_t sx, const dim_t sy,
+                        const dim_t px, const dim_t py, const bool is_column) {
+    wrap<T>(getArray<T>(*out), getArray<T>(in), wx, wy, sx, sy, px, py,
             is_column);
 }
 
@@ -60,18 +59,18 @@ void af_wrap_common(af_array* out, const af_array in, const dim_t ox,
 
     // clang-format off
     switch(in_type) {
-        case f32: wrap<float  >(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);  break;
-        case f64: wrap<double >(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);  break;
-        case c32: wrap<cfloat >(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);  break;
-        case c64: wrap<cdouble>(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);  break;
-        case s32: wrap<int    >(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);  break;
-        case u32: wrap<uint   >(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);  break;
-        case s64: wrap<intl   >(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);  break;
-        case u64: wrap<uintl  >(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);  break;
-        case s16: wrap<short  >(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);  break;
-        case u16: wrap<ushort >(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);  break;
-        case u8:  wrap<uchar  >(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);  break;
-        case b8:  wrap<char   >(out, in, ox, oy, wx, wy, sx, sy, px, py, is_column);  break;
+        case f32: wrap<float  >(out, in, wx, wy, sx, sy, px, py, is_column);  break;
+        case f64: wrap<double >(out, in, wx, wy, sx, sy, px, py, is_column);  break;
+        case c32: wrap<cfloat >(out, in, wx, wy, sx, sy, px, py, is_column);  break;
+        case c64: wrap<cdouble>(out, in, wx, wy, sx, sy, px, py, is_column);  break;
+        case s32: wrap<int    >(out, in, wx, wy, sx, sy, px, py, is_column);  break;
+        case u32: wrap<uint   >(out, in, wx, wy, sx, sy, px, py, is_column);  break;
+        case s64: wrap<intl   >(out, in, wx, wy, sx, sy, px, py, is_column);  break;
+        case u64: wrap<uintl  >(out, in, wx, wy, sx, sy, px, py, is_column);  break;
+        case s16: wrap<short  >(out, in, wx, wy, sx, sy, px, py, is_column);  break;
+        case u16: wrap<ushort >(out, in, wx, wy, sx, sy, px, py, is_column);  break;
+        case u8:  wrap<uchar  >(out, in, wx, wy, sx, sy, px, py, is_column);  break;
+        case b8:  wrap<char   >(out, in, wx, wy, sx, sy, px, py, is_column);  break;
         default:  TYPE_ERROR(1, in_type);
     }
     // clang-format on

--- a/src/api/c/wrap.cpp
+++ b/src/api/c/wrap.cpp
@@ -36,7 +36,7 @@ void af_wrap_common(af_array* out, const af_array in, const dim_t ox,
 
     const ArrayInfo& info  = getInfo(in);
     const af_dtype in_type = info.getType();
-    const dim4 in_dims     = info.dims();
+    const dim4& in_dims    = info.dims();
     const dim4 out_dims(ox, oy, in_dims[2], in_dims[3]);
 
     ARG_ASSERT(4, wx > 0);

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -137,12 +137,16 @@ af_array initDataArray(const void *ptr, int ty, af::source src, dim_t d0,
 namespace af {
 
 struct array::array_proxy::array_proxy_impl {
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     array *parent_;          //< The original array
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     af_index_t indices_[4];  //< Indexing array or seq objects
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     bool is_linear_;
 
     // if true the parent_ object will be deleted on distruction. This is
     // necessary only when calling indexing functions in array_proxy objects.
+    // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     bool delete_on_destruction_;
     array_proxy_impl(array &parent, af_index_t *idx, bool linear)
         : parent_(&parent)
@@ -194,7 +198,7 @@ array::array(dim_t dim0, dim_t dim1, dim_t dim2, dim_t dim3, af::dtype ty)
 template<>
 struct dtype_traits<half_float::half> {
     enum { af_type = f16, ctype = f16 };
-    typedef half base_type;
+    using base_type = half;
     static const char *getName() { return "half"; }
 };
 
@@ -292,7 +296,7 @@ array::~array() {
     }
 #else
     // THOU SHALL NOT THROW IN DESTRUCTORS
-    if (af_array arr = get()) af_release_array(arr);
+    if (af_array arr = get()) { af_release_array(arr); }
 #endif
 }
 
@@ -386,6 +390,7 @@ array::array_proxy array::operator()(const index &s0, const index &s1,
     return const_cast<const array *>(this)->operator()(s0, s1, s2, s3);
 }
 
+// NOLINTNEXTLINE(readability-const-return-type)
 const array::array_proxy array::operator()(const index &s0) const {
     index z = index(0);
     if (isvector()) {
@@ -401,12 +406,14 @@ const array::array_proxy array::operator()(const index &s0) const {
     }
 }
 
+// NOLINTNEXTLINE(readability-const-return-type)
 const array::array_proxy array::operator()(const index &s0, const index &s1,
                                            const index &s2,
                                            const index &s3) const {
     return gen_indexing(*this, s0, s1, s2, s3);
 }
 
+// NOLINTNEXTLINE(readability-const-return-type)
 const array::array_proxy array::row(int index) const {
     return this->operator()(index, span, span, span);
 }
@@ -415,6 +422,7 @@ array::array_proxy array::row(int index) {
     return const_cast<const array *>(this)->row(index);
 }
 
+// NOLINTNEXTLINE(readability-const-return-type)
 const array::array_proxy array::col(int index) const {
     return this->operator()(span, index, span, span);
 }
@@ -423,6 +431,7 @@ array::array_proxy array::col(int index) {
     return const_cast<const array *>(this)->col(index);
 }
 
+// NOLINTNEXTLINE(readability-const-return-type)
 const array::array_proxy array::slice(int index) const {
     return this->operator()(span, span, index, span);
 }
@@ -431,6 +440,7 @@ array::array_proxy array::slice(int index) {
     return const_cast<const array *>(this)->slice(index);
 }
 
+// NOLINTNEXTLINE(readability-const-return-type)
 const array::array_proxy array::rows(int first, int last) const {
     seq idx(first, last, 1);
     return this->operator()(idx, span, span, span);
@@ -440,6 +450,7 @@ array::array_proxy array::rows(int first, int last) {
     return const_cast<const array *>(this)->rows(first, last);
 }
 
+// NOLINTNEXTLINE(readability-const-return-type)
 const array::array_proxy array::cols(int first, int last) const {
     seq idx(first, last, 1);
     return this->operator()(span, idx, span, span);
@@ -449,6 +460,7 @@ array::array_proxy array::cols(int first, int last) {
     return const_cast<const array *>(this)->cols(first, last);
 }
 
+// NOLINTNEXTLINE(readability-const-return-type)
 const array::array_proxy array::slices(int first, int last) const {
     seq idx(first, last, 1);
     return this->operator()(span, span, idx, span);
@@ -458,6 +470,7 @@ array::array_proxy array::slices(int first, int last) {
     return const_cast<const array *>(this)->slices(first, last);
 }
 
+// NOLINTNEXTLINE(readability-const-return-type)
 const array array::as(af::dtype type) const {
     af_array out;
     AF_THROW(af_cast(&out, this->get(), type));
@@ -576,6 +589,7 @@ array::array_proxy &af::array::array_proxy::operator=(const array &other) {
 
 array::array_proxy &af::array::array_proxy::operator=(
     const array::array_proxy &other) {
+    if (this == &other) { return *this; }
     array out = other;
     *this     = out;
     return *this;
@@ -588,6 +602,7 @@ af::array::array_proxy::array_proxy(const array_proxy &other)
     : impl(new array_proxy_impl(*other.impl->parent_, other.impl->indices_,
                                 other.impl->is_linear_)) {}
 
+// NOLINTNEXTLINE(hicpp-noexcept-move) too late to change public API
 af::array::array_proxy::array_proxy(array_proxy &&other) {
     impl       = other.impl;
     other.impl = nullptr;
@@ -758,12 +773,17 @@ array::array_proxy::operator array() {
         proxy.impl->delete_on_destruction(true);                  \
         return proxy;                                             \
     }
-
+// NOLINTNEXTLINE(readability-const-return-type)
 MEM_INDEX(row(int index), row(index));
+// NOLINTNEXTLINE(readability-const-return-type)
 MEM_INDEX(rows(int first, int last), rows(first, last));
+// NOLINTNEXTLINE(readability-const-return-type)
 MEM_INDEX(col(int index), col(index));
+// NOLINTNEXTLINE(readability-const-return-type)
 MEM_INDEX(cols(int first, int last), cols(first, last));
+// NOLINTNEXTLINE(readability-const-return-type)
 MEM_INDEX(slice(int index), slice(index));
+// NOLINTNEXTLINE(readability-const-return-type)
 MEM_INDEX(slices(int first, int last), slices(first, last));
 
 #undef MEM_INDEX
@@ -772,7 +792,7 @@ MEM_INDEX(slices(int first, int last), slices(first, last));
 // Operator =
 ///////////////////////////////////////////////////////////////////////////
 array &array::operator=(const array &other) {
-    if (this->get() == other.get()) { return *this; }
+    if (this == &other || this->get() == other.get()) { return *this; }
     // TODO(umar): Unsafe. loses data if af_weak_copy fails
     if (this->arr != nullptr) { AF_THROW(af_release_array(this->arr)); }
 
@@ -1067,6 +1087,8 @@ INSTANTIATE(half_float::half)
 // FIXME: These functions need to be implemented properly at a later point
 void array::array_proxy::unlock() const {}
 void array::array_proxy::lock() const {}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
 bool array::array_proxy::isLocked() const { return false; }
 
 int array::nonzeros() const { return count<int>(*this); }

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -138,7 +138,7 @@ namespace af {
 
 struct array::array_proxy::array_proxy_impl {
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
-    array *parent_;          //< The original array
+    array *parent_;  //< The original array
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)
     af_index_t indices_[4];  //< Indexing array or seq objects
     // NOLINTNEXTLINE(misc-non-private-member-variables-in-classes)

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -89,7 +89,7 @@ af::dim4 seqToDims(af_index_t *indices, af::dim4 parentDims,
             }
         }
         return odims;
-    } catch (logic_error &err) { AF_THROW_ERR(err.what(), AF_ERR_SIZE); }
+    } catch (const logic_error &err) { AF_THROW_ERR(err.what(), AF_ERR_SIZE); }
 }
 
 unsigned numDims(const af_array arr) {

--- a/src/api/cpp/blas.cpp
+++ b/src/api/cpp/blas.cpp
@@ -38,8 +38,8 @@ array matmulTT(const array &lhs, const array &rhs) {
 }
 
 array matmul(const array &a, const array &b, const array &c) {
-    int tmp1 = a.dims(0) * b.dims(1);
-    int tmp2 = b.dims(0) * c.dims(1);
+    dim_t tmp1 = a.dims(0) * b.dims(1);
+    dim_t tmp2 = b.dims(0) * c.dims(1);
 
     if (tmp1 < tmp2) {
         return matmul(matmul(a, b), c);
@@ -49,8 +49,8 @@ array matmul(const array &a, const array &b, const array &c) {
 }
 
 array matmul(const array &a, const array &b, const array &c, const array &d) {
-    int tmp1 = a.dims(0) * c.dims(1);
-    int tmp2 = b.dims(0) * d.dims(1);
+    dim_t tmp1 = a.dims(0) * c.dims(1);
+    dim_t tmp2 = b.dims(0) * d.dims(1);
 
     if (tmp1 < tmp2) {
         return matmul(matmul(a, b, c), d);

--- a/src/api/cpp/convolve.cpp
+++ b/src/api/cpp/convolve.cpp
@@ -25,8 +25,8 @@ array convolve(const array &signal, const array &filter, const convMode mode,
     switch (std::min(sN, fN)) {
         case 1: return convolve1(signal, filter, mode, domain);
         case 2: return convolve2(signal, filter, mode, domain);
+        default:
         case 3: return convolve3(signal, filter, mode, domain);
-        default: return convolve3(signal, filter, mode, domain);
     }
 }
 
@@ -52,20 +52,24 @@ array convolve2(const array &signal, const array &filter, const convMode mode,
     return array(out);
 }
 
-array convolve2NN(const array &signal, const array &filter, const dim4 stride,
-                  const dim4 padding, const dim4 dilation) {
+array convolve2NN(
+    const array &signal, const array &filter,
+    const dim4 stride,      // NOLINT(performance-unnecessary-value-param)
+    const dim4 padding,     // NOLINT(performance-unnecessary-value-param)
+    const dim4 dilation) {  // NOLINT(performance-unnecessary-value-param)
     af_array out = 0;
     AF_THROW(af_convolve2_nn(&out, signal.get(), filter.get(), 2, stride.get(),
                              2, padding.get(), 2, dilation.get()));
     return array(out);
 }
 
-array convolve2GradientNN(const array &incoming_gradient,
-                          const array &original_signal,
-                          const array &original_filter,
-                          const array &convolved_output, const dim4 stride,
-                          const dim4 padding, const dim4 dilation,
-                          af_conv_gradient_type gradType) {
+array convolve2GradientNN(
+    const array &incoming_gradient, const array &original_signal,
+    const array &original_filter, const array &convolved_output,
+    const dim4 stride,    // NOLINT(performance-unnecessary-value-param)
+    const dim4 padding,   // NOLINT(performance-unnecessary-value-param)
+    const dim4 dilation,  // NOLINT(performance-unnecessary-value-param)
+    af_conv_gradient_type gradType) {
     af_array out = 0;
     AF_THROW(af_convolve2_gradient_nn(
         &out, incoming_gradient.get(), original_signal.get(),

--- a/src/api/cpp/data.cpp
+++ b/src/api/cpp/data.cpp
@@ -44,14 +44,15 @@ struct is_complex<af::cdouble> {
 
 array constant(af_half val, const dim4 &dims, const dtype type) {
     af_array res;
+    UNUSED(val);
     AF_THROW(af_constant(&res, 0,  //(double)val,
                          dims.ndims(), dims.get(), type));
     return array(res);
 }
 
-template<typename T,
-         typename = typename enable_if<is_complex<T>::value == false, T>::type>
-array constant(T val, const dim4 &dims, const dtype type) {
+template<typename T, typename = typename enable_if<
+                         !static_cast<bool>(is_complex<T>::value), T>::type>
+array constant(T val, const dim4 &dims, dtype type) {
     af_array res;
     if (type != s64 && type != u64) {
         AF_THROW(
@@ -67,8 +68,8 @@ array constant(T val, const dim4 &dims, const dtype type) {
 }
 
 template<typename T>
-typename enable_if<is_complex<T>::value == true, array>::type constant(
-    T val, const dim4 &dims, const dtype type) {
+typename enable_if<static_cast<bool>(is_complex<T>::value), array>::type
+constant(T val, const dim4 &dims, const dtype type) {
     if (type != c32 && type != c64) {
         return ::constant(real(val), dims, type);
     }

--- a/src/api/cpp/device.cpp
+++ b/src/api/cpp/device.cpp
@@ -31,7 +31,7 @@ int getAvailableBackends() {
 }
 
 af::Backend getBackendId(const array &in) {
-    af::Backend result = (af::Backend)0;
+    auto result = static_cast<af::Backend>(0);
     AF_THROW(af_get_backend_id(&result, in.get()));
     return result;
 }
@@ -44,7 +44,7 @@ int getDeviceId(const array &in) {
 }
 
 af::Backend getActiveBackend() {
-    af::Backend result = (af::Backend)0;
+    auto result = static_cast<af::Backend>(0);
     AF_THROW(af_get_active_backend(&result));
     return result;
 }
@@ -54,7 +54,7 @@ void info() { AF_THROW(af_info()); }
 const char *infoString(const bool verbose) {
     char *str = NULL;
     AF_THROW(af_info_string(&str, verbose));
-    return (const char *)str;
+    return str;
 }
 
 void deviceprop(char *d_name, char *d_platform, char *d_toolkit,

--- a/src/api/cpp/error.hpp
+++ b/src/api/cpp/error.hpp
@@ -20,7 +20,7 @@
         af::exception ex(msg, __PRETTY_FUNCTION__, __AF_FILENAME__, __LINE__, \
                          __err);                                              \
         af_free_host(msg);                                                    \
-        throw ex; /* NOLINT(misc-throw-by-value-catch-by-reference)*/         \
+        throw std::move(ex);                                                  \
     } while (0)
 
 #define AF_THROW_ERR(__msg, __err)                                       \

--- a/src/api/cpp/event.cpp
+++ b/src/api/cpp/event.cpp
@@ -12,13 +12,13 @@
 
 namespace af {
 
-event::event() { AF_THROW(af_create_event(&e_)); }
+event::event() : e_{} { AF_THROW(af_create_event(&e_)); }
 
 event::event(af_event e) : e_(e) {}
 
 event::~event() {
     // No dtor throw
-    if (e_) af_delete_event(e_);
+    if (e_) { af_delete_event(e_); }
 }
 
 event::event(event&& other) : e_(other.e_) { other.e_ = 0; }

--- a/src/api/cpp/exception.cpp
+++ b/src/api/cpp/exception.cpp
@@ -7,10 +7,10 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include <stdio.h>
-#include <string.h>  // strncpy
 #include <af/exception.h>
 #include <algorithm>
+#include <cstdio>
+#include <cstring>  // strncpy
 
 #ifdef OS_WIN
 #define snprintf _snprintf
@@ -18,38 +18,40 @@
 
 namespace af {
 
-exception::exception() : m_err(AF_ERR_UNKNOWN) {
+exception::exception() : m_msg{}, m_err(AF_ERR_UNKNOWN) {
     strncpy(m_msg, "unknown exception", sizeof(m_msg));
 }
 
-exception::exception(const char *msg) : m_err(AF_ERR_UNKNOWN) {
+exception::exception(const char *msg) : m_msg{}, m_err(AF_ERR_UNKNOWN) {
     strncpy(m_msg, msg, sizeof(m_msg));
     m_msg[sizeof(m_msg) - 1] = '\0';
 }
 
-exception::exception(const char *file, unsigned line, af_err err) : m_err(err) {
+exception::exception(const char *file, unsigned line, af_err err)
+    : m_msg{}, m_err(err) {
     snprintf(m_msg, sizeof(m_msg) - 1, "ArrayFire Exception (%s:%d):\nIn %s:%u",
-             af_err_to_string(err), (int)err, file, line);
+             af_err_to_string(err), static_cast<int>(err), file, line);
 
     m_msg[sizeof(m_msg) - 1] = '\0';
 }
 
 exception::exception(const char *msg, const char *file, unsigned line,
                      af_err err)
-    : m_err(err) {
+    : m_msg{}, m_err(err) {
     snprintf(m_msg, sizeof(m_msg) - 1,
              "ArrayFire Exception (%s:%d):\n%s\nIn %s:%u",
-             af_err_to_string(err), (int)(err), msg, file, line);
+             af_err_to_string(err), static_cast<int>(err), msg, file, line);
 
     m_msg[sizeof(m_msg) - 1] = '\0';
 }
 
 exception::exception(const char *msg, const char *func, const char *file,
                      unsigned line, af_err err)
-    : m_err(err) {
+    : m_msg{}, m_err(err) {
     snprintf(m_msg, sizeof(m_msg) - 1,
              "ArrayFire Exception (%s:%d):\n%s\nIn function %s\nIn file %s:%u",
-             af_err_to_string(err), (int)(err), msg, func, file, line);
+             af_err_to_string(err), static_cast<int>(err), msg, func, file,
+             line);
 
     m_msg[sizeof(m_msg) - 1] = '\0';
 }

--- a/src/api/cpp/features.cpp
+++ b/src/api/cpp/features.cpp
@@ -13,9 +13,9 @@
 
 namespace af {
 
-features::features() { AF_THROW(af_create_features(&feat, 0)); }
+features::features() : feat{} { AF_THROW(af_create_features(&feat, 0)); }
 
-features::features(const size_t n) {
+features::features(const size_t n) : feat{} {
     AF_THROW(af_create_features(&feat, (int)n));
 }
 

--- a/src/api/cpp/fft.cpp
+++ b/src/api/cpp/fft.cpp
@@ -12,6 +12,9 @@
 #include <af/signal.h>
 #include "error.hpp"
 
+using af::array;
+using af::dim4;
+
 namespace af {
 array fftNorm(const array& in, const double norm_factor, const dim_t odim0) {
     af_array out = 0;
@@ -46,6 +49,7 @@ array fft3(const array& in, const dim_t odim0, const dim_t odim1,
     return fft3Norm(in, 1.0, odim0, odim1, odim2);
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 array dft(const array& in, const double norm_factor, const dim4 outDims) {
     array temp;
     switch (in.dims().ndims()) {
@@ -60,6 +64,7 @@ array dft(const array& in, const double norm_factor, const dim4 outDims) {
     return temp;
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 array dft(const array& in, const dim4 outDims) { return dft(in, 1.0, outDims); }
 
 array dft(const array& in) { return dft(in, 1.0, dim4(0, 0, 0, 0)); }
@@ -87,7 +92,7 @@ array ifft3Norm(const array& in, const double norm_factor, const dim_t odim0,
 array ifft(const array& in, const dim_t odim0) {
     const dim4 dims    = in.dims();
     dim_t dim0         = odim0 == 0 ? dims[0] : odim0;
-    double norm_factor = 1.0 / dim0;
+    double norm_factor = 1.0 / static_cast<double>(dim0);
     return ifftNorm(in, norm_factor, odim0);
 }
 
@@ -95,7 +100,7 @@ array ifft2(const array& in, const dim_t odim0, const dim_t odim1) {
     const dim4 dims    = in.dims();
     dim_t dim0         = odim0 == 0 ? dims[0] : odim0;
     dim_t dim1         = odim1 == 0 ? dims[1] : odim1;
-    double norm_factor = 1.0 / (dim0 * dim1);
+    double norm_factor = 1.0 / static_cast<double>(dim0 * dim1);
     return ifft2Norm(in, norm_factor, odim0, odim1);
 }
 
@@ -105,10 +110,11 @@ array ifft3(const array& in, const dim_t odim0, const dim_t odim1,
     dim_t dim0         = odim0 == 0 ? dims[0] : odim0;
     dim_t dim1         = odim1 == 0 ? dims[1] : odim1;
     dim_t dim2         = odim2 == 0 ? dims[2] : odim2;
-    double norm_factor = 1.0 / (dim0 * dim1 * dim2);
+    double norm_factor = 1.0 / static_cast<double>(dim0 * dim1 * dim2);
     return ifft3Norm(in, norm_factor, odim0, odim1, odim2);
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 array idft(const array& in, const double norm_factor, const dim4 outDims) {
     array temp;
     switch (in.dims().ndims()) {
@@ -125,6 +131,7 @@ array idft(const array& in, const double norm_factor, const dim4 outDims) {
     return temp;
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 array idft(const array& in, const dim4 outDims) {
     return idft(in, 1.0, outDims);
 }
@@ -145,19 +152,20 @@ void fft3InPlace(array& in, const double norm_factor) {
 
 void ifftInPlace(array& in, const double norm_factor) {
     const dim4 dims = in.dims();
-    double norm     = norm_factor * (1.0 / dims[0]);
+    double norm     = norm_factor * (1.0 / static_cast<double>(dims[0]));
     AF_THROW(af_ifft_inplace(in.get(), norm));
 }
 
 void ifft2InPlace(array& in, const double norm_factor) {
     const dim4 dims = in.dims();
-    double norm     = norm_factor * (1.0 / (dims[0] * dims[1]));
+    double norm = norm_factor * (1.0 / static_cast<double>(dims[0] * dims[1]));
     AF_THROW(af_ifft2_inplace(in.get(), norm));
 }
 
 void ifft3InPlace(array& in, const double norm_factor) {
     const dim4 dims = in.dims();
-    double norm     = norm_factor * (1.0 / (dims[0] * dims[1] * dims[2]));
+    double norm =
+        norm_factor * (1.0 / static_cast<double>(dims[0] * dims[1] * dims[2]));
     AF_THROW(af_ifft3_inplace(in.get(), norm));
 }
 
@@ -200,7 +208,7 @@ AFAPI array fftC2R<1>(const array& in, const bool is_odd,
     if (norm == 0) {
         dim4 idims = in.dims();
         dim_t dim0 = getOrigDim(idims[0], is_odd);
-        norm       = 1.0 / dim0;
+        norm       = 1.0 / static_cast<double>(dim0);
     }
 
     af_array res;
@@ -217,7 +225,7 @@ AFAPI array fftC2R<2>(const array& in, const bool is_odd,
         dim4 idims = in.dims();
         dim_t dim0 = getOrigDim(idims[0], is_odd);
         dim_t dim1 = idims[1];
-        norm       = 1.0 / (dim0 * dim1);
+        norm       = 1.0 / static_cast<double>(dim0 * dim1);
     }
 
     af_array res;
@@ -235,7 +243,7 @@ AFAPI array fftC2R<3>(const array& in, const bool is_odd,
         dim_t dim0 = getOrigDim(idims[0], is_odd);
         dim_t dim1 = idims[1];
         dim_t dim2 = idims[2];
-        norm       = 1.0 / (dim0 * dim1 * dim2);
+        norm       = 1.0 / static_cast<double>(dim0 * dim1 * dim2);
     }
 
     af_array res;

--- a/src/api/cpp/fftconvolve.cpp
+++ b/src/api/cpp/fftconvolve.cpp
@@ -22,8 +22,8 @@ array fftConvolve(const array& signal, const array& filter,
     switch (std::min(sN, fN)) {
         case 1: return fftConvolve1(signal, filter, mode);
         case 2: return fftConvolve2(signal, filter, mode);
+        default:
         case 3: return fftConvolve3(signal, filter, mode);
-        default: return fftConvolve3(signal, filter, mode);
     }
 }
 

--- a/src/api/cpp/gfor.cpp
+++ b/src/api/cpp/gfor.cpp
@@ -29,8 +29,9 @@ bool gforToggle() {
 }
 
 array batchFunc(const array &lhs, const array &rhs, batchFunc_t func) {
-    if (gforGet())
+    if (gforGet()) {
         AF_THROW_ERR("batchFunc can not be used inside GFOR", AF_ERR_ARG);
+    }
     gforSet(true);
     array res = func(lhs, rhs);
     gforSet(false);

--- a/src/api/cpp/internal.cpp
+++ b/src/api/cpp/internal.cpp
@@ -14,8 +14,8 @@
 namespace af {
 array createStridedArray(
     const void *data, const dim_t offset,
-    const dim4 dims,  // NOLINT(performance-unnecessary-value-param)
-    const dim4 strides,   // NOLINT(performance-unnecessary-value-param)
+    const dim4 dims,     // NOLINT(performance-unnecessary-value-param)
+    const dim4 strides,  // NOLINT(performance-unnecessary-value-param)
     const af::dtype ty, const af::source location) {
     af_array res;
     AF_THROW(af_create_strided_array(&res, data, offset, dims.ndims(),

--- a/src/api/cpp/internal.cpp
+++ b/src/api/cpp/internal.cpp
@@ -12,9 +12,11 @@
 #include "error.hpp"
 
 namespace af {
-array createStridedArray(const void *data, const dim_t offset, const dim4 dims,
-                         const dim4 strides, const af::dtype ty,
-                         const af::source location) {
+array createStridedArray(
+    const void *data, const dim_t offset,
+    const dim4 dims,  // NOLINT(performance-unnecessary-value-param)
+    const dim4 strides,   // NOLINT(performance-unnecessary-value-param)
+    const af::dtype ty, const af::source location) {
     af_array res;
     AF_THROW(af_create_strided_array(&res, data, offset, dims.ndims(),
                                      dims.get(), strides.get(), ty, location));

--- a/src/api/cpp/mean.cpp
+++ b/src/api/cpp/mean.cpp
@@ -52,28 +52,28 @@ template<>
 AFAPI af_cfloat mean(const array& in) {
     double real, imag;
     AF_THROW(af_mean_all(&real, &imag, in.get()));
-    return af_cfloat((float)real, (float)imag);
+    return {static_cast<float>(real), static_cast<float>(imag)};
 }
 
 template<>
 AFAPI af_cdouble mean(const array& in) {
     double real, imag;
     AF_THROW(af_mean_all(&real, &imag, in.get()));
-    return af_cdouble(real, imag);
+    return {real, imag};
 }
 
 template<>
 AFAPI af_cfloat mean(const array& in, const array& weights) {
     double real, imag;
     AF_THROW(af_mean_all_weighted(&real, &imag, in.get(), weights.get()));
-    return af_cfloat((float)real, (float)imag);
+    return {static_cast<float>(real), static_cast<float>(imag)};
 }
 
 template<>
 AFAPI af_cdouble mean(const array& in, const array& weights) {
     double real, imag;
     AF_THROW(af_mean_all_weighted(&real, &imag, in.get(), weights.get()));
-    return af_cdouble(real, imag);
+    return {real, imag};
 }
 
 INSTANTIATE_MEAN(float);

--- a/src/api/cpp/random.cpp
+++ b/src/api/cpp/random.cpp
@@ -25,7 +25,7 @@ randomEngine::randomEngine(const randomEngine &other) : engine(0) {
     }
 }
 
-randomEngine::randomEngine(af_random_engine handle) : engine(handle) {}
+randomEngine::randomEngine(af_random_engine engine) : engine(engine) {}
 
 randomEngine::~randomEngine() {
     if (engine) { af_release_random_engine(engine); }
@@ -39,7 +39,7 @@ randomEngine &randomEngine::operator=(const randomEngine &other) {
     return *this;
 }
 
-randomEngineType randomEngine::getType(void) {
+randomEngineType randomEngine::getType() {
     af_random_engine_type type;
     AF_THROW(af_random_engine_get_type(&type, engine));
     return type;
@@ -53,13 +53,13 @@ void randomEngine::setSeed(const unsigned long long seed) {
     AF_THROW(af_random_engine_set_seed(&engine, seed));
 }
 
-unsigned long long randomEngine::getSeed(void) const {
+unsigned long long randomEngine::getSeed() const {
     unsigned long long seed;
     AF_THROW(af_random_engine_get_seed(&seed, engine));
     return seed;
 }
 
-af_random_engine randomEngine::get(void) const { return engine; }
+af_random_engine randomEngine::get() const { return engine; }
 
 array randu(const dim4 &dims, const dtype ty, randomEngine &r) {
     af_array out;
@@ -121,7 +121,7 @@ void setDefaultRandomEngineType(randomEngineType rtype) {
     AF_THROW(af_set_default_random_engine_type(rtype));
 }
 
-randomEngine getDefaultRandomEngine(void) {
+randomEngine getDefaultRandomEngine() {
     af_random_engine internal_handle = 0;
     af_random_engine handle          = 0;
     AF_THROW(af_get_default_random_engine(&internal_handle));

--- a/src/api/cpp/seq.cpp
+++ b/src/api/cpp/seq.cpp
@@ -33,47 +33,51 @@ void seq::init(double begin, double end, double step) {
 #ifndef signbit
 // wtf windows?!
 inline int signbit(double x) {
-    if (x < 0) return -1;
+    if (x < 0) { return -1; }
     return 0;
 }
 #endif
 
-seq::~seq() {}
+seq::~seq() = default;
 
-seq::seq(double n) : m_gfor(false) {
-    if (n < 0) {
-        init(0, n, 1);
+seq::seq(double length) : s{}, size{}, m_gfor(false) {
+    if (length < 0) {
+        init(0, length, 1);
     } else {
-        init(0, n - 1, 1);
+        init(0, length - 1, 1);
     }
 }
 
-seq::seq(const af_seq& s_) : m_gfor(false) { init(s_.begin, s_.end, s_.step); }
+seq::seq(const af_seq& s_) : s{}, size{}, m_gfor(false) {
+    init(s_.begin, s_.end, s_.step);
+}
 
 seq& seq::operator=(const af_seq& s_) {
     init(s_.begin, s_.end, s_.step);
     return *this;
 }
 
-seq::seq(double begin, double end, double step) : m_gfor(false) {
+seq::seq(double begin, double end, double step) : s{}, size{}, m_gfor(false) {
     if (step == 0) {
-        if (begin != end)  // Span
+        if (begin != end) {  // Span
             AF_THROW_ERR("Invalid step size", AF_ERR_ARG);
+        }
     }
     if ((signbit(end) == signbit(begin)) &&
-        (signbit(end - begin) != signbit(step)))
+        (signbit(end - begin) != signbit(step))) {
         AF_THROW_ERR("Sequence is invalid", AF_ERR_ARG);
+    }
     init(begin, end, step);
 }
 
-seq::seq(seq other, bool is_gfor)
+seq::seq(seq other,  // NOLINT(performance-unnecessary-value-param)
+         bool is_gfor)
     : s(other.s), size(other.size), m_gfor(is_gfor) {}
 
 seq::operator array() const {
     double diff = s.end - s.begin;
-    dim_t len =
-        (int)((diff + std::fabs(s.step) * (signbit(diff) == 0 ? 1 : -1)) /
-              s.step);
+    dim_t len   = static_cast<int>(
+        (diff + std::fabs(s.step) * (signbit(diff) == 0 ? 1 : -1)) / s.step);
 
     array tmp = (m_gfor) ? range(1, 1, 1, len, 3) : range(len);
 

--- a/src/api/cpp/sparse.cpp
+++ b/src/api/cpp/sparse.cpp
@@ -12,8 +12,11 @@
 #include "error.hpp"
 
 namespace af {
-array sparse(const dim_t nRows, const dim_t nCols, const array values,
-             const array rowIdx, const array colIdx, const af::storage stype) {
+array sparse(const dim_t nRows, const dim_t nCols,
+             const array values,  // NOLINT(performance-unnecessary-value-param)
+             const array rowIdx,  // NOLINT(performance-unnecessary-value-param)
+             const array colIdx,  // NOLINT(performance-unnecessary-value-param)
+             const af::storage stype) {
     af_array out = 0;
     AF_THROW(af_create_sparse_array(&out, nRows, nCols, values.get(),
                                     rowIdx.get(), colIdx.get(), stype));
@@ -21,8 +24,8 @@ array sparse(const dim_t nRows, const dim_t nCols, const array values,
 }
 
 array sparse(const dim_t nRows, const dim_t nCols, const dim_t nNZ,
-             const void *const values, const int *const rowIdx,
-             const int *const colIdx, const dtype type, const af::storage stype,
+             const void* const values, const int* const rowIdx,
+             const int* const colIdx, const dtype type, const af::storage stype,
              const af::source src) {
     af_array out = 0;
     AF_THROW(af_create_sparse_array_from_ptr(&out, nRows, nCols, nNZ, values,
@@ -30,26 +33,30 @@ array sparse(const dim_t nRows, const dim_t nCols, const dim_t nNZ,
     return array(out);
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 array sparse(const array dense, const af::storage stype) {
     af_array out = 0;
     AF_THROW(af_create_sparse_array_from_dense(&out, dense.get(), stype));
     return array(out);
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 array sparseConvertTo(const array in, const af::storage stype) {
     af_array out = 0;
     AF_THROW(af_sparse_convert_to(&out, in.get(), stype));
     return array(out);
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 array dense(const array sparse) {
     af_array out = 0;
     AF_THROW(af_sparse_to_dense(&out, sparse.get()));
     return array(out);
 }
 
-void sparseGetInfo(array &values, array &rowIdx, array &colIdx, storage &stype,
-                   const array in) {
+void sparseGetInfo(
+    array& values, array& rowIdx, array& colIdx, storage& stype,
+    const array in) {  // NOLINT(performance-unnecessary-value-param)
     af_array values_ = 0, rowIdx_ = 0, colIdx_ = 0;
     af_storage stype_ = AF_STORAGE_DENSE;
     AF_THROW(
@@ -58,33 +65,37 @@ void sparseGetInfo(array &values, array &rowIdx, array &colIdx, storage &stype,
     rowIdx = array(rowIdx_);
     colIdx = array(colIdx_);
     stype  = stype_;
-    return;
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 array sparseGetValues(const array in) {
     af_array out = 0;
     AF_THROW(af_sparse_get_values(&out, in.get()));
     return array(out);
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 array sparseGetRowIdx(const array in) {
     af_array out = 0;
     AF_THROW(af_sparse_get_row_idx(&out, in.get()));
     return array(out);
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 array sparseGetColIdx(const array in) {
     af_array out = 0;
     AF_THROW(af_sparse_get_col_idx(&out, in.get()));
     return array(out);
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 dim_t sparseGetNNZ(const array in) {
     dim_t out = 0;
     AF_THROW(af_sparse_get_nnz(&out, in.get()));
     return out;
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 af::storage sparseGetStorage(const array in) {
     af::storage out;
     AF_THROW(af_sparse_get_storage(&out, in.get()));

--- a/src/api/cpp/stdev.cpp
+++ b/src/api/cpp/stdev.cpp
@@ -27,14 +27,14 @@ template<>
 AFAPI af_cfloat stdev(const array& in) {
     double real, imag;
     AF_THROW(af_stdev_all(&real, &imag, in.get()));
-    return af_cfloat((float)real, (float)imag);
+    return {static_cast<float>(real), static_cast<float>(imag)};
 }
 
 template<>
 AFAPI af_cdouble stdev(const array& in) {
     double real, imag;
     AF_THROW(af_stdev_all(&real, &imag, in.get()));
-    return af_cdouble(real, imag);
+    return {real, imag};
 }
 
 INSTANTIATE_STDEV(float);

--- a/src/api/cpp/timing.cpp
+++ b/src/api/cpp/timing.cpp
@@ -7,16 +7,16 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include <math.h>
 #include <af/device.h>
 #include <af/timing.h>
 #include <algorithm>
+#include <cmath>
 #include <vector>
 
 using namespace af;
 
 // get current time
-static inline timer time_now(void) {
+static inline timer time_now() {
 #if defined(OS_WIN)
     timer time;
     QueryPerformanceCounter(&time.val);
@@ -53,7 +53,7 @@ static inline double time_seconds(timer start, timer end) {
     double nano = (double)info.numer / (double)info.denom;
     return (end.val - start.val) * nano * 1e-9;
 #elif defined(OS_LNX)
-    struct timeval elapsed;
+    struct timeval elapsed {};
     timersub(&start.val, &end.val, &elapsed);
     long sec  = elapsed.tv_sec;
     long usec = elapsed.tv_usec;
@@ -98,12 +98,12 @@ double timeit(void (*fn)()) {
     //   then run (min time / (trials * median_time)) batches
     // else
     //   run 1 batch
-    int batches     = (int)ceilf(min_time / (trials * median_time));
+    int batches = static_cast<int>(ceilf(min_time / (trials * median_time)));
     double run_time = 0;
 
     for (int b = 0; b < batches; b++) {
         timer start = timer::start();
-        for (int i = 0; i < trials; ++i) fn();
+        for (int i = 0; i < trials; ++i) { fn(); }
         sync();
         run_time += timer::stop(start) / trials;
     }

--- a/src/api/cpp/util.cpp
+++ b/src/api/cpp/util.cpp
@@ -17,12 +17,10 @@ using namespace std;
 namespace af {
 void print(const char *exp, const array &arr) {
     AF_THROW(af_print_array_gen(exp, arr.get(), 4));
-    return;
 }
 
 void print(const char *exp, const array &arr, const int precision) {
     AF_THROW(af_print_array_gen(exp, arr.get(), precision));
-    return;
 }
 
 int saveArray(const char *key, const array &arr, const char *filename,
@@ -53,7 +51,6 @@ int readArrayCheck(const char *filename, const char *key) {
 void toString(char **output, const char *exp, const array &arr,
               const int precision, const bool transpose) {
     AF_THROW(af_array_to_string(output, exp, arr.get(), precision, transpose));
-    return;
 }
 
 const char *toString(const char *exp, const array &arr, const int precision,

--- a/src/api/cpp/var.cpp
+++ b/src/api/cpp/var.cpp
@@ -53,28 +53,28 @@ template<>
 AFAPI af_cfloat var(const array& in, const bool isbiased) {
     double real, imag;
     AF_THROW(af_var_all(&real, &imag, in.get(), isbiased));
-    return af_cfloat((float)real, (float)imag);
+    return {static_cast<float>(real), static_cast<float>(imag)};
 }
 
 template<>
 AFAPI af_cdouble var(const array& in, const bool isbiased) {
     double real, imag;
     AF_THROW(af_var_all(&real, &imag, in.get(), isbiased));
-    return af_cdouble(real, imag);
+    return {real, imag};
 }
 
 template<>
 AFAPI af_cfloat var(const array& in, const array& weights) {
     double real, imag;
     AF_THROW(af_var_all_weighted(&real, &imag, in.get(), weights.get()));
-    return af_cfloat((float)real, (float)imag);
+    return {static_cast<float>(real), static_cast<float>(imag)};
 }
 
 template<>
 AFAPI af_cdouble var(const array& in, const array& weights) {
     double real, imag;
     AF_THROW(af_var_all_weighted(&real, &imag, in.get(), weights.get()));
-    return af_cdouble(real, imag);
+    return {real, imag};
 }
 
 INSTANTIATE_VAR(float);

--- a/src/backend/common/ArrayInfo.cpp
+++ b/src/backend/common/ArrayInfo.cpp
@@ -30,7 +30,7 @@ dim4 calcStrides(const dim4 &parentDim) {
     return out;
 }
 
-int ArrayInfo::getDevId() const {
+unsigned ArrayInfo::getDevId() const {
     // The actual device ID is only stored in the first 8 bits of devId
     // See ArrayInfo.hpp for more
     return devId & 0xffU;
@@ -40,25 +40,25 @@ void ArrayInfo::setId(int id) const {
     // 1 << (backendId + 8) sets the 9th, 10th or 11th bit of devId to 1
     // for CPU, CUDA and OpenCL respectively
     // See ArrayInfo.hpp for more
-    int backendId =
-        detail::getBackend() >> 1;  // Convert enums 1, 2, 4 to ints 0, 1, 2
-    const_cast<ArrayInfo *>(this)->setId(id | 1 << (backendId + 8));
+    unsigned backendId =
+        detail::getBackend() >> 1U;  // Convert enums 1, 2, 4 to ints 0, 1, 2
+    const_cast<ArrayInfo *>(this)->setId(id | 1 << (backendId + 8U));
 }
 
 void ArrayInfo::setId(int id) {
     // 1 << (backendId + 8) sets the 9th, 10th or 11th bit of devId to 1
     // for CPU, CUDA and OpenCL respectively
     // See ArrayInfo.hpp for more
-    int backendId =
-        detail::getBackend() >> 1;  // Convert enums 1, 2, 4 to ints 0, 1, 2
-    devId = id | 1 << (backendId + 8U);
+    unsigned backendId =
+        detail::getBackend() >> 1U;  // Convert enums 1, 2, 4 to ints 0, 1, 2
+    devId = id | 1U << (backendId + 8U);
 }
 
 af_backend ArrayInfo::getBackendId() const {
     // devId >> 8 converts the backend info to 1, 2, 4 which are enums
     // for CPU, CUDA and OpenCL respectively
     // See ArrayInfo.hpp for more
-    int backendId = devId >> 8U;
+    unsigned backendId = devId >> 8U;
     return static_cast<af_backend>(backendId);
 }
 

--- a/src/backend/common/ArrayInfo.cpp
+++ b/src/backend/common/ArrayInfo.cpp
@@ -33,7 +33,7 @@ dim4 calcStrides(const dim4 &parentDim) {
 int ArrayInfo::getDevId() const {
     // The actual device ID is only stored in the first 8 bits of devId
     // See ArrayInfo.hpp for more
-    return devId & 0xff;
+    return devId & 0xffU;
 }
 
 void ArrayInfo::setId(int id) const {
@@ -51,15 +51,15 @@ void ArrayInfo::setId(int id) {
     // See ArrayInfo.hpp for more
     int backendId =
         detail::getBackend() >> 1;  // Convert enums 1, 2, 4 to ints 0, 1, 2
-    devId = id | 1 << (backendId + 8);
+    devId = id | 1 << (backendId + 8U);
 }
 
 af_backend ArrayInfo::getBackendId() const {
     // devId >> 8 converts the backend info to 1, 2, 4 which are enums
     // for CPU, CUDA and OpenCL respectively
     // See ArrayInfo.hpp for more
-    int backendId = devId >> 8;
-    return (af_backend)backendId;
+    int backendId = devId >> 8U;
+    return static_cast<af_backend>(backendId);
 }
 
 void ArrayInfo::modStrides(const dim4 &newStrides) { dim_strides = newStrides; }
@@ -120,7 +120,7 @@ bool ArrayInfo::isLinear() const {
     if (ndims() == 1) { return dim_strides[0] == 1; }
 
     dim_t count = 1;
-    for (int i = 0; i < (int)ndims(); i++) {
+    for (size_t i = 0; i < ndims(); i++) {
         if (count != dim_strides[i]) { return false; }
         count *= dim_size[i];
     }
@@ -150,8 +150,9 @@ dim4 toDims(const vector<af_seq> &seqs, const dim4 &parentDims) {
     dim4 outDims(1, 1, 1, 1);
     for (unsigned i = 0; i < seqs.size(); i++) {
         outDims[i] = af::calcDim(seqs[i], parentDims[i]);
-        if (outDims[i] > parentDims[i])
+        if (outDims[i] > parentDims[i]) {
             AF_ERROR("Size mismatch between input and output", AF_ERR_SIZE);
+        }
     }
     return outDims;
 }
@@ -167,8 +168,9 @@ dim4 toOffset(const vector<af_seq> &seqs, const dim4 &parentDims) {
             outOffsets[i] = 0;
         }
 
-        if (outOffsets[i] >= parentDims[i])
+        if (outOffsets[i] >= parentDims[i]) {
             AF_ERROR("Index out of range", AF_ERR_SIZE);
+        }
     }
     return outOffsets;
 }

--- a/src/backend/common/ArrayInfo.hpp
+++ b/src/backend/common/ArrayInfo.hpp
@@ -39,7 +39,7 @@ class ArrayInfo {
     // This can be changed in the future if the need arises for more devices as
     // this implementation is internal. Make sure to change the bit shift ops
     // when such a change is being made
-    int devId;
+    unsigned devId;
     af_dtype type;
     af::dim4 dim_size;
     dim_t offset;

--- a/src/backend/common/ArrayInfo.hpp
+++ b/src/backend/common/ArrayInfo.hpp
@@ -95,7 +95,7 @@ class ArrayInfo {
     const af::dim4& dims() const { return dim_size; }
     size_t total() const { return offset + dim_strides[3] * dim_size[3]; }
 
-    int getDevId() const;
+    unsigned getDevId() const;
 
     void setId(int id) const;
 

--- a/src/backend/common/DefaultMemoryManager.hpp
+++ b/src/backend/common/DefaultMemoryManager.hpp
@@ -118,9 +118,10 @@ class DefaultMemoryManager final : public common::memory::MemoryManagerBase {
     float getMemoryPressure() override;
     bool jitTreeExceedsMemoryPressure(size_t bytes) override;
 
+    ~DefaultMemoryManager() = default;
+
    protected:
     DefaultMemoryManager()                                  = delete;
-    ~DefaultMemoryManager()                                 = default;
     DefaultMemoryManager(const DefaultMemoryManager &other) = delete;
     DefaultMemoryManager(DefaultMemoryManager &&other)      = default;
     DefaultMemoryManager &operator=(const DefaultMemoryManager &other) = delete;

--- a/src/backend/common/DependencyModule.cpp
+++ b/src/backend/common/DependencyModule.cpp
@@ -38,7 +38,7 @@ using std::vector;
 
 namespace {
 
-std::string libName(std::string name) {
+std::string libName(const std::string& name) {
     return libraryPrefix + name + librarySuffix;
 }
 }  // namespace
@@ -62,9 +62,9 @@ DependencyModule::DependencyModule(const char* plugin_file_name,
     }
 }
 
-DependencyModule::DependencyModule(const vector<string> plugin_base_file_name,
-                                   const vector<string> suffixes,
-                                   const vector<string> paths)
+DependencyModule::DependencyModule(const vector<string>& plugin_base_file_name,
+                                   const vector<string>& suffixes,
+                                   const vector<string>& paths)
     : handle(nullptr), logger(common::loggerFactory("platform")) {
     for (const string& base_name : plugin_base_file_name) {
         for (const string& path : paths) {
@@ -86,14 +86,15 @@ DependencyModule::~DependencyModule() noexcept {
     if (handle) { unloadLibrary(handle); }
 }
 
-bool DependencyModule::isLoaded() const noexcept { return (bool)handle; }
+bool DependencyModule::isLoaded() const noexcept { return static_cast<bool>(handle);
+}
 
 bool DependencyModule::symbolsLoaded() const noexcept {
     return all_of(begin(functions), end(functions),
                   [](void* ptr) { return ptr != nullptr; });
 }
 
-string DependencyModule::getErrorMessage() const noexcept {
+string DependencyModule::getErrorMessage() noexcept {
     return common::getErrorMessage();
 }
 

--- a/src/backend/common/DependencyModule.cpp
+++ b/src/backend/common/DependencyModule.cpp
@@ -86,7 +86,8 @@ DependencyModule::~DependencyModule() noexcept {
     if (handle) { unloadLibrary(handle); }
 }
 
-bool DependencyModule::isLoaded() const noexcept { return static_cast<bool>(handle);
+bool DependencyModule::isLoaded() const noexcept {
+    return static_cast<bool>(handle);
 }
 
 bool DependencyModule::symbolsLoaded() const noexcept {

--- a/src/backend/common/DependencyModule.hpp
+++ b/src/backend/common/DependencyModule.hpp
@@ -37,9 +37,9 @@ class DependencyModule {
     DependencyModule(const char* plugin_file_name,
                      const char** paths = nullptr);
 
-    DependencyModule(const std::vector<std::string> plugin_base_file_name,
-                     const std::vector<std::string> suffixes,
-                     const std::vector<std::string> paths);
+    DependencyModule(const std::vector<std::string>& plugin_base_file_name,
+                     const std::vector<std::string>& suffixes,
+                     const std::vector<std::string>& paths);
 
     ~DependencyModule() noexcept;
 
@@ -58,7 +58,7 @@ class DependencyModule {
 
     /// Returns the last error message that occurred because of loading the
     /// library
-    std::string getErrorMessage() const noexcept;
+    static std::string getErrorMessage() noexcept;
 
     spdlog::logger* getLogger() const noexcept;
 };

--- a/src/backend/common/InteropManager.hpp
+++ b/src/backend/common/InteropManager.hpp
@@ -31,7 +31,7 @@ class InteropManager {
     ~InteropManager() {
         try {
             destroyResources();
-        } catch (AfError &ex) {
+        } catch (const AfError &ex) {
             std::string perr = getEnvVar("AF_PRINT_ERRORS");
             if (!perr.empty()) {
                 if (perr != "0") fprintf(stderr, "%s\n", ex.what());

--- a/src/backend/common/Logger.cpp
+++ b/src/backend/common/Logger.cpp
@@ -22,10 +22,8 @@
 #include <string>
 
 using std::array;
-using std::make_shared;
 using std::shared_ptr;
 using std::string;
-using std::to_string;
 
 using spdlog::get;
 using spdlog::logger;
@@ -33,7 +31,7 @@ using spdlog::stdout_logger_mt;
 
 namespace common {
 
-shared_ptr<logger> loggerFactory(string name) {
+shared_ptr<logger> loggerFactory(const string& name) {
     shared_ptr<logger> logger;
     if (!(logger = get(name))) {
         logger = stdout_logger_mt(name);
@@ -52,15 +50,15 @@ shared_ptr<logger> loggerFactory(string name) {
 }
 
 string bytesToString(size_t bytes) {
-    constexpr array<const char *, 7> units{
+    constexpr array<const char*, 7> units{
         {"B", "KB", "MB", "GB", "TB", "PB", "EB"}};
     size_t count     = 0;
-    double fbytes    = static_cast<double>(bytes);
+    auto fbytes      = static_cast<double>(bytes);
     size_t num_units = units.size();
     for (count = 0; count < num_units && fbytes > 1000.0f; count++) {
         fbytes *= (1.0f / 1024.0f);
     }
-    if (count == units.size()) count--;
+    if (count == units.size()) { count--; }
     return fmt::format("{:.3g} {}", fbytes, units[count]);
 }
 }  // namespace common

--- a/src/backend/common/Logger.hpp
+++ b/src/backend/common/Logger.hpp
@@ -16,7 +16,7 @@
 #include <spdlog/spdlog.h>
 
 namespace common {
-std::shared_ptr<spdlog::logger> loggerFactory(std::string name);
+std::shared_ptr<spdlog::logger> loggerFactory(const std::string& name);
 std::string bytesToString(size_t bytes);
 }  // namespace common
 

--- a/src/backend/common/SparseArray.cpp
+++ b/src/backend/common/SparseArray.cpp
@@ -71,7 +71,8 @@ SparseArrayBase::SparseArrayBase(af::dim4 _dims, dim_t _nNZ, int *const _rowIdx,
     }
 }
 
-SparseArrayBase::SparseArrayBase(af::dim4 _dims, const Array<int> &_rowIdx,
+SparseArrayBase::SparseArrayBase(const af::dim4 &_dims,
+                                 const Array<int> &_rowIdx,
                                  const Array<int> &_colIdx,
                                  const af::storage _storage, af_dtype _type,
                                  bool _copy)
@@ -90,13 +91,13 @@ SparseArrayBase::SparseArrayBase(const SparseArrayBase &base, bool copy)
     , rowIdx(copy ? copyArray<int>(base.rowIdx) : base.rowIdx)
     , colIdx(copy ? copyArray<int>(base.colIdx) : base.colIdx) {}
 
-SparseArrayBase::~SparseArrayBase() {}
+SparseArrayBase::~SparseArrayBase() = default;
 
 dim_t SparseArrayBase::getNNZ() const {
-    if (stype == AF_STORAGE_COO || stype == AF_STORAGE_CSC)
+    if (stype == AF_STORAGE_COO || stype == AF_STORAGE_CSC) {
         return rowIdx.elements();
-    else if (stype == AF_STORAGE_CSR)
-        return colIdx.elements();
+    }
+    if (stype == AF_STORAGE_CSR) { return colIdx.elements(); }
 
     // This is to ensure future storages are properly configured
     return 0;
@@ -126,12 +127,11 @@ SparseArray<T> createHostDataSparseArray(const af::dim4 &_dims, const dim_t nNZ,
 }
 
 template<typename T>
-SparseArray<T> createDeviceDataSparseArray(const af::dim4 &_dims,
-                                           const dim_t nNZ, T *const _values,
-                                           int *const _rowIdx,
-                                           int *const _colIdx,
-                                           const af::storage _storage,
-                                           const bool _copy) {
+SparseArray<T> createDeviceDataSparseArray(
+    const af::dim4 &_dims, const dim_t nNZ, T *const _values,
+    int *const _rowIdx,  // NOLINT(readability-non-const-parameter)
+    int *const _colIdx,  // NOLINT(readability-non-const-parameter)
+    const af::storage _storage, const bool _copy) {
     return SparseArray<T>(_dims, nNZ, _values, _rowIdx, _colIdx, _storage, true,
                           _copy);
 }
@@ -162,7 +162,7 @@ void destroySparseArray(SparseArray<T> *sparse) {
 // Sparse Array Class Implementations
 ////////////////////////////////////////////////////////////////////////////
 template<typename T>
-SparseArray<T>::SparseArray(dim4 _dims, dim_t _nNZ, af::storage _storage)
+SparseArray<T>::SparseArray(const dim4 &_dims, dim_t _nNZ, af::storage _storage)
     : base(_dims, _nNZ, _storage, (af_dtype)dtype_traits<T>::af_type)
     , values(createValueArray<T>(dim4(_nNZ), scalar<T>(0))) {
     static_assert(std::is_standard_layout<SparseArray<T>>::value,
@@ -173,7 +173,7 @@ SparseArray<T>::SparseArray(dim4 _dims, dim_t _nNZ, af::storage _storage)
 }
 
 template<typename T>
-SparseArray<T>::SparseArray(af::dim4 _dims, dim_t _nNZ, T *const _values,
+SparseArray<T>::SparseArray(const af::dim4 &_dims, dim_t _nNZ, T *const _values,
                             int *const _rowIdx, int *const _colIdx,
                             const af::storage _storage, bool _is_device,
                             bool _copy_device)
@@ -189,7 +189,7 @@ SparseArray<T>::SparseArray(af::dim4 _dims, dim_t _nNZ, T *const _values,
 }
 
 template<typename T>
-SparseArray<T>::SparseArray(af::dim4 _dims, const Array<T> &_values,
+SparseArray<T>::SparseArray(const af::dim4 &_dims, const Array<T> &_values,
                             const Array<int> &_rowIdx,
                             const Array<int> &_colIdx,
                             const af::storage _storage, bool _copy)
@@ -202,9 +202,6 @@ SparseArray<T>::SparseArray(const SparseArray<T> &other, bool copy)
     : base(other.base, copy)
     , values(copy ? copyArray<T>(other.values) : other.values) {}
 
-template<typename T>
-SparseArray<T>::~SparseArray() {}
-
 #define INSTANTIATE(T)                                                       \
     template SparseArray<T> createEmptySparseArray<T>(                       \
         const af::dim4 &_dims, dim_t _nNZ, const af::storage _storage);      \
@@ -213,7 +210,8 @@ SparseArray<T>::~SparseArray() {}
         const int *const _rowIdx, const int *const _colIdx,                  \
         const af::storage _storage);                                         \
     template SparseArray<T> createDeviceDataSparseArray<T>(                  \
-        const af::dim4 &_dims, const dim_t _nNZ, T *const _values,           \
+        const af::dim4 &_dims, const dim_t _nNZ,                             \
+        T *const _values, /*  NOLINT */                                      \
         int *const _rowIdx, int *const _colIdx, const af::storage _storage,  \
         const bool _copy);                                                   \
     template SparseArray<T> createArrayDataSparseArray<T>(                   \
@@ -224,16 +222,16 @@ SparseArray<T>::~SparseArray() {}
     template SparseArray<T> copySparseArray<T>(const SparseArray<T> &other); \
     template void destroySparseArray<T>(SparseArray<T> * sparse);            \
                                                                              \
-    template SparseArray<T>::SparseArray(af::dim4 _dims, dim_t _nNZ,         \
+    template SparseArray<T>::SparseArray(const af::dim4 &_dims, dim_t _nNZ,  \
                                          af::storage _storage);              \
     template SparseArray<T>::SparseArray(                                    \
-        af::dim4 _dims, dim_t _nNZ, T *const _values, int *const _rowIdx,    \
-        int *const _colIdx, const af::storage _storage, bool _is_device,     \
-        bool _copy_device);                                                  \
+        const af::dim4 &_dims, dim_t _nNZ, T *const _values, /* NOLINT */    \
+        int *const _rowIdx, int *const _colIdx, const af::storage _storage,  \
+        bool _is_device, bool _copy_device);                                 \
     template SparseArray<T>::SparseArray(                                    \
-        af::dim4 _dims, const Array<T> &_values, const Array<int> &_rowIdx,  \
-        const Array<int> &_colIdx, const af::storage _storage, bool _copy);  \
-    template SparseArray<T>::~SparseArray();
+        const af::dim4 &_dims, const Array<T> &_values,                      \
+        const Array<int> &_rowIdx, const Array<int> &_colIdx,                \
+        const af::storage _storage, bool _copy)
 
 // Instantiate only floating types
 INSTANTIATE(float);

--- a/src/backend/common/SparseArray.cpp
+++ b/src/backend/common/SparseArray.cpp
@@ -163,7 +163,8 @@ void destroySparseArray(SparseArray<T> *sparse) {
 ////////////////////////////////////////////////////////////////////////////
 template<typename T>
 SparseArray<T>::SparseArray(const dim4 &_dims, dim_t _nNZ, af::storage _storage)
-    : base(_dims, _nNZ, _storage, (af_dtype)dtype_traits<T>::af_type)
+    : base(_dims, _nNZ, _storage,
+           static_cast<af_dtype>(dtype_traits<T>::af_type))
     , values(createValueArray<T>(dim4(_nNZ), scalar<T>(0))) {
     static_assert(std::is_standard_layout<SparseArray<T>>::value,
                   "SparseArray<T> must be a standard layout type");
@@ -178,7 +179,8 @@ SparseArray<T>::SparseArray(const af::dim4 &_dims, dim_t _nNZ, T *const _values,
                             const af::storage _storage, bool _is_device,
                             bool _copy_device)
     : base(_dims, _nNZ, _rowIdx, _colIdx, _storage,
-           (af_dtype)dtype_traits<T>::af_type, _is_device, _copy_device)
+           static_cast<af_dtype>(dtype_traits<T>::af_type), _is_device,
+           _copy_device)
     , values(_is_device ? (!_copy_device
                                ? createDeviceDataArray<T>(dim4(_nNZ), _values)
                                : createValueArray<T>(dim4(_nNZ), scalar<T>(0)))
@@ -194,7 +196,7 @@ SparseArray<T>::SparseArray(const af::dim4 &_dims, const Array<T> &_values,
                             const Array<int> &_colIdx,
                             const af::storage _storage, bool _copy)
     : base(_dims, _rowIdx, _colIdx, _storage,
-           (af_dtype)dtype_traits<T>::af_type, _copy)
+           static_cast<af_dtype>(dtype_traits<T>::af_type), _copy)
     , values(_copy ? copyArray<T>(_values) : _values) {}
 
 template<typename T>

--- a/src/backend/common/SparseArray.hpp
+++ b/src/backend/common/SparseArray.hpp
@@ -48,7 +48,7 @@ class SparseArrayBase {
                     af_dtype _type, bool _is_device = false,
                     bool _copy_device = false);
 
-    SparseArrayBase(af::dim4 _dims, const Array<int> &_rowIdx,
+    SparseArrayBase(const af::dim4 &_dims, const Array<int> &_rowIdx,
                     const Array<int> &_colIdx, const af::storage _storage,
                     af_dtype _type, bool _copy = false);
 
@@ -59,7 +59,7 @@ class SparseArrayBase {
     ///
     /// \param[in] in         The array that will be copied
     /// \param[in] deep_copy  If true a deep copy is performed
-    SparseArrayBase(const SparseArrayBase &in, bool deep_copy = false);
+    SparseArrayBase(const SparseArrayBase &base, bool deep_copy = false);
 
     ~SparseArrayBase();
 
@@ -130,14 +130,14 @@ class SparseArray {
         base;         ///< This must be the first element of SparseArray<T>.
     Array<T> values;  ///< Linear array containing actual values
 
-    SparseArray(af::dim4 _dims, dim_t _nNZ, af::storage stype);
+    SparseArray(const af::dim4 &_dims, dim_t _nNZ, af::storage _storage);
 
-    explicit SparseArray(af::dim4 _dims, dim_t _nNZ, T *const _values,
+    explicit SparseArray(const af::dim4 &_dims, dim_t _nNZ, T *const _values,
                          int *const _rowIdx, int *const _colIdx,
                          const af::storage _storage, bool _is_device = false,
                          bool _copy_device = false);
 
-    SparseArray(af::dim4 _dims, const Array<T> &_values,
+    SparseArray(const af::dim4 &_dims, const Array<T> &_values,
                 const Array<int> &_rowIdx, const Array<int> &_colIdx,
                 const af::storage _storage, bool _copy = false);
 
@@ -146,12 +146,12 @@ class SparseArray {
     /// This constructor copies the \p in SparseArray and creates a new object
     /// from it. It can also perform a deep copy if the second argument is true.
     ///
-    /// \param[in] in         The array that will be copied
+    /// \param[in] other      The array that will be copied
     /// \param[in] deep_copy  If true a deep copy is performed
-    SparseArray(const SparseArray<T> &in, bool deep_copy);
+    SparseArray(const SparseArray<T> &other, bool deep_copy);
 
    public:
-    ~SparseArray();
+    ~SparseArray() noexcept = default;
 
 // Functions that call ArrayInfo object's functions
 #define INSTANTIATE_INFO(return_type, func) \

--- a/src/backend/common/dim4.cpp
+++ b/src/backend/common/dim4.cpp
@@ -23,7 +23,6 @@ static_assert(std::is_standard_layout<dim4>::value,
 
 using std::abs;
 using std::numeric_limits;
-using std::vector;
 
 dim4::dim4() : dims{0, 0, 0, 0} {}
 
@@ -33,7 +32,7 @@ dim4::dim4(dim_t first, dim_t second, dim_t third, dim_t fourth)
 dim4::dim4(const dim4& other)
     : dims{other.dims[0], other.dims[1], other.dims[2], other.dims[3]} {}
 
-dim4::dim4(const unsigned ndims_, const dim_t* const dims_) {
+dim4::dim4(const unsigned ndims_, const dim_t* const dims_) : dims{} {
     for (unsigned i = 0; i < 4; i++) { dims[i] = ndims_ > i ? dims_[i] : 1; }
 }
 
@@ -43,12 +42,12 @@ dim_t dim4::elements() { return static_cast<const dim4&>(*this).elements(); }
 
 dim_t dim4::ndims() const {
     dim_t num = elements();
-    if (num == 0) return 0;
-    if (num == 1) return 1;
+    if (num == 0) { return 0; }
+    if (num == 1) { return 1; }
 
-    if (dims[3] != 1) return 4;
-    if (dims[2] != 1) return 3;
-    if (dims[1] != 1) return 2;
+    if (dims[3] != 1) { return 4; }
+    if (dims[2] != 1) { return 3; }
+    if (dims[1] != 1) { return 2; }
 
     return 1;
 }
@@ -127,8 +126,8 @@ dim_t calcDim(const af_seq& seq, const dim_t& parentDim) {
         outDim = parentDim;
     } else if (hasEnd(seq)) {
         af_seq temp = {seq.begin, seq.end, seq.step};
-        if (seq.begin < 0) temp.begin += parentDim;
-        if (seq.end < 0) temp.end += parentDim;
+        if (seq.begin < 0) { temp.begin += parentDim; }
+        if (seq.end < 0) { temp.end += parentDim; }
         outDim = seqElements(temp);
     } else {
         DIM_ASSERT(1, seq.begin >= -DBL_MIN && seq.begin < parentDim);

--- a/src/backend/common/dispatch.cpp
+++ b/src/backend/common/dispatch.cpp
@@ -10,11 +10,11 @@
 #include "dispatch.hpp"
 
 unsigned nextpow2(unsigned x) {
-    x = x - 1;
-    x = x | (x >> 1);
-    x = x | (x >> 2);
-    x = x | (x >> 4);
-    x = x | (x >> 8);
-    x = x | (x >> 16);
-    return x + 1;
+    x = x - 1U;
+    x = x | (x >> 1U);
+    x = x | (x >> 2U);
+    x = x | (x >> 4U);
+    x = x | (x >> 8U);
+    x = x | (x >> 16U);
+    return x + 1U;
 }

--- a/src/backend/common/err_common.cpp
+++ b/src/backend/common/err_common.cpp
@@ -49,15 +49,15 @@ AfError::AfError(string func, string file, const int line, string message,
     , error(err)
     , st_(move(st)) {}
 
-const string &AfError::getFunctionName() const { return functionName; }
+const string &AfError::getFunctionName() const noexcept { return functionName; }
 
-const string &AfError::getFileName() const { return fileName; }
+const string &AfError::getFileName() const noexcept { return fileName; }
 
-int AfError::getLine() const { return lineNumber; }
+int AfError::getLine() const noexcept { return lineNumber; }
 
-af_err AfError::getError() const { return error; }
+af_err AfError::getError() const noexcept { return error; }
 
-AfError::~AfError() throw() {}
+AfError::~AfError() noexcept {}
 
 TypeError::TypeError(const char *const func, const char *const file,
                      const int line, const int index, const af_dtype type,
@@ -66,9 +66,9 @@ TypeError::TypeError(const char *const func, const char *const file,
     , argIndex(index)
     , errTypeName(getName(type)) {}
 
-const string &TypeError::getTypeName() const { return errTypeName; }
+const string &TypeError::getTypeName() const noexcept { return errTypeName; }
 
-int TypeError::getArgIndex() const { return argIndex; }
+int TypeError::getArgIndex() const noexcept { return argIndex; }
 
 ArgumentError::ArgumentError(const char *const func, const char *const file,
                              const int line, const int index,
@@ -78,9 +78,11 @@ ArgumentError::ArgumentError(const char *const func, const char *const file,
     , argIndex(index)
     , expected(expectString) {}
 
-const string &ArgumentError::getExpectedCondition() const { return expected; }
+const string &ArgumentError::getExpectedCondition() const noexcept {
+    return expected;
+}
 
-int ArgumentError::getArgIndex() const { return argIndex; }
+int ArgumentError::getArgIndex() const noexcept { return argIndex; }
 
 SupportError::SupportError(const char *const func, const char *const file,
                            const int line, const char *const back,
@@ -89,7 +91,7 @@ SupportError::SupportError(const char *const func, const char *const file,
               move(st))
     , backend(back) {}
 
-const string &SupportError::getBackendName() const { return backend; }
+const string &SupportError::getBackendName() const noexcept { return backend; }
 
 DimensionError::DimensionError(const char *const func, const char *const file,
                                const int line, const int index,
@@ -99,9 +101,11 @@ DimensionError::DimensionError(const char *const func, const char *const file,
     , argIndex(index)
     , expected(expectString) {}
 
-const string &DimensionError::getExpectedCondition() const { return expected; }
+const string &DimensionError::getExpectedCondition() const noexcept {
+    return expected;
+}
 
-int DimensionError::getArgIndex() const { return argIndex; }
+int DimensionError::getArgIndex() const noexcept { return argIndex; }
 
 af_err set_global_error_string(const string &msg, af_err err) {
     std::string perr = getEnvVar("AF_PRINT_ERRORS");
@@ -172,7 +176,7 @@ af_err processException() {
     return err;
 }
 
-std::string &get_global_error_string() {
+std::string &get_global_error_string() noexcept {
     thread_local std::string *global_error_string = new std::string("");
     return *global_error_string;
 }
@@ -217,7 +221,7 @@ const char *af_err_to_string(const af_err err) {
 
 namespace common {
 
-bool &is_stacktrace_enabled() {
+bool &is_stacktrace_enabled() noexcept {
     static bool stacktrace_enabled = true;
     return stacktrace_enabled;
 }

--- a/src/backend/common/err_common.hpp
+++ b/src/backend/common/err_common.hpp
@@ -38,17 +38,22 @@ class AfError : public std::logic_error {
     AfError(std::string func, std::string file, const int line,
             std::string message, af_err err, boost::stacktrace::stacktrace st);
 
-    const std::string& getFunctionName() const;
+    AfError(const AfError& other) noexcept = delete;
+    AfError(AfError&& other) noexcept = default;
 
-    const std::string& getFileName() const;
+    const std::string& getFunctionName() const noexcept;
 
-    const boost::stacktrace::stacktrace& getStacktrace() const { return st_; };
+    const std::string& getFileName() const noexcept;
 
-    int getLine() const;
+    const boost::stacktrace::stacktrace& getStacktrace() const noexcept {
+        return st_;
+    };
 
-    af_err getError() const;
+    int getLine() const noexcept;
 
-    virtual ~AfError() throw();
+    af_err getError() const noexcept;
+
+    virtual ~AfError() noexcept;
 };
 
 // TODO: Perhaps add a way to return supported types
@@ -62,11 +67,13 @@ class TypeError : public AfError {
               const int index, const af_dtype type,
               const boost::stacktrace::stacktrace st);
 
-    const std::string& getTypeName() const;
+    TypeError(TypeError&& other) noexcept = default;
 
-    int getArgIndex() const;
+    const std::string& getTypeName() const noexcept;
 
-    ~TypeError() throw() {}
+    int getArgIndex() const noexcept;
+
+    ~TypeError() noexcept {}
 };
 
 class ArgumentError : public AfError {
@@ -79,12 +86,13 @@ class ArgumentError : public AfError {
                   const int line, const int index,
                   const char* const expectString,
                   const boost::stacktrace::stacktrace st);
+    ArgumentError(ArgumentError&& other) noexcept = default;
 
-    const std::string& getExpectedCondition() const;
+    const std::string& getExpectedCondition() const noexcept;
 
-    int getArgIndex() const;
+    int getArgIndex() const noexcept;
 
-    ~ArgumentError() throw() {}
+    ~ArgumentError() noexcept {}
 };
 
 class SupportError : public AfError {
@@ -95,10 +103,11 @@ class SupportError : public AfError {
     SupportError(const char* const func, const char* const file, const int line,
                  const char* const back,
                  const boost::stacktrace::stacktrace st);
+    SupportError(SupportError&& other) noexcept = default;
 
-    ~SupportError() throw() {}
+    ~SupportError() noexcept {}
 
-    const std::string& getBackendName() const;
+    const std::string& getBackendName() const noexcept;
 };
 
 class DimensionError : public AfError {
@@ -111,12 +120,13 @@ class DimensionError : public AfError {
                    const int line, const int index,
                    const char* const expectString,
                    const boost::stacktrace::stacktrace st);
+    DimensionError(DimensionError&& other) noexcept = default;
 
-    const std::string& getExpectedCondition() const;
+    const std::string& getExpectedCondition() const noexcept;
 
-    int getArgIndex() const;
+    int getArgIndex() const noexcept;
 
-    ~DimensionError() throw() {}
+    ~DimensionError() noexcept {}
 };
 
 af_err processException();
@@ -187,10 +197,10 @@ af_err set_global_error_string(const std::string& msg,
     } while (0)
 
 static const int MAX_ERR_SIZE = 1024;
-std::string& get_global_error_string();
+std::string& get_global_error_string() noexcept;
 
 namespace common {
 
-bool& is_stacktrace_enabled();
+bool& is_stacktrace_enabled() noexcept;
 
 }  // namespace common

--- a/src/backend/common/err_common.hpp
+++ b/src/backend/common/err_common.hpp
@@ -36,10 +36,11 @@ class AfError : public std::logic_error {
             boost::stacktrace::stacktrace st);
 
     AfError(std::string func, std::string file, const int line,
-            std::string message, af_err err, boost::stacktrace::stacktrace st);
+            const std::string& message, af_err err,
+            boost::stacktrace::stacktrace st);
 
     AfError(const AfError& other) noexcept = delete;
-    AfError(AfError&& other) noexcept = default;
+    AfError(AfError&& other) noexcept      = default;
 
     const std::string& getFunctionName() const noexcept;
 
@@ -119,7 +120,7 @@ class DimensionError : public AfError {
     DimensionError(const char* const func, const char* const file,
                    const int line, const int index,
                    const char* const expectString,
-                   const boost::stacktrace::stacktrace st);
+                   const boost::stacktrace::stacktrace& st);
     DimensionError(DimensionError&& other) noexcept = default;
 
     const std::string& getExpectedCondition() const noexcept;

--- a/src/backend/common/graphics_common.hpp
+++ b/src/backend/common/graphics_common.hpp
@@ -252,7 +252,8 @@ class ForgeManager {
     constexpr static unsigned long long _32BIT = 0x00000000FFFFFFFF;
     constexpr static unsigned long long _48BIT = 0x0000FFFFFFFFFFFF;
 
-    static unsigned long long genImageKey(unsigned w, unsigned h, fg_channel_format mode,
+    static unsigned long long genImageKey(unsigned w, unsigned h,
+                                          fg_channel_format mode,
                                           fg_dtype type);
 
 #define DEFINE_WRAPPER_OBJECT(OBJECT, RELEASE)                           \

--- a/src/backend/common/graphics_common.hpp
+++ b/src/backend/common/graphics_common.hpp
@@ -244,15 +244,16 @@ class ForgeManager {
     void setChartAxesOverride(const fg_chart chart, bool flag = true);
 
    private:
-    constexpr static unsigned int WIDTH  = 1280;
-    constexpr static unsigned int HEIGHT = 720;
-    constexpr static long long _4BIT     = 0x000000000000000F;
-    constexpr static long long _8BIT     = 0x00000000000000FF;
-    constexpr static long long _16BIT    = 0x000000000000FFFF;
-    constexpr static long long _32BIT    = 0x00000000FFFFFFFF;
-    constexpr static long long _48BIT    = 0x0000FFFFFFFFFFFF;
+    constexpr static unsigned int WIDTH        = 1280;
+    constexpr static unsigned int HEIGHT       = 720;
+    constexpr static unsigned long long _4BIT  = 0x000000000000000F;
+    constexpr static unsigned long long _8BIT  = 0x00000000000000FF;
+    constexpr static unsigned long long _16BIT = 0x000000000000FFFF;
+    constexpr static unsigned long long _32BIT = 0x00000000FFFFFFFF;
+    constexpr static unsigned long long _48BIT = 0x0000FFFFFFFFFFFF;
 
-    long long genImageKey(int w, int h, fg_channel_format mode, fg_dtype type);
+    static unsigned long long genImageKey(unsigned w, unsigned h, fg_channel_format mode,
+                                          fg_dtype type);
 
 #define DEFINE_WRAPPER_OBJECT(OBJECT, RELEASE)                           \
     struct OBJECT {                                                      \
@@ -281,7 +282,7 @@ class ForgeManager {
     using HistogramPtr   = std::unique_ptr<Histogram, Histogram::Deleter>;
     using VectorFieldPtr = std::unique_ptr<VectorField, VectorField::Deleter>;
     using ChartList      = std::vector<ChartPtr>;
-    using ChartKey       = std::pair<long long, fg_chart>;
+    using ChartKey       = std::pair<unsigned long long, fg_chart>;
 
     using ChartMapIterator     = std::map<fg_window, ChartList>::iterator;
     using WindGridMapIterator  = std::map<fg_window, WindowGridDims>::iterator;

--- a/src/backend/common/half.hpp
+++ b/src/backend/common/half.hpp
@@ -991,6 +991,10 @@ CONSTEXPR_DH static inline bool operator<(common::half lhs,
 #ifndef __CUDA_ARCH__
 std::ostream& operator<<(std::ostream& os, const half& val);
 
+static inline std::string to_string(const half& val) {
+    return std::to_string(static_cast<float>(val));
+}
+
 static inline std::string to_string(const half&& val) {
     return std::to_string(static_cast<float>(val));
 }

--- a/src/backend/common/host_memory.cpp
+++ b/src/backend/common/host_memory.cpp
@@ -80,7 +80,8 @@ size_t getHostMemorySize() {
 
 #elif defined(_SC_PHYS_PAGES) && defined(_SC_PAGESIZE)
     /* FreeBSD, Linux, OpenBSD, and Solaris. -------------------- */
-    return (size_t)sysconf(_SC_PHYS_PAGES) * (size_t)sysconf(_SC_PAGESIZE);
+    return static_cast<size_t>(sysconf(_SC_PHYS_PAGES)) *
+           static_cast<size_t>(sysconf(_SC_PAGESIZE));
 
 #elif defined(_SC_PHYS_PAGES) && defined(_SC_PAGE_SIZE)
     /* Legacy. -------------------------------------------------- */

--- a/src/backend/common/jit/Node.cpp
+++ b/src/backend/common/jit/Node.cpp
@@ -12,7 +12,8 @@
 
 #include <string>
 #include <vector>
-using namespace std;
+
+using std::vector;
 
 namespace common {
 
@@ -20,7 +21,7 @@ int Node::getNodesMap(Node_map_t &node_map, vector<const Node *> &full_nodes,
                       vector<Node_ids> &full_ids) const {
     auto iter = node_map.find(this);
     if (iter == node_map.end()) {
-        Node_ids ids;
+        Node_ids ids{};
 
         for (int i = 0; i < kMaxChildren && m_children[i] != nullptr; i++) {
             ids.child_ids[i] =

--- a/src/backend/common/module_loading_unix.cpp
+++ b/src/backend/common/module_loading_unix.cpp
@@ -28,13 +28,10 @@ void unloadLibrary(LibHandle handle) { dlclose(handle); }
 
 string getErrorMessage() {
     char* errMsg = dlerror();
-    if (errMsg) {
-        return string(errMsg);
-    } else {
-        // constructing std::basic_string from NULL/0 address is
-        // invalid and has undefined behavior
-        return string("No Error");
-    }
+    if (errMsg) { return string(errMsg); }
+    // constructing std::basic_string from NULL/0 address is
+    // invalid and has undefined behavior
+    return string("No Error");
 }
 
 }  // namespace common

--- a/src/backend/common/sparse_helpers.hpp
+++ b/src/backend/common/sparse_helpers.hpp
@@ -56,9 +56,9 @@ void destroySparseArray(SparseArray<T> *sparse);
 
 /// Performs a deep copy of the \p input array.
 ///
-/// \param[in] input    The sparse array that is to be copied
+/// \param[in] other    The sparse array that is to be copied
 /// \returns A deep copy of the input sparse array
 template<typename T>
-SparseArray<T> copySparseArray(const SparseArray<T> &input);
+SparseArray<T> copySparseArray(const SparseArray<T> &other);
 
 }  // namespace common

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -62,7 +62,7 @@ const char* getName(af_dtype type) {
 void saveKernel(const std::string& funcName, const std::string& jit_ker,
                 const std::string& ext) {
     static const char* jitKernelsOutput = getenv(saveJitKernelsEnvVarName);
-    if (!jitKernelsOutput) return;
+    if (!jitKernelsOutput) { return; }
     if (std::strcmp(jitKernelsOutput, "stdout") == 0) {
         fputs(jit_ker.c_str(), stdout);
         return;
@@ -74,12 +74,13 @@ void saveKernel(const std::string& funcName, const std::string& jit_ker,
     // Path to a folder
     const std::string ffp =
         std::string(jitKernelsOutput) + AF_PATH_SEPARATOR + funcName + ext;
-    FILE* f = fopen(ffp.c_str(), "w");
+    FILE* f = fopen(ffp.c_str(), "we");
     if (!f) {
         fprintf(stderr, "Cannot open file %s\n", ffp.c_str());
         return;
     }
-    if (fputs(jit_ker.c_str(), f) == EOF)
+    if (fputs(jit_ker.c_str(), f) == EOF) {
         fprintf(stderr, "Failed to write kernel to file %s\n", ffp.c_str());
+    }
     fclose(f);
 }

--- a/src/backend/cpu/Array.hpp
+++ b/src/backend/cpu/Array.hpp
@@ -43,7 +43,7 @@ using af::dim4;
 using std::shared_ptr;
 
 template<typename T>
-void evalMultiple(std::vector<Array<T> *> arrays);
+void evalMultiple(std::vector<Array<T> *> array_ptrs);
 
 // Creates a new Array object on the heap and returns a reference to it.
 template<typename T>

--- a/src/backend/cpu/Event.cpp
+++ b/src/backend/cpu/Event.cpp
@@ -14,8 +14,9 @@
 #include <platform.hpp>
 #include <queue.hpp>
 #include <af/event.h>
-
 #include <memory>
+
+using std::make_unique;
 
 namespace cpu {
 /// \brief Creates a new event and marks it in the queue
@@ -26,8 +27,7 @@ Event makeEvent(cpu::queue& queue) {
 }
 
 af_event createEvent() {
-    std::unique_ptr<Event> e;
-    e.reset(new Event());
+    auto e = make_unique<Event>();
     // Ensure that the default queue is initialized
     getQueue();
     if (e->create() != 0) {

--- a/src/backend/cpu/anisotropic_diffusion.cpp
+++ b/src/backend/cpu/anisotropic_diffusion.cpp
@@ -16,12 +16,13 @@ template<typename T>
 void anisotropicDiffusion(Array<T>& inout, const float dt, const float mct,
                           const af::fluxFunction fftype,
                           const af::diffusionEq eq) {
-    if (eq == AF_DIFFUSION_MCDE)
+    if (eq == AF_DIFFUSION_MCDE) {
         getQueue().enqueue(kernel::anisotropicDiffusion<T, true>, inout, dt,
                            mct, fftype);
-    else
+    } else {
         getQueue().enqueue(kernel::anisotropicDiffusion<T, false>, inout, dt,
                            mct, fftype);
+    }
 }
 
 #define INSTANTIATE(T)                                     \

--- a/src/backend/cpu/assign.cpp
+++ b/src/backend/cpu/assign.cpp
@@ -26,7 +26,6 @@
 #include <vector>
 
 using af::dim4;
-using common::half;
 using std::vector;
 
 namespace cpu {
@@ -70,6 +69,6 @@ INSTANTIATE(uchar)
 INSTANTIATE(char)
 INSTANTIATE(ushort)
 INSTANTIATE(short)
-INSTANTIATE(half)
+INSTANTIATE(common::half)
 
 }  // namespace cpu

--- a/src/backend/cpu/bilateral.cpp
+++ b/src/backend/cpu/bilateral.cpp
@@ -22,7 +22,7 @@ namespace cpu {
 template<typename inType, typename outType, bool isColor>
 Array<outType> bilateral(const Array<inType> &in, const float &s_sigma,
                          const float &c_sigma) {
-    const dim4 dims    = in.dims();
+    const dim4 &dims   = in.dims();
     Array<outType> out = createEmptyArray<outType>(dims);
     getQueue().enqueue(kernel::bilateral<outType, inType, isColor>, out, in,
                        s_sigma, c_sigma);

--- a/src/backend/cpu/cholesky.cpp
+++ b/src/backend/cpu/cholesky.cpp
@@ -50,10 +50,11 @@ Array<T> cholesky(int *info, const Array<T> &in, const bool is_upper) {
     Array<T> out = copyArray<T>(in);
     *info        = cholesky_inplace(out, is_upper);
 
-    if (is_upper)
+    if (is_upper) {
         triangle<T, true, false>(out, out);
-    else
+    } else {
         triangle<T, false, false>(out, out);
+    }
 
     return out;
 }
@@ -64,7 +65,7 @@ int cholesky_inplace(Array<T> &in, const bool is_upper) {
     int N      = iDims[0];
 
     char uplo = 'L';
-    if (is_upper) uplo = 'U';
+    if (is_upper) { uplo = 'U'; }
 
     int info  = 0;
     auto func = [&](int *info, Param<T> in) {

--- a/src/backend/cpu/convolve.cpp
+++ b/src/backend/cpu/convolve.cpp
@@ -29,7 +29,6 @@
 using af::dim4;
 using common::flip;
 using common::half;
-using std::vector;
 
 namespace cpu {
 
@@ -51,7 +50,7 @@ Array<T> convolve(Array<T> const &signal, Array<accT> const &filter,
     } else {
         oDims = sDims;
         if (kind == AF_BATCH_RHS) {
-            for (dim_t i = baseDim; i < 4; ++i) oDims[i] = fDims[i];
+            for (dim_t i = baseDim; i < 4; ++i) { oDims[i] = fDims[i]; }
         }
     }
 
@@ -66,7 +65,7 @@ Array<T> convolve(Array<T> const &signal, Array<accT> const &filter,
 template<typename T, typename accT, bool expand>
 Array<T> convolve2(Array<T> const &signal, Array<accT> const &c_filter,
                    Array<accT> const &r_filter) {
-    auto sDims = signal.dims();
+    const auto &sDims = signal.dims();
     dim4 tDims = sDims;
     dim4 oDims = sDims;
 
@@ -74,8 +73,8 @@ Array<T> convolve2(Array<T> const &signal, Array<accT> const &c_filter,
         auto cfDims = c_filter.dims();
         auto rfDims = r_filter.dims();
 
-        dim_t cflen = (dim_t)cfDims.elements();
-        dim_t rflen = (dim_t)rfDims.elements();
+        auto cflen = cfDims.elements();
+        auto rflen = rfDims.elements();
         // separable convolve only does AF_BATCH_NONE and standard
         // batch(AF_BATCH_LHS)
         tDims[0] += cflen - 1;
@@ -134,8 +133,8 @@ INSTANTIATE(intl, float)
 
 template<typename T>
 Array<T> convolve2_unwrap(const Array<T> &signal, const Array<T> &filter,
-                          const dim4 stride, const dim4 padding,
-                          const dim4 dilation) {
+                          const dim4 &stride, const dim4 &padding,
+                          const dim4 &dilation) {
     dim4 sDims = signal.dims();
     dim4 fDims = filter.dims();
 
@@ -190,11 +189,12 @@ template<typename T>
 Array<T> conv2DataGradient(const Array<T> &incoming_gradient,
                            const Array<T> &original_signal,
                            const Array<T> &original_filter,
-                           const Array<T> &convolved_output, af::dim4 stride,
-                           af::dim4 padding, af::dim4 dilation) {
-    const dim4 cDims = incoming_gradient.dims();
-    const dim4 sDims = original_signal.dims();
-    const dim4 fDims = original_filter.dims();
+                           const Array<T> & /*convolved_output*/,
+                           af::dim4 stride, af::dim4 padding,
+                           af::dim4 dilation) {
+    const dim4 &cDims = incoming_gradient.dims();
+    const dim4 &sDims = original_signal.dims();
+    const dim4 &fDims = original_filter.dims();
 
     Array<T> collapsed_filter = flip(original_filter, {1, 1, 0, 0});
     collapsed_filter.modDims(dim4(fDims[0] * fDims[1] * fDims[2], fDims[3]));
@@ -221,10 +221,11 @@ template<typename T>
 Array<T> conv2FilterGradient(const Array<T> &incoming_gradient,
                              const Array<T> &original_signal,
                              const Array<T> &original_filter,
-                             const Array<T> &convolved_output, af::dim4 stride,
-                             af::dim4 padding, af::dim4 dilation) {
-    const dim4 cDims = incoming_gradient.dims();
-    const dim4 fDims = original_filter.dims();
+                             const Array<T> & /*convolved_output*/,
+                             af::dim4 stride, af::dim4 padding,
+                             af::dim4 dilation) {
+    const dim4 &cDims = incoming_gradient.dims();
+    const dim4 &fDims = original_filter.dims();
 
     const bool retCols = false;
     Array<T> unwrapped =

--- a/src/backend/cpu/convolve.cpp
+++ b/src/backend/cpu/convolve.cpp
@@ -66,8 +66,8 @@ template<typename T, typename accT, bool expand>
 Array<T> convolve2(Array<T> const &signal, Array<accT> const &c_filter,
                    Array<accT> const &r_filter) {
     const auto &sDims = signal.dims();
-    dim4 tDims = sDims;
-    dim4 oDims = sDims;
+    dim4 tDims        = sDims;
+    dim4 oDims        = sDims;
 
     if (expand) {
         auto cfDims = c_filter.dims();

--- a/src/backend/cpu/copy.cpp
+++ b/src/backend/cpu/copy.cpp
@@ -23,7 +23,7 @@
 #include <cstdio>
 #include <cstring>
 
-using common::half;
+using common::half;  // NOLINT(misc-unused-using-decls) bug in clang-tidy
 using common::is_complex;
 
 namespace cpu {

--- a/src/backend/cpu/copy.hpp
+++ b/src/backend/cpu/copy.hpp
@@ -20,7 +20,7 @@ class dim4;
 namespace cpu {
 
 template<typename T>
-void copyData(T *data, const Array<T> &A);
+void copyData(T *to, const Array<T> &from);
 
 template<typename T>
 Array<T> copyArray(const Array<T> &A);

--- a/src/backend/cpu/device_manager.hpp
+++ b/src/backend/cpu/device_manager.hpp
@@ -80,9 +80,9 @@ class CPUInfo {
     // Attributes
     std::string mVendorId;
     std::string mModelName;
-    int mNumSMT;
-    int mNumCores;
-    int mNumLogCpus;
+    unsigned mNumSMT;
+    unsigned mNumCores;
+    unsigned mNumLogCpus;
     bool mIsHTT;
 };
 

--- a/src/backend/cpu/diagonal.cpp
+++ b/src/backend/cpu/diagonal.cpp
@@ -19,13 +19,15 @@
 #include <algorithm>
 #include <cstdlib>
 
-using common::half;
+using common::half;  // NOLINT(misc-unused-using-decls) bug in clang-tidy
+using std::abs;      // NOLINT(misc-unused-using-decls) bug in clang-tidy
+using std::min;      // NOLINT(misc-unused-using-decls) bug in clang-tidy
 
 namespace cpu {
 
 template<typename T>
 Array<T> diagCreate(const Array<T> &in, const int num) {
-    int size     = in.dims()[0] + std::abs(num);
+    int size     = in.dims()[0] + abs(num);
     int batch    = in.dims()[1];
     Array<T> out = createEmptyArray<T>(dim4(size, size, batch));
 
@@ -36,9 +38,9 @@ Array<T> diagCreate(const Array<T> &in, const int num) {
 
 template<typename T>
 Array<T> diagExtract(const Array<T> &in, const int num) {
-    const dim4 idims = in.dims();
-    dim_t size       = std::min(idims[0], idims[1]) - std::abs(num);
-    Array<T> out     = createEmptyArray<T>(dim4(size, 1, idims[2], idims[3]));
+    const dim4 &idims = in.dims();
+    dim_t size        = min(idims[0], idims[1]) - abs(num);
+    Array<T> out      = createEmptyArray<T>(dim4(size, 1, idims[2], idims[3]));
 
     getQueue().enqueue(kernel::diagExtract<T>, out, in, num);
 

--- a/src/backend/cpu/fast.cpp
+++ b/src/backend/cpu/fast.cpp
@@ -11,15 +11,17 @@
 #include <kernel/fast.hpp>
 
 #include <Array.hpp>
-#include <math.h>
 #include <platform.hpp>
 #include <queue.hpp>
 #include <af/dim4.hpp>
+#include <cmath>
 
 #include <algorithm>
+#include <cmath>
 #include <cstddef>
 
 using af::dim4;
+using std::ceil;
 
 namespace cpu {
 
@@ -38,7 +40,7 @@ unsigned fast(Array<float> &x_out, Array<float> &y_out, Array<float> &score_out,
     Array<float> V = createEmptyArray<float>(dim4());
     if (nonmax == 1) {
         dim4 V_dims(in_dims[0], in_dims[1]);
-        V = createValueArray<float>(V_dims, (float)0);
+        V = createValueArray<float>(V_dims, 0.f);
         V.eval();
     }
     getQueue().sync();

--- a/src/backend/cpu/fast.hpp
+++ b/src/backend/cpu/fast.hpp
@@ -14,7 +14,7 @@ class Array;
 template<typename T>
 unsigned fast(Array<float> &x_out, Array<float> &y_out, Array<float> &score_out,
               const Array<T> &in, const float thr, const unsigned arc_length,
-              const bool non_max, const float feature_ratio,
+              const bool nonmax, const float feature_ratio,
               const unsigned edge);
 
 }  // namespace cpu

--- a/src/backend/cpu/fftconvolve.cpp
+++ b/src/backend/cpu/fftconvolve.cpp
@@ -18,31 +18,34 @@
 #include <queue.hpp>
 #include <af/dim4.hpp>
 
+using af::dim4;
+using std::ceil;
+
 namespace cpu {
 
 template<typename T, typename convT, typename cT, bool isDouble, bool roundOut,
          dim_t baseDim>
 Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
                      const bool expand, AF_BATCH_KIND kind) {
-    const af::dim4 sd = signal.dims();
-    const af::dim4 fd = filter.dims();
+    const dim4& sd = signal.dims();
+    const dim4& fd = filter.dims();
 
     dim_t fftScale = 1;
 
-    af::dim4 packed_dims(1, 1, 1, 1);
+    dim4 packed_dims(1, 1, 1, 1);
     int fft_dims[baseDim];
-    af::dim4 sig_tmp_dims, sig_tmp_strides;
-    af::dim4 filter_tmp_dims, filter_tmp_strides;
+    dim4 sig_tmp_dims, sig_tmp_strides;
+    dim4 filter_tmp_dims, filter_tmp_strides;
 
     // Pack both signal and filter on same memory array, this will ensure
     // better use of batched FFT capabilities
-    fft_dims[baseDim - 1] =
-        nextpow2((unsigned)((int)ceil(sd[0] / 2.f) + fd[0] - 1));
+    fft_dims[baseDim - 1] = nextpow2(
+        static_cast<unsigned>(static_cast<int>(ceil(sd[0] / 2.f)) + fd[0] - 1));
     packed_dims[0] = 2 * fft_dims[baseDim - 1];
     fftScale *= fft_dims[baseDim - 1];
 
     for (dim_t k = 1; k < baseDim; k++) {
-        packed_dims[k]            = nextpow2((unsigned)(sd[k] + fd[k] - 1));
+        packed_dims[k] = nextpow2(static_cast<unsigned>(sd[k] + fd[k] - 1));
         fft_dims[baseDim - k - 1] = packed_dims[k];
         fftScale *= fft_dims[baseDim - k - 1];
     }
@@ -87,31 +90,34 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
                        filter_tmp_strides, filter, offset);
 
     dim4 fftDims(1, 1, 1, 1);
-    for (int i = 0; i < baseDim; ++i) fftDims[i] = fft_dims[i];
+    for (int i = 0; i < baseDim; ++i) { fftDims[i] = fft_dims[i]; }
 
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     auto upstream_dft = [=](Param<convT> packed, const dim4 fftDims) {
         int fft_dims[baseDim];
-        for (int i = 0; i < baseDim; ++i) fft_dims[i] = fftDims[i];
+        for (int i = 0; i < baseDim; ++i) { fft_dims[i] = fftDims[i]; }
         const dim4 packed_dims        = packed.dims();
-        const af::dim4 packed_strides = packed.strides();
+        const dim4 packed_strides = packed.strides();
         // Compute forward FFT
         if (isDouble) {
             fftw_plan plan = fftw_plan_many_dft(
                 baseDim, fft_dims, packed_dims[baseDim],
-                (fftw_complex*)packed.get(), NULL, packed_strides[0],
-                packed_strides[baseDim] / 2, (fftw_complex*)packed.get(), NULL,
+                reinterpret_cast<fftw_complex*>(packed.get()), nullptr,
+                packed_strides[0], packed_strides[baseDim] / 2,
+                reinterpret_cast<fftw_complex*>(packed.get()), nullptr,
                 packed_strides[0], packed_strides[baseDim] / 2, FFTW_FORWARD,
-                FFTW_ESTIMATE);
+                FFTW_ESTIMATE);  // NOLINT(hicpp-signed-bitwise)
 
             fftw_execute(plan);
             fftw_destroy_plan(plan);
         } else {
             fftwf_plan plan = fftwf_plan_many_dft(
                 baseDim, fft_dims, packed_dims[baseDim],
-                (fftwf_complex*)packed.get(), NULL, packed_strides[0],
-                packed_strides[baseDim] / 2, (fftwf_complex*)packed.get(), NULL,
+                reinterpret_cast<fftwf_complex*>(packed.get()), nullptr,
+                packed_strides[0], packed_strides[baseDim] / 2,
+                reinterpret_cast<fftwf_complex*>(packed.get()), nullptr,
                 packed_strides[0], packed_strides[baseDim] / 2, FFTW_FORWARD,
-                FFTW_ESTIMATE);
+                FFTW_ESTIMATE);  // NOLINT(hicpp-signed-bitwise)
 
             fftwf_execute(plan);
             fftwf_destroy_plan(plan);
@@ -124,29 +130,32 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
                        sig_tmp_strides, filter_tmp_dims, filter_tmp_strides,
                        kind, offset);
 
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
     auto upstream_idft = [=](Param<convT> packed, const dim4 fftDims) {
         int fft_dims[baseDim];
-        for (int i = 0; i < baseDim; ++i) fft_dims[i] = fftDims[i];
+        for (int i = 0; i < baseDim; ++i) { fft_dims[i] = fftDims[i]; }
         const dim4 packed_dims        = packed.dims();
-        const af::dim4 packed_strides = packed.strides();
+        const dim4 packed_strides = packed.strides();
         // Compute inverse FFT
         if (isDouble) {
             fftw_plan plan = fftw_plan_many_dft(
                 baseDim, fft_dims, packed_dims[baseDim],
-                (fftw_complex*)packed.get(), NULL, packed_strides[0],
-                packed_strides[baseDim] / 2, (fftw_complex*)packed.get(), NULL,
+                reinterpret_cast<fftw_complex*>(packed.get()), nullptr,
+                packed_strides[0], packed_strides[baseDim] / 2,
+                reinterpret_cast<fftw_complex*>(packed.get()), nullptr,
                 packed_strides[0], packed_strides[baseDim] / 2, FFTW_BACKWARD,
-                FFTW_ESTIMATE);
+                FFTW_ESTIMATE);  // NOLINT(hicpp-signed-bitwise)
 
             fftw_execute(plan);
             fftw_destroy_plan(plan);
         } else {
             fftwf_plan plan = fftwf_plan_many_dft(
                 baseDim, fft_dims, packed_dims[baseDim],
-                (fftwf_complex*)packed.get(), NULL, packed_strides[0],
-                packed_strides[baseDim] / 2, (fftwf_complex*)packed.get(), NULL,
+                reinterpret_cast<fftwf_complex*>(packed.get()), nullptr,
+                packed_strides[0], packed_strides[baseDim] / 2,
+                reinterpret_cast<fftwf_complex*>(packed.get()), nullptr,
                 packed_strides[0], packed_strides[baseDim] / 2, FFTW_BACKWARD,
-                FFTW_ESTIMATE);
+                FFTW_ESTIMATE);  // NOLINT(hicpp-signed-bitwise)
 
             fftwf_execute(plan);
             fftwf_destroy_plan(plan);
@@ -167,7 +176,7 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
     } else {
         oDims = sd;
         if (kind == AF_BATCH_RHS) {
-            for (dim_t i = baseDim; i < 4; ++i) oDims[i] = fd[i];
+            for (dim_t i = baseDim; i < 4; ++i) { oDims[i] = fd[i]; }
         }
     }
 

--- a/src/backend/cpu/fftconvolve.cpp
+++ b/src/backend/cpu/fftconvolve.cpp
@@ -96,7 +96,7 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
     auto upstream_dft = [=](Param<convT> packed, const dim4 fftDims) {
         int fft_dims[baseDim];
         for (int i = 0; i < baseDim; ++i) { fft_dims[i] = fftDims[i]; }
-        const dim4 packed_dims        = packed.dims();
+        const dim4 packed_dims    = packed.dims();
         const dim4 packed_strides = packed.strides();
         // Compute forward FFT
         if (isDouble) {
@@ -134,7 +134,7 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
     auto upstream_idft = [=](Param<convT> packed, const dim4 fftDims) {
         int fft_dims[baseDim];
         for (int i = 0; i < baseDim; ++i) { fft_dims[i] = fftDims[i]; }
-        const dim4 packed_dims        = packed.dims();
+        const dim4 packed_dims    = packed.dims();
         const dim4 packed_strides = packed.strides();
         // Compute inverse FFT
         if (isDouble) {

--- a/src/backend/cpu/flood_fill.cpp
+++ b/src/backend/cpu/flood_fill.cpp
@@ -13,7 +13,6 @@
 #include <kernel/flood_fill.hpp>
 
 using af::connectivity;
-using af::dim4;
 
 namespace cpu {
 

--- a/src/backend/cpu/harris.cpp
+++ b/src/backend/cpu/harris.cpp
@@ -35,10 +35,12 @@ unsigned harris(Array<float> &x_out, Array<float> &y_out,
     auto h_filter = memAlloc<convAccT>(filter_len);
     // Decide between rectangular or circular filter
     if (sigma < 0.5f) {
-        for (unsigned i = 0; i < filter_len; i++)
-            h_filter[i] = (T)1.f / (filter_len);
+        for (unsigned i = 0; i < filter_len; i++) {
+            h_filter[i] = static_cast<T>(1) / (filter_len);
+        }
     } else {
-        gaussian1D<convAccT>(h_filter.get(), (int)filter_len, sigma);
+        gaussian1D<convAccT>(h_filter.get(), static_cast<int>(filter_len),
+                             sigma);
     }
     Array<convAccT> filter =
         createDeviceDataArray<convAccT>(dim4(filter_len), h_filter.release());
@@ -74,7 +76,8 @@ unsigned harris(Array<float> &x_out, Array<float> &y_out,
     Array<float> yCorners    = createEmptyArray<float>(dim4(corner_lim));
     Array<float> respCorners = createEmptyArray<float>(dim4(corner_lim));
 
-    const unsigned min_r = (max_corners > 0) ? 0.f : min_response;
+    const unsigned min_r =
+        (max_corners > 0) ? 0U : static_cast<unsigned>(min_response);
 
     // Performs non-maximal suppression
     getQueue().sync();
@@ -85,7 +88,7 @@ unsigned harris(Array<float> &x_out, Array<float> &y_out,
 
     const unsigned corners_out =
         min(corners_found, (max_corners > 0) ? max_corners : corner_lim);
-    if (corners_out == 0) return 0;
+    if (corners_out == 0) { return 0; }
 
     if (max_corners > 0 && corners_found > corners_out) {
         respCorners.resetDims(dim4(corners_found));
@@ -111,8 +114,10 @@ unsigned harris(Array<float> &x_out, Array<float> &y_out,
         resp_out = createEmptyArray<float>(dim4(corners_out));
 
         auto copyFunc = [=](Param<float> x_out, Param<float> y_out,
-                            Param<float> outResponses, CParam<float> x_crnrs,
-                            CParam<float> y_crnrs, CParam<float> inResponses,
+                            Param<float> outResponses,
+                            const CParam<float> &x_crnrs,
+                            const CParam<float> &y_crnrs,
+                            const CParam<float> &inResponses,
                             const unsigned corners_out) {
             memcpy(x_out.get(), x_crnrs.get(), corners_out * sizeof(float));
             memcpy(y_out.get(), y_crnrs.get(), corners_out * sizeof(float));

--- a/src/backend/cpu/harris.cpp
+++ b/src/backend/cpu/harris.cpp
@@ -113,17 +113,16 @@ unsigned harris(Array<float> &x_out, Array<float> &y_out,
         y_out    = createEmptyArray<float>(dim4(corners_out));
         resp_out = createEmptyArray<float>(dim4(corners_out));
 
-        auto copyFunc = [=](Param<float> x_out, Param<float> y_out,
-                            Param<float> outResponses,
-                            const CParam<float> &x_crnrs,
-                            const CParam<float> &y_crnrs,
-                            const CParam<float> &inResponses,
-                            const unsigned corners_out) {
-            memcpy(x_out.get(), x_crnrs.get(), corners_out * sizeof(float));
-            memcpy(y_out.get(), y_crnrs.get(), corners_out * sizeof(float));
-            memcpy(outResponses.get(), inResponses.get(),
-                   corners_out * sizeof(float));
-        };
+        auto copyFunc =
+            [=](Param<float> x_out, Param<float> y_out,
+                Param<float> outResponses, const CParam<float> &x_crnrs,
+                const CParam<float> &y_crnrs, const CParam<float> &inResponses,
+                const unsigned corners_out) {
+                memcpy(x_out.get(), x_crnrs.get(), corners_out * sizeof(float));
+                memcpy(y_out.get(), y_crnrs.get(), corners_out * sizeof(float));
+                memcpy(outResponses.get(), inResponses.get(),
+                       corners_out * sizeof(float));
+            };
         getQueue().enqueue(copyFunc, x_out, y_out, resp_out, xCorners, yCorners,
                            respCorners, corners_out);
     } else {

--- a/src/backend/cpu/histogram.cpp
+++ b/src/backend/cpu/histogram.cpp
@@ -21,7 +21,7 @@ namespace cpu {
 template<typename inType, typename outType, bool isLinear>
 Array<outType> histogram(const Array<inType> &in, const unsigned &nbins,
                          const double &minval, const double &maxval) {
-    const dim4 inDims  = in.dims();
+    const dim4 &inDims = in.dims();
     dim4 outDims       = dim4(nbins, 1, inDims[2], inDims[3]);
     Array<outType> out = createValueArray<outType>(outDims, outType(0));
 

--- a/src/backend/cpu/hsv_rgb.cpp
+++ b/src/backend/cpu/hsv_rgb.cpp
@@ -14,8 +14,6 @@
 #include <queue.hpp>
 #include <af/dim4.hpp>
 
-using af::dim4;
-
 namespace cpu {
 
 template<typename T>

--- a/src/backend/cpu/identity.cpp
+++ b/src/backend/cpu/identity.cpp
@@ -15,7 +15,7 @@
 #include <queue.hpp>
 #include <af/dim4.hpp>
 
-using common::half;
+using common::half;  // NOLINT(misc-unused-using-decls) bug in clang-tidy
 
 namespace cpu {
 

--- a/src/backend/cpu/image.cpp
+++ b/src/backend/cpu/image.cpp
@@ -17,8 +17,6 @@
 #include <platform.hpp>
 #include <queue.hpp>
 
-using af::dim4;
-
 namespace cpu {
 
 template<typename T>

--- a/src/backend/cpu/index.cpp
+++ b/src/backend/cpu/index.cpp
@@ -21,7 +21,7 @@
 #include <vector>
 
 using af::dim4;
-using common::half;
+using common::half;  // NOLINT(misc-unused-using-decls) bug in clang-tidy
 using std::vector;
 
 namespace cpu {

--- a/src/backend/cpu/iota.cpp
+++ b/src/backend/cpu/iota.cpp
@@ -15,7 +15,7 @@
 #include <platform.hpp>
 #include <queue.hpp>
 
-using common::half;
+using common::half;  // NOLINT(misc-unused-using-decls) bug in clang-tidy
 
 namespace cpu {
 

--- a/src/backend/cpu/kernel/random_engine.hpp
+++ b/src/backend/cpu/kernel/random_engine.hpp
@@ -154,8 +154,8 @@ void philoxUniform(T *out, size_t elements, const uintl seed, uintl counter) {
                 // calculates these per thread
                 uint key[2] = {lo, hi};
                 uint ctr[4] = {loc + (uint)first_write_idx, 0, 0, 0};
-                ctr[1] = hic + (ctr[0] < loc);
-                ctr[2] = (ctr[1] < hic);
+                ctr[1]      = hic + (ctr[0] < loc);
+                ctr[2]      = (ctr[1] < hic);
                 philox(key, ctr);
 
                 // Use the same ctr array for each of the 4 locations,

--- a/src/backend/cpu/kernel/random_engine.hpp
+++ b/src/backend/cpu/kernel/random_engine.hpp
@@ -153,8 +153,9 @@ void philoxUniform(T *out, size_t elements, const uintl seed, uintl counter) {
                 // Recalculate key and ctr to emulate how the CUDA backend
                 // calculates these per thread
                 uint key[2] = {lo, hi};
-                uint ctr[4] = {loc + (uint)first_write_idx,
-                               hic + (ctr[0] < loc), (ctr[1] < hic), 0};
+                uint ctr[4] = {loc + (uint)first_write_idx, 0, 0, 0};
+                ctr[1] = hic + (ctr[0] < loc);
+                ctr[2] = (ctr[1] < hic);
                 philox(key, ctr);
 
                 // Use the same ctr array for each of the 4 locations,

--- a/src/backend/cpu/lookup.cpp
+++ b/src/backend/cpu/lookup.cpp
@@ -20,11 +20,12 @@ namespace cpu {
 template<typename in_t, typename idx_t>
 Array<in_t> lookup(const Array<in_t> &input, const Array<idx_t> &indices,
                    const unsigned dim) {
-    const dim4 iDims = input.dims();
+    const dim4 &iDims = input.dims();
 
     dim4 oDims(1);
-    for (int d = 0; d < 4; ++d)
+    for (int d = 0; d < 4; ++d) {
         oDims[d] = (d == int(dim) ? indices.elements() : iDims[d]);
+    }
 
     Array<in_t> out = createEmptyArray<in_t>(oDims);
     getQueue().enqueue(kernel::lookup<in_t, idx_t>, out, input, indices, dim);

--- a/src/backend/cpu/math.cpp
+++ b/src/backend/cpu/math.cpp
@@ -16,7 +16,7 @@ uchar abs(uchar val) { return val; }
 uintl abs(uintl val) { return val; }
 
 cfloat scalar(float val) {
-    cfloat cval = {(float)val, 0};
+    cfloat cval = {val, 0};
     return cval;
 }
 

--- a/src/backend/cpu/mean.cpp
+++ b/src/backend/cpu/mean.cpp
@@ -72,8 +72,8 @@ T mean(const Array<T> &in, const Array<Tw> &wt) {
     const T *inPtr   = in.get();
     const Tw *wtPtr  = wt.get();
 
-    compute_t<T> input   = compute_t<T>(inPtr[0]);
-    compute_t<Tw> weight = compute_t<Tw>(wtPtr[0]);
+    auto input  = compute_t<T>(inPtr[0]);
+    auto weight = compute_t<Tw>(wtPtr[0]);
     MeanOpT Op(input, weight);
 
     for (dim_t l = 0; l < dims[3]; l++) {

--- a/src/backend/cpu/meanshift.cpp
+++ b/src/backend/cpu/meanshift.cpp
@@ -24,16 +24,17 @@ using std::vector;
 namespace cpu {
 template<typename T>
 Array<T> meanshift(const Array<T> &in, const float &spatialSigma,
-                   const float &chromaticSigma, const unsigned &numInterations,
+                   const float &chromaticSigma, const unsigned &numIterations,
                    const bool &isColor) {
     Array<T> out = createEmptyArray<T>(in.dims());
 
-    if (isColor)
+    if (isColor) {
         getQueue().enqueue(kernel::meanShift<T, true>, out, in, spatialSigma,
-                           chromaticSigma, numInterations);
-    else
+                           chromaticSigma, numIterations);
+    } else {
         getQueue().enqueue(kernel::meanShift<T, false>, out, in, spatialSigma,
-                           chromaticSigma, numInterations);
+                           chromaticSigma, numIterations);
+    }
 
     return out;
 }

--- a/src/backend/cpu/memory.cpp
+++ b/src/backend/cpu/memory.cpp
@@ -42,7 +42,7 @@ void setMemStepSize(size_t step_bytes) {
     memoryManager().setMemStepSize(step_bytes);
 }
 
-size_t getMemStepSize(void) { return memoryManager().getMemStepSize(); }
+size_t getMemStepSize() { return memoryManager().getMemStepSize(); }
 
 void signalMemoryCleanup() { memoryManager().signalMemoryCleanup(); }
 
@@ -56,8 +56,9 @@ template<typename T>
 unique_ptr<T[], function<void(T *)>> memAlloc(const size_t &elements) {
     // TODO: make memAlloc aware of array shapes
     dim4 dims(elements);
-    void *ptr = memoryManager().alloc(false, 1, dims.get(), sizeof(T));
-    return unique_ptr<T[], function<void(T *)>>((T *)ptr, memFree<T>);
+    T *ptr = static_cast<T *>(
+        memoryManager().alloc(false, 1, dims.get(), sizeof(T)));
+    return unique_ptr<T[], function<void(T *)>>(ptr, memFree<T>);
 }
 
 void *memAllocUser(const size_t &bytes) {
@@ -68,18 +69,16 @@ void *memAllocUser(const size_t &bytes) {
 
 template<typename T>
 void memFree(T *ptr) {
-    return memoryManager().unlock((void *)ptr, false);
+    return memoryManager().unlock(static_cast<void *>(ptr), false);
 }
 
 void memFreeUser(void *ptr) { memoryManager().unlock(ptr, true); }
 
-void memLock(const void *ptr) { memoryManager().userLock((void *)ptr); }
+void memLock(const void *ptr) { memoryManager().userLock(ptr); }
 
-bool isLocked(const void *ptr) {
-    return memoryManager().isUserLocked((void *)ptr);
-}
+bool isLocked(const void *ptr) { return memoryManager().isUserLocked(ptr); }
 
-void memUnlock(const void *ptr) { memoryManager().userUnlock((void *)ptr); }
+void memUnlock(const void *ptr) { memoryManager().userUnlock(ptr); }
 
 void deviceMemoryInfo(size_t *alloc_bytes, size_t *alloc_buffers,
                       size_t *lock_bytes, size_t *lock_buffers) {
@@ -92,12 +91,12 @@ T *pinnedAlloc(const size_t &elements) {
     // TODO: make pinnedAlloc aware of array shapes
     dim4 dims(elements);
     void *ptr = memoryManager().alloc(false, 1, dims.get(), sizeof(T));
-    return (T *)ptr;
+    return static_cast<T *>(ptr);
 }
 
 template<typename T>
 void pinnedFree(T *ptr) {
-    memoryManager().unlock((void *)ptr, false);
+    memoryManager().unlock(static_cast<void *>(ptr), false);
 }
 
 #define INSTANTIATE(T)                                                \
@@ -141,9 +140,9 @@ size_t Allocator::getMaxMemorySize(int id) {
 }
 
 void *Allocator::nativeAlloc(const size_t bytes) {
-    void *ptr = malloc(bytes);
+    void *ptr = malloc(bytes);  // NOLINT(hicpp-no-malloc)
     AF_TRACE("nativeAlloc: {:>7} {}", bytesToString(bytes), ptr);
-    if (!ptr) AF_ERROR("Unable to allocate memory", AF_ERR_NO_MEM);
+    if (!ptr) { AF_ERROR("Unable to allocate memory", AF_ERR_NO_MEM); }
     return ptr;
 }
 
@@ -152,6 +151,6 @@ void Allocator::nativeFree(void *ptr) {
     // Make sure this pointer is not being used on the queue before freeing the
     // memory.
     getQueue().sync();
-    return free((void *)ptr);
+    free(ptr);  // NOLINT(hicpp-no-malloc)
 }
 }  // namespace cpu

--- a/src/backend/cpu/memory.cpp
+++ b/src/backend/cpu/memory.cpp
@@ -128,7 +128,7 @@ void Allocator::shutdown() {
         try {
             cpu::setDevice(n);
             shutdownMemoryManager();
-        } catch (AfError err) {
+        } catch (const AfError &err) {
             continue;  // Do not throw any errors while shutting down
         }
     }

--- a/src/backend/cpu/moments.cpp
+++ b/src/backend/cpu/moments.cpp
@@ -16,10 +16,10 @@
 
 namespace cpu {
 
-static inline int bitCount(int v) {
-    v = v - ((v >> 1) & 0x55555555);
-    v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
-    return (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
+static inline unsigned bitCount(unsigned v) {
+    v = v - ((v >> 1U) & 0x55555555U);
+    v = (v & 0x33333333U) + ((v >> 2U) & 0x33333333U);
+    return (((v + (v >> 4U)) & 0xF0F0F0FU) * 0x1010101U) >> 24U;
 }
 
 using af::dim4;

--- a/src/backend/cpu/morph.cpp
+++ b/src/backend/cpu/morph.cpp
@@ -22,11 +22,11 @@ namespace cpu {
 template<typename T, bool isDilation>
 Array<T> morph(const Array<T> &in, const Array<T> &mask) {
     af::borderType padType = isDilation ? AF_PAD_ZERO : AF_PAD_CLAMP_TO_EDGE;
-    const af::dim4 idims   = in.dims();
-    const af::dim4 mdims   = mask.dims();
+    const af::dim4 &idims  = in.dims();
+    const af::dim4 &mdims  = mask.dims();
 
     const af::dim4 lpad(mdims[0] / 2, mdims[1] / 2, 0, 0);
-    const af::dim4 upad(lpad);
+    const af::dim4 &upad(lpad);
     const af::dim4 odims(lpad[0] + idims[0] + upad[0],
                          lpad[1] + idims[1] + upad[1], idims[2], idims[3]);
 

--- a/src/backend/cpu/nearest_neighbour.cpp
+++ b/src/backend/cpu/nearest_neighbour.cpp
@@ -24,7 +24,7 @@ template<typename T, typename To>
 void nearest_neighbour(Array<uint>& idx, Array<To>& dist, const Array<T>& query,
                        const Array<T>& train, const uint dist_dim,
                        const uint n_dist, const af_match_type dist_type) {
-    uint sample_dim  = (dist_dim == 0) ? 1 : 0;
+    uint sample_dim   = (dist_dim == 0) ? 1 : 0;
     const dim4& qDims = query.dims();
     const dim4& tDims = train.dims();
     const dim4 outDims(n_dist, qDims[sample_dim]);

--- a/src/backend/cpu/nearest_neighbour.cpp
+++ b/src/backend/cpu/nearest_neighbour.cpp
@@ -25,8 +25,8 @@ void nearest_neighbour(Array<uint>& idx, Array<To>& dist, const Array<T>& query,
                        const Array<T>& train, const uint dist_dim,
                        const uint n_dist, const af_match_type dist_type) {
     uint sample_dim  = (dist_dim == 0) ? 1 : 0;
-    const dim4 qDims = query.dims();
-    const dim4 tDims = train.dims();
+    const dim4& qDims = query.dims();
+    const dim4& tDims = train.dims();
     const dim4 outDims(n_dist, qDims[sample_dim]);
     const dim4 distDims(tDims[sample_dim], qDims[sample_dim]);
 

--- a/src/backend/cpu/orb.cpp
+++ b/src/backend/cpu/orb.cpp
@@ -51,7 +51,7 @@ unsigned orb(Array<float>& x, Array<float>& y, Array<float>& score,
     float patch_size = REF_PAT_SIZE;
 
     const dim4& idims   = image.dims();
-    float min_side   = min(idims[0], idims[1]);
+    float min_side      = min(idims[0], idims[1]);
     unsigned max_levels = 0;
     float scl_sum       = 0.f;
 

--- a/src/backend/cpu/platform.cpp
+++ b/src/backend/cpu/platform.cpp
@@ -31,7 +31,7 @@ using std::unique_ptr;
 
 namespace cpu {
 
-static const string get_system(void) {
+static string get_system() {
     string arch = (sizeof(void*) == 4) ? "32-bit " : "64-bit ";
 
     return arch +
@@ -68,10 +68,11 @@ string getDeviceInfo() noexcept {
 
     info << string("[0] ") << cinfo.vendor() << ": " << ltrim(model);
 
-    if (memMB)
+    if (memMB) {
         info << ", " << memMB << " MB, ";
-    else
+    } else {
         info << ", Unknown MB, ";
+    }
 
     info << "Max threads(" << cinfo.threads() << ") ";
 #ifndef NDEBUG

--- a/src/backend/cpu/random_engine.cpp
+++ b/src/backend/cpu/random_engine.cpp
@@ -16,7 +16,7 @@ using common::half;
 
 namespace cpu {
 void initMersenneState(Array<uint> &state, const uintl seed,
-                       const Array<uint> tbl) {
+                       const Array<uint> &tbl) {
     getQueue().enqueue(kernel::initMersenneState, state.get(), tbl.get(), seed);
 }
 
@@ -157,10 +157,10 @@ INSTANTIATE_NORMAL(float)
 INSTANTIATE_NORMAL(double)
 INSTANTIATE_NORMAL(half)
 
-COMPLEX_UNIFORM_DISTRIBUTION(cdouble, double)
-COMPLEX_UNIFORM_DISTRIBUTION(cfloat, float)
+COMPLEX_UNIFORM_DISTRIBUTION(cdouble, double)  // NOLINT
+COMPLEX_UNIFORM_DISTRIBUTION(cfloat, float)    // NOLINT
 
-COMPLEX_NORMAL_DISTRIBUTION(cdouble, double)
-COMPLEX_NORMAL_DISTRIBUTION(cfloat, float)
+COMPLEX_NORMAL_DISTRIBUTION(cdouble, double)  // NOLINT
+COMPLEX_NORMAL_DISTRIBUTION(cfloat, float)    // NOLINT
 
 }  // namespace cpu

--- a/src/backend/cpu/random_engine.hpp
+++ b/src/backend/cpu/random_engine.hpp
@@ -14,10 +14,8 @@
 #include <af/defines.h>
 
 namespace cpu {
-Array<uint> initMersenneState(const uintl seed, Array<uint> tbl);
-
 void initMersenneState(Array<uint> &state, const uintl seed,
-                       const Array<uint> tbl);
+                       const Array<uint> &tbl);
 
 template<typename T>
 Array<T> uniformDistribution(const af::dim4 &dims,

--- a/src/backend/cpu/regions.cpp
+++ b/src/backend/cpu/regions.cpp
@@ -25,7 +25,7 @@ namespace cpu {
 
 template<typename T>
 Array<T> regions(const Array<char> &in, af_connectivity connectivity) {
-    Array<T> out = createValueArray(in.dims(), (T)0);
+    Array<T> out = createValueArray(in.dims(), static_cast<T>(0));
     getQueue().enqueue(kernel::regions<T>, out, in, connectivity);
 
     return out;

--- a/src/backend/cpu/reorder.cpp
+++ b/src/backend/cpu/reorder.cpp
@@ -20,9 +20,9 @@ namespace cpu {
 
 template<typename T>
 Array<T> reorder(const Array<T> &in, const af::dim4 &rdims) {
-    const af::dim4 iDims = in.dims();
+    const af::dim4 &iDims = in.dims();
     af::dim4 oDims(0);
-    for (int i = 0; i < 4; i++) oDims[i] = iDims[rdims[i]];
+    for (int i = 0; i < 4; i++) { oDims[i] = iDims[rdims[i]]; }
 
     Array<T> out = createEmptyArray<T>(oDims);
     getQueue().enqueue(kernel::reorder<T>, out, in, oDims, rdims);

--- a/src/backend/cpu/resize.cpp
+++ b/src/backend/cpu/resize.cpp
@@ -22,7 +22,7 @@ Array<T> resize(const Array<T> &in, const dim_t odim0, const dim_t odim1,
     af::dim4 idims = in.dims();
     af::dim4 odims(odim0, odim1, idims[2], idims[3]);
     // Create output placeholder
-    Array<T> out = createValueArray(odims, (T)0);
+    Array<T> out = createValueArray(odims, static_cast<T>(0));
 
     switch (method) {
         case AF_INTERP_NEAREST:

--- a/src/backend/cpu/scan.cpp
+++ b/src/backend/cpu/scan.cpp
@@ -23,7 +23,7 @@ namespace cpu {
 template<af_op_t op, typename Ti, typename To>
 Array<To> scan(const Array<Ti>& in, const int dim, bool inclusive_scan) {
     const dim4& dims = in.dims();
-    Array<To> out = createEmptyArray<To>(dims);
+    Array<To> out    = createEmptyArray<To>(dims);
 
     if (inclusive_scan) {
         switch (in.ndims()) {

--- a/src/backend/cpu/scan.cpp
+++ b/src/backend/cpu/scan.cpp
@@ -22,7 +22,7 @@ namespace cpu {
 
 template<af_op_t op, typename Ti, typename To>
 Array<To> scan(const Array<Ti>& in, const int dim, bool inclusive_scan) {
-    dim4 dims     = in.dims();
+    const dim4& dims = in.dims();
     Array<To> out = createEmptyArray<To>(dims);
 
     if (inclusive_scan) {

--- a/src/backend/cpu/scan_by_key.cpp
+++ b/src/backend/cpu/scan_by_key.cpp
@@ -22,7 +22,7 @@ namespace cpu {
 template<af_op_t op, typename Ti, typename Tk, typename To>
 Array<To> scan(const Array<Tk>& key, const Array<Ti>& in, const int dim,
                bool inclusive_scan) {
-    dim4 dims     = in.dims();
+    const dim4& dims = in.dims();
     Array<To> out = createEmptyArray<To>(dims);
     kernel::scan_dim_by_key<op, Ti, Tk, To, 1> func1(inclusive_scan);
     kernel::scan_dim_by_key<op, Ti, Tk, To, 2> func2(inclusive_scan);

--- a/src/backend/cpu/scan_by_key.cpp
+++ b/src/backend/cpu/scan_by_key.cpp
@@ -23,7 +23,7 @@ template<af_op_t op, typename Ti, typename Tk, typename To>
 Array<To> scan(const Array<Tk>& key, const Array<Ti>& in, const int dim,
                bool inclusive_scan) {
     const dim4& dims = in.dims();
-    Array<To> out = createEmptyArray<To>(dims);
+    Array<To> out    = createEmptyArray<To>(dims);
     kernel::scan_dim_by_key<op, Ti, Tk, To, 1> func1(inclusive_scan);
     kernel::scan_dim_by_key<op, Ti, Tk, To, 2> func2(inclusive_scan);
     kernel::scan_dim_by_key<op, Ti, Tk, To, 3> func3(inclusive_scan);

--- a/src/backend/cpu/set.cpp
+++ b/src/backend/cpu/set.cpp
@@ -30,10 +30,11 @@ using std::unique;
 template<typename T>
 Array<T> setUnique(const Array<T> &in, const bool is_sorted) {
     Array<T> out = createEmptyArray<T>(af::dim4());
-    if (is_sorted)
+    if (is_sorted) {
         out = copyArray<T>(in);
-    else
+    } else {
         out = sort<T>(in, 0, true);
+    }
 
     // Need to sync old jobs since we need to
     // operator on pointers directly in std::unique
@@ -41,7 +42,7 @@ Array<T> setUnique(const Array<T> &in, const bool is_sorted) {
 
     T *ptr     = out.get();
     T *last    = unique(ptr, ptr + in.elements());
-    dim_t dist = (dim_t)distance(ptr, last);
+    auto dist  = static_cast<dim_t>(distance(ptr, last));
 
     dim4 dims(dist, 1, 1, 1);
     out.resetDims(dims);
@@ -70,7 +71,7 @@ Array<T> setUnion(const Array<T> &first, const Array<T> &second,
     T *last = set_union(uFirst.get(), uFirst.get() + first_elements,
                         uSecond.get(), uSecond.get() + second_elements, ptr);
 
-    dim_t dist = (dim_t)distance(ptr, last);
+    auto dist = static_cast<dim_t>(distance(ptr, last));
     dim4 dims(dist, 1, 1, 1);
     out.resetDims(dims);
 
@@ -99,7 +100,7 @@ Array<T> setIntersect(const Array<T> &first, const Array<T> &second,
         set_intersection(uFirst.get(), uFirst.get() + first_elements,
                          uSecond.get(), uSecond.get() + second_elements, ptr);
 
-    dim_t dist = (dim_t)distance(ptr, last);
+    auto dist = static_cast<dim_t>(distance(ptr, last));
     dim4 dims(dist, 1, 1, 1);
     out.resetDims(dims);
 

--- a/src/backend/cpu/set.cpp
+++ b/src/backend/cpu/set.cpp
@@ -40,9 +40,9 @@ Array<T> setUnique(const Array<T> &in, const bool is_sorted) {
     // operator on pointers directly in std::unique
     getQueue().sync();
 
-    T *ptr     = out.get();
-    T *last    = unique(ptr, ptr + in.elements());
-    auto dist  = static_cast<dim_t>(distance(ptr, last));
+    T *ptr    = out.get();
+    T *last   = unique(ptr, ptr + in.elements());
+    auto dist = static_cast<dim_t>(distance(ptr, last));
 
     dim4 dims(dist, 1, 1, 1);
     out.resetDims(dims);

--- a/src/backend/cpu/sift.cpp
+++ b/src/backend/cpu/sift.cpp
@@ -54,14 +54,15 @@ unsigned sift(Array<float>& x, Array<float>& y, Array<float>& score,
     UNUSED(double_input);
     UNUSED(img_scale);
     UNUSED(feature_ratio);
-    if (compute_GLOH)
+    if (compute_GLOH) {
         AF_ERROR(
             "ArrayFire was not built with nonfree support, GLOH disabled\n",
             AF_ERR_NONFREE);
-    else
+    } else {
         AF_ERROR(
             "ArrayFire was not built with nonfree support, SIFT disabled\n",
             AF_ERR_NONFREE);
+    }
 #endif
 }
 

--- a/src/backend/cpu/solve.cpp
+++ b/src/backend/cpu/solve.cpp
@@ -79,6 +79,7 @@ Array<T> solveLU(const Array<T> &A, const Array<int> &pivot, const Array<T> &b,
     int NRHS   = b.dims()[1];
     Array<T> B = copyArray<T>(b);
 
+    // NOLINTNEXTLINE
     auto func = [=](CParam<T> A, Param<T> B, CParam<int> pivot, int N,
                     int NRHS) {
         getrs_func<T>()(AF_LAPACK_COL_MAJOR, 'N', N, NRHS, A.get(),

--- a/src/backend/cpu/sort.cpp
+++ b/src/backend/cpu/sort.cpp
@@ -52,10 +52,11 @@ template<typename T>
 void sort0(Array<T>& val, bool isAscending) {
     int higherDims = val.elements() / val.dims()[0];
     // TODO Make a better heurisitic
-    if (higherDims > 10)
+    if (higherDims > 10) {
         sortBatched<T, 0>(val, isAscending);
-    else
+    } else {
         getQueue().enqueue(kernel::sort0Iterative<T>, val, isAscending);
+    }
 }
 
 template<typename T>
@@ -74,7 +75,7 @@ Array<T> sort(const Array<T>& in, const unsigned dim, bool isAscending) {
         af::dim4 reorderDims(0, 1, 2, 3);
         reorderDims[dim] = 0;
         preorderDims[0]  = out.dims()[dim];
-        for (int i = 1; i <= (int)dim; i++) {
+        for (int i = 1; i <= static_cast<int>(dim); i++) {
             reorderDims[i - 1] = i;
             preorderDims[i]    = out.dims()[i - 1];
         }

--- a/src/backend/cpu/sort_by_key.cpp
+++ b/src/backend/cpu/sort_by_key.cpp
@@ -44,7 +44,7 @@ void sort_by_key(Array<Tk> &okey, Array<Tv> &oval, const Array<Tk> &ikey,
         af::dim4 reorderDims(0, 1, 2, 3);
         reorderDims[dim] = 0;
         preorderDims[0]  = okey.dims()[dim];
-        for (int i = 1; i <= (int)dim; i++) {
+        for (int i = 1; i <= static_cast<int>(dim); i++) {
             reorderDims[i - 1] = i;
             preorderDims[i]    = okey.dims()[i - 1];
         }

--- a/src/backend/cpu/sort_index.cpp
+++ b/src/backend/cpu/sort_index.cpp
@@ -49,7 +49,7 @@ void sort_index(Array<T> &okey, Array<uint> &oval, const Array<T> &in,
         af::dim4 reorderDims(0, 1, 2, 3);
         reorderDims[dim] = 0;
         preorderDims[0]  = okey.dims()[dim];
-        for (int i = 1; i <= (int)dim; i++) {
+        for (int i = 1; i <= static_cast<int>(dim); i++) {
             reorderDims[i - 1] = i;
             preorderDims[i]    = okey.dims()[i - 1];
         }

--- a/src/backend/cpu/sort_index.hpp
+++ b/src/backend/cpu/sort_index.hpp
@@ -11,6 +11,6 @@
 
 namespace cpu {
 template<typename T>
-void sort_index(Array<T> &val, Array<unsigned> &idx, const Array<T> &in,
+void sort_index(Array<T> &okey, Array<unsigned> &oval, const Array<T> &in,
                 const unsigned dim, bool isAscending);
 }

--- a/src/backend/cpu/sparse.cpp
+++ b/src/backend/cpu/sparse.cpp
@@ -83,13 +83,14 @@ Array<T> sparseConvertStorageToDense(const SparseArray<T> &in) {
     Array<int> rowIdx = in.getRowIdx();
     Array<int> colIdx = in.getColIdx();
 
-    if (stype == AF_STORAGE_CSR)
+    if (stype == AF_STORAGE_CSR) {
         getQueue().enqueue(kernel::csr2dense<T>, dense, values, rowIdx, colIdx);
-    else if (stype == AF_STORAGE_COO)
+    } else if (stype == AF_STORAGE_COO) {
         getQueue().enqueue(kernel::coo2dense<T>, dense, values, rowIdx, colIdx);
-    else
+    } else {
         AF_ERROR("CPU Backend only supports CSR or COO to Dense",
                  AF_ERR_NOT_SUPPORTED);
+    }
 
     return dense;
 }
@@ -98,8 +99,8 @@ template<typename T, af_storage dest, af_storage src>
 SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in) {
     in.eval();
 
-    auto converted =
-        createEmptySparseArray<T>(in.dims(), (int)in.getNNZ(), dest);
+    auto converted = createEmptySparseArray<T>(
+        in.dims(), static_cast<int>(in.getNNZ()), dest);
     converted.eval();
 
     function<void(Param<T>, Param<int>, Param<int>, CParam<T>, CParam<int>,

--- a/src/backend/cpu/sparse_arith.cpp
+++ b/src/backend/cpu/sparse_arith.cpp
@@ -27,25 +27,28 @@
 #include <string>
 #include <vector>
 
-namespace cpu {
+using std::numeric_limits;
+using common::SparseArray;
+using common::createArrayDataSparseArray;
+using common::createEmptySparseArray;
 
-using namespace common;
+namespace cpu {
 
 template<typename T>
 T getInf() {
-    return scalar<T>(std::numeric_limits<T>::infinity());
+    return scalar<T>(numeric_limits<T>::infinity());
 }
 
 template<>
 cfloat getInf() {
-    return scalar<cfloat, float>(std::numeric_limits<float>::infinity(),
-                                 std::numeric_limits<float>::infinity());
+    return scalar<cfloat, float>(numeric_limits<float>::infinity(),
+                                 numeric_limits<float>::infinity());
 }
 
 template<>
 cdouble getInf() {
-    return scalar<cdouble, double>(std::numeric_limits<double>::infinity(),
-                                   std::numeric_limits<double>::infinity());
+    return scalar<cdouble, double>(numeric_limits<double>::infinity(),
+                                   numeric_limits<double>::infinity());
 }
 
 template<typename T, af_op_t op>
@@ -109,7 +112,7 @@ template<typename T, af_op_t op>
 SparseArray<T> arithOp(const SparseArray<T> &lhs, const SparseArray<T> &rhs) {
     af::storage sfmt = lhs.getStorage();
 
-    const dim4 dims = lhs.dims();
+    const dim4 &dims = lhs.dims();
     const uint M    = dims[0];
     const uint N    = dims[1];
 

--- a/src/backend/cpu/sparse_arith.cpp
+++ b/src/backend/cpu/sparse_arith.cpp
@@ -27,10 +27,10 @@
 #include <string>
 #include <vector>
 
-using std::numeric_limits;
-using common::SparseArray;
 using common::createArrayDataSparseArray;
 using common::createEmptySparseArray;
+using common::SparseArray;
+using std::numeric_limits;
 
 namespace cpu {
 
@@ -113,8 +113,8 @@ SparseArray<T> arithOp(const SparseArray<T> &lhs, const SparseArray<T> &rhs) {
     af::storage sfmt = lhs.getStorage();
 
     const dim4 &dims = lhs.dims();
-    const uint M    = dims[0];
-    const uint N    = dims[1];
+    const uint M     = dims[0];
+    const uint N     = dims[1];
 
     auto rowArr = createEmptyArray<int>(dim4(M + 1));
 

--- a/src/backend/cpu/sparse_blas.cpp
+++ b/src/backend/cpu/sparse_blas.cpp
@@ -69,12 +69,12 @@ using scale_type =
                               const typename blas_base<T>::type, const T>::type;
 
 template<typename To, typename Ti>
-To getScaleValue(Ti val) {
-    return (To)(val);
+auto getScaleValue(Ti val) -> std::remove_cv_t<To> {
+    return static_cast<std::remove_cv_t<To>>(val);
 }
 
 template<typename T, int value>
-scale_type<T> getScale() {
+scale_type<T> getScale() {  // NOLINT(readability-const-return-type)
     static T val(value);
     return getScaleValue<scale_type<T>, T>(val);
 }
@@ -93,7 +93,7 @@ sparse_operation_t toSparseTranspose(af_mat_prop opt) {
 #ifdef USE_MKL
 
 template<>
-const sp_cfloat getScaleValue<const sp_cfloat, cfloat>(cfloat val) {
+sp_cfloat getScaleValue<const sp_cfloat, cfloat>(cfloat val) {
     sp_cfloat ret;
     ret.real = val.real();
     ret.imag = val.imag();
@@ -101,7 +101,7 @@ const sp_cfloat getScaleValue<const sp_cfloat, cfloat>(cfloat val) {
 }
 
 template<>
-const sp_cdouble getScaleValue<const sp_cdouble, cdouble>(cdouble val) {
+sp_cdouble getScaleValue<const sp_cdouble, cdouble>(cdouble val) {
     sp_cdouble ret;
     ret.real = val.real();
     ret.imag = val.imag();
@@ -240,7 +240,7 @@ Array<T> matmul(const common::SparseArray<T> &lhs, const Array<T> &rhs,
                              pE, const_cast<int *>(colIdx.get()),
                              reinterpret_cast<ptr_type<T>>(vptr));
 
-        struct matrix_descr descrLhs;
+        struct matrix_descr descrLhs {};
         descrLhs.type = SPARSE_MATRIX_TYPE_GENERAL;
 
         mkl_sparse_optimize(csrLhs);

--- a/src/backend/cpu/tile.cpp
+++ b/src/backend/cpu/tile.cpp
@@ -20,7 +20,7 @@ namespace cpu {
 
 template<typename T>
 Array<T> tile(const Array<T> &in, const af::dim4 &tileDims) {
-    const af::dim4 iDims = in.dims();
+    const af::dim4 &iDims = in.dims();
     af::dim4 oDims       = iDims;
     oDims *= tileDims;
 

--- a/src/backend/cpu/tile.cpp
+++ b/src/backend/cpu/tile.cpp
@@ -21,7 +21,7 @@ namespace cpu {
 template<typename T>
 Array<T> tile(const Array<T> &in, const af::dim4 &tileDims) {
     const af::dim4 &iDims = in.dims();
-    af::dim4 oDims       = iDims;
+    af::dim4 oDims        = iDims;
     oDims *= tileDims;
 
     if (iDims.elements() == 0 || oDims.elements() == 0) {

--- a/src/backend/cpu/topk.cpp
+++ b/src/backend/cpu/topk.cpp
@@ -34,7 +34,7 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
     int ndims = in.dims().ndims();
     for (int i = 0; i < ndims; i++) {
         if (i == dim) {
-            out_dims[i] = min(k, (int)in.dims()[i]);
+            out_dims[i] = min(k, static_cast<int>(in.dims()[i]));
         } else {
             out_dims[i] = in.dims()[i];
         }

--- a/src/backend/cpu/transform.cpp
+++ b/src/backend/cpu/transform.cpp
@@ -19,6 +19,7 @@ template<typename T>
 void transform(Array<T> &out, const Array<T> &in, const Array<float> &tf,
                const dim4 &odims, const af_interp_type method,
                const bool inverse, const bool perspective) {
+    UNUSED(odims);
     out.eval();
     in.eval();
     tf.eval();

--- a/src/backend/cpu/transform.cpp
+++ b/src/backend/cpu/transform.cpp
@@ -17,9 +17,8 @@ namespace cpu {
 
 template<typename T>
 void transform(Array<T> &out, const Array<T> &in, const Array<float> &tf,
-               const dim4 &odims, const af_interp_type method,
-               const bool inverse, const bool perspective) {
-    UNUSED(odims);
+               const af_interp_type method, const bool inverse,
+               const bool perspective) {
     out.eval();
     in.eval();
     tf.eval();
@@ -46,7 +45,7 @@ void transform(Array<T> &out, const Array<T> &in, const Array<float> &tf,
 
 #define INSTANTIATE(T)                                                       \
     template void transform(Array<T> &out, const Array<T> &in,               \
-                            const Array<float> &tf, const dim4 &odims,       \
+                            const Array<float> &tf,                          \
                             const af_interp_type method, const bool inverse, \
                             const bool perspective);
 

--- a/src/backend/cpu/transform.hpp
+++ b/src/backend/cpu/transform.hpp
@@ -12,6 +12,6 @@
 namespace cpu {
 template<typename T>
 void transform(Array<T> &out, const Array<T> &in, const Array<float> &tf,
-               const af::dim4 &odims, const af_interp_type method,
-               const bool inverse, const bool perspective);
+               const af_interp_type method, const bool inverse,
+               const bool perspective);
 }

--- a/src/backend/cpu/transpose.cpp
+++ b/src/backend/cpu/transpose.cpp
@@ -24,7 +24,7 @@ namespace cpu {
 
 template<typename T>
 Array<T> transpose(const Array<T> &in, const bool conjugate) {
-    const dim4 inDims  = in.dims();
+    const dim4 &inDims = in.dims();
     const dim4 outDims = dim4(inDims[1], inDims[0], inDims[2], inDims[3]);
     // create an array with first two dimensions swapped
     Array<T> out = createEmptyArray<T>(outDims);

--- a/src/backend/cpu/types.hpp
+++ b/src/backend/cpu/types.hpp
@@ -30,7 +30,7 @@ using data_t = typename common::kernel_type<T>::data;
 
 namespace common {
 template<typename T>
-class kernel_type;
+struct kernel_type;
 
 class half;
 

--- a/src/backend/cpu/vector_field.hpp
+++ b/src/backend/cpu/vector_field.hpp
@@ -14,6 +14,5 @@ namespace cpu {
 
 template<typename T>
 void copy_vector_field(const Array<T> &points, const Array<T> &directions,
-                       fg_vector_field vector_field);
-
+                       fg_vector_field vfield);
 }

--- a/src/backend/cpu/wrap.cpp
+++ b/src/backend/cpu/wrap.cpp
@@ -20,9 +20,9 @@ using common::half;
 namespace cpu {
 
 template<typename T>
-void wrap(Array<T> &out, const Array<T> &in, const dim_t ox, const dim_t oy,
-          const dim_t wx, const dim_t wy, const dim_t sx, const dim_t sy,
-          const dim_t px, const dim_t py, const bool is_column) {
+void wrap(Array<T> &out, const Array<T> &in, const dim_t wx, const dim_t wy,
+          const dim_t sx, const dim_t sy, const dim_t px, const dim_t py,
+          const bool is_column) {
     evalMultiple<T>(std::vector<Array<T> *>{const_cast<Array<T> *>(&in), &out});
 
     if (is_column) {
@@ -35,10 +35,10 @@ void wrap(Array<T> &out, const Array<T> &in, const dim_t ox, const dim_t oy,
 }
 
 #define INSTANTIATE(T)                                                        \
-    template void wrap<T>(Array<T> & out, const Array<T> &in, const dim_t ox, \
-                          const dim_t oy, const dim_t wx, const dim_t wy,     \
-                          const dim_t sx, const dim_t sy, const dim_t px,     \
-                          const dim_t py, const bool is_column);
+    template void wrap<T>(Array<T> & out, const Array<T> &in, const dim_t wx, \
+                          const dim_t wy, const dim_t sx, const dim_t sy,     \
+                          const dim_t px, const dim_t py,                     \
+                          const bool is_column);
 
 INSTANTIATE(float)
 INSTANTIATE(double)

--- a/src/backend/cpu/wrap.hpp
+++ b/src/backend/cpu/wrap.hpp
@@ -12,9 +12,9 @@
 namespace cpu {
 
 template<typename T>
-void wrap(Array<T> &out, const Array<T> &in,
-          const dim_t wx, const dim_t wy, const dim_t sx, const dim_t sy,
-          const dim_t px, const dim_t py, const bool is_column);
+void wrap(Array<T> &out, const Array<T> &in, const dim_t wx, const dim_t wy,
+          const dim_t sx, const dim_t sy, const dim_t px, const dim_t py,
+          const bool is_column);
 
 template<typename T>
 Array<T> wrap_dilated(const Array<T> &in, const dim_t ox, const dim_t oy,

--- a/src/backend/cpu/wrap.hpp
+++ b/src/backend/cpu/wrap.hpp
@@ -12,7 +12,7 @@
 namespace cpu {
 
 template<typename T>
-void wrap(Array<T> &out, const Array<T> &in, const dim_t ox, const dim_t oy,
+void wrap(Array<T> &out, const Array<T> &in,
           const dim_t wx, const dim_t wy, const dim_t sx, const dim_t sy,
           const dim_t px, const dim_t py, const bool is_column);
 

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -56,7 +56,7 @@ Node_ptr bufferNodePtr() {
 template<typename T>
 Array<T>::Array(const af::dim4 &dims)
     : info(getActiveDeviceId(), dims, 0, calcStrides(dims),
-           (af_dtype)dtype_traits<T>::af_type)
+           static_cast<af_dtype>(dtype_traits<T>::af_type))
     , data((dims.elements() ? memAlloc<T>(dims.elements()).release() : nullptr),
            memFree<T>)
     , data_dims(dims)
@@ -68,7 +68,7 @@ template<typename T>
 Array<T>::Array(const af::dim4 &dims, const T *const in_data, bool is_device,
                 bool copy_device)
     : info(getActiveDeviceId(), dims, 0, calcStrides(dims),
-           (af_dtype)dtype_traits<T>::af_type)
+           static_cast<af_dtype>(dtype_traits<T>::af_type))
     , data(
           ((is_device & !copy_device) ? const_cast<T *>(in_data)
                                       : memAlloc<T>(dims.elements()).release()),
@@ -101,7 +101,7 @@ template<typename T>
 Array<T>::Array(const Array<T> &parent, const dim4 &dims, const dim_t &offset_,
                 const dim4 &strides)
     : info(parent.getDevId(), dims, offset_, strides,
-           (af_dtype)dtype_traits<T>::af_type)
+           static_cast<af_dtype>(dtype_traits<T>::af_type))
     , data(parent.getData())
     , data_dims(parent.getDataDims())
     , node(bufferNodePtr<T>())
@@ -114,7 +114,7 @@ Array<T>::Array(Param<T> &tmp, bool owner_)
            af::dim4(tmp.dims[0], tmp.dims[1], tmp.dims[2], tmp.dims[3]), 0,
            af::dim4(tmp.strides[0], tmp.strides[1], tmp.strides[2],
                     tmp.strides[3]),
-           (af_dtype)dtype_traits<T>::af_type)
+           static_cast<af_dtype>(dtype_traits<T>::af_type))
     , data(tmp.ptr, owner_ ? std::function<void(T *)>(memFree<T>)
                            : std::function<void(T *)>([](T * /*unused*/) {}))
     , data_dims(af::dim4(tmp.dims[0], tmp.dims[1], tmp.dims[2], tmp.dims[3]))
@@ -125,7 +125,7 @@ Array<T>::Array(Param<T> &tmp, bool owner_)
 template<typename T>
 Array<T>::Array(const af::dim4 &dims, common::Node_ptr n)
     : info(getActiveDeviceId(), dims, 0, calcStrides(dims),
-           (af_dtype)dtype_traits<T>::af_type)
+           static_cast<af_dtype>(dtype_traits<T>::af_type))
     , data()
     , data_dims(dims)
     , node(move(n))
@@ -136,8 +136,9 @@ template<typename T>
 Array<T>::Array(const af::dim4 &dims, const af::dim4 &strides, dim_t offset_,
                 const T *const in_data, bool is_device)
     : info(getActiveDeviceId(), dims, offset_, strides,
-           (af_dtype)dtype_traits<T>::af_type)
-    , data(is_device ? (T *)in_data : memAlloc<T>(info.total()).release(),
+           static_cast<af_dtype>(dtype_traits<T>::af_type))
+    , data(is_device ? const_cast<T *>(in_data)
+                     : memAlloc<T>(info.total()).release(),
            memFree<T>)
     , data_dims(dims)
     , node(bufferNodePtr<T>())

--- a/src/backend/cuda/Array.hpp
+++ b/src/backend/cuda/Array.hpp
@@ -33,7 +33,8 @@ template<typename T>
 void evalNodes(Param<T> out, common::Node *node);
 
 template<typename T>
-void evalNodes(std::vector<Param<T>> &out, const std::vector<common::Node *> &nodes);
+void evalNodes(std::vector<Param<T>> &out,
+               const std::vector<common::Node *> &nodes);
 
 template<typename T>
 void evalMultiple(std::vector<Array<T> *> arrays);

--- a/src/backend/cuda/Array.hpp
+++ b/src/backend/cuda/Array.hpp
@@ -33,16 +33,16 @@ template<typename T>
 void evalNodes(Param<T> out, common::Node *node);
 
 template<typename T>
-void evalNodes(std::vector<Param<T>> &out, std::vector<common::Node *> nodes);
+void evalNodes(std::vector<Param<T>> &out, const std::vector<common::Node *> &nodes);
 
 template<typename T>
 void evalMultiple(std::vector<Array<T> *> arrays);
 
 template<typename T>
-Array<T> createNodeArray(const af::dim4 &size, common::Node_ptr node);
+Array<T> createNodeArray(const af::dim4 &dims, common::Node_ptr node);
 
 template<typename T>
-Array<T> createValueArray(const af::dim4 &size, const T &value);
+Array<T> createValueArray(const af::dim4 &dims, const T &value);
 
 // Creates an array and copies from the \p data pointer located in host memory
 //
@@ -52,11 +52,12 @@ template<typename T>
 Array<T> createHostDataArray(const af::dim4 &dims, const T *const data);
 
 template<typename T>
-Array<T> createDeviceDataArray(const af::dim4 &size, void *data);
+Array<T> createDeviceDataArray(const af::dim4 &dims, void *data);
 
 template<typename T>
-Array<T> createStridedArray(af::dim4 dims, af::dim4 strides, dim_t offset,
-                            const T *const in_data, bool is_device) {
+Array<T> createStridedArray(const af::dim4 &dims, const af::dim4 &strides,
+                            dim_t offset, const T *const in_data,
+                            bool is_device) {
     return Array<T>(dims, strides, offset, in_data, is_device);
 }
 
@@ -73,7 +74,7 @@ void writeDeviceDataArray(Array<T> &arr, const void *const data,
 ///
 /// \param[in] size The dimension of the output array
 template<typename T>
-Array<T> createEmptyArray(const af::dim4 &size);
+Array<T> createEmptyArray(const af::dim4 &dims);
 
 /// Create an Array object from Param<T> object.
 ///
@@ -82,7 +83,7 @@ Array<T> createEmptyArray(const af::dim4 &size);
 /// If false
 ///                  the Array<T> will not delete the object on destruction
 template<typename T>
-Array<T> createParamArray(Param<T> &in, bool owner);
+Array<T> createParamArray(Param<T> &tmp, bool owner);
 
 template<typename T>
 Array<T> createSubArray(const Array<T> &parent,
@@ -124,18 +125,18 @@ class Array {
     bool ready;
     bool owner;
 
-    Array(af::dim4 dims);
+    Array(const af::dim4 &dims);
 
-    explicit Array(af::dim4 dims, const T *const in_data,
+    explicit Array(const af::dim4 &dims, const T *const in_data,
                    bool is_device = false, bool copy_device = false);
-    Array(const Array<T> &parnt, const dim4 &dims, const dim_t &offset,
+    Array(const Array<T> &parent, const dim4 &dims, const dim_t &offset,
           const dim4 &stride);
     Array(Param<T> &tmp, bool owner);
-    Array(af::dim4 dims, common::Node_ptr n);
+    Array(const af::dim4 &dims, common::Node_ptr n);
 
    public:
-    Array(af::dim4 dims, af::dim4 strides, dim_t offset, const T *const in_data,
-          bool is_device = false);
+    Array(const af::dim4 &dims, const af::dim4 &strides, dim_t offset,
+          const T *const in_data, bool is_device = false);
 
     void resetInfo(const af::dim4 &dims) { info.resetInfo(dims); }
     void resetDims(const af::dim4 &dims) { info.resetDims(dims); }
@@ -241,8 +242,9 @@ class Array {
     friend Array<T> createHostDataArray<T>(const af::dim4 &size,
                                            const T *const data);
     friend Array<T> createDeviceDataArray<T>(const af::dim4 &size, void *data);
-    friend Array<T> createStridedArray<T>(af::dim4 dims, af::dim4 strides,
-                                          dim_t offset, const T *const in_data,
+    friend Array<T> createStridedArray<T>(const af::dim4 &dims,
+                                          const af::dim4 &strides, dim_t offset,
+                                          const T *const in_data,
                                           bool is_device);
 
     friend Array<T> createEmptyArray<T>(const af::dim4 &size);

--- a/src/backend/cuda/Array.hpp
+++ b/src/backend/cuda/Array.hpp
@@ -240,15 +240,15 @@ class Array {
 
     friend void evalMultiple<T>(std::vector<Array<T> *> arrays);
     friend Array<T> createValueArray<T>(const af::dim4 &size, const T &value);
-    friend Array<T> createHostDataArray<T>(const af::dim4 &size,
+    friend Array<T> createHostDataArray<T>(const af::dim4 &dims,
                                            const T *const data);
-    friend Array<T> createDeviceDataArray<T>(const af::dim4 &size, void *data);
+    friend Array<T> createDeviceDataArray<T>(const af::dim4 &dims, void *data);
     friend Array<T> createStridedArray<T>(const af::dim4 &dims,
                                           const af::dim4 &strides, dim_t offset,
                                           const T *const in_data,
                                           bool is_device);
 
-    friend Array<T> createEmptyArray<T>(const af::dim4 &size);
+    friend Array<T> createEmptyArray<T>(const af::dim4 &dims);
     friend Array<T> createParamArray<T>(Param<T> &tmp, bool owner);
     friend Array<T> createNodeArray<T>(const af::dim4 &dims,
                                        common::Node_ptr node);

--- a/src/backend/cuda/Event.hpp
+++ b/src/backend/cuda/Event.hpp
@@ -51,7 +51,7 @@ class CUDARuntimeEventPolicy {
 using Event = common::EventBase<CUDARuntimeEventPolicy>;
 
 /// \brief Creates a new event and marks it in the stream
-Event makeEvent(cudaStream_t stream);
+Event makeEvent(cudaStream_t queue);
 
 af_event createEvent();
 

--- a/src/backend/cuda/GraphicsResourceManager.cpp
+++ b/src/backend/cuda/GraphicsResourceManager.cpp
@@ -18,7 +18,8 @@
 
 namespace cuda {
 GraphicsResourceManager::ShrdResVector
-GraphicsResourceManager::registerResources(std::vector<uint32_t> resources) {
+GraphicsResourceManager::registerResources(
+    const std::vector<uint32_t>& resources) {
     ShrdResVector output;
 
     auto deleter = [](cudaGraphicsResource_t* handle) {

--- a/src/backend/cuda/GraphicsResourceManager.hpp
+++ b/src/backend/cuda/GraphicsResourceManager.hpp
@@ -23,7 +23,8 @@ class GraphicsResourceManager
     using ShrdResVector = std::vector<std::shared_ptr<cudaGraphicsResource_t>>;
 
     GraphicsResourceManager() {}
-    ShrdResVector registerResources(std::vector<uint32_t> resources);
+    static ShrdResVector registerResources(
+        const std::vector<uint32_t> &resources);
 
    protected:
     GraphicsResourceManager(GraphicsResourceManager const&);

--- a/src/backend/cuda/GraphicsResourceManager.hpp
+++ b/src/backend/cuda/GraphicsResourceManager.hpp
@@ -27,7 +27,7 @@ class GraphicsResourceManager
         const std::vector<uint32_t> &resources);
 
    protected:
-    GraphicsResourceManager(GraphicsResourceManager const&);
-    void operator=(GraphicsResourceManager const&);
+    GraphicsResourceManager(GraphicsResourceManager const &);
+    void operator=(GraphicsResourceManager const &);
 };
 }  // namespace cuda

--- a/src/backend/cuda/ThrustArrayFirePolicy.cpp
+++ b/src/backend/cuda/ThrustArrayFirePolicy.cpp
@@ -11,9 +11,11 @@
 
 namespace cuda {
 
-cudaStream_t get_stream(ThrustArrayFirePolicy) { return getActiveStream(); }
+cudaStream_t get_stream(ThrustArrayFirePolicy /*unused*/) {
+    return getActiveStream();
+}
 
-cudaError_t synchronize_stream(ThrustArrayFirePolicy) {
+cudaError_t synchronize_stream(ThrustArrayFirePolicy /*unused*/) {
     return cudaStreamSynchronize(getActiveStream());
 }
 

--- a/src/backend/cuda/blas.cu
+++ b/src/backend/cuda/blas.cu
@@ -176,7 +176,6 @@ cudaDataType_t getComputeType() {
 
 template<>
 cudaDataType_t getComputeType<half>() {
-    auto dev            = getDeviceProp(getActiveDeviceId());
     cudaDataType_t algo = getType<half>();
     // There is probbaly a bug in nvidia cuda docs and/or drivers: According to
     // https://docs.nvidia.com/cuda/cublas/index.html#cublas-GemmEx computeType
@@ -186,6 +185,7 @@ cudaDataType_t getComputeType<half>() {
     // returns OK. At the moment let's comment out : the drawback is just that
     // the speed of f16 computation on these GPUs is very slow:
     //
+    // auto dev            = getDeviceProp(getActiveDeviceId());
     // if (dev.major == // 6 && dev.minor == 1) { algo = CUDA_R_32F; }
 
     return algo;
@@ -193,9 +193,7 @@ cudaDataType_t getComputeType<half>() {
 
 template<typename T>
 cublasGemmAlgo_t selectGEMMAlgorithm() {
-    auto dev              = getDeviceProp(getActiveDeviceId());
-    cublasGemmAlgo_t algo = CUBLAS_GEMM_DEFAULT;
-    return algo;
+    return CUBLAS_GEMM_DEFAULT;
 }
 
 template<>

--- a/src/backend/cuda/cholesky.cpp
+++ b/src/backend/cuda/cholesky.cpp
@@ -41,16 +41,16 @@ namespace cuda {
 
 template<typename T>
 struct potrf_func_def_t {
-    typedef cusolverStatus_t (*potrf_func_def)(cusolverDnHandle_t,
-                                               cublasFillMode_t, int, T *, int,
-                                               T *, int, int *);
+    using potrf_func_def = cusolverStatus_t (*)(cusolverDnHandle_t,
+                                                cublasFillMode_t, int, T *, int,
+                                                T *, int, int *);
 };
 
 template<typename T>
 struct potrf_buf_func_def_t {
-    typedef cusolverStatus_t (*potrf_buf_func_def)(cusolverDnHandle_t,
-                                                   cublasFillMode_t, int, T *,
-                                                   int, int *);
+    using potrf_buf_func_def = cusolverStatus_t (*)(cusolverDnHandle_t,
+                                                    cublasFillMode_t, int, T *,
+                                                    int, int *);
 };
 
 #define CH_FUNC_DEF(FUNC)                                         \
@@ -85,10 +85,11 @@ Array<T> cholesky(int *info, const Array<T> &in, const bool is_upper) {
     Array<T> out = copyArray<T>(in);
     *info        = cholesky_inplace(out, is_upper);
 
-    if (is_upper)
+    if (is_upper) {
         triangle<T, true, false>(out, out);
-    else
+    } else {
         triangle<T, false, false>(out, out);
+    }
 
     return out;
 }
@@ -101,7 +102,7 @@ int cholesky_inplace(Array<T> &in, const bool is_upper) {
     int lwork = 0;
 
     cublasFillMode_t uplo = CUBLAS_FILL_MODE_LOWER;
-    if (is_upper) uplo = CUBLAS_FILL_MODE_UPPER;
+    if (is_upper) { uplo = CUBLAS_FILL_MODE_UPPER; }
 
     CUSOLVER_CHECK(potrf_buf_func<T>()(solverDnHandle(), uplo, N, in.get(),
                                        in.strides()[1], &lwork));

--- a/src/backend/cuda/convolve.cpp
+++ b/src/backend/cuda/convolve.cpp
@@ -66,8 +66,8 @@ Array<T> convolve2(Array<T> const &signal, Array<accT> const &c_filter,
     const dim_t rfLen = rfDims.elements();
 
     const dim4 &sDims = signal.dims();
-    dim4 tDims       = sDims;
-    dim4 oDims       = sDims;
+    dim4 tDims        = sDims;
+    dim4 oDims        = sDims;
 
     if (expand) {
         tDims[0] += cfLen - 1;

--- a/src/backend/cuda/convolve.cpp
+++ b/src/backend/cuda/convolve.cpp
@@ -30,8 +30,8 @@ namespace cuda {
 template<typename T, typename accT, dim_t baseDim, bool expand>
 Array<T> convolve(Array<T> const &signal, Array<accT> const &filter,
                   AF_BATCH_KIND kind) {
-    const dim4 sDims = signal.dims();
-    const dim4 fDims = filter.dims();
+    const dim4 &sDims = signal.dims();
+    const dim4 &fDims = filter.dims();
 
     dim4 oDims(1);
     if (expand) {
@@ -45,7 +45,7 @@ Array<T> convolve(Array<T> const &signal, Array<accT> const &filter,
     } else {
         oDims = sDims;
         if (kind == AF_BATCH_RHS) {
-            for (dim_t i = baseDim; i < 4; ++i) oDims[i] = fDims[i];
+            for (dim_t i = baseDim; i < 4; ++i) { oDims[i] = fDims[i]; }
         }
     }
 
@@ -59,13 +59,13 @@ Array<T> convolve(Array<T> const &signal, Array<accT> const &filter,
 template<typename T, typename accT, bool expand>
 Array<T> convolve2(Array<T> const &signal, Array<accT> const &c_filter,
                    Array<accT> const &r_filter) {
-    const dim4 cfDims = c_filter.dims();
-    const dim4 rfDims = r_filter.dims();
+    const dim4 &cfDims = c_filter.dims();
+    const dim4 &rfDims = r_filter.dims();
 
     const dim_t cfLen = cfDims.elements();
     const dim_t rfLen = rfDims.elements();
 
-    const dim4 sDims = signal.dims();
+    const dim4 &sDims = signal.dims();
     dim4 tDims       = sDims;
     dim4 oDims       = sDims;
 

--- a/src/backend/cuda/convolveNN.cpp
+++ b/src/backend/cuda/convolveNN.cpp
@@ -209,6 +209,7 @@ Array<T> data_gradient_base(const Array<T> &incoming_gradient,
                             const Array<T> &original_filter,
                             const Array<T> &convolved_output, af::dim4 stride,
                             af::dim4 padding, af::dim4 dilation) {
+    UNUSED(convolved_output);
     const dim4 &cDims = incoming_gradient.dims();
     const dim4 &sDims = original_signal.dims();
     const dim4 &fDims = original_filter.dims();
@@ -250,6 +251,7 @@ Array<T> data_gradient_cudnn(const Array<T> &incoming_gradient,
                              const Array<T> &original_filter,
                              const Array<T> &convolved_output, af::dim4 stride,
                              af::dim4 padding, af::dim4 dilation) {
+    UNUSED(convolved_output);
     auto cudnn = nnHandle();
 
     const dim4 &iDims = incoming_gradient.dims();
@@ -333,6 +335,7 @@ Array<T> filter_gradient_base(const Array<T> &incoming_gradient,
                               const Array<T> &original_filter,
                               const Array<T> &convolved_output, af::dim4 stride,
                               af::dim4 padding, af::dim4 dilation) {
+    UNUSED(convolved_output);
     const dim4 &cDims = incoming_gradient.dims();
     const dim4 &sDims = original_signal.dims();
     const dim4 &fDims = original_filter.dims();
@@ -372,6 +375,7 @@ Array<T> filter_gradient_cudnn(const Array<T> &incoming_gradient,
                                const Array<T> &convolved_output,
                                af::dim4 stride, af::dim4 padding,
                                af::dim4 dilation) {
+    UNUSED(convolved_output);
     auto cudnn = nnHandle();
 
     const dim4 &iDims = incoming_gradient.dims();

--- a/src/backend/cuda/convolveNN.cpp
+++ b/src/backend/cuda/convolveNN.cpp
@@ -59,7 +59,7 @@ Array<T> convolve2_cudnn(const Array<T> &signal, const Array<T> &filter,
                          const dim4 &dilation) {
     cudnnHandle_t cudnn = nnHandle();
 
-    dim4 sDims = signal.dims();
+    dim4 sDims        = signal.dims();
     const dim4 &fDims = filter.dims();
 
     const int n = sDims[3];
@@ -253,8 +253,8 @@ Array<T> data_gradient_cudnn(const Array<T> &incoming_gradient,
     auto cudnn = nnHandle();
 
     const dim4 &iDims = incoming_gradient.dims();
-    dim4 sDims = original_signal.dims();
-    dim4 fDims = original_filter.dims();
+    dim4 sDims        = original_signal.dims();
+    dim4 fDims        = original_filter.dims();
 
     cudnnDataType_t cudnn_dtype = getCudnnDataType<T>();
 

--- a/src/backend/cuda/convolveNN.cpp
+++ b/src/backend/cuda/convolveNN.cpp
@@ -41,7 +41,7 @@ namespace cuda {
 
 template<typename Desc, typename T>
 unique_handle<Desc> toCudnn(Array<T> arr) {
-    dim4 dims = arr.dims();
+    const dim4 &dims = arr.dims();
 
     auto descriptor             = make_handle<Desc>();
     cudnnDataType_t cudnn_dtype = getCudnnDataType<T>();
@@ -55,12 +55,12 @@ using scale_type =
 
 template<typename T>
 Array<T> convolve2_cudnn(const Array<T> &signal, const Array<T> &filter,
-                         const dim4 stride, const dim4 padding,
-                         const dim4 dilation) {
+                         const dim4 &stride, const dim4 &padding,
+                         const dim4 &dilation) {
     cudnnHandle_t cudnn = nnHandle();
 
     dim4 sDims = signal.dims();
-    dim4 fDims = filter.dims();
+    const dim4 &fDims = filter.dims();
 
     const int n = sDims[3];
     const int c = sDims[2];
@@ -115,8 +115,8 @@ Array<T> convolve2_cudnn(const Array<T> &signal, const Array<T> &filter,
     auto workspace_buffer = memAlloc<char>(workspace_bytes);
 
     // perform convolution
-    scale_type<T> alpha = scalar<scale_type<T>>(1.0);
-    scale_type<T> beta  = scalar<scale_type<T>>(0.0);
+    auto alpha = scalar<scale_type<T>>(1.0);
+    auto beta  = scalar<scale_type<T>>(0.0);
     CUDNN_CHECK(cuda::cudnnConvolutionForward(
         cudnn, &alpha, input_descriptor, signal.device(), filter_descriptor,
         filter.device(), convolution_descriptor, convolution_algorithm,
@@ -138,8 +138,8 @@ constexpr void checkTypeSupport() {
 
 template<typename T>
 Array<T> convolve2_base(const Array<T> &signal, const Array<T> &filter,
-                        const dim4 stride, const dim4 padding,
-                        const dim4 dilation) {
+                        const dim4 &stride, const dim4 &padding,
+                        const dim4 &dilation) {
     dim4 sDims = signal.dims();
     dim4 fDims = filter.dims();
 
@@ -209,9 +209,9 @@ Array<T> data_gradient_base(const Array<T> &incoming_gradient,
                             const Array<T> &original_filter,
                             const Array<T> &convolved_output, af::dim4 stride,
                             af::dim4 padding, af::dim4 dilation) {
-    const dim4 cDims = incoming_gradient.dims();
-    const dim4 sDims = original_signal.dims();
-    const dim4 fDims = original_filter.dims();
+    const dim4 &cDims = incoming_gradient.dims();
+    const dim4 &sDims = original_signal.dims();
+    const dim4 &fDims = original_filter.dims();
 
     Array<T> collapsed_filter = original_filter;
 
@@ -252,7 +252,7 @@ Array<T> data_gradient_cudnn(const Array<T> &incoming_gradient,
                              af::dim4 padding, af::dim4 dilation) {
     auto cudnn = nnHandle();
 
-    dim4 iDims = incoming_gradient.dims();
+    const dim4 &iDims = incoming_gradient.dims();
     dim4 sDims = original_signal.dims();
     dim4 fDims = original_filter.dims();
 
@@ -295,8 +295,8 @@ Array<T> data_gradient_cudnn(const Array<T> &incoming_gradient,
     auto workspace_buffer = memAlloc<char>(workspace_bytes);
 
     // perform convolution
-    scale_type<T> alpha = scalar<scale_type<T>>(1.0);
-    scale_type<T> beta  = scalar<scale_type<T>>(0.0);
+    auto alpha = scalar<scale_type<T>>(1.0);
+    auto beta  = scalar<scale_type<T>>(0.0);
 
     CUDNN_CHECK(cuda::cudnnConvolutionBackwardData(
         cudnn, &alpha, w_descriptor, original_filter.get(), dy_descriptor,
@@ -333,9 +333,9 @@ Array<T> filter_gradient_base(const Array<T> &incoming_gradient,
                               const Array<T> &original_filter,
                               const Array<T> &convolved_output, af::dim4 stride,
                               af::dim4 padding, af::dim4 dilation) {
-    const dim4 cDims = incoming_gradient.dims();
-    const dim4 sDims = original_signal.dims();
-    const dim4 fDims = original_filter.dims();
+    const dim4 &cDims = incoming_gradient.dims();
+    const dim4 &sDims = original_signal.dims();
+    const dim4 &fDims = original_filter.dims();
 
     const bool retCols = false;
     Array<T> unwrapped =
@@ -374,9 +374,9 @@ Array<T> filter_gradient_cudnn(const Array<T> &incoming_gradient,
                                af::dim4 dilation) {
     auto cudnn = nnHandle();
 
-    dim4 iDims = incoming_gradient.dims();
-    dim4 sDims = original_signal.dims();
-    dim4 fDims = original_filter.dims();
+    const dim4 &iDims = incoming_gradient.dims();
+    const dim4 &sDims = original_signal.dims();
+    const dim4 &fDims = original_filter.dims();
 
     // create dx descriptor
     cudnnDataType_t cudnn_dtype = getCudnnDataType<T>();
@@ -410,8 +410,8 @@ Array<T> filter_gradient_cudnn(const Array<T> &incoming_gradient,
     auto workspace_buffer = memAlloc<char>(workspace_bytes);
 
     // perform convolution
-    scale_type<T> alpha = scalar<scale_type<T>>(1.0);
-    scale_type<T> beta  = scalar<scale_type<T>>(0.0);
+    auto alpha = scalar<scale_type<T>>(1.0);
+    auto beta  = scalar<scale_type<T>>(0.0);
     CUDNN_CHECK(cuda::cudnnConvolutionBackwardFilter(
         cudnn, &alpha, x_descriptor, original_signal.device(), dy_descriptor,
         incoming_gradient.device(), convolution_descriptor,

--- a/src/backend/cuda/copy.cpp
+++ b/src/backend/cuda/copy.cpp
@@ -44,7 +44,6 @@ void copyData(T *dst, const Array<T> &src) {
     CUDA_CHECK(cudaMemcpyAsync(dst, ptr, src.elements() * sizeof(T),
                                cudaMemcpyDeviceToHost, stream));
     CUDA_CHECK(cudaStreamSynchronize(stream));
-    return;
 }
 
 template<typename T>
@@ -221,7 +220,7 @@ INSTANTIATE_PAD_ARRAY_COMPLEX(cdouble)
 
 template<typename T>
 T getScalar(const Array<T> &in) {
-    T retVal;
+    T retVal{};
     CUDA_CHECK(cudaMemcpyAsync(&retVal, in.get(), sizeof(T),
                                cudaMemcpyDeviceToHost,
                                cuda::getActiveStream()));

--- a/src/backend/cuda/cudnnModule.cpp
+++ b/src/backend/cuda/cudnnModule.cpp
@@ -135,7 +135,7 @@ cudnnModule::cudnnModule()
 }
 
 cudnnModule& getCudnnPlugin() noexcept {
-    static cudnnModule* plugin = new cudnnModule();
+    static auto* plugin = new cudnnModule();
     return *plugin;
 }
 

--- a/src/backend/cuda/cudnnModule.cpp
+++ b/src/backend/cuda/cudnnModule.cpp
@@ -16,6 +16,7 @@
 #include <string>
 #include <tuple>
 
+using std::make_tuple;
 using std::string;
 
 namespace cuda {
@@ -25,10 +26,10 @@ spdlog::logger* cudnnModule::getLogger() const noexcept {
 }
 
 auto cudnnVersionComponents(size_t version) {
-    int major = version / 1000;
-    int minor = (version - (major * 1000)) / 100;
-    int patch = (version - (major * 1000) - (minor * 100));
-    return std::tuple<int, int, int>(major, minor, patch);
+    size_t major = version / 1000;
+    size_t minor = (version - (major * 1000)) / 100;
+    size_t patch = (version - (major * 1000) - (minor * 100));
+    return make_tuple(major, minor, patch);
 }
 
 cudnnModule::cudnnModule()
@@ -48,8 +49,8 @@ cudnnModule::cudnnModule()
     MODULE_FUNCTION_INIT(cudnnGetVersion);
 
     int rtmajor, rtminor;
-    int cudnn_version             = this->cudnnGetVersion();
-    int cudnn_rtversion           = 0;
+    size_t cudnn_version          = this->cudnnGetVersion();
+    size_t cudnn_rtversion        = 0;
     std::tie(major, minor, patch) = cudnnVersionComponents(cudnn_version);
 
     if (cudnn_version >= 6000) {

--- a/src/backend/cuda/cudnnModule.hpp
+++ b/src/backend/cuda/cudnnModule.hpp
@@ -35,7 +35,7 @@ namespace cuda {
 
 class cudnnModule {
     common::DependencyModule module;
-    int major, minor, patch;
+    int major{}, minor{}, patch{};
 
    public:
     cudnnModule();

--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -156,7 +156,7 @@ pair<int, int> getComputeCapability(const int device) {
 }
 
 // pulled from CUTIL from CUDA SDK
-static inline int compute2cores(int major, int minor) {
+static inline int compute2cores(unsigned major, unsigned minor) {
     struct {
         int compute;  // 0xMm (hex), M = major version, m = minor version
         int cores;
@@ -168,7 +168,7 @@ static inline int compute2cores(int major, int minor) {
     };
 
     for (int i = 0; gpus[i].compute != -1; ++i) {
-        if (gpus[i].compute == (major << 4) + minor) { return gpus[i].cores; }
+        if (gpus[i].compute == (major << 4U) + minor) { return gpus[i].cores; }
     }
     return 0;
 }
@@ -476,7 +476,7 @@ void DeviceManager::checkCudaVsDriverVersion() {
 /// are assuming that the initilization is done in the main thread.
 void initNvrtc() {
     nvrtcProgram prog;
-    auto err = nvrtcCreateProgram(&prog, " ", "dummy", 0, nullptr, nullptr);
+    nvrtcCreateProgram(&prog, " ", "dummy", 0, nullptr, nullptr);
     nvrtcDestroyProgram(&prog);
 }
 
@@ -540,7 +540,7 @@ DeviceManager::DeviceManager()
     // Initialize all streams to 0.
     // Streams will be created in setActiveDevice()
     for (size_t i = 0; i < MAX_DEVICES; i++) {
-        streams[i] = (cudaStream_t)0;
+        streams[i] = static_cast<cudaStream_t>(0);
         if (i < nDevices) {
             auto prop =
                 make_pair(cuDevices[i].prop.major, cuDevices[i].prop.minor);

--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -94,10 +94,11 @@ bool checkDeviceWithRuntime(int runtime, pair<int, int> compute) {
     }
 
     if (rt->major >= compute.first) {
-        if (rt->major == compute.first)
+        if (rt->major == compute.first) {
             return rt->minor >= compute.second;
-        else
+        } else {
             return true;
+        }
     } else {
         return false;
     }
@@ -167,7 +168,7 @@ static inline int compute2cores(int major, int minor) {
     };
 
     for (int i = 0; gpus[i].compute != -1; ++i) {
-        if (gpus[i].compute == (major << 4) + minor) return gpus[i].cores;
+        if (gpus[i].compute == (major << 4) + minor) { return gpus[i].cores; }
     }
     return 0;
 }
@@ -263,7 +264,7 @@ bool DeviceManager::checkGraphicsInteropCapability() {
 }
 
 DeviceManager &DeviceManager::getInstance() {
-    static DeviceManager *my_instance = new DeviceManager();
+    static auto *my_instance = new DeviceManager();
     return *my_instance;
 }
 
@@ -477,7 +478,6 @@ void initNvrtc() {
     nvrtcProgram prog;
     auto err = nvrtcCreateProgram(&prog, " ", "dummy", 0, nullptr, nullptr);
     nvrtcDestroyProgram(&prog);
-    return;
 }
 
 DeviceManager::DeviceManager()
@@ -501,7 +501,7 @@ DeviceManager::DeviceManager()
         int cudaMajorVer = cudaRtVer / 1000;
 
         for (int i = 0; i < nDevices; i++) {
-            cudaDevice_t dev;
+            cudaDevice_t dev{};
             CUDA_CHECK(cudaGetDeviceProperties(&dev.prop, i));
             if (dev.prop.major < getMinSupportedCompute(cudaMajorVer)) {
                 AF_TRACE("Unsuppored device: {}", dev.prop.name);
@@ -601,11 +601,11 @@ int DeviceManager::setActiveDevice(int device, int nId) {
 
     int numDevices = cuDevices.size();
 
-    if (device >= numDevices) return -1;
+    if (device >= numDevices) { return -1; }
 
     int old = getActiveDeviceId();
 
-    if (nId == -1) nId = getDeviceNativeId(device);
+    if (nId == -1) { nId = getDeviceNativeId(device); }
 
     cudaError_t err = cudaSetDevice(nId);
 
@@ -645,7 +645,7 @@ int DeviceManager::setActiveDevice(int device, int nId) {
         // otherwise fails streamCreate with this error.
         // All other errors will error out
         device++;
-        if (device >= numDevices) break;
+        if (device >= numDevices) { break; }
 
         // Can't call getNativeId here as it will cause an infinite loop with
         // the constructor

--- a/src/backend/cuda/device_manager.hpp
+++ b/src/backend/cuda/device_manager.hpp
@@ -112,7 +112,7 @@ class DeviceManager {
     void checkCudaVsDriverVersion();
     void sortDevices(sort_mode mode = flops);
 
-    int setActiveDevice(int device, int native = -1);
+    int setActiveDevice(int device, int nId = -1);
 
     std::shared_ptr<spdlog::logger> logger;
 
@@ -120,7 +120,7 @@ class DeviceManager {
     std::vector<std::pair<int, int>> devJitComputes;
 
     int nDevices;
-    cudaStream_t streams[MAX_DEVICES];
+    cudaStream_t streams[MAX_DEVICES]{};
 
     std::unique_ptr<graphics::ForgeManager> fgMngr;
 

--- a/src/backend/cuda/device_manager.hpp
+++ b/src/backend/cuda/device_manager.hpp
@@ -74,7 +74,7 @@ class DeviceManager {
 
     friend std::string getPlatformInfo() noexcept;
 
-    friend std::string getDriverVersion();
+    friend std::string getDriverVersion() noexcept;
 
     friend std::string getCUDARuntimeVersion() noexcept;
 

--- a/src/backend/cuda/diff.cpp
+++ b/src/backend/cuda/diff.cpp
@@ -17,7 +17,7 @@ namespace cuda {
 
 template<typename T>
 Array<T> diff(const Array<T> &in, const int dim, const bool isDiff2) {
-    const af::dim4 iDims = in.dims();
+    const af::dim4 &iDims = in.dims();
     af::dim4 oDims       = iDims;
     oDims[dim] -= (isDiff2 + 1);
 

--- a/src/backend/cuda/diff.cpp
+++ b/src/backend/cuda/diff.cpp
@@ -18,7 +18,7 @@ namespace cuda {
 template<typename T>
 Array<T> diff(const Array<T> &in, const int dim, const bool isDiff2) {
     const af::dim4 &iDims = in.dims();
-    af::dim4 oDims       = iDims;
+    af::dim4 oDims        = iDims;
     oDims[dim] -= (isDiff2 + 1);
 
     if (iDims.elements() == 0 || oDims.elements() == 0) {

--- a/src/backend/cuda/driver.cpp
+++ b/src/backend/cuda/driver.cpp
@@ -8,8 +8,8 @@
  ********************************************************/
 
 #include <driver.h>
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 #ifdef OS_WIN
 #include <stdlib.h>
@@ -59,34 +59,39 @@ int nvDriverVersion(char *result, int len) {
     char buffer[1024];
     FILE *f = NULL;
 
-    if (NULL == (f = fopen("/proc/driver/nvidia/version", "r"))) { return 0; }
+    if (NULL == (f = fopen("/proc/driver/nvidia/version", "re"))) { return 0; }
     if (fgets(buffer, 1024, f) == NULL) {
-        if (f) fclose(f);
+        if (f) { fclose(f); }
         return 0;
     }
 
     // just close it now since we've already read what we need
-    if (f) fclose(f);
+    if (f) { fclose(f); }
 
     for (i = 1; i < 8; i++) {
-        while (buffer[pos] != ' ' && buffer[pos] != '\t')
-            if (pos >= 1024 || buffer[pos] == '\0' || buffer[pos] == '\n')
+        while (buffer[pos] != ' ' && buffer[pos] != '\t') {
+            if (pos >= 1024 || buffer[pos] == '\0' || buffer[pos] == '\n') {
                 return 0;
-            else
+            } else {
                 pos++;
-        while (buffer[pos] == ' ' || buffer[pos] == '\t')
-            if (pos >= 1024 || buffer[pos] == '\0' || buffer[pos] == '\n')
+            }
+        }
+        while (buffer[pos] == ' ' || buffer[pos] == '\t') {
+            if (pos >= 1024 || buffer[pos] == '\0' || buffer[pos] == '\n') {
                 return 0;
-            else
+            } else {
                 pos++;
+            }
+        }
     }
 
     epos = pos;
     while (buffer[epos] != ' ' && buffer[epos] != '\t') {
-        if (epos >= 1024 || buffer[epos] == '\0' || buffer[epos] == '\n')
+        if (epos >= 1024 || buffer[epos] == '\0' || buffer[epos] == '\n') {
             return 0;
-        else
+        } else {
             epos++;
+        }
     }
 
     buffer[epos] = '\0';

--- a/src/backend/cuda/driver.h
+++ b/src/backend/cuda/driver.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-int nvDriverVersion(char *buffer, int len);
+int nvDriverVersion(char *result, int len);
 
 #ifdef __cplusplus
 }

--- a/src/backend/cuda/fast_pyramid.cpp
+++ b/src/backend/cuda/fast_pyramid.cpp
@@ -36,10 +36,10 @@ void fast_pyramid(vector<unsigned> &feat_pyr, vector<Array<float>> &x_pyr,
         min_side /= scl_fctr;
 
         // Minimum image side for a descriptor to be computed
-        if (min_side < patch_size || max_levels == levels) break;
+        if (min_side < patch_size || max_levels == levels) { break; }
 
         max_levels++;
-        scl_sum += 1.f / (float)std::pow(scl_fctr, (float)i);
+        scl_sum += 1.f / std::pow(scl_fctr, static_cast<float>(i));
     }
 
     // Compute number of features to keep for each level
@@ -47,13 +47,14 @@ void fast_pyramid(vector<unsigned> &feat_pyr, vector<Array<float>> &x_pyr,
     lvl_scl.resize(max_levels);
     unsigned feat_sum = 0;
     for (unsigned i = 0; i < max_levels - 1; i++) {
-        float scl  = (float)std::pow(scl_fctr, (float)i);
+        auto scl   = std::pow(scl_fctr, static_cast<float>(i));
         lvl_scl[i] = scl;
 
         lvl_best[i] = ceil((max_feat / scl_sum) / lvl_scl[i]);
         feat_sum += lvl_best[i];
     }
-    lvl_scl[max_levels - 1]  = (float)std::pow(scl_fctr, (float)max_levels - 1);
+    lvl_scl[max_levels - 1] =
+        std::pow(scl_fctr, static_cast<float>(max_levels) - 1);
     lvl_best[max_levels - 1] = max_feat - feat_sum;
 
     // Hold multi-scale image pyramids

--- a/src/backend/cuda/fast_pyramid.hpp
+++ b/src/backend/cuda/fast_pyramid.hpp
@@ -19,7 +19,7 @@ void fast_pyramid(std::vector<unsigned> &feat_pyr,
                   std::vector<Array<float>> &d_x_pyr,
                   std::vector<Array<float>> &d_y_pyr,
                   std::vector<unsigned> &lvl_best, std::vector<float> &lvl_scl,
-                  std::vector<Array<T>> &img_pyr, const Array<T> &image,
+                  std::vector<Array<T>> &img_pyr, const Array<T> &in,
                   const float fast_thr, const unsigned max_feat,
                   const float scl_fctr, const unsigned levels,
                   const unsigned patch_size);

--- a/src/backend/cuda/fftconvolve.cpp
+++ b/src/backend/cuda/fftconvolve.cpp
@@ -20,20 +20,21 @@ using af::dim4;
 namespace cuda {
 
 template<typename T>
-const dim4 calcPackedSize(Array<T> const& i1, Array<T> const& i2,
-                          const dim_t baseDim) {
-    const dim4 i1d = i1.dims();
-    const dim4 i2d = i2.dims();
+dim4 calcPackedSize(Array<T> const& i1, Array<T> const& i2,
+                    const dim_t baseDim) {
+    const dim4& i1d = i1.dims();
+    const dim4& i2d = i2.dims();
 
     dim_t pd[4] = {1, 1, 1, 1};
 
     dim_t max_d0 = (i1d[0] > i2d[0]) ? i1d[0] : i2d[0];
     dim_t min_d0 = (i1d[0] < i2d[0]) ? i1d[0] : i2d[0];
-    pd[0]        = nextpow2((unsigned)((int)ceil(max_d0 / 2.f) + min_d0 - 1));
+    pd[0]        = nextpow2(static_cast<unsigned>(
+        static_cast<int>(ceil(max_d0 / 2.f)) + min_d0 - 1));
 
     for (dim_t k = 1; k < 4; k++) {
         if (k < baseDim) {
-            pd[k] = nextpow2((unsigned)(i1d[k] + i2d[k] - 1));
+            pd[k] = nextpow2(static_cast<unsigned>(i1d[k] + i2d[k] - 1));
         } else {
             pd[k] = i1d[k];
         }
@@ -46,8 +47,8 @@ template<typename T, typename convT, typename cT, bool isDouble, bool roundOut,
          dim_t baseDim>
 Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
                      const bool expand, AF_BATCH_KIND kind) {
-    const dim4 sDims = signal.dims();
-    const dim4 fDims = filter.dims();
+    const dim4& sDims = signal.dims();
+    const dim4& fDims = filter.dims();
 
     dim4 oDims(1);
     if (expand) {
@@ -61,7 +62,7 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
     } else {
         oDims = sDims;
         if (kind == AF_BATCH_RHS) {
-            for (dim_t i = baseDim; i < 4; ++i) oDims[i] = fDims[i];
+            for (dim_t i = baseDim; i < 4; ++i) { oDims[i] = fDims[i]; }
         }
     }
 
@@ -81,20 +82,22 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
 
     if (kind == AF_BATCH_RHS) {
         fft_inplace<cT, baseDim, false>(filter_packed);
-        if (expand)
+        if (expand) {
             kernel::reorderOutputHelper<T, cT, roundOut, baseDim, true>(
                 out, filter_packed, signal, filter);
-        else
+        } else {
             kernel::reorderOutputHelper<T, cT, roundOut, baseDim, false>(
                 out, filter_packed, signal, filter);
+        }
     } else {
         fft_inplace<cT, baseDim, false>(signal_packed);
-        if (expand)
+        if (expand) {
             kernel::reorderOutputHelper<T, cT, roundOut, baseDim, true>(
                 out, signal_packed, signal, filter);
-        else
+        } else {
             kernel::reorderOutputHelper<T, cT, roundOut, baseDim, false>(
                 out, signal_packed, signal, filter);
+        }
     }
 
     return out;

--- a/src/backend/cuda/hist_graphics.cpp
+++ b/src/backend/cuda/hist_graphics.cpp
@@ -43,7 +43,8 @@ void copy_histogram(const Array<T> &data, fg_histogram hist) {
 
         CheckGL("Begin CUDA fallback-resource copy");
         glBindBuffer(GL_ARRAY_BUFFER, buffer);
-        GLubyte *ptr = (GLubyte *)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        auto *ptr =
+            static_cast<GLubyte *>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
         if (ptr) {
             CUDA_CHECK(cudaMemcpyAsync(ptr, data.get(), bytes,
                                        cudaMemcpyDeviceToHost, stream));

--- a/src/backend/cuda/histogram.cpp
+++ b/src/backend/cuda/histogram.cpp
@@ -22,7 +22,7 @@ namespace cuda {
 template<typename inType, typename outType, bool isLinear>
 Array<outType> histogram(const Array<inType> &in, const unsigned &nbins,
                          const double &minval, const double &maxval) {
-    const dim4 dims    = in.dims();
+    const dim4 &dims   = in.dims();
     dim4 outDims       = dim4(nbins, 1, dims[2], dims[3]);
     Array<outType> out = createValueArray<outType>(outDims, outType(0));
 

--- a/src/backend/cuda/iir.cpp
+++ b/src/backend/cuda/iir.cpp
@@ -34,7 +34,7 @@ Array<T> iir(const Array<T> &b, const Array<T> &a, const Array<T> &x) {
 
     int num_a = a.dims()[0];
 
-    if (num_a == 1) return c;
+    if (num_a == 1) { return c; }
 
     dim4 ydims = c.dims();
     Array<T> y = createEmptyArray<T>(ydims);

--- a/src/backend/cuda/image.cpp
+++ b/src/backend/cuda/image.cpp
@@ -47,8 +47,8 @@ void copy_image(const Array<T> &in, fg_image image) {
 
         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, buffer);
         glBufferData(GL_PIXEL_UNPACK_BUFFER, data_size, 0, GL_STREAM_DRAW);
-        GLubyte *ptr =
-            (GLubyte *)glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY);
+        auto *ptr = static_cast<GLubyte *>(
+            glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY));
         if (ptr) {
             CUDA_CHECK(cudaMemcpyAsync(ptr, in.get(), data_size,
                                        cudaMemcpyDeviceToHost, stream));

--- a/src/backend/cuda/index.cpp
+++ b/src/backend/cuda/index.cpp
@@ -33,7 +33,7 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
     }
 
     // retrieve dimensions, strides and offsets
-    dim4 iDims  = in.dims();
+    const dim4& iDims = in.dims();
     dim4 dDims  = in.getDataDims();
     dim4 oDims  = toDims(seqs, iDims);
     dim4 iOffs  = toOffset(seqs, dDims);

--- a/src/backend/cuda/index.cpp
+++ b/src/backend/cuda/index.cpp
@@ -34,10 +34,10 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
 
     // retrieve dimensions, strides and offsets
     const dim4& iDims = in.dims();
-    dim4 dDims  = in.getDataDims();
-    dim4 oDims  = toDims(seqs, iDims);
-    dim4 iOffs  = toOffset(seqs, dDims);
-    dim4 iStrds = in.strides();
+    dim4 dDims        = in.getDataDims();
+    dim4 oDims        = toDims(seqs, iDims);
+    dim4 iOffs        = toOffset(seqs, dDims);
+    dim4 iStrds       = in.strides();
 
     for (dim_t i = 0; i < 4; ++i) {
         p.isSeq[i] = idxrs[i].isSeq;

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -362,21 +362,30 @@ template void evalNodes<short>(Param<short> out, Node *node);
 template void evalNodes<ushort>(Param<ushort> out, Node *node);
 template void evalNodes<half>(Param<half> out, Node *node);
 
-template void evalNodes<float>(vector<Param<float>> &out, const vector<Node *> &node);
+template void evalNodes<float>(vector<Param<float>> &out,
+                               const vector<Node *> &node);
 template void evalNodes<double>(vector<Param<double>> &out,
                                 const vector<Node *> &node);
 template void evalNodes<cfloat>(vector<Param<cfloat>> &out,
                                 const vector<Node *> &node);
 template void evalNodes<cdouble>(vector<Param<cdouble>> &out,
                                  const vector<Node *> &node);
-template void evalNodes<int>(vector<Param<int>> &out, const vector<Node *> &node);
-template void evalNodes<uint>(vector<Param<uint>> &out, const vector<Node *> &node);
-template void evalNodes<char>(vector<Param<char>> &out, const vector<Node *> &node);
-template void evalNodes<uchar>(vector<Param<uchar>> &out, const vector<Node *> &node);
-template void evalNodes<intl>(vector<Param<intl>> &out, const vector<Node *> &node);
-template void evalNodes<uintl>(vector<Param<uintl>> &out, const vector<Node *> &node);
-template void evalNodes<short>(vector<Param<short>> &out, const vector<Node *> &node);
+template void evalNodes<int>(vector<Param<int>> &out,
+                             const vector<Node *> &node);
+template void evalNodes<uint>(vector<Param<uint>> &out,
+                              const vector<Node *> &node);
+template void evalNodes<char>(vector<Param<char>> &out,
+                              const vector<Node *> &node);
+template void evalNodes<uchar>(vector<Param<uchar>> &out,
+                               const vector<Node *> &node);
+template void evalNodes<intl>(vector<Param<intl>> &out,
+                              const vector<Node *> &node);
+template void evalNodes<uintl>(vector<Param<uintl>> &out,
+                               const vector<Node *> &node);
+template void evalNodes<short>(vector<Param<short>> &out,
+                               const vector<Node *> &node);
 template void evalNodes<ushort>(vector<Param<ushort>> &out,
                                 const vector<Node *> &node);
-template void evalNodes<half>(vector<Param<half>> &out, const vector<Node *> &node);
+template void evalNodes<half>(vector<Param<half>> &out,
+                              const vector<Node *> &node);
 }  // namespace cuda

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -206,7 +206,7 @@ static CUfunction getKernel(const vector<Node *> &output_nodes,
                             const vector<const Node *> &full_nodes,
                             const vector<Node_ids> &full_ids,
                             const bool is_linear) {
-    typedef map<string, Kernel> kc_t;
+    using kc_t = map<string, Kernel>;
 
     thread_local kc_t kernelCaches[DeviceManager::MAX_DEVICES];
 
@@ -232,8 +232,8 @@ static CUfunction getKernel(const vector<Node *> &output_nodes,
 
 template<typename T>
 void evalNodes(vector<Param<T>> &outputs, const vector<Node *> &output_nodes) {
-    int num_outputs = (int)outputs.size();
-    int device      = getActiveDeviceId();
+    size_t num_outputs = outputs.size();
+    int device         = getActiveDeviceId();
 
     if (num_outputs == 0) { return; }
 
@@ -318,14 +318,14 @@ void evalNodes(vector<Param<T>> &outputs, const vector<Node *> &output_nodes) {
                       });
     }
 
-    for (int i = 0; i < num_outputs; i++) {
-        args.push_back((void *)&outputs[i]);
+    for (size_t i = 0; i < num_outputs; i++) {
+        args.push_back(static_cast<void *>(&outputs[i]));
     }
 
-    args.push_back((void *)&blocks_x_);
-    args.push_back((void *)&blocks_y_);
-    args.push_back((void *)&blocks_x_total);
-    args.push_back((void *)&num_odims);
+    args.push_back(static_cast<void *>(&blocks_x_));
+    args.push_back(static_cast<void *>(&blocks_y_));
+    args.push_back(static_cast<void *>(&blocks_x_total));
+    args.push_back(static_cast<void *>(&num_odims));
 
     CU_CHECK(cuLaunchKernel(ker, blocks_x, blocks_y, blocks_z, threads_x,
                             threads_y, 1, 0, getActiveStream(), args.data(),

--- a/src/backend/cuda/join.cpp
+++ b/src/backend/cuda/join.cpp
@@ -20,7 +20,7 @@ using common::half;
 
 namespace cuda {
 
-af::dim4 calcOffset(const af::dim4 dims, const int dim) {
+af::dim4 calcOffset(const af::dim4 &dims, const int dim) {
     af::dim4 offset;
     offset[0] = (dim == 0) * dims[0];
     offset[1] = (dim == 1) * dims[1];
@@ -77,7 +77,7 @@ Array<T> join(const int dim, const std::vector<Array<T>> &inputs) {
     std::vector<af::dim4> idims(n_arrays);
 
     dim_t dim_size = 0;
-    for (int i = 0; i < (int)idims.size(); i++) {
+    for (int i = 0; i < static_cast<int>(idims.size()); i++) {
         idims[i] = inputs[i].dims();
         dim_size += idims[i][dim];
     }

--- a/src/backend/cuda/lookup.cpp
+++ b/src/backend/cuda/lookup.cpp
@@ -20,11 +20,12 @@ namespace cuda {
 template<typename in_t, typename idx_t>
 Array<in_t> lookup(const Array<in_t> &input, const Array<idx_t> &indices,
                    const unsigned dim) {
-    const dim4 iDims = input.dims();
+    const dim4 &iDims = input.dims();
 
     dim4 oDims(1);
-    for (dim_t d = 0; d < 4; ++d)
+    for (dim_t d = 0; d < 4; ++d) {
         oDims[d] = (d == dim ? indices.elements() : iDims[d]);
+    }
 
     Array<in_t> out = createEmptyArray<in_t>(oDims);
 

--- a/src/backend/cuda/lu.cpp
+++ b/src/backend/cuda/lu.cpp
@@ -37,14 +37,14 @@ namespace cuda {
 
 template<typename T>
 struct getrf_func_def_t {
-    typedef cusolverStatus_t (*getrf_func_def)(cusolverDnHandle_t, int, int,
-                                               T *, int, T *, int *, int *);
+    using getrf_func_def = cusolverStatus_t (*)(cusolverDnHandle_t, int, int,
+                                                T *, int, T *, int *, int *);
 };
 
 template<typename T>
 struct getrf_buf_func_def_t {
-    typedef cusolverStatus_t (*getrf_buf_func_def)(cusolverDnHandle_t, int, int,
-                                                   T *, int, int *);
+    using getrf_buf_func_def = cusolverStatus_t (*)(cusolverDnHandle_t, int,
+                                                    int, T *, int, int *);
 };
 
 #define LU_FUNC_DEF(FUNC)                                         \
@@ -129,7 +129,7 @@ Array<int> lu_inplace(Array<T> &in, const bool convert_pivot) {
                                    in.strides()[1], workspace.get(),
                                    pivot.get(), info.get()));
 
-    if (convert_pivot) convertPivot(pivot, M);
+    if (convert_pivot) { convertPivot(pivot, M); }
 
     return pivot;
 }

--- a/src/backend/cuda/math.hpp
+++ b/src/backend/cuda/math.hpp
@@ -38,7 +38,7 @@ namespace cuda {
 
 template<typename T>
 static inline __DH__ T abs(T val) {
-    return abs(val);
+    return ::abs(val);
 }
 static inline __DH__ int abs(int val) { return (val > 0 ? val : -val); }
 static inline __DH__ char abs(char val) { return (val > 0 ? val : -val); }

--- a/src/backend/cuda/meanshift.cpp
+++ b/src/backend/cuda/meanshift.cpp
@@ -20,7 +20,7 @@ template<typename T>
 Array<T> meanshift(const Array<T> &in, const float &spatialSigma,
                    const float &chromaticSigma, const unsigned &numIterations,
                    const bool &isColor) {
-    const dim4 dims = in.dims();
+    const dim4 &dims = in.dims();
     Array<T> out    = createEmptyArray<T>(dims);
     kernel::meanshift<T>(out, in, spatialSigma, chromaticSigma, numIterations,
                          isColor);

--- a/src/backend/cuda/meanshift.cpp
+++ b/src/backend/cuda/meanshift.cpp
@@ -21,7 +21,7 @@ Array<T> meanshift(const Array<T> &in, const float &spatialSigma,
                    const float &chromaticSigma, const unsigned &numIterations,
                    const bool &isColor) {
     const dim4 &dims = in.dims();
-    Array<T> out    = createEmptyArray<T>(dims);
+    Array<T> out     = createEmptyArray<T>(dims);
     kernel::meanshift<T>(out, in, spatialSigma, chromaticSigma, numIterations,
                          isColor);
     return out;

--- a/src/backend/cuda/medfilt.cpp
+++ b/src/backend/cuda/medfilt.cpp
@@ -24,7 +24,7 @@ Array<T> medfilt1(const Array<T> &in, dim_t w_wid) {
     ARG_ASSERT(2, (w_wid % 2 != 0));
 
     const dim4 &dims = in.dims();
-    Array<T> out    = createEmptyArray<T>(dims);
+    Array<T> out     = createEmptyArray<T>(dims);
 
     kernel::medfilt1<T>(out, in, pad, w_wid);
 
@@ -37,7 +37,7 @@ Array<T> medfilt2(const Array<T> &in, dim_t w_len, dim_t w_wid) {
     ARG_ASSERT(2, (w_len % 2 != 0));
 
     const dim4 &dims = in.dims();
-    Array<T> out    = createEmptyArray<T>(dims);
+    Array<T> out     = createEmptyArray<T>(dims);
 
     kernel::medfilt2<T>(out, in, pad, w_len, w_wid);
 

--- a/src/backend/cuda/medfilt.cpp
+++ b/src/backend/cuda/medfilt.cpp
@@ -23,7 +23,7 @@ Array<T> medfilt1(const Array<T> &in, dim_t w_wid) {
     ARG_ASSERT(2, (w_wid <= kernel::MAX_MEDFILTER1_LEN));
     ARG_ASSERT(2, (w_wid % 2 != 0));
 
-    const dim4 dims = in.dims();
+    const dim4 &dims = in.dims();
     Array<T> out    = createEmptyArray<T>(dims);
 
     kernel::medfilt1<T>(out, in, pad, w_wid);
@@ -36,7 +36,7 @@ Array<T> medfilt2(const Array<T> &in, dim_t w_len, dim_t w_wid) {
     ARG_ASSERT(2, (w_len <= kernel::MAX_MEDFILTER2_LEN));
     ARG_ASSERT(2, (w_len % 2 != 0));
 
-    const dim4 dims = in.dims();
+    const dim4 &dims = in.dims();
     Array<T> out    = createEmptyArray<T>(dims);
 
     kernel::medfilt2<T>(out, in, pad, w_len, w_wid);

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -135,7 +135,7 @@ void Allocator::shutdown() {
         try {
             cuda::setDevice(n);
             shutdownMemoryManager();
-        } catch (AfError err) {
+        } catch (const AfError& err) {
             continue;  // Do not throw any errors while shutting down
         }
     }

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -76,7 +76,7 @@ void *memAllocUser(const size_t &bytes) {
 
 template<typename T>
 void memFree(T *ptr) {
-    memoryManager().unlock((void *)ptr, false);
+    memoryManager().unlock(static_cast<void *>(ptr), false);
 }
 
 void memFreeUser(void *ptr) { memoryManager().unlock(ptr, true); }
@@ -109,7 +109,7 @@ T *pinnedAlloc(const size_t &elements) {
 
 template<typename T>
 void pinnedFree(T *ptr) {
-    pinnedMemoryManager().unlock((void *)ptr, false);
+    pinnedMemoryManager().unlock(static_cast<void *>(ptr), false);
 }
 
 #define INSTANTIATE(T)                                 \

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -139,7 +139,7 @@ void Allocator::shutdown() {
         try {
             cuda::setDevice(n);
             shutdownMemoryManager();
-        } catch (const AfError& err) {
+        } catch (const AfError &err) {
             continue;  // Do not throw any errors while shutting down
         }
     }

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -47,7 +47,7 @@ void setMemStepSize(size_t step_bytes) {
     memoryManager().setMemStepSize(step_bytes);
 }
 
-size_t getMemStepSize(void) { return memoryManager().getMemStepSize(); }
+size_t getMemStepSize() { return memoryManager().getMemStepSize(); }
 
 void signalMemoryCleanup() { memoryManager().signalMemoryCleanup(); }
 
@@ -79,14 +79,18 @@ void memFree(T *ptr) {
     memoryManager().unlock((void *)ptr, false);
 }
 
-void memFreeUser(void *ptr) { memoryManager().unlock((void *)ptr, true); }
+void memFreeUser(void *ptr) { memoryManager().unlock(ptr, true); }
 
-void memLock(const void *ptr) { memoryManager().userLock((void *)ptr); }
+void memLock(const void *ptr) {
+    memoryManager().userLock(const_cast<void *>(ptr));
+}
 
-void memUnlock(const void *ptr) { memoryManager().userUnlock((void *)ptr); }
+void memUnlock(const void *ptr) {
+    memoryManager().userUnlock(const_cast<void *>(ptr));
+}
 
 bool isLocked(const void *ptr) {
-    return memoryManager().isUserLocked((void *)ptr);
+    return memoryManager().isUserLocked(const_cast<void *>(ptr));
 }
 
 void deviceMemoryInfo(size_t *alloc_bytes, size_t *alloc_buffers,

--- a/src/backend/cuda/moments.cpp
+++ b/src/backend/cuda/moments.cpp
@@ -16,10 +16,10 @@
 
 namespace cuda {
 
-static inline int bitCount(int v) {
-    v = v - ((v >> 1) & 0x55555555);
-    v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
-    return (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
+static inline unsigned bitCount(unsigned v) {
+    v = v - ((v >> 1U) & 0x55555555U);
+    v = (v & 0x33333333U) + ((v >> 2U) & 0x33333333U);
+    return (((v + (v >> 4U)) & 0xF0F0F0FU) * 0x1010101U) >> 24U;
 }
 
 using af::dim4;

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -53,6 +53,7 @@
 
 using std::accumulate;
 using std::array;
+using std::back_insert_iterator;
 using std::begin;
 using std::end;
 using std::extent;
@@ -257,7 +258,10 @@ Kernel buildKernel(const int device, const string &nameExpr,
 #endif
     };
     if (!isJIT) {
-        for (auto &s : opts) { compiler_options.push_back(&s[0]); }
+        transform(begin(opts), end(opts),
+                  back_insert_iterator<vector<const char *>>(compiler_options),
+                  [](const std::string &s) { return s.data(); });
+
         compiler_options.push_back("--device-as-default-execution-space");
         NVRTC_CHECK(nvrtcAddNameExpression(prog, ker_name));
     }
@@ -469,16 +473,16 @@ string toString(af_op_t val) {
 }
 
 template<>
-string toString(const char *str) {
-    return string(str);
+string toString(const char *val) {
+    return string(val);
 }
 
 template<>
-string toString(af_interp_type p) {
+string toString(af_interp_type val) {
     const char *retVal = NULL;
 #define CASE_STMT(v) \
     case v: retVal = #v; break
-    switch (p) {
+    switch (val) {
         CASE_STMT(AF_INTERP_NEAREST);
         CASE_STMT(AF_INTERP_LINEAR);
         CASE_STMT(AF_INTERP_BILINEAR);
@@ -495,11 +499,11 @@ string toString(af_interp_type p) {
 }
 
 template<>
-string toString(af_border_type p) {
+string toString(af_border_type val) {
     const char *retVal = NULL;
 #define CASE_STMT(v) \
     case v: retVal = #v; break
-    switch (p) {
+    switch (val) {
         CASE_STMT(AF_PAD_ZERO);
         CASE_STMT(AF_PAD_SYM);
         CASE_STMT(AF_PAD_CLAMP_TO_EDGE);
@@ -510,11 +514,11 @@ string toString(af_border_type p) {
 }
 
 template<>
-string toString(af_moment_type p) {
+string toString(af_moment_type val) {
     const char *retVal = NULL;
 #define CASE_STMT(v) \
     case v: retVal = #v; break
-    switch (p) {
+    switch (val) {
         CASE_STMT(AF_MOMENT_M00);
         CASE_STMT(AF_MOMENT_M01);
         CASE_STMT(AF_MOMENT_M10);
@@ -526,11 +530,11 @@ string toString(af_moment_type p) {
 }
 
 template<>
-string toString(af_match_type p) {
+string toString(af_match_type val) {
     const char *retVal = NULL;
 #define CASE_STMT(v) \
     case v: retVal = #v; break
-    switch (p) {
+    switch (val) {
         CASE_STMT(AF_SAD);
         CASE_STMT(AF_ZSAD);
         CASE_STMT(AF_LSAD);
@@ -539,47 +543,51 @@ string toString(af_match_type p) {
         CASE_STMT(AF_LSSD);
         CASE_STMT(AF_NCC);
         CASE_STMT(AF_ZNCC);
+        CASE_STMT(AF_SHD);
     }
 #undef CASE_STMT
     return retVal;
 }
 
 template<>
-string toString(af_flux_function p) {
+string toString(af_flux_function val) {
     const char *retVal = NULL;
 #define CASE_STMT(v) \
     case v: retVal = #v; break
-    switch (p) {
+    switch (val) {
         CASE_STMT(AF_FLUX_QUADRATIC);
         CASE_STMT(AF_FLUX_EXPONENTIAL);
+        CASE_STMT(AF_FLUX_DEFAULT);
     }
 #undef CASE_STMT
     return retVal;
 }
 
 template<>
-string toString(AF_BATCH_KIND p) {
+string toString(AF_BATCH_KIND val) {
     const char *retVal = NULL;
 #define CASE_STMT(v) \
     case v: retVal = #v; break
-    switch (p) {
+    switch (val) {
         CASE_STMT(AF_BATCH_NONE);
         CASE_STMT(AF_BATCH_LHS);
         CASE_STMT(AF_BATCH_RHS);
         CASE_STMT(AF_BATCH_SAME);
         CASE_STMT(AF_BATCH_DIFF);
+        CASE_STMT(AF_BATCH_UNSUPPORTED);
     }
 #undef CASE_STMT
     return retVal;
 }
 
 Kernel getKernel(const string &nameExpr, const string &source,
-                 const vector<TemplateArg> &targs,
+                 const vector<TemplateArg> &templateArgs,
                  const vector<string> &compileOpts) {
     vector<string> args;
-    args.reserve(targs.size());
+    args.reserve(templateArgs.size());
 
-    transform(targs.begin(), targs.end(), std::back_inserter(args),
+    transform(templateArgs.begin(), templateArgs.end(),
+              std::back_inserter(args),
               [](const TemplateArg &arg) -> string { return arg._tparam; });
 
     string tInstance = nameExpr + "<" + args[0];

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -245,7 +245,7 @@ Kernel buildKernel(const int device, const string &nameExpr,
     }
 
     auto computeFlag = getComputeCapability(device);
-    array<char, 32> arch;
+    array<char, 32> arch{};
     snprintf(arch.data(), arch.size(), "--gpu-architecture=compute_%d%d",
              computeFlag.first, computeFlag.second);
     vector<const char *> compiler_options = {
@@ -335,15 +335,15 @@ kc_t &getCache(int device) {
     return caches[device];
 }
 
-Kernel findKernel(int device, const string nameExpr) {
+Kernel findKernel(int device, const string &nameExpr) {
     kc_t &cache = getCache(device);
 
-    kc_t::iterator iter = cache.find(nameExpr);
+    auto iter = cache.find(nameExpr);
 
     return (iter == cache.end() ? Kernel{0, 0} : iter->second);
 }
 
-void addKernelToCache(int device, const string nameExpr, Kernel entry) {
+void addKernelToCache(int device, const string &nameExpr, Kernel entry) {
     getCache(device).emplace(nameExpr, entry);
 }
 

--- a/src/backend/cuda/nvrtc/cache.hpp
+++ b/src/backend/cuda/nvrtc/cache.hpp
@@ -105,7 +105,7 @@ struct Kernel {
 
 // TODO(pradeep): remove this in API and merge JIT and nvrtc caches
 Kernel buildKernel(const int device, const std::string& nameExpr,
-                   const std::string& jitSourceString,
+                   const std::string& jit_ker,
                    const std::vector<std::string>& opts = {},
                    const bool isJIT                     = false);
 
@@ -200,6 +200,6 @@ SPECIALIZE(unsigned long long, unsigned long long);
 ///            the kernel compilation.
 ///
 Kernel getKernel(const std::string& nameExpr, const std::string& source,
-                 const std::vector<TemplateArg>& templateArgs,
+                 const std::vector<TemplateArg>& targs,
                  const std::vector<std::string>& compileOpts = {});
 }  // namespace cuda

--- a/src/backend/cuda/nvrtc/cache.hpp
+++ b/src/backend/cuda/nvrtc/cache.hpp
@@ -110,7 +110,7 @@ Kernel buildKernel(const int device, const std::string& nameExpr,
                    const bool isJIT                     = false);
 
 template<typename T>
-std::string toString(T value);
+std::string toString(T val);
 
 struct TemplateArg {
     std::string _tparam;
@@ -200,6 +200,6 @@ SPECIALIZE(unsigned long long, unsigned long long);
 ///            the kernel compilation.
 ///
 Kernel getKernel(const std::string& nameExpr, const std::string& source,
-                 const std::vector<TemplateArg>& targs,
+                 const std::vector<TemplateArg>& templateArgs,
                  const std::vector<std::string>& compileOpts = {});
 }  // namespace cuda

--- a/src/backend/cuda/platform.hpp
+++ b/src/backend/cuda/platform.hpp
@@ -62,7 +62,7 @@ std::string getDeviceInfo(int device) noexcept;
 
 std::string getPlatformInfo() noexcept;
 
-std::string getDriverVersion();
+std::string getDriverVersion() noexcept;
 
 // Returns the cuda runtime version as a string for the current build. If no
 // runtime is found or an error occured, the string "N/A" is returned

--- a/src/backend/cuda/plot.cpp
+++ b/src/backend/cuda/plot.cpp
@@ -45,7 +45,8 @@ void copy_plot(const Array<T> &P, fg_plot plot) {
 
         CheckGL("Begin CUDA fallback-resource copy");
         glBindBuffer(GL_ARRAY_BUFFER, buffer);
-        GLubyte *ptr = (GLubyte *)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        auto *ptr =
+            static_cast<GLubyte *>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
         if (ptr) {
             CUDA_CHECK(cudaMemcpyAsync(ptr, P.get(), bytes,
                                        cudaMemcpyDeviceToHost, stream));

--- a/src/backend/cuda/qr.cpp
+++ b/src/backend/cuda/qr.cpp
@@ -51,23 +51,23 @@ namespace cuda {
 
 template<typename T>
 struct geqrf_func_def_t {
-    typedef cusolverStatus_t (*geqrf_func_def)(cusolverDnHandle_t, int, int,
-                                               T *, int, T *, T *, int, int *);
+    using geqrf_func_def = cusolverStatus_t (*)(cusolverDnHandle_t, int, int,
+                                                T *, int, T *, T *, int, int *);
 };
 
 template<typename T>
 struct geqrf_buf_func_def_t {
-    typedef cusolverStatus_t (*geqrf_buf_func_def)(cusolverDnHandle_t, int, int,
-                                                   T *, int, int *);
+    using geqrf_buf_func_def = cusolverStatus_t (*)(cusolverDnHandle_t, int,
+                                                    int, T *, int, int *);
 };
 
 template<typename T>
 struct mqr_func_def_t {
-    typedef cusolverStatus_t (*mqr_func_def)(cusolverDnHandle_t,
-                                             cublasSideMode_t,
-                                             cublasOperation_t, int, int, int,
-                                             const T *, int, const T *, T *,
-                                             int, T *, int, int *);
+    using mqr_func_def = cusolverStatus_t (*)(cusolverDnHandle_t,
+                                              cublasSideMode_t,
+                                              cublasOperation_t, int, int, int,
+                                              const T *, int, const T *, T *,
+                                              int, T *, int, int *);
 };
 
 #define QR_FUNC_DEF(FUNC)                                         \

--- a/src/backend/cuda/random_engine.cu
+++ b/src/backend/cuda/random_engine.cu
@@ -17,7 +17,7 @@ using common::half;
 
 namespace cuda {
 void initMersenneState(Array<uint> &state, const uintl seed,
-                       const Array<uint> tbl) {
+                       const Array<uint> &tbl) {
     kernel::initMersenneState(state.get(), tbl.get(), seed);
 }
 

--- a/src/backend/cuda/random_engine.hpp
+++ b/src/backend/cuda/random_engine.hpp
@@ -14,10 +14,8 @@
 #include <af/defines.h>
 
 namespace cuda {
-Array<uint> initMersenneState(const uintl seed, Array<uint> tbl);
-
 void initMersenneState(Array<uint> &state, const uintl seed,
-                       const Array<uint> tbl);
+                       const Array<uint> &tbl);
 
 template<typename T>
 Array<T> uniformDistribution(const af::dim4 &dims,

--- a/src/backend/cuda/range.cpp
+++ b/src/backend/cuda/range.cpp
@@ -28,8 +28,9 @@ Array<T> range(const dim4& dim, const int seq_dim) {
         _seq_dim = 0;  // column wise sequence
     }
 
-    if (_seq_dim < 0 || _seq_dim > 3)
+    if (_seq_dim < 0 || _seq_dim > 3) {
         AF_ERROR("Invalid rep selection", AF_ERR_ARG);
+    }
 
     Array<T> out = createEmptyArray<T>(dim);
     kernel::range<T>(out, _seq_dim);

--- a/src/backend/cuda/reorder.cpp
+++ b/src/backend/cuda/reorder.cpp
@@ -22,9 +22,9 @@ namespace cuda {
 
 template<typename T>
 Array<T> reorder(const Array<T> &in, const af::dim4 &rdims) {
-    const af::dim4 iDims = in.dims();
+    const af::dim4 &iDims = in.dims();
     af::dim4 oDims(0);
-    for (int i = 0; i < 4; i++) oDims[i] = iDims[rdims[i]];
+    for (int i = 0; i < 4; i++) { oDims[i] = iDims[rdims[i]]; }
 
     Array<T> out = createEmptyArray<T>(oDims);
 

--- a/src/backend/cuda/resize.cpp
+++ b/src/backend/cuda/resize.cpp
@@ -17,7 +17,7 @@ namespace cuda {
 template<typename T>
 Array<T> resize(const Array<T> &in, const dim_t odim0, const dim_t odim1,
                 const af_interp_type method) {
-    const af::dim4 iDims = in.dims();
+    const af::dim4 &iDims = in.dims();
     af::dim4 oDims(odim0, odim1, iDims[2], iDims[3]);
 
     Array<T> out = createEmptyArray<T>(oDims);

--- a/src/backend/cuda/select.cpp
+++ b/src/backend/cuda/select.cpp
@@ -46,9 +46,9 @@ Array<T> createSelectNode(const Array<char> &cond, const Array<T> &a,
     auto b_node    = b.getNode();
     int height     = max(a_node->getHeight(), b_node->getHeight());
     height         = max(height, cond_node->getHeight()) + 1;
-    auto node      = make_shared<NaryNode>(
-        NaryNode(getFullName<T>(), shortname<T>(true), "__select", 3,
-                 {{cond_node, a_node, b_node}}, (int)af_select_t, height));
+    auto node      = make_shared<NaryNode>(NaryNode(
+        getFullName<T>(), shortname<T>(true), "__select", 3,
+        {{cond_node, a_node, b_node}}, static_cast<int>(af_select_t), height));
 
     if (detail::passesJitHeuristics<T>(node.get()) == kJITHeuristics::Pass) {
         return createNodeArray<T>(odims, node);

--- a/src/backend/cuda/select.cpp
+++ b/src/backend/cuda/select.cpp
@@ -78,7 +78,7 @@ Array<T> createSelectNode(const Array<char> &cond, const Array<T> &a,
     auto node = make_shared<NaryNode>(NaryNode(
         getFullName<T>(), shortname<T>(true),
         (flip ? "__not_select" : "__select"), 3, {{cond_node, a_node, b_node}},
-        (int)(flip ? af_not_select_t : af_select_t), height));
+        static_cast<int>(flip ? af_not_select_t : af_select_t), height));
 
     if (detail::passesJitHeuristics<T>(node.get()) == kJITHeuristics::Pass) {
         return createNodeArray<T>(odims, node);

--- a/src/backend/cuda/shift.cpp
+++ b/src/backend/cuda/shift.cpp
@@ -39,15 +39,16 @@ Array<T> shift(const Array<T> &in, const int sdims[4]) {
 
     string name_str("Sh");
     name_str += shortname<T>(true);
-    const dim4 iDims = in.dims();
+    const dim4 &iDims = in.dims();
     dim4 oDims       = iDims;
 
-    array<int, 4> shifts;
+    array<int, 4> shifts{};
     for (int i = 0; i < 4; i++) {
         // sdims_[i] will always be positive and always [0, oDims[i]].
         // Negative shifts are converted to position by going the other way
         // round
-        shifts[i] = -(sdims[i] % (int)oDims[i]) + oDims[i] * (sdims[i] > 0);
+        shifts[i] = -(sdims[i] % static_cast<int>(oDims[i])) +
+                    oDims[i] * (sdims[i] > 0);
         assert(shifts[i] >= 0 && shifts[i] <= oDims[i]);
     }
 

--- a/src/backend/cuda/shift.cpp
+++ b/src/backend/cuda/shift.cpp
@@ -40,7 +40,7 @@ Array<T> shift(const Array<T> &in, const int sdims[4]) {
     string name_str("Sh");
     name_str += shortname<T>(true);
     const dim4 &iDims = in.dims();
-    dim4 oDims       = iDims;
+    dim4 oDims        = iDims;
 
     array<int, 4> shifts{};
     for (int i = 0; i < 4; i++) {

--- a/src/backend/cuda/surface.cpp
+++ b/src/backend/cuda/surface.cpp
@@ -45,7 +45,8 @@ void copy_surface(const Array<T> &P, fg_surface surface) {
 
         CheckGL("Begin CUDA fallback-resource copy");
         glBindBuffer(GL_ARRAY_BUFFER, buffer);
-        GLubyte *ptr = (GLubyte *)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        auto *ptr =
+            static_cast<GLubyte *>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
         if (ptr) {
             CUDA_CHECK(cudaMemcpyAsync(ptr, P.get(), bytes,
                                        cudaMemcpyDeviceToHost, stream));

--- a/src/backend/cuda/susan.cpp
+++ b/src/backend/cuda/susan.cpp
@@ -49,12 +49,12 @@ unsigned susan(Array<float> &x_out, Array<float> &y_out, Array<float> &resp_out,
         resp_out = createEmptyArray<float>(dim4());
         return 0;
     } else {
-        x_out    = createDeviceDataArray<float>(dim4(corners_out),
-                                             (void *)x_corners.get());
-        y_out    = createDeviceDataArray<float>(dim4(corners_out),
-                                             (void *)y_corners.get());
-        resp_out = createDeviceDataArray<float>(dim4(corners_out),
-                                                (void *)resp_corners.get());
+        x_out = createDeviceDataArray<float>(
+            dim4(corners_out), static_cast<void *>(x_corners.get()));
+        y_out = createDeviceDataArray<float>(
+            dim4(corners_out), static_cast<void *>(y_corners.get()));
+        resp_out = createDeviceDataArray<float>(
+            dim4(corners_out), static_cast<void *>(resp_corners.get()));
         x_corners.release();
         y_corners.release();
         resp_corners.release();

--- a/src/backend/cuda/susan.hpp
+++ b/src/backend/cuda/susan.hpp
@@ -15,10 +15,8 @@ using af::features;
 namespace cuda {
 
 template<typename T>
-unsigned susan(Array<float> &x_out, Array<float> &y_out,
-               Array<float> &score_out, const Array<T> &in,
-               const unsigned radius, const float diff_thr,
+unsigned susan(Array<float> &x_out, Array<float> &y_out, Array<float> &resp_out,
+               const Array<T> &in, const unsigned radius, const float diff_thr,
                const float geom_thr, const float feature_ratio,
                const unsigned edge);
-
 }

--- a/src/backend/cuda/svd.cpp
+++ b/src/backend/cuda/svd.cpp
@@ -21,16 +21,17 @@
 
 namespace cuda {
 template<typename T>
-cusolverStatus_t gesvd_buf_func(cusolverDnHandle_t handle, int m, int n,
-                                int *Lwork) {
+cusolverStatus_t gesvd_buf_func(cusolverDnHandle_t /*handle*/, int /*m*/,
+                                int /*n*/, int * /*Lwork*/) {
     return CUSOLVER_STATUS_ARCH_MISMATCH;
 }
 
 template<typename T, typename Tr>
-cusolverStatus_t gesvd_func(cusolverDnHandle_t handle, char jobu, char jobvt,
-                            int m, int n, T *A, int lda, Tr *S, T *U, int ldu,
-                            T *VT, int ldvt, T *Work, int Lwork, Tr *rwork,
-                            int *devInfo) {
+cusolverStatus_t gesvd_func(cusolverDnHandle_t /*handle*/, char /*jobu*/,
+                            char /*jobvt*/, int /*m*/, int /*n*/, T * /*A*/,
+                            int /*lda*/, Tr * /*S*/, T * /*U*/, int /*ldu*/,
+                            T * /*VT*/, int /*ldvt*/, T * /*Work*/,
+                            int /*Lwork*/, Tr * /*rwork*/, int * /*devInfo*/) {
     return CUSOLVER_STATUS_ARCH_MISMATCH;
 }
 

--- a/src/backend/cuda/tile.cpp
+++ b/src/backend/cuda/tile.cpp
@@ -21,7 +21,7 @@ using common::half;
 namespace cuda {
 template<typename T>
 Array<T> tile(const Array<T> &in, const af::dim4 &tileDims) {
-    const af::dim4 iDims = in.dims();
+    const af::dim4 &iDims = in.dims();
     af::dim4 oDims       = iDims;
     oDims *= tileDims;
 

--- a/src/backend/cuda/tile.cpp
+++ b/src/backend/cuda/tile.cpp
@@ -22,7 +22,7 @@ namespace cuda {
 template<typename T>
 Array<T> tile(const Array<T> &in, const af::dim4 &tileDims) {
     const af::dim4 &iDims = in.dims();
-    af::dim4 oDims       = iDims;
+    af::dim4 oDims        = iDims;
     oDims *= tileDims;
 
     if (iDims.elements() == 0 || oDims.elements() == 0) {

--- a/src/backend/cuda/transform.cpp
+++ b/src/backend/cuda/transform.cpp
@@ -16,15 +16,15 @@ namespace cuda {
 
 template<typename T>
 void transform(Array<T> &out, const Array<T> &in, const Array<float> &tf,
-               const af::dim4 &odims, const af::interpType method,
-               const bool inverse, const bool perspective) {
+               const af::interpType method, const bool inverse,
+               const bool perspective) {
     kernel::transform<T>(out, in, tf, inverse, perspective, method,
                          interpOrder(method));
 }
 
 #define INSTANTIATE(T)                                                       \
     template void transform(Array<T> &out, const Array<T> &in,               \
-                            const Array<float> &tf, const af::dim4 &odims,   \
+                            const Array<float> &tf,                          \
                             const af_interp_type method, const bool inverse, \
                             const bool perspective);
 

--- a/src/backend/cuda/transform.hpp
+++ b/src/backend/cuda/transform.hpp
@@ -12,6 +12,6 @@
 namespace cuda {
 template<typename T>
 void transform(Array<T> &out, const Array<T> &in, const Array<float> &tf,
-               const af::dim4 &odims, const af_interp_type method,
-               const bool inverse, const bool perspective);
+               const af_interp_type method, const bool inverse,
+               const bool perspective);
 }

--- a/src/backend/cuda/transpose.cpp
+++ b/src/backend/cuda/transpose.cpp
@@ -20,7 +20,7 @@ namespace cuda {
 
 template<typename T>
 Array<T> transpose(const Array<T> &in, const bool conjugate) {
-    const dim4 inDims = in.dims();
+    const dim4 &inDims = in.dims();
 
     dim4 outDims = dim4(inDims[1], inDims[0], inDims[2], inDims[3]);
 

--- a/src/backend/cuda/types.hpp
+++ b/src/backend/cuda/types.hpp
@@ -139,7 +139,7 @@ const char *getFullName<common::half>() {
 
 namespace common {
 template<typename T>
-class kernel_type;
+struct kernel_type;
 }
 
 namespace common {

--- a/src/backend/cuda/vector_field.cpp
+++ b/src/backend/cuda/vector_field.cpp
@@ -65,7 +65,8 @@ void copy_vector_field(const Array<T> &points, const Array<T> &directions,
 
         // Points
         glBindBuffer(GL_ARRAY_BUFFER, buff1);
-        GLubyte *ptr = (GLubyte *)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        auto *ptr =
+            static_cast<GLubyte *>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
         if (ptr) {
             CUDA_CHECK(cudaMemcpyAsync(ptr, points.get(), size1,
                                        cudaMemcpyDeviceToHost, stream));
@@ -76,7 +77,8 @@ void copy_vector_field(const Array<T> &points, const Array<T> &directions,
 
         // Directions
         glBindBuffer(GL_ARRAY_BUFFER, buff2);
-        ptr = (GLubyte *)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        ptr =
+            static_cast<GLubyte *>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
         if (ptr) {
             CUDA_CHECK(cudaMemcpyAsync(ptr, directions.get(), size2,
                                        cudaMemcpyDeviceToHost, stream));

--- a/src/backend/cuda/vector_field.hpp
+++ b/src/backend/cuda/vector_field.hpp
@@ -14,6 +14,5 @@ namespace cuda {
 
 template<typename T>
 void copy_vector_field(const Array<T> &points, const Array<T> &directions,
-                       fg_vector_field vector_field);
-
+                       fg_vector_field vfield);
 }

--- a/src/backend/cuda/wrap.cpp
+++ b/src/backend/cuda/wrap.cpp
@@ -23,17 +23,17 @@ using common::half;
 namespace cuda {
 
 template<typename T>
-void wrap(Array<T> &out, const Array<T> &in, const dim_t ox, const dim_t oy,
-          const dim_t wx, const dim_t wy, const dim_t sx, const dim_t sy,
-          const dim_t px, const dim_t py, const bool is_column) {
+void wrap(Array<T> &out, const Array<T> &in, const dim_t wx, const dim_t wy,
+          const dim_t sx, const dim_t sy, const dim_t px, const dim_t py,
+          const bool is_column) {
     kernel::wrap<T>(out, in, wx, wy, sx, sy, px, py, is_column);
 }
 
 #define INSTANTIATE(T)                                                        \
-    template void wrap<T>(Array<T> & out, const Array<T> &in, const dim_t ox, \
-                          const dim_t oy, const dim_t wx, const dim_t wy,     \
-                          const dim_t sx, const dim_t sy, const dim_t px,     \
-                          const dim_t py, const bool is_column);
+    template void wrap<T>(Array<T> & out, const Array<T> &in, const dim_t wx, \
+                          const dim_t wy, const dim_t sx, const dim_t sy,     \
+                          const dim_t px, const dim_t py,                     \
+                          const bool is_column);
 
 INSTANTIATE(float)
 INSTANTIATE(double)

--- a/src/backend/cuda/wrap.hpp
+++ b/src/backend/cuda/wrap.hpp
@@ -11,9 +11,9 @@
 
 namespace cuda {
 template<typename T>
-void wrap(Array<T> &out, const Array<T> &in, const dim_t ox, const dim_t oy,
-          const dim_t wx, const dim_t wy, const dim_t sx, const dim_t sy,
-          const dim_t px, const dim_t py, const bool is_column);
+void wrap(Array<T> &out, const Array<T> &in, const dim_t wx, const dim_t wy,
+          const dim_t sx, const dim_t sy, const dim_t px, const dim_t py,
+          const bool is_column);
 
 template<typename T>
 Array<T> wrap_dilated(const Array<T> &in, const dim_t ox, const dim_t oy,

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -455,7 +455,7 @@ void writeDeviceDataArray(Array<T> &arr, const void *const data,
 
     Buffer &buf = *arr.get();
 
-    clRetainMemObject(reinterpret_cast<cl_mem>(const_cast<void*>(data)));
+    clRetainMemObject(reinterpret_cast<cl_mem>(const_cast<void *>(data)));
     Buffer data_buf =
         Buffer(reinterpret_cast<cl_mem>(const_cast<void *>(data)));
 

--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -31,7 +31,8 @@ template<typename T>
 void evalMultiple(std::vector<Array<T> *> arrays);
 
 void evalNodes(Param &out, common::Node *node);
-void evalNodes(std::vector<Param> &outputs, std::vector<common::Node *> nodes);
+void evalNodes(std::vector<Param> &outputs,
+               const std::vector<common::Node *> &nodes);
 
 /// Creates a new Array object on the heap and returns a reference to it.
 template<typename T>
@@ -49,8 +50,9 @@ template<typename T>
 Array<T> createDeviceDataArray(const af::dim4 &dims, void *data);
 
 template<typename T>
-Array<T> createStridedArray(af::dim4 dims, af::dim4 strides, dim_t offset,
-                            const T *const in_data, bool is_device) {
+Array<T> createStridedArray(const af::dim4 &dims, const af::dim4 &strides,
+                            dim_t offset, const T *const in_data,
+                            bool is_device) {
     return Array<T>(dims, strides, offset, in_data, is_device);
 }
 
@@ -126,18 +128,18 @@ class Array {
     bool ready;
     bool owner;
 
-    Array(af::dim4 dims);
+    Array(const af::dim4 &dims);
 
-    Array(const Array<T> &parnt, const dim4 &dims, const dim_t &offset,
+    Array(const Array<T> &parent, const dim4 &dims, const dim_t &offset,
           const dim4 &stride);
     Array(Param &tmp, bool owner);
-    explicit Array(af::dim4 dims, common::Node_ptr n);
-    explicit Array(af::dim4 dims, const T *const in_data);
-    explicit Array(af::dim4 dims, cl_mem mem, size_t offset, bool copy);
+    explicit Array(const af::dim4 &dims, common::Node_ptr n);
+    explicit Array(const af::dim4 &dims, const T *const in_data);
+    explicit Array(const af::dim4 &dims, cl_mem mem, size_t offset, bool copy);
 
    public:
-    Array(af::dim4 dims, af::dim4 strides, dim_t offset, const T *const in_data,
-          bool is_device = false);
+    Array(const af::dim4 &dims, const af::dim4 &strides, dim_t offset,
+          const T *const in_data, bool is_device = false);
 
     void resetInfo(const af::dim4 &dims) { info.resetInfo(dims); }
     void resetDims(const af::dim4 &dims) { info.resetDims(dims); }
@@ -178,7 +180,7 @@ class Array {
     INFO_IS_FUNC(isSparse);
 
 #undef INFO_IS_FUNC
-    ~Array();
+    ~Array() = default;
 
     bool isReady() const { return ready; }
     bool isOwner() const { return owner; }
@@ -275,8 +277,9 @@ class Array {
     friend Array<T> createHostDataArray<T>(const af::dim4 &dims,
                                            const T *const data);
     friend Array<T> createDeviceDataArray<T>(const af::dim4 &dims, void *data);
-    friend Array<T> createStridedArray<T>(af::dim4 dims, af::dim4 strides,
-                                          dim_t offset, const T *const in_data,
+    friend Array<T> createStridedArray<T>(const af::dim4 &dims,
+                                          const af::dim4 &strides, dim_t offset,
+                                          const T *const in_data,
                                           bool is_device);
 
     friend Array<T> createEmptyArray<T>(const af::dim4 &dims);

--- a/src/backend/opencl/Event.cpp
+++ b/src/backend/opencl/Event.cpp
@@ -13,8 +13,12 @@
 #include <events.hpp>
 #include <platform.hpp>
 #include <af/event.h>
+#include <memory>
 
 #include <memory>
+
+using std::make_unique;
+using std::unique_ptr;
 
 namespace opencl {
 /// \brief Creates a new event and marks it in the queue
@@ -25,8 +29,7 @@ Event makeEvent(cl::CommandQueue& queue) {
 }
 
 af_event createEvent() {
-    std::unique_ptr<Event> e;
-    e.reset(new Event());
+    auto e = make_unique<Event>();
     // Ensure the default CL command queue is initialized
     getQueue()();
     if (e->create() != CL_SUCCESS) {

--- a/src/backend/opencl/GraphicsResourceManager.cpp
+++ b/src/backend/opencl/GraphicsResourceManager.cpp
@@ -12,12 +12,15 @@
 
 namespace opencl {
 GraphicsResourceManager::ShrdResVector
-GraphicsResourceManager::registerResources(std::vector<uint32_t> resources) {
+GraphicsResourceManager::registerResources(
+    const std::vector<uint32_t>& resources) {
     ShrdResVector output;
 
-    for (auto id : resources)
-        output.emplace_back(
-            new cl::BufferGL(getContext(), CL_MEM_WRITE_ONLY, id, NULL));
+    for (auto id : resources) {
+        output.emplace_back(new cl::BufferGL(
+            getContext(), CL_MEM_WRITE_ONLY,  // NOLINT(hicpp-signed-bitwise)
+            id, NULL));
+    }
 
     return output;
 }

--- a/src/backend/opencl/GraphicsResourceManager.hpp
+++ b/src/backend/opencl/GraphicsResourceManager.hpp
@@ -25,7 +25,8 @@ class GraphicsResourceManager
     using ShrdResVector = std::vector<std::shared_ptr<cl::Buffer>>;
 
     GraphicsResourceManager() {}
-    ShrdResVector registerResources(std::vector<uint32_t> resources);
+    static ShrdResVector registerResources(
+        const std::vector<uint32_t>& resources);
 
    protected:
     GraphicsResourceManager(GraphicsResourceManager const&);

--- a/src/backend/opencl/Param.cpp
+++ b/src/backend/opencl/Param.cpp
@@ -16,7 +16,7 @@ namespace opencl {
 Param::Param() : data(nullptr), info{{0, 0, 0, 0}, {0, 0, 0, 0}, 0} {}
 Param::Param(cl::Buffer *data_, KParam info_) : data(data_), info(info_) {}
 
-Param makeParam(cl_mem mem, int off, int dims[4], int strides[4]) {
+Param makeParam(cl_mem mem, int off, const int dims[4], const int strides[4]) {
     Param out;
     out.data        = new cl::Buffer(mem);
     out.info.offset = off;

--- a/src/backend/opencl/Param.hpp
+++ b/src/backend/opencl/Param.hpp
@@ -28,5 +28,5 @@ struct Param {
 };
 
 // AF_DEPRECATED("Use Array<T>")
-Param makeParam(cl_mem mem, int off, int dims[4], int strides[4]);
+Param makeParam(cl_mem mem, int off, const int dims[4], const int strides[4]);
 }  // namespace opencl

--- a/src/backend/opencl/anisotropic_diffusion.cpp
+++ b/src/backend/opencl/anisotropic_diffusion.cpp
@@ -18,10 +18,11 @@ template<typename T>
 void anisotropicDiffusion(Array<T>& inout, const float dt, const float mct,
                           const af::fluxFunction fftype,
                           const af::diffusionEq eq) {
-    if (eq == AF_DIFFUSION_MCDE)
+    if (eq == AF_DIFFUSION_MCDE) {
         kernel::anisotropicDiffusion<T, true>(inout, dt, mct, fftype);
-    else
+    } else {
         kernel::anisotropicDiffusion<T, false>(inout, dt, mct, fftype);
+    }
 }
 
 #define INSTANTIATE(T)                                     \

--- a/src/backend/opencl/api.cpp
+++ b/src/backend/opencl/api.cpp
@@ -4,10 +4,11 @@
 namespace af {
 template<>
 AFAPI cl_mem *array::device() const {
-    cl_mem *mem_ptr = new cl_mem;
-    af_err err      = af_get_device_ptr((void **)mem_ptr, get());
-    if (err != AF_SUCCESS)
+    auto *mem_ptr = new cl_mem;
+    af_err err = af_get_device_ptr(reinterpret_cast<void **>(mem_ptr), get());
+    if (err != AF_SUCCESS) {
         throw af::exception("Failed to get cl_mem from array object");
+    }
     return mem_ptr;
 }
 }  // namespace af

--- a/src/backend/opencl/assign.cpp
+++ b/src/backend/opencl/assign.cpp
@@ -33,7 +33,7 @@ void assign(Array<T>& out, const af_index_t idxrs[], const Array<T>& rhs) {
     }
 
     // retrieve dimensions, strides and offsets
-    dim4 dDims = out.dims();
+    const dim4& dDims = out.dims();
     // retrieve dimensions & strides for array
     // to which rhs is being copied to
     dim4 dstOffs  = toOffset(seqs, dDims);
@@ -58,8 +58,9 @@ void assign(Array<T>& out, const af_index_t idxrs[], const Array<T>& rhs) {
             // alloc an 1-element buffer to avoid OpenCL from failing using
             // direct buffer allocation as opposed to mem manager to avoid
             // reference count desprepancies between different backends
-            static cl::Buffer* empty =
-                new Buffer(getContext(), CL_MEM_READ_ONLY, sizeof(uint));
+            static auto* empty = new Buffer(
+                getContext(), CL_MEM_READ_ONLY,  // NOLINT(hicpp-signed-bitwise)
+                sizeof(uint));
             bPtrs[x] = empty;
         }
     }

--- a/src/backend/opencl/blas.cpp
+++ b/src/backend/opencl/blas.cpp
@@ -54,10 +54,10 @@ void gemm_fallback(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs,
 }
 
 template<>
-void gemm_fallback<half>(Array<half> &out, af_mat_prop optLhs,
-                         af_mat_prop optRhs, const half *alpha,
-                         const Array<half> &lhs, const Array<half> &rhs,
-                         const half *beta) {
+void gemm_fallback<half>(Array<half> & /*out*/, af_mat_prop /*optLhs*/,
+                         af_mat_prop /*optRhs*/, const half * /*alpha*/,
+                         const Array<half> & /*lhs*/,
+                         const Array<half> & /*rhs*/, const half * /*beta*/) {
     assert(false && "CPU fallback not implemented for f16");
 }
 
@@ -66,7 +66,8 @@ void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
           const Array<T> &lhs, const Array<T> &rhs, const T *beta) {
 #if defined(WITH_LINEAR_ALGEBRA)
     // Do not force offload gemm on OSX Intel devices
-    if (OpenCLCPUOffload(false) && (af_dtype)dtype_traits<T>::af_type != f16) {
+    if (OpenCLCPUOffload(false) &&
+        static_cast<af_dtype>(dtype_traits<T>::af_type) != f16) {
         gemm_fallback(out, optLhs, optRhs, alpha, lhs, rhs, beta);
         return;
     }
@@ -78,18 +79,18 @@ void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
     const auto aColDim = (lOpts == OPENCL_BLAS_NO_TRANS) ? 1 : 0;
     const auto bColDim = (rOpts == OPENCL_BLAS_NO_TRANS) ? 1 : 0;
 
-    const dim4 lDims = lhs.dims();
-    const dim4 rDims = rhs.dims();
+    const dim4 &lDims = lhs.dims();
+    const dim4 &rDims = rhs.dims();
     const int M      = lDims[aRowDim];
     const int N      = rDims[bColDim];
     const int K      = lDims[aColDim];
     const dim4 oDims = out.dims();
 
-    const dim4 lStrides = lhs.strides();
-    const dim4 rStrides = rhs.strides();
+    const dim4 &lStrides = lhs.strides();
+    const dim4 &rStrides = rhs.strides();
     const dim4 oStrides = out.strides();
 
-    int batchSize = oDims[2] * oDims[3];
+    int batchSize = static_cast<int>(oDims[2] * oDims[3]);
 
     bool is_l_d2_batched = oDims[2] == lDims[2];
     bool is_l_d3_batched = oDims[3] == lDims[3];
@@ -97,8 +98,8 @@ void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
     bool is_r_d3_batched = oDims[3] == rDims[3];
 
     for (int n = 0; n < batchSize; n++) {
-        int w = n / oDims[2];
-        int z = n - w * oDims[2];
+        int w = static_cast<int>(n / oDims[2]);
+        int z = static_cast<int>(n - w * oDims[2]);
 
         int loff = z * (is_l_d2_batched * lStrides[2]) +
                    w * (is_l_d3_batched * lStrides[3]);

--- a/src/backend/opencl/blas.cpp
+++ b/src/backend/opencl/blas.cpp
@@ -81,14 +81,14 @@ void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
 
     const dim4 &lDims = lhs.dims();
     const dim4 &rDims = rhs.dims();
-    const int M      = lDims[aRowDim];
-    const int N      = rDims[bColDim];
-    const int K      = lDims[aColDim];
-    const dim4 oDims = out.dims();
+    const int M       = lDims[aRowDim];
+    const int N       = rDims[bColDim];
+    const int K       = lDims[aColDim];
+    const dim4 oDims  = out.dims();
 
     const dim4 &lStrides = lhs.strides();
     const dim4 &rStrides = rhs.strides();
-    const dim4 oStrides = out.strides();
+    const dim4 oStrides  = out.strides();
 
     int batchSize = static_cast<int>(oDims[2] * oDims[3]);
 

--- a/src/backend/opencl/cholesky.cpp
+++ b/src/backend/opencl/cholesky.cpp
@@ -43,10 +43,11 @@ Array<T> cholesky(int *info, const Array<T> &in, const bool is_upper) {
     Array<T> out = copyArray<T>(in);
     *info        = cholesky_inplace(out, is_upper);
 
-    if (is_upper)
+    if (is_upper) {
         triangle<T, true, false>(out, out);
-    else
+    } else {
         triangle<T, false, false>(out, out);
+    }
 
     return out;
 }

--- a/src/backend/opencl/convolve.cpp
+++ b/src/backend/opencl/convolve.cpp
@@ -33,8 +33,8 @@ namespace opencl {
 template<typename T, typename accT, dim_t baseDim, bool expand>
 Array<T> convolve(Array<T> const &signal, Array<accT> const &filter,
                   AF_BATCH_KIND kind) {
-    const dim4 sDims = signal.dims();
-    const dim4 fDims = filter.dims();
+    const dim4 &sDims = signal.dims();
+    const dim4 &fDims = filter.dims();
 
     dim4 oDims(1);
     if (expand) {
@@ -48,7 +48,7 @@ Array<T> convolve(Array<T> const &signal, Array<accT> const &filter,
     } else {
         oDims = sDims;
         if (kind == AF_BATCH_RHS) {
-            for (dim_t i = baseDim; i < 4; ++i) oDims[i] = fDims[i];
+            for (dim_t i = baseDim; i < 4; ++i) { oDims[i] = fDims[i]; }
         }
     }
 
@@ -59,15 +59,17 @@ Array<T> convolve(Array<T> const &signal, Array<accT> const &filter,
     dim_t MCFL3 = kernel::MAX_CONV3_FILTER_LEN;
     switch (baseDim) {
         case 1:
-            if (fDims[0] > kernel::MAX_CONV1_FILTER_LEN) callKernel = false;
+            if (fDims[0] > kernel::MAX_CONV1_FILTER_LEN) { callKernel = false; }
             break;
         case 2:
-            if ((fDims[0] * fDims[1]) > (MCFL2 * MCFL2)) callKernel = false;
+            if ((fDims[0] * fDims[1]) > (MCFL2 * MCFL2)) { callKernel = false; }
             break;
         case 3:
-            if ((fDims[0] * fDims[1] * fDims[2]) > (MCFL3 * MCFL3 * MCFL3))
+            if ((fDims[0] * fDims[1] * fDims[2]) > (MCFL3 * MCFL3 * MCFL3)) {
                 callKernel = false;
+            }
             break;
+        default: AF_ERROR("baseDim only supports values 1-3.", AF_ERR_UNKNOWN);
     }
 
     if (!callKernel) {
@@ -120,8 +122,8 @@ INSTANTIATE(intl, float)
 
 template<typename T>
 Array<T> convolve2_unwrap(const Array<T> &signal, const Array<T> &filter,
-                          const dim4 stride, const dim4 padding,
-                          const dim4 dilation) {
+                          const dim4 &stride, const dim4 &padding,
+                          const dim4 &dilation) {
     dim4 sDims = signal.dims();
     dim4 fDims = filter.dims();
 
@@ -179,11 +181,12 @@ template<typename T>
 Array<T> conv2DataGradient(const Array<T> &incoming_gradient,
                            const Array<T> &original_signal,
                            const Array<T> &original_filter,
-                           const Array<T> &convolved_output, af::dim4 stride,
-                           af::dim4 padding, af::dim4 dilation) {
-    const dim4 cDims = incoming_gradient.dims();
-    const dim4 sDims = original_signal.dims();
-    const dim4 fDims = original_filter.dims();
+                           const Array<T> & /*convolved_output*/,
+                           af::dim4 stride, af::dim4 padding,
+                           af::dim4 dilation) {
+    const dim4 &cDims = incoming_gradient.dims();
+    const dim4 &sDims = original_signal.dims();
+    const dim4 &fDims = original_filter.dims();
 
     Array<T> collapsed_filter = original_filter;
 
@@ -212,11 +215,12 @@ template<typename T>
 Array<T> conv2FilterGradient(const Array<T> &incoming_gradient,
                              const Array<T> &original_signal,
                              const Array<T> &original_filter,
-                             const Array<T> &convolved_output, af::dim4 stride,
-                             af::dim4 padding, af::dim4 dilation) {
-    const dim4 cDims = incoming_gradient.dims();
-    const dim4 sDims = original_signal.dims();
-    const dim4 fDims = original_filter.dims();
+                             const Array<T> & /*convolved_output*/,
+                             af::dim4 stride, af::dim4 padding,
+                             af::dim4 dilation) {
+    const dim4 &cDims = incoming_gradient.dims();
+    const dim4 &sDims = original_signal.dims();
+    const dim4 &fDims = original_filter.dims();
 
     const bool retCols = false;
     Array<T> unwrapped =

--- a/src/backend/opencl/convolve_separable.cpp
+++ b/src/backend/opencl/convolve_separable.cpp
@@ -20,23 +20,23 @@ namespace opencl {
 template<typename T, typename accT, bool expand>
 Array<T> convolve2(Array<T> const& signal, Array<accT> const& c_filter,
                    Array<accT> const& r_filter) {
-    const dim_t cflen = (dim_t)c_filter.elements();
-    const dim_t rflen = (dim_t)r_filter.elements();
+    const auto cflen = c_filter.elements();
+    const auto rflen = r_filter.elements();
 
     if ((cflen > kernel::MAX_SCONV_FILTER_LEN) ||
         (rflen > kernel::MAX_SCONV_FILTER_LEN)) {
         // TODO call upon fft
         char errMessage[256];
         snprintf(errMessage, sizeof(errMessage),
-                 "\nOpenCL Separable convolution doesn't support %lld(coloumn) "
-                 "%lld(row) filters\n",
+                 "\nOpenCL Separable convolution doesn't support %zu(coloumn) "
+                 "%zu(row) filters\n",
                  cflen, rflen);
         OPENCL_NOT_SUPPORTED(errMessage);
     }
 
-    const dim4 sDims = signal.dims();
-    dim4 tDims       = sDims;
-    dim4 oDims       = sDims;
+    const dim4& sDims = signal.dims();
+    dim4 tDims        = sDims;
+    dim4 oDims        = sDims;
 
     if (expand) {
         tDims[0] += cflen - 1;

--- a/src/backend/opencl/copy.cpp
+++ b/src/backend/opencl/copy.cpp
@@ -44,7 +44,6 @@ void copyData(T *data, const Array<T> &A) {
     // FIXME: Add checks
     getQueue().enqueueReadBuffer(buf, CL_TRUE, sizeof(T) * offset,
                                  sizeof(T) * A.elements(), data);
-    return;
 }
 
 template<typename T>
@@ -69,12 +68,13 @@ Array<outType> padArray(Array<inType> const &in, dim4 const &dims,
                         outType default_value, double factor) {
     Array<outType> ret = createEmptyArray<outType>(dims);
 
-    if (in.dims() == dims)
+    if (in.dims() == dims) {
         kernel::copy<inType, outType, true>(ret, in, in.ndims(), default_value,
                                             factor);
-    else
+    } else {
         kernel::copy<inType, outType, false>(ret, in, in.ndims(), default_value,
                                              factor);
+    }
     return ret;
 }
 
@@ -86,12 +86,13 @@ void multiply_inplace(Array<T> &in, double val) {
 template<typename inType, typename outType>
 struct copyWrapper {
     void operator()(Array<outType> &out, Array<inType> const &in) {
-        if (in.dims() == out.dims())
+        if (in.dims() == out.dims()) {
             kernel::copy<inType, outType, true>(out, in, in.ndims(),
                                                 scalar<outType>(0), 1);
-        else
+        } else {
             kernel::copy<inType, outType, false>(out, in, in.ndims(),
                                                  scalar<outType>(0), 1);
+        }
     }
 };
 
@@ -106,10 +107,11 @@ struct copyWrapper<T, T> {
             getQueue().enqueueCopyBuffer(*in.get(), *out.get(), in_offset,
                                          out_offset, in.elements() * sizeof(T));
         } else {
-            if (in.dims() == out.dims())
+            if (in.dims() == out.dims()) {
                 kernel::copy<T, T, true>(out, in, in.ndims(), scalar<T>(0), 1);
-            else
+            } else {
                 kernel::copy<T, T, false>(out, in, in.ndims(), scalar<T>(0), 1);
+            }
         }
     }
 };
@@ -237,7 +239,7 @@ INSTANTIATE_PAD_ARRAY_COMPLEX(cdouble)
 
 template<typename T>
 T getScalar(const Array<T> &in) {
-    T retVal;
+    T retVal{};
     getQueue().enqueueReadBuffer(*in.get(), CL_TRUE, sizeof(T) * in.getOffset(),
                                  sizeof(T), &retVal);
     return retVal;

--- a/src/backend/opencl/cpu/cpu_blas.cpp
+++ b/src/backend/opencl/cpu/cpu_blas.cpp
@@ -180,12 +180,12 @@ void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
     const int aColDim = (lOpts == CblasNoTrans) ? 1 : 0;
     const int bColDim = (rOpts == CblasNoTrans) ? 1 : 0;
 
-    const dim4 lDims = lhs.dims();
-    const dim4 rDims = rhs.dims();
+    const dim4 &lDims = lhs.dims();
+    const dim4 &rDims = rhs.dims();
     const int M      = lDims[aRowDim];
     const int N      = rDims[bColDim];
     const int K      = lDims[aColDim];
-    const dim4 oDims = out.dims();
+    const dim4 &oDims = out.dims();
 
     dim4 lStrides = lhs.strides();
     dim4 rStrides = rhs.strides();

--- a/src/backend/opencl/cpu/cpu_blas.cpp
+++ b/src/backend/opencl/cpu/cpu_blas.cpp
@@ -182,9 +182,9 @@ void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
 
     const dim4 &lDims = lhs.dims();
     const dim4 &rDims = rhs.dims();
-    const int M      = lDims[aRowDim];
-    const int N      = rDims[bColDim];
-    const int K      = lDims[aColDim];
+    const int M       = lDims[aRowDim];
+    const int N       = rDims[bColDim];
+    const int K       = lDims[aColDim];
     const dim4 &oDims = out.dims();
 
     dim4 lStrides = lhs.strides();

--- a/src/backend/opencl/cpu/cpu_blas.cpp
+++ b/src/backend/opencl/cpu/cpu_blas.cpp
@@ -212,9 +212,10 @@ void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
         int roff = z * (is_r_d2_batched * rStrides[2]) +
                    w * (is_r_d3_batched * rStrides[3]);
 
-        CBT *lptr = (CBT *)(lPtr.get() + loff);
-        CBT *rptr = (CBT *)(rPtr.get() + roff);
-        BT *optr  = (BT *)(oPtr.get() + z * oStrides[2] + w * oStrides[3]);
+        CBT *lptr = static_cast<CBT *>(lPtr.get() + loff);
+        CBT *rptr = static_cast<CBT *>(rPtr.get() + roff);
+        BT *optr =
+            static_cast<BT *>(oPtr.get() + z * oStrides[2] + w * oStrides[3]);
 
         if (rDims[bColDim] == 1) {
             dim_t incr = (rOpts == CblasNoTrans) ? rStrides[0] : rStrides[1];

--- a/src/backend/opencl/cpu/cpu_cholesky.cpp
+++ b/src/backend/opencl/cpu/cpu_cholesky.cpp
@@ -42,12 +42,13 @@ Array<T> cholesky(int *info, const Array<T> &in, const bool is_upper) {
 
     mapped_ptr<T> oPtr = out.getMappedPtr();
 
-    if (is_upper)
+    if (is_upper) {
         triangle<T, true, false>(oPtr.get(), oPtr.get(), out.dims(),
                                  out.strides(), out.strides());
-    else
+    } else {
         triangle<T, false, false>(oPtr.get(), oPtr.get(), out.dims(),
                                   out.strides(), out.strides());
+    }
 
     return out;
 }
@@ -58,7 +59,7 @@ int cholesky_inplace(Array<T> &in, const bool is_upper) {
     int N      = iDims[0];
 
     char uplo = 'L';
-    if (is_upper) uplo = 'U';
+    if (is_upper) { uplo = 'U'; }
 
     mapped_ptr<T> inPtr = in.getMappedPtr();
 

--- a/src/backend/opencl/cpu/cpu_lu.cpp
+++ b/src/backend/opencl/cpu/cpu_lu.cpp
@@ -76,14 +76,14 @@ void lu_split(Array<T> &lower, Array<T> &upper, const Array<T> &in) {
                     const dim_t uMem = uYZW + ox;
                     const dim_t iMem = iYZW + ox;
                     if (ox > oy) {
-                        if (oy < ldm[1]) l[lMem] = i[iMem];
-                        if (ox < udm[0]) u[uMem] = scalar<T>(0);
+                        if (oy < ldm[1]) { l[lMem] = i[iMem]; }
+                        if (ox < udm[0]) { u[uMem] = scalar<T>(0); }
                     } else if (oy > ox) {
-                        if (oy < ldm[1]) l[lMem] = scalar<T>(0);
-                        if (ox < udm[0]) u[uMem] = i[iMem];
+                        if (oy < ldm[1]) { l[lMem] = scalar<T>(0); }
+                        if (ox < udm[0]) { u[uMem] = i[iMem]; }
                     } else if (ox == oy) {
-                        if (oy < ldm[1]) l[lMem] = scalar<T>(1.0);
-                        if (ox < udm[0]) u[uMem] = i[iMem];
+                        if (oy < ldm[1]) { l[lMem] = scalar<T>(1.0); }
+                        if (ox < udm[0]) { u[uMem] = i[iMem]; }
                     }
                 }
             }
@@ -95,7 +95,7 @@ void convertPivot(int *pivot, int out_sz, size_t pivot_dim) {
     std::vector<int> p(out_sz);
     iota(begin(p), end(p), 0);
 
-    for (int j = 0; j < (int)pivot_dim; j++) {
+    for (int j = 0; j < static_cast<int>(pivot_dim); j++) {
         // 1 indexed in pivot
         std::swap(p[j], p[pivot[j] - 1]);
     }
@@ -138,7 +138,7 @@ Array<int> lu_inplace(Array<T> &in, const bool convert_pivot) {
     getrf_func<T>()(AF_LAPACK_COL_MAJOR, M, N, inPtr.get(), in.strides()[1],
                     piPtr.get());
 
-    if (convert_pivot) convertPivot(piPtr.get(), M, min(M, N));
+    if (convert_pivot) { convertPivot(piPtr.get(), M, min(M, N)); }
 
     return pivot;
 }

--- a/src/backend/opencl/cpu/cpu_sparse_blas.cpp
+++ b/src/backend/opencl/cpu/cpu_sparse_blas.cpp
@@ -57,8 +57,8 @@ using scale_type =
                          const typename blas_base<T>::type, const T>::type;
 
 template<typename To, typename Ti>
-To getScaleValue(Ti val) {
-    return (To)(val);
+auto getScaleValue(Ti val) -> std::remove_cv_t<To> {
+    return static_cast<std::remove_cv_t<To>>(val);
 }
 
 #ifdef USE_MKL
@@ -143,7 +143,7 @@ SPARSE_FUNC(mm, cdouble, z)
 #undef SPARSE_FUNC_DEF
 
 template<>
-const sp_cfloat getScaleValue<const sp_cfloat, cfloat>(cfloat val) {
+sp_cfloat getScaleValue<const sp_cfloat, cfloat>(cfloat val) {
     sp_cfloat ret;
     ret.real = val.s[0];
     ret.imag = val.s[1];
@@ -151,7 +151,7 @@ const sp_cfloat getScaleValue<const sp_cfloat, cfloat>(cfloat val) {
 }
 
 template<>
-const sp_cdouble getScaleValue<const sp_cdouble, cdouble>(cdouble val) {
+sp_cdouble getScaleValue<const sp_cdouble, cdouble>(cdouble val) {
     sp_cdouble ret;
     ret.real = val.s[0];
     ret.imag = val.s[1];
@@ -241,7 +241,7 @@ Array<T> matmul(const common::SparseArray<T> lhs, const Array<T> rhs,
                          lhs.dims()[1], pB, pE, cPtr.get(),
                          reinterpret_cast<ptr_type<T>>(vPtr.get()));
 
-    struct matrix_descr descrLhs;
+    struct matrix_descr descrLhs {};
     descrLhs.type = SPARSE_MATRIX_TYPE_GENERAL;
 
     mkl_sparse_optimize(csrLhs);

--- a/src/backend/opencl/cpu/cpu_sparse_blas.cpp
+++ b/src/backend/opencl/cpu/cpu_sparse_blas.cpp
@@ -181,7 +181,7 @@ sparse_operation_t toSparseTranspose(af_mat_prop opt) {
 }
 
 template<typename T, int value>
-scale_type<T> getScale() {
+scale_type<T> getScale() {  // NOLINT(readability-const-return-type)
     thread_local T val = scalar<T>(value);
     return getScaleValue<scale_type<T>, T>(val);
 }

--- a/src/backend/opencl/device_manager.hpp
+++ b/src/backend/opencl/device_manager.hpp
@@ -86,10 +86,10 @@ class DeviceManager {
 
     friend int setDevice(int device);
 
-    friend void addDeviceContext(cl_device_id dev, cl_context cxt,
+    friend void addDeviceContext(cl_device_id dev, cl_context ctx,
                                  cl_command_queue que);
 
-    friend void setDeviceContext(cl_device_id dev, cl_context cxt);
+    friend void setDeviceContext(cl_device_id dev, cl_context ctx);
 
     friend void removeDeviceContext(cl_device_id dev, cl_context ctx);
 

--- a/src/backend/opencl/diff.cpp
+++ b/src/backend/opencl/diff.cpp
@@ -17,7 +17,7 @@ namespace opencl {
 template<typename T, bool isDiff2>
 static Array<T> diff(const Array<T> &in, const int dim) {
     const af::dim4 &iDims = in.dims();
-    af::dim4 oDims       = iDims;
+    af::dim4 oDims        = iDims;
     oDims[dim] -= (isDiff2 + 1);
 
     if (iDims.elements() == 0 || oDims.elements() == 0) {

--- a/src/backend/opencl/diff.cpp
+++ b/src/backend/opencl/diff.cpp
@@ -16,7 +16,7 @@
 namespace opencl {
 template<typename T, bool isDiff2>
 static Array<T> diff(const Array<T> &in, const int dim) {
-    const af::dim4 iDims = in.dims();
+    const af::dim4 &iDims = in.dims();
     af::dim4 oDims       = iDims;
     oDims[dim] -= (isDiff2 + 1);
 
@@ -27,13 +27,11 @@ static Array<T> diff(const Array<T> &in, const int dim) {
     Array<T> out = createEmptyArray<T>(oDims);
 
     switch (dim) {
-        case (0): kernel::diff<T, 0, isDiff2>(out, in, in.ndims()); break;
-
-        case (1): kernel::diff<T, 1, isDiff2>(out, in, in.ndims()); break;
-
-        case (2): kernel::diff<T, 2, isDiff2>(out, in, in.ndims()); break;
-
-        case (3): kernel::diff<T, 3, isDiff2>(out, in, in.ndims()); break;
+        case 0: kernel::diff<T, 0, isDiff2>(out, in, in.ndims()); break;
+        case 1: kernel::diff<T, 1, isDiff2>(out, in, in.ndims()); break;
+        case 2: kernel::diff<T, 2, isDiff2>(out, in, in.ndims()); break;
+        case 3: kernel::diff<T, 3, isDiff2>(out, in, in.ndims()); break;
+        default: AF_ERROR("dim only supports values 0-3.", AF_ERR_UNKNOWN);
     }
 
     return out;

--- a/src/backend/opencl/fft.cpp
+++ b/src/backend/opencl/fft.cpp
@@ -37,32 +37,33 @@ struct Precision<cdouble> {
 };
 
 static void computeDims(size_t rdims[4], const dim4 &idims) {
-    for (int i = 0; i < 4; i++) { rdims[i] = (size_t)idims[i]; }
+    for (int i = 0; i < 4; i++) { rdims[i] = static_cast<size_t>(idims[i]); }
 }
 
 //(currently) true is in clFFT if length is a power of 2,3,5
 inline bool isSupLen(dim_t length) {
     while (length > 1) {
-        if (length % 2 == 0)
+        if (length % 2 == 0) {
             length /= 2;
-        else if (length % 3 == 0)
+        } else if (length % 3 == 0) {
             length /= 3;
-        else if (length % 5 == 0)
+        } else if (length % 5 == 0) {
             length /= 5;
-        else if (length % 7 == 0)
+        } else if (length % 7 == 0) {
             length /= 7;
-        else if (length % 11 == 0)
+        } else if (length % 11 == 0) {
             length /= 11;
-        else if (length % 13 == 0)
+        } else if (length % 13 == 0) {
             length /= 13;
-        else
+        } else {
             return false;
+        }
     }
     return true;
 }
 
 template<int rank>
-void verifySupported(const dim4 dims) {
+void verifySupported(const dim4 &dims) {
     for (int i = 0; i < rank; i++) { ARG_ASSERT(1, isSupLen(dims[i])); }
 }
 
@@ -77,10 +78,10 @@ void fft_inplace(Array<T> &in) {
     int batch = 1;
     for (int i = rank; i < 4; i++) { batch *= tdims[i]; }
 
-    SharedPlan plan =
-        findPlan(CLFFT_COMPLEX_INTERLEAVED, CLFFT_COMPLEX_INTERLEAVED,
-                 (clfftDim)rank, tdims, istrides, istrides[rank], istrides,
-                 istrides[rank], (clfftPrecision)Precision<T>::type, batch);
+    SharedPlan plan = findPlan(
+        CLFFT_COMPLEX_INTERLEAVED, CLFFT_COMPLEX_INTERLEAVED,
+        static_cast<clfftDim>(rank), tdims, istrides, istrides[rank], istrides,
+        istrides[rank], static_cast<clfftPrecision>(Precision<T>::type), batch);
 
     cl_mem imem            = (*in.get())();
     cl_command_queue queue = getQueue()();
@@ -108,10 +109,10 @@ Array<Tc> fft_r2c(const Array<Tr> &in) {
     int batch = 1;
     for (int i = rank; i < 4; i++) { batch *= tdims[i]; }
 
-    SharedPlan plan =
-        findPlan(CLFFT_REAL, CLFFT_HERMITIAN_INTERLEAVED, (clfftDim)rank, tdims,
-                 istrides, istrides[rank], ostrides, ostrides[rank],
-                 (clfftPrecision)Precision<Tc>::type, batch);
+    SharedPlan plan = findPlan(
+        CLFFT_REAL, CLFFT_HERMITIAN_INTERLEAVED, static_cast<clfftDim>(rank),
+        tdims, istrides, istrides[rank], ostrides, ostrides[rank],
+        static_cast<clfftPrecision>(Precision<Tc>::type), batch);
 
     cl_mem imem            = (*in.get())();
     cl_mem omem            = (*out.get())();
@@ -137,10 +138,10 @@ Array<Tr> fft_c2r(const Array<Tc> &in, const dim4 &odims) {
     int batch = 1;
     for (int i = rank; i < 4; i++) { batch *= tdims[i]; }
 
-    SharedPlan plan =
-        findPlan(CLFFT_HERMITIAN_INTERLEAVED, CLFFT_REAL, (clfftDim)rank, tdims,
-                 istrides, istrides[rank], ostrides, ostrides[rank],
-                 (clfftPrecision)Precision<Tc>::type, batch);
+    SharedPlan plan = findPlan(
+        CLFFT_HERMITIAN_INTERLEAVED, CLFFT_REAL, static_cast<clfftDim>(rank),
+        tdims, istrides, istrides[rank], ostrides, ostrides[rank],
+        static_cast<clfftPrecision>(Precision<Tc>::type), batch);
 
     cl_mem imem            = (*in.get())();
     cl_mem omem            = (*out.get())();

--- a/src/backend/opencl/fftconvolve.cpp
+++ b/src/backend/opencl/fftconvolve.cpp
@@ -19,19 +19,20 @@ using af::dim4;
 namespace opencl {
 
 template<typename T>
-static const dim4 calcPackedSize(Array<T> const& i1, Array<T> const& i2,
-                                 const dim_t baseDim) {
-    const dim4 i1d = i1.dims();
-    const dim4 i2d = i2.dims();
+static dim4 calcPackedSize(Array<T> const& i1, Array<T> const& i2,
+                           const dim_t baseDim) {
+    const dim4& i1d = i1.dims();
+    const dim4& i2d = i2.dims();
 
     dim_t pd[4] = {1, 1, 1, 1};
 
     // Pack both signal and filter on same memory array, this will ensure
     // better use of batched cuFFT capabilities
-    pd[0] = nextpow2((unsigned)((int)ceil(i1d[0] / 2.f) + i2d[0] - 1));
+    pd[0] = nextpow2(static_cast<unsigned>(
+        static_cast<int>(std::ceil(i1d[0] / 2.f)) + i2d[0] - 1));
 
     for (dim_t k = 1; k < baseDim; k++) {
-        pd[k] = nextpow2((unsigned)(i1d[k] + i2d[k] - 1));
+        pd[k] = nextpow2(static_cast<unsigned>(i1d[k] + i2d[k] - 1));
     }
 
     dim_t i1batch = 1;
@@ -49,8 +50,8 @@ template<typename T, typename convT, typename cT, bool isDouble, bool roundOut,
          dim_t baseDim>
 Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
                      const bool expand, AF_BATCH_KIND kind) {
-    const dim4 sDims = signal.dims();
-    const dim4 fDims = filter.dims();
+    const dim4& sDims = signal.dims();
+    const dim4& fDims = filter.dims();
 
     dim4 oDims(1);
     if (expand) {
@@ -64,7 +65,7 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
     } else {
         oDims = sDims;
         if (kind == AF_BATCH_RHS) {
-            for (dim_t i = baseDim; i < 4; ++i) oDims[i] = fDims[i];
+            for (dim_t i = baseDim; i < 4; ++i) { oDims[i] = fDims[i]; }
         }
     }
 
@@ -83,12 +84,13 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
     if (kind == AF_BATCH_RHS) {
         std::vector<af_seq> seqs;
         for (dim_t k = 0; k < 4; k++) {
-            if (k < baseDim)
+            if (k < baseDim) {
                 seqs.push_back({0., static_cast<double>(pDims[k] - 1), 1.});
-            else if (k == baseDim)
+            } else if (k == baseDim) {
                 seqs.push_back({1., static_cast<double>(pDims[k] - 1), 1.});
-            else
+            } else {
                 seqs.push_back({0., 0., 1.});
+            }
         }
 
         Array<cT> subPacked = createSubArray<cT>(packed, seqs);
@@ -96,12 +98,13 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
     } else {
         std::vector<af_seq> seqs;
         for (dim_t k = 0; k < 4; k++) {
-            if (k < baseDim)
-                seqs.push_back({0., (double)pDims[k] - 1, 1.});
-            else if (k == baseDim)
+            if (k < baseDim) {
+                seqs.push_back({0., static_cast<double>(pDims[k]) - 1, 1.});
+            } else if (k == baseDim) {
                 seqs.push_back({0., static_cast<double>(pDims[k] - 2), 1.});
-            else
+            } else {
                 seqs.push_back({0., 0., 1.});
+            }
         }
 
         Array<cT> subPacked = createSubArray<cT>(packed, seqs);
@@ -110,12 +113,13 @@ Array<T> fftconvolve(Array<T> const& signal, Array<T> const& filter,
 
     Array<T> out = createEmptyArray<T>(oDims);
 
-    if (expand)
+    if (expand) {
         kernel::reorderOutputHelper<T, cT, isDouble, roundOut, true, convT>(
             out, packed, signal, filter, baseDim, kind);
-    else
+    } else {
         kernel::reorderOutputHelper<T, cT, isDouble, roundOut, false, convT>(
             out, packed, signal, filter, baseDim, kind);
+    }
 
     return out;
 }

--- a/src/backend/opencl/hist_graphics.cpp
+++ b/src/backend/opencl/hist_graphics.cpp
@@ -51,7 +51,8 @@ void copy_histogram(const Array<T> &data, fg_histogram hist) {
 
         CheckGL("Begin OpenCL fallback-resource copy");
         glBindBuffer(GL_ARRAY_BUFFER, buffer);
-        GLubyte *ptr = (GLubyte *)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        auto *ptr =
+            static_cast<GLubyte *>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
         if (ptr) {
             getQueue().enqueueReadBuffer(*data.get(), CL_TRUE, 0, bytes, ptr);
             glUnmapBuffer(GL_ARRAY_BUFFER);

--- a/src/backend/opencl/histogram.cpp
+++ b/src/backend/opencl/histogram.cpp
@@ -22,7 +22,7 @@ namespace opencl {
 template<typename inType, typename outType, bool isLinear>
 Array<outType> histogram(const Array<inType> &in, const unsigned &nbins,
                          const double &minval, const double &maxval) {
-    const dim4 dims    = in.dims();
+    const dim4 &dims   = in.dims();
     dim4 outDims       = dim4(nbins, 1, dims[2], dims[3]);
     Array<outType> out = createValueArray<outType>(outDims, outType(0));
 

--- a/src/backend/opencl/homography.cpp
+++ b/src/backend/opencl/homography.cpp
@@ -51,9 +51,10 @@ int homography(Array<T> &bestH, const Array<float> &x_src,
     af::dim4 rdims(4, iter_sz);
     Array<float> fctr =
         createValueArray<float>(rdims, static_cast<float>(nsamples));
-    Array<float> rnd  = arithOp<float, af_mul_t>(initial, fctr, rdims);
+    Array<float> rnd = arithOp<float, af_mul_t>(initial, fctr, rdims);
 
-    Array<T> tmpH = createValueArray<T>(af::dim4(9, iter_sz), static_cast<T>(0));
+    Array<T> tmpH =
+        createValueArray<T>(af::dim4(9, iter_sz), static_cast<T>(0));
 
     bestH = createValueArray<T>(af::dim4(3, 3), static_cast<T>(0));
     switch (htype) {

--- a/src/backend/opencl/homography.cpp
+++ b/src/backend/opencl/homography.cpp
@@ -30,15 +30,16 @@ int homography(Array<T> &bestH, const Array<float> &x_src,
                const Array<float> &y_dst, const Array<float> &initial,
                const af_homography_type htype, const float inlier_thr,
                const unsigned iterations) {
-    const af::dim4 idims    = x_src.dims();
+    const af::dim4 &idims   = x_src.dims();
     const unsigned nsamples = idims[0];
 
     unsigned iter    = iterations;
     Array<float> err = createEmptyArray<float>(af::dim4());
     if (htype == AF_HOMOGRAPHY_LMEDS) {
-        iter = ::std::min(
-            iter, (unsigned)(log(1.f - LMEDSConfidence) /
-                             log(1.f - pow(1.f - LMEDSOutlierRatio, 4.f))));
+        iter =
+            ::std::min(iter, static_cast<unsigned>(
+                                 log(1.f - LMEDSConfidence) /
+                                 log(1.f - pow(1.f - LMEDSOutlierRatio, 4.f))));
         err = createValueArray<float>(af::dim4(nsamples, iter), FLT_MAX);
     } else {
         // Avoid passing "null" cl_mem object to kernels
@@ -48,12 +49,13 @@ int homography(Array<T> &bestH, const Array<float> &x_src,
     const size_t iter_sz = divup(iter, 256) * 256;
 
     af::dim4 rdims(4, iter_sz);
-    Array<float> fctr = createValueArray<float>(rdims, (float)nsamples);
+    Array<float> fctr =
+        createValueArray<float>(rdims, static_cast<float>(nsamples));
     Array<float> rnd  = arithOp<float, af_mul_t>(initial, fctr, rdims);
 
-    Array<T> tmpH = createValueArray<T>(af::dim4(9, iter_sz), (T)0);
+    Array<T> tmpH = createValueArray<T>(af::dim4(9, iter_sz), static_cast<T>(0));
 
-    bestH = createValueArray<T>(af::dim4(3, 3), (T)0);
+    bestH = createValueArray<T>(af::dim4(3, 3), static_cast<T>(0));
     switch (htype) {
         case AF_HOMOGRAPHY_RANSAC:
             return kernel::computeH<T, AF_HOMOGRAPHY_RANSAC>(

--- a/src/backend/opencl/iir.cpp
+++ b/src/backend/opencl/iir.cpp
@@ -34,7 +34,7 @@ Array<T> iir(const Array<T> &b, const Array<T> &a, const Array<T> &x) {
 
     int num_a = a.dims()[0];
 
-    if (num_a == 1) return c;
+    if (num_a == 1) { return c; }
 
     dim4 ydims = c.dims();
     Array<T> y = createEmptyArray<T>(ydims);

--- a/src/backend/opencl/image.cpp
+++ b/src/backend/opencl/image.cpp
@@ -57,8 +57,8 @@ void copy_image(const Array<T> &in, fg_image image) {
 
         glBindBuffer(GL_PIXEL_UNPACK_BUFFER, buffer);
         glBufferData(GL_PIXEL_UNPACK_BUFFER, bytes, 0, GL_STREAM_DRAW);
-        GLubyte *ptr =
-            (GLubyte *)glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY);
+        auto *ptr = static_cast<GLubyte *>(
+            glMapBuffer(GL_PIXEL_UNPACK_BUFFER, GL_WRITE_ONLY));
         if (ptr) {
             getQueue().enqueueReadBuffer(*in.get(), CL_TRUE, 0, bytes, ptr);
             glUnmapBuffer(GL_PIXEL_UNPACK_BUFFER);

--- a/src/backend/opencl/index.cpp
+++ b/src/backend/opencl/index.cpp
@@ -31,14 +31,14 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
     }
 
     // retrieve dimensions, strides and offsets
-    dim4 iDims  = in.dims();
+    const dim4& iDims = in.dims();
     dim4 dDims  = in.getDataDims();
     dim4 oDims  = toDims(seqs, iDims);
     dim4 iOffs  = toOffset(seqs, dDims);
     dim4 iStrds = in.strides();
 
     for (dim_t i = 0; i < 4; ++i) {
-        p.isSeq[i] = idxrs[i].isSeq;
+        p.isSeq[i] = idxrs[i].isSeq ? 1 : 0;
         p.offs[i]  = iOffs[i];
         p.strds[i] = iStrds[i];
     }
@@ -66,7 +66,7 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
     kernel::index<T>(out, in, p, bPtrs);
 
     for (dim_t x = 0; x < 4; ++x) {
-        if (p.isSeq[x]) bufferFree(bPtrs[x]);
+        if (p.isSeq[x]) { bufferFree(bPtrs[x]); }
     }
 
     return out;

--- a/src/backend/opencl/index.cpp
+++ b/src/backend/opencl/index.cpp
@@ -32,10 +32,10 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
 
     // retrieve dimensions, strides and offsets
     const dim4& iDims = in.dims();
-    dim4 dDims  = in.getDataDims();
-    dim4 oDims  = toDims(seqs, iDims);
-    dim4 iOffs  = toOffset(seqs, dDims);
-    dim4 iStrds = in.strides();
+    dim4 dDims        = in.getDataDims();
+    dim4 oDims        = toDims(seqs, iDims);
+    dim4 iOffs        = toOffset(seqs, dDims);
+    dim4 iStrds       = in.strides();
 
     for (dim_t i = 0; i < 4; ++i) {
         p.isSeq[i] = idxrs[i].isSeq ? 1 : 0;

--- a/src/backend/opencl/inverse.cpp
+++ b/src/backend/opencl/inverse.cpp
@@ -20,7 +20,7 @@ namespace opencl {
 template<typename T>
 Array<T> inverse(const Array<T> &in) {
     if (OpenCLCPUOffload()) {
-        if (in.dims()[0] == in.dims()[1]) return cpu::inverse(in);
+        if (in.dims()[0] == in.dims()[1]) { return cpu::inverse(in); }
     }
     Array<T> I = identity<T>(in.dims());
     return solve<T>(in, I);

--- a/src/backend/opencl/join.cpp
+++ b/src/backend/opencl/join.cpp
@@ -13,14 +13,19 @@
 #include <join.hpp>
 #include <kernel/join.hpp>
 
+#include <algorithm>
 #include <stdexcept>
+#include <vector>
 
+using af::dim4;
 using common::half;
+using std::transform;
+using std::vector;
 
 namespace opencl {
 template<int dim>
-af::dim4 calcOffset(const af::dim4 dims) {
-    af::dim4 offset;
+dim4 calcOffset(const dim4 &dims) {
+    dim4 offset;
     offset[0] = (dim == 0) ? dims[0] : 0;
     offset[1] = (dim == 1) ? dims[1] : 0;
     offset[2] = (dim == 2) ? dims[2] : 0;
@@ -32,9 +37,9 @@ template<typename Tx, typename Ty>
 Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second) {
     // All dimensions except join dimension must be equal
     // Compute output dims
-    af::dim4 odims;
-    af::dim4 fdims = first.dims();
-    af::dim4 sdims = second.dims();
+    dim4 odims;
+    dim4 fdims = first.dims();
+    dim4 sdims = second.dims();
 
     for (int i = 0; i < 4; i++) {
         if (i == dim) {
@@ -46,7 +51,7 @@ Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second) {
 
     Array<Tx> out = createEmptyArray<Tx>(odims);
 
-    af::dim4 zero(0, 0, 0, 0);
+    dim4 zero(0, 0, 0, 0);
 
     switch (dim) {
         case 0:
@@ -72,9 +77,9 @@ Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second) {
 
 template<typename T, int n_arrays>
 void join_wrapper(const int dim, Array<T> &out,
-                  const std::vector<Array<T>> &inputs) {
-    af::dim4 zero(0, 0, 0, 0);
-    af::dim4 d = zero;
+                  const vector<Array<T>> &inputs) {
+    dim4 zero(0, 0, 0, 0);
+    dim4 d = zero;
 
     switch (dim) {
         case 0:
@@ -109,15 +114,15 @@ void join_wrapper(const int dim, Array<T> &out,
 }
 
 template<typename T>
-Array<T> join(const int dim, const std::vector<Array<T>> &inputs) {
+Array<T> join(const int dim, const vector<Array<T>> &inputs) {
     // All dimensions except join dimension must be equal
     // Compute output dims
-    af::dim4 odims;
+    dim4 odims;
     const dim_t n_arrays = inputs.size();
-    std::vector<af::dim4> idims(n_arrays);
+    vector<dim4> idims(n_arrays);
 
     dim_t dim_size = 0;
-    for (int i = 0; i < (int)idims.size(); i++) {
+    for (size_t i = 0; i < idims.size(); i++) {
         idims[i] = inputs[i].dims();
         dim_size += idims[i][dim];
     }
@@ -130,12 +135,12 @@ Array<T> join(const int dim, const std::vector<Array<T>> &inputs) {
         }
     }
 
-    std::vector<Array<T> *> input_ptrs(inputs.size());
-    std::transform(
+    vector<Array<T> *> input_ptrs(inputs.size());
+    transform(
         begin(inputs), end(inputs), begin(input_ptrs),
         [](const Array<T> &input) { return const_cast<Array<T> *>(&input); });
     evalMultiple(input_ptrs);
-    std::vector<Param> inputParams(inputs.begin(), inputs.end());
+    vector<Param> inputParams(inputs.begin(), inputs.end());
     Array<T> out = createEmptyArray<T>(odims);
 
     switch (n_arrays) {
@@ -175,7 +180,7 @@ INSTANTIATE(half, half)
 
 #define INSTANTIATE(T)                       \
     template Array<T> join<T>(const int dim, \
-                              const std::vector<Array<T>> &inputs);
+                              const vector<Array<T>> &inputs);
 
 INSTANTIATE(float)
 INSTANTIATE(double)

--- a/src/backend/opencl/join.cpp
+++ b/src/backend/opencl/join.cpp
@@ -178,9 +178,8 @@ INSTANTIATE(half, half)
 
 #undef INSTANTIATE
 
-#define INSTANTIATE(T)                       \
-    template Array<T> join<T>(const int dim, \
-                              const vector<Array<T>> &inputs);
+#define INSTANTIATE(T) \
+    template Array<T> join<T>(const int dim, const vector<Array<T>> &inputs);
 
 INSTANTIATE(float)
 INSTANTIATE(double)

--- a/src/backend/opencl/kernel/approx.hpp
+++ b/src/backend/opencl/kernel/approx.hpp
@@ -50,8 +50,8 @@ std::string generateOptionsString() {
             << " -D InterpPosTy=" << dtype_traits<Tp>::getName()
             << " -D ZERO=" << toNumStr(scalar<Ty>(0));
 
-    if ((af_dtype)dtype_traits<Ty>::af_type == c32 ||
-        (af_dtype)dtype_traits<Ty>::af_type == c64) {
+    if (static_cast<af_dtype>(dtype_traits<Ty>::af_type) == c32 ||
+        static_cast<af_dtype>(dtype_traits<Ty>::af_type) == c64) {
         options << " -D IS_CPLX=1";
     } else {
         options << " -D IS_CPLX=0";

--- a/src/backend/opencl/kernel/convolve/conv2_b8.cpp
+++ b/src/backend/opencl/kernel/convolve/conv2_b8.cpp
@@ -15,6 +15,6 @@ namespace kernel {
 
 INSTANTIATE(char, float)
 
-}
+}  // namespace kernel
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/convolve/conv2_c32.cpp
+++ b/src/backend/opencl/kernel/convolve/conv2_c32.cpp
@@ -15,6 +15,6 @@ namespace kernel {
 
 INSTANTIATE(cfloat, cfloat)
 
-}
+}  // namespace kernel
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/convolve/conv2_c64.cpp
+++ b/src/backend/opencl/kernel/convolve/conv2_c64.cpp
@@ -15,6 +15,6 @@ namespace kernel {
 
 INSTANTIATE(cdouble, cdouble)
 
-}
+}  // namespace kernel
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/convolve/conv2_f32.cpp
+++ b/src/backend/opencl/kernel/convolve/conv2_f32.cpp
@@ -15,6 +15,6 @@ namespace kernel {
 
 INSTANTIATE(float, float)
 
-}
+}  // namespace kernel
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/convolve/conv2_f64.cpp
+++ b/src/backend/opencl/kernel/convolve/conv2_f64.cpp
@@ -15,6 +15,6 @@ namespace kernel {
 
 INSTANTIATE(double, double)
 
-}
+}  // namespace kernel
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/convolve/conv2_impl.hpp
+++ b/src/backend/opencl/kernel/convolve/conv2_impl.hpp
@@ -45,8 +45,8 @@ void conv2Helper(const conv_kparam_t& param, Param out, const Param signal,
                 << " -D EXPAND=" << expand << " -D C_SIZE=" << LOC_SIZE
                 << " -D " << binOpName<af_mul_t>();
 
-        if ((af_dtype)dtype_traits<T>::af_type == c32 ||
-            (af_dtype)dtype_traits<T>::af_type == c64) {
+        if (static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
+            static_cast<af_dtype>(dtype_traits<T>::af_type) == c64) {
             options << " -D CPLX=1";
         } else {
             options << " -D CPLX=0";

--- a/src/backend/opencl/kernel/convolve/conv2_s16.cpp
+++ b/src/backend/opencl/kernel/convolve/conv2_s16.cpp
@@ -15,6 +15,6 @@ namespace kernel {
 
 INSTANTIATE(short, float)
 
-}
+}  // namespace kernel
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/convolve/conv2_s32.cpp
+++ b/src/backend/opencl/kernel/convolve/conv2_s32.cpp
@@ -15,6 +15,6 @@ namespace kernel {
 
 INSTANTIATE(int, float)
 
-}
+}  // namespace kernel
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/convolve/conv2_s64.cpp
+++ b/src/backend/opencl/kernel/convolve/conv2_s64.cpp
@@ -15,6 +15,6 @@ namespace kernel {
 
 INSTANTIATE(intl, float)
 
-}
+}  // namespace kernel
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/convolve/conv2_u16.cpp
+++ b/src/backend/opencl/kernel/convolve/conv2_u16.cpp
@@ -15,6 +15,6 @@ namespace kernel {
 
 INSTANTIATE(ushort, float)
 
-}
+}  // namespace kernel
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/convolve/conv2_u32.cpp
+++ b/src/backend/opencl/kernel/convolve/conv2_u32.cpp
@@ -15,6 +15,6 @@ namespace kernel {
 
 INSTANTIATE(uint, float)
 
-}
+}  // namespace kernel
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/convolve/conv2_u64.cpp
+++ b/src/backend/opencl/kernel/convolve/conv2_u64.cpp
@@ -15,6 +15,6 @@ namespace kernel {
 
 INSTANTIATE(uintl, float)
 
-}
+}  // namespace kernel
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/convolve/conv2_u8.cpp
+++ b/src/backend/opencl/kernel/convolve/conv2_u8.cpp
@@ -15,6 +15,6 @@ namespace kernel {
 
 INSTANTIATE(uchar, float)
 
-}
+}  // namespace kernel
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/convolve/conv_common.hpp
+++ b/src/backend/opencl/kernel/convolve/conv_common.hpp
@@ -112,8 +112,8 @@ void convNHelper(const conv_kparam_t& param, Param& out, const Param& signal,
                 << " -D BASE_DIM=" << bDim << " -D EXPAND=" << expand << " -D "
                 << binOpName<af_mul_t>();
 
-        if ((af_dtype)dtype_traits<T>::af_type == c32 ||
-            (af_dtype)dtype_traits<T>::af_type == c64) {
+        if (static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
+            static_cast<af_dtype>(dtype_traits<T>::af_type) == c64) {
             options << " -D CPLX=1";
         } else {
             options << " -D CPLX=0";

--- a/src/backend/opencl/kernel/convolve_separable.cpp
+++ b/src/backend/opencl/kernel/convolve_separable.cpp
@@ -66,8 +66,8 @@ void convSep(Param out, const Param signal, const Param filter) {
                 << " -D FLEN=" << fLen << " -D LOCAL_MEM_SIZE=" << locSize
                 << " -D " << binOpName<af_mul_t>();
 
-        if ((af_dtype)dtype_traits<T>::af_type == c32 ||
-            (af_dtype)dtype_traits<T>::af_type == c64) {
+        if (static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
+            static_cast<af_dtype>(dtype_traits<T>::af_type) == c64) {
             options << " -D CPLX=1";
         } else {
             options << " -D CPLX=0";

--- a/src/backend/opencl/kernel/fftconvolve.hpp
+++ b/src/backend/opencl/kernel/fftconvolve.hpp
@@ -83,9 +83,10 @@ void packDataHelper(Param packed, Param sig, Param filter, const int baseDim,
 
         options << " -D T=" << dtype_traits<T>::getName();
 
-        if ((af_dtype)dtype_traits<convT>::af_type == c32) {
+        if (static_cast<af_dtype>(dtype_traits<convT>::af_type) == c32) {
             options << " -D CONVT=float";
-        } else if ((af_dtype)dtype_traits<convT>::af_type == c64 && isDouble) {
+        } else if (static_cast<af_dtype>(dtype_traits<convT>::af_type) == c64 &&
+                   isDouble) {
             options << " -D CONVT=double"
                     << " -D USE_DOUBLE";
         }
@@ -140,9 +141,10 @@ void packDataHelper(Param packed, Param sig, Param filter, const int baseDim,
 
         options << " -D T=" << dtype_traits<T>::getName();
 
-        if ((af_dtype)dtype_traits<convT>::af_type == c32) {
+        if (static_cast<af_dtype>(dtype_traits<convT>::af_type) == c32) {
             options << " -D CONVT=float";
-        } else if ((af_dtype)dtype_traits<convT>::af_type == c64 && isDouble) {
+        } else if (static_cast<af_dtype>(dtype_traits<convT>::af_type) == c64 &&
+                   isDouble) {
             options << " -D CONVT=double"
                     << " -D USE_DOUBLE";
         }
@@ -189,9 +191,10 @@ void complexMultiplyHelper(Param packed, Param sig, Param filter,
                 << " -D AF_BATCH_RHS=" << (int)AF_BATCH_RHS
                 << " -D AF_BATCH_SAME=" << (int)AF_BATCH_SAME;
 
-        if ((af_dtype)dtype_traits<convT>::af_type == c32) {
+        if (static_cast<af_dtype>(dtype_traits<convT>::af_type) == c32) {
             options << " -D CONVT=float";
-        } else if ((af_dtype)dtype_traits<convT>::af_type == c64 && isDouble) {
+        } else if (static_cast<af_dtype>(dtype_traits<convT>::af_type) == c64 &&
+                   isDouble) {
             options << " -D CONVT=double"
                     << " -D USE_DOUBLE";
         }
@@ -251,9 +254,10 @@ void reorderOutputHelper(Param out, Param packed, Param sig, Param filter,
                 << " -D ROUND_OUT=" << (int)roundOut
                 << " -D EXPAND=" << (int)expand;
 
-        if ((af_dtype)dtype_traits<convT>::af_type == c32) {
+        if (static_cast<af_dtype>(dtype_traits<convT>::af_type) == c32) {
             options << " -D CONVT=float";
-        } else if ((af_dtype)dtype_traits<convT>::af_type == c64 && isDouble) {
+        } else if (static_cast<af_dtype>(dtype_traits<convT>::af_type) == c64 &&
+                   isDouble) {
             options << " -D CONVT=double"
                     << " -D USE_DOUBLE";
         }

--- a/src/backend/opencl/kernel/gradient.hpp
+++ b/src/backend/opencl/kernel/gradient.hpp
@@ -48,8 +48,8 @@ void gradient(Param grad0, Param grad1, const Param in) {
         options << " -D T=" << dtype_traits<T>::getName() << " -D TX=" << TX
                 << " -D TY=" << TY << " -D ZERO=" << toNumStr(scalar<T>(0));
 
-        if ((af_dtype)dtype_traits<T>::af_type == c32 ||
-            (af_dtype)dtype_traits<T>::af_type == c64) {
+        if (static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
+            static_cast<af_dtype>(dtype_traits<T>::af_type) == c64) {
             options << " -D CPLX=1";
         } else {
             options << " -D CPLX=0";

--- a/src/backend/opencl/kernel/ireduce.hpp
+++ b/src/backend/opencl/kernel/ireduce.hpp
@@ -326,20 +326,21 @@ T ireduce_all(uint *loc, Param in) {
         cl::Buffer *tidx = bufferAlloc(tmp_elements * sizeof(uint));
 
         Param rlen;
-        rlen.data = new cl::Buffer();
+        auto buff = std::make_unique<cl::Buffer>();
+        rlen.data = buff.get();
         ireduce_first_launcher<T, op>(tmp, tidx, in, tidx, threads_x, true,
                                       groups_x, groups_y, rlen);
 
-        unique_ptr<T[]> h_ptr(new T[tmp_elements]);
-        unique_ptr<uint[]> h_iptr(new uint[tmp_elements]);
+        std::vector<T> h_ptr(tmp_elements);
+        std::vector<uint> h_iptr(tmp_elements);
 
         getQueue().enqueueReadBuffer(*tmp.get(), CL_TRUE, 0,
-                                     sizeof(T) * tmp_elements, h_ptr.get());
+                                     sizeof(T) * tmp_elements, h_ptr.data());
         getQueue().enqueueReadBuffer(*tidx, CL_TRUE, 0,
-                                     sizeof(uint) * tmp_elements, h_iptr.get());
+                                     sizeof(uint) * tmp_elements, h_iptr.data());
 
-        T *h_ptr_raw     = h_ptr.get();
-        uint *h_iptr_raw = h_iptr.get();
+        T *h_ptr_raw     = h_ptr.data();
+        uint *h_iptr_raw = h_iptr.data();
 
         if (!is_linear) {
             // Converting n-d index into a linear index

--- a/src/backend/opencl/kernel/ireduce.hpp
+++ b/src/backend/opencl/kernel/ireduce.hpp
@@ -336,8 +336,8 @@ T ireduce_all(uint *loc, Param in) {
 
         getQueue().enqueueReadBuffer(*tmp.get(), CL_TRUE, 0,
                                      sizeof(T) * tmp_elements, h_ptr.data());
-        getQueue().enqueueReadBuffer(*tidx, CL_TRUE, 0,
-                                     sizeof(uint) * tmp_elements, h_iptr.data());
+        getQueue().enqueueReadBuffer(
+            *tidx, CL_TRUE, 0, sizeof(uint) * tmp_elements, h_iptr.data());
 
         T *h_ptr_raw     = h_ptr.data();
         uint *h_iptr_raw = h_iptr.data();

--- a/src/backend/opencl/kernel/resize.hpp
+++ b/src/backend/opencl/kernel/resize.hpp
@@ -55,8 +55,8 @@ void resize(Param out, const Param in) {
             default: break;
         }
 
-        if ((af_dtype)dtype_traits<T>::af_type == c32 ||
-            (af_dtype)dtype_traits<T>::af_type == c64) {
+        if (static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
+            static_cast<af_dtype>(dtype_traits<T>::af_type) == c64) {
             options << " -D CPLX=1";
             options << " -D TB=" << dtype_traits<BT>::getName();
         } else {

--- a/src/backend/opencl/kernel/rotate.hpp
+++ b/src/backend/opencl/kernel/rotate.hpp
@@ -63,8 +63,8 @@ void rotate(Param out, const Param in, const float theta,
         options << " -D InterpValTy=" << dtype_traits<vtype_t<T>>::getName();
         options << " -D InterpPosTy=" << dtype_traits<wtype_t<BT>>::getName();
 
-        if ((af_dtype)dtype_traits<T>::af_type == c32 ||
-            (af_dtype)dtype_traits<T>::af_type == c64) {
+        if (static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
+            static_cast<af_dtype>(dtype_traits<T>::af_type) == c64) {
             options << " -D IS_CPLX=1";
             options << " -D TB=" << dtype_traits<BT>::getName();
         } else {

--- a/src/backend/opencl/kernel/sparse_arith.hpp
+++ b/src/backend/opencl/kernel/sparse_arith.hpp
@@ -60,8 +60,8 @@ void sparseArithOpCSR(Param out, const Param values, const Param rowIdx,
         options << " -D T=" << dtype_traits<T>::getName();
         options << " -D OP=" << getOpString<op>();
 
-        if ((af_dtype)dtype_traits<T>::af_type == c32 ||
-            (af_dtype)dtype_traits<T>::af_type == c64) {
+        if (static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
+            static_cast<af_dtype>(dtype_traits<T>::af_type) == c64) {
             options << " -D IS_CPLX=1";
         } else {
             options << " -D IS_CPLX=0";
@@ -113,8 +113,8 @@ void sparseArithOpCOO(Param out, const Param values, const Param rowIdx,
         options << " -D T=" << dtype_traits<T>::getName();
         options << " -D OP=" << getOpString<op>();
 
-        if ((af_dtype)dtype_traits<T>::af_type == c32 ||
-            (af_dtype)dtype_traits<T>::af_type == c64) {
+        if (static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
+            static_cast<af_dtype>(dtype_traits<T>::af_type) == c64) {
             options << " -D IS_CPLX=1";
         } else {
             options << " -D IS_CPLX=0";
@@ -166,8 +166,8 @@ void sparseArithOpCSR(Param values, Param rowIdx, Param colIdx, const Param rhs,
         options << " -D T=" << dtype_traits<T>::getName();
         options << " -D OP=" << getOpString<op>();
 
-        if ((af_dtype)dtype_traits<T>::af_type == c32 ||
-            (af_dtype)dtype_traits<T>::af_type == c64) {
+        if (static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
+            static_cast<af_dtype>(dtype_traits<T>::af_type) == c64) {
             options << " -D IS_CPLX=1";
         } else {
             options << " -D IS_CPLX=0";
@@ -218,8 +218,8 @@ void sparseArithOpCOO(Param values, Param rowIdx, Param colIdx, const Param rhs,
         options << " -D T=" << dtype_traits<T>::getName();
         options << " -D OP=" << getOpString<op>();
 
-        if ((af_dtype)dtype_traits<T>::af_type == c32 ||
-            (af_dtype)dtype_traits<T>::af_type == c64) {
+        if (static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
+            static_cast<af_dtype>(dtype_traits<T>::af_type) == c64) {
             options << " -D IS_CPLX=1";
         } else {
             options << " -D IS_CPLX=0";

--- a/src/backend/opencl/kernel/transform.hpp
+++ b/src/backend/opencl/kernel/transform.hpp
@@ -65,8 +65,8 @@ void transform(Param out, const Param in, const Param tf, bool isInverse,
         options << " -D InterpValTy=" << dtype_traits<vtype_t<T>>::getName();
         options << " -D InterpPosTy=" << dtype_traits<wtype_t<BT>>::getName();
 
-        if ((af_dtype)dtype_traits<T>::af_type == c32 ||
-            (af_dtype)dtype_traits<T>::af_type == c64) {
+        if (static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
+            static_cast<af_dtype>(dtype_traits<T>::af_type) == c64) {
             options << " -D IS_CPLX=1";
             options << " -D TB=" << dtype_traits<BT>::getName();
         } else {

--- a/src/backend/opencl/lookup.cpp
+++ b/src/backend/opencl/lookup.cpp
@@ -21,11 +21,12 @@ namespace opencl {
 template<typename in_t, typename idx_t>
 Array<in_t> lookup(const Array<in_t> &input, const Array<idx_t> &indices,
                    const unsigned dim) {
-    const dim4 iDims = input.dims();
+    const dim4 &iDims = input.dims();
 
     dim4 oDims(1);
-    for (int d = 0; d < 4; ++d)
+    for (int d = 0; d < 4; ++d) {
         oDims[d] = (d == int(dim) ? indices.elements() : iDims[d]);
+    }
 
     Array<in_t> out = createEmptyArray<in_t>(oDims);
 
@@ -34,6 +35,7 @@ Array<in_t> lookup(const Array<in_t> &input, const Array<idx_t> &indices,
         case 1: kernel::lookup<in_t, idx_t, 1>(out, input, indices); break;
         case 2: kernel::lookup<in_t, idx_t, 2>(out, input, indices); break;
         case 3: kernel::lookup<in_t, idx_t, 3>(out, input, indices); break;
+        default: AF_ERROR("dim only supports values 0-3.", AF_ERR_UNKNOWN);
     }
 
     return out;

--- a/src/backend/opencl/lu.cpp
+++ b/src/backend/opencl/lu.cpp
@@ -71,7 +71,7 @@ Array<int> lu_inplace(Array<T> &in, const bool convert_pivot) {
     magma_getrf_gpu<T>(M, N, (*in_buf)(), in.getOffset(), in.strides()[1],
                        &ipiv[0], getQueue()(), &info);
 
-    if (!convert_pivot) return createHostDataArray<int>(dim4(MN), &ipiv[0]);
+    if (!convert_pivot) { return createHostDataArray<int>(dim4(MN), &ipiv[0]); }
 
     Array<int> pivot = convertPivot(&ipiv[0], MN, M);
     return pivot;

--- a/src/backend/opencl/magma/gebrd.cpp
+++ b/src/backend/opencl/magma/gebrd.cpp
@@ -190,7 +190,7 @@ magma_int_t magma_gebrd_hybrid(magma_int_t m, magma_int_t n, Ty *a,
         the vector defining G(i).
         ===================================================================== */
 
-    typedef typename af::dtype_traits<Ty>::base_type Tr;
+    using Tr = typename af::dtype_traits<Ty>::base_type;
 
     Tr *d = (Tr *)_d;
     Tr *e = (Tr *)_e;
@@ -228,8 +228,9 @@ magma_int_t magma_gebrd_hybrid(magma_int_t m, magma_int_t n, Ty *a,
     if (*info < 0) {
         // magma_xerbla(__func__, -(*info));
         return *info;
-    } else if (lquery)
+    } else if (lquery) {
         return *info;
+    }
 
     /* Quick return if possible */
     minmn = std::min(m, n);

--- a/src/backend/opencl/magma/geqrf2.cpp
+++ b/src/backend/opencl/magma/geqrf2.cpp
@@ -210,7 +210,7 @@ magma_int_t magma_geqrf2_gpu(magma_int_t m, magma_int_t n, cl_mem dA,
     }
 
     k = std::min(m, n);
-    if (k == 0) return *info;
+    if (k == 0) { return *info; }
 
     nb = magma_get_geqrf_nb<Ty>(m);
 

--- a/src/backend/opencl/magma/geqrf3.cpp
+++ b/src/backend/opencl/magma/geqrf3.cpp
@@ -193,7 +193,7 @@ magma_int_t magma_geqrf3_gpu(magma_int_t m, magma_int_t n, cl_mem dA,
     }
 
     k = minmn = std::min(m, n);
-    if (k == 0) return *info;
+    if (k == 0) { return *info; }
 
     nb = magma_get_geqrf_nb<Ty>(m);
 
@@ -252,7 +252,7 @@ magma_int_t magma_geqrf3_gpu(magma_int_t m, magma_int_t n, cl_mem dA,
 
             /* Put 0s in the upper triangular part of a panel (and 1s on the
                diagonal); copy the upper triangular in ut and invert it. */
-            if (i > 0) magma_event_sync(event[0]);
+            if (i > 0) { magma_event_sync(event[0]); }
             // Change me
             split_diag_block<Ty>(ib, work_ref(i), ldwork, ut);
             magma_setmatrix<Ty>(rows, ib, work_ref(i), ldwork, a_ref(i, i),

--- a/src/backend/opencl/magma/getrf.cpp
+++ b/src/backend/opencl/magma/getrf.cpp
@@ -130,12 +130,13 @@ magma_int_t magma_getrf_gpu(magma_int_t m, magma_int_t n, cl_mem dA,
 
     /* Check arguments */
     *info = 0;
-    if (m < 0)
+    if (m < 0) {
         *info = -1;
-    else if (n < 0)
+    } else if (n < 0) {
         *info = -2;
-    else if (ldda < std::max(1, m))
+    } else if (ldda < std::max(1, m)) {
         *info = -4;
+    }
 
     if (*info != 0) {
         // magma_xerbla(__func__, -(*info));
@@ -143,7 +144,7 @@ magma_int_t magma_getrf_gpu(magma_int_t m, magma_int_t n, cl_mem dA,
     }
 
     /* Quick return if possible */
-    if (m == 0 || n == 0) return *info;
+    if (m == 0 || n == 0) { return *info; }
 
     gpu_blas_gemm_func<Ty> gpu_blas_gemm;
     gpu_blas_trsm_func<Ty> gpu_blas_trsm;
@@ -196,7 +197,7 @@ magma_int_t magma_getrf_gpu(magma_int_t m, magma_int_t n, cl_mem dA,
         ldwork = maxm;
         if (MAGMA_SUCCESS != magma_malloc_cpu<Ty>(&work, ldwork * nb)) {
             magma_free(dAP);
-            if (dA != dAT) magma_free(dAT);
+            if (dA != dAT) { magma_free(dAT); }
 
             *info = MAGMA_ERR_HOST_ALLOC;
             return *info;
@@ -232,7 +233,7 @@ magma_int_t magma_getrf_gpu(magma_int_t m, magma_int_t n, cl_mem dA,
             rows = m - j * nb;
             LAPACKE_CHECK(
                 cpu_lapack_getrf(rows, nb, work, ldwork, ipiv + j * nb));
-            if (*info == 0 && iinfo > 0) *info = iinfo + j * nb;
+            if (*info == 0 && iinfo > 0) { *info = iinfo + j * nb; }
 
             for (i = j * nb; i < j * nb + nb; ++i) { ipiv[i] += j * nb; }
             magmablas_laswp<Ty>(n, dAT(0, 0), lddat, j * nb + 1, j * nb + nb,
@@ -291,7 +292,7 @@ magma_int_t magma_getrf_gpu(magma_int_t m, magma_int_t n, cl_mem dA,
             // do the cpu part
             LAPACKE_CHECK(
                 cpu_lapack_getrf(rows, nb0, work, ldwork, ipiv + s * nb));
-            if (*info == 0 && iinfo > 0) *info = iinfo + s * nb;
+            if (*info == 0 && iinfo > 0) { *info = iinfo + s * nb; }
 
             for (i = s * nb; i < s * nb + nb0; ++i) { ipiv[i] += s * nb; }
             magmablas_laswp<Ty>(n, dAT(0, 0), lddat, s * nb + 1, s * nb + nb0,

--- a/src/backend/opencl/magma/getrs.cpp
+++ b/src/backend/opencl/magma/getrs.cpp
@@ -245,7 +245,7 @@ magma_int_t magma_getrs_gpu(magma_trans_t trans, magma_int_t n,
         magma_setmatrix<Ty>(n, nrhs, work, n, dB, dB_offset, lddb, queue);
     }
 
-    if (nrhs > 1 && dAT != 0) magma_free(dAT);
+    if (nrhs > 1 && dAT != 0) { magma_free(dAT); }
     magma_free_cpu(work);
     return *info;
 }

--- a/src/backend/opencl/magma/labrd.cpp
+++ b/src/backend/opencl/magma/labrd.cpp
@@ -201,7 +201,7 @@ magma_int_t magma_labrd_gpu(magma_int_t m, magma_int_t n, magma_int_t nb, Ty *a,
         of the vector defining G(i).
         ===================================================================== */
 
-    typedef typename af::dtype_traits<Ty>::base_type Tr;
+    using Tr = typename af::dtype_traits<Ty>::base_type;
 
     constexpr bool is_cplx = common::is_complex<Ty>::value;
 
@@ -216,7 +216,7 @@ magma_int_t magma_labrd_gpu(magma_int_t m, magma_int_t n, magma_int_t nb, Ty *a,
     magma_int_t a_dim1, a_offset, x_dim1, x_offset, y_dim1, y_offset, i__2,
         i__3;
     magma_int_t i__;
-    Ty alpha;
+    Ty alpha{};
 
     a_dim1   = lda;
     a_offset = 1 + a_dim1;

--- a/src/backend/opencl/magma/larfb.cpp
+++ b/src/backend/opencl/magma/larfb.cpp
@@ -237,10 +237,11 @@ magma_int_t magma_larfb_gpu(magma_side_t side, magma_trans_t trans,
 
     // whether T is upper or lower triangular
     OPENCL_BLAS_TRIANGLE_T uplo;
-    if (direct == MagmaForward)
+    if (direct == MagmaForward) {
         uplo = OPENCL_BLAS_TRIANGLE_UPPER;
-    else
+    } else {
         uplo = OPENCL_BLAS_TRIANGLE_LOWER;
+    }
 
     // whether V is stored transposed or not
     OPENCL_BLAS_TRANS_T notransV, transV;

--- a/src/backend/opencl/magma/laset.cpp
+++ b/src/backend/opencl/magma/laset.cpp
@@ -61,14 +61,15 @@ void magmablas_laset(magma_uplo_t uplo, magma_int_t m, magma_int_t n, T offdiag,
                      T diag, cl_mem dA, size_t dA_offset, magma_int_t ldda,
                      magma_queue_t queue) {
     magma_int_t info = 0;
-    if (uplo != MagmaLower && uplo != MagmaUpper && uplo != MagmaFull)
+    if (uplo != MagmaLower && uplo != MagmaUpper && uplo != MagmaFull) {
         info = -1;
-    else if (m < 0)
+    } else if (m < 0) {
         info = -2;
-    else if (n < 0)
+    } else if (n < 0) {
         info = -3;
-    else if (ldda < std::max(1, m))
+    } else if (ldda < std::max(1, m)) {
         info = -7;
+    }
 
     if (info != 0) {
         return;  // info;

--- a/src/backend/opencl/magma/laswp.cpp
+++ b/src/backend/opencl/magma/laswp.cpp
@@ -62,14 +62,15 @@ void magmablas_laswp(magma_int_t n, cl_mem dAT, size_t dAT_offset,
                      const magma_int_t *ipiv, magma_int_t inci,
                      magma_queue_t queue) {
     magma_int_t info = 0;
-    if (n < 0)
+    if (n < 0) {
         info = -1;
-    else if (k1 < 1)
+    } else if (k1 < 1) {
         info = -4;
-    else if (k2 < 1)
+    } else if (k2 < 1) {
         info = -5;
-    else if (inci <= 0)
+    } else if (inci <= 0) {
         info = -7;
+    }
 
     if (info != 0) {
         // magma_xerbla( __func__, -(info) );

--- a/src/backend/opencl/magma/magma_helper.cpp
+++ b/src/backend/opencl/magma/magma_helper.cpp
@@ -63,11 +63,11 @@ template double magma_real<float>(float val);
 template double magma_real<double>(double val);
 template<>
 double magma_real<magmaFloatComplex>(magmaFloatComplex val) {
-    return (double)val.s[0];
+    return static_cast<double>(val.s[0]);
 }
 template<>
 double magma_real<magmaDoubleComplex>(magmaDoubleComplex val) {
-    return (double)val.s[0];
+    return static_cast<double>(val.s[0]);
 }
 
 #define INSTANTIATE_CPLX_SCALAR(T)  \
@@ -99,60 +99,66 @@ bool magma_is_real<magmaDoubleComplex>() {
 
 template<typename T>
 magma_int_t magma_get_getrf_nb(magma_int_t m) {
-    if (m <= 3200)
+    if (m <= 3200) {
         return 128;
-    else if (m < 9000)
+    } else if (m < 9000) {
         return 256;
-    else
+    } else {
         return 320;
+    }
 }
 
 template magma_int_t magma_get_getrf_nb<float>(magma_int_t m);
 
 template<>
 magma_int_t magma_get_getrf_nb<double>(magma_int_t m) {
-    if (m <= 2048)
+    if (m <= 2048) {
         return 64;
-    else if (m < 7200)
+    } else if (m < 7200) {
         return 192;
-    else
+    } else {
         return 256;
+    }
 }
 
 template<>
 magma_int_t magma_get_getrf_nb<magmaFloatComplex>(magma_int_t m) {
-    if (m <= 2048)
+    if (m <= 2048) {
         return 64;
-    else
+    } else {
         return 128;
+    }
 }
 
 template<>
 magma_int_t magma_get_getrf_nb<magmaDoubleComplex>(magma_int_t m) {
-    if (m <= 3072)
+    if (m <= 3072) {
         return 32;
-    else if (m <= 9024)
+    } else if (m <= 9024) {
         return 64;
-    else
+    } else {
         return 128;
+    }
 }
 
 template<typename T>
 magma_int_t magma_get_potrf_nb(magma_int_t m) {
-    if (m <= 1024)
+    if (m <= 1024) {
         return 128;
-    else
+    } else {
         return 320;
+    }
 }
 
 template magma_int_t magma_get_potrf_nb<float>(magma_int_t m);
 
 template<>
 magma_int_t magma_get_potrf_nb<double>(magma_int_t m) {
-    if (m <= 4256)
+    if (m <= 4256) {
         return 128;
-    else
+    } else {
         return 256;
+    }
 }
 
 template<>
@@ -177,28 +183,30 @@ template magma_int_t magma_get_geqrf_nb<float>(magma_int_t m);
 
 template<>
 magma_int_t magma_get_geqrf_nb<double>(magma_int_t m) {
-    if (m <= 2048) return 64;
+    if (m <= 2048) { return 64; }
     return 128;
 }
 
 template<>
 magma_int_t magma_get_geqrf_nb<magmaFloatComplex>(magma_int_t m) {
-    if (m <= 2048)
+    if (m <= 2048) {
         return 32;
-    else if (m <= 4032)
+    } else if (m <= 4032) {
         return 64;
-    else
+    } else {
         return 128;
+    }
 }
 
 template<>
 magma_int_t magma_get_geqrf_nb<magmaDoubleComplex>(magma_int_t m) {
-    if (m <= 2048)
+    if (m <= 2048) {
         return 32;
-    else if (m <= 4032)
+    } else if (m <= 4032) {
         return 64;
-    else
+    } else {
         return 128;
+    }
 }
 
 #if defined(__GNUC__) || defined(__GNUG__)
@@ -218,7 +226,7 @@ template float magma_make<float>(double r, double i);
 template double magma_make<double>(double r, double i);
 template<>
 magmaFloatComplex magma_make<magmaFloatComplex>(double r, double i) {
-    magmaFloatComplex tmp = {(float)r, (float)i};
+    magmaFloatComplex tmp = {static_cast<float>(r), static_cast<float>(i)};
     return tmp;
 }
 template<>

--- a/src/backend/opencl/magma/transpose.cpp
+++ b/src/backend/opencl/magma/transpose.cpp
@@ -60,14 +60,15 @@ void magmablas_transpose(magma_int_t m, magma_int_t n, cl_mem dA,
                          size_t dAT_offset, magma_int_t lddat,
                          magma_queue_t queue) {
     magma_int_t info = 0;
-    if (m < 0)
+    if (m < 0) {
         info = -1;
-    else if (n < 0)
+    } else if (n < 0) {
         info = -2;
-    else if (ldda < m)
+    } else if (ldda < m) {
         info = -4;
-    else if (lddat < n)
+    } else if (lddat < n) {
         info = -6;
+    }
 
     if (info != 0) {
         // magma_xerbla( __func__, -(info) );
@@ -75,7 +76,7 @@ void magmablas_transpose(magma_int_t m, magma_int_t n, cl_mem dA,
     }
 
     /* Quick return */
-    if ((m == 0) || (n == 0)) return;
+    if ((m == 0) || (n == 0)) { return; }
 
     int idims[]    = {m, n, 1, 1};
     int odims[]    = {n, m, 1, 1};

--- a/src/backend/opencl/magma/transpose_inplace.cpp
+++ b/src/backend/opencl/magma/transpose_inplace.cpp
@@ -58,17 +58,18 @@ template<typename T>
 void magmablas_transpose_inplace(magma_int_t n, cl_mem dA, size_t dA_offset,
                                  magma_int_t ldda, magma_queue_t queue) {
     magma_int_t info = 0;
-    if (n < 0)
+    if (n < 0) {
         info = -1;
-    else if (ldda < n)
+    } else if (ldda < n) {
         info = -3;
+    }
 
     if (info != 0) {
         // magma_xerbla( __func__, -(info) );
         return;  // info;
     }
 
-    if (n == 0) return;
+    if (n == 0) { return; }
 
     int dims[]    = {n, n, 1, 1};
     int strides[] = {1, ldda, ldda * n, ldda * n};

--- a/src/backend/opencl/magma/unmqr.cpp
+++ b/src/backend/opencl/magma/unmqr.cpp
@@ -296,13 +296,13 @@ magma_int_t magma_unmqr_gpu(magma_side_t side, magma_trans_t trans,
                 jc = i;
             }
 
-            if (mi == 0 || ni == 0) break;
+            if (mi == 0 || ni == 0) { break; }
 
             ret = magma_larfb_gpu<Ty>(
                 MagmaLeft, is_real ? MagmaTrans : MagmaConjTrans, MagmaForward,
                 MagmaColumnwise, mi, ni, ib, a_ref(i, i), ldda, t_ref(i), nb,
                 c_ref(ic, jc), lddc, dwork, 0, nw, queue);
-            if (ret != MAGMA_SUCCESS) return ret;
+            if (ret != MAGMA_SUCCESS) { return ret; }
         }
     } else {
         i = i1;

--- a/src/backend/opencl/match_template.cpp
+++ b/src/backend/opencl/match_template.cpp
@@ -26,10 +26,11 @@ Array<outType> match_template(const Array<inType> &sImg,
     bool needMean = mType == AF_ZSAD || mType == AF_LSAD || mType == AF_ZSSD ||
                     mType == AF_LSSD || mType == AF_ZNCC;
 
-    if (needMean)
+    if (needMean) {
         kernel::matchTemplate<inType, outType, mType, true>(out, sImg, tImg);
-    else
+    } else {
         kernel::matchTemplate<inType, outType, mType, false>(out, sImg, tImg);
+    }
 
     return out;
 }

--- a/src/backend/opencl/math.cpp
+++ b/src/backend/opencl/math.cpp
@@ -11,26 +11,26 @@
 #include <common/half.hpp>
 
 namespace opencl {
-bool operator==(cfloat a, cfloat b) {
-    return (a.s[0] == b.s[0]) && (a.s[1] == b.s[1]);
+bool operator==(cfloat lhs, cfloat rhs) {
+    return (lhs.s[0] == rhs.s[0]) && (lhs.s[1] == rhs.s[1]);
 }
-bool operator!=(cfloat a, cfloat b) { return !(a == b); }
-bool operator==(cdouble a, cdouble b) {
-    return (a.s[0] == b.s[0]) && (a.s[1] == b.s[1]);
+bool operator!=(cfloat lhs, cfloat rhs) { return !(lhs == rhs); }
+bool operator==(cdouble lhs, cdouble rhs) {
+    return (lhs.s[0] == rhs.s[0]) && (lhs.s[1] == rhs.s[1]);
 }
-bool operator!=(cdouble a, cdouble b) { return !(a == b); }
+bool operator!=(cdouble lhs, cdouble rhs) { return !(lhs == rhs); }
 
-cfloat operator+(cfloat a, cfloat b) {
-    cfloat res = {{a.s[0] + b.s[0], a.s[1] + b.s[1]}};
+cfloat operator+(cfloat lhs, cfloat rhs) {
+    cfloat res = {{lhs.s[0] + rhs.s[0], lhs.s[1] + rhs.s[1]}};
     return res;
 }
 
-common::half operator+(common::half a, common::half b) noexcept {
-    return common::half(static_cast<float>(a) + static_cast<float>(b));
+common::half operator+(common::half lhs, common::half rhs) noexcept {
+    return common::half(static_cast<float>(lhs) + static_cast<float>(rhs));
 }
 
-cdouble operator+(cdouble a, cdouble b) {
-    cdouble res = {{a.s[0] + b.s[0], a.s[1] + b.s[1]}};
+cdouble operator+(cdouble lhs, cdouble rhs) {
+    cdouble res = {{lhs.s[0] + rhs.s[0], lhs.s[1] + rhs.s[1]}};
     return res;
 }
 

--- a/src/backend/opencl/math.hpp
+++ b/src/backend/opencl/math.hpp
@@ -143,9 +143,9 @@ cfloat operator+(cfloat a, cfloat b);
 cfloat operator+(cfloat a);
 cdouble operator+(cdouble a, cdouble b);
 cdouble operator+(cdouble a);
-cfloat operator*(cfloat a, cfloat b);
-cdouble operator*(cdouble a, cdouble b);
-common::half operator+(common::half lhs, common::half rhs) noexcept;
+cfloat operator*(cfloat lhs, cfloat rhs);
+cdouble operator*(cdouble lhs, cdouble rhs);
+common::half operator+(common::half a, common::half b) noexcept;
 }  // namespace opencl
 
 #if defined(__GNUC__) || defined(__GNUG__)

--- a/src/backend/opencl/math.hpp
+++ b/src/backend/opencl/math.hpp
@@ -135,17 +135,17 @@ static inline float real(cfloat in) { return in.s[0]; }
 static inline double imag(cdouble in) { return in.s[1]; }
 static inline float imag(cfloat in) { return in.s[1]; }
 
-bool operator==(cfloat a, cfloat b);
-bool operator!=(cfloat a, cfloat b);
-bool operator==(cdouble a, cdouble b);
-bool operator!=(cdouble a, cdouble b);
-cfloat operator+(cfloat a, cfloat b);
-cfloat operator+(cfloat a);
-cdouble operator+(cdouble a, cdouble b);
-cdouble operator+(cdouble a);
+bool operator==(cfloat lhs, cfloat rhs);
+bool operator!=(cfloat lhs, cfloat rhs);
+bool operator==(cdouble lhs, cdouble rhs);
+bool operator!=(cdouble lhs, cdouble rhs);
+cfloat operator+(cfloat lhs, cfloat rhs);
+cfloat operator+(cfloat lhs);
+cdouble operator+(cdouble lhs, cdouble rhs);
+cdouble operator+(cdouble lhs);
 cfloat operator*(cfloat lhs, cfloat rhs);
 cdouble operator*(cdouble lhs, cdouble rhs);
-common::half operator+(common::half a, common::half b) noexcept;
+common::half operator+(common::half lhs, common::half rhs) noexcept;
 }  // namespace opencl
 
 #if defined(__GNUC__) || defined(__GNUG__)

--- a/src/backend/opencl/meanshift.cpp
+++ b/src/backend/opencl/meanshift.cpp
@@ -21,7 +21,7 @@ Array<T> meanshift(const Array<T> &in, const float &spatialSigma,
                    const float &chromaticSigma, const unsigned &numIterations,
                    const bool &isColor) {
     const dim4 &dims = in.dims();
-    Array<T> out    = createEmptyArray<T>(dims);
+    Array<T> out     = createEmptyArray<T>(dims);
     if (isColor) {
         kernel::meanshift<T, true>(out, in, spatialSigma, chromaticSigma,
                                    numIterations);

--- a/src/backend/opencl/meanshift.cpp
+++ b/src/backend/opencl/meanshift.cpp
@@ -20,14 +20,15 @@ template<typename T>
 Array<T> meanshift(const Array<T> &in, const float &spatialSigma,
                    const float &chromaticSigma, const unsigned &numIterations,
                    const bool &isColor) {
-    const dim4 dims = in.dims();
+    const dim4 &dims = in.dims();
     Array<T> out    = createEmptyArray<T>(dims);
-    if (isColor)
+    if (isColor) {
         kernel::meanshift<T, true>(out, in, spatialSigma, chromaticSigma,
                                    numIterations);
-    else
+    } else {
         kernel::meanshift<T, false>(out, in, spatialSigma, chromaticSigma,
                                     numIterations);
+    }
     return out;
 }
 

--- a/src/backend/opencl/medfilt.cpp
+++ b/src/backend/opencl/medfilt.cpp
@@ -22,7 +22,7 @@ Array<T> medfilt1(const Array<T> &in, dim_t w_wid) {
     ARG_ASSERT(2, (w_wid <= kernel::MAX_MEDFILTER1_LEN));
     ARG_ASSERT(2, (w_wid % 2 != 0));
 
-    const dim4 dims = in.dims();
+    const dim4 &dims = in.dims();
 
     Array<T> out = createEmptyArray<T>(dims);
 
@@ -37,7 +37,7 @@ Array<T> medfilt2(const Array<T> &in, dim_t w_len, dim_t w_wid) {
     ARG_ASSERT(2, (w_len <= kernel::MAX_MEDFILTER2_LEN));
     ARG_ASSERT(2, (w_len % 2 != 0));
 
-    const dim4 dims = in.dims();
+    const dim4 &dims = in.dims();
 
     Array<T> out = createEmptyArray<T>(dims);
 
@@ -49,6 +49,9 @@ Array<T> medfilt2(const Array<T> &in, dim_t w_len, dim_t w_wid) {
         case 11: kernel::medfilt2<T, pad, 11, 11>(out, in); break;
         case 13: kernel::medfilt2<T, pad, 13, 13>(out, in); break;
         case 15: kernel::medfilt2<T, pad, 15, 15>(out, in); break;
+        default:
+            AF_ERROR("w_len only supports values 3, 5, 7, 9, 11, 12, and 15.",
+                     AF_ERR_UNKNOWN);
     }
     return out;
 }

--- a/src/backend/opencl/memory.cpp
+++ b/src/backend/opencl/memory.cpp
@@ -140,7 +140,7 @@ void Allocator::shutdown() {
         try {
             opencl::setDevice(n);
             shutdownMemoryManager();
-        } catch (AfError err) {
+        } catch (const AfError& err) {
             continue;  // Do not throw any errors while shutting down
         }
     }

--- a/src/backend/opencl/memory.cpp
+++ b/src/backend/opencl/memory.cpp
@@ -39,7 +39,7 @@ void setMemStepSize(size_t step_bytes) {
     memoryManager().setMemStepSize(step_bytes);
 }
 
-size_t getMemStepSize(void) { return memoryManager().getMemStepSize(); }
+size_t getMemStepSize() { return memoryManager().getMemStepSize(); }
 
 void signalMemoryCleanup() { memoryManager().signalMemoryCleanup(); }
 
@@ -56,8 +56,8 @@ unique_ptr<cl::Buffer, function<void(cl::Buffer *)>> memAlloc(
     const size_t &elements) {
     // TODO: make memAlloc aware of array shapes
     dim4 dims(elements);
-    void *ptr       = memoryManager().alloc(false, 1, dims.get(), sizeof(T));
-    cl::Buffer *buf = static_cast<cl::Buffer *>(ptr);
+    void *ptr = memoryManager().alloc(false, 1, dims.get(), sizeof(T));
+    auto *buf = static_cast<cl::Buffer *>(ptr);
     return unique_ptr<cl::Buffer, function<void(cl::Buffer *)>>(buf,
                                                                 bufferFree);
 }
@@ -70,10 +70,10 @@ void *memAllocUser(const size_t &bytes) {
 
 template<typename T>
 void memFree(T *ptr) {
-    return memoryManager().unlock((void *)ptr, false);
+    return memoryManager().unlock(static_cast<void *>(ptr), false);
 }
 
-void memFreeUser(void *ptr) { memoryManager().unlock((void *)ptr, true); }
+void memFreeUser(void *ptr) { memoryManager().unlock(ptr, true); }
 
 cl::Buffer *bufferAlloc(const size_t &bytes) {
     dim4 dims(bytes);
@@ -82,15 +82,19 @@ cl::Buffer *bufferAlloc(const size_t &bytes) {
 }
 
 void bufferFree(cl::Buffer *buf) {
-    return memoryManager().unlock((void *)buf, false);
+    return memoryManager().unlock(static_cast<void *>(buf), false);
 }
 
-void memLock(const void *ptr) { memoryManager().userLock((void *)ptr); }
+void memLock(const void *ptr) {
+    memoryManager().userLock(const_cast<void *>(ptr));
+}
 
-void memUnlock(const void *ptr) { memoryManager().userUnlock((void *)ptr); }
+void memUnlock(const void *ptr) {
+    memoryManager().userUnlock(const_cast<void *>(ptr));
+}
 
 bool isLocked(const void *ptr) {
-    return memoryManager().isUserLocked((void *)ptr);
+    return memoryManager().isUserLocked(const_cast<void *>(ptr));
 }
 
 void deviceMemoryInfo(size_t *alloc_bytes, size_t *alloc_buffers,
@@ -109,7 +113,7 @@ T *pinnedAlloc(const size_t &elements) {
 
 template<typename T>
 void pinnedFree(T *ptr) {
-    pinnedMemoryManager().unlock((void *)ptr, false);
+    pinnedMemoryManager().unlock(static_cast<void *>(ptr), false);
 }
 
 #define INSTANTIATE(T)                                                         \
@@ -140,7 +144,7 @@ void Allocator::shutdown() {
         try {
             opencl::setDevice(n);
             shutdownMemoryManager();
-        } catch (const AfError& err) {
+        } catch (const AfError &err) {
             continue;  // Do not throw any errors while shutting down
         }
     }
@@ -153,14 +157,16 @@ size_t Allocator::getMaxMemorySize(int id) {
 }
 
 void *Allocator::nativeAlloc(const size_t bytes) {
-    auto ptr = (void *)(new cl::Buffer(getContext(), CL_MEM_READ_WRITE, bytes));
+    auto ptr = static_cast<void *>(new cl::Buffer(
+        getContext(), CL_MEM_READ_WRITE,  // NOLINT(hicpp-signed-bitwise)
+        bytes));
     AF_TRACE("nativeAlloc: {} {}", bytesToString(bytes), ptr);
     return ptr;
 }
 
 void Allocator::nativeFree(void *ptr) {
     AF_TRACE("nativeFree:          {}", ptr);
-    delete (cl::Buffer *)ptr;
+    delete static_cast<cl::Buffer *>(ptr);
 }
 
 AllocatorPinned::AllocatorPinned() : pinnedMaps(opencl::getDeviceCount()) {
@@ -187,8 +193,7 @@ size_t AllocatorPinned::getMaxMemorySize(int id) {
 
 void *AllocatorPinned::nativeAlloc(const size_t bytes) {
     void *ptr = NULL;
-    cl::Buffer *buf =
-        new cl::Buffer(getContext(), CL_MEM_ALLOC_HOST_PTR, bytes);
+    auto *buf = new cl::Buffer(getContext(), CL_MEM_ALLOC_HOST_PTR, bytes);
     ptr = getQueue().enqueueMapBuffer(*buf, true, CL_MAP_READ | CL_MAP_WRITE, 0,
                                       bytes);
     AF_TRACE("Pinned::nativeAlloc: {:>7} {}", bytesToString(bytes), ptr);

--- a/src/backend/opencl/moments.cpp
+++ b/src/backend/opencl/moments.cpp
@@ -14,10 +14,10 @@
 
 namespace opencl {
 
-static inline int bitCount(int v) {
-    v = v - ((v >> 1) & 0x55555555);
-    v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
-    return (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
+static inline unsigned bitCount(unsigned v) {
+    v = v - ((v >> 1U) & 0x55555555U);
+    v = (v & 0x33333333U) + ((v >> 2U) & 0x33333333U);
+    return (((v + (v >> 4U)) & 0xF0F0F0FU) * 0x1010101U) >> 24U;
 }
 
 template<typename T>

--- a/src/backend/opencl/nearest_neighbour.cpp
+++ b/src/backend/opencl/nearest_neighbour.cpp
@@ -25,8 +25,8 @@ void nearest_neighbour_(Array<uint>& idx, Array<To>& dist,
                         const Array<T>& query, const Array<T>& train,
                         const uint dist_dim, const uint n_dist) {
     uint sample_dim  = (dist_dim == 0) ? 1 : 0;
-    const dim4 qDims = query.dims();
-    const dim4 tDims = train.dims();
+    const dim4& qDims = query.dims();
+    const dim4& tDims = train.dims();
 
     const dim4 outDims(n_dist, qDims[sample_dim]);
     const dim4 distDims(tDims[sample_dim], qDims[sample_dim]);

--- a/src/backend/opencl/nearest_neighbour.cpp
+++ b/src/backend/opencl/nearest_neighbour.cpp
@@ -24,7 +24,7 @@ template<typename T, typename To, af_match_type dist_type>
 void nearest_neighbour_(Array<uint>& idx, Array<To>& dist,
                         const Array<T>& query, const Array<T>& train,
                         const uint dist_dim, const uint n_dist) {
-    uint sample_dim  = (dist_dim == 0) ? 1 : 0;
+    uint sample_dim   = (dist_dim == 0) ? 1 : 0;
     const dim4& qDims = query.dims();
     const dim4& tDims = train.dims();
 

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -93,7 +93,7 @@ static inline string& ltrim(string& s) {
 }
 
 static string platformMap(string& platStr) {
-    typedef map<string, string> strmap_t;
+    using strmap_t                = map<string, string>;
     static const strmap_t platMap = {
         make_pair("NVIDIA CUDA", "NVIDIA"),
         make_pair("Intel(R) OpenCL", "INTEL"),

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -128,7 +128,7 @@ string getDeviceInfo() noexcept {
         for (auto device : devices) {
             const Platform platform(device->getInfo<CL_DEVICE_PLATFORM>());
 
-            string dstr      = device->getInfo<CL_DEVICE_NAME>();
+            string dstr = device->getInfo<CL_DEVICE_NAME>();
             bool show_braces =
                 (static_cast<unsigned>(getActiveDeviceId()) == nDevices);
 
@@ -283,7 +283,7 @@ size_t getHostMemorySize() { return common::getHostMemorySize(); }
 
 cl_device_type getDeviceType() {
     const cl::Device& device = getDevice();
-    cl_device_type type = device.getInfo<CL_DEVICE_TYPE>();
+    cl_device_type type      = device.getInfo<CL_DEVICE_TYPE>();
     return type;
 }
 
@@ -363,9 +363,9 @@ bool isHalfSupported(int device) {
 }
 
 void devprop(char* d_name, char* d_platform, char* d_toolkit, char* d_compute) {
-    unsigned nDevices        = 0;
-    auto currActiveDevId     = static_cast<unsigned>(getActiveDeviceId());
-    bool devset              = false;
+    unsigned nDevices    = 0;
+    auto currActiveDevId = static_cast<unsigned>(getActiveDeviceId());
+    bool devset          = false;
 
     DeviceManager& devMngr = DeviceManager::getInstance();
 

--- a/src/backend/opencl/platform.hpp
+++ b/src/backend/opencl/platform.hpp
@@ -96,9 +96,9 @@ std::string getPlatformName(const cl::Device& device);
 
 int setDevice(int device);
 
-void addDeviceContext(cl_device_id dev, cl_context cxt, cl_command_queue que);
+void addDeviceContext(cl_device_id dev, cl_context ctx, cl_command_queue que);
 
-void setDeviceContext(cl_device_id dev, cl_context cxt);
+void setDeviceContext(cl_device_id dev, cl_context ctx);
 
 void removeDeviceContext(cl_device_id dev, cl_context ctx);
 

--- a/src/backend/opencl/plot.cpp
+++ b/src/backend/opencl/plot.cpp
@@ -53,7 +53,8 @@ void copy_plot(const Array<T> &P, fg_plot plot) {
 
         CheckGL("Begin OpenCL fallback-resource copy");
         glBindBuffer(GL_ARRAY_BUFFER, buffer);
-        GLubyte *ptr = (GLubyte *)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        auto *ptr =
+            static_cast<GLubyte *>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
         if (ptr) {
             getQueue().enqueueReadBuffer(*P.get(), CL_TRUE, 0, bytes, ptr);
             glUnmapBuffer(GL_ARRAY_BUFFER);

--- a/src/backend/opencl/program.hpp
+++ b/src/backend/opencl/program.hpp
@@ -45,8 +45,8 @@ class Program;
 
 namespace opencl {
 void buildProgram(cl::Program &prog, const char *ker_str, const int ker_len,
-                  std::string options);
+                  const std::string &options);
 
 void buildProgram(cl::Program &prog, const int num_files, const char **ker_str,
-                  const int *ker_len, std::string options);
+                  const int *ker_len, const std::string &options);
 }  // namespace opencl

--- a/src/backend/opencl/qr.hpp
+++ b/src/backend/opencl/qr.hpp
@@ -11,7 +11,7 @@
 
 namespace opencl {
 template<typename T>
-void qr(Array<T> &q, Array<T> &r, Array<T> &t, const Array<T> &in);
+void qr(Array<T> &q, Array<T> &r, Array<T> &t, const Array<T> &orig);
 
 template<typename T>
 Array<T> qr_inplace(Array<T> &in);

--- a/src/backend/opencl/random_engine.cpp
+++ b/src/backend/opencl/random_engine.cpp
@@ -16,7 +16,7 @@ using common::half;
 
 namespace opencl {
 void initMersenneState(Array<uint> &state, const uintl seed,
-                       const Array<uint> tbl) {
+                       const Array<uint> &tbl) {
     kernel::initMersenneState(*state.get(), *tbl.get(), seed);
 }
 

--- a/src/backend/opencl/random_engine.hpp
+++ b/src/backend/opencl/random_engine.hpp
@@ -14,10 +14,8 @@
 #include <af/defines.h>
 
 namespace opencl {
-Array<uint> initMersenneState(const uintl seed, Array<uint> tbl);
-
 void initMersenneState(Array<uint> &state, const uintl seed,
-                       const Array<uint> tbl);
+                       const Array<uint> &tbl);
 
 template<typename T>
 Array<T> uniformDistribution(const af::dim4 &dims,

--- a/src/backend/opencl/range.cpp
+++ b/src/backend/opencl/range.cpp
@@ -27,8 +27,9 @@ Array<T> range(const dim4& dim, const int seq_dim) {
         _seq_dim = 0;  // column wise sequence
     }
 
-    if (_seq_dim < 0 || _seq_dim > 3)
+    if (_seq_dim < 0 || _seq_dim > 3) {
         AF_ERROR("Invalid rep selection", AF_ERR_ARG);
+    }
 
     Array<T> out = createEmptyArray<T>(dim);
     kernel::range<T>(out, _seq_dim);

--- a/src/backend/opencl/regions.cpp
+++ b/src/backend/opencl/regions.cpp
@@ -19,7 +19,7 @@ namespace opencl {
 
 template<typename T>
 Array<T> regions(const Array<char> &in, af_connectivity connectivity) {
-    const af::dim4 dims = in.dims();
+    const af::dim4 &dims = in.dims();
 
     Array<T> out = createEmptyArray<T>(dims);
 

--- a/src/backend/opencl/reorder.cpp
+++ b/src/backend/opencl/reorder.cpp
@@ -19,9 +19,9 @@ using common::half;
 namespace opencl {
 template<typename T>
 Array<T> reorder(const Array<T> &in, const af::dim4 &rdims) {
-    const af::dim4 iDims = in.dims();
+    const af::dim4 &iDims = in.dims();
     af::dim4 oDims(0);
-    for (int i = 0; i < 4; i++) oDims[i] = iDims[rdims[i]];
+    for (int i = 0; i < 4; i++) { oDims[i] = iDims[rdims[i]]; }
 
     Array<T> out = createEmptyArray<T>(oDims);
 

--- a/src/backend/opencl/resize.cpp
+++ b/src/backend/opencl/resize.cpp
@@ -17,7 +17,7 @@ namespace opencl {
 template<typename T>
 Array<T> resize(const Array<T> &in, const dim_t odim0, const dim_t odim1,
                 const af_interp_type method) {
-    const af::dim4 iDims = in.dims();
+    const af::dim4 &iDims = in.dims();
     af::dim4 oDims(odim0, odim1, iDims[2], iDims[3]);
 
     Array<T> out = createEmptyArray<T>(oDims);

--- a/src/backend/opencl/scan.cpp
+++ b/src/backend/opencl/scan.cpp
@@ -25,15 +25,17 @@ Array<To> scan(const Array<Ti>& in, const int dim, bool inclusive_scan) {
     Param In  = in;
 
     if (inclusive_scan) {
-        if (dim == 0)
+        if (dim == 0) {
             kernel::scan_first<Ti, To, op, true>(Out, In);
-        else
+        } else {
             kernel::scan_dim<Ti, To, op, true>(Out, In, dim);
+        }
     } else {
-        if (dim == 0)
+        if (dim == 0) {
             kernel::scan_first<Ti, To, op, false>(Out, In);
-        else
+        } else {
             kernel::scan_dim<Ti, To, op, false>(Out, In, dim);
+        }
     }
 
     return out;

--- a/src/backend/opencl/scan_by_key.cpp
+++ b/src/backend/opencl/scan_by_key.cpp
@@ -27,15 +27,17 @@ Array<To> scan(const Array<Tk>& key, const Array<Ti>& in, const int dim,
     Param In  = in;
 
     if (inclusive_scan) {
-        if (dim == 0)
+        if (dim == 0) {
             kernel::scan_first<Ti, Tk, To, op, true>(Out, In, Key);
-        else
+        } else {
             kernel::scan_dim<Ti, Tk, To, op, true>(Out, In, Key, dim);
+        }
     } else {
-        if (dim == 0)
+        if (dim == 0) {
             kernel::scan_first<Ti, Tk, To, op, false>(Out, In, Key);
-        else
+        } else {
             kernel::scan_dim<Ti, Tk, To, op, false>(Out, In, Key, dim);
+        }
     }
     return out;
 }

--- a/src/backend/opencl/select.cpp
+++ b/src/backend/opencl/select.cpp
@@ -34,9 +34,9 @@ Array<T> createSelectNode(const Array<char> &cond, const Array<T> &a,
     auto b_node    = b.getNode();
     int height     = max(a_node->getHeight(), b_node->getHeight());
     height         = max(height, cond_node->getHeight()) + 1;
-    auto node      = make_shared<NaryNode>(
-        NaryNode(dtype_traits<T>::getName(), shortname<T>(true), "__select", 3,
-                 {{cond_node, a_node, b_node}}, (int)af_select_t, height));
+    auto node      = make_shared<NaryNode>(NaryNode(
+        dtype_traits<T>::getName(), shortname<T>(true), "__select", 3,
+        {{cond_node, a_node, b_node}}, static_cast<int>(af_select_t), height));
 
     if (detail::passesJitHeuristics<T>(node.get()) == kJITHeuristics::Pass) {
         return createNodeArray<T>(odims, node);

--- a/src/backend/opencl/select.cpp
+++ b/src/backend/opencl/select.cpp
@@ -66,7 +66,7 @@ Array<T> createSelectNode(const Array<char> &cond, const Array<T> &a,
     auto node = make_shared<NaryNode>(NaryNode(
         dtype_traits<T>::getName(), shortname<T>(true),
         (flip ? "__not_select" : "__select"), 3, {{cond_node, a_node, b_node}},
-        (int)(flip ? af_not_select_t : af_select_t), height));
+        static_cast<int>(flip ? af_not_select_t : af_select_t), height));
 
     if (detail::passesJitHeuristics<T>(node.get()) == kJITHeuristics::Pass) {
         return createNodeArray<T>(odims, node);

--- a/src/backend/opencl/set.cpp
+++ b/src/backend/opencl/set.cpp
@@ -56,7 +56,7 @@ Array<T> setUnique(const Array<T> &in, const bool is_sorted) {
         out.resetDims(dim4(std::distance(begin, end), 1, 1, 1));
 
         return out;
-    } catch (std::exception &ex) { AF_ERROR(ex.what(), AF_ERR_INTERNAL); }
+    } catch (const std::exception &ex) { AF_ERROR(ex.what(), AF_ERR_INTERNAL); }
 }
 
 template<typename T>
@@ -94,7 +94,7 @@ Array<T> setUnion(const Array<T> &first, const Array<T> &second,
         out.resetDims(dim4(std::distance(out_begin, out_end), 1, 1, 1));
         return out;
 
-    } catch (std::exception &ex) { AF_ERROR(ex.what(), AF_ERR_INTERNAL); }
+    } catch (const std::exception &ex) { AF_ERROR(ex.what(), AF_ERR_INTERNAL); }
 }
 
 template<typename T>
@@ -132,7 +132,7 @@ Array<T> setIntersect(const Array<T> &first, const Array<T> &second,
 
         out.resetDims(dim4(std::distance(out_begin, out_end), 1, 1, 1));
         return out;
-    } catch (std::exception &ex) { AF_ERROR(ex.what(), AF_ERR_INTERNAL); }
+    } catch (const std::exception &ex) { AF_ERROR(ex.what(), AF_ERR_INTERNAL); }
 }
 
 #define INSTANTIATE(T)                                                        \

--- a/src/backend/opencl/shift.cpp
+++ b/src/backend/opencl/shift.cpp
@@ -37,15 +37,16 @@ Array<T> shift(const Array<T> &in, const int sdims[4]) {
 
     string name_str("Sh");
     name_str += shortname<T>(true);
-    const dim4 iDims = in.dims();
+    const dim4 &iDims = in.dims();
     dim4 oDims       = iDims;
 
-    array<int, 4> shifts;
+    array<int, 4> shifts{};
     for (int i = 0; i < 4; i++) {
         // sdims_[i] will always be positive and always [0, oDims[i]].
         // Negative shifts are converted to position by going the other way
         // round
-        shifts[i] = -(sdims[i] % (int)oDims[i]) + oDims[i] * (sdims[i] > 0);
+        shifts[i] = -(sdims[i] % static_cast<int>(oDims[i])) +
+                    oDims[i] * (sdims[i] > 0);
         assert(shifts[i] >= 0 && shifts[i] <= oDims[i]);
     }
 

--- a/src/backend/opencl/shift.cpp
+++ b/src/backend/opencl/shift.cpp
@@ -38,7 +38,7 @@ Array<T> shift(const Array<T> &in, const int sdims[4]) {
     string name_str("Sh");
     name_str += shortname<T>(true);
     const dim4 &iDims = in.dims();
-    dim4 oDims       = iDims;
+    dim4 oDims        = iDims;
 
     array<int, 4> shifts{};
     for (int i = 0; i < 4; i++) {

--- a/src/backend/opencl/sift.cpp
+++ b/src/backend/opencl/sift.cpp
@@ -74,14 +74,15 @@ unsigned sift(Array<float>& x_out, Array<float>& y_out, Array<float>& score_out,
     UNUSED(double_input);
     UNUSED(img_scale);
     UNUSED(feature_ratio);
-    if (compute_GLOH)
+    if (compute_GLOH) {
         AF_ERROR(
             "ArrayFire was not built with nonfree support, GLOH disabled\n",
             AF_ERR_NONFREE);
-    else
+    } else {
         AF_ERROR(
             "ArrayFire was not built with nonfree support, SIFT disabled\n",
             AF_ERR_NONFREE);
+    }
 #endif
 }
 

--- a/src/backend/opencl/sort.cpp
+++ b/src/backend/opencl/sort.cpp
@@ -34,7 +34,7 @@ Array<T> sort(const Array<T> &in, const unsigned dim, bool isAscending) {
             af::dim4 reorderDims(0, 1, 2, 3);
             reorderDims[dim] = 0;
             preorderDims[0]  = out.dims()[dim];
-            for (int i = 1; i <= (int)dim; i++) {
+            for (int i = 1; i <= static_cast<int>(dim); i++) {
                 reorderDims[i - 1] = i;
                 preorderDims[i]    = out.dims()[i - 1];
             }

--- a/src/backend/opencl/sort_by_key.cpp
+++ b/src/backend/opencl/sort_by_key.cpp
@@ -39,7 +39,7 @@ void sort_by_key(Array<Tk> &okey, Array<Tv> &oval, const Array<Tk> &ikey,
             af::dim4 reorderDims(0, 1, 2, 3);
             reorderDims[dim] = 0;
             preorderDims[0]  = okey.dims()[dim];
-            for (int i = 1; i <= (int)dim; i++) {
+            for (unsigned i = 1; i <= dim; i++) {
                 reorderDims[i - 1] = i;
                 preorderDims[i]    = okey.dims()[i - 1];
             }

--- a/src/backend/opencl/sort_by_key.cpp
+++ b/src/backend/opencl/sort_by_key.cpp
@@ -50,7 +50,7 @@ void sort_by_key(Array<Tk> &okey, Array<Tv> &oval, const Array<Tk> &ikey,
             okey = reorder<Tk>(okey, reorderDims);
             oval = reorder<Tv>(oval, reorderDims);
         }
-    } catch (std::exception &ex) { AF_ERROR(ex.what(), AF_ERR_INTERNAL); }
+    } catch (const std::exception &ex) { AF_ERROR(ex.what(), AF_ERR_INTERNAL); }
 }
 
 #define INSTANTIATE(Tk, Tv)                                        \

--- a/src/backend/opencl/sort_index.cpp
+++ b/src/backend/opencl/sort_index.cpp
@@ -56,7 +56,7 @@ void sort_index(Array<T> &okey, Array<uint> &oval, const Array<T> &in,
             okey = reorder<T>(okey, reorderDims);
             oval = reorder<uint>(oval, reorderDims);
         }
-    } catch (std::exception &ex) { AF_ERROR(ex.what(), AF_ERR_INTERNAL); }
+    } catch (const std::exception &ex) { AF_ERROR(ex.what(), AF_ERR_INTERNAL); }
 }
 
 #define INSTANTIATE(T)                                              \

--- a/src/backend/opencl/sort_index.cpp
+++ b/src/backend/opencl/sort_index.cpp
@@ -45,7 +45,7 @@ void sort_index(Array<T> &okey, Array<uint> &oval, const Array<T> &in,
             af::dim4 reorderDims(0, 1, 2, 3);
             reorderDims[dim] = 0;
             preorderDims[0]  = okey.dims()[dim];
-            for (int i = 1; i <= (int)dim; i++) {
+            for (uint i = 1; i <= dim; i++) {
                 reorderDims[i - 1] = i;
                 preorderDims[i]    = okey.dims()[i - 1];
             }

--- a/src/backend/opencl/sort_index.hpp
+++ b/src/backend/opencl/sort_index.hpp
@@ -11,6 +11,6 @@
 
 namespace opencl {
 template<typename T>
-void sort_index(Array<T> &val, Array<unsigned> &idx, const Array<T> &in,
+void sort_index(Array<T> &okey, Array<unsigned> &oval, const Array<T> &in,
                 const unsigned dim, bool isAscending);
 }

--- a/src/backend/opencl/sparse.cpp
+++ b/src/backend/opencl/sparse.cpp
@@ -122,8 +122,8 @@ template<typename T, af_storage dest, af_storage src>
 SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in) {
     in.eval();
 
-    SparseArray<T> converted =
-        createEmptySparseArray<T>(in.dims(), (int)in.getNNZ(), dest);
+    SparseArray<T> converted = createEmptySparseArray<T>(
+        in.dims(), static_cast<int>(in.getNNZ()), dest);
     converted.eval();
 
     if (src == AF_STORAGE_CSR && dest == AF_STORAGE_COO) {

--- a/src/backend/opencl/sparse.cpp
+++ b/src/backend/opencl/sparse.cpp
@@ -94,9 +94,10 @@ Array<T> sparseConvertCOOToDense(const SparseArray<T> &in) {
 
 template<typename T, af_storage stype>
 Array<T> sparseConvertStorageToDense(const SparseArray<T> &in_) {
-    if (stype != AF_STORAGE_CSR)
+    if (stype != AF_STORAGE_CSR) {
         AF_ERROR("OpenCL Backend only supports CSR or COO to Dense",
                  AF_ERR_NOT_SUPPORTED);
+    }
 
     in_.eval();
 
@@ -107,11 +108,12 @@ Array<T> sparseConvertStorageToDense(const SparseArray<T> &in_) {
     const Array<int> &rowIdx = in_.getRowIdx();
     const Array<int> &colIdx = in_.getColIdx();
 
-    if (stype == AF_STORAGE_CSR)
+    if (stype == AF_STORAGE_CSR) {
         kernel::csr2dense<T>(dense_, values, rowIdx, colIdx);
-    else
+    } else {
         AF_ERROR("OpenCL Backend only supports CSR or COO to Dense",
                  AF_ERR_NOT_SUPPORTED);
+    }
 
     return dense_;
 }

--- a/src/backend/opencl/sparse_arith.cpp
+++ b/src/backend/opencl/sparse_arith.cpp
@@ -115,7 +115,7 @@ SparseArray<T> arithOp(const SparseArray<T> &lhs, const SparseArray<T> &rhs) {
     rhs.eval();
     af::storage sfmt = lhs.getStorage();
 
-    const dim4 ldims = lhs.dims();
+    const dim4 &ldims = lhs.dims();
 
     const uint M = ldims[0];
     const uint N = ldims[1];

--- a/src/backend/opencl/surface.cpp
+++ b/src/backend/opencl/surface.cpp
@@ -56,7 +56,8 @@ void copy_surface(const Array<T> &P, fg_surface surface) {
 
         CheckGL("Begin OpenCL fallback-resource copy");
         glBindBuffer(GL_ARRAY_BUFFER, buffer);
-        GLubyte *ptr = (GLubyte *)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        auto *ptr =
+            static_cast<GLubyte *>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
         if (ptr) {
             getQueue().enqueueReadBuffer(*P.get(), CL_TRUE, 0, bytes, ptr);
             glUnmapBuffer(GL_ARRAY_BUFFER);

--- a/src/backend/opencl/svd.cpp
+++ b/src/backend/opencl/svd.cpp
@@ -65,9 +65,9 @@ void svd(Array<T> &arrU, Array<Tr> &arrS, Array<T> &arrVT, Array<T> &arrA,
     dim4 idims    = arrA.dims();
     dim4 istrides = arrA.strides();
 
-    const int m      = (int)idims[0];
-    const int n      = (int)idims[1];
-    const int ldda   = (int)istrides[1];
+    const int m      = static_cast<int>(idims[0]);
+    const int n      = static_cast<int>(idims[1]);
+    const int ldda   = static_cast<int>(istrides[1]);
     const int lda    = m;
     const int min_mn = std::min(m, n);
     const int ldu    = m;
@@ -92,12 +92,12 @@ void svd(Array<T> &arrU, Array<Tr> &arrS, Array<T> &arrVT, Array<T> &arrA,
     static const int ione  = 1;
     static const int izero = 0;
 
-    bool iscl = 0;
+    bool iscl = false;
     if (anrm > 0. && anrm < smlnum) {
-        iscl  = 1;
+        iscl  = true;
         scale = scalar<T>(calc_scale<Tr>(anrm, smlnum));
     } else if (anrm > bignum) {
-        iscl  = 1;
+        iscl  = true;
         scale = scalar<T>(calc_scale<Tr>(anrm, bignum));
     }
 

--- a/src/backend/opencl/tile.cpp
+++ b/src/backend/opencl/tile.cpp
@@ -18,7 +18,7 @@ using common::half;
 namespace opencl {
 template<typename T>
 Array<T> tile(const Array<T> &in, const af::dim4 &tileDims) {
-    const af::dim4 iDims = in.dims();
+    const af::dim4 &iDims = in.dims();
     af::dim4 oDims       = iDims;
     oDims *= tileDims;
 

--- a/src/backend/opencl/tile.cpp
+++ b/src/backend/opencl/tile.cpp
@@ -19,7 +19,7 @@ namespace opencl {
 template<typename T>
 Array<T> tile(const Array<T> &in, const af::dim4 &tileDims) {
     const af::dim4 &iDims = in.dims();
-    af::dim4 oDims       = iDims;
+    af::dim4 oDims        = iDims;
     oDims *= tileDims;
 
     Array<T> out = createEmptyArray<T>(oDims);

--- a/src/backend/opencl/topk.cpp
+++ b/src/backend/opencl/topk.cpp
@@ -33,7 +33,7 @@ using std::vector;
 namespace opencl {
 vector<af_index_t> indexForTopK(const int k) {
     af_index_t idx;
-    idx.idx.seq = af_seq{0.0, (double)k - 1, 1.0};
+    idx.idx.seq = af_seq{0.0, static_cast<double>(k) - 1.0, 1.0};
     idx.isSeq   = true;
     idx.isBatch = false;
 

--- a/src/backend/opencl/transform.cpp
+++ b/src/backend/opencl/transform.cpp
@@ -17,8 +17,8 @@ namespace opencl {
 
 template<typename T>
 void transform(Array<T> &out, const Array<T> &in, const Array<float> &tf,
-               const dim4 &odims, const af_interp_type method,
-               const bool inverse, const bool perspective) {
+               const af_interp_type method, const bool inverse,
+               const bool perspective) {
     switch (method) {
         case AF_INTERP_NEAREST:
         case AF_INTERP_LOWER:
@@ -38,7 +38,7 @@ void transform(Array<T> &out, const Array<T> &in, const Array<float> &tf,
 
 #define INSTANTIATE(T)                                                       \
     template void transform(Array<T> &out, const Array<T> &in,               \
-                            const Array<float> &tf, const dim4 &odims,       \
+                            const Array<float> &tf,                          \
                             const af_interp_type method, const bool inverse, \
                             const bool perspective);
 

--- a/src/backend/opencl/transform.hpp
+++ b/src/backend/opencl/transform.hpp
@@ -12,6 +12,6 @@
 namespace opencl {
 template<typename T>
 void transform(Array<T> &out, const Array<T> &in, const Array<float> &tf,
-               const af::dim4 &odims, const af_interp_type method,
-               const bool inverse, const bool perspective);
+               const af_interp_type method, const bool inverse,
+               const bool perspective);
 }

--- a/src/backend/opencl/transpose.cpp
+++ b/src/backend/opencl/transpose.cpp
@@ -21,8 +21,8 @@ namespace opencl {
 template<typename T>
 Array<T> transpose(const Array<T> &in, const bool conjugate) {
     const dim4 &inDims = in.dims();
-    dim4 outDims      = dim4(inDims[1], inDims[0], inDims[2], inDims[3]);
-    Array<T> out      = createEmptyArray<T>(outDims);
+    dim4 outDims       = dim4(inDims[1], inDims[0], inDims[2], inDims[3]);
+    Array<T> out       = createEmptyArray<T>(outDims);
 
     if (conjugate) {
         if (inDims[0] % kernel::TILE_DIM == 0 &&

--- a/src/backend/opencl/transpose.cpp
+++ b/src/backend/opencl/transpose.cpp
@@ -20,22 +20,24 @@ namespace opencl {
 
 template<typename T>
 Array<T> transpose(const Array<T> &in, const bool conjugate) {
-    const dim4 inDims = in.dims();
+    const dim4 &inDims = in.dims();
     dim4 outDims      = dim4(inDims[1], inDims[0], inDims[2], inDims[3]);
     Array<T> out      = createEmptyArray<T>(outDims);
 
     if (conjugate) {
         if (inDims[0] % kernel::TILE_DIM == 0 &&
-            inDims[1] % kernel::TILE_DIM == 0)
+            inDims[1] % kernel::TILE_DIM == 0) {
             kernel::transpose<T, true, true>(out, in, getQueue());
-        else
+        } else {
             kernel::transpose<T, true, false>(out, in, getQueue());
+        }
     } else {
         if (inDims[0] % kernel::TILE_DIM == 0 &&
-            inDims[1] % kernel::TILE_DIM == 0)
+            inDims[1] % kernel::TILE_DIM == 0) {
             kernel::transpose<T, false, true>(out, in, getQueue());
-        else
+        } else {
             kernel::transpose<T, false, false>(out, in, getQueue());
+        }
     }
     return out;
 }

--- a/src/backend/opencl/transpose_inplace.cpp
+++ b/src/backend/opencl/transpose_inplace.cpp
@@ -24,16 +24,18 @@ void transpose_inplace(Array<T> &in, const bool conjugate) {
 
     if (conjugate) {
         if (iDims[0] % kernel::TILE_DIM == 0 &&
-            iDims[1] % kernel::TILE_DIM == 0)
+            iDims[1] % kernel::TILE_DIM == 0) {
             kernel::transpose_inplace<T, true, true>(in, getQueue());
-        else
+        } else {
             kernel::transpose_inplace<T, true, false>(in, getQueue());
+        }
     } else {
         if (iDims[0] % kernel::TILE_DIM == 0 &&
-            iDims[1] % kernel::TILE_DIM == 0)
+            iDims[1] % kernel::TILE_DIM == 0) {
             kernel::transpose_inplace<T, false, true>(in, getQueue());
-        else
+        } else {
             kernel::transpose_inplace<T, false, false>(in, getQueue());
+        }
     }
 }
 

--- a/src/backend/opencl/types.cpp
+++ b/src/backend/opencl/types.cpp
@@ -18,8 +18,8 @@
 
 using common::half;
 using common::to_string;
-using std::to_string;
 using std::move;
+using std::to_string;
 
 namespace opencl {
 

--- a/src/backend/opencl/types.cpp
+++ b/src/backend/opencl/types.cpp
@@ -17,9 +17,6 @@
 #include <string>
 
 using common::half;
-using common::to_string;
-using std::move;
-using std::to_string;
 
 namespace opencl {
 
@@ -68,7 +65,7 @@ std::string ToNumStr<half>::operator()(half val) {
     static const char *PINF = "+INFINITY";
     static const char *NINF = "-INFINITY";
     if (common::isinf(val)) { return val < 0.f ? NINF : PINF; }
-    return to_string(val);
+    return common::to_string(val);
 }
 
 template<>

--- a/src/backend/opencl/types.cpp
+++ b/src/backend/opencl/types.cpp
@@ -17,6 +17,9 @@
 #include <string>
 
 using common::half;
+using common::to_string;
+using std::to_string;
+using std::move;
 
 namespace opencl {
 
@@ -65,7 +68,7 @@ std::string ToNumStr<half>::operator()(half val) {
     static const char *PINF = "+INFINITY";
     static const char *NINF = "-INFINITY";
     if (common::isinf(val)) { return val < 0.f ? NINF : PINF; }
-    return to_string(move(val));
+    return to_string(val);
 }
 
 template<>

--- a/src/backend/opencl/vector_field.cpp
+++ b/src/backend/opencl/vector_field.cpp
@@ -65,7 +65,8 @@ void copy_vector_field(const Array<T> &points, const Array<T> &directions,
 
         // Points
         glBindBuffer(GL_ARRAY_BUFFER, buff1);
-        GLubyte *pPtr = (GLubyte *)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        auto *pPtr =
+            static_cast<GLubyte *>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
         if (pPtr) {
             getQueue().enqueueReadBuffer(*points.get(), CL_TRUE, 0, size1,
                                          pPtr);
@@ -75,7 +76,8 @@ void copy_vector_field(const Array<T> &points, const Array<T> &directions,
 
         // Directions
         glBindBuffer(GL_ARRAY_BUFFER, buff2);
-        GLubyte *dPtr = (GLubyte *)glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY);
+        auto *dPtr =
+            static_cast<GLubyte *>(glMapBuffer(GL_ARRAY_BUFFER, GL_WRITE_ONLY));
         if (dPtr) {
             getQueue().enqueueReadBuffer(*directions.get(), CL_TRUE, 0, size2,
                                          dPtr);

--- a/src/backend/opencl/vector_field.hpp
+++ b/src/backend/opencl/vector_field.hpp
@@ -14,6 +14,5 @@ namespace opencl {
 
 template<typename T>
 void copy_vector_field(const Array<T> &points, const Array<T> &directions,
-                       fg_vector_field vector_field);
-
+                       fg_vector_field vfield);
 }

--- a/src/backend/opencl/wrap.cpp
+++ b/src/backend/opencl/wrap.cpp
@@ -21,17 +21,17 @@ using common::half;
 namespace opencl {
 
 template<typename T>
-void wrap(Array<T> &out, const Array<T> &in, const dim_t ox, const dim_t oy,
-          const dim_t wx, const dim_t wy, const dim_t sx, const dim_t sy,
-          const dim_t px, const dim_t py, const bool is_column) {
+void wrap(Array<T> &out, const Array<T> &in, const dim_t wx, const dim_t wy,
+          const dim_t sx, const dim_t sy, const dim_t px, const dim_t py,
+          const bool is_column) {
     kernel::wrap<T>(out, in, wx, wy, sx, sy, px, py, is_column);
 }
 
 #define INSTANTIATE(T)                                                        \
-    template void wrap<T>(Array<T> & out, const Array<T> &in, const dim_t ox, \
-                          const dim_t oy, const dim_t wx, const dim_t wy,     \
-                          const dim_t sx, const dim_t sy, const dim_t px,     \
-                          const dim_t py, const bool is_column);
+    template void wrap<T>(Array<T> & out, const Array<T> &in, const dim_t wx, \
+                          const dim_t wy, const dim_t sx, const dim_t sy,     \
+                          const dim_t px, const dim_t py,                     \
+                          const bool is_column);
 
 INSTANTIATE(float)
 INSTANTIATE(double)

--- a/src/backend/opencl/wrap.hpp
+++ b/src/backend/opencl/wrap.hpp
@@ -12,9 +12,9 @@
 namespace opencl {
 
 template<typename T>
-void wrap(Array<T> &out, const Array<T> &in, const dim_t ox, const dim_t oy,
-          const dim_t wx, const dim_t wy, const dim_t sx, const dim_t sy,
-          const dim_t px, const dim_t py, const bool is_column);
+void wrap(Array<T> &out, const Array<T> &in, const dim_t wx, const dim_t wy,
+          const dim_t sx, const dim_t sy, const dim_t px, const dim_t py,
+          const bool is_column);
 
 template<typename T>
 Array<T> wrap_dilated(const Array<T> &in, const dim_t ox, const dim_t oy,


### PR DESCRIPTION
This PR adds a clang-tidy config file and applies the changes to the code. There are many changes that still need to be made but the current state is working and all backends are built with these settings. Many settings were disabled because they produced warnings that were invalid in our code base or would require changes to headers we don't control. Several bugs have been found in the course of this change. I tried to include only changes that did not change the functionality of the code. Bug fixes have been or will be submitted in other PRs.

You can run clang-tidy by passing -DCMAKE_CXX_CLANG_TIDY="clang-tidy". If you want to apply fixes you can pass -DCMAKE_CXX_CLANG_TIDY="clang-tidy;--fix" although this will make some changes in the code below which I want to investigate further.

