### PR TITLE
Fix errors found with Address Sanitizer in the OpenCL backend

### DIFF
--- a/CMakeModules/LSANSuppression.txt
+++ b/CMakeModules/LSANSuppression.txt
@@ -2,6 +2,7 @@
 leak:libnvidia-ptxjitcompile
 leak:tbb::internal::task_stream
 leak:libnvidia-opencl.so
+leak:FFTRepo::FFTRepoKey::privatizeData
 
 # Allocated by Intel's OpenMP implementation during inverse_dense_cpu
 # This is not something we can control in ArrayFire

--- a/CMakeModules/LSANSuppression.txt
+++ b/CMakeModules/LSANSuppression.txt
@@ -1,8 +1,7 @@
 # This is a known leak.
-leak:getKernel
-#leak:libOpenCL
 leak:libnvidia-ptxjitcompile
 leak:tbb::internal::task_stream
+leak:libnvidia-opencl.so
 
 # Allocated by Intel's OpenMP implementation during inverse_dense_cpu
 # This is not something we can control in ArrayFire

--- a/src/backend/common/ModuleInterface.hpp
+++ b/src/backend/common/ModuleInterface.hpp
@@ -18,6 +18,12 @@ class ModuleInterface {
     ModuleType mModuleHandle;
 
    public:
+    /// \brief Creates an uninitialized Module
+    ModuleInterface() = default;
+
+    /// \brief Creates a module given a backend specific ModuleType
+    ///
+    /// \param[in] mod The backend specific module
     ModuleInterface(ModuleType mod) : mModuleHandle(mod) {}
 
     /// \brief Set module
@@ -28,10 +34,13 @@ class ModuleInterface {
     /// \brief Get module
     ///
     /// \returns handle to backend specific module
-    inline ModuleType get() const { return mModuleHandle; }
+    inline const ModuleType& get() const { return mModuleHandle; }
 
     /// \brief Unload module
     virtual void unload() = 0;
+
+    /// \brief Returns true if the module mModuleHandle is initialized
+    virtual operator bool() const = 0;
 };
 
 }  // namespace common

--- a/src/backend/cuda/Module.hpp
+++ b/src/backend/cuda/Module.hpp
@@ -28,9 +28,12 @@ class Module : public common::ModuleInterface<CUmodule> {
     using ModuleType = CUmodule;
     using BaseClass  = common::ModuleInterface<ModuleType>;
 
+    Module() = default;
     Module(ModuleType mod) : BaseClass(mod) {
         mInstanceMangledNames.reserve(1);
     }
+
+    operator bool() const final { return get(); }
 
     void unload() final {
         CU_CHECK(cuModuleUnload(get()));

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -246,9 +246,7 @@ void evalMultiple(vector<Array<T> *> arrays) {
              info.strides()[3]},
             0};
 
-        Param res = {array->data.get(), kInfo};
-
-        outputs.push_back(res);
+        outputs.emplace_back(array->data.get(), kInfo);
         output_arrays.push_back(array);
         nodes.push_back(array->node.get());
     }

--- a/src/backend/opencl/Kernel.hpp
+++ b/src/backend/opencl/Kernel.hpp
@@ -18,24 +18,24 @@ namespace opencl {
 
 struct Enqueuer {
     template<typename... Args>
-    void operator()(void* ker, const cl::EnqueueArgs& qArgs, Args... args) {
-        auto launchOp =
-            cl::KernelFunctor<Args...>(*static_cast<const cl::Kernel*>(ker));
+    void operator()(cl::Kernel ker, const cl::EnqueueArgs& qArgs,
+                    Args... args) {
+        auto launchOp = cl::KernelFunctor<Args...>(ker);
         launchOp(qArgs, std::forward<Args>(args)...);
     }
 };
 
 class Kernel
-    : public common::KernelInterface<cl::Program*, cl::Kernel*, Enqueuer,
+    : public common::KernelInterface<const cl::Program*, cl::Kernel, Enqueuer,
                                      cl::Buffer*> {
    public:
-    using ModuleType = cl::Program*;
-    using KernelType = cl::Kernel*;
+    using ModuleType = const cl::Program*;
+    using KernelType = cl::Kernel;
     using DevPtrType = cl::Buffer*;
     using BaseClass =
         common::KernelInterface<ModuleType, KernelType, Enqueuer, DevPtrType>;
 
-    Kernel() : BaseClass(nullptr, nullptr) {}
+    Kernel() : BaseClass(nullptr, cl::Kernel{nullptr, false}) {}
     Kernel(ModuleType mod, KernelType ker) : BaseClass(mod, ker) {}
 
     // clang-format off

--- a/src/backend/opencl/Module.hpp
+++ b/src/backend/opencl/Module.hpp
@@ -16,17 +16,22 @@
 namespace opencl {
 
 /// OpenCL backend wrapper for cl::Program object
-class Module : public common::ModuleInterface<cl::Program*> {
+class Module : public common::ModuleInterface<cl::Program> {
    public:
-    using ModuleType = cl::Program*;
+    using ModuleType = cl::Program;
     using BaseClass  = common::ModuleInterface<ModuleType>;
 
+    /// \brief Create an uninitialized Module
+    Module() = default;
+
+    /// \brief Create a module given a cl::Program type
     Module(ModuleType mod) : BaseClass(mod) {}
 
-    void unload() final {
-        delete get();
-        set(nullptr);
-    }
+    /// \brief Unload module
+    operator bool() const final { return get()(); }
+
+    /// Unload the module
+    void unload() final { set(cl::Program()); }
 };
 
 }  // namespace opencl

--- a/src/backend/opencl/Param.cpp
+++ b/src/backend/opencl/Param.cpp
@@ -16,9 +16,10 @@ namespace opencl {
 Param::Param() : data(nullptr), info{{0, 0, 0, 0}, {0, 0, 0, 0}, 0} {}
 Param::Param(cl::Buffer *data_, KParam info_) : data(data_), info(info_) {}
 
-Param makeParam(cl_mem mem, int off, const int dims[4], const int strides[4]) {
+Param makeParam(cl::Buffer &mem, int off, const int dims[4],
+                const int strides[4]) {
     Param out;
-    out.data        = new cl::Buffer(mem);
+    out.data        = &mem;
     out.info.offset = off;
     for (int i = 0; i < 4; i++) {
         out.info.dims[i]    = dims[i];

--- a/src/backend/opencl/Param.hpp
+++ b/src/backend/opencl/Param.hpp
@@ -29,5 +29,6 @@ struct Param {
 };
 
 // AF_DEPRECATED("Use Array<T>")
-Param makeParam(cl_mem mem, int off, const int dims[4], const int strides[4]);
+Param makeParam(cl::Buffer& mem, int off, const int dims[4],
+                const int strides[4]);
 }  // namespace opencl

--- a/src/backend/opencl/clfft.cpp
+++ b/src/backend/opencl/clfft.cpp
@@ -169,8 +169,7 @@ SharedPlan findPlan(clfftLayout iLayout, clfftLayout oLayout, clfftDim rank,
         // thrown. This is related to
         // https://github.com/arrayfire/arrayfire/pull/1899
         CLFFT_CHECK(clfftDestroyPlan(p));
-        // NOLINTNEXTLINE(hicpp-no-malloc)
-        free(p);
+        delete p;
 #endif
     });
     // push the plan into plan cache

--- a/src/backend/opencl/index.cpp
+++ b/src/backend/opencl/index.cpp
@@ -45,6 +45,7 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
 
     cl::Buffer* bPtrs[4];
 
+    auto buf = cl::Buffer();
     std::vector<Array<uint>> idxArrs(4, createEmptyArray<uint>(dim4()));
     // look through indexs to read af_array indexs
     for (dim_t x = 0; x < 4; ++x) {
@@ -56,7 +57,7 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
             oDims[x] = idxArrs[x].elements();
         } else {
             // alloc an 1-element buffer to avoid OpenCL from failing
-            bPtrs[x] = bufferAlloc(sizeof(uint));
+            bPtrs[x] = &buf;
         }
     }
 
@@ -64,10 +65,6 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
     if (oDims.elements() == 0) { return out; }
 
     kernel::index<T>(out, in, p, bPtrs);
-
-    for (dim_t x = 0; x < 4; ++x) {
-        if (p.isSeq[x]) { bufferFree(bPtrs[x]); }
-    }
 
     return out;
 }

--- a/src/backend/opencl/kernel/ireduce.hpp
+++ b/src/backend/opencl/kernel/ireduce.hpp
@@ -183,18 +183,20 @@ void ireduceFirst(Param out, cl::Buffer *oidx, Param in, Param rlen) {
 
 template<typename T, af_op_t op>
 void ireduce(Param out, cl::Buffer *oidx, Param in, int dim, Param rlen) {
+    cl::Buffer buf;
     if (rlen.info.dims[0] * rlen.info.dims[1] * rlen.info.dims[2] *
             rlen.info.dims[3] ==
         0) {
         // empty opencl::Param() does not have nullptr by default
         // set to nullptr explicitly here for consequent kernel calls
         // through cl::Buffer's constructor
-        rlen.data = new cl::Buffer();
+        rlen.data = &buf;
     }
-    if (dim == 0)
-        return ireduceFirst<T, op>(out, oidx, in, rlen);
-    else
-        return ireduceDim<T, op>(out, oidx, in, dim, rlen);
+    if (dim == 0) {
+        ireduceFirst<T, op>(out, oidx, in, rlen);
+    } else {
+        ireduceDim<T, op>(out, oidx, in, dim, rlen);
+    }
 }
 
 #if defined(__GNUC__) || defined(__GNUG__)

--- a/src/backend/opencl/kernel/sparse_arith.hpp
+++ b/src/backend/opencl/kernel/sparse_arith.hpp
@@ -156,8 +156,8 @@ static void csrCalcOutNNZ(Param outRowIdx, unsigned &nnzC, const uint M,
     cl::NDRange local(256, 1);
     cl::NDRange global(divup(M, local[0]) * local[0], 1, 1);
 
-    nnzC            = 0;
-    cl::Buffer *out = bufferAlloc(sizeof(unsigned));
+    nnzC     = 0;
+    auto out = memAlloc<unsigned>(1);
     getQueue().enqueueWriteBuffer(*out, CL_TRUE, 0, sizeof(unsigned), &nnzC);
 
     calcNNZ(cl::EnqueueArgs(getQueue(), global, local), *out, *outRowIdx.data,

--- a/src/backend/opencl/kernel/susan.hpp
+++ b/src/backend/opencl/kernel/susan.hpp
@@ -15,6 +15,7 @@
 #include <debug_opencl.hpp>
 #include <kernel/config.hpp>
 #include <kernel_headers/susan.hpp>
+#include <memory.hpp>
 #include <traits.hpp>
 #include <af/defines.h>
 
@@ -81,8 +82,8 @@ unsigned nonMaximal(cl::Buffer* x_out, cl::Buffer* y_out, cl::Buffer* resp_out,
     auto nonMax =
         common::getKernel("non_maximal", {susanSrc()}, targs, compileOpts);
 
-    unsigned corners_found      = 0;
-    cl::Buffer* d_corners_found = bufferAlloc(sizeof(unsigned));
+    unsigned corners_found = 0;
+    auto d_corners_found   = memAlloc<unsigned>(1);
     getQueue().enqueueWriteBuffer(*d_corners_found, CL_FALSE, 0,
                                   sizeof(unsigned), &corners_found);
 
@@ -95,7 +96,6 @@ unsigned nonMaximal(cl::Buffer* x_out, cl::Buffer* y_out, cl::Buffer* resp_out,
            max_corners);
     getQueue().enqueueReadBuffer(*d_corners_found, CL_TRUE, 0, sizeof(unsigned),
                                  &corners_found);
-    bufferFree(d_corners_found);
     return corners_found;
 }
 }  // namespace kernel

--- a/src/backend/opencl/magma/transpose.cpp
+++ b/src/backend/opencl/magma/transpose.cpp
@@ -54,6 +54,11 @@
 #include "kernel/transpose.hpp"
 #include "magma_data.h"
 
+using cl::Buffer;
+using cl::CommandQueue;
+using opencl::makeParam;
+using opencl::kernel::transpose;
+
 template<typename T>
 void magmablas_transpose(magma_int_t m, magma_int_t n, cl_mem dA,
                          size_t dA_offset, magma_int_t ldda, cl_mem dAT,
@@ -83,12 +88,13 @@ void magmablas_transpose(magma_int_t m, magma_int_t n, cl_mem dA,
     int istrides[] = {1, ldda, ldda * n, ldda * n};
     int ostrides[] = {1, lddat, lddat * m, lddat * m};
 
-    using namespace opencl;
+    Buffer dATBuf(dAT, true);
+    Buffer dABuf(dA, true);
 
-    cl::CommandQueue q(queue, true);
-    kernel::transpose<T>(makeParam(dAT, dAT_offset, odims, ostrides),
-                         makeParam(dA, dA_offset, idims, istrides), q, false,
-                         m % 32 == 0 && n % 32 == 0);
+    CommandQueue q(queue, true);
+    transpose<T>(makeParam(dATBuf, dAT_offset, odims, ostrides),
+                 makeParam(dABuf, dA_offset, idims, istrides), q, false,
+                 m % 32 == 0 && n % 32 == 0);
 }
 
 #define INSTANTIATE(T)                                                      \

--- a/src/backend/opencl/magma/transpose_inplace.cpp
+++ b/src/backend/opencl/magma/transpose_inplace.cpp
@@ -54,6 +54,11 @@
 #include "kernel/transpose_inplace.hpp"
 #include "magma_data.h"
 
+using cl::Buffer;
+using cl::CommandQueue;
+using opencl::makeParam;
+using opencl::kernel::transpose_inplace;
+
 template<typename T>
 void magmablas_transpose_inplace(magma_int_t n, cl_mem dA, size_t dA_offset,
                                  magma_int_t ldda, magma_queue_t queue) {
@@ -74,11 +79,11 @@ void magmablas_transpose_inplace(magma_int_t n, cl_mem dA, size_t dA_offset,
     int dims[]    = {n, n, 1, 1};
     int strides[] = {1, ldda, ldda * n, ldda * n};
 
-    using namespace opencl;
+    Buffer dABuf(dA, true);
 
-    cl::CommandQueue q(queue, true);
-    kernel::transpose_inplace<T>(makeParam(dA, dA_offset, dims, strides), q,
-                                 false, n % 32 == 0);
+    CommandQueue q(queue, true);
+    transpose_inplace<T>(makeParam(dABuf, dA_offset, dims, strides), q, false,
+                         n % 32 == 0);
 }
 
 #define INSTANTIATE(T)                                                \

--- a/test/meanvar.cpp
+++ b/test/meanvar.cpp
@@ -26,6 +26,7 @@ using std::move;
 using std::string;
 using std::vector;
 
+af_err init_err = af_init();
 template<typename T>
 struct elseType {
     typedef typename cond_type<is_same_type<T, uintl>::value ||
@@ -91,7 +92,7 @@ struct meanvar_test {
 
     ~meanvar_test() {
 #ifndef _WIN32
-        af_release_array(in_);
+        if (in_) af_release_array(in_);
         if (weights_) {
             af_release_array(weights_);
             weights_ = 0;


### PR DESCRIPTION
* Refactor Module and fix a leak of the cl::Kernel objects. These objects should be around for a while so the accumulated leak wasn't significant in most applications.
* Fix leak in makeParam. This function was leaking the cl::Buffer object but not the cl_mem object so we were only leaking 8 bytes in the transpose function in a couple of operations in the magma code
* Changed the free to delete because the object was allocated using a new call
* Fixed a minor leak of the cl::Buffer object in susan, sparseArith, ireduce, and indexing. These were small leaks of only a few bytes.
* Updated the LSAN Suppressions file to suppress intentional leaks in the clFFT library and internal buffers in libnvidia-opencl