### PR TITLE
Add minval and maxval for half in OpenCL and CPU backends

### DIFF
--- a/src/backend/cpu/math.hpp
+++ b/src/backend/cpu/math.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <common/defines.hpp>
+#include <common/half.hpp>
 #include <types.hpp>
 #include <af/defines.h>
 
@@ -75,12 +76,20 @@ STATIC_ double maxval() {
     return std::numeric_limits<double>::infinity();
 }
 template<>
+STATIC_ common::half maxval() {
+    return std::numeric_limits<common::half>::infinity();
+}
+template<>
 STATIC_ float minval() {
     return -std::numeric_limits<float>::infinity();
 }
 template<>
 STATIC_ double minval() {
     return -std::numeric_limits<double>::infinity();
+}
+template<>
+STATIC_ common::half minval() {
+    return -std::numeric_limits<common::half>::infinity();
 }
 
 template<typename T>

--- a/src/backend/opencl/math.hpp
+++ b/src/backend/opencl/math.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <common/defines.hpp>
+#include <common/half.hpp>
 #include <af/defines.h>
 
 #include <backend.hpp>
@@ -121,13 +122,24 @@ template<>
 STATIC_ double maxval() {
     return std::numeric_limits<double>::infinity();
 }
+
+template<>
+STATIC_ common::half maxval() {
+    return std::numeric_limits<common::half>::infinity();
+}
+
 template<>
 STATIC_ float minval() {
     return -std::numeric_limits<float>::infinity();
 }
+
 template<>
 STATIC_ double minval() {
     return -std::numeric_limits<double>::infinity();
+}
+template<>
+STATIC_ common::half minval() {
+    return -std::numeric_limits<common::half>::infinity();
 }
 
 static inline double real(cdouble in) { return in.s[0]; }


### PR DESCRIPTION
Add missing minval and maxval functions for common::half in the CPU and OpenCL backends. This is needed for reductions to work correctly.