### PR TITLE
Improve the performance of CPU join and transpose

### DIFF
--- a/CMakeModules/InternalUtils.cmake
+++ b/CMakeModules/InternalUtils.cmake
@@ -71,6 +71,12 @@ function(arrayfire_set_default_cxx_flags target)
         target_compile_options(${target}
           PRIVATE -Wno-ignored-attributes)
     endif()
+
+    check_cxx_compiler_flag(-Wall has_all_warnings_flag)
+    if(has_all_warnings_flag)
+      target_compile_options(${target}
+        PRIVATE -Wall)
+    endif()
   endif()
 endfunction()
 

--- a/examples/getting_started/vectorize.cpp
+++ b/examples/getting_started/vectorize.cpp
@@ -183,7 +183,7 @@ int main(int, char **) {
         printf("Time for dist_tile1: %2.2fms\n", 1000 * timeit(bench_tile1));
         printf("Time for dist_tile2: %2.2fms\n", 1000 * timeit(bench_tile2));
 
-    } catch (af::exception ex) {
+    } catch (const af::exception &ex) {
         fprintf(stderr, "%s\n", ex.what());
         throw;
     }

--- a/examples/image_processing/confidence_connected_components.cpp
+++ b/examples/image_processing/confidence_connected_components.cpp
@@ -17,7 +17,6 @@ using namespace af;
 
 int main(int argc, char* argv[]) {
     try {
-        unsigned s[1]       = {132};
         unsigned radius     = 3;
         unsigned multiplier = 3;
         int iter            = 5;

--- a/examples/machine_learning/neural_network.cpp
+++ b/examples/machine_learning/neural_network.cpp
@@ -45,8 +45,8 @@ double error(const array &out, const array &pred) {
 class ann {
    private:
     int num_layers;
-    dtype datatype;
     vector<array> weights;
+    dtype datatype;
 
     // Add bias input to the output from previous layer
     array add_bias(const array &in);

--- a/src/api/c/assign.cpp
+++ b/src/api/c/assign.cpp
@@ -64,7 +64,9 @@ static void assign(Array<Tout>& out, const vector<af_seq> seqs,
 
     isVec &= in.isVector() || in.isScalar();
 
-    for (dim_t i = ndims; i < in.ndims(); i++) { oDims[i] = 1; }
+    for (dim_t i = static_cast<dim_t>(ndims); i < in.ndims(); i++) {
+        oDims[i] = 1;
+    }
 
     if (isVec) {
         if (oDims.elements() != in.elements() && in.elements() != 1) {

--- a/src/api/c/handle.hpp
+++ b/src/api/c/handle.hpp
@@ -77,7 +77,8 @@ detail::Array<T> &getArray(af_array &arr) {
 }
 
 template<>
-detail::Array<common::half> &getArray<common::half>(af_array &arr) {
+[[gnu::unused]] detail::Array<common::half> &getArray<common::half>(
+    af_array &arr) {
     detail::Array<common::half> *A =
         static_cast<detail::Array<common::half> *>(arr);
     if (f16 != A->getType())

--- a/src/api/c/index.cpp
+++ b/src/api/c/index.cpp
@@ -58,10 +58,10 @@ af_seq convert2Canonical(const af_seq s, const dim_t len) {
 template<typename T>
 static af_array indexBySeqs(const af_array& src,
                             const vector<af_seq> indicesV) {
-    size_t ndims      = indicesV.size();
+    dim_t ndims       = static_cast<dim_t>(indicesV.size());
     const auto& input = getArray<T>(src);
 
-    if (ndims == 1 && ndims != input.ndims()) {
+    if (ndims == 1U && ndims != input.ndims()) {
         return getHandle(createSubArray(::flat(input), indicesV));
     } else {
         return getHandle(createSubArray(input, indicesV));

--- a/src/api/c/join.cpp
+++ b/src/api/c/join.cpp
@@ -20,11 +20,10 @@ using af::dim4;
 using common::half;
 using namespace detail;
 
-template<typename Tx, typename Ty>
+template<typename T>
 static inline af_array join(const int dim, const af_array first,
                             const af_array second) {
-    return getHandle(
-        join<Tx, Ty>(dim, getArray<Tx>(first), getArray<Ty>(second)));
+    return getHandle(join<T>(dim, getArray<T>(first), getArray<T>(second)));
 }
 
 template<typename T>
@@ -65,21 +64,19 @@ af_err af_join(af_array *out, const int dim, const af_array first,
         af_array output;
 
         switch (finfo.getType()) {
-            case f32: output = join<float, float>(dim, first, second); break;
-            case c32: output = join<cfloat, cfloat>(dim, first, second); break;
-            case f64: output = join<double, double>(dim, first, second); break;
-            case c64:
-                output = join<cdouble, cdouble>(dim, first, second);
-                break;
-            case b8: output = join<char, char>(dim, first, second); break;
-            case s32: output = join<int, int>(dim, first, second); break;
-            case u32: output = join<uint, uint>(dim, first, second); break;
-            case s64: output = join<intl, intl>(dim, first, second); break;
-            case u64: output = join<uintl, uintl>(dim, first, second); break;
-            case s16: output = join<short, short>(dim, first, second); break;
-            case u16: output = join<ushort, ushort>(dim, first, second); break;
-            case u8: output = join<uchar, uchar>(dim, first, second); break;
-            case f16: output = join<half, half>(dim, first, second); break;
+            case f32: output = join<float>(dim, first, second); break;
+            case c32: output = join<cfloat>(dim, first, second); break;
+            case f64: output = join<double>(dim, first, second); break;
+            case c64: output = join<cdouble>(dim, first, second); break;
+            case b8: output = join<char>(dim, first, second); break;
+            case s32: output = join<int>(dim, first, second); break;
+            case u32: output = join<uint>(dim, first, second); break;
+            case s64: output = join<intl>(dim, first, second); break;
+            case u64: output = join<uintl>(dim, first, second); break;
+            case s16: output = join<short>(dim, first, second); break;
+            case u16: output = join<ushort>(dim, first, second); break;
+            case u8: output = join<uchar>(dim, first, second); break;
+            case f16: output = join<half>(dim, first, second); break;
             default: TYPE_ERROR(1, finfo.getType());
         }
         std::swap(*out, output);
@@ -92,7 +89,14 @@ af_err af_join(af_array *out, const int dim, const af_array first,
 af_err af_join_many(af_array *out, const int dim, const unsigned n_arrays,
                     const af_array *inputs) {
     try {
-        ARG_ASSERT(3, n_arrays > 1 && n_arrays <= 10);
+        ARG_ASSERT(3, inputs != nullptr);
+
+        if (n_arrays == 1) {
+            af_array ret = nullptr;
+            AF_CHECK(af_retain_array(&ret, inputs[0]));
+            std::swap(*out, ret);
+            return AF_SUCCESS;
+        }
 
         std::vector<ArrayInfo> info;
         info.reserve(n_arrays);

--- a/src/api/c/rgb_gray.cpp
+++ b/src/api/c/rgb_gray.cpp
@@ -88,8 +88,8 @@ static af_array gray2rgb(const af_array& in, const float r, const float g,
     AF_CHECK(af_release_array(mod_input));
 
     // join channels
-    Array<cType> expr4 = join<cType, cType>(2, expr1, expr2);
-    return getHandle(join<cType, cType>(2, expr3, expr4));
+    Array<cType> expr4 = join<cType>(2, expr1, expr2);
+    return getHandle(join<cType>(2, expr3, expr4));
 }
 
 template<typename T, typename cType, bool isRGB2GRAY>

--- a/src/api/c/sparse.cpp
+++ b/src/api/c/sparse.cpp
@@ -34,7 +34,8 @@ const SparseArrayBase &getSparseArrayBase(const af_array in,
             AF_ERR_ARG);
     }
 
-    if (device_check && base->getDevId() != detail::getActiveDeviceId()) {
+    if (device_check &&
+        base->getDevId() != static_cast<int>(detail::getActiveDeviceId())) {
         AF_ERROR("Input Array not created on current device", AF_ERR_DEVICE);
     }
 
@@ -84,7 +85,7 @@ af_err af_create_sparse_array(af_array *out, const dim_t nRows,
         ARG_ASSERT(5, cInfo.getType() == s32);
         DIM_ASSERT(5, cInfo.isLinear());
 
-        const size_t nNZ = vInfo.elements();
+        const dim_t nNZ = vInfo.elements();
         if (stype == AF_STORAGE_COO) {
             DIM_ASSERT(4, rInfo.elements() == nNZ);
             DIM_ASSERT(5, cInfo.elements() == nNZ);

--- a/src/api/c/var.cpp
+++ b/src/api/c/var.cpp
@@ -90,8 +90,9 @@ static tuple<Array<outType>, Array<outType>> meanvar(
     Array<outType> normArr = createEmptyArray<outType>({0});
     if (weights.isEmpty()) {
         meanArr  = mean<outType, weightType, outType>(input, dim);
-        auto val = 1.0 / (bias == AF_VARIANCE_POPULATION ? iDims[dim]
-                                                         : iDims[dim] - 1);
+        auto val = 1.0 / static_cast<double>(bias == AF_VARIANCE_POPULATION
+                                                 ? iDims[dim]
+                                                 : iDims[dim] - 1);
         normArr =
             createValueArray<outType>(meanArr.dims(), scalar<outType>(val));
     } else {

--- a/src/api/c/var.cpp
+++ b/src/api/c/var.cpp
@@ -16,7 +16,6 @@
 #include <math.hpp>
 #include <mean.hpp>
 #include <reduce.hpp>
-#include <tile.hpp>
 #include <af/defines.h>
 #include <af/dim4.hpp>
 #include <af/statistics.h>
@@ -107,14 +106,8 @@ static tuple<Array<outType>, Array<outType>> meanvar(
         normArr = arithOp<outType, af_div_t>(ones, wtsSum, meanArr.dims());
     }
 
-    /* now tile meanArr along dim and use it for variance computation */
-    dim4 tileDims(1);
-    tileDims[dim]           = iDims[dim];
-    Array<outType> tMeanArr = tile<outType>(meanArr, tileDims);
-    /* now mean array is ready */
-
     Array<outType> diff =
-        arithOp<outType, af_sub_t>(input, tMeanArr, tMeanArr.dims());
+        arithOp<outType, af_sub_t>(input, meanArr, input.dims());
     Array<outType> diffSq = arithOp<outType, af_mul_t>(diff, diff, diff.dims());
     Array<outType> redDiff = reduce<af_add_t, outType, outType>(diffSq, dim);
 

--- a/src/api/c/ycbcr_rgb.cpp
+++ b/src/api/c/ycbcr_rgb.cpp
@@ -104,8 +104,8 @@ static af_array convert(const af_array& in, const af_ycc_std standard) {
                    INV_112 * (kb - 1) * kb * invKl);
         Array<T> B = mix<T>(Y_, Cb_, INV_219, INV_112 * (1 - kb));
         // join channels
-        Array<T> RG = join<T, T>(2, R, G);
-        return getHandle(join<T, T>(2, RG, B));
+        Array<T> RG = join<T>(2, R, G);
+        return getHandle(join<T>(2, RG, B));
     }
     Array<T> Ey = mix<T>(X, Y, Z, kr, kl, kb);
     Array<T> Ecr =
@@ -116,8 +116,8 @@ static af_array convert(const af_array& in, const af_ycc_std standard) {
     Array<T> Cr = digitize<T>(Ecr, 224.0, 128.0);
     Array<T> Cb = digitize<T>(Ecb, 224.0, 128.0);
     // join channels
-    Array<T> YCb = join<T, T>(2, Y_, Cb);
-    return getHandle(join<T, T>(2, YCb, Cr));
+    Array<T> YCb = join<T>(2, Y_, Cb);
+    return getHandle(join<T>(2, YCb, Cr));
 }
 
 template<bool isYCbCr2RGB>

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -21,7 +21,11 @@
 #include <af/traits.hpp>
 #include <af/util.h>
 #include "error.hpp"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wparentheses"
 #include "half.hpp"  //note: NOT common. From extern/half/include/half.hpp
+#pragma GCC diagnostic pop
 
 #ifdef AF_CUDA
 // NOTE: Adding ifdef here to avoid copying code constructor in the cuda backend
@@ -257,7 +261,6 @@ array::~array() {
 #ifdef AF_UNIFIED
     using af_release_array_ptr =
         std::add_pointer<decltype(af_release_array)>::type;
-    static auto &instance = unified::AFSymbolManager::getInstance();
 
     if (get()) {
         af_backend backend = unified::getActiveBackend();
@@ -291,6 +294,10 @@ array::~array() {
                     func(get());
                     break;
                 }
+                case AF_BACKEND_DEFAULT:
+                    assert(1 != 1 &&
+                           "AF_BACKEND_DEFAULT cannot be set as a backend for "
+                           "an array");
             }
         }
     }

--- a/src/api/cpp/common.hpp
+++ b/src/api/cpp/common.hpp
@@ -9,7 +9,11 @@
 
 #include <af/dim4.hpp>
 #include <af/half.h>
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wparentheses"
 #include "half.hpp"
+#pragma GCC diagnostic pop
 
 #include <cstring>
 
@@ -37,11 +41,12 @@ To cast(T in) {
 }
 
 template<>
-af_half cast<af_half, double>(double in) {
+[[gnu::unused]] af_half cast<af_half, double>(double in) {
     half_float::half tmp = static_cast<half_float::half>(in);
     af_half out;
     memcpy(&out, &tmp, sizeof(af_half));
     return out;
 }
+
 }  // namespace
 }  // namespace af

--- a/src/api/cpp/data.cpp
+++ b/src/api/cpp/data.cpp
@@ -8,7 +8,11 @@
  ********************************************************/
 #include <af/data.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wparentheses"
 #include <half.hpp>
+#pragma GCC diagnostic pop
+
 #include <af/arith.h>
 #include <af/array.h>
 #include <af/complex.h>

--- a/src/api/cpp/device.cpp
+++ b/src/api/cpp/device.cpp
@@ -38,7 +38,6 @@ af::Backend getBackendId(const array &in) {
 
 int getDeviceId(const array &in) {
     int device = getDevice();
-    ;
     AF_THROW(af_get_device_id(&device, in.get()));
     return device;
 }

--- a/src/api/cpp/exception.cpp
+++ b/src/api/cpp/exception.cpp
@@ -23,7 +23,7 @@ exception::exception() : m_msg{}, m_err(AF_ERR_UNKNOWN) {
 }
 
 exception::exception(const char *msg) : m_msg{}, m_err(AF_ERR_UNKNOWN) {
-    strncpy(m_msg, msg, sizeof(m_msg));
+    strncpy(m_msg, msg, sizeof(m_msg) - 1);
     m_msg[sizeof(m_msg) - 1] = '\0';
 }
 

--- a/src/api/unified/symbol_manager.cpp
+++ b/src/api/unified/symbol_manager.cpp
@@ -189,8 +189,8 @@ AFSymbolManager::AFSymbolManager()
     static const af_backend order[] = {AF_BACKEND_CUDA, AF_BACKEND_OPENCL,
                                        AF_BACKEND_CPU};
 
-    LibHandle handle;
-    af::Backend backend;
+    LibHandle handle    = nullptr;
+    af::Backend backend = AF_BACKEND_DEFAULT;
     // Decremeting loop. The last successful backend loaded will be the most
     // prefered one.
     for (int i = NUM_BACKENDS - 1; i >= 0; i--) {
@@ -205,12 +205,15 @@ AFSymbolManager::AFSymbolManager()
     }
     if (backend) {
         AF_TRACE("AF_DEFAULT_BACKEND: {}", getBackendDirectoryName(backend));
+        defaultBackend = backend;
+    } else {
+        logger->error("Backend was not found");
+        defaultBackend = AF_BACKEND_DEFAULT;
     }
 
     // Keep a copy of default order handle inorder to use it in ::setBackend
     // when the user passes AF_BACKEND_DEFAULT
-    defaultHandle  = handle;
-    defaultBackend = backend;
+    defaultHandle = handle;
 }
 
 AFSymbolManager::~AFSymbolManager() {

--- a/src/api/unified/symbol_manager.hpp
+++ b/src/api/unified/symbol_manager.hpp
@@ -100,7 +100,7 @@ bool checkArray(af_backend activeBackend, const af_array a) {
     return backend == activeBackend;
 }
 
-bool checkArray(af_backend activeBackend, const af_array* a) {
+[[gnu::unused]] bool checkArray(af_backend activeBackend, const af_array* a) {
     if (a) {
         return checkArray(activeBackend, *a);
     } else {
@@ -108,7 +108,7 @@ bool checkArray(af_backend activeBackend, const af_array* a) {
     }
 }
 
-bool checkArrays(af_backend activeBackend) {
+[[gnu::unused]] bool checkArrays(af_backend activeBackend) {
     UNUSED(activeBackend);
     // Dummy
     return true;
@@ -140,7 +140,6 @@ bool checkArrays(af_backend activeBackend, T a, Args... arg) {
 
 #define CALL(FUNCTION, ...)                                                      \
     using af_func                  = std::add_pointer<decltype(FUNCTION)>::type; \
-    static auto& instance          = unified::AFSymbolManager::getInstance();    \
     thread_local af_backend index_ = unified::getActiveBackend();                \
     if (unified::getActiveHandle()) {                                            \
         thread_local af_func func = (af_func)common::getFunctionPointer(         \

--- a/src/backend/common/ArrayInfo.cpp
+++ b/src/backend/common/ArrayInfo.cpp
@@ -120,7 +120,7 @@ bool ArrayInfo::isLinear() const {
     if (ndims() == 1) { return dim_strides[0] == 1; }
 
     dim_t count = 1;
-    for (size_t i = 0; i < ndims(); i++) {
+    for (dim_t i = 0; i < ndims(); i++) {
         if (count != dim_strides[i]) { return false; }
         count *= dim_size[i];
     }

--- a/src/backend/common/ArrayInfo.hpp
+++ b/src/backend/common/ArrayInfo.hpp
@@ -90,8 +90,8 @@ class ArrayInfo {
 
     const af::dim4& strides() const { return dim_strides; }
 
-    size_t elements() const { return dim_size.elements(); }
-    size_t ndims() const { return dim_size.ndims(); }
+    dim_t elements() const { return dim_size.elements(); }
+    dim_t ndims() const { return dim_size.ndims(); }
     const af::dim4& dims() const { return dim_size; }
     size_t total() const { return offset + dim_strides[3] * dim_size[3]; }
 

--- a/src/backend/common/DefaultMemoryManager.cpp
+++ b/src/backend/common/DefaultMemoryManager.cpp
@@ -72,8 +72,8 @@ DefaultMemoryManager::DefaultMemoryManager(int num_devices,
                                            unsigned max_buffers, bool debug)
     : mem_step_size(1024)
     , max_buffers(max_buffers)
-    , memory(num_devices)
-    , debug_mode(debug) {
+    , debug_mode(debug)
+    , memory(num_devices) {
     // Check for environment variables
 
     // Debug mode
@@ -171,7 +171,7 @@ void *DefaultMemoryManager::alloc(bool user_lock, const unsigned ndims,
                 // Delete existing buffer info and underlying event
                 // Set to existing in from free map
                 vector<void *> &free_buffer_vector = free_buffer_iter->second;
-                ptr = free_buffer_vector.back();
+                ptr                                = free_buffer_vector.back();
                 free_buffer_vector.pop_back();
                 current.locked_map[ptr] = info;
                 current.lock_bytes += alloc_bytes;
@@ -221,7 +221,7 @@ void DefaultMemoryManager::unlock(void *ptr, bool user_unlock) {
         lock_guard_t lock(this->memory_mutex);
         memory_info &current = this->getCurrentMemoryInfo();
 
-        auto locked_buffer_iter         = current.locked_map.find(ptr);
+        auto locked_buffer_iter = current.locked_map.find(ptr);
         if (locked_buffer_iter == current.locked_map.end()) {
             // Pointer not found in locked map
             // Probably came from user, just free it

--- a/src/backend/common/DefaultMemoryManager.hpp
+++ b/src/backend/common/DefaultMemoryManager.hpp
@@ -42,11 +42,11 @@ class DefaultMemoryManager final : public common::memory::MemoryManagerBase {
         locked_t locked_map;
         free_t free_map;
 
-        size_t lock_bytes;
-        size_t lock_buffers;
+        size_t max_bytes;
         size_t total_bytes;
         size_t total_buffers;
-        size_t max_bytes;
+        size_t lock_bytes;
+        size_t lock_buffers;
 
         memory_info()
             // Calling getMaxMemorySize() here calls the virtual function

--- a/src/backend/common/DependencyModule.cpp
+++ b/src/backend/common/DependencyModule.cpp
@@ -68,6 +68,7 @@ DependencyModule::DependencyModule(const vector<string>& plugin_base_file_name,
     : handle(nullptr), logger(common::loggerFactory("platform")) {
     for (const string& base_name : plugin_base_file_name) {
         for (const string& path : paths) {
+            UNUSED(path);
             for (const string& suffix : suffixes) {
                 string filename = libName(base_name + suffix);
                 AF_TRACE("Attempting to load: {}", filename);

--- a/src/backend/common/half.hpp
+++ b/src/backend/common/half.hpp
@@ -60,11 +60,11 @@ CONSTEXPR_DH native_half_t int2half_impl(T value) noexcept {
     uint16_t bits = S << 15;
     if (value > 0xFFFF) {
         if (R == std::round_toward_infinity)
-            bits |= 0x7C00 - S;
+            bits |= (0x7C00 - S);
         else if (R == std::round_toward_neg_infinity)
-            bits |= 0x7BFF + S;
+            bits |= (0x7BFF + S);
         else
-            bits |= 0x7BFF + (R != std::round_toward_zero);
+            bits |= (0x7BFF + (R != std::round_toward_zero));
     } else if (value) {
         uint32_t m = value, exp = 24;
         for (; m < 0x400; m <<= 1, --exp)
@@ -262,10 +262,10 @@ CONSTEXPR_DH native_half_t float2half_impl(double value) {
                (0x3FF & -static_cast<unsigned>((bits & 0xFFFFFFFFFFFFF) != 0));
     if (exp > 1038) {
         if (R == std::round_toward_infinity)
-            return hbits | 0x7C00 - (hbits >> 15);
+            return hbits | (0x7C00 - (hbits >> 15));
         if (R == std::round_toward_neg_infinity)
-            return hbits | 0x7BFF + (hbits >> 15);
-        return hbits | 0x7BFF + (R != std::round_toward_zero);
+            return hbits | (0x7BFF + (hbits >> 15));
+        return hbits | (0x7BFF + (R != std::round_toward_zero));
     }
     int g, s = lo != 0;
     if (exp > 1008) {

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -61,6 +61,8 @@ const char* getName(af_dtype type) {
 
 void saveKernel(const std::string& funcName, const std::string& jit_ker,
                 const std::string& ext) {
+    static constexpr const char* saveJitKernelsEnvVarName =
+        "AF_JIT_KERNEL_TRACE";
     static const char* jitKernelsOutput = getenv(saveJitKernelsEnvVarName);
     if (!jitKernelsOutput) { return; }
     if (std::strcmp(jitKernelsOutput, "stdout") == 0) {
@@ -83,4 +85,9 @@ void saveKernel(const std::string& funcName, const std::string& jit_ker,
         fprintf(stderr, "Failed to write kernel to file %s\n", ffp.c_str());
     }
     fclose(f);
+}
+
+std::string int_version_to_string(int version) {
+    return std::to_string(version / 1000) + "." +
+           std::to_string((int)((version % 1000) / 10.));
 }

--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -19,12 +19,5 @@ std::string getEnvVar(const std::string& key);
 // Dump the kernel sources only if the environment variable is defined
 void saveKernel(const std::string& funcName, const std::string& jit_ker,
                 const std::string& ext);
-namespace {
-static constexpr const char* saveJitKernelsEnvVarName = "AF_JIT_KERNEL_TRACE";
 
-std::string int_version_to_string(int version) {
-    return std::to_string(version / 1000) + "." +
-           std::to_string((int)((version % 1000) / 10.));
-}
-
-}  // namespace
+std::string int_version_to_string(int version);

--- a/src/backend/cpu/Array.hpp
+++ b/src/backend/cpu/Array.hpp
@@ -144,8 +144,8 @@ class Array {
 
     INFO_FUNC(const af_dtype &, getType)
     INFO_FUNC(const af::dim4 &, strides)
-    INFO_FUNC(size_t, elements)
-    INFO_FUNC(size_t, ndims)
+    INFO_FUNC(dim_t, elements)
+    INFO_FUNC(dim_t, ndims)
     INFO_FUNC(const af::dim4 &, dims)
     INFO_FUNC(int, getDevId)
 

--- a/src/backend/cpu/device_manager.cpp
+++ b/src/backend/cpu/device_manager.cpp
@@ -123,10 +123,10 @@ namespace cpu {
 
 DeviceManager::DeviceManager()
     : queues(MAX_QUEUES)
+    , fgMngr(new graphics::ForgeManager())
     , memManager(new common::DefaultMemoryManager(
           getDeviceCount(), common::MAX_BUFFERS,
-          AF_MEM_DEBUG || AF_CPU_MEM_DEBUG))
-    , fgMngr(new graphics::ForgeManager()) {
+          AF_MEM_DEBUG || AF_CPU_MEM_DEBUG)) {
     // Use the default ArrayFire memory manager
     std::unique_ptr<cpu::Allocator> deviceMemoryManager(new cpu::Allocator());
     memManager->setAllocator(std::move(deviceMemoryManager));

--- a/src/backend/cpu/device_manager.hpp
+++ b/src/backend/cpu/device_manager.hpp
@@ -90,10 +90,10 @@ namespace cpu {
 
 class DeviceManager {
    public:
-    static const int MAX_QUEUES           = 1;
-    static const int NUM_DEVICES          = 1;
-    static const int ACTIVE_DEVICE_ID     = 0;
-    static const bool IS_DOUBLE_SUPPORTED = true;
+    static const int MAX_QUEUES            = 1;
+    static const int NUM_DEVICES           = 1;
+    static const unsigned ACTIVE_DEVICE_ID = 0;
+    static const bool IS_DOUBLE_SUPPORTED  = true;
 
     // TODO(umar): Half is not supported for BLAS and FFT on x86_64
     static const bool IS_HALF_SUPPORTED = true;

--- a/src/backend/cpu/join.cpp
+++ b/src/backend/cpu/join.cpp
@@ -20,8 +20,8 @@ using common::half;
 
 namespace cpu {
 
-template<typename Tx, typename Ty>
-Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second) {
+template<typename T>
+Array<T> join(const int dim, const Array<T> &first, const Array<T> &second) {
     // All dimensions except join dimension must be equal
     // Compute output dims
     af::dim4 odims;
@@ -36,9 +36,9 @@ Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second) {
         }
     }
 
-    Array<Tx> out = createEmptyArray<Tx>(odims);
-
-    getQueue().enqueue(kernel::join<Tx, Ty>, out, dim, first, second);
+    Array<T> out = createEmptyArray<T>(odims);
+    std::vector<CParam<T>> v{first, second};
+    getQueue().enqueue(kernel::join<T>, dim, out, v, 2);
 
     return out;
 }
@@ -73,59 +73,28 @@ Array<T> join(const int dim, const std::vector<Array<T>> &inputs) {
     std::vector<CParam<T>> inputParams(inputs.begin(), inputs.end());
     Array<T> out = createEmptyArray<T>(odims);
 
-    switch (n_arrays) {
-        case 1:
-            getQueue().enqueue(kernel::join<T, 1>, dim, out, inputParams);
-            break;
-        case 2:
-            getQueue().enqueue(kernel::join<T, 2>, dim, out, inputParams);
-            break;
-        case 3:
-            getQueue().enqueue(kernel::join<T, 3>, dim, out, inputParams);
-            break;
-        case 4:
-            getQueue().enqueue(kernel::join<T, 4>, dim, out, inputParams);
-            break;
-        case 5:
-            getQueue().enqueue(kernel::join<T, 5>, dim, out, inputParams);
-            break;
-        case 6:
-            getQueue().enqueue(kernel::join<T, 6>, dim, out, inputParams);
-            break;
-        case 7:
-            getQueue().enqueue(kernel::join<T, 7>, dim, out, inputParams);
-            break;
-        case 8:
-            getQueue().enqueue(kernel::join<T, 8>, dim, out, inputParams);
-            break;
-        case 9:
-            getQueue().enqueue(kernel::join<T, 9>, dim, out, inputParams);
-            break;
-        case 10:
-            getQueue().enqueue(kernel::join<T, 10>, dim, out, inputParams);
-            break;
-    }
+    getQueue().enqueue(kernel::join<T>, dim, out, inputParams, n_arrays);
 
     return out;
 }
 
-#define INSTANTIATE(Tx, Ty)                                                \
-    template Array<Tx> join<Tx, Ty>(const int dim, const Array<Tx> &first, \
-                                    const Array<Ty> &second);
+#define INSTANTIATE(T)                                              \
+    template Array<T> join<T>(const int dim, const Array<T> &first, \
+                              const Array<T> &second);
 
-INSTANTIATE(float, float)
-INSTANTIATE(double, double)
-INSTANTIATE(cfloat, cfloat)
-INSTANTIATE(cdouble, cdouble)
-INSTANTIATE(int, int)
-INSTANTIATE(uint, uint)
-INSTANTIATE(intl, intl)
-INSTANTIATE(uintl, uintl)
-INSTANTIATE(uchar, uchar)
-INSTANTIATE(char, char)
-INSTANTIATE(ushort, ushort)
-INSTANTIATE(short, short)
-INSTANTIATE(half, half)
+INSTANTIATE(float)
+INSTANTIATE(double)
+INSTANTIATE(cfloat)
+INSTANTIATE(cdouble)
+INSTANTIATE(int)
+INSTANTIATE(uint)
+INSTANTIATE(intl)
+INSTANTIATE(uintl)
+INSTANTIATE(uchar)
+INSTANTIATE(char)
+INSTANTIATE(ushort)
+INSTANTIATE(short)
+INSTANTIATE(half)
 
 #undef INSTANTIATE
 

--- a/src/backend/cpu/join.hpp
+++ b/src/backend/cpu/join.hpp
@@ -11,8 +11,8 @@
 #include <vector>
 
 namespace cpu {
-template<typename Tx, typename Ty>
-Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second);
+template<typename T>
+Array<T> join(const int dim, const Array<T> &first, const Array<T> &second);
 
 template<typename T>
 Array<T> join(const int dim, const std::vector<Array<T>> &inputs);

--- a/src/backend/cpu/kernel/join.hpp
+++ b/src/backend/cpu/kernel/join.hpp
@@ -13,8 +13,7 @@
 namespace cpu {
 namespace kernel {
 
-template<int dim>
-af::dim4 calcOffset(const af::dim4 dims) {
+af::dim4 calcOffset(const af::dim4 dims, int dim) {
     af::dim4 offset;
     offset[0] = (dim == 0) ? dims[0] : 0;
     offset[1] = (dim == 1) ? dims[1] : 0;
@@ -23,8 +22,8 @@ af::dim4 calcOffset(const af::dim4 dims) {
     return offset;
 }
 
-template<typename To, typename Tx, int dim>
-void join_append(To *out, const Tx *X, const af::dim4 &offset,
+template<typename T>
+void join_append(T *out, const T *X, const af::dim4 &offset,
                  const af::dim4 &xdims, const af::dim4 &ost,
                  const af::dim4 &xst) {
     for (dim_t ow = 0; ow < xdims[3]; ow++) {
@@ -39,99 +38,23 @@ void join_append(To *out, const Tx *X, const af::dim4 &offset,
                 const dim_t xYZW = xZW + oy * xst[1];
                 const dim_t oYZW = oZW + (oy + offset[1]) * ost[1];
 
-                memcpy(out + oYZW + offset[0], X + xYZW, xdims[0] * sizeof(To));
+                memcpy(out + oYZW + offset[0], X + xYZW, xdims[0] * sizeof(T));
             }
         }
     }
 }
 
-template<typename Tx, typename Ty>
-void join(Param<Tx> out, const int dim, CParam<Tx> first, CParam<Ty> second) {
-    Tx *outPtr     = out.get();
-    const Tx *fptr = first.get();
-    const Ty *sptr = second.get();
-
-    af::dim4 zero(0, 0, 0, 0);
-    const af::dim4 fdims = first.dims();
-    const af::dim4 sdims = second.dims();
-
-    switch (dim) {
-        case 0:
-            join_append<Tx, Tx, 0>(outPtr, fptr, zero, fdims, out.strides(),
-                                   first.strides());
-            join_append<Tx, Ty, 0>(outPtr, sptr, calcOffset<0>(fdims), sdims,
-                                   out.strides(), second.strides());
-            break;
-        case 1:
-            join_append<Tx, Tx, 1>(outPtr, fptr, zero, fdims, out.strides(),
-                                   first.strides());
-            join_append<Tx, Ty, 1>(outPtr, sptr, calcOffset<1>(fdims), sdims,
-                                   out.strides(), second.strides());
-            break;
-        case 2:
-            join_append<Tx, Tx, 2>(outPtr, fptr, zero, fdims, out.strides(),
-                                   first.strides());
-            join_append<Tx, Ty, 2>(outPtr, sptr, calcOffset<2>(fdims), sdims,
-                                   out.strides(), second.strides());
-            break;
-        case 3:
-            join_append<Tx, Tx, 3>(outPtr, fptr, zero, fdims, out.strides(),
-                                   first.strides());
-            join_append<Tx, Ty, 3>(outPtr, sptr, calcOffset<3>(fdims), sdims,
-                                   out.strides(), second.strides());
-            break;
-    }
-}
-
-template<typename T, int n_arrays>
-void join(const int dim, Param<T> out, const std::vector<CParam<T>> inputs) {
+template<typename T>
+void join(const int dim, Param<T> out, const std::vector<CParam<T>> inputs,
+          int n_arrays) {
     af::dim4 zero(0, 0, 0, 0);
     af::dim4 d = zero;
-    switch (dim) {
-        case 0:
-            join_append<T, T, 0>(out.get(), inputs[0].get(), zero,
-                                 inputs[0].dims(), out.strides(),
-                                 inputs[0].strides());
-            for (int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims();
-                join_append<T, T, 0>(out.get(), inputs[i].get(),
-                                     calcOffset<0>(d), inputs[i].dims(),
-                                     out.strides(), inputs[i].strides());
-            }
-            break;
-        case 1:
-            join_append<T, T, 1>(out.get(), inputs[0].get(), zero,
-                                 inputs[0].dims(), out.strides(),
-                                 inputs[0].strides());
-            for (int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims();
-                join_append<T, T, 1>(out.get(), inputs[i].get(),
-                                     calcOffset<1>(d), inputs[i].dims(),
-                                     out.strides(), inputs[i].strides());
-            }
-            break;
-        case 2:
-            join_append<T, T, 2>(out.get(), inputs[0].get(), zero,
-                                 inputs[0].dims(), out.strides(),
-                                 inputs[0].strides());
-            for (int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims();
-                join_append<T, T, 2>(out.get(), inputs[i].get(),
-                                     calcOffset<2>(d), inputs[i].dims(),
-                                     out.strides(), inputs[i].strides());
-            }
-            break;
-        case 3:
-            join_append<T, T, 3>(out.get(), inputs[0].get(), zero,
-                                 inputs[0].dims(), out.strides(),
-                                 inputs[0].strides());
-            for (int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims();
-                join_append<T, T, 3>(out.get(), inputs[i].get(),
-                                     calcOffset<3>(d), inputs[i].dims(),
-                                     out.strides(), inputs[i].strides());
-            }
-            break;
+    join_append<T>(out.get(), inputs[0].get(), zero, inputs[0].dims(),
+                   out.strides(), inputs[0].strides());
+    for (int i = 1; i < n_arrays; i++) {
+        d += inputs[i - 1].dims();
+        join_append<T>(out.get(), inputs[i].get(), calcOffset(d, dim),
+                       inputs[i].dims(), out.strides(), inputs[i].strides());
     }
 }
 

--- a/src/backend/cpu/kernel/join.hpp
+++ b/src/backend/cpu/kernel/join.hpp
@@ -39,11 +39,7 @@ void join_append(To *out, const Tx *X, const af::dim4 &offset,
                 const dim_t xYZW = xZW + oy * xst[1];
                 const dim_t oYZW = oZW + (oy + offset[1]) * ost[1];
 
-                for (dim_t ox = 0; ox < xdims[0]; ox++) {
-                    const dim_t iMem = xYZW + ox;
-                    const dim_t oMem = oYZW + (ox + offset[0]);
-                    out[oMem]        = X[iMem];
-                }
+                memcpy(out + oYZW + offset[0], X + xYZW, xdims[0] * sizeof(To));
             }
         }
     }

--- a/src/backend/cpu/kernel/mean.hpp
+++ b/src/backend/cpu/kernel/mean.hpp
@@ -22,7 +22,9 @@ struct MeanOp {
     MeanOp(Ti mean, Tw count)
         : transform(), runningMean(transform(mean)), runningCount(count) {}
 
-    void operator()(Ti _newMean, Tw newCount) {
+    /// Prevents the optimzation of the mean calculation by some compiler flags
+    /// specifically -march=native.
+    [[gnu::optimize("01")]] void operator()(Ti _newMean, Tw newCount) {
         To newMean = transform(_newMean);
         if ((newCount != 0) || (runningCount != 0)) {
             Tw runningScale = runningCount;

--- a/src/backend/cpu/kernel/reduce.hpp
+++ b/src/backend/cpu/kernel/reduce.hpp
@@ -62,8 +62,7 @@ struct reduce_dim<op, Ti, To, 0> {
 
 template<typename Tk>
 void n_reduced_keys(Param<Tk> okeys, int *n_reduced, CParam<Tk> keys) {
-    const af::dim4 kstrides = keys.strides();
-    const af::dim4 kdims    = keys.dims();
+    const af::dim4 kdims = keys.dims();
 
     Tk *const outKeysPtr      = okeys.get();
     Tk const *const inKeysPtr = keys.get();
@@ -117,14 +116,10 @@ struct reduce_dim_by_key<op, Ti, Tk, To, 0> {
     void operator()(Param<To> ovals, const dim_t ovOffset, CParam<Tk> keys,
                     CParam<Ti> vals, const dim_t vOffset, int *n_reduced,
                     const int dim, bool change_nan, double nanval) {
-        const af::dim4 kstrides = keys.strides();
-        const af::dim4 kdims    = keys.dims();
-
         const af::dim4 vstrides = vals.strides();
         const af::dim4 vdims    = vals.dims();
 
         const af::dim4 ovstrides = ovals.strides();
-        const af::dim4 ovdims    = ovals.dims();
 
         data_t<Tk> const *const inKeysPtr = keys.get();
         data_t<Ti> const *const inValsPtr = vals.get();
@@ -138,7 +133,6 @@ struct reduce_dim_by_key<op, Ti, Tk, To, 0> {
         dim_t ostride = ovstrides[dim];
 
         for (dim_t i = 0; i < vdims[dim]; i++) {
-            dim_t off            = vOffset;
             compute_t<Tk> keyval = inKeysPtr[i];
 
             if (keyval == current_key) {

--- a/src/backend/cpu/kernel/transpose.hpp
+++ b/src/backend/cpu/kernel/transpose.hpp
@@ -31,8 +31,77 @@ cdouble getConjugate(const cdouble &in) {
     return std::conj(in);
 }
 
-template<typename T, bool conjugate>
-void transpose(Param<T> output, CParam<T> input) {
+template<typename T, int M, int N>
+void transpose_kernel(T *output, const T *input, int ostride, int istride) {
+    for (int j = 0; j < N; j++) {
+        for (int i = 0; i < M; i++) { output[i * ostride] = input[i]; }
+        input += istride;
+        output++;
+    }
+}
+
+template<typename T>
+void transpose_real(Param<T> output, CParam<T> input) {
+    const af::dim4 odims    = output.dims();
+    const af::dim4 ostrides = output.strides();
+    const af::dim4 istrides = input.strides();
+
+    T *out            = output.get();
+    T const *const in = input.get();
+
+    constexpr int M = 8;
+    constexpr int N = 8;
+
+    dim_t odims1_down = floor(odims[1] / N) * N;
+    dim_t odims0_down = floor(odims[0] / M) * M;
+
+    for (dim_t l = 0; l < odims[3]; ++l) {
+        for (dim_t k = 0; k < odims[2]; ++k) {
+            // Outermost loop handles batch mode
+            // if input has no data along third dimension
+            // this loop runs only once
+            T *out_      = out + l * ostrides[3] + k * ostrides[2];
+            const T *in_ = in + l * istrides[3] + k * istrides[2];
+
+            if (odims1_down > 0) {
+                for (dim_t j = 0; j <= odims1_down; j += N) {
+                    for (dim_t i = 0; i < odims0_down; i += M) {
+                        transpose_kernel<T, M, N>(out_, in_, ostrides[1],
+                                                  istrides[1]);
+                        out_ += M;
+                        in_ += istrides[1] * N;
+                    }
+
+                    for (dim_t jj = 0; jj < N; jj++) {
+                        for (dim_t i = odims0_down; i < odims[0]; i++) {
+                            *out_ = *in_;
+                            out_++;
+                            in_ += istrides[1];
+                        }
+                        out_ += ostrides[1] - (odims[0] - odims0_down);
+                        in_ -= (odims[0] - odims0_down) * istrides[1] - 1;
+                    }
+                    out_ = out + l * ostrides[3] + k * ostrides[2] +
+                           j * ostrides[1];
+                    in_ = in + l * istrides[3] + k * istrides[2] + j;
+                }
+            }
+            for (dim_t j = odims1_down; j < odims[1]; j++) {
+                out_ =
+                    out + l * ostrides[3] + k * ostrides[2] + j * ostrides[1];
+                in_ = in + l * istrides[3] + k * istrides[2] + j;
+                for (dim_t i = 0; i < odims[0]; i++) {
+                    *out_ = *in_;
+                    out_++;
+                    in_ += istrides[1];
+                }
+            }
+        }
+    }
+}
+
+template<typename T>
+void transpose_conj(Param<T> output, CParam<T> input) {
     const af::dim4 odims    = output.dims();
     const af::dim4 ostrides = output.strides();
     const af::dim4 istrides = input.strides();
@@ -45,16 +114,14 @@ void transpose(Param<T> output, CParam<T> input) {
             // Outermost loop handles batch mode
             // if input has no data along third dimension
             // this loop runs only once
+
             for (dim_t j = 0; j < odims[1]; ++j) {
                 for (dim_t i = 0; i < odims[0]; ++i) {
                     // calculate array indices based on offsets and strides
                     // the helper getIdx takes care of indices
                     const dim_t inIdx  = getIdx(istrides, j, i, k, l);
                     const dim_t outIdx = getIdx(ostrides, i, j, k, l);
-                    if (conjugate)
-                        out[outIdx] = getConjugate(in[inIdx]);
-                    else
-                        out[outIdx] = in[inIdx];
+                    out[outIdx]        = getConjugate(in[inIdx]);
                 }
             }
             // outData and inData pointers doesn't need to be
@@ -66,8 +133,8 @@ void transpose(Param<T> output, CParam<T> input) {
 
 template<typename T>
 void transpose(Param<T> out, CParam<T> in, const bool conjugate) {
-    return (conjugate ? transpose<T, true>(out, in)
-                      : transpose<T, false>(out, in));
+    return (conjugate ? transpose_conj<T>(out, in)
+                      : transpose_real<T>(out, in));
 }
 
 template<typename T, bool conjugate>

--- a/src/backend/cpu/platform.cpp
+++ b/src/backend/cpu/platform.cpp
@@ -121,7 +121,7 @@ unsigned getMaxJitSize() {
 int getDeviceCount() { return DeviceManager::NUM_DEVICES; }
 
 // Get the currently active device id
-int getActiveDeviceId() { return DeviceManager::ACTIVE_DEVICE_ID; }
+unsigned getActiveDeviceId() { return DeviceManager::ACTIVE_DEVICE_ID; }
 
 size_t getDeviceMemorySize(int device) {
     UNUSED(device);

--- a/src/backend/cpu/platform.hpp
+++ b/src/backend/cpu/platform.hpp
@@ -40,7 +40,7 @@ unsigned getMaxJitSize();
 
 int getDeviceCount();
 
-int getActiveDeviceId();
+unsigned getActiveDeviceId();
 
 size_t getDeviceMemorySize(int device);
 

--- a/src/backend/cuda/Array.hpp
+++ b/src/backend/cuda/Array.hpp
@@ -150,8 +150,8 @@ class Array {
 
     INFO_FUNC(const af_dtype &, getType)
     INFO_FUNC(const af::dim4 &, strides)
-    INFO_FUNC(size_t, elements)
-    INFO_FUNC(size_t, ndims)
+    INFO_FUNC(dim_t, elements)
+    INFO_FUNC(dim_t, ndims)
     INFO_FUNC(const af::dim4 &, dims)
     INFO_FUNC(int, getDevId)
 

--- a/src/backend/cuda/Param.hpp
+++ b/src/backend/cuda/Param.hpp
@@ -22,7 +22,7 @@ class Param {
     dim_t strides[4];
     T *ptr;
 
-    __DH__ Param() noexcept : ptr(nullptr) {}
+    __DH__ Param() noexcept : dims(), strides(), ptr(nullptr) {}
 
     __DH__
     Param(T *iptr, const dim_t *idims, const dim_t *istrides) noexcept

--- a/src/backend/cuda/convolveNN.cpp
+++ b/src/backend/cuda/convolveNN.cpp
@@ -59,14 +59,6 @@ Array<T> convolve2_cudnn(const Array<T> &signal, const Array<T> &filter,
                          const dim4 &dilation) {
     cudnnHandle_t cudnn = nnHandle();
 
-    dim4 sDims        = signal.dims();
-    const dim4 &fDims = filter.dims();
-
-    const int n = sDims[3];
-    const int c = sDims[2];
-    const int h = sDims[1];
-    const int w = sDims[0];
-
     cudnnDataType_t cudnn_dtype = getCudnnDataType<T>();
     auto input_descriptor       = toCudnn<cudnnTensorDescriptor_t>(signal);
     auto filter_descriptor      = toCudnn<cudnnFilterDescriptor_t>(filter);
@@ -149,7 +141,6 @@ Array<T> convolve2_base(const Array<T> &signal, const Array<T> &filter,
     dim_t outputHeight =
         1 + (sDims[1] + 2 * padding[1] - (((fDims[1] - 1) * dilation[1]) + 1)) /
                 stride[1];
-    dim4 oDims = dim4(outputWidth, outputHeight, fDims[3], sDims[3]);
 
     const bool retCols = false;
     Array<T> unwrapped =
@@ -254,9 +245,8 @@ Array<T> data_gradient_cudnn(const Array<T> &incoming_gradient,
     UNUSED(convolved_output);
     auto cudnn = nnHandle();
 
-    const dim4 &iDims = incoming_gradient.dims();
-    dim4 sDims        = original_signal.dims();
-    dim4 fDims        = original_filter.dims();
+    dim4 sDims = original_signal.dims();
+    dim4 fDims = original_filter.dims();
 
     cudnnDataType_t cudnn_dtype = getCudnnDataType<T>();
 
@@ -337,7 +327,6 @@ Array<T> filter_gradient_base(const Array<T> &incoming_gradient,
                               af::dim4 padding, af::dim4 dilation) {
     UNUSED(convolved_output);
     const dim4 &cDims = incoming_gradient.dims();
-    const dim4 &sDims = original_signal.dims();
     const dim4 &fDims = original_filter.dims();
 
     const bool retCols = false;
@@ -378,8 +367,6 @@ Array<T> filter_gradient_cudnn(const Array<T> &incoming_gradient,
     UNUSED(convolved_output);
     auto cudnn = nnHandle();
 
-    const dim4 &iDims = incoming_gradient.dims();
-    const dim4 &sDims = original_signal.dims();
     const dim4 &fDims = original_filter.dims();
 
     // create dx descriptor

--- a/src/backend/cuda/copy.cpp
+++ b/src/backend/cuda/copy.cpp
@@ -63,7 +63,7 @@ Array<T> copyArray(const Array<T> &src) {
 template<typename inType, typename outType>
 Array<outType> padArray(Array<inType> const &in, dim4 const &dims,
                         outType default_value, double factor) {
-    ARG_ASSERT(1, (in.ndims() == (size_t)dims.ndims()));
+    ARG_ASSERT(1, (in.ndims() == dims.ndims()));
     Array<outType> ret = createEmptyArray<outType>(dims);
     kernel::copy<inType, outType>(ret, in, in.ndims(), default_value, factor);
     return ret;
@@ -100,7 +100,7 @@ template<typename inType, typename outType>
 void copyArray(Array<outType> &out, Array<inType> const &in) {
     static_assert(!(is_complex<inType>::value && !is_complex<outType>::value),
                   "Cannot copy from complex value to a non complex value");
-    ARG_ASSERT(1, (in.ndims() == (size_t)out.dims().ndims()));
+    ARG_ASSERT(1, (in.ndims() == out.dims().ndims()));
     copyWrapper<inType, outType> copyFn;
     copyFn(out, in);
 }

--- a/src/backend/cuda/cudnnModule.cpp
+++ b/src/backend/cuda/cudnnModule.cpp
@@ -12,6 +12,7 @@
 #include <common/util.hpp>
 #include <cudnnModule.hpp>
 #include <device_manager.hpp>
+#include <utility.hpp>
 
 #include <string>
 #include <tuple>
@@ -81,7 +82,7 @@ cudnnModule::cudnnModule()
 
     int afcuda_runtime = 0;
     cudaRuntimeGetVersion(&afcuda_runtime);
-    if (afcuda_runtime != cudnn_version) {
+    if (afcuda_runtime != static_cast<int>(cudnn_version)) {
         getLogger()->warn(
             "WARNING: ArrayFire CUDA Runtime({}) and cuDNN CUDA "
             "Runtime({}.{}) do not match. For maximum compatibility, make sure "

--- a/src/backend/cuda/device_manager.hpp
+++ b/src/backend/cuda/device_manager.hpp
@@ -37,7 +37,7 @@ bool checkDeviceWithRuntime(int runtime, std::pair<int, int> compute);
 
 class DeviceManager {
    public:
-    static const size_t MAX_DEVICES = 16;
+    static const int MAX_DEVICES = 16;
 
     static bool checkGraphicsInteropCapability();
 

--- a/src/backend/cuda/join.hpp
+++ b/src/backend/cuda/join.hpp
@@ -10,8 +10,8 @@
 #include <Array.hpp>
 
 namespace cuda {
-template<typename Tx, typename Ty>
-Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second);
+template<typename T>
+Array<T> join(const int dim, const Array<T> &first, const Array<T> &second);
 
 template<typename T>
 Array<T> join(const int dim, const std::vector<Array<T>> &inputs);

--- a/src/backend/cuda/kernel/join.cuh
+++ b/src/backend/cuda/kernel/join.cuh
@@ -13,8 +13,8 @@
 
 namespace cuda {
 
-template<typename To, typename Ti, int dim>
-__global__ void join(Param<To> out, CParam<Ti> in, const int o0, const int o1,
+template<typename T>
+__global__ void join(Param<T> out, CParam<T> in, const int o0, const int o1,
                      const int o2, const int o3, const int blocksPerMatX,
                      const int blocksPerMatY) {
     const int incy = blocksPerMatY * blockDim.y;
@@ -24,8 +24,8 @@ __global__ void join(Param<To> out, CParam<Ti> in, const int o0, const int o1,
     const int blockIdx_x = blockIdx.x - iz * blocksPerMatX;
     const int xx         = threadIdx.x + blockIdx_x * blockDim.x;
 
-    To *d_out      = out.ptr;
-    Ti const *d_in = in.ptr;
+    T *d_out      = out.ptr;
+    T const *d_in = in.ptr;
 
     const int iw = (blockIdx.y + (blockIdx.z * gridDim.y)) / blocksPerMatY;
     const int blockIdx_y =
@@ -37,8 +37,8 @@ __global__ void join(Param<To> out, CParam<Ti> in, const int o0, const int o1,
         d_in  = d_in + iz * in.strides[2] + iw * in.strides[3];
 
         for (int iy = yy; iy < in.dims[1]; iy += incy) {
-            Ti const *d_in_ = d_in + iy * in.strides[1];
-            To *d_out_      = d_out + (iy + o1) * out.strides[1];
+            T const *d_in_ = d_in + iy * in.strides[1];
+            T *d_out_      = d_out + (iy + o1) * out.strides[1];
 
             for (int ix = xx; ix < in.dims[0]; ix += incx) {
                 d_out_[ix + o0] = d_in_[ix];

--- a/src/backend/cuda/kernel/join.hpp
+++ b/src/backend/cuda/kernel/join.hpp
@@ -20,8 +20,8 @@
 namespace cuda {
 namespace kernel {
 
-template<typename To, typename Tx>
-void join(Param<To> out, CParam<Tx> X, const af::dim4 &offset, int dim) {
+template<typename T>
+void join(Param<T> out, CParam<T> X, const af::dim4 &offset, int dim) {
     constexpr unsigned TX    = 32;
     constexpr unsigned TY    = 8;
     constexpr unsigned TILEX = 256;
@@ -29,9 +29,7 @@ void join(Param<To> out, CParam<Tx> X, const af::dim4 &offset, int dim) {
 
     static const std::string source(join_cuh, join_cuh_len);
 
-    auto join = getKernel(
-        "cuda::join", source,
-        {TemplateTypename<To>(), TemplateTypename<Tx>(), TemplateArg(dim)});
+    auto join = getKernel("cuda::join", source, {TemplateTypename<T>()});
 
     dim3 threads(TX, TY, 1);
 

--- a/src/backend/cuda/kernel/lookup.hpp
+++ b/src/backend/cuda/kernel/lookup.hpp
@@ -31,7 +31,7 @@ void lookup(Param<in_t> out, CParam<in_t> in, CParam<idx_t> indices, int nDims,
     static const std::string src(lookup_cuh, lookup_cuh_len);
 
     /* find which dimension has non-zero # of elements */
-    int vDim = 0;
+    unsigned vDim = 0;
     for (int i = 0; i < 4; i++) {
         if (in.dims[i] == 1)
             vDim++;

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -63,8 +63,7 @@ template<typename T>
 uptr<T> memAlloc(const size_t &elements) {
     // TODO: make memAlloc aware of array shapes
     dim4 dims(elements);
-    size_t size = elements * sizeof(T);
-    void *ptr   = memoryManager().alloc(false, 1, dims.get(), sizeof(T));
+    void *ptr = memoryManager().alloc(false, 1, dims.get(), sizeof(T));
     return uptr<T>(static_cast<T *>(ptr), memFree<T>);
 }
 

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -84,7 +84,7 @@ using kc_t = map<string, Kernel>;
     do {                                                                     \
         CUresult res = fn;                                                   \
         if (res == CUDA_SUCCESS) break;                                      \
-        char cu_err_msg[1024];                                               \
+        char cu_err_msg[1024 + 48];                                          \
         const char *cu_err_name;                                             \
         cuGetErrorName(res, &cu_err_name);                                   \
         snprintf(cu_err_msg, sizeof(cu_err_msg), "CU Error %s(%d): %s\n",    \

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -34,11 +34,11 @@
 #include <err_cuda.hpp>
 #include <memory.hpp>
 #include <spdlog/spdlog.h>
+#include <utility.hpp>
 #include <version.hpp>
 #include <af/cuda.h>
 #include <af/device.h>
 #include <af/version.h>
-#include <memory>
 
 #include <algorithm>
 #include <array>
@@ -215,7 +215,7 @@ string getDeviceInfo(int device) noexcept {
     size_t mem_gpu_total = dev.totalGlobalMem;
     // double cc = double(dev.major) + double(dev.minor) / 10;
 
-    bool show_braces = getActiveDeviceId() == device;
+    bool show_braces = getActiveDeviceId() == static_cast<unsigned>(device);
 
     string id = (show_braces ? string("[") : "-") + to_string(device) +
                 (show_braces ? string("]") : "-");
@@ -356,7 +356,7 @@ int getDeviceCount() {
     }
 }
 
-int getActiveDeviceId() { return tlocalActiveDeviceId(); }
+unsigned getActiveDeviceId() { return tlocalActiveDeviceId(); }
 
 int getDeviceNativeId(int device) {
     if (device <

--- a/src/backend/cuda/platform.hpp
+++ b/src/backend/cuda/platform.hpp
@@ -80,7 +80,7 @@ unsigned getMaxJitSize();
 
 int getDeviceCount();
 
-int getActiveDeviceId();
+unsigned getActiveDeviceId();
 
 int getDeviceNativeId(int device);
 

--- a/src/backend/cuda/utility.hpp
+++ b/src/backend/cuda/utility.hpp
@@ -14,7 +14,8 @@
 
 namespace cuda {
 
-static __DH__ dim_t trimIndex(const int &idx, const dim_t &len) {
+[[gnu::unused]] static __DH__ dim_t trimIndex(const int &idx,
+                                              const dim_t &len) {
     int ret_val = idx;
     if (ret_val < 0) {
         int offset = (abs(ret_val) - 1) % len;

--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -152,8 +152,8 @@ class Array {
 
     INFO_FUNC(const af_dtype &, getType)
     INFO_FUNC(const af::dim4 &, strides)
-    INFO_FUNC(size_t, elements)
-    INFO_FUNC(size_t, ndims)
+    INFO_FUNC(dim_t, elements)
+    INFO_FUNC(dim_t, ndims)
     INFO_FUNC(const af::dim4 &, dims)
     INFO_FUNC(int, getDevId)
 
@@ -255,7 +255,8 @@ class Array {
         auto func = [this](void *ptr) {
             if (ptr != nullptr) {
                 cl_int err = getQueue().enqueueUnmapMemObject(*data, ptr);
-                ptr        = nullptr;
+                UNUSED(err);
+                ptr = nullptr;
             }
         };
 

--- a/src/backend/opencl/convolve.cpp
+++ b/src/backend/opencl/convolve.cpp
@@ -133,7 +133,6 @@ Array<T> convolve2_unwrap(const Array<T> &signal, const Array<T> &filter,
     dim_t outputHeight =
         1 + (sDims[1] + 2 * padding[1] - (((fDims[1] - 1) * dilation[1]) + 1)) /
                 stride[1];
-    dim4 oDims = dim4(outputWidth, outputHeight, fDims[3], sDims[3]);
 
     const bool retCols = false;
     Array<T> unwrapped =
@@ -219,7 +218,6 @@ Array<T> conv2FilterGradient(const Array<T> &incoming_gradient,
                              af::dim4 stride, af::dim4 padding,
                              af::dim4 dilation) {
     const dim4 &cDims = incoming_gradient.dims();
-    const dim4 &sDims = original_signal.dims();
     const dim4 &fDims = original_filter.dims();
 
     const bool retCols = false;

--- a/src/backend/opencl/convolve_separable.cpp
+++ b/src/backend/opencl/convolve_separable.cpp
@@ -28,8 +28,8 @@ Array<T> convolve2(Array<T> const& signal, Array<accT> const& c_filter,
         // TODO call upon fft
         char errMessage[256];
         snprintf(errMessage, sizeof(errMessage),
-                 "\nOpenCL Separable convolution doesn't support %zu(coloumn) "
-                 "%zu(row) filters\n",
+                 "\nOpenCL Separable convolution doesn't support %llu(coloumn) "
+                 "%llu(row) filters\n",
                  cflen, rflen);
         OPENCL_NOT_SUPPORTED(errMessage);
     }

--- a/src/backend/opencl/device_manager.hpp
+++ b/src/backend/opencl/device_manager.hpp
@@ -98,7 +98,7 @@ class DeviceManager {
     friend int getActivePlatform();
 
    public:
-    static const unsigned MAX_DEVICES = 32;
+    static const int MAX_DEVICES = 32;
 
     static DeviceManager& getInstance();
 

--- a/src/backend/opencl/join.cpp
+++ b/src/backend/opencl/join.cpp
@@ -23,8 +23,7 @@ using std::transform;
 using std::vector;
 
 namespace opencl {
-template<int dim>
-dim4 calcOffset(const dim4 &dims) {
+dim4 calcOffset(const dim4 &dims, int dim) {
     dim4 offset;
     offset[0] = (dim == 0) ? dims[0] : 0;
     offset[1] = (dim == 1) ? dims[1] : 0;
@@ -33,8 +32,8 @@ dim4 calcOffset(const dim4 &dims) {
     return offset;
 }
 
-template<typename Tx, typename Ty>
-Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second) {
+template<typename T>
+Array<T> join(const int dim, const Array<T> &first, const Array<T> &second) {
     // All dimensions except join dimension must be equal
     // Compute output dims
     dim4 odims;
@@ -49,67 +48,26 @@ Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second) {
         }
     }
 
-    Array<Tx> out = createEmptyArray<Tx>(odims);
+    Array<T> out = createEmptyArray<T>(odims);
 
     dim4 zero(0, 0, 0, 0);
 
-    switch (dim) {
-        case 0:
-            kernel::join<Tx, Tx, 0>(out, first, zero);
-            kernel::join<Tx, Ty, 0>(out, second, calcOffset<0>(fdims));
-            break;
-        case 1:
-            kernel::join<Tx, Tx, 1>(out, first, zero);
-            kernel::join<Tx, Ty, 1>(out, second, calcOffset<1>(fdims));
-            break;
-        case 2:
-            kernel::join<Tx, Tx, 2>(out, first, zero);
-            kernel::join<Tx, Ty, 2>(out, second, calcOffset<2>(fdims));
-            break;
-        case 3:
-            kernel::join<Tx, Tx, 3>(out, first, zero);
-            kernel::join<Tx, Ty, 3>(out, second, calcOffset<3>(fdims));
-            break;
-    }
+    kernel::join<T>(out, first, dim, zero);
+    kernel::join<T>(out, second, dim, calcOffset(fdims, dim));
 
     return out;
 }
 
-template<typename T, int n_arrays>
+template<typename T>
 void join_wrapper(const int dim, Array<T> &out,
                   const vector<Array<T>> &inputs) {
     dim4 zero(0, 0, 0, 0);
     dim4 d = zero;
 
-    switch (dim) {
-        case 0:
-            kernel::join<T, T, 0>(out, inputs[0], zero);
-            for (int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims();
-                kernel::join<T, T, 0>(out, inputs[i], calcOffset<0>(d));
-            }
-            break;
-        case 1:
-            kernel::join<T, T, 1>(out, inputs[0], zero);
-            for (int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims();
-                kernel::join<T, T, 1>(out, inputs[i], calcOffset<1>(d));
-            }
-            break;
-        case 2:
-            kernel::join<T, T, 1>(out, inputs[0], zero);
-            for (int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims();
-                kernel::join<T, T, 2>(out, inputs[i], calcOffset<2>(d));
-            }
-            break;
-        case 3:
-            kernel::join<T, T, 3>(out, inputs[0], zero);
-            for (int i = 1; i < n_arrays; i++) {
-                d += inputs[i - 1].dims();
-                kernel::join<T, T, 3>(out, inputs[i], calcOffset<3>(d));
-            }
-            break;
+    kernel::join<T>(out, inputs[0], dim, zero);
+    for (size_t i = 1; i < inputs.size(); i++) {
+        d += inputs[i - 1].dims();
+        kernel::join<T>(out, inputs[i], dim, calcOffset(d, dim));
     }
 }
 
@@ -143,38 +101,27 @@ Array<T> join(const int dim, const vector<Array<T>> &inputs) {
     vector<Param> inputParams(inputs.begin(), inputs.end());
     Array<T> out = createEmptyArray<T>(odims);
 
-    switch (n_arrays) {
-        case 1: join_wrapper<T, 1>(dim, out, inputs); break;
-        case 2: join_wrapper<T, 2>(dim, out, inputs); break;
-        case 3: join_wrapper<T, 3>(dim, out, inputs); break;
-        case 4: join_wrapper<T, 4>(dim, out, inputs); break;
-        case 5: join_wrapper<T, 5>(dim, out, inputs); break;
-        case 6: join_wrapper<T, 6>(dim, out, inputs); break;
-        case 7: join_wrapper<T, 7>(dim, out, inputs); break;
-        case 8: join_wrapper<T, 8>(dim, out, inputs); break;
-        case 9: join_wrapper<T, 9>(dim, out, inputs); break;
-        case 10: join_wrapper<T, 10>(dim, out, inputs); break;
-    }
+    join_wrapper<T>(dim, out, inputs);
     return out;
 }
 
-#define INSTANTIATE(Tx, Ty)                                                \
-    template Array<Tx> join<Tx, Ty>(const int dim, const Array<Tx> &first, \
-                                    const Array<Ty> &second);
+#define INSTANTIATE(T)                                              \
+    template Array<T> join<T>(const int dim, const Array<T> &first, \
+                              const Array<T> &second);
 
-INSTANTIATE(float, float)
-INSTANTIATE(double, double)
-INSTANTIATE(cfloat, cfloat)
-INSTANTIATE(cdouble, cdouble)
-INSTANTIATE(int, int)
-INSTANTIATE(uint, uint)
-INSTANTIATE(intl, intl)
-INSTANTIATE(uintl, uintl)
-INSTANTIATE(short, short)
-INSTANTIATE(ushort, ushort)
-INSTANTIATE(uchar, uchar)
-INSTANTIATE(char, char)
-INSTANTIATE(half, half)
+INSTANTIATE(float)
+INSTANTIATE(double)
+INSTANTIATE(cfloat)
+INSTANTIATE(cdouble)
+INSTANTIATE(int)
+INSTANTIATE(uint)
+INSTANTIATE(intl)
+INSTANTIATE(uintl)
+INSTANTIATE(short)
+INSTANTIATE(ushort)
+INSTANTIATE(uchar)
+INSTANTIATE(char)
+INSTANTIATE(half)
 
 #undef INSTANTIATE
 

--- a/src/backend/opencl/join.hpp
+++ b/src/backend/opencl/join.hpp
@@ -10,8 +10,8 @@
 #include <Array.hpp>
 
 namespace opencl {
-template<typename Tx, typename Ty>
-Array<Tx> join(const int dim, const Array<Tx> &first, const Array<Ty> &second);
+template<typename T>
+Array<T> join(const int dim, const Array<T> &first, const Array<T> &second);
 
 template<typename T>
 Array<T> join(const int dim, const std::vector<Array<T>> &inputs);

--- a/src/backend/opencl/kernel/join.cl
+++ b/src/backend/opencl/kernel/join.cl
@@ -7,8 +7,8 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-__kernel void join_kernel(__global To *d_out, const KParam out,
-                          __global const Ti *d_in, const KParam in,
+__kernel void join_kernel(__global T *d_out, const KParam out,
+                          __global const T *d_in, const KParam in,
                           const int o0, const int o1, const int o2,
                           const int o3, const int blocksPerMatX,
                           const int blocksPerMatY) {
@@ -31,8 +31,8 @@ __kernel void join_kernel(__global To *d_out, const KParam out,
         d_in  = d_in + iz * in.strides[2] + iw * in.strides[3];
 
         for (int iy = yy; iy < in.dims[1]; iy += incy) {
-            __global Ti *d_in_  = d_in + iy * in.strides[1];
-            __global To *d_out_ = d_out + (iy + o1) * out.strides[1];
+            __global T *d_in_  = d_in + iy * in.strides[1];
+            __global T *d_out_ = d_out + (iy + o1) * out.strides[1];
 
             for (int ix = xx; ix < in.dims[0]; ix += incx) {
                 d_out_[ix + o0] = d_in_[ix];

--- a/src/backend/opencl/kernel/join.hpp
+++ b/src/backend/opencl/kernel/join.hpp
@@ -35,26 +35,20 @@ static const int TY    = 8;
 static const int TILEX = 256;
 static const int TILEY = 32;
 
-template<typename To, typename Ti, int dim>
-void join(Param out, const Param in, const af::dim4 offset) {
+template<typename T>
+void join(Param out, const Param in, dim_t dim, const af::dim4 offset) {
     std::string refName =
-        std::string("join_kernel_") + std::string(dtype_traits<To>::getName()) +
-        std::string(dtype_traits<Ti>::getName()) + std::to_string(dim);
+        std::string("join_kernel_") + std::string(dtype_traits<T>::getName()) +
+        std::string(dtype_traits<T>::getName()) + std::to_string(dim);
 
     int device       = getActiveDeviceId();
     kc_entry_t entry = kernelCache(device, refName);
 
     if (entry.prog == 0 && entry.ker == 0) {
         std::ostringstream options;
-        options << " -D To=" << dtype_traits<To>::getName()
-                << " -D Ti=" << dtype_traits<Ti>::getName()
-                << " -D kDim=" << dim;
+        options << " -D T=" << dtype_traits<T>::getName();
 
-        if (std::is_same<To, double>::value ||
-            std::is_same<To, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        } else if (std::is_same<Ti, double>::value ||
-                   std::is_same<Ti, cdouble>::value) {
+        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
             options << " -D USE_DOUBLE";
         }
 

--- a/src/backend/opencl/kernel/reduce_by_key.hpp
+++ b/src/backend/opencl/kernel/reduce_by_key.hpp
@@ -309,8 +309,6 @@ void launch_compact(cl::Buffer *reduced_block_sizes, Param keys_out,
     kc_entry_t entry = kernelCache(device, ref_name);
 
     if (entry.prog == 0 && entry.ker == 0) {
-        ToNumStr<To> toNumStr;
-
         std::ostringstream options;
         options << " -D To=" << dtype_traits<To>::getName()
                 << " -D Tk=" << dtype_traits<Tk>::getName() << " -D T=To"
@@ -363,8 +361,6 @@ void launch_compact_dim(cl::Buffer *reduced_block_sizes, Param keys_out,
     kc_entry_t entry = kernelCache(device, ref_name);
 
     if (entry.prog == 0 && entry.ker == 0) {
-        ToNumStr<To> toNumStr;
-
         std::ostringstream options;
         options << " -D To=" << dtype_traits<To>::getName()
                 << " -D Tk=" << dtype_traits<Tk>::getName() << " -D T=To"

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -112,6 +112,23 @@ static string platformMap(string& platStr) {
     }
 }
 
+afcl::platform getPlatformEnum(cl::Device dev) {
+    std::string pname = getPlatformName(dev);
+    if (verify_present(pname, "AMD"))
+        return AFCL_PLATFORM_AMD;
+    else if (verify_present(pname, "NVIDIA"))
+        return AFCL_PLATFORM_NVIDIA;
+    else if (verify_present(pname, "INTEL"))
+        return AFCL_PLATFORM_INTEL;
+    else if (verify_present(pname, "APPLE"))
+        return AFCL_PLATFORM_APPLE;
+    else if (verify_present(pname, "BEIGNET"))
+        return AFCL_PLATFORM_BEIGNET;
+    else if (verify_present(pname, "POCL"))
+        return AFCL_PLATFORM_POCL;
+    return AFCL_PLATFORM_UNKNOWN;
+}
+
 string getDeviceInfo() noexcept {
     ostringstream info;
     info << "ArrayFire v" << AF_VERSION << " (OpenCL, " << get_system()
@@ -196,7 +213,7 @@ int getDeviceCount() noexcept try {
     return 0;
 }
 
-int getActiveDeviceId() {
+unsigned getActiveDeviceId() {
     // Second element is the queue id, which is
     // what we mean by active device id in opencl backend
     return get<1>(tlocalActiveDeviceId());

--- a/src/backend/opencl/platform.hpp
+++ b/src/backend/opencl/platform.hpp
@@ -14,6 +14,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Wcatch-value="
 #include <CL/cl2.hpp>
 #pragma GCC diagnostic pop
 
@@ -63,7 +64,7 @@ std::string getDeviceInfo() noexcept;
 
 int getDeviceCount() noexcept;
 
-int getActiveDeviceId();
+unsigned getActiveDeviceId();
 
 unsigned getMaxJitSize();
 
@@ -137,22 +138,7 @@ void removeKernelFromCache(int device, const std::string& key);
 
 kc_entry_t kernelCache(int device, const std::string& key);
 
-static afcl::platform getPlatformEnum(cl::Device dev) {
-    std::string pname = getPlatformName(dev);
-    if (verify_present(pname, "AMD"))
-        return AFCL_PLATFORM_AMD;
-    else if (verify_present(pname, "NVIDIA"))
-        return AFCL_PLATFORM_NVIDIA;
-    else if (verify_present(pname, "INTEL"))
-        return AFCL_PLATFORM_INTEL;
-    else if (verify_present(pname, "APPLE"))
-        return AFCL_PLATFORM_APPLE;
-    else if (verify_present(pname, "BEIGNET"))
-        return AFCL_PLATFORM_BEIGNET;
-    else if (verify_present(pname, "POCL"))
-        return AFCL_PLATFORM_POCL;
-    return AFCL_PLATFORM_UNKNOWN;
-}
+afcl::platform getPlatformEnum(cl::Device dev);
 
 void setActiveContext(int device);
 

--- a/src/backend/opencl/surface.cpp
+++ b/src/backend/opencl/surface.cpp
@@ -11,12 +11,11 @@
 #include <GraphicsResourceManager.hpp>
 #include <debug_opencl.hpp>
 #include <err_opencl.hpp>
-#include <join.hpp>
-#include <reduce.hpp>
-#include <reorder.hpp>
 #include <surface.hpp>
 
 using af::dim4;
+using cl::Memory;
+using std::vector;
 
 namespace opencl {
 
@@ -31,7 +30,7 @@ void copy_surface(const Array<T> &P, fg_surface surface) {
 
         auto res = interopManager().getSurfaceResources(surface);
 
-        std::vector<cl::Memory> shared_objects;
+        vector<Memory> shared_objects;
         shared_objects.push_back(*(res[0].get()));
 
         glFinish();

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -10,7 +10,6 @@
 #define GTEST_LINKED_AS_SHARED_LIBRARY 1
 #include <arrayfire.h>
 #include <gtest/gtest.h>
-#include <half.hpp>
 #include <testHelpers.hpp>
 #include <cstddef>
 #include <cstdlib>

--- a/test/binary.cpp
+++ b/test/binary.cpp
@@ -9,7 +9,6 @@
 
 #define GTEST_LINKED_AS_SHARED_LIBRARY 1
 #include <gtest/gtest.h>
-#include <half.hpp>
 #include <testHelpers.hpp>
 #include <af/arith.h>
 #include <af/array.h>

--- a/test/blas.cpp
+++ b/test/blas.cpp
@@ -417,7 +417,7 @@ INSTANTIATE_TEST_CASE_P(
     print_blas_params);
 
 TEST_P(MatrixMultiplyBatch, Batched) {
-    array out         = matmul(lhs, rhs);
+    array out = matmul(lhs, rhs);
     ASSERT_ARRAYS_NEAR(gold, out, 1e-3);
 }
 

--- a/test/blas.cpp
+++ b/test/blas.cpp
@@ -295,14 +295,14 @@ struct blas_params {
 
 class MatrixMultiplyBatch : public ::testing::TestWithParam<blas_params> {
    public:
-    array lhs, rhs, out;
+    array lhs, rhs, out, gold;
     void SetUp() {
         blas_params params = GetParam();
         lhs = randu(params.m, params.k, params.ld2, params.ld3, params.type);
         rhs = randu(params.k, params.n, params.rd2, params.rd3, params.type);
 
-        array gold(params.m, params.n, std::max(params.ld2, params.rd2),
-                   std::max(params.ld3, params.rd3));
+        gold = array(params.m, params.n, std::max(params.ld2, params.rd2),
+                     std::max(params.ld3, params.rd3));
 
         if (params.ld2 == params.rd2 && params.ld3 == params.rd3) {
             for (int i = 0; i < params.ld2; i++) {
@@ -418,7 +418,7 @@ INSTANTIATE_TEST_CASE_P(
 
 TEST_P(MatrixMultiplyBatch, Batched) {
     array out         = matmul(lhs, rhs);
-    blas_params param = GetParam();
+    ASSERT_ARRAYS_NEAR(gold, out, 1e-3);
 }
 
 float alpha = 1.f;

--- a/test/clamp.cpp
+++ b/test/clamp.cpp
@@ -68,7 +68,7 @@ class Clamp : public ::testing::TestWithParam<clamp_params> {
         lo_.as((dtype)af::dtype_traits<T>::af_type).host(&hlo[0]);
         hi_.as((dtype)af::dtype_traits<T>::af_type).host(&hhi[0]);
 
-        for (int i = 0; i < num; i++) {
+        for (size_t i = 0; i < num; i++) {
             if (hin[i] < hlo[i])
                 hgold[i] = hlo[i];
             else if (hin[i] > hhi[i])

--- a/test/confidence_connected.cpp
+++ b/test/confidence_connected.cpp
@@ -84,7 +84,6 @@ void testImage(const std::string pTestFile, const size_t numSeeds,
         af_array outArray   = 0;
         af_array _goldArray = 0;
         af_array goldArray  = 0;
-        dim_t nElems        = 0;
 
         inFiles[testId].insert(0, string(TEST_DIR "/confidence_cc/"));
         outFiles[testId].insert(0, string(TEST_DIR "/confidence_cc/"));

--- a/test/convolve.cpp
+++ b/test/convolve.cpp
@@ -942,8 +942,6 @@ void convolve2stridedTest(string pTestFile, dim4 stride, dim4 padding,
 
     vector<T> &currGoldBar = tests[0];
 
-    size_t nElems = currGoldBar.size();
-
     dim_t expectedDim0 =
         1 + (sDims[0] + 2 * padding[0] - (((fDims[0] - 1) * dilation[0]) + 1)) /
                 stride[0];

--- a/test/gen_index.cpp
+++ b/test/gen_index.cpp
@@ -80,9 +80,9 @@ class IndexGeneralizedLegacy : public ::testing::TestWithParam<index_params> {
     }
 
     void TearDown() {
-        if (inArray_) ASSERT_SUCCESS(af_release_array(inArray_));
-        if (idxArray_) ASSERT_SUCCESS(af_release_array(idxArray_));
-        if (gold_) ASSERT_SUCCESS(af_release_array(gold_));
+        if (inArray_) { ASSERT_SUCCESS(af_release_array(inArray_)); }
+        if (idxArray_) { ASSERT_SUCCESS(af_release_array(idxArray_)); }
+        if (gold_) { ASSERT_SUCCESS(af_release_array(gold_)); }
     }
 
    public:

--- a/test/hsv_rgb.cpp
+++ b/test/hsv_rgb.cpp
@@ -31,7 +31,7 @@ TEST(hsv_rgb, InvalidArray) {
     try {
         array output = hsv2rgb(input);
         ASSERT_EQ(true, false);
-    } catch (exception) {
+    } catch (const exception & /* ex */) {
         ASSERT_EQ(true, true);
         return;
     }

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -9,7 +9,6 @@
 
 #include <arrayfire.h>
 #include <gtest/gtest.h>
-#include <half.hpp>
 #include <testHelpers.hpp>
 #include <af/data.h>
 #include <af/defines.h>

--- a/test/jit.cpp
+++ b/test/jit.cpp
@@ -736,7 +736,7 @@ TEST(JIT, AllBuffers) {
 
   int inc = 2;
   for(int ii = buffers/2; ii > 2; ii/=2) {
-      for(int i = 0; i < arrs.size(); i += inc) {
+      for(size_t i = 0; i < arrs.size(); i += inc) {
           arrs[i] = arrs[i] + arrs[i + inc/2];
       }
       inc *= 2;

--- a/test/join.cpp
+++ b/test/join.cpp
@@ -214,9 +214,9 @@ TEST(Join, DifferentSizes) {
     vector<float> hb(11);
     vector<float> hc(12);
 
-    for (int i = 0; i < ha.size(); i++) { ha[i] = i; }
-    for (int i = 0; i < hb.size(); i++) { hb[i] = i; }
-    for (int i = 0; i < hc.size(); i++) { hc[i] = i; }
+    for (size_t i = 0; i < ha.size(); i++) { ha[i] = i; }
+    for (size_t i = 0; i < hb.size(); i++) { hb[i] = i; }
+    for (size_t i = 0; i < hc.size(); i++) { hc[i] = i; }
     vector<float> hgold(10 + 11 + 12);
     vector<float>::iterator it = copy(ha.begin(), ha.end(), hgold.begin());
     it                         = copy(hb.begin(), hb.end(), it);
@@ -236,9 +236,9 @@ TEST(Join, SameSize) {
     vector<float> hb(10);
     vector<float> hc(10);
 
-    for (int i = 0; i < ha.size(); i++) { ha[i] = i; }
-    for (int i = 0; i < hb.size(); i++) { hb[i] = i; }
-    for (int i = 0; i < hc.size(); i++) { hc[i] = i; }
+    for (size_t i = 0; i < ha.size(); i++) { ha[i] = i; }
+    for (size_t i = 0; i < hb.size(); i++) { hb[i] = i; }
+    for (size_t i = 0; i < hc.size(); i++) { hc[i] = i; }
     vector<float> hgold(10 + 10 + 10);
     vector<float>::iterator it = copy(ha.begin(), ha.end(), hgold.begin());
     it                         = copy(hb.begin(), hb.end(), it);

--- a/test/math.cpp
+++ b/test/math.cpp
@@ -7,7 +7,6 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 #include <gtest/gtest.h>
-#include <half.hpp>
 #include <testHelpers.hpp>
 #include <af/arith.h>
 #include <af/data.h>
@@ -42,21 +41,21 @@ T rsqrt(T in) {
     return T(1.0 / sqrt(in));
 }
 
-#define MATH_TEST(T, func, err, lo, hi)                                     \
-    TEST(MathTests, Test_##func##_##T) {                                    \
-        try {                                                               \
-            SUPPORTED_TYPE_CHECK(T);                                        \
-            af_dtype ty = (af_dtype)dtype_traits<T>::af_type;               \
-            array a     = (hi - lo) * randu(num, ty) + lo + err;            \
-            a           = a.as(ty);                                         \
-            eval(a);                                                        \
-            array b = func(a);                                              \
-            vector<T> h_a(a.elements());                                    \
-            a.host(&h_a[0]);                                                \
-            for (int i = 0; i < h_a.size(); i++) { h_a[i] = func(h_a[i]); } \
-                                                                            \
-            ASSERT_VEC_ARRAY_NEAR(h_a, dim4(h_a.size()), b, err);           \
-        } catch (exception & ex) { FAIL() << ex.what(); }                   \
+#define MATH_TEST(T, func, err, lo, hi)                                        \
+    TEST(MathTests, Test_##func##_##T) {                                       \
+        try {                                                                  \
+            SUPPORTED_TYPE_CHECK(T);                                           \
+            af_dtype ty = (af_dtype)dtype_traits<T>::af_type;                  \
+            array a     = (hi - lo) * randu(num, ty) + lo + err;               \
+            a           = a.as(ty);                                            \
+            eval(a);                                                           \
+            array b = func(a);                                                 \
+            vector<T> h_a(a.elements());                                       \
+            a.host(&h_a[0]);                                                   \
+            for (size_t i = 0; i < h_a.size(); i++) { h_a[i] = func(h_a[i]); } \
+                                                                               \
+            ASSERT_VEC_ARRAY_NEAR(h_a, dim4(h_a.size()), b, err);              \
+        } catch (exception & ex) { FAIL() << ex.what(); }                      \
     }
 
 #define MATH_TESTS_HALF(func) MATH_TEST(half, func, hlf_err, 0.05f, 0.95f)

--- a/test/mean.cpp
+++ b/test/mean.cpp
@@ -105,7 +105,6 @@ void meanDimTest(string pFileName, dim_t dim, bool isWeighted = false) {
         outArray.host((void*)outData.data());
 
         vector<outType> currGoldBar(tests[0].begin(), tests[0].end());
-        size_t nElems = currGoldBar.size();
 
         dim4 goldDims = dims;
         goldDims[dim] = 1;
@@ -128,7 +127,6 @@ void meanDimTest(string pFileName, dim_t dim, bool isWeighted = false) {
         outArray.host((void*)outData.data());
 
         vector<outType> currGoldBar(tests[0].begin(), tests[0].end());
-        size_t nElems = currGoldBar.size();
 
         ASSERT_VEC_ARRAY_NEAR(currGoldBar, goldDims, outArray, tol);
     }
@@ -214,7 +212,7 @@ void meanAllTest(half_float::half const_value, dim4 dims) {
     // make sure output2 and output are binary equals. This is necessary
     // because af_half is not a complete type
     half output2_copy;
-    memcpy(&output2_copy, &output2, sizeof(af_half));
+    memcpy(static_cast<void*>(&output2_copy), &output2, sizeof(af_half));
     ASSERT_EQ(output, output2_copy);
 
     ASSERT_NEAR(output, gold, 1.0e-3);

--- a/test/meanvar.cpp
+++ b/test/meanvar.cpp
@@ -11,7 +11,6 @@
 #include <arrayfire.h>
 #include <gtest/gtest.h>
 
-#include <half.hpp>
 #include <testHelpers.hpp>
 
 #include <iterator>
@@ -266,7 +265,7 @@ template<typename T>
 vector<meanvar_test<T> > large_test_values() {
     return {
         // clang-format off
-        //               |           Name |     in_index | weight_index |                  bias |  dim | mean_index | var_index |
+        //                  |       Name |      in_index | weight_index |                  bias |  dim | mean_index | var_index |
         meanvar_test_gen<T>("Sample1Ddim0",             0,            -1,     AF_VARIANCE_SAMPLE,     0,           0,          1, MEANVAR_LARGE),
         meanvar_test_gen<T>("Sample1Ddim1",             1,            -1,     AF_VARIANCE_SAMPLE,     1,           0,          1, MEANVAR_LARGE),
         meanvar_test_gen<T>("Sample1Ddim2",             2,            -1,     AF_VARIANCE_SAMPLE,     2,           0,          1, MEANVAR_LARGE),

--- a/test/nodevice.cpp
+++ b/test/nodevice.cpp
@@ -29,10 +29,7 @@ TEST(NoDevice, GetDeviceCount) {
     ASSERT_SUCCESS(af_get_device_count(&device));
 }
 
-TEST(NoDevice, GetDeviceCountCxx) {
-    int device = 0;
-    af::getDeviceCount();
-}
+TEST(NoDevice, GetDeviceCountCxx) { af::getDeviceCount(); }
 
 TEST(NoDevice, GetSizeOf) {
     size_t size;
@@ -52,6 +49,7 @@ TEST(NoDevice, GetBackendCount) {
 
 TEST(NoDevice, GetBackendCountCxx) {
     unsigned int nbackends = af::getBackendCount();
+    UNUSED(nbackends);
 }
 
 TEST(NoDevice, GetVersion) {
@@ -64,4 +62,7 @@ TEST(NoDevice, GetVersion) {
     ASSERT_EQ(AF_VERSION_PATCH, patch);
 }
 
-TEST(NoDevice, GetRevision) { const char* revision = af_get_revision(); }
+TEST(NoDevice, GetRevision) {
+    const char* revision = af_get_revision();
+    UNUSED(revision);
+}

--- a/test/pad_borders.cpp
+++ b/test/pad_borders.cpp
@@ -9,7 +9,6 @@
 
 #include <arrayfire.h>
 #include <gtest/gtest.h>
-#include <half.hpp>
 #include <testHelpers.hpp>
 #include <af/dim4.hpp>
 #include <af/traits.hpp>

--- a/test/random.cpp
+++ b/test/random.cpp
@@ -310,10 +310,22 @@ void testRandomEngineUniform(randomEngineType type) {
     int elem = 16 * 1024 * 1024;
     randomEngine r(type, 0);
     array A = randu(elem, ty, r);
-    T m     = mean<T>(A);
-    T s     = stdev<T>(A);
-    ASSERT_NEAR(m, 0.5, 1e-3);
-    ASSERT_NEAR(s, 0.2887, 1e-2);
+
+    // If double precision is available then perform the mean calculation using
+    // double because the A array is large and causes accuracy issues when using
+    // certain compiler flags (i.e. --march=native)
+    if (af::isDoubleAvailable(af::getDevice())) {
+        array Ad = A.as(f64);
+        double m = mean<double>(Ad);
+        double s = stdev<double>(Ad);
+        ASSERT_NEAR(m, 0.5, 1e-3);
+        ASSERT_NEAR(s, 0.2887, 1e-2);
+    } else {
+        T m = mean<T>(A);
+        T s = stdev<T>(A);
+        ASSERT_NEAR(m, 0.5, 1e-3);
+        ASSERT_NEAR(s, 0.2887, 1e-2);
+    }
 }
 
 template<typename T>

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -334,11 +334,11 @@ struct reduce_by_key_params {
 //
 template<typename Tk, typename Tv, typename To>
 struct reduce_by_key_params_t : public reduce_by_key_params {
-    string testname_;
     vector<Tk> iKeys_;
     vector<Tv> iVals_;
     vector<Tk> oKeys_;
     vector<To> oVals_;
+    string testname_;
 
     reduce_by_key_params_t(vector<Tk> ikeys, vector<Tv> ivals, vector<Tk> okeys,
                            vector<To> ovals, string testname)
@@ -597,7 +597,7 @@ void reduce_by_key_test(std::string test_fn) {
     vector<vector<float> > tests;
     readTests<float, float, float>(test_fn, numDims, data, tests);
 
-    for (int t = 0; t < numDims.size() / 2; ++t) {
+    for (size_t t = 0; t < numDims.size() / 2; ++t) {
         dim4 kdim = numDims[t * 2];
         dim4 vdim = numDims[t * 2 + 1];
 

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -12,7 +12,11 @@
 
 #include <arrayfire.h>
 #include <gtest/gtest.h>
+#pragma once
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wparentheses"
 #include <half.hpp>
+#pragma GCC diagnostic pop
 #include <af/array.h>
 #include <af/defines.h>
 #include <af/dim4.hpp>
@@ -145,7 +149,9 @@ float convert(af::half in) {
 template<>
 af_half convert(int in) {
     half_float::half h = half_float::half(in);
-    return *reinterpret_cast<af_half *>(&h);
+    af_half out;
+    memcpy(&out, &h, sizeof(af_half));
+    return out;
 }
 
 template<typename inType, typename outType, typename FileElementType>
@@ -599,7 +605,8 @@ void cleanSlate() {
 //  as numbers
 af_half abs(af_half in) {
     half_float::half in_;
-    memcpy(&in_, &in, sizeof(af_half));
+    // casting to void* to avoid class-memaccess warnings on windows
+    memcpy(static_cast<void *>(&in_), &in, sizeof(af_half));
     half_float::half out_ = abs(in_);
     af_half out;
     memcpy(&out, &out_, sizeof(af_half));
@@ -609,8 +616,10 @@ af_half abs(af_half in) {
 af_half operator-(af_half lhs, af_half rhs) {
     half_float::half lhs_;
     half_float::half rhs_;
-    memcpy(&lhs_, &lhs, sizeof(af_half));
-    memcpy(&rhs_, &rhs, sizeof(af_half));
+
+    // casting to void* to avoid class-memaccess warnings on windows
+    memcpy(static_cast<void *>(&lhs_), &lhs, sizeof(af_half));
+    memcpy(static_cast<void *>(&rhs_), &rhs, sizeof(af_half));
     half_float::half out = lhs_ - rhs_;
     af_half o;
     memcpy(&o, &out, sizeof(af_half));

--- a/test/threading.cpp
+++ b/test/threading.cpp
@@ -41,7 +41,7 @@ void calc(ArithOp opcode, array op1, array op2, float outValue,
           int iteration_count) {
     setDevice(0);
     array res;
-    for (unsigned i = 0; i < iteration_count; ++i) {
+    for (int i = 0; i < iteration_count; ++i) {
         switch (opcode) {
             case ADD: res = op1 + op2; break;
             case SUB: res = op1 - op2; break;

--- a/test/topk.cpp
+++ b/test/topk.cpp
@@ -9,7 +9,6 @@
 #define GTEST_LINKED_AS_SHARED_LIBRARY 1
 #include <arrayfire.h>
 #include <gtest/gtest.h>
-#include <half.hpp>
 #include <testHelpers.hpp>
 
 #include <algorithm>

--- a/test/ycbcr_rgb.cpp
+++ b/test/ycbcr_rgb.cpp
@@ -29,7 +29,7 @@ TEST(ycbcr_rgb, InvalidArray) {
     try {
         array output = hsv2rgb(input);
         ASSERT_EQ(true, false);
-    } catch (af::exception) {
+    } catch (const af::exception &ex) {
         ASSERT_EQ(true, true);
         return;
     }


### PR DESCRIPTION
This PR improves the performance of the transpose and join kernels in the CPU backend. The previous approach was naive and was not optimized for data locality. This new version is slightly improved and uses a tile based approach to speed up the operation.

The join kernel is improved by using a memcpy call instead of a for loop to perform the copy to the output matrix.

Fixed several warnings using the -Wall flag in GCC and enabled it by default in CMake

Fixed a matrix multiplication test where the output matrix was not being tested

Fixed a potential issue with mean where the optimizer could remove some operations that could reduce the accuracy of the result.

Use double to calculate the mean for the random engine uniform tests to avoid overflow issues with larger arrays

Fixed a bug in the DefaultMemoryManager introduced in f2112530c where I was dereferencing an iterator before checking if the find function returned an actual value.