### PR TITLE
Fix pinnedMemManager check. Fix MKL Sequential layer

### DIFF
--- a/CMakeModules/FindMKL.cmake
+++ b/CMakeModules/FindMKL.cmake
@@ -357,8 +357,7 @@ find_package_handle_standard_args(MKL_Shared
   REQUIRED_VARS MKL_INCLUDE_DIR
                 MKL_Core_LINK_LIBRARY
                 MKL_Interface_LINK_LIBRARY
-                MKL_ThreadLayer_LINK_LIBRARY
-                MKL_ThreadingLibrary_LINK_LIBRARY)
+                MKL_ThreadLayer_LINK_LIBRARY)
 
 find_package_handle_standard_args(MKL_Static
   FAIL_MESSAGE "Could NOT find MKL: Source the compilervars.sh or mklvars.sh scripts included with your installation of MKL. This script searches for the libraries in MKLROOT, LIBRARY_PATHS(Linux), and LIB(Windows) environment variables"
@@ -366,8 +365,7 @@ find_package_handle_standard_args(MKL_Static
   REQUIRED_VARS MKL_INCLUDE_DIR
                 MKL_Core_STATIC_LINK_LIBRARY
                 MKL_Interface_STATIC_LINK_LIBRARY
-                MKL_ThreadLayer_STATIC_LINK_LIBRARY
-                MKL_ThreadingLibrary_LINK_LIBRARY)
+                MKL_ThreadLayer_STATIC_LINK_LIBRARY)
 
 if(NOT WIN32)
   find_library(M_LIB m)

--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -301,7 +301,7 @@ void DeviceManager::setMemoryManagerPinned(
     // pinnedMemoryManager()
     pinnedMemoryManager();
     // Calls shutdown() on the existing memory manager.
-    if (pinnedMemoryManager) { pinnedMemManager->shutdownAllocator(); }
+    if (pinnedMemManager) { pinnedMemManager->shutdownAllocator(); }
     // Set the backend memory manager for this new manager to register native
     // functions correctly.
     pinnedMemManager = std::move(newMgr);

--- a/src/backend/opencl/device_manager.cpp
+++ b/src/backend/opencl/device_manager.cpp
@@ -362,10 +362,10 @@ void DeviceManager::setMemoryManagerPinned(
     // pinnedMemoryManager()
     pinnedMemoryManager();
     // Calls shutdown() on the existing memory manager.
-    pinnedMemManager->shutdownAllocator();
-    pinnedMemManager = std::move(newMgr);
+    if (pinnedMemManager) { pinnedMemManager->shutdownAllocator(); }
     // Set the backend pinned memory manager for this new manager to register
     // native functions correctly.
+    pinnedMemManager = std::move(newMgr);
     std::unique_ptr<opencl::AllocatorPinned> deviceMemoryManager(
         new opencl::AllocatorPinned());
     pinnedMemManager->setAllocator(std::move(deviceMemoryManager));


### PR DESCRIPTION
* The setMemorymanagerPinned function was incorrectly checking the function pointer instead of the pinnedMemManager pointer.
* MKL with the Sequential layer was broken because the ThreadingLibrary variable was required. The sequential layer does not have a threading library so MKL was set to not found because that variable was not set.