### PR TITLE
Add allocV2 and freeV2 which return cl_mem on OpenCL backends

### DIFF
--- a/docs/details/device.dox
+++ b/docs/details/device.dox
@@ -84,15 +84,26 @@ have finished.
 
 This function will allocate memory on the device and return a pointer
 to it. The memory is allocated using ArrayFire's memory manager which
-has some different characteristics to standard method of memory
-allocation
+will defer releasing memory to the driver and reuse the same memory
+for later operations.
+
+This function will return different objects based on the type used. The
+interface returns a void pointer that needs to be cast to the backend
+appropriate memory type.
+
+
+| function           | CPU | CUDA | OpenCL      |
+|--------------------|-----|------|-------------|
+| af_alloc_device    | T*  | T*   | cl::Buffer* |
+| af::alloc          | T*  | T*   | cl::Buffer* |
 
 ===============================================================================
 
 \defgroup device_func_free free
 \ingroup device_mat
 
-\brief Free device memory allocated by ArrayFire's memory manager
+\brief Returns memory to ArrayFire's memory manager. The memory will
+       return to the memory pool.
 
 These calls free the device memory. These functions need to be called on
 pointers allocated using alloc function.

--- a/docs/details/device.dox
+++ b/docs/details/device.dox
@@ -77,7 +77,7 @@ have finished.
 
 ===============================================================================
 
-\defgroup device_func_alloc alloc
+\defgroup device_func_alloc allocV2
 \ingroup device_mat
 
 \brief Allocate memory using the ArrayFire memory manager
@@ -92,21 +92,36 @@ interface returns a void pointer that needs to be cast to the backend
 appropriate memory type.
 
 
-| function           | CPU | CUDA | OpenCL      |
-|--------------------|-----|------|-------------|
-| af_alloc_device    | T*  | T*   | cl::Buffer* |
-| af::alloc          | T*  | T*   | cl::Buffer* |
+| function                     | CPU | CUDA | OpenCL      |
+|------------------------------|-----|------|-------------|
+| af_alloc_device_v2           | T*  | T*   | cl_mem      |
+| af::allocV2                  | T*  | T*   | cl_mem      |
+| af_alloc_device (deprecated) | T*  | T*   | cl::Buffer* |
+| af::alloc (deprecated)       | T*  | T*   | cl::Buffer* |
+
+CPU Backend
+-----------
+\snippet test/memory.cpp ex_alloc_v2_cpu
+
+CUDA Backend
+------------
+\snippet test/cuda.cu ex_alloc_v2_cuda
+
+OpenCL Backend
+--------------
+\snippet test/ocl_ext_context.cpp ex_alloc_v2_opencl
 
 ===============================================================================
 
-\defgroup device_func_free free
+\defgroup device_func_free freeV2
 \ingroup device_mat
 
 \brief Returns memory to ArrayFire's memory manager. The memory will
        return to the memory pool.
 
-These calls free the device memory. These functions need to be called on
-pointers allocated using alloc function.
+Releases control of the memory allocated by af::allocV2 functions to ArrayFire's
+memory manager. ArrayFire may reuse the memory for subsequent operations. This
+memory should not be used by the client after this point.
 
 ===============================================================================
 

--- a/include/af/device.h
+++ b/include/af/device.h
@@ -115,7 +115,25 @@ namespace af
     ///
     /// \note The device memory returned by this function is only freed if
     ///       af::free() is called explicitly
+    /// \deprecated Use allocV2 instead. allocV2 accepts number of bytes
+    ///             instead of number of elements and returns a cl_mem object
+    ///             instead of the cl::Buffer object for the OpenCL backend.
+    ///             Otherwise the functionallity is identical to af::alloc.
+    AF_DEPRECATED("Use af::allocV2 instead")
     AFAPI void *alloc(const size_t elements, const dtype type);
+
+#if AF_API_VERSION >= 38
+    /// \brief Allocates memory using ArrayFire's memory manager
+    ///
+    /// \param[in] bytes the number of bytes to allocate
+    /// \returns Pointer to the device memory on the current device. This is a
+    ///          CUDA device pointer for the CUDA backend. A cl_mem pointer
+    ///          on the OpenCL backend and a C pointer for the CPU backend
+    ///
+    /// \note The device memory returned by this function is only freed if
+    ///       af::freeV2() is called explicitly
+    AFAPI void *allocV2(const size_t bytes);
+#endif
 
     /// \brief Allocates memory using ArrayFire's memory manager
     //
@@ -129,7 +147,13 @@ namespace af
     ///       sizeof(type)
     /// \note The device memory returned by this function is only freed if
     ///       af::free() is called explicitly
-    template <typename T> T *alloc(const size_t elements);
+    /// \deprecated Use allocV2 instead. allocV2 accepts number of bytes
+    ///             instead of number of elements and returns a cl_mem object
+    ///             instead of the cl::Buffer object for the OpenCL backend.
+    ///             Otherwise the functionallity is identical to af::alloc.
+    template <typename T>
+    AF_DEPRECATED("Use af::allocV2 instead")
+    T *alloc(const size_t elements);
     /// @}
 
     /// \ingroup device_func_free
@@ -140,7 +164,21 @@ namespace af
     ///
     /// \note This function will free a device pointer even if it has been
     ///       previously locked.
+    /// \deprecated Use af::freeV2 instead. af_alloc_device_v2 returns a
+    ///             cl_mem object instead of the cl::Buffer object for the
+    ///             OpenCL backend. Otherwise the functionallity is identical
+    AF_DEPRECATED("Use af::freeV2 instead")
     AFAPI void free(const void *ptr);
+
+#if AF_API_VERSION >= 38
+    /// \ingroup device_func_free
+    /// \copydoc device_func_free
+    /// \param[in] ptr The pointer returned by af::allocV2
+    ///
+    /// This function will free a device pointer even if it has been previously
+    /// locked.
+    AFAPI void freeV2(const void *ptr);
+#endif
 
     /// \ingroup device_func_pinned
     /// @{
@@ -330,7 +368,11 @@ extern "C" {
 
        \returns AF_SUCCESS if a pointer could be allocated. AF_ERR_NO_MEM if
                 there is no memory
+       \deprecated Use af_alloc_device_v2 instead. af_alloc_device_v2 returns a
+                   cl_mem object instead of the cl::Buffer object for the OpenCL
+                   backend. Otherwise the functionallity is identical
     */
+    AF_DEPRECATED("Use af_alloc_device_v2 instead")
     AFAPI af_err af_alloc_device(void **ptr, const dim_t bytes);
 
     /**
@@ -341,10 +383,45 @@ extern "C" {
 
        \param[in] ptr The pointer allocated by af_alloc_device to be freed
 
+       \deprecated Use af_free_device_v2 instead. The new function handles the
+                   new behavior of the af_alloc_device_v2 function.
        \ingroup device_func_free
     */
+    AF_DEPRECATED("Use af_free_device_v2 instead")
     AFAPI af_err af_free_device(void *ptr);
 
+#if AF_API_VERSION >= 38
+    /**
+       \brief Allocates memory using ArrayFire's memory manager
+
+       This device memory returned by this function can only be freed using
+       af_free_device_v2.
+
+       \param [out] ptr Pointer to the device memory on the current device. This
+                        is a CUDA device pointer for the CUDA backend. A
+                        cl::Buffer pointer on the OpenCL backend and a C pointer
+                        for the CPU backend
+       \param [in] bytes The number of bites to allocate on the device
+
+       \returns AF_SUCCESS if a pointer could be allocated. AF_ERR_NO_MEM if
+                there is no memory
+       \ingroup device_func_alloc
+    */
+    AFAPI af_err af_alloc_device_v2(void **ptr, const dim_t bytes);
+
+    /**
+       \brief Returns memory to ArrayFire's memory manager.
+
+       This function will free a device pointer even if it has been previously
+       locked.
+
+       \param[in] ptr The pointer allocated by af_alloc_device_v2 to be freed
+       \note this function will not work for pointers allocated using the
+             af_alloc_device function for all backends
+       \ingroup device_func_free
+    */
+    AFAPI af_err af_free_device_v2(void *ptr);
+#endif
     /**
        \ingroup device_func_pinned
     */

--- a/include/af/device.h
+++ b/include/af/device.h
@@ -106,40 +106,44 @@ namespace af
     /// @{
     /// \brief Allocates memory using ArrayFire's memory manager
     ///
-    /// \copydoc device_func_alloc
     /// \param[in] elements the number of elements to allocate
     /// \param[in] type is the type of the elements to allocate
-    /// \returns the pointer to the memory
+    /// \returns Pointer to the device memory on the current device. This is a
+    ///          CUDA device pointer for the CUDA backend. A cl::Buffer pointer
+    ///          from the cl2.hpp header on the OpenCL backend and a C pointer
+    ///          for the CPU backend
     ///
-    /// \note The device memory returned by this function is only freed if af::free() is called explicitly
-
+    /// \note The device memory returned by this function is only freed if
+    ///       af::free() is called explicitly
     AFAPI void *alloc(const size_t elements, const dtype type);
 
     /// \brief Allocates memory using ArrayFire's memory manager
     //
-    /// \copydoc device_func_alloc
     /// \param[in] elements the number of elements to allocate
-    /// \returns the pointer to the memory
+    /// \returns Pointer to the device memory on the current device. This is a
+    ///          CUDA device pointer for the CUDA backend. A cl::Buffer pointer
+    ///          from the cl2.hpp header on the OpenCL backend and a C pointer
+    ///          for the CPU backend
     ///
     /// \note the size of the memory allocated is the number of \p elements *
-    ///         sizeof(type)
-    ///
-    /// \note The device memory returned by this function is only freed if af::free() is called explicitly
-    template<typename T>
-    T* alloc(const size_t elements);
+    ///       sizeof(type)
+    /// \note The device memory returned by this function is only freed if
+    ///       af::free() is called explicitly
+    template <typename T> T *alloc(const size_t elements);
     /// @}
 
     /// \ingroup device_func_free
     ///
     /// \copydoc device_func_free
-    /// \param[in] ptr the memory to free
+    /// \param[in] ptr the memory allocated by the af::alloc function that
+    ///                will be freed
     ///
-    /// This function will free a device pointer even if it has been previously locked.
+    /// \note This function will free a device pointer even if it has been
+    ///       previously locked.
     AFAPI void free(const void *ptr);
 
     /// \ingroup device_func_pinned
     /// @{
-    ///
     /// \copydoc device_func_pinned
     ///
     /// \param[in] elements the number of elements to allocate
@@ -312,18 +316,32 @@ extern "C" {
     AFAPI af_err af_sync(const int device);
 
     /**
+       \brief Allocates memory using ArrayFire's memory manager
        \ingroup device_func_alloc
 
        This device memory returned by this function can only be freed using
        af_free_device
+
+       \param [out] ptr Pointer to the device memory on the current device. This
+                        is a CUDA device pointer for the CUDA backend. A
+                        cl::Buffer pointer on the OpenCL backend and a C pointer
+                        for the CPU backend
+       \param [in] bytes The number of bites to allocate on the device
+
+       \returns AF_SUCCESS if a pointer could be allocated. AF_ERR_NO_MEM if
+                there is no memory
     */
     AFAPI af_err af_alloc_device(void **ptr, const dim_t bytes);
 
     /**
-       \ingroup device_func_free
+       \brief Returns memory to ArrayFire's memory manager.
 
        This function will free a device pointer even if it has been previously
        locked.
+
+       \param[in] ptr The pointer allocated by af_alloc_device to be freed
+
+       \ingroup device_func_free
     */
     AFAPI af_err af_free_device(void *ptr);
 

--- a/include/af/memory.h
+++ b/include/af/memory.h
@@ -533,7 +533,7 @@ AFAPI af_err af_memory_manager_get_active_device_id(af_memory_manager handle,
 
    \param[in] handle the \ref af_memory_manager handle
    \param[out] ptr the pointer to the allocated buffer (for the CUDA and CPU
-   backends). For the OpenCL backend, this is a pointer to a cl::Buffer, which
+   backends). For the OpenCL backend, this is a pointer to a cl_mem, which
    can be cast accordingly
    \param[in] size the size of the pointer allocation
 

--- a/src/api/c/memory.cpp
+++ b/src/api/c/memory.cpp
@@ -147,7 +147,7 @@ inline void lockArray(const af_array arr) {
     // Ideally we need to use .get(false), i.e. get ptr without offset
     // This is however not supported in opencl
     // Use getData().get() as alternative
-    memLock(static_cast<void *>(getArray<T>(arr).getData().get()));
+    memLock(getArray<T>(arr).getData().get());
 }
 
 af_err af_lock_device_ptr(const af_array arr) { return af_lock_array(arr); }
@@ -217,7 +217,7 @@ inline void unlockArray(const af_array arr) {
     // Ideally we need to use .get(false), i.e. get ptr without offset
     // This is however not supported in opencl
     // Use getData().get() as alternative
-    memUnlock(static_cast<void *>(getArray<T>(arr).getData().get()));
+    memUnlock(getArray<T>(arr).getData().get());
 }
 
 af_err af_unlock_device_ptr(const af_array arr) { return af_unlock_array(arr); }

--- a/src/api/cpp/device.cpp
+++ b/src/api/cpp/device.cpp
@@ -102,8 +102,18 @@ void sync(int device) { AF_THROW(af_sync(device)); }
 // Alloc device memory
 void *alloc(const size_t elements, const af::dtype type) {
     void *ptr;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     AF_THROW(af_alloc_device(&ptr, elements * size_of(type)));
+#pragma GCC diagnostic pop
     // FIXME: Add to map
+    return ptr;
+}
+
+// Alloc device memory
+void *allocV2(const size_t bytes) {
+    void *ptr;
+    AF_THROW(af_alloc_device_v2(&ptr, bytes));
     return ptr;
 }
 
@@ -117,7 +127,14 @@ void *pinned(const size_t elements, const af::dtype type) {
 
 void free(const void *ptr) {
     // FIXME: look up map and call the right free
-    AF_THROW(af_free_device((void *)ptr));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    AF_THROW(af_free_device(const_cast<void *>(ptr)));
+#pragma GCC diagnostic pop
+}
+
+void freeV2(const void *ptr) {
+    AF_THROW(af_free_device_v2(const_cast<void *>(ptr)));
 }
 
 void freePinned(const void *ptr) {
@@ -155,6 +172,8 @@ size_t getMemStepSize() {
     return size_bytes;
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #define INSTANTIATE(T)                                                        \
     template<>                                                                \
     AFAPI T *alloc(const size_t elements) {                                   \
@@ -181,5 +200,6 @@ INSTANTIATE(short)
 INSTANTIATE(unsigned short)
 INSTANTIATE(long long)
 INSTANTIATE(unsigned long long)
+#pragma GCC diagnostic pop
 
 }  // namespace af

--- a/src/api/unified/device.cpp
+++ b/src/api/unified/device.cpp
@@ -74,14 +74,28 @@ af_err af_get_device(int *device) { CALL(af_get_device, device); }
 af_err af_sync(const int device) { CALL(af_sync, device); }
 
 af_err af_alloc_device(void **ptr, const dim_t bytes) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     CALL(af_alloc_device, ptr, bytes);
+#pragma GCC diagnostic pop
+}
+
+af_err af_alloc_device_v2(void **ptr, const dim_t bytes) {
+    CALL(af_alloc_device_v2, ptr, bytes);
 }
 
 af_err af_alloc_pinned(void **ptr, const dim_t bytes) {
     CALL(af_alloc_pinned, ptr, bytes);
 }
 
-af_err af_free_device(void *ptr) { CALL(af_free_device, ptr); }
+af_err af_free_device(void *ptr) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    CALL(af_free_device, ptr);
+#pragma GCC diagnostic pop
+}
+
+af_err af_free_device_v2(void *ptr) { CALL(af_free_device_v2, ptr); }
 
 af_err af_free_pinned(void *ptr) { CALL(af_free_pinned, ptr); }
 

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -378,7 +378,7 @@ template<typename T>
 void *getDevicePtr(const Array<T> &arr) {
     const cl::Buffer *buf = arr.device();
     if (!buf) { return NULL; }
-    memLock((T *)buf);
+    memLock(buf);
     cl_mem mem = (*buf)();
     return (void *)mem;
 }

--- a/src/backend/opencl/memory.hpp
+++ b/src/backend/opencl/memory.hpp
@@ -36,8 +36,8 @@ template<typename T>
 void memFree(T *ptr);
 void memFreeUser(void *ptr);
 
-void memLock(const void *ptr);
-void memUnlock(const void *ptr);
+void memLock(const cl::Buffer *ptr);
+void memUnlock(const cl::Buffer *ptr);
 bool isLocked(const void *ptr);
 
 template<typename T>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -283,8 +283,49 @@ make_test(SRC nodevice.cpp CXX11)
 if(OpenCL_FOUND)
   make_test(SRC ocl_ext_context.cpp
             LIBRARIES OpenCL::OpenCL
-            BACKENDS "opencl")
+            BACKENDS "opencl"
+            CXX11)
 endif()
+
+if(CUDA_FOUND)
+  foreach(backend ${enabled_backends})
+    set(cuda_test_backends "cuda" "unified")
+    if(${backend} IN_LIST cuda_test_backends)
+      set(target test_cuda_${backend})
+      cuda_add_executable(${target} cuda.cu  $<TARGET_OBJECTS:arrayfire_test>)
+      target_include_directories(${target} PRIVATE
+        ${ArrayFire_SOURCE_DIR}/extern/half/include
+        ${CMAKE_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR})
+      if(${backend} STREQUAL "unified")
+        target_link_libraries(${target}
+          ArrayFire::af)
+      else()
+        target_link_libraries(${target}
+          ArrayFire::af${backend})
+      endif()
+      target_link_libraries(${target}
+        mmio
+        gtest)
+
+      # Couldn't get Threads::Threads to work with this cuda binary. The import
+      # target would not add the -pthread flag which is required for this
+      # executable (on Ubuntu 18.04 anyway)
+      check_cxx_compiler_flag(-pthread pthread_flag)
+      if(pthread_flag)
+        target_link_libraries(${target} -pthread)
+      endif()
+
+      set_target_properties(${target}
+        PROPERTIES
+        FOLDER "Tests"
+        OUTPUT_NAME "cuda_${backend}")
+
+      add_test(NAME ${target} COMMAND ${target})
+    endif()
+  endforeach()
+endif()
+
 
 make_test(SRC orb.cpp)
 make_test(SRC pad_borders.cpp CXX11)

--- a/test/cuda.cu
+++ b/test/cuda.cu
@@ -1,0 +1,35 @@
+/*******************************************************
+ * Copyright (c) 2020, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <gtest/gtest.h>
+#include <testHelpers.hpp>
+#include <af/array.h>
+#include <af/device.h>
+
+TEST(Memory, AfAllocDeviceCUDA) {
+    void *ptr;
+    ASSERT_SUCCESS(af_alloc_device(&ptr, sizeof(float)));
+
+    /// Tests to see if the pointer returned can be used by cuda functions
+    float gold_val = 5;
+    float *gold    = NULL;
+    ASSERT_EQ(cudaSuccess, cudaMalloc(&gold, sizeof(float)));
+    ASSERT_EQ(cudaSuccess, cudaMemcpy(gold, &gold_val, sizeof(float),
+                                      cudaMemcpyHostToDevice));
+
+    ASSERT_EQ(cudaSuccess,
+              cudaMemcpy(ptr, gold, sizeof(float), cudaMemcpyDeviceToDevice));
+
+    float host;
+    ASSERT_EQ(cudaSuccess,
+              cudaMemcpy(&host, ptr, sizeof(float), cudaMemcpyDeviceToHost));
+    ASSERT_SUCCESS(af_free_device(ptr));
+
+    ASSERT_EQ(5, host);
+}

--- a/test/cuda.cu
+++ b/test/cuda.cu
@@ -12,6 +12,11 @@
 #include <af/array.h>
 #include <af/device.h>
 
+using af::allocV2;
+using af::freeV2;
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST(Memory, AfAllocDeviceCUDA) {
     void *ptr;
     ASSERT_SUCCESS(af_alloc_device(&ptr, sizeof(float)));
@@ -32,4 +37,43 @@ TEST(Memory, AfAllocDeviceCUDA) {
     ASSERT_SUCCESS(af_free_device(ptr));
 
     ASSERT_EQ(5, host);
+}
+#pragma GCC diagnostic pop
+
+TEST(Memory, AfAllocDeviceV2CUDA) {
+    void *ptr;
+    ASSERT_SUCCESS(af_alloc_device_v2(&ptr, sizeof(float)));
+
+    /// Tests to see if the pointer returned can be used by cuda functions
+    float gold_val = 5;
+    float *gold    = NULL;
+    ASSERT_EQ(cudaSuccess, cudaMalloc(&gold, sizeof(float)));
+    ASSERT_EQ(cudaSuccess, cudaMemcpy(gold, &gold_val, sizeof(float),
+                                      cudaMemcpyHostToDevice));
+
+    ASSERT_EQ(cudaSuccess,
+              cudaMemcpy(ptr, gold, sizeof(float), cudaMemcpyDeviceToDevice));
+
+    float host;
+    ASSERT_EQ(cudaSuccess,
+              cudaMemcpy(&host, ptr, sizeof(float), cudaMemcpyDeviceToHost));
+    ASSERT_SUCCESS(af_free_device_v2(ptr));
+
+    ASSERT_EQ(5, host);
+}
+
+TEST(Memory, SNIPPET_AllocCUDA) {
+    //! [ex_alloc_v2_cuda]
+
+    void *ptr = allocV2(sizeof(float));
+
+    float *dptr     = static_cast<float *>(ptr);
+    float host_data = 5.0f;
+
+    cudaError_t error = cudaSuccess;
+    error = cudaMemcpy(dptr, &host_data, sizeof(float), cudaMemcpyHostToDevice);
+    freeV2(ptr);
+
+    //! [ex_alloc_v2_cuda]
+    ASSERT_EQ(cudaSuccess, error);
 }

--- a/test/manual_memory_test.cpp
+++ b/test/manual_memory_test.cpp
@@ -26,7 +26,7 @@ TEST(Memory, recover) {
             vec[i] = randu(1024, 1024, 256);  // Allocating 1GB
         }
 
-        ASSERT_EQ(true, false);  // Is there a simple assert statement?
+        FAIL();
     } catch (exception &ae) {
         ASSERT_EQ(ae.err(), AF_ERR_NO_MEM);
 


### PR DESCRIPTION
The af_alloc_device functions were returning C++ objects instead of C objects. This behavior is now decremented in favor of cl_mem objects in the OpenCL backends. The behavior of the CUDA and CPU backends have not changed.

Updated documentation to clarify proper usage and behavior

Deprecated af_alloc_device af_free_device

Added several memory tests.