### PR TITLE
enqueueWriteBuffer asynchronously in vision kernels

### DIFF
--- a/src/backend/opencl/kernel/fast.hpp
+++ b/src/backend/opencl/kernel/fast.hpp
@@ -60,7 +60,7 @@ void fast(const unsigned arc_length, unsigned *out_feat, Param &x_out,
         bufferAlloc(in.info.dims[0] * in.info.dims[1] * sizeof(float));
     std::vector<float> score_init(in.info.dims[0] * in.info.dims[1], (float)0);
     getQueue().enqueueWriteBuffer(
-        *d_score, CL_TRUE, 0, in.info.dims[0] * in.info.dims[1] * sizeof(float),
+        *d_score, CL_FALSE, 0, in.info.dims[0] * in.info.dims[1] * sizeof(float),
         &score_init[0]);
 
     cl::Buffer *d_flags = d_score;
@@ -92,7 +92,7 @@ void fast(const unsigned arc_length, unsigned *out_feat, Param &x_out,
 
     unsigned count_init = 0;
     cl::Buffer *d_total = bufferAlloc(sizeof(unsigned));
-    getQueue().enqueueWriteBuffer(*d_total, CL_TRUE, 0, sizeof(unsigned),
+    getQueue().enqueueWriteBuffer(*d_total, CL_FALSE, 0, sizeof(unsigned),
                                   &count_init);
 
     // size_t *global_nonmax_dims = global_nonmax();

--- a/src/backend/opencl/kernel/fast.hpp
+++ b/src/backend/opencl/kernel/fast.hpp
@@ -60,8 +60,8 @@ void fast(const unsigned arc_length, unsigned *out_feat, Param &x_out,
         bufferAlloc(in.info.dims[0] * in.info.dims[1] * sizeof(float));
     std::vector<float> score_init(in.info.dims[0] * in.info.dims[1], (float)0);
     getQueue().enqueueWriteBuffer(
-        *d_score, CL_FALSE, 0, in.info.dims[0] * in.info.dims[1] * sizeof(float),
-        &score_init[0]);
+        *d_score, CL_FALSE, 0,
+        in.info.dims[0] * in.info.dims[1] * sizeof(float), &score_init[0]);
 
     cl::Buffer *d_flags = d_score;
     if (nonmax) {

--- a/src/backend/opencl/kernel/flood_fill.hpp
+++ b/src/backend/opencl/kernel/flood_fill.hpp
@@ -108,7 +108,7 @@ void floodFill(Param out, const Param image, const Param seedsx,
 
     while (notFinished) {
         notFinished = 0;
-        getQueue().enqueueWriteBuffer(*dContinue, CL_TRUE, 0, sizeof(int),
+        getQueue().enqueueWriteBuffer(*dContinue, CL_FALSE, 0, sizeof(int),
                                       &notFinished);
 
         floodStep(cl::EnqueueArgs(getQueue(), global, local), *out.data,

--- a/src/backend/opencl/kernel/orb.hpp
+++ b/src/backend/opencl/kernel/orb.hpp
@@ -366,8 +366,8 @@ void orb(unsigned* out_feat, Param& x_out, Param& y_out, Param& score_out,
 
         // Compute ORB descriptors
         Buffer* d_desc_lvl = bufferAlloc(usable_feat * 8 * sizeof(unsigned));
+        vector<unsigned> h_desc_lvl(usable_feat * 8, 0);
         {
-            vector<unsigned> h_desc_lvl(usable_feat * 8);
             getQueue().enqueueWriteBuffer(*d_desc_lvl, CL_FALSE, 0,
                                           usable_feat * 8 * sizeof(unsigned),
                                           h_desc_lvl.data());

--- a/src/backend/opencl/kernel/orb.hpp
+++ b/src/backend/opencl/kernel/orb.hpp
@@ -210,7 +210,7 @@ void orb(unsigned* out_feat, Param& x_out, Param& y_out, Param& score_out,
 
         unsigned usable_feat  = 0;
         Buffer* d_usable_feat = bufferAlloc(sizeof(unsigned));
-        getQueue().enqueueWriteBuffer(*d_usable_feat, CL_TRUE, 0,
+        getQueue().enqueueWriteBuffer(*d_usable_feat, CL_FALSE, 0,
                                       sizeof(unsigned), &usable_feat);
 
         Buffer* d_x_harris     = bufferAlloc(lvl_feat * sizeof(float));
@@ -368,7 +368,7 @@ void orb(unsigned* out_feat, Param& x_out, Param& y_out, Param& score_out,
         Buffer* d_desc_lvl = bufferAlloc(usable_feat * 8 * sizeof(unsigned));
         {
             vector<unsigned> h_desc_lvl(usable_feat * 8);
-            getQueue().enqueueWriteBuffer(*d_desc_lvl, CL_TRUE, 0,
+            getQueue().enqueueWriteBuffer(*d_desc_lvl, CL_FALSE, 0,
                                           usable_feat * 8 * sizeof(unsigned),
                                           h_desc_lvl.data());
         }

--- a/src/backend/opencl/kernel/regions.hpp
+++ b/src/backend/opencl/kernel/regions.hpp
@@ -108,7 +108,7 @@ void regions(Param out, Param in, const bool full_conn,
 
     while (h_continue) {
         h_continue = 0;
-        getQueue().enqueueWriteBuffer(*d_continue, CL_TRUE, 0, sizeof(int),
+        getQueue().enqueueWriteBuffer(*d_continue, CL_FALSE, 0, sizeof(int),
                                       &h_continue);
         ueOp(EnqueueArgs(getQueue(), global, local), *out.data, out.info,
              *d_continue);

--- a/src/backend/opencl/kernel/sift_nonfree.hpp
+++ b/src/backend/opencl/kernel/sift_nonfree.hpp
@@ -485,7 +485,7 @@ void sift(unsigned* out_feat, unsigned* out_dlen, Param& x_out, Param& y_out,
         Buffer* d_extrema_layer = bufferAlloc(max_feat * sizeof(unsigned));
 
         unsigned extrema_feat = 0;
-        getQueue().enqueueWriteBuffer(*d_count, CL_TRUE, 0, sizeof(unsigned),
+        getQueue().enqueueWriteBuffer(*d_count, CL_FALSE, 0, sizeof(unsigned),
                                       &extrema_feat);
 
         int dim0 = dog_pyr[o].info.dims[0];
@@ -520,7 +520,7 @@ void sift(unsigned* out_feat, unsigned* out_dlen, Param& x_out, Param& y_out,
         }
 
         unsigned interp_feat = 0;
-        getQueue().enqueueWriteBuffer(*d_count, CL_TRUE, 0, sizeof(unsigned),
+        getQueue().enqueueWriteBuffer(*d_count, CL_FALSE, 0, sizeof(unsigned),
                                       &interp_feat);
 
         Buffer* d_interp_x     = bufferAlloc(extrema_feat * sizeof(float));
@@ -596,7 +596,7 @@ void sift(unsigned* out_feat, unsigned* out_dlen, Param& x_out, Param& y_out,
         apply_permutation<float>(interp_size_begin, permutation, queue);
 
         unsigned nodup_feat = 0;
-        getQueue().enqueueWriteBuffer(*d_count, CL_TRUE, 0, sizeof(unsigned),
+        getQueue().enqueueWriteBuffer(*d_count, CL_FALSE, 0, sizeof(unsigned),
                                       &nodup_feat);
 
         Buffer* d_nodup_x        = bufferAlloc(interp_feat * sizeof(float));
@@ -628,7 +628,7 @@ void sift(unsigned* out_feat, unsigned* out_dlen, Param& x_out, Param& y_out,
         bufferFree(d_interp_size);
 
         unsigned oriented_feat = 0;
-        getQueue().enqueueWriteBuffer(*d_count, CL_TRUE, 0, sizeof(unsigned),
+        getQueue().enqueueWriteBuffer(*d_count, CL_FALSE, 0, sizeof(unsigned),
                                       &oriented_feat);
         const unsigned max_oriented_feat = nodup_feat * 3;
 

--- a/src/backend/opencl/kernel/susan.hpp
+++ b/src/backend/opencl/kernel/susan.hpp
@@ -83,7 +83,7 @@ unsigned nonMaximal(cl::Buffer* x_out, cl::Buffer* y_out, cl::Buffer* resp_out,
 
     unsigned corners_found      = 0;
     cl::Buffer* d_corners_found = bufferAlloc(sizeof(unsigned));
-    getQueue().enqueueWriteBuffer(*d_corners_found, CL_TRUE, 0,
+    getQueue().enqueueWriteBuffer(*d_corners_found, CL_FALSE, 0,
                                   sizeof(unsigned), &corners_found);
 
     cl::NDRange local(SUSAN_THREADS_X, SUSAN_THREADS_Y);


### PR DESCRIPTION
There are few locations where initializing the flags or buffers were
earlier using synchronous copy to GPU memory which is not needed since
the kernel execution in-order. Hence, changed them to be asynchronous
copies.

Fixes #2909 