### PR TITLE
adds bitwise not(~) operation to all backends

### DIFF
--- a/include/af/arith.h
+++ b/include/af/arith.h
@@ -741,6 +741,19 @@ extern "C" {
     */
     AFAPI af_err af_not   (af_array *out, const af_array in);
 
+#if AF_API_VERSION >= 38
+    /**
+       C Interface for performing bitwise not on input
+
+       \param[out] out will contain result of bitwise not of \p in.
+       \param[in] in is the input
+       \return \ref AF_SUCCESS if the execution completes properly
+
+       \ingroup arith_func_bitnot
+    */
+    AFAPI af_err af_bitnot   (af_array *out, const af_array in);
+#endif
+
     /**
        C Interface for performing bitwise and on two arrays
 

--- a/include/af/array.h
+++ b/include/af/array.h
@@ -996,6 +996,15 @@ namespace af
         /// \returns an \ref array with negated values
         array operator !() const;
 
+#if AF_API_VERSION >= 38
+        ///
+        /// \brief Performs a bitwise not operation on the values of the array
+        /// \ingroup arith_func_bitnot
+        ///
+        /// \returns an \ref array with inverted values
+        array operator ~() const;
+#endif
+
         ///
         /// \brief Get the count of non-zero elements in the array
         ///

--- a/src/api/c/optypes.hpp
+++ b/src/api/c/optypes.hpp
@@ -29,6 +29,7 @@ typedef enum {
     af_bitxor_t,
     af_bitshiftl_t,
     af_bitshiftr_t,
+    af_bitnot_t,
 
     af_min_t,
     af_max_t,

--- a/src/api/c/unary.cpp
+++ b/src/api/c/unary.cpp
@@ -560,6 +560,41 @@ af_err af_not(af_array *out, const af_array in) {
     return AF_SUCCESS;
 }
 
+template<typename T>
+static inline af_array bitOpNot(const af_array in) {
+    return unaryOp<T, af_bitnot_t>(in);
+}
+
+af_err af_bitnot(af_array *out, const af_array in) {
+    try {
+        const ArrayInfo &iinfo = getInfo(in);
+        const af_dtype type    = iinfo.getType();
+
+        dim4 odims = iinfo.dims();
+
+        if (odims.ndims() == 0) {
+            return af_create_handle(out, 0, nullptr, type);
+        }
+
+        af_array res;
+        switch (type) {
+            case s32: res = bitOpNot<int>(in); break;
+            case u32: res = bitOpNot<uint>(in); break;
+            case u8: res = bitOpNot<uchar>(in); break;
+            case b8: res = bitOpNot<char>(in); break;
+            case s64: res = bitOpNot<intl>(in); break;
+            case u64: res = bitOpNot<uintl>(in); break;
+            case s16: res = bitOpNot<short>(in); break;
+            case u16: res = bitOpNot<ushort>(in); break;
+            default: TYPE_ERROR(0, type);
+        }
+
+        std::swap(*out, res);
+    }
+    CATCHALL;
+    return AF_SUCCESS;
+}
+
 af_err af_arg(af_array *out, const af_array in) {
     try {
         const ArrayInfo &in_info = getInfo(in);

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -988,6 +988,13 @@ array array::operator!() const {
     return array(out);
 }
 
+array array::operator~() const {
+    af_array lhs = this->get();
+    af_array out = nullptr;
+    AF_THROW(af_bitnot(&out, lhs));
+    return array(out);
+}
+
 void array::eval() const { AF_THROW(af_eval(get())); }
 
 // array instanciations

--- a/src/api/unified/arith.cpp
+++ b/src/api/unified/arith.cpp
@@ -99,6 +99,7 @@ UNARY_HAPI_DEF(af_iszero)
 UNARY_HAPI_DEF(af_isinf)
 UNARY_HAPI_DEF(af_isnan)
 UNARY_HAPI_DEF(af_not)
+UNARY_HAPI_DEF(af_bitnot)
 
 af_err af_clamp(af_array* out, const af_array in, const af_array lo,
                 const af_array hi, const bool batch) {

--- a/src/backend/cpu/unary.hpp
+++ b/src/backend/cpu/unary.hpp
@@ -77,6 +77,8 @@ UNARY_OP(cbrt)
 UNARY_OP(tgamma)
 UNARY_OP(lgamma)
 
+UNARY_OP_FN(bitnot, ~)
+
 #undef UNARY_OP
 #undef UNARY_OP_FN
 

--- a/src/backend/cuda/kernel/jit.cuh
+++ b/src/backend/cuda/kernel/jit.cuh
@@ -47,6 +47,7 @@ typedef cuDoubleComplex cdouble;
 #define __abs(in) abs(in)
 #define __sigmoid(in) (1.0 / (1 + exp(-(in))))
 
+#define __bitnot(in) (~(in))
 #define __bitor(lhs, rhs) ((lhs) | (rhs))
 #define __bitand(lhs, rhs) ((lhs) & (rhs))
 #define __bitxor(lhs, rhs) ((lhs) ^ (rhs))

--- a/src/backend/cuda/nvrtc/cache.cpp
+++ b/src/backend/cuda/nvrtc/cache.cpp
@@ -474,6 +474,7 @@ string getOpEnumStr(af_op_t val) {
         CASE_STMT(af_gt_t);
         CASE_STMT(af_ge_t);
 
+        CASE_STMT(af_bitnot_t);
         CASE_STMT(af_bitor_t);
         CASE_STMT(af_bitand_t);
         CASE_STMT(af_bitxor_t);

--- a/src/backend/cuda/unary.hpp
+++ b/src/backend/cuda/unary.hpp
@@ -66,6 +66,7 @@ UNARY_FN(signbit)
 UNARY_FN(ceil)
 UNARY_FN(floor)
 
+UNARY_DECL(bitnot, "__bitnot")
 UNARY_DECL(isinf, "__isinf")
 UNARY_DECL(isnan, "__isnan")
 UNARY_FN(iszero)

--- a/src/backend/opencl/kernel/jit.cl
+++ b/src/backend/opencl/kernel/jit.cl
@@ -95,6 +95,7 @@ float2 __cdivf(float2 lhs, float2 rhs) {
 #define __cgt(lhs, rhs) (__cabs(lhs) > __cabs(rhs))
 #define __cge(lhs, rhs) (__cabs(lhs) >= __cabs(rhs))
 
+#define __bitnot(in) (~(in))
 #define __bitor(lhs, rhs) ((lhs) | (rhs))
 #define __bitand(lhs, rhs) ((lhs) & (rhs))
 #define __bitxor(lhs, rhs) ((lhs) ^ (rhs))

--- a/src/backend/opencl/unary.hpp
+++ b/src/backend/opencl/unary.hpp
@@ -70,6 +70,8 @@ UNARY_FN(isnan)
 UNARY_FN(iszero)
 UNARY_DECL(noop, "__noop")
 
+UNARY_DECL(bitnot, "__bitnot")
+
 #undef UNARY_FN
 
 template<typename T, af_op_t op>

--- a/test/binary.cpp
+++ b/test/binary.cpp
@@ -289,6 +289,26 @@ BITOP(bitxor, uintl, ^)
 BITOP(bitshiftl, uintl, <<)
 BITOP(bitshiftr, uintl, >>)
 
+#define UBITOP(func, T)                                     \
+    TEST(BinaryTests, Test_##func##_##T) {                  \
+        af_dtype ty   = (af_dtype)dtype_traits<T>::af_type; \
+        const T vala  = 4095;                               \
+        const T valc  = ~vala;                              \
+        const int num = 10;                                 \
+        af::array a   = af::constant(vala, num, ty);        \
+        af::array b   = af::constant(valc, num, ty);        \
+        af::array c   = ~a;                                 \
+        ASSERT_ARRAYS_EQ(c, b);                             \
+    }
+
+UBITOP(bitnot, int)
+UBITOP(bitnot, uint)
+UBITOP(bitnot, intl)
+UBITOP(bitnot, uintl)
+UBITOP(bitnot, uchar)
+UBITOP(bitnot, short)
+UBITOP(bitnot, ushort)
+
 TEST(BinaryTests, Test_pow_cfloat_float) {
     af::array a        = randgen(num, c32);
     af::array b        = randgen(num, f32);


### PR DESCRIPTION
This unary operation had been missing. Twos complement -x - 1 trick would fail for some types due to our upcasting behavior.