### PR TITLE
Automatically cache compiled CUDA kernels on disk to speed up kernel compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ option(AF_BUILD_FORGE
 option(AF_WITH_NONFREE  "Build ArrayFire nonfree algorithms"   OFF)
 option(AF_WITH_LOGGING  "Build ArrayFire with logging support" ON)
 option(AF_WITH_STACKTRACE  "Add stacktraces to the error messages." ON)
+option(AF_CACHE_KERNELS "Enable caching kernels on disk"       ON)
 
 if(WIN32)
   set(AF_STACKTRACE_TYPE "Windbg" CACHE STRING "The type of backtrace features. Windbg(simple), None")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,10 @@ foreach(backend ${built_backends})
     target_compile_definitions(${backend}
       PRIVATE AF_WITH_LOGGING)
   endif()
+  if(AF_CACHE_KERNELS_TO_DISK)
+    target_compile_definitions(${backend}
+      PRIVATE AF_CACHE_KERNELS_TO_DISK)
+  endif()
 endforeach()
 
 if(AF_BUILD_FRAMEWORK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ option(AF_BUILD_FORGE
 option(AF_WITH_NONFREE  "Build ArrayFire nonfree algorithms"   OFF)
 option(AF_WITH_LOGGING  "Build ArrayFire with logging support" ON)
 option(AF_WITH_STACKTRACE  "Add stacktraces to the error messages." ON)
-option(AF_CACHE_KERNELS "Enable caching kernels on disk"       ON)
+option(AF_CACHE_KERNELS_TO_DISK "Enable caching kernels to disk" ON)
 
 if(WIN32)
   set(AF_STACKTRACE_TYPE "Windbg" CACHE STRING "The type of backtrace features. Windbg(simple), None")

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -180,7 +180,7 @@ const string& getCacheDirectory() {
         auto iterDir = std::find_if(pathList.begin(), pathList.end(), 
             isDirectoryWritable);
 
-        return iterDir != pathList.end() ? *iterDir : "";
+        cacheDirectory = iterDir != pathList.end() ? *iterDir : "";
     });
 
     return cacheDirectory;

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <numeric>
 #include <string>
+#include <thread>
 #include <vector>
 
 using std::string;

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -20,6 +20,7 @@
 #include <af/defines.h>
 
 #include <sys/stat.h>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -146,6 +147,10 @@ bool removeFile(const string& path) {
 #endif
 }
 
+bool renameFile(const string& sourcePath, const string& destPath) {
+    return std::rename(sourcePath.c_str(), destPath.c_str()) == 0;
+}
+
 bool isDirectoryWritable(const string& path) {
     if (!directoryExists(path) && !createDirectory(path)) return false;
 
@@ -180,4 +185,15 @@ const string& getCacheDirectory() {
     });
 
     return cacheDirectory;
+}
+
+string makeTempFilename() {
+    thread_local std::size_t fileCount = 0u;
+
+    ++fileCount;
+    const std::size_t threadID =
+        std::hash<std::thread::id>{}(std::this_thread::get_id());
+
+    return std::to_string(std::hash<string>{}(std::to_string(threadID) + "_" +
+                                              std::to_string(fileCount)));
 }

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -120,7 +120,7 @@ string getTemporaryDirectory() {
 }
 #endif
 
-bool folderExists(const string& path) {
+bool directoryExists(const string& path) {
 #if !defined(OS_WIN)
     struct stat status;
     return stat(path.c_str(), &status) == 0 && (status.st_mode & S_IFDIR) != 0;
@@ -130,7 +130,7 @@ bool folderExists(const string& path) {
 #endif
 }
 
-bool createFolder(const string& path) {
+bool createDirectory(const string& path) {
 #if !defined(OS_WIN)
     return mkdir(path.c_str(), 0777) == 0;
 #else
@@ -147,7 +147,7 @@ bool removeFile(const string& path) {
 }
 
 bool isDirectoryWritable(const string& path) {
-    if (!folderExists(path) && !createFolder(path)) return false;
+    if (!directoryExists(path) && !createDirectory(path)) return false;
 
     const string testPath = path + AF_PATH_SEPARATOR + "test";
     if (!std::ofstream(testPath).is_open()) return false;

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -120,7 +120,7 @@ string getTemporaryDirectory() {
 }
 #endif
 
-bool folderExists(const string &path) {
+bool folderExists(const string& path) {
 #if !defined(OS_WIN)
     struct stat status;
     return stat(path.c_str(), &status) == 0 && (status.st_mode & S_IFDIR) != 0;
@@ -130,7 +130,7 @@ bool folderExists(const string &path) {
 #endif
 }
 
-bool createFolder(const string &path) {
+bool createFolder(const string& path) {
 #if !defined(OS_WIN)
     return mkdir(path.c_str(), 0777) == 0;
 #else
@@ -138,7 +138,7 @@ bool createFolder(const string &path) {
 #endif
 }
 
-bool removeFile(const string &path) {
+bool removeFile(const string& path) {
 #if !defined(OS_WIN)
     return unlink(path.c_str()) == 0;
 #else
@@ -146,7 +146,7 @@ bool removeFile(const string &path) {
 #endif
 }
 
-bool isDirectoryWritable(const string &path) {
+bool isDirectoryWritable(const string& path) {
     if (!folderExists(path) && !createFolder(path)) return false;
 
     const string testPath = path + AF_PATH_SEPARATOR + "test";
@@ -156,7 +156,7 @@ bool isDirectoryWritable(const string &path) {
     return true;
 }
 
-const string &getCacheDirectory() {
+const string& getCacheDirectory() {
     thread_local std::once_flag flag;
     thread_local string cacheDirectory;
 
@@ -171,7 +171,7 @@ const string &getCacheDirectory() {
 #endif
         };
 
-        for (const string &path : pathList) {
+        for (const string& path : pathList) {
             if (isDirectoryWritable(path)) {
                 cacheDirectory = path;
                 break;

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -178,8 +178,8 @@ const string& getCacheDirectory() {
 #endif
         };
 
-        auto iterDir = std::find_if(pathList.begin(), pathList.end(), 
-            isDirectoryWritable);
+        auto iterDir =
+            std::find_if(pathList.begin(), pathList.end(), isDirectoryWritable);
 
         cacheDirectory = iterDir != pathList.end() ? *iterDir : "";
     });
@@ -201,8 +201,8 @@ string makeTempFilename() {
 std::size_t deterministicHash(const void* data, std::size_t byteSize) {
     // Fowler-Noll-Vo "1a" 32 bit hash
     // https://en.wikipedia.org/wiki/Fowler-Noll-Vo_hash_function
-    constexpr std::size_t seed = 0x811C9DC5;
-    constexpr std::size_t prime = 0x01000193;
+    constexpr std::size_t seed   = 0x811C9DC5;
+    constexpr std::size_t prime  = 0x01000193;
     const std::uint8_t* byteData = static_cast<const std::uint8_t*>(data);
     return std::accumulate(byteData, byteData + byteSize, seed,
                            [&](std::size_t hash, std::uint8_t data) {

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -20,6 +20,7 @@
 #include <af/defines.h>
 
 #include <sys/stat.h>
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -176,12 +177,10 @@ const string& getCacheDirectory() {
 #endif
         };
 
-        for (const string& path : pathList) {
-            if (isDirectoryWritable(path)) {
-                cacheDirectory = path;
-                break;
-            }
-        }
+        auto iterDir = std::find_if(pathList.begin(), pathList.end(), 
+            isDirectoryWritable);
+
+        return iterDir != pathList.end() ? *iterDir : "";
     });
 
     return cacheDirectory;

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -195,4 +196,20 @@ string makeTempFilename() {
 
     return std::to_string(std::hash<string>{}(std::to_string(threadID) + "_" +
                                               std::to_string(fileCount)));
+}
+
+std::size_t deterministicHash(const void* data, std::size_t byteSize) {
+    // Fowler-Noll-Vo "1a" 32 bit hash
+    // https://en.wikipedia.org/wiki/Fowler-Noll-Vo_hash_function
+    constexpr std::size_t seed = 0x811C9DC5;
+    constexpr std::size_t prime = 0x01000193;
+    const std::uint8_t* byteData = static_cast<const std::uint8_t*>(data);
+    return std::accumulate(byteData, byteData + byteSize, seed,
+                           [&](std::size_t hash, std::uint8_t data) {
+                               return (hash ^ data) * prime;
+                           });
+}
+
+std::size_t deterministicHash(const std::string& data) {
+    return deterministicHash(data.data(), data.size());
 }

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -162,8 +162,8 @@ bool isDirectoryWritable(const string& path) {
 }
 
 const string& getCacheDirectory() {
-    thread_local std::once_flag flag;
-    thread_local string cacheDirectory;
+    static std::once_flag flag;
+    static string cacheDirectory;
 
     std::call_once(flag, []() {
         const vector<string> pathList = {

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -120,7 +120,7 @@ string getHomeDirectory() {
     home = getEnvVar("HOME");
     if (!home.empty()) return home;
 
-    home = getpwuid(getuid())->pw_dir;
+    return getpwuid(getuid())->pw_dir;
 }
 #endif
 

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -173,7 +173,6 @@ const string& getCacheDirectory() {
 #if defined(OS_WIN)
             getTemporaryDirectory() + "\\ArrayFire"
 #else
-            "/var/lib/arrayfire",
             getHomeDirectory() + "/.arrayfire",
             "/tmp/arrayfire"
 #endif

--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -34,7 +34,7 @@ bool renameFile(const std::string& sourcePath, const std::string& destPath);
 
 bool isDirectoryWritable(const std::string& path);
 
-/// Return a string suitable for naming a temporary file. 
+/// Return a string suitable for naming a temporary file.
 ///
 /// Every call to this function will generate a new string with a very low
 /// probability of colliding with past or future outputs of this function,

--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -34,8 +34,21 @@ bool renameFile(const std::string& sourcePath, const std::string& destPath);
 
 bool isDirectoryWritable(const std::string& path);
 
+/// Return a string suitable for naming a temporary file. 
+/// 
+/// Every call to this function will generate a new string with a very low
+/// probability of colliding with past or future outputs of this function, 
+/// including calls from other threads or processes. The string contains
+/// no extension.
 std::string makeTempFilename();
 
+/// Return the FNV-1a hash of the provided bata.
+///
+/// \param[in] data Binary data to hash
+/// \param[in] byteSize Size of the data in bytes
+///
+/// \returns An unsigned integer representing the hash of the data
 std::size_t deterministicHash(const void* data, std::size_t byteSize);
 
+// This is just a wrapper around the above function.
 std::size_t deterministicHash(const std::string& data);

--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -35,3 +35,7 @@ bool renameFile(const std::string& sourcePath, const std::string& destPath);
 bool isDirectoryWritable(const std::string& path);
 
 std::string makeTempFilename();
+
+std::size_t deterministicHash(const void* data, std::size_t byteSize);
+
+std::size_t deterministicHash(const std::string& data);

--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -35,9 +35,9 @@ bool renameFile(const std::string& sourcePath, const std::string& destPath);
 bool isDirectoryWritable(const std::string& path);
 
 /// Return a string suitable for naming a temporary file. 
-/// 
+///
 /// Every call to this function will generate a new string with a very low
-/// probability of colliding with past or future outputs of this function, 
+/// probability of colliding with past or future outputs of this function,
 /// including calls from other threads or processes. The string contains
 /// no extension.
 std::string makeTempFilename();

--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -30,4 +30,8 @@ bool createDirectory(const std::string& path);
 
 bool removeFile(const std::string& path);
 
+bool renameFile(const std::string& sourcePath, const std::string& destPath);
+
 bool isDirectoryWritable(const std::string& path);
+
+std::string makeTempFilename();

--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -24,9 +24,9 @@ std::string int_version_to_string(int version);
 
 const std::string& getCacheDirectory();
 
-bool folderExists(const std::string& path);
+bool directoryExists(const std::string& path);
 
-bool createFolder(const std::string& path);
+bool createDirectory(const std::string& path);
 
 bool removeFile(const std::string& path);
 

--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -21,3 +21,13 @@ void saveKernel(const std::string& funcName, const std::string& jit_ker,
                 const std::string& ext);
 
 std::string int_version_to_string(int version);
+
+const std::string& getCacheDirectory();
+
+bool folderExists(const std::string& path);
+
+bool createFolder(const std::string& path);
+
+bool removeFile(const std::string& path);
+
+bool isDirectoryWritable(const std::string& path);

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -221,7 +221,7 @@ static CUfunction getKernel(const vector<Node *> &output_nodes,
         entry = loadKernel(device, funcName);
         if (entry.prog == nullptr || entry.ker == nullptr) {
             string jit_ker = getKernelString(funcName, full_nodes, full_ids,
-                output_ids, is_linear);
+                                             output_ids, is_linear);
             saveKernel(funcName, jit_ker, ".cu");
             entry = buildKernel(device, funcName, jit_ker, {}, true);
         }

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -23,7 +23,6 @@
 #include <af/dim4.hpp>
 
 #include <cstdio>
-#include <functional>
 #include <map>
 #include <stdexcept>
 #include <thread>
@@ -34,7 +33,6 @@ using common::Node;
 using common::Node_ids;
 using common::Node_map_t;
 
-using std::hash;
 using std::map;
 using std::string;
 using std::stringstream;
@@ -62,10 +60,8 @@ static string getFuncName(const vector<Node *> &output_nodes,
         full_nodes[i]->genKerName(funcName, full_ids[i]);
     }
 
-    hash<string> hash_fn;
-
     hashName << "KER";
-    hashName << hash_fn(funcName.str());
+    hashName << deterministicHash(funcName.str());
     return hashName.str();
 }
 

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -218,7 +218,9 @@ static CUfunction getKernel(const vector<Node *> &output_nodes,
     Kernel entry{nullptr, nullptr};
 
     if (idx == kernelCaches[device].end()) {
+#ifdef AF_CACHE_KERNELS
         entry = loadKernel(device, funcName);
+#endif
         if (entry.prog == nullptr || entry.ker == nullptr) {
             string jit_ker = getKernelString(funcName, full_nodes, full_ids,
                                              output_ids, is_linear);

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -218,10 +218,13 @@ static CUfunction getKernel(const vector<Node *> &output_nodes,
     Kernel entry{nullptr, nullptr};
 
     if (idx == kernelCaches[device].end()) {
-        string jit_ker = getKernelString(funcName, full_nodes, full_ids,
-                                         output_ids, is_linear);
-        saveKernel(funcName, jit_ker, ".cu");
-        entry = buildKernel(device, funcName, jit_ker, {}, true);
+        entry = loadKernel(device, funcName);
+        if (entry.prog == nullptr || entry.ker == nullptr) {
+            string jit_ker = getKernelString(funcName, full_nodes, full_ids,
+                output_ids, is_linear);
+            saveKernel(funcName, jit_ker, ".cu");
+            entry = buildKernel(device, funcName, jit_ker, {}, true);
+        }
         kernelCaches[device][funcName] = entry;
     } else {
         entry = idx->second;

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -214,7 +214,7 @@ static CUfunction getKernel(const vector<Node *> &output_nodes,
     Kernel entry{nullptr, nullptr};
 
     if (idx == kernelCaches[device].end()) {
-#ifdef AF_CACHE_KERNELS
+#ifdef AF_CACHE_KERNELS_TO_DISK
         entry = loadKernel(device, funcName);
 #endif
         if (entry.prog == nullptr || entry.ker == nullptr) {

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -483,15 +483,15 @@ Kernel loadKernel(const int device, const string &nameExpr) {
 
         AF_TRACE("{{{:<30} : loaded from {} for {} }}",
             nameExpr, cacheFile, getDeviceProp(device).name);
+
+        return Kernel{ module, kernel };
     } catch (...) {
         if (module != nullptr) {
             CU_CHECK(cuModuleUnload(module));
         }
         removeFile(cacheFile);
-        throw;
+        return Kernel{nullptr, nullptr};
     }
-
-    return Kernel{ module, kernel };
 }
 
 kc_t &getCache(int device) {

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -336,11 +336,12 @@ Kernel buildKernel(const int device, const string &nameExpr,
         const string tempFile = cacheDirectory + AF_PATH_SEPARATOR +
                                 makeTempFilename();
 
+        // write kernel function name and CUBIN binary data
         std::ofstream out(tempFile, std::ios::binary);
         const size_t nameSize = strlen(name);
-        out << nameSize;
+        out.write(reinterpret_cast<const char *>(&nameSize), sizeof(nameSize));
         out.write(name, nameSize);
-        out << cubinSize;
+        out.write(reinterpret_cast<const char *>(&cubinSize), sizeof(cubinSize));
         out.write(static_cast<const char *>(cubin), cubinSize);
         out.close();
 
@@ -390,14 +391,14 @@ Kernel loadKernel(const int device, const string &nameExpr) {
 
         in.exceptions(std::ios::failbit | std::ios::badbit);
 
-        size_t nameSize;
-        in >> nameSize;
+        size_t nameSize = 0;
+        in.read(reinterpret_cast<char *>(&nameSize), sizeof(nameSize));
         string name;
         name.resize(nameSize);
         in.read(&name[0], nameSize);
 
-        size_t cubinSize;
-        in >> cubinSize;
+        size_t cubinSize = 0;
+        in.read(reinterpret_cast<char *>(&cubinSize), sizeof(cubinSize));
         vector<char> cubin(cubinSize);
         in.read(cubin.data(), cubinSize);
         in.close();

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -156,10 +156,10 @@ string getKernelCacheFilename(const int device, const string &nameExpr) {
     const string mangledName = "KER" + std::hash<string>{}(nameExpr);
 
     const auto computeFlag = getComputeCapability(device);
-    const string computeVersion = 
+    const string computeVersion =
         to_string(computeFlag.first) + to_string(computeFlag.second);
 
-    return mangledName + "_CU_" + computeVersion + "_AF_" + 
+    return mangledName + "_CU_" + computeVersion + "_AF_" +
            to_string(AF_API_VERSION_CURRENT) + ".cubin";
 }
 

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -326,7 +326,7 @@ Kernel buildKernel(const int device, const string &nameExpr,
     CU_CHECK(cuModuleGetFunction(&kernel, module, name));
     Kernel entry = {module, kernel};
 
-#ifdef AF_CACHE_KERNELS
+#ifdef AF_CACHE_KERNELS_TO_DISK
     // save kernel in cache
     const string &cacheDirectory = getCacheDirectory();
     if (!cacheDirectory.empty()) {
@@ -444,7 +444,7 @@ Kernel findKernel(int device, const string &nameExpr) {
     auto iter = cache.find(nameExpr);
     if (iter != cache.end()) return iter->second;
 
-#ifdef AF_CACHE_KERNELS
+#ifdef AF_CACHE_KERNELS_TO_DISK
     Kernel kernel = loadKernel(device, nameExpr);
     if (kernel.prog != nullptr && kernel.ker != nullptr) {
         addKernelToCache(device, nameExpr, kernel);

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -45,7 +45,6 @@
 #include <array>
 #include <chrono>
 #include <fstream>
-#include <functional>
 #include <iterator>
 #include <map>
 #include <memory>
@@ -153,7 +152,7 @@ template void Kernel::setScalar<int>(const char *, int);
 template void Kernel::getScalar<int>(int &, const char *);
 
 string getKernelCacheFilename(const int device, const string &nameExpr) {
-    const string mangledName = "KER" + to_string(std::hash<string>{}(nameExpr));
+    const string mangledName = "KER" + to_string(deterministicHash(nameExpr));
 
     const auto computeFlag = getComputeCapability(device);
     const string computeVersion =

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -159,7 +159,7 @@ template void Kernel::getScalar<int>(int &, const char *);
 
 #if !defined(OS_WIN)
 string getHomeDirectory() {
-    string home = getEnvVar("XDG_CONFIG_HOME");
+    string home = getEnvVar("XDG_CACHE_HOME");
     if (!home.empty()) return home;
 
     home = getEnvVar("HOME");

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -153,7 +153,7 @@ template void Kernel::setScalar<int>(const char *, int);
 template void Kernel::getScalar<int>(int &, const char *);
 
 string getKernelCacheFilename(const int device, const string &nameExpr) {
-    const string mangledName = "KER" + std::hash<string>{}(nameExpr);
+    const string mangledName = "KER" + to_string(std::hash<string>{}(nameExpr));
 
     const auto computeFlag = getComputeCapability(device);
     const string computeVersion =

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -332,8 +332,8 @@ Kernel buildKernel(const int device, const string &nameExpr,
     if (!cacheDirectory.empty()) {
         const string cacheFile = cacheDirectory + AF_PATH_SEPARATOR +
                                  getKernelCacheFilename(device, nameExpr);
-        const string tempFile = cacheDirectory + AF_PATH_SEPARATOR +
-                                makeTempFilename();
+        const string tempFile =
+            cacheDirectory + AF_PATH_SEPARATOR + makeTempFilename();
 
         // compute CUBIN hash
         const size_t cubinHash = deterministicHash(cubin, cubinSize);
@@ -343,17 +343,17 @@ Kernel buildKernel(const int device, const string &nameExpr,
         const size_t nameSize = strlen(name);
         out.write(reinterpret_cast<const char *>(&nameSize), sizeof(nameSize));
         out.write(name, nameSize);
-        out.write(reinterpret_cast<const char *>(&cubinHash), sizeof(cubinHash));
-        out.write(reinterpret_cast<const char *>(&cubinSize), sizeof(cubinSize));
+        out.write(reinterpret_cast<const char *>(&cubinHash),
+                  sizeof(cubinHash));
+        out.write(reinterpret_cast<const char *>(&cubinSize),
+                  sizeof(cubinSize));
         out.write(static_cast<const char *>(cubin), cubinSize);
         out.close();
 
         // try to rename temporary file into final cache file, if this fails
         // this means another thread has finished compiling this kernel before
         // the current thread.
-        if (!renameFile(tempFile, cacheFile)) {
-            removeFile(tempFile);
-        }
+        if (!renameFile(tempFile, cacheFile)) { removeFile(tempFile); }
     }
 #endif
 
@@ -409,7 +409,8 @@ Kernel loadKernel(const int device, const string &nameExpr) {
         in.close();
 
         // check CUBIN binary data has not been corrupted
-        const size_t recomputedHash = deterministicHash(cubin.data(), cubinSize);
+        const size_t recomputedHash =
+            deterministicHash(cubin.data(), cubinSize);
         if (recomputedHash != cubinHash) {
             AF_ERROR("cached kernel data is corrupted", AF_ERR_LOAD_SYM);
         }

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -327,6 +327,7 @@ Kernel buildKernel(const int device, const string &nameExpr,
     CU_CHECK(cuModuleGetFunction(&kernel, module, name));
     Kernel entry = {module, kernel};
 
+#ifdef AF_CACHE_KERNELS
     // save kernel in cache
     const string &cacheDirectory = getCacheDirectory();
     if (!cacheDirectory.empty()) {
@@ -350,6 +351,7 @@ Kernel buildKernel(const int device, const string &nameExpr,
             removeFile(tempFile);
         }
     }
+#endif
 
     CU_LINK_CHECK(cuLinkDestroy(linkState));
     NVRTC_CHECK(nvrtcDestroyProgram(&prog));
@@ -429,11 +431,13 @@ Kernel findKernel(int device, const string &nameExpr) {
     auto iter = cache.find(nameExpr);
     if (iter != cache.end()) return iter->second;
 
+#ifdef AF_CACHE_KERNELS
     Kernel kernel = loadKernel(device, nameExpr);
     if (kernel.prog != nullptr && kernel.ker != nullptr) {
         addKernelToCache(device, nameExpr, kernel);
         return kernel;
     }
+#endif
 
     return Kernel{nullptr, nullptr};
 }

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -240,22 +240,14 @@ const string &getKernelCacheDirectory() {
     return cacheDirectory;
 }
 
-string hashKernelName(const string &nameExpr) {
-    return to_string(std::hash<string>{}(nameExpr));
-}
-
 string getKernelCacheFilename(const int device, const string &nameExpr) {
-    string mangledName = nameExpr;
-    if (mangledName.substr(0, 3) != "KER") {
-        mangledName = "KERF" + hashKernelName(nameExpr);
-    }
-
+    const string mangledName = "KER" + std::hash<string>{}(nameExpr);
     auto computeFlag = getComputeCapability(device);
 
-    return mangledName
-        + "_CU" + to_string(computeFlag.first) + to_string(computeFlag.second) 
-        + "_AF" + to_string(AF_API_VERSION_CURRENT)
-        + ".cubin";
+    return mangledName + 
+        "_CU_" + to_string(computeFlag.first) + to_string(computeFlag.second) +
+        "_AF_" + to_string(AF_API_VERSION_CURRENT) +
+        ".cubin";
 }
 
 Kernel buildKernel(const int device, const string &nameExpr,

--- a/src/backend/cuda/nvrtc/cache.hpp
+++ b/src/backend/cuda/nvrtc/cache.hpp
@@ -110,7 +110,7 @@ Kernel buildKernel(const int device, const std::string& nameExpr,
                    const bool isJIT                     = false);
 
 
-Kernel loadKernel(const int device, const std::string &nameExpr);
+Kernel loadKernel(const int device, const std::string& nameExpr);
 
 template<typename T>
 std::string toString(T val);

--- a/src/backend/cuda/nvrtc/cache.hpp
+++ b/src/backend/cuda/nvrtc/cache.hpp
@@ -109,7 +109,6 @@ Kernel buildKernel(const int device, const std::string& nameExpr,
                    const std::vector<std::string>& opts = {},
                    const bool isJIT                     = false);
 
-
 Kernel loadKernel(const int device, const std::string& nameExpr);
 
 template<typename T>

--- a/src/backend/cuda/nvrtc/cache.hpp
+++ b/src/backend/cuda/nvrtc/cache.hpp
@@ -109,6 +109,9 @@ Kernel buildKernel(const int device, const std::string& nameExpr,
                    const std::vector<std::string>& opts = {},
                    const bool isJIT                     = false);
 
+
+Kernel loadKernel(const int device, const std::string &nameExpr);
+
 template<typename T>
 std::string toString(T val);
 


### PR DESCRIPTION
This PR addresses #2503 ~~and #2845~~ (addressed in separate PR: #2850). 

Kernels are saved to disk in CUBIN format straight after being compiled in ``buildKernel()``. The folder they are saved into is platform-dependent:
 - linux: ``/var/lib/arrayfire``, or ``~/.arrayfire``, or ``/tmp/arrayfire`` (in order of decreasing priority)
 - windows: ``%APPDATA%\Temp\ArrayFire``

Each kernel is saved in a separate file, and the file name is built from a hash of the kernel function name (that name is already used internally for caching, so hopefully won't collide). The device compute capabilities and the AF API version are also encoded in the file name, so if these ever change, kernels will get recompiled automatically.

Disk usage looks very reasonable; on average 5 kB per kernel on the tests I ran.

Then, whenever a kernel is requested, we first look if the kernel is in the memory cache (as was done before), and if not, try the disk cache (that's new), and if that fails too, build the kernel from scratch (as was done before).

I have tested the implementation on Windows by running our own software with the ArrayFire DLLs built from that branch, and all worked fine. The linux implementation, however, is untested.