### PR TITLE
Add an ArrayFire conanfile.py that pulls from the linux binary installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ compile_commands.json
 venv
 test/gtest
 src/backend/cuda/cub
+conanbuildinfo*
+conaninfo*
+conan.lock
+graph_info.json

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,104 @@
+from conans import ConanFile, CMake, tools
+import os
+
+
+class ArrayFireConan(ConanFile):
+    name = "arrayfire"
+    version = "3.7.1"
+    license = "BSD"
+    author = "jacobkahn jacobkahn1@gmail.com"
+    url = "https://github.com/arrayfire/arrayfire"
+    requires = []
+    description = "ArrayFire: a general purpose GPU library"
+    topics = ("arrayfire", "gpu", "cuda", "opencl", "gpgpu",
+              "hpc", "performance", "scientific-computing")
+    settings = "os", "compiler", "build_type", "arch"
+    options = {"shared": [True, False], "backend": ["CPU", "CUDA", "OPENCL"]}
+    default_options = {"shared": True}
+    generators = "cmake"  # unused
+
+    def configure(self):
+        if self.settings.os == "Windows":
+            raise ConanInvalidConfiguration(
+                "Linux binary installer not compaible with Windows.")
+
+    def _download_arrayfire(self):
+        # Download ArrayFire 3.7.1
+        self.af_installer_local_path = 'ArrayFire-v3.7.1-1_Linux_x86_64.sh'
+        if not os.path.exists(self.af_installer_local_path):
+            self.output.info(
+                "Downloading the ArrayFire 3.7.1 binary installer...")
+            tools.download(
+                'https://arrayfire.s3.amazonaws.com/3.7.1/ArrayFire-v3.7.1-1_Linux_x86_64.sh', self.af_installer_local_path)
+            self.output.success(
+                f"ArrayFire 3.7.1 binary installer successfully downloaded to {self.af_installer_local_path}")
+        else:
+            self.output.info(
+                "ArrayFire 3.7.1 binary installer already exists - skipping download.")
+
+    def _unpack_arrayfire(self):
+        if not os.path.exists(self.af_unpack_path):
+            os.mkdir(self.af_unpack_path)
+        self.output.info("Unpacking ArrayFire 3.7.1 binary installer...")
+        cmd = f"bash {self.af_installer_local_path} --prefix={self.af_unpack_path} --skip-license"
+        self.run(cmd)
+        self.output.success("ArrayFire 3.7.1 successfully unpacked.")
+
+    def _process_arrayfire(self):
+        # Install ArrayFire to requisite path
+        self.af_unpack_path = os.path.join(self.source_folder, 'arrayfire')
+
+        # Only proceed if missing
+        if os.path.exists(os.path.join(self.af_unpack_path, 'include', 'arrayfire.h')):
+            self.output.info("ArrayFire 3.7.1 already unpacked - skipping.")
+        else:
+            self._download_arrayfire()
+            self._unpack_arrayfire()
+
+    def build(self):
+        self._process_arrayfire()
+
+    def package(self):
+        # libs
+        self.copy("*.so", dst="lib", keep_path=False, symlinks=True)
+        self.copy("*.so.*", dst="lib", keep_path=False, symlinks=True)
+
+        # headers
+        self.copy("*.h", dst="include", src="arrayfire/include")
+        self.copy("*.hpp", dst="include", src="arrayfire/include")
+
+    def package_info(self):
+        self.cpp_info.libs = [
+            "libaf.so.3.7.1",
+            "libforge.so.1.0.5",
+        ]
+        if self.options.backend == 'CUDA':
+            self.cpp_info.libs.extend([
+                "libnvrtc-builtins.so",
+                "libcudnn.so.10.0",
+                "libcusparse.so.10.0",
+                "libcublas.so.10.0",
+                "libafcuda.so.3.7.1",
+                "libcusolver.so.10.0",
+                "libnvrtc.so.10.0",
+                "libcufft.so.10.0",
+            ])
+        elif self.options.backend == 'CPU':
+            self.cpp_info.libs.extend([
+                "libmkl_avx2.so",
+                "libmkl_mc.so",
+                "libmkl_intel_lp64.so",
+                "libmkl_core.so",
+                "libmkl_avx.so",
+                "libmkl_def.so",
+                "libiomp5.so",
+                "libafopencl.so.3.7.1",
+                "libmkl_avx512.so",
+                "libmkl_intel_thread.so",
+                "libmkl_mc3.so",
+                "libafcpu.so.3.7.1",
+            ])
+        elif self.options.backend == 'OPENCL':
+            self.cpp_info.libs.extend([
+                "libOpenCL.so.1",
+            ])

--- a/conanfile.py
+++ b/conanfile.py
@@ -2,9 +2,14 @@ from conans import ConanFile, CMake, tools
 import os
 
 
+ARRAYFIRE_VERSION = "3.7.1"
+BINARY_INSTALLER_NAME_SUFFIX = "-1"
+BINARY_INSTALLER_NAME = f"ArrayFire-v{ARRAYFIRE_VERSION}{BINARY_INSTALLER_NAME_SUFFIX}_Linux_x86_64.sh"
+CUDA_TOOLKIT_VERSION = "10.0"
+
 class ArrayFireConan(ConanFile):
     name = "arrayfire"
-    version = "3.7.1"
+    version = ARRAYFIRE_VERSION
     license = "BSD"
     author = "jacobkahn jacobkahn1@gmail.com"
     url = "https://github.com/arrayfire/arrayfire"
@@ -13,8 +18,13 @@ class ArrayFireConan(ConanFile):
     topics = ("arrayfire", "gpu", "cuda", "opencl", "gpgpu",
               "hpc", "performance", "scientific-computing")
     settings = "os", "compiler", "build_type", "arch"
-    options = {"shared": [True, False], "backend": ["CPU", "CUDA", "OPENCL"]}
-    default_options = {"shared": True}
+    options = {
+        "cpu_backend": [True, False],
+        "cuda_backend": [True, False],
+        "opencl_backend": [True, False],
+        "unified_backend": [True, False],
+        "graphics": [True, False],
+    }
     generators = "cmake"  # unused
 
     def configure(self):
@@ -22,27 +32,32 @@ class ArrayFireConan(ConanFile):
             raise ConanInvalidConfiguration(
                 "Linux binary installer not compaible with Windows.")
 
+    def requirements(self):
+        if self.options.graphics:
+            self.requires('glfw/3.3.2@bincrafters/stable')
+
     def _download_arrayfire(self):
-        # Download ArrayFire 3.7.1
-        self.af_installer_local_path = 'ArrayFire-v3.7.1-1_Linux_x86_64.sh'
+        self.af_installer_local_path = BINARY_INSTALLER_NAME
         if not os.path.exists(self.af_installer_local_path):
             self.output.info(
-                "Downloading the ArrayFire 3.7.1 binary installer...")
+                f"Downloading the ArrayFire {ARRAYFIRE_VERSION} binary installer...")
             tools.download(
-                'https://arrayfire.s3.amazonaws.com/3.7.1/ArrayFire-v3.7.1-1_Linux_x86_64.sh', self.af_installer_local_path)
+                f"https://arrayfire.s3.amazonaws.com/{ARRAYFIRE_VERSION}/{BINARY_INSTALLER_NAME}", self.af_installer_local_path)
             self.output.success(
-                f"ArrayFire 3.7.1 binary installer successfully downloaded to {self.af_installer_local_path}")
+                f"ArrayFire {ARRAYFIRE_VERSION} binary installer successfully downloaded to {self.af_installer_local_path}")
         else:
             self.output.info(
-                "ArrayFire 3.7.1 binary installer already exists - skipping download.")
+                f"ArrayFire {ARRAYFIRE_VERSION} binary installer already exists - skipping download.")
 
     def _unpack_arrayfire(self):
         if not os.path.exists(self.af_unpack_path):
             os.mkdir(self.af_unpack_path)
-        self.output.info("Unpacking ArrayFire 3.7.1 binary installer...")
+        self.output.info(
+            f"Unpacking ArrayFire {ARRAYFIRE_VERSION} binary installer...")
         cmd = f"bash {self.af_installer_local_path} --prefix={self.af_unpack_path} --skip-license"
         self.run(cmd)
-        self.output.success("ArrayFire 3.7.1 successfully unpacked.")
+        self.output.success(
+            f"ArrayFire {ARRAYFIRE_VERSION} successfully unpacked.")
 
     def _process_arrayfire(self):
         # Install ArrayFire to requisite path
@@ -50,7 +65,8 @@ class ArrayFireConan(ConanFile):
 
         # Only proceed if missing
         if os.path.exists(os.path.join(self.af_unpack_path, 'include', 'arrayfire.h')):
-            self.output.info("ArrayFire 3.7.1 already unpacked - skipping.")
+            self.output.info(
+                f"ArrayFire {ARRAYFIRE_VERSION} already unpacked - skipping.")
         else:
             self._download_arrayfire()
             self._unpack_arrayfire()
@@ -68,23 +84,29 @@ class ArrayFireConan(ConanFile):
         self.copy("*.hpp", dst="include", src="arrayfire/include")
 
     def package_info(self):
-        self.cpp_info.libs = [
-            "libaf.so.3.7.1",
-            "libforge.so.1.0.5",
-        ]
-        if self.options.backend == 'CUDA':
+        self.cpp_info.libs = []
+        if self.options.unified_backend:
             self.cpp_info.libs.extend([
-                "libnvrtc-builtins.so",
-                "libcudnn.so.10.0",
-                "libcusparse.so.10.0",
-                "libcublas.so.10.0",
-                "libafcuda.so.3.7.1",
-                "libcusolver.so.10.0",
-                "libnvrtc.so.10.0",
-                "libcufft.so.10.0",
+                f"libaf.so.{ARRAYFIRE_VERSION}",
             ])
-        elif self.options.backend == 'CPU':
+        if self.options.graphics:
             self.cpp_info.libs.extend([
+                "libforge.so.1.0.5",
+            ])
+        if self.options.cuda_backend:
+            self.cpp_info.libs.extend([
+                f"libafcuda.so.{ARRAYFIRE_VERSION}",
+                "libnvrtc-builtins.so",
+                f"libcudnn.so.{CUDA_TOOLKIT_VERSION}",
+                f"libcusparse.so.{CUDA_TOOLKIT_VERSION}",
+                f"libcublas.so.{CUDA_TOOLKIT_VERSION}",
+                f"libcusolver.so.{CUDA_TOOLKIT_VERSION}",
+                f"libnvrtc.so.{CUDA_TOOLKIT_VERSION}",
+                f"libcufft.so.{CUDA_TOOLKIT_VERSION}",
+            ])
+        if self.options.cpu_backend:
+            self.cpp_info.libs.extend([
+                f"libafcpu.so.{ARRAYFIRE_VERSION}",
                 "libmkl_avx2.so",
                 "libmkl_mc.so",
                 "libmkl_intel_lp64.so",
@@ -92,13 +114,13 @@ class ArrayFireConan(ConanFile):
                 "libmkl_avx.so",
                 "libmkl_def.so",
                 "libiomp5.so",
-                "libafopencl.so.3.7.1",
                 "libmkl_avx512.so",
                 "libmkl_intel_thread.so",
                 "libmkl_mc3.so",
-                "libafcpu.so.3.7.1",
+
             ])
-        elif self.options.backend == 'OPENCL':
+        if self.options.opencl_backend:
             self.cpp_info.libs.extend([
+                f"libafopencl.so.{ARRAYFIRE_VERSION}",
                 "libOpenCL.so.1",
             ])


### PR DESCRIPTION
[Conan](https://conan.io/) is a C++ package manager with a large ecosystem and several projects that have dependencies on CUDA/OpenCL (e.g. [OpenCV](https://github.com/conan-community/conan-opencv/blob/release/4.1.1/conanfile.py)).

This Conan configuration is minimal and only pulls from the Linux binary installer. I've tested it with other downstream projects (e.g. [flashlight](https://github.com/facebookresearch/flashlight)), and it works. The installer as it stands is backend agnostic since it installs all libraries in the binary installer (except for `debug` libraries). One could eventually add a version that builds from source (and is thus eligible for all of the configuration options that Conan provides), but the Linux installer is already quite generic/has many of these things already.

I'll also be adding the package provided by this installer to the [`conan-community` remote](https://docs.conan.io/en/latest/uploading_packages/remotes.html#conan-community) which has packages which are still experimental/being improved. We can easily push breaking changes to those at any point.

(I've added myself as author of the package config for now -- we should change that to be an appropriate author/a generic AF point of contact)