### PR TITLE
Fix premature deallocation when deallocating with multiple devices.

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -42,6 +42,7 @@ jobs:
                       -DAF_BUILD_CPU:BOOL=OFF -DAF_BUILD_CUDA:BOOL=OFF \
                       -DAF_BUILD_OPENCL:BOOL=OFF -DAF_BUILD_UNIFIED:BOOL=OFF \
                       -DAF_BUILD_EXAMPLES:BOOL=OFF -DBUILD_TESTING:BOOL=OFF \
+                      -DBOOST_ROOT:PATH=${BOOST_ROOT_1_72_0} \
                       -DDOXYGEN_EXECUTABLE:FILEPATH=${GITHUB_WORKSPACE}/doxygen/bin/doxygen \
                       ..
 

--- a/CMakeModules/boost_package.cmake
+++ b/CMakeModules/boost_package.cmake
@@ -5,7 +5,7 @@
 # The complete license agreement can be obtained at:
 # http://arrayfire.com/licenses/BSD-3-Clause
 
-find_package(Boost)
+find_package(Boost 1.66 REQUIRED)
 
 set(Boost_MIN_VER 107000)
 set(Boost_MIN_VER_STR "1.70")
@@ -45,8 +45,8 @@ if(NOT
   add_dependencies(Boost::boost boost_compute)
 
   set_target_properties(Boost::boost PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIR};${source_dir}/include"
-    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIR};${source_dir}/include"
+    INTERFACE_INCLUDE_DIRECTORIES "${source_dir}/include;${Boost_INCLUDE_DIR}"
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${source_dir}/include;${Boost_INCLUDE_DIR}"
     )
 else()
   if(NOT TARGET Boost::boost)

--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -52,7 +52,7 @@ endif()
 ExternalProject_Add(
     CLBlast-ext
     GIT_REPOSITORY https://github.com/cnugteren/CLBlast.git
-    GIT_TAG 1.5.0
+    GIT_TAG 1.5.1
     PREFIX "${prefix}"
     INSTALL_DIR "${prefix}"
     UPDATE_COMMAND ""

--- a/docs/doxygen.mk
+++ b/docs/doxygen.mk
@@ -258,12 +258,6 @@ ALIASES += "convolve_t{2}=\1 \ast \2"
 ALIASES += "set_eq{2}=\f$ \left\\{ \1 \ \Bigg\vert \ \2 \right\\} \f$"
 ALIASES += "set_t{2}=\left\\\{ \1 \ \Bigg\vert \ \2 \right\\\}"
 
-# This tag can be used to specify a number of word-keyword mappings (TCL only).
-# A mapping has the form "name=value". For example adding "class=itcl::class"
-# will allow you to use the command class in the itcl::class meaning.
-
-TCL_SUBST              =
-
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For
 # instance, some of the names that are used will be different. The list of all

--- a/src/api/c/handle.hpp
+++ b/src/api/c/handle.hpp
@@ -139,7 +139,16 @@ af_array copyArray(const af_array in) {
 
 template<typename T>
 void releaseHandle(const af_array arr) {
-    detail::destroyArray(static_cast<detail::Array<T> *>(arr));
+    auto &Arr      = getArray<T>(arr);
+    int old_device = detail::getActiveDeviceId();
+    int array_id   = Arr.getDevId();
+    if (array_id != old_device) {
+        detail::setDevice(array_id);
+        detail::destroyArray(static_cast<detail::Array<T> *>(arr));
+        detail::setDevice(old_device);
+    } else {
+        detail::destroyArray(static_cast<detail::Array<T> *>(arr));
+    }
 }
 
 template<typename T>

--- a/src/backend/common/err_common.hpp
+++ b/src/backend/common/err_common.hpp
@@ -11,6 +11,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wattributes"
+#pragma GCC diagnostic ignored "-Wparentheses"
 #include <boost/stacktrace.hpp>
 #pragma GCC diagnostic pop
 #include <common/defines.hpp>

--- a/src/backend/cpu/ParamIterator.hpp
+++ b/src/backend/cpu/ParamIterator.hpp
@@ -26,6 +26,7 @@ class ParamIterator {
     using value_type        = T;
     using pointer           = T*;
     using reference         = T&;
+    using const_reference   = const T&;
     using iterator_category = std::forward_iterator_tag;
 
     /// Creates a sentinel iterator. This is equivalent to the end iterator
@@ -76,7 +77,9 @@ class ParamIterator {
         return *this;
     }
 
-    const reference operator*() const noexcept { return *ptr; }
+    reference operator*() noexcept { return *ptr; }
+
+    const_reference operator*() const noexcept { return *ptr; }
 
     const pointer operator->() const noexcept { return ptr; }
 


### PR DESCRIPTION
* Fix an issue with multiple GPU and memory being freed because the correct device was not active when free was called.
* Update CLBlast to 1.5.1
* Set the minimum version for Boost
* Make sure that the downloaded version of Boost compute is preferred over the system version in case the Boost version is less than 1.7.1
* Remove old doxygen variable
* Fix const correctness of the operator* variable
