### PR TITLE
Fix mem leak caused in opencl::removeDeviceContext function

### DIFF
--- a/src/backend/opencl/compile_kernel.cpp
+++ b/src/backend/opencl/compile_kernel.cpp
@@ -131,9 +131,8 @@ Kernel compileKernel(const string &kernelName, const string &tInstance,
     auto compileBegin = high_resolution_clock::now();
     auto prog         = detail::buildProgram(sources, compileOpts);
     auto prg          = new cl::Program(prog);
-    auto krn =
-        new cl::Kernel(*static_cast<cl::Program *>(prg), kernelName.c_str());
-    auto compileEnd = high_resolution_clock::now();
+    auto krn          = new cl::Kernel(*prg, kernelName.c_str());
+    auto compileEnd   = high_resolution_clock::now();
 
     AF_TRACE("{{{:<30} : {{ compile:{:>5} ms, {{ {} }}, {} }}}}", kernelName,
              duration_cast<milliseconds>(compileEnd - compileBegin).count(),

--- a/src/backend/opencl/device_manager.hpp
+++ b/src/backend/opencl/device_manager.hpp
@@ -155,9 +155,9 @@ class DeviceManager {
     // Attributes
     std::shared_ptr<spdlog::logger> logger;
     std::mutex deviceMutex;
-    std::vector<cl::Device*> mDevices;
-    std::vector<cl::Context*> mContexts;
-    std::vector<cl::CommandQueue*> mQueues;
+    std::vector<std::unique_ptr<cl::Device>> mDevices;
+    std::vector<std::unique_ptr<cl::Context>> mContexts;
+    std::vector<std::unique_ptr<cl::CommandQueue>> mQueues;
     std::vector<bool> mIsGLSharingOn;
     std::vector<int> mDeviceTypes;
     std::vector<int> mPlatforms;


### PR DESCRIPTION
* The OpenCL Wrapper objects were being leaked by OpenCL when calling the
  removeDeviceContext function. The handles were decremented correctly but
  the objects were not released so it caused a very small leak in the
  binary.
