### PR TITLE
CMake support to link against static Intel MKL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ mark_as_advanced(
   SPDLOG_BUILD_TESTING
   ADDR2LINE_PROGRAM
   Backtrace_LIBRARY
+  AF_WITH_STATIC_MKL
   )
 
 #Configure forge submodule

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ option(AF_WITH_NONFREE  "Build ArrayFire nonfree algorithms"   OFF)
 option(AF_WITH_LOGGING  "Build ArrayFire with logging support" ON)
 option(AF_WITH_STACKTRACE  "Add stacktraces to the error messages." ON)
 option(AF_CACHE_KERNELS_TO_DISK "Enable caching kernels to disk" ON)
+option(AF_WITH_STATIC_MKL "Link against static Intel MKL libraries" OFF)
 
 if(WIN32)
   set(AF_STACKTRACE_TYPE "Windbg" CACHE STRING "The type of backtrace features. Windbg(simple), None")
@@ -311,7 +312,7 @@ install(FILES ${ArrayFire_BINARY_DIR}/cmake/install/ArrayFireConfig.cmake
               DESTINATION ${AF_INSTALL_CMAKE_DIR}
               COMPONENT cmake)
 
-if((USE_CPU_MKL OR USE_OPENCL_MKL) AND TARGET MKL::Shared AND AF_INSTALL_STANDALONE)
+if((USE_CPU_MKL OR USE_OPENCL_MKL) AND AF_INSTALL_STANDALONE)
   if(TARGET MKL::ThreadingLibrary)
     install(FILES
       $<TARGET_FILE:MKL::ThreadingLibrary>
@@ -319,24 +320,26 @@ if((USE_CPU_MKL OR USE_OPENCL_MKL) AND TARGET MKL::Shared AND AF_INSTALL_STANDAL
       COMPONENT mkl_dependencies)
   endif()
 
-  if(NOT WIN32)
+  if(NOT AF_WITH_STATIC_MKL AND TARGET MKL::Shared)
+    if(NOT WIN32)
+      install(FILES
+        $<TARGET_FILE:MKL::Interface>
+        DESTINATION ${AF_INSTALL_LIB_DIR}
+        COMPONENT mkl_dependencies)
+    endif()
+
     install(FILES
-      $<TARGET_FILE:MKL::Interface>
+      $<TARGET_FILE:MKL::Shared>
+      $<TARGET_FILE:MKL::ThreadLayer>
+      ${MKL_RUNTIME_KERNEL_LIBRARIES}
+
+      # This variable is used to add tbb.so.2 library because the main lib
+      # is a linker script and not a symlink so it cant be resolved using
+      # get_filename_component
+      ${AF_ADDITIONAL_MKL_LIBRARIES}
       DESTINATION ${AF_INSTALL_LIB_DIR}
       COMPONENT mkl_dependencies)
   endif()
-
-  install(FILES
-    $<TARGET_FILE:MKL::Shared>
-    $<TARGET_FILE:MKL::ThreadLayer>
-    ${MKL_RUNTIME_KERNEL_LIBRARIES}
-
-    # This variable is used to add tbb.so.2 library because the main lib
-    # is a linker script and not a symlink so it cant be resolved using
-    # get_filename_component
-    ${AF_ADDITIONAL_MKL_LIBRARIES}
-    DESTINATION ${AF_INSTALL_LIB_DIR}
-    COMPONENT mkl_dependencies)
 endif()
 
 # This file will be used to create the config file for the build directory.

--- a/src/api/unified/CMakeLists.txt
+++ b/src/api/unified/CMakeLists.txt
@@ -91,7 +91,9 @@ target_link_libraries(af
 if((USE_CPU_MKL OR USE_OPENCL_MKL) AND TARGET MKL::Shared)
   target_link_libraries(af
     PRIVATE
-      MKL::Shared)
+      $<$<BOOL:${AF_WITH_STATIC_MKL}>:MKL::Static>
+      $<$<NOT:$<BOOL:${AF_WITH_STATIC_MKL}>>:MKL::Shared>
+      )
 endif()
 
 

--- a/src/api/unified/CMakeLists.txt
+++ b/src/api/unified/CMakeLists.txt
@@ -88,12 +88,8 @@ target_link_libraries(af
 # pass the RTLD_GLOBAL flag to dlload, but that causes issues with the ArrayFire
 # libraries. To get around this we are also linking the unified backend with
 # the MKL library
-if((USE_CPU_MKL OR USE_OPENCL_MKL) AND TARGET MKL::Shared)
-  target_link_libraries(af
-    PRIVATE
-      $<$<BOOL:${AF_WITH_STATIC_MKL}>:MKL::Static>
-      $<$<NOT:$<BOOL:${AF_WITH_STATIC_MKL}>>:MKL::Shared>
-      )
+if((USE_CPU_MKL OR USE_OPENCL_MKL) AND TARGET MKL::Shared AND NOT AF_WITH_STATIC_MKL)
+  target_link_libraries(af PRIVATE MKL::Shared)
 endif()
 
 

--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -304,7 +304,8 @@ if(USE_CPU_MKL)
       cpp_api_interface
       afcommon_interface
       cpu_sort_by_key
-      MKL::Shared
+      $<$<BOOL:${AF_WITH_STATIC_MKL}>:MKL::Static>
+      $<$<NOT:$<BOOL:${AF_WITH_STATIC_MKL}>>:MKL::Shared>
       Threads::Threads
     )
 else()

--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -304,10 +304,13 @@ if(USE_CPU_MKL)
       cpp_api_interface
       afcommon_interface
       cpu_sort_by_key
-      $<$<BOOL:${AF_WITH_STATIC_MKL}>:MKL::Static>
-      $<$<NOT:$<BOOL:${AF_WITH_STATIC_MKL}>>:MKL::Shared>
       Threads::Threads
     )
+  if(AF_WITH_STATIC_MKL)
+      target_link_libraries(afcpu PRIVATE MKL::Static)
+  else()
+      target_link_libraries(afcpu PRIVATE MKL::Shared)
+  endif()
 else()
   dependency_check(FFTW_FOUND "FFTW not found")
   dependency_check(CBLAS_FOUND "CBLAS not found")

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -493,7 +493,9 @@ if(LAPACK_FOUND OR MKL_Shared_FOUND)
 
     target_link_libraries(afopencl
       PRIVATE
-        MKL::Shared)
+        $<$<BOOL:${AF_WITH_STATIC_MKL}>:MKL::Static>
+        $<$<NOT:$<BOOL:${AF_WITH_STATIC_MKL}>>:MKL::Shared>
+        )
   else()
     dependency_check(OpenCL_FOUND "OpenCL not found.")
 

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -491,11 +491,11 @@ if(LAPACK_FOUND OR MKL_Shared_FOUND)
     dependency_check(MKL_Shared_FOUND "MKL not found")
     target_compile_definitions(afopencl PRIVATE USE_MKL)
 
-    target_link_libraries(afopencl
-      PRIVATE
-        $<$<BOOL:${AF_WITH_STATIC_MKL}>:MKL::Static>
-        $<$<NOT:$<BOOL:${AF_WITH_STATIC_MKL}>>:MKL::Shared>
-        )
+    if(AF_WITH_STATIC_MKL)
+        target_link_libraries(afopencl PRIVATE MKL::Static)
+    else()
+        target_link_libraries(afopencl PRIVATE MKL::Shared)
+    endif()
   else()
     dependency_check(OpenCL_FOUND "OpenCL not found.")
 


### PR DESCRIPTION
Static linking of Intel MKL is turned off by default.

Note that this however increases binary size of CPU backend by ~200MB and
OpenCL backend by ~100MB, respectively.

Resolves #2671 