### PR TITLE
remove placeholder pooling docs

### DIFF
--- a/include/arrayfire.h
+++ b/include/arrayfire.h
@@ -364,9 +364,6 @@
 
      Machine learning functions
 
-     @defgroup ml_pool Pooling operations
-     Pool 2D, ND, maxpooling, minpooling, meanpooling
-
      @defgroup ml_convolution Convolutions
      Forward and backward convolution passes
    @}


### PR DESCRIPTION
stray ml_pool page was created in ml_group for unimplemented pooling operations