### PR TITLE
Pass USE_(DOUBLE,HALF) definitions to OpenCL build in a uniform way

### DIFF
--- a/src/backend/opencl/kernel/anisotropic_diffusion.hpp
+++ b/src/backend/opencl/kernel/anisotropic_diffusion.hpp
@@ -49,7 +49,7 @@ void anisotropicDiffusion(Param inout, const float dt, const float mct,
                 << " -D SHRD_MEM_WIDTH=" << (THREADS_X + 2)
                 << " -D IS_MCDE=" << isMCDE << " -D FLUX_FN=" << fluxFnCode
                 << " -D YDIM_LOAD=" << YDIM_LOAD;
-        if (std::is_same<T, double>::value) options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {anisotropic_diffusion_cl};
         const int ker_lens[]   = {anisotropic_diffusion_cl_len};

--- a/src/backend/opencl/kernel/approx.hpp
+++ b/src/backend/opencl/kernel/approx.hpp
@@ -56,9 +56,7 @@ std::string generateOptionsString() {
     } else {
         options << " -D IS_CPLX=0";
     }
-    if (std::is_same<Ty, double>::value || std::is_same<Ty, cdouble>::value) {
-        options << " -D USE_DOUBLE";
-    }
+    options << getTypeBuildDefinition<Ty>();
 
     options << " -D INTERP_ORDER=" << order;
     addInterpEnumOptions(options);

--- a/src/backend/opencl/kernel/assign.hpp
+++ b/src/backend/opencl/kernel/assign.hpp
@@ -48,8 +48,7 @@ void assign(Param out, const Param in, const AssignKernelParam_t& p,
     if (entry.prog == 0 && entry.ker == 0) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {assign_cl};
         const int ker_lens[]   = {assign_cl_len};

--- a/src/backend/opencl/kernel/bilateral.hpp
+++ b/src/backend/opencl/kernel/bilateral.hpp
@@ -47,10 +47,10 @@ void bilateral(Param out, const Param in, float s_sigma, float c_sigma) {
         std::ostringstream options;
         options << " -D inType=" << dtype_traits<inType>::getName()
                 << " -D outType=" << dtype_traits<outType>::getName();
-        if (std::is_same<inType, double>::value ||
+
+        options << getTypeBuildDefinition<inType>();
+        if (!std::is_same<inType, double>::value ||
             std::is_same<inType, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        } else {
             options << " -D USE_NATIVE_EXP";
         }
 

--- a/src/backend/opencl/kernel/canny.hpp
+++ b/src/backend/opencl/kernel/canny.hpp
@@ -47,7 +47,7 @@ void nonMaxSuppression(Param output, const Param magnitude, const Param dx,
                 << " -D SHRD_MEM_HEIGHT=" << (THREADS_X + 2)
                 << " -D SHRD_MEM_WIDTH=" << (THREADS_Y + 2)
                 << " -D NON_MAX_SUPPRESSION";
-        if (std::is_same<T, double>::value) options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {nonmax_suppression_cl};
         const int ker_lens[]   = {nonmax_suppression_cl_len};
@@ -92,7 +92,7 @@ void initEdgeOut(Param output, const Param strong, const Param weak) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName()
                 << " -D INIT_EDGE_OUT";
-        if (std::is_same<T, double>::value) options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {trace_edge_cl};
         const int ker_lens[]   = {trace_edge_cl_len};
@@ -135,7 +135,7 @@ void suppressLeftOver(Param output) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName()
                 << " -D SUPPRESS_LEFT_OVER";
-        if (std::is_same<T, double>::value) options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {trace_edge_cl};
         const int ker_lens[]   = {trace_edge_cl_len};
@@ -183,7 +183,7 @@ void edgeTrackingHysteresis(Param output, const Param strong,
                 << " -D SHRD_MEM_WIDTH=" << (THREADS_Y + 2)
                 << " -D TOTAL_NUM_THREADS=" << (THREADS_X * THREADS_Y)
                 << " -D EDGE_TRACER";
-        if (std::is_same<T, double>::value) options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {trace_edge_cl};
         const int ker_lens[]   = {trace_edge_cl_len};

--- a/src/backend/opencl/kernel/convolve/conv2_impl.hpp
+++ b/src/backend/opencl/kernel/convolve/conv2_impl.hpp
@@ -51,8 +51,7 @@ void conv2Helper(const conv_kparam_t& param, Param out, const Param signal,
         } else {
             options << " -D CPLX=0";
         }
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {ops_cl, convolve_cl};
         const int ker_lens[]   = {ops_cl_len, convolve_cl_len};

--- a/src/backend/opencl/kernel/convolve/conv_common.hpp
+++ b/src/backend/opencl/kernel/convolve/conv_common.hpp
@@ -118,8 +118,7 @@ void convNHelper(const conv_kparam_t& param, Param& out, const Param& signal,
         } else {
             options << " -D CPLX=0";
         }
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {ops_cl, convolve_cl};
         const int ker_lens[]   = {ops_cl_len, convolve_cl_len};

--- a/src/backend/opencl/kernel/convolve_separable.cpp
+++ b/src/backend/opencl/kernel/convolve_separable.cpp
@@ -72,9 +72,7 @@ void convSep(Param out, const Param signal, const Param filter) {
         } else {
             options << " -D CPLX=0";
         }
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {ops_cl, convolve_separable_cl};
         const int ker_lens[]   = {ops_cl_len, convolve_separable_cl_len};

--- a/src/backend/opencl/kernel/cscmm.hpp
+++ b/src/backend/opencl/kernel/cscmm.hpp
@@ -69,10 +69,8 @@ void cscmm_nn(Param out, const Param &values, const Param &colIdx,
         options << " -D THREADS=" << threads;
         options << " -D ROWS_PER_GROUP=" << rows_per_group;
         options << " -D COLS_PER_GROUP=" << cols_per_group;
+        options << getTypeBuildDefinition<T>();
 
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
         if (std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value) {
             options << " -D IS_CPLX=1";
         } else {

--- a/src/backend/opencl/kernel/cscmv.hpp
+++ b/src/backend/opencl/kernel/cscmv.hpp
@@ -68,9 +68,8 @@ void cscmv(Param out, const Param &values, const Param &colIdx,
         options << " -D THREADS=" << threads;
         options << " -D ROWS_PER_GROUP=" << rows_per_group;
 
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
+
         if (std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value) {
             options << " -D IS_CPLX=1";
         } else {

--- a/src/backend/opencl/kernel/csrmm.hpp
+++ b/src/backend/opencl/kernel/csrmm.hpp
@@ -65,9 +65,7 @@ void csrmm_nt(Param out, const Param &values, const Param &rowIdx,
         options << " -D USE_GREEDY=" << use_greedy;
         options << " -D THREADS_PER_GROUP=" << THREADS_PER_GROUP;
 
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
         if (std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value) {
             options << " -D IS_CPLX=1";
         } else {

--- a/src/backend/opencl/kernel/csrmv.hpp
+++ b/src/backend/opencl/kernel/csrmv.hpp
@@ -68,9 +68,8 @@ void csrmv(Param out, const Param &values, const Param &rowIdx,
         options << " -D USE_GREEDY=" << use_greedy;
         options << " -D THREADS=" << threads;
 
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
+
         if (std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value) {
             options << " -D IS_CPLX=1";
         } else {

--- a/src/backend/opencl/kernel/diagonal.hpp
+++ b/src/backend/opencl/kernel/diagonal.hpp
@@ -34,9 +34,8 @@ std::string generateOptionsString() {
     std::ostringstream options;
     options << " -D T=" << dtype_traits<T>::getName() << " -D ZERO=(T)("
             << scalar_to_option(scalar<T>(0)) << ")";
-    if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-        options << " -D USE_DOUBLE";
-    }
+    options << getTypeBuildDefinition<T>();
+
     return options.str();
 }
 

--- a/src/backend/opencl/kernel/diff.hpp
+++ b/src/backend/opencl/kernel/diff.hpp
@@ -43,9 +43,7 @@ void diff(Param out, const Param in, const unsigned indims) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName() << " -D DIM=" << dim
                 << " -D isDiff2=" << isDiff2;
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {diff_cl};
         const int ker_lens[]   = {diff_cl_len};

--- a/src/backend/opencl/kernel/exampleFunction.hpp
+++ b/src/backend/opencl/kernel/exampleFunction.hpp
@@ -74,9 +74,7 @@ void exampleFunc(Param c, const Param a, const Param b, const af_someenum_t p) {
         // The following option is passed to kernel compilation
         // if template parameter T is double or complex double
         // to enable FP64 extension
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {example_cl};
         const int ker_lens[]   = {example_cl_len};

--- a/src/backend/opencl/kernel/fast.hpp
+++ b/src/backend/opencl/kernel/fast.hpp
@@ -53,9 +53,7 @@ void fast(const unsigned arc_length, unsigned *out_feat, Param &x_out,
                 << " -D ARC_LENGTH=" << arc_length
                 << " -D NONMAX=" << static_cast<unsigned>(nonmax);
 
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         cl::Program prog;
         buildProgram(prog, fast_cl, fast_cl_len, options.str());

--- a/src/backend/opencl/kernel/flood_fill.hpp
+++ b/src/backend/opencl/kernel/flood_fill.hpp
@@ -49,7 +49,7 @@ void initSeeds(Param out, const Param seedsx, const Param seedsy) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName()
                 << " -D VALID=" << T(VALID) << " -D INIT_SEEDS";
-        if (std::is_same<T, double>::value) options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {flood_fill_cl};
         const int ker_lens[]   = {flood_fill_cl_len};
@@ -82,7 +82,7 @@ void finalizeOutput(Param out, const T newValue) {
         options << " -D T=" << dtype_traits<T>::getName()
                 << " -D VALID=" << T(VALID) << " -D ZERO=" << T(ZERO)
                 << " -D FINALIZE_OUTPUT";
-        if (std::is_same<T, double>::value) options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {flood_fill_cl};
         const int ker_lens[]   = {flood_fill_cl_len};
@@ -123,7 +123,7 @@ void floodFill(Param out, const Param image, const Param seedsx,
                 << " -D GROUP_SIZE=" << (THREADS_Y * THREADS_X)
                 << " -D VALID=" << T(VALID) << " -D INVALID=" << T(INVALID)
                 << " -D ZERO=" << T(ZERO) << " -D FLOOD_FILL_STEP";
-        if (std::is_same<T, double>::value) options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {flood_fill_cl};
         const int ker_lens[]   = {flood_fill_cl_len};

--- a/src/backend/opencl/kernel/gradient.hpp
+++ b/src/backend/opencl/kernel/gradient.hpp
@@ -54,9 +54,7 @@ void gradient(Param grad0, Param grad1, const Param in) {
         } else {
             options << " -D CPLX=0";
         }
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {gradient_cl};
         const int ker_lens[]   = {gradient_cl_len};

--- a/src/backend/opencl/kernel/harris.hpp
+++ b/src/backend/opencl/kernel/harris.hpp
@@ -82,8 +82,7 @@ getHarrisKernels() {
     if (entries[0].prog == 0 && entries[0].ker == 0) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {harris_cl};
         const int ker_lens[]   = {harris_cl_len};

--- a/src/backend/opencl/kernel/histogram.hpp
+++ b/src/backend/opencl/kernel/histogram.hpp
@@ -47,10 +47,7 @@ void histogram(Param out, const Param in, int nbins, float minval,
                 << " -D outType=" << dtype_traits<outType>::getName()
                 << " -D THRD_LOAD=" << THRD_LOAD << " -D MAX_BINS=" << MAX_BINS;
         if (isLinear) options << " -D IS_LINEAR";
-        if (std::is_same<inType, double>::value ||
-            std::is_same<inType, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<inType>();
 
         const char* ker_strs[] = {histogram_cl};
         const int ker_lens[]   = {histogram_cl_len};

--- a/src/backend/opencl/kernel/homography.hpp
+++ b/src/backend/opencl/kernel/homography.hpp
@@ -54,8 +54,8 @@ std::array<cl::Kernel*, 5> getHomographyKernels() {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
 
+        options << getTypeBuildDefinition<T>();
         if (std::is_same<T, double>::value) {
-            options << " -D USE_DOUBLE";
             options << " -D EPS=" << DBL_EPSILON;
         } else
             options << " -D EPS=" << FLT_EPSILON;

--- a/src/backend/opencl/kernel/hsv_rgb.hpp
+++ b/src/backend/opencl/kernel/hsv_rgb.hpp
@@ -44,7 +44,7 @@ void hsv2rgb_convert(Param out, const Param in) {
         options << " -D T=" << dtype_traits<T>::getName();
 
         if (isHSV2RGB) options << " -D isHSV2RGB";
-        if (std::is_same<T, double>::value) options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {hsv_rgb_cl};
         const int ker_lens[]   = {hsv_rgb_cl_len};

--- a/src/backend/opencl/kernel/identity.hpp
+++ b/src/backend/opencl/kernel/identity.hpp
@@ -45,9 +45,7 @@ static void identity(Param out) {
         options << " -D T=" << dtype_traits<T>::getName() << " -D ONE=(T)("
                 << scalar_to_option(scalar<T>(1)) << ")"
                 << " -D ZERO=(T)(" << scalar_to_option(scalar<T>(0)) << ")";
-        if (is_same<T, double>::value || is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         if (is_same<T, half>::value) { options << " -D USE_HALF"; }
 

--- a/src/backend/opencl/kernel/iir.hpp
+++ b/src/backend/opencl/kernel/iir.hpp
@@ -48,8 +48,7 @@ void iir(Param y, Param c, Param a) {
                 << " -D ZERO=(T)(" << scalar_to_option(scalar<T>(0)) << ")"
                 << " -D T=" << dtype_traits<T>::getName();
 
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {iir_cl};
         const int ker_lens[]   = {iir_cl_len};

--- a/src/backend/opencl/kernel/index.hpp
+++ b/src/backend/opencl/kernel/index.hpp
@@ -49,8 +49,7 @@ void index(Param out, const Param in, const IndexKernelParam_t& p,
         std::ostringstream options;
 
         options << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {index_cl};
         const int ker_lens[]   = {index_cl_len};

--- a/src/backend/opencl/kernel/iota.hpp
+++ b/src/backend/opencl/kernel/iota.hpp
@@ -47,10 +47,7 @@ void iota(Param out, const af::dim4& sdims) {
         std::ostringstream options;
 
         options << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
-
-        if (std::is_same<T, common::half>::value) options << " -D USE_HALF";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {iota_cl};
         const int ker_lens[]   = {iota_cl_len};

--- a/src/backend/opencl/kernel/ireduce.hpp
+++ b/src/backend/opencl/kernel/ireduce.hpp
@@ -63,10 +63,7 @@ void ireduce_dim_launcher(Param out, cl::Buffer *oidx, Param in,
                 << " -D init=" << toNumStr(Binary<T, op>::init()) << " -D "
                 << binOpName<op>() << " -D CPLX=" << af::iscplx<T>()
                 << " -D IS_FIRST=" << is_first;
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {iops_cl, ireduce_dim_cl};
         const int ker_lens[]   = {iops_cl_len, ireduce_dim_cl_len};
@@ -157,10 +154,7 @@ void ireduce_first_launcher(Param out, cl::Buffer *oidx, Param in,
                 << " -D init=" << toNumStr(Binary<T, op>::init()) << " -D "
                 << binOpName<op>() << " -D CPLX=" << af::iscplx<T>()
                 << " -D IS_FIRST=" << is_first;
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {iops_cl, ireduce_first_cl};
         const int ker_lens[]   = {iops_cl_len, ireduce_first_cl_len};

--- a/src/backend/opencl/kernel/join.hpp
+++ b/src/backend/opencl/kernel/join.hpp
@@ -47,10 +47,7 @@ void join(Param out, const Param in, dim_t dim, const af::dim4 offset) {
     if (entry.prog == 0 && entry.ker == 0) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {join_cl};
         const int ker_lens[]   = {join_cl_len};

--- a/src/backend/opencl/kernel/laset.hpp
+++ b/src/backend/opencl/kernel/laset.hpp
@@ -65,8 +65,7 @@ void laset(int m, int n, T offdiag, T diag, cl_mem dA, size_t dA_offset,
                 << " -D BLK_X=" << BLK_X << " -D BLK_Y=" << BLK_Y
                 << " -D IS_CPLX=" << af::iscplx<T>();
 
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {laset_cl};
         const int ker_lens[]   = {laset_cl_len};

--- a/src/backend/opencl/kernel/laset_band.hpp
+++ b/src/backend/opencl/kernel/laset_band.hpp
@@ -53,8 +53,7 @@ void laset_band(int m, int  n, int k,
             << " -D NB=" << NB
             << " -D IS_CPLX=" << af::iscplx<T>();
 
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {laset_band_cl};
         const int   ker_lens[] = {laset_band_cl_len};

--- a/src/backend/opencl/kernel/laswp.hpp
+++ b/src/backend/opencl/kernel/laswp.hpp
@@ -50,8 +50,7 @@ void laswp(int n, cl_mem in, size_t offset, int ldda, int k1, int k2,
         options << " -D T=" << dtype_traits<T>::getName()
                 << " -D MAX_PIVOTS=" << MAX_PIVOTS;
 
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {laswp_cl};
         const int ker_lens[]   = {laswp_cl_len};

--- a/src/backend/opencl/kernel/lookup.hpp
+++ b/src/backend/opencl/kernel/lookup.hpp
@@ -48,11 +48,7 @@ void lookup(Param out, const Param in, const Param indices) {
         options << " -D in_t=" << dtype_traits<in_t>::getName()
                 << " -D idx_t=" << dtype_traits<idx_t>::getName()
                 << " -D DIM=" << dim;
-
-        if (is_same<in_t, double>::value || is_same<in_t, cdouble>::value ||
-            is_same<idx_t, double>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<in_t, idx_t>();
 
         if (is_same<in_t, common::half>::value) { options << " -D USE_HALF"; }
 

--- a/src/backend/opencl/kernel/lu_split.hpp
+++ b/src/backend/opencl/kernel/lu_split.hpp
@@ -52,8 +52,7 @@ void lu_split_launcher(Param lower, Param upper, const Param in) {
                 << scalar_to_option(scalar<T>(0)) << ")"
                 << " -D ONE=(T)(" << scalar_to_option(scalar<T>(1)) << ")";
 
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {lu_split_cl};
         const int ker_lens[]   = {lu_split_cl_len};

--- a/src/backend/opencl/kernel/match_template.hpp
+++ b/src/backend/opencl/kernel/match_template.hpp
@@ -50,7 +50,7 @@ void matchTemplate(Param out, const Param srch, const Param tmplt) {
                 << " -D AF_ZSSD=" << AF_ZSSD << " -D AF_LSSD=" << AF_LSSD
                 << " -D AF_NCC=" << AF_NCC << " -D AF_ZNCC=" << AF_ZNCC
                 << " -D AF_SHD=" << AF_SHD;
-        if (std::is_same<outType, double>::value) options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<outType>();
 
         const char* ker_strs[] = {matchTemplate_cl};
         const int ker_lens[]   = {matchTemplate_cl_len};

--- a/src/backend/opencl/kernel/mean.hpp
+++ b/src/backend/opencl/kernel/mean.hpp
@@ -143,16 +143,7 @@ void mean_dim_launcher(Param out, Param owt, Param in, Param inWeight,
 
         if (input_weight) { options << " -D INPUT_WEIGHT"; }
         if (output_weight) { options << " -D OUTPUT_WEIGHT"; }
-
-        if (std::is_same<Ti, double>::value ||
-            std::is_same<Ti, cdouble>::value ||
-            std::is_same<To, double>::value) {
-            options << " -D USE_DOUBLE";
-        }
-
-        if (std::is_same<Ti, half>::value || std::is_same<To, half>::value) {
-            options << " -D USE_HALF";
-        }
+        options << getTypeBuildDefinition<Ti, To>();
 
         const char *ker_strs[] = {mean_ops_cl, mean_dim_cl};
         const int ker_lens[]   = {mean_ops_cl_len, mean_dim_cl_len};
@@ -272,16 +263,7 @@ void mean_first_launcher(Param out, Param owt, Param in, Param inWeight,
 
         if (input_weight) { options << " -D INPUT_WEIGHT"; }
         if (output_weight) { options << " -D OUTPUT_WEIGHT"; }
-
-        if (std::is_same<Ti, double>::value ||
-            std::is_same<Ti, cdouble>::value ||
-            std::is_same<To, double>::value) {
-            options << " -D USE_DOUBLE";
-        }
-
-        if (std::is_same<Ti, half>::value || std::is_same<To, half>::value) {
-            options << " -D USE_HALF";
-        }
+        options << getTypeBuildDefinition<Ti, To>();
 
         const char *ker_strs[] = {mean_ops_cl, mean_first_cl};
         const int ker_lens[]   = {mean_ops_cl_len, mean_first_cl_len};

--- a/src/backend/opencl/kernel/meanshift.hpp
+++ b/src/backend/opencl/kernel/meanshift.hpp
@@ -50,8 +50,7 @@ void meanshift(Param out, const Param in, const float spatialSigma,
         options << " -D T=" << dtype_traits<T>::getName()
                 << " -D AccType=" << dtype_traits<AccType>::getName()
                 << " -D MAX_CHANNELS=" << (is_color ? 3 : 1);
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {meanshift_cl};
         const int ker_lens[]   = {meanshift_cl_len};

--- a/src/backend/opencl/kernel/medfilt.hpp
+++ b/src/backend/opencl/kernel/medfilt.hpp
@@ -51,8 +51,7 @@ void medfilt1(Param out, const Param in, unsigned w_wid) {
                 << " -D AF_PAD_ZERO=" << AF_PAD_ZERO
                 << " -D AF_PAD_SYM=" << AF_PAD_SYM
                 << " -D ARR_SIZE=" << ARR_SIZE << " -D w_wid=" << w_wid;
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {medfilt1_cl};
         const int ker_lens[]   = {medfilt1_cl_len};
@@ -101,8 +100,7 @@ void medfilt2(Param out, const Param in) {
                 << " -D AF_PAD_SYM=" << AF_PAD_SYM
                 << " -D ARR_SIZE=" << ARR_SIZE << " -D w_len=" << w_len
                 << " -D w_wid=" << w_wid;
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {medfilt2_cl};
         const int ker_lens[]   = {medfilt2_cl_len};

--- a/src/backend/opencl/kernel/memcopy.hpp
+++ b/src/backend/opencl/kernel/memcopy.hpp
@@ -53,8 +53,7 @@ void memcopy(cl::Buffer out, const dim_t *ostrides, const cl::Buffer in,
         std::ostringstream options;
 
         options << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {memcopy_cl};
         const int ker_lens[]   = {memcopy_cl_len};
@@ -112,12 +111,7 @@ void copy(Param dst, const Param src, int ndims, outType default_value,
                 << " -D inType_" << dtype_traits<inType>::getName()
                 << " -D outType_" << dtype_traits<outType>::getName()
                 << " -D SAME_DIMS=" << same_dims;
-
-        if (std::is_same<inType, double>::value ||
-            std::is_same<inType, cdouble>::value ||
-            std::is_same<outType, double>::value ||
-            std::is_same<outType, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<inType, outType>();
 
         const char *ker_strs[] = {copy_cl};
         const int ker_lens[]   = {copy_cl_len};

--- a/src/backend/opencl/kernel/moments.hpp
+++ b/src/backend/opencl/kernel/moments.hpp
@@ -50,10 +50,7 @@ void moments(Param out, const Param in, af_moment_type moment) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
         options << " -D MOMENTS_SZ=" << out.info.dims[0];
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         Program prog;
         buildProgram(prog, moments_cl, moments_cl_len, options.str());

--- a/src/backend/opencl/kernel/morph.hpp
+++ b/src/backend/opencl/kernel/morph.hpp
@@ -47,8 +47,8 @@ std::string generateOptionsString() {
     options << " -D T=" << dtype_traits<T>::getName()
             << " -D isDilation=" << isDilation << " -D init=" << toNumStr(init)
             << " -D SeLength=" << SeLength;
-    if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-        options << " -D USE_DOUBLE";
+    options << getTypeBuildDefinition<T>();
+
     return options.str();
 }
 

--- a/src/backend/opencl/kernel/nearest_neighbour.hpp
+++ b/src/backend/opencl/kernel/nearest_neighbour.hpp
@@ -72,9 +72,7 @@ void all_distances(Param dist, Param query, Param train, const dim_t dist_dim) {
             default: break;
         }
 
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         if (use_lmem) options << " -D USE_LOCAL_MEM";
 

--- a/src/backend/opencl/kernel/orb.hpp
+++ b/src/backend/opencl/kernel/orb.hpp
@@ -98,9 +98,7 @@ std::tuple<cl::Kernel*, cl::Kernel*, cl::Kernel*, cl::Kernel*> getOrbKernels() {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName()
                 << " -D BLOCK_SIZE=" << ORB_THREADS_X;
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {orb_cl};
         const int ker_lens[]   = {orb_cl_len};

--- a/src/backend/opencl/kernel/pad_array_borders.hpp
+++ b/src/backend/opencl/kernel/pad_array_borders.hpp
@@ -46,8 +46,7 @@ void padBorders(Param out, const Param in, dim4 const& lBPadding) {
                 << " -D AF_PAD_SYM=" << AF_PAD_SYM
                 << " -D AF_PAD_PERIODIC=" << AF_PAD_PERIODIC
                 << " -D AF_PAD_CLAMP_TO_EDGE=" << AF_PAD_CLAMP_TO_EDGE;
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {pad_array_borders_cl};
         const int ker_lens[]   = {pad_array_borders_cl_len};

--- a/src/backend/opencl/kernel/random_engine.hpp
+++ b/src/backend/opencl/kernel/random_engine.hpp
@@ -83,8 +83,7 @@ static cl::Kernel get_random_engine_kernel(const af_random_engine_type type,
         if (type != AF_RANDOM_ENGINE_MERSENNE_GP11213) {
             options << " -D ELEMENTS_PER_BLOCK=" << elementsPerBlock;
         }
-        if (std::is_same<T, double>::value) { options << " -D USE_DOUBLE"; }
-        if (std::is_same<T, common::half>::value) { options << " -D USE_HALF"; }
+        options << getTypeBuildDefinition<T>();
 #if defined(OS_MAC)  // Because apple is "special"
         options << " -D IS_APPLE"
                 << " -D log10_val=" << std::log(10.0);

--- a/src/backend/opencl/kernel/range.hpp
+++ b/src/backend/opencl/kernel/range.hpp
@@ -45,10 +45,7 @@ void range(Param out, const int dim) {
     if (entry.prog == 0 && entry.ker == 0) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
-
-        if (std::is_same<T, common::half>::value) options << " -D USE_HALF";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {range_cl};
         const int ker_lens[]   = {range_cl_len};

--- a/src/backend/opencl/kernel/reduce.hpp
+++ b/src/backend/opencl/kernel/reduce.hpp
@@ -64,14 +64,7 @@ void reduce_dim_launcher(Param out, Param in, const int dim,
                 << " -D THREADS_X=" << THREADS_X
                 << " -D init=" << toNumStr(Binary<To, op>::init()) << " -D "
                 << binOpName<op>() << " -D CPLX=" << af::iscplx<Ti>();
-        if (std::is_same<Ti, double>::value ||
-            std::is_same<Ti, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
-
-        if (std::is_same<Ti, half>::value || std::is_same<To, half>::value) {
-            options << " -D USE_HALF";
-        }
+        options << getTypeBuildDefinition<Ti, To>();
 
         const char *ker_strs[] = {ops_cl, reduce_dim_cl};
         const int ker_lens[]   = {ops_cl_len, reduce_dim_cl_len};
@@ -164,14 +157,7 @@ void reduce_first_launcher(Param out, Param in, const uint groups_x,
                 << " -D THREADS_PER_GROUP=" << THREADS_PER_GROUP
                 << " -D init=" << toNumStr(Binary<To, op>::init()) << " -D "
                 << binOpName<op>() << " -D CPLX=" << af::iscplx<Ti>();
-        if (std::is_same<Ti, double>::value ||
-            std::is_same<Ti, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
-
-        if (std::is_same<Ti, half>::value || std::is_same<To, half>::value) {
-            options << " -D USE_HALF";
-        }
+        options << getTypeBuildDefinition<Ti, To>();
 
         const char *ker_strs[] = {ops_cl, reduce_first_cl};
         const int ker_lens[]   = {ops_cl_len, reduce_first_cl_len};

--- a/src/backend/opencl/kernel/reduce_by_key.hpp
+++ b/src/backend/opencl/kernel/reduce_by_key.hpp
@@ -83,10 +83,7 @@ void launch_reduce_blocks_dim_by_key(cl::Buffer *reduced_block_sizes,
                 << " -D init=" << toNumStr(reduce.init()) << " -D "
                 << binOpName<op>() << " -D CPLX=" << af::iscplx<Ti>();
 
-        if (std::is_same<Ti, double>::value ||
-            std::is_same<Ti, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<Ti>();
 
         const char *ker_strs[] = {ops_cl, reduce_blocks_by_key_dim_cl};
         const int ker_lens[]   = {ops_cl_len, reduce_blocks_by_key_dim_cl_len};
@@ -147,10 +144,7 @@ void launch_reduce_blocks_by_key(cl::Buffer *reduced_block_sizes,
                 << " -D init=" << toNumStr(reduce.init()) << " -D "
                 << binOpName<op>() << " -D CPLX=" << af::iscplx<Ti>();
 
-        if (std::is_same<Ti, double>::value ||
-            std::is_same<Ti, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<Ti>();
 
         const char *ker_strs[] = {ops_cl, reduce_blocks_by_key_first_cl};
         const int ker_lens[] = {ops_cl_len, reduce_blocks_by_key_first_cl_len};
@@ -207,10 +201,7 @@ void launch_final_boundary_reduce(cl::Buffer *reduced_block_sizes,
                 << " -D init=" << toNumStr(reduce.init()) << " -D "
                 << binOpName<op>() << " -D CPLX=" << af::iscplx<To>();
 
-        if (std::is_same<To, double>::value ||
-            std::is_same<To, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<To>();
 
         const char *ker_strs[] = {ops_cl, reduce_by_key_boundary_cl};
         const int ker_lens[]   = {ops_cl_len, reduce_by_key_boundary_cl_len};
@@ -263,10 +254,7 @@ void launch_final_boundary_reduce_dim(cl::Buffer *reduced_block_sizes,
                 << " -D init=" << toNumStr(reduce.init()) << " -D "
                 << binOpName<op>() << " -D CPLX=" << af::iscplx<To>();
 
-        if (std::is_same<To, double>::value ||
-            std::is_same<To, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<To>();
 
         const char *ker_strs[] = {ops_cl, reduce_by_key_boundary_dim_cl};
         const int ker_lens[] = {ops_cl_len, reduce_by_key_boundary_dim_cl_len};
@@ -314,10 +302,7 @@ void launch_compact(cl::Buffer *reduced_block_sizes, Param keys_out,
                 << " -D Tk=" << dtype_traits<Tk>::getName() << " -D T=To"
                 << " -D DIMX=" << threads_x << " -D CPLX=" << af::iscplx<To>();
 
-        if (std::is_same<To, double>::value ||
-            std::is_same<To, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<To>();
 
         const char *ker_strs[] = {ops_cl, reduce_by_key_compact_cl};
         const int ker_lens[]   = {ops_cl_len, reduce_by_key_compact_cl_len};
@@ -367,10 +352,7 @@ void launch_compact_dim(cl::Buffer *reduced_block_sizes, Param keys_out,
                 << " -D DIMX=" << threads_x << " -D DIM=" << dim
                 << " -D CPLX=" << af::iscplx<To>();
 
-        if (std::is_same<To, double>::value ||
-            std::is_same<To, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<To>();
 
         const char *ker_strs[] = {ops_cl, reduce_by_key_compact_dim_cl};
         const int ker_lens[]   = {ops_cl_len, reduce_by_key_compact_dim_cl_len};

--- a/src/backend/opencl/kernel/regions.hpp
+++ b/src/backend/opencl/kernel/regions.hpp
@@ -82,8 +82,7 @@ std::tuple<cl::Kernel*, cl::Kernel*, cl::Kernel*> getRegionsKernels() {
                     << " -D N_PER_THREAD=" << n_per_thread
                     << " -D LIMIT_MAX=" << toNumStr(maxval<T>());
         }
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {regions_cl};
         const int ker_lens[]   = {regions_cl_len};

--- a/src/backend/opencl/kernel/reorder.hpp
+++ b/src/backend/opencl/kernel/reorder.hpp
@@ -44,8 +44,7 @@ void reorder(Param out, const Param in, const dim_t* rdims) {
     if (entry.prog == 0 && entry.ker == 0) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {reorder_cl};
         const int ker_lens[]   = {reorder_cl_len};

--- a/src/backend/opencl/kernel/resize.hpp
+++ b/src/backend/opencl/kernel/resize.hpp
@@ -62,9 +62,7 @@ void resize(Param out, const Param in) {
         } else {
             options << " -D CPLX=0";
         }
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {resize_cl};
         const int ker_lens[]   = {resize_cl_len};

--- a/src/backend/opencl/kernel/rotate.hpp
+++ b/src/backend/opencl/kernel/rotate.hpp
@@ -70,8 +70,7 @@ void rotate(Param out, const Param in, const float theta,
         } else {
             options << " -D IS_CPLX=0";
         }
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         options << " -D INTERP_ORDER=" << order;
         addInterpEnumOptions(options);

--- a/src/backend/opencl/kernel/scan_dim.hpp
+++ b/src/backend/opencl/kernel/scan_dim.hpp
@@ -60,10 +60,7 @@ static Kernel get_scan_dim_kernels(int kerIdx, int dim, bool isFinalPass,
                 << binOpName<op>() << " -D CPLX=" << af::iscplx<Ti>()
                 << " -D isFinalPass=" << (int)(isFinalPass)
                 << " -D inclusive_scan=" << inclusive_scan;
-        if (std::is_same<Ti, double>::value ||
-            std::is_same<Ti, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<Ti>();
 
         const char *ker_strs[] = {ops_cl, scan_dim_cl};
         const int ker_lens[]   = {ops_cl_len, scan_dim_cl_len};

--- a/src/backend/opencl/kernel/scan_dim_by_key_impl.hpp
+++ b/src/backend/opencl/kernel/scan_dim_by_key_impl.hpp
@@ -64,10 +64,7 @@ static Kernel get_scan_dim_kernels(int kerIdx, int dim, bool calculateFlags,
                 << binOpName<op>() << " -D CPLX=" << af::iscplx<Ti>()
                 << " -D calculateFlags=" << calculateFlags
                 << " -D inclusive_scan=" << inclusive_scan;
-        if (std::is_same<Ti, double>::value ||
-            std::is_same<Ti, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<Ti>();
 
         const char *ker_strs[] = {ops_cl, scan_dim_by_key_cl};
         const int ker_lens[]   = {ops_cl_len, scan_dim_by_key_cl_len};

--- a/src/backend/opencl/kernel/scan_first.hpp
+++ b/src/backend/opencl/kernel/scan_first.hpp
@@ -65,10 +65,7 @@ static Kernel get_scan_first_kernels(int kerIdx, bool isFinalPass,
                 << binOpName<op>() << " -D CPLX=" << af::iscplx<Ti>()
                 << " -D isFinalPass=" << (int)(isFinalPass)
                 << " -D inclusive_scan=" << inclusive_scan;
-        if (std::is_same<Ti, double>::value ||
-            std::is_same<Ti, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<Ti>();
 
         const char *ker_strs[] = {ops_cl, scan_first_cl};
         const int ker_lens[]   = {ops_cl_len, scan_first_cl_len};

--- a/src/backend/opencl/kernel/scan_first_by_key_impl.hpp
+++ b/src/backend/opencl/kernel/scan_first_by_key_impl.hpp
@@ -66,10 +66,7 @@ static Kernel get_scan_first_kernels(int kerIdx, bool calculateFlags,
                 << binOpName<op>() << " -D CPLX=" << af::iscplx<Ti>()
                 << " -D calculateFlags=" << calculateFlags
                 << " -D inclusive_scan=" << inclusive_scan;
-        if (std::is_same<Ti, double>::value ||
-            std::is_same<Ti, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<Ti>();
 
         const char *ker_strs[] = {ops_cl, scan_first_by_key_cl};
         const int ker_lens[]   = {ops_cl_len, scan_first_by_key_cl_len};

--- a/src/backend/opencl/kernel/select.hpp
+++ b/src/backend/opencl/kernel/select.hpp
@@ -46,8 +46,7 @@ void select_launcher(Param out, Param cond, Param a, Param b, int ndims) {
         std::ostringstream options;
         options << " -D is_same=" << is_same
                 << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {select_cl};
         const int ker_lens[]   = {select_cl_len};
@@ -109,8 +108,7 @@ void select_scalar(Param out, Param cond, Param a, const double b, int ndims) {
         std::ostringstream options;
         options << " -D flip=" << flip
                 << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {select_cl};
         const int ker_lens[]   = {select_cl_len};

--- a/src/backend/opencl/kernel/sift_nonfree.hpp
+++ b/src/backend/opencl/kernel/sift_nonfree.hpp
@@ -438,8 +438,7 @@ std::array<cl::Kernel*, 7> getSiftKernels() {
     if (entries[0].prog == 0 && entries[0].ker == 0) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         cl::Program prog;
         buildProgram(prog, sift_nonfree_cl, sift_nonfree_cl_len, options.str());

--- a/src/backend/opencl/kernel/sobel.hpp
+++ b/src/backend/opencl/kernel/sobel.hpp
@@ -44,7 +44,7 @@ void sobel(Param dx, Param dy, const Param in) {
         options << " -D Ti=" << dtype_traits<Ti>::getName()
                 << " -D To=" << dtype_traits<To>::getName()
                 << " -D KER_SIZE=" << ker_size;
-        if (std::is_same<Ti, double>::value) options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<Ti>();
 
         const char* ker_strs[] = {sobel_cl};
         const int ker_lens[]   = {sobel_cl_len};

--- a/src/backend/opencl/kernel/sparse.hpp
+++ b/src/backend/opencl/kernel/sparse.hpp
@@ -52,10 +52,7 @@ void coo2dense(Param out, const Param values, const Param rowIdx,
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName()
                 << " -D reps=" << REPEAT;
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         Program prog;
         buildProgram(prog, coo2dense_cl, coo2dense_cl_len, options.str());
@@ -101,10 +98,7 @@ void csr2dense(Param output, const Param values, const Param rowIdx,
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
         options << " -D THREADS=" << threads;
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {csr2dense_cl};
         const int ker_lens[]   = {csr2dense_cl_len};
@@ -159,9 +153,7 @@ void dense2csr(Param values, Param rowIdx, Param colIdx, const Param dense) {
     if (entry.prog == 0 && entry.ker == 0) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
         if (std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value) {
             options << " -D IS_CPLX=1";
         } else {
@@ -206,10 +198,7 @@ void swapIndex(Param ovalues, Param oindex, const Param ivalues,
     if (entry.prog == 0 && entry.ker == 0) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         Program prog;
         buildProgram(prog, csr2coo_cl, csr2coo_cl_len, options.str());
@@ -247,10 +236,7 @@ void csr2coo(Param ovalues, Param orowIdx, Param ocolIdx, const Param ivalues,
     if (entry.prog == 0 && entry.ker == 0) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {csr2coo_cl};
         const int ker_lens[]   = {csr2coo_cl_len};
@@ -308,10 +294,7 @@ void coo2csr(Param ovalues, Param orowIdx, Param ocolIdx, const Param ivalues,
     if (entry.prog == 0 && entry.ker == 0) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         Program prog;
         buildProgram(prog, csr2coo_cl, csr2coo_cl_len, options.str());

--- a/src/backend/opencl/kernel/sparse_arith.hpp
+++ b/src/backend/opencl/kernel/sparse_arith.hpp
@@ -66,9 +66,7 @@ void sparseArithOpCSR(Param out, const Param values, const Param rowIdx,
         } else {
             options << " -D IS_CPLX=0";
         }
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {sparse_arith_common_cl, sparse_arith_csr_cl};
         const int ker_lens[]   = {sparse_arith_common_cl_len,
@@ -119,9 +117,7 @@ void sparseArithOpCOO(Param out, const Param values, const Param rowIdx,
         } else {
             options << " -D IS_CPLX=0";
         }
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {sparse_arith_common_cl, sparse_arith_coo_cl};
         const int ker_lens[]   = {sparse_arith_common_cl_len,
@@ -172,9 +168,7 @@ void sparseArithOpCSR(Param values, Param rowIdx, Param colIdx, const Param rhs,
         } else {
             options << " -D IS_CPLX=0";
         }
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {sparse_arith_common_cl, sparse_arith_csr_cl};
         const int ker_lens[]   = {sparse_arith_common_cl_len,
@@ -224,9 +218,7 @@ void sparseArithOpCOO(Param values, Param rowIdx, Param colIdx, const Param rhs,
         } else {
             options << " -D IS_CPLX=0";
         }
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {sparse_arith_common_cl, sparse_arith_coo_cl};
         const int ker_lens[]   = {sparse_arith_common_cl_len,
@@ -316,9 +308,7 @@ void ssArithCSR(Param oVals, Param oColIdx, const Param oRowIdx, const uint M,
                 << af::scalar_to_option(iden_val) << ")";
 
         options << " -D IS_CPLX=" << common::is_complex<T>::value;
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         const char *kerStrs[] = {sparse_arith_common_cl, sp_sp_arith_csr_cl};
         const int kerLens[]   = {sparse_arith_common_cl_len,

--- a/src/backend/opencl/kernel/susan.hpp
+++ b/src/backend/opencl/kernel/susan.hpp
@@ -51,8 +51,7 @@ void susan(cl::Buffer* out, const cl::Buffer* in, const unsigned in_off,
                 << " -D BLOCK_X=" << SUSAN_THREADS_X
                 << " -D BLOCK_Y=" << SUSAN_THREADS_Y << " -D RADIUS=" << radius
                 << " -D RESPONSE";
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {susan_cl};
         const int ker_lens[]   = {susan_cl_len};
@@ -91,8 +90,7 @@ unsigned nonMaximal(cl::Buffer* x_out, cl::Buffer* y_out, cl::Buffer* resp_out,
     if (entry.prog == 0 && entry.ker == 0) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName() << " -D NONMAX";
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {susan_cl};
         const int ker_lens[]   = {susan_cl_len};

--- a/src/backend/opencl/kernel/swapdblk.hpp
+++ b/src/backend/opencl/kernel/swapdblk.hpp
@@ -42,8 +42,7 @@ void swapdblk(int n, int nb, cl_mem dA, size_t dA_offset, int ldda, int inca,
         std::ostringstream options;
 
         options << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {swapdblk_cl};
         const int ker_lens[]   = {swapdblk_cl_len};

--- a/src/backend/opencl/kernel/tile.hpp
+++ b/src/backend/opencl/kernel/tile.hpp
@@ -44,8 +44,7 @@ void tile(Param out, const Param in) {
     if (entry.prog == 0 && entry.ker == 0) {
         std::ostringstream options;
         options << " -D T=" << dtype_traits<T>::getName();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {tile_cl};
         const int ker_lens[]   = {tile_cl_len};

--- a/src/backend/opencl/kernel/transform.hpp
+++ b/src/backend/opencl/kernel/transform.hpp
@@ -72,9 +72,7 @@ void transform(Param out, const Param in, const Param tf, bool isInverse,
         } else {
             options << " -D IS_CPLX=0";
         }
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         options << " -D INTERP_ORDER=" << order;
         addInterpEnumOptions(options);

--- a/src/backend/opencl/kernel/transpose.hpp
+++ b/src/backend/opencl/kernel/transpose.hpp
@@ -47,11 +47,7 @@ void transpose(Param out, const Param in, cl::CommandQueue queue) {
                 << " -D IS32MULTIPLE=" << IS32MULTIPLE
                 << " -D DOCONJUGATE=" << (conjugate && af::iscplx<T>())
                 << " -D T=" << dtype_traits<T>::getName();
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
-
-        if (std::is_same<T, common::half>::value) options << " -D USE_HALF";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {transpose_cl};
         const int ker_lens[]   = {transpose_cl_len};

--- a/src/backend/opencl/kernel/transpose_inplace.hpp
+++ b/src/backend/opencl/kernel/transpose_inplace.hpp
@@ -48,9 +48,7 @@ void transpose_inplace(Param in, cl::CommandQueue& queue) {
                 << " -D IS32MULTIPLE=" << IS32MULTIPLE
                 << " -D DOCONJUGATE=" << (conjugate && af::iscplx<T>())
                 << " -D T=" << dtype_traits<T>::getName();
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {transpose_inplace_cl};
         const int ker_lens[]   = {transpose_inplace_cl_len};

--- a/src/backend/opencl/kernel/triangle.hpp
+++ b/src/backend/opencl/kernel/triangle.hpp
@@ -53,10 +53,7 @@ void triangle(Param out, const Param in) {
                 << " -D is_unit_diag=" << is_unit_diag << " -D ZERO=(T)("
                 << scalar_to_option(scalar<T>(0)) << ")"
                 << " -D ONE=(T)(" << scalar_to_option(scalar<T>(1)) << ")";
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
-
-        if (std::is_same<T, common::half>::value) options << " -D USE_HALF";
+        options << getTypeBuildDefinition<T>();
 
         const char* ker_strs[] = {triangle_cl};
         const int ker_lens[]   = {triangle_cl_len};

--- a/src/backend/opencl/kernel/unwrap.hpp
+++ b/src/backend/opencl/kernel/unwrap.hpp
@@ -52,10 +52,7 @@ void unwrap(Param out, const Param in, const dim_t wx, const dim_t wy,
         options << " -D IS_COLUMN=" << is_column
                 << " -D ZERO=" << toNumStr(scalar<T>(0))
                 << " -D T=" << dtype_traits<T>::getName();
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         Program prog;
         buildProgram(prog, unwrap_cl, unwrap_cl_len, options.str());

--- a/src/backend/opencl/kernel/where.hpp
+++ b/src/backend/opencl/kernel/where.hpp
@@ -47,8 +47,7 @@ static void get_out_idx(Buffer *out_data, Param &otmp, Param &rtmp, Param &in,
         options << " -D T=" << dtype_traits<T>::getName()
                 << " -D zero=" << toNumStr(scalar<T>(0))
                 << " -D CPLX=" << af::iscplx<T>();
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value)
-            options << " -D USE_DOUBLE";
+        options << getTypeBuildDefinition<T>();
 
         const char *ker_strs[] = {where_cl};
         const int ker_lens[]   = {where_cl_len};

--- a/src/backend/opencl/kernel/wrap.hpp
+++ b/src/backend/opencl/kernel/wrap.hpp
@@ -52,10 +52,8 @@ void wrap(Param out, const Param in, const dim_t wx, const dim_t wy,
         options << " -D is_column=" << is_column
                 << " -D ZERO=" << toNumStr(scalar<T>(0))
                 << " -D T=" << dtype_traits<T>::getName();
+        options << getTypeBuildDefinition<T>();
 
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
         Program prog;
         buildProgram(prog, wrap_cl, wrap_cl_len, options.str());
 
@@ -107,10 +105,7 @@ void wrap_dilated(Param out, const Param in, const dim_t wx, const dim_t wy,
         options << " -D is_column=" << is_column
                 << " -D ZERO=" << toNumStr(scalar<T>(0))
                 << " -D T=" << dtype_traits<T>::getName();
-
-        if (std::is_same<T, double>::value || std::is_same<T, cdouble>::value) {
-            options << " -D USE_DOUBLE";
-        }
+        options << getTypeBuildDefinition<T>();
 
         Program prog;
         buildProgram(prog, wrap_dilated_cl, wrap_dilated_cl_len, options.str());


### PR DESCRIPTION
* Creates the getTypeBuildDefinition which will pass the USE_DOUBLE
  and USE_HALF types to the OpenCL build step in a consistent way
* The reduce by key step was not passing the USE_HALF flag so
  things weren't compiling on the Intel OpenCL GPU implementation