### PR TITLE
Use kernel source with instance name for hashing

### DIFF
--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -214,12 +214,12 @@ static CUfunction getKernel(const vector<Node *> &output_nodes,
     Kernel entry{nullptr, nullptr};
 
     if (idx == kernelCaches[device].end()) {
+        string jit_ker = getKernelString(funcName, full_nodes, full_ids,
+                                         output_ids, is_linear);
 #ifdef AF_CACHE_KERNELS_TO_DISK
-        entry = loadKernel(device, funcName);
+        entry = loadKernel(device, funcName, jit_ker);
 #endif
         if (entry.prog == nullptr || entry.ker == nullptr) {
-            string jit_ker = getKernelString(funcName, full_nodes, full_ids,
-                                             output_ids, is_linear);
             saveKernel(funcName, jit_ker, ".cu");
             entry = buildKernel(device, funcName, jit_ker, {}, true);
         }

--- a/src/backend/cuda/nvrtc/cache.hpp
+++ b/src/backend/cuda/nvrtc/cache.hpp
@@ -109,7 +109,8 @@ Kernel buildKernel(const int device, const std::string& nameExpr,
                    const std::vector<std::string>& opts = {},
                    const bool isJIT                     = false);
 
-Kernel loadKernel(const int device, const std::string& nameExpr);
+Kernel loadKernel(const int device, const std::string& nameExpr,
+                  const std::string& source);
 
 template<typename T>
 std::string toString(T val);


### PR DESCRIPTION
This will ensure updated kernels are used/cached when their respective
source changes during development.

This change will not change any behavior of programs using
arrayfire.