### PR TITLE
Fix errors and warnings with CUDA 9.0 builds

### DIFF
--- a/src/api/cpp/common.hpp
+++ b/src/api/cpp/common.hpp
@@ -15,6 +15,10 @@
 #include "half.hpp"
 #pragma GCC diagnostic pop
 
+#ifdef AF_CUDA
+#include <cuda_fp16.h>
+#endif
+
 #include <cstring>
 
 namespace af {
@@ -36,9 +40,19 @@ static inline dim_t getFNSD(const int dim, af::dim4 dims) {
 namespace {
 // casts from one type to another. Needed for af_half conversions specialization
 template<typename To, typename T>
-To cast(T in) {
+inline To cast(T in) {
     return static_cast<To>(in);
 }
+
+#if defined(AF_CUDA) && CUDA_VERSION < 10000
+template<>
+inline __half cast<__half, double>(double in) {
+    __half_raw out;
+    half_float::half h(in);
+    memcpy(&out, &h, sizeof(__half_raw));
+    return out;
+}
+#endif
 
 template<>
 [[gnu::unused]] af_half cast<af_half, double>(double in) {

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -7,7 +7,7 @@
 
 dependency_check(CUDA_FOUND "CUDA not found.")
 if(AF_WITH_CUDNN)
-  dependency_check(cuDNN_FOUND "CUDA not found.")
+  dependency_check(cuDNN_FOUND "CUDNN not found.")
 endif()
 
 include(AFcuda_helpers)
@@ -34,7 +34,7 @@ endif()
 
 # Find if CUDA Toolkit is at least 10.0 to use static
 # lapack library. Otherwise, we have to use regular shared library
-if(UNIX AND CUDA_VERSION_MAJOR VERSION_GREATER 10 OR CUDA_VERSION_MAJOR VERSION_EQUAL 10)
+if(UNIX AND (CUDA_VERSION_MAJOR VERSION_GREATER 10 OR CUDA_VERSION_MAJOR VERSION_EQUAL 10))
   set(use_static_cuda_lapack ON)
 else()
   set(use_static_cuda_lapack OFF)
@@ -52,7 +52,6 @@ if(UNIX)
   # FIXME When NVCC resolves this particular issue.
   # NVCC doesn't like -l<full_path_static_lib>, hence we cannot
   # use ${CMAKE_*_LIBRARY} variables in the following flags.
-  set(af_cuda_static_flags "-rdc=true;-dlink")
   set(af_cuda_static_flags "${af_cuda_static_flags};-lculibos")
   set(af_cuda_static_flags "${af_cuda_static_flags};-lcublas_static")
   set(af_cuda_static_flags "${af_cuda_static_flags};-lcublasLt_static")
@@ -71,7 +70,7 @@ if(UNIX)
 
     set(af_cuda_static_flags "${af_cuda_static_flags};-lcusolver_static")
   else()
-    set(cusolver_lib "${CUDA_cusolver_LIBRARY}")
+    set(cusolver_lib "${CUDA_cusolver_LIBRARY}" OpenMP::OpenMP_CXX)
   endif()
 endif()
 
@@ -88,12 +87,6 @@ cuda_select_nvcc_arch_flags(cuda_architecture_flags ${CUDA_architecture_build_ta
 message(STATUS "CUDA_architecture_build_targets: ${CUDA_architecture_build_targets}")
 
 set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};${cuda_architecture_flags})
-
-if(${CUDA_SEPARABLE_COMPILATION})
-  # Enable relocatable device code generation for separable
-  # compilation which is in turn required for any device linking done.
-  set(CUDA_NVCC_FLAGS ${CUDA_NVCC_FLAGS};-rdc=true)
-endif()
 
 mark_as_advanced(
     CUDA_LIBRARIES_PATH
@@ -301,13 +294,19 @@ if(UNIX)
       -Wl,--start-group
       ${CUDA_culibos_LIBRARY} #also a static libary
       ${CUDA_cublas_static_LIBRARY}
-      ${CUDA_cublasLt_static_LIBRARY}
       ${CUDA_cufft_static_LIBRARY}
-      ${CUDA_lapack_static_LIBRARY}
       ${CUDA_cusparse_static_LIBRARY}
       ${cusolver_static_lib}
       -Wl,--end-group
   )
+
+  if(CUDA_VERSION VERSION_GREATER 9.5)
+    target_link_libraries(af_cuda_static_cuda_library
+      PRIVATE
+        ${CUDA_cublasLt_static_LIBRARY}
+        ${CUDA_lapack_static_LIBRARY})
+  endif()
+
   set(CUDA_SEPARABLE_COMPILATION ${pior_val_CUDA_SEPARABLE_COMPILATION})
 else()
   target_link_libraries(af_cuda_static_cuda_library

--- a/src/backend/cuda/ThrustArrayFirePolicy.hpp
+++ b/src/backend/cuda/ThrustArrayFirePolicy.hpp
@@ -34,8 +34,8 @@ get_temporary_buffer(ThrustArrayFirePolicy, std::ptrdiff_t n) {
 }
 
 template<typename Pointer>
-void return_temporary_buffer(ThrustArrayFirePolicy, Pointer p) {
-    memFree(p.get());
+inline void return_temporary_buffer(ThrustArrayFirePolicy, Pointer p) {
+    memFree(thrust::raw_pointer_cast(p));
 }
 
 }  // namespace cuda

--- a/src/backend/cuda/cusolverDn.hpp
+++ b/src/backend/cuda/cusolverDn.hpp
@@ -14,16 +14,16 @@ namespace cuda {
 
 const char* errorString(cusolverStatus_t err);
 
-#define CUSOLVER_CHECK(fn)                                                  \
-    do {                                                                    \
-        cusolverStatus_t _error = fn;                                       \
-        if (_error != CUSOLVER_STATUS_SUCCESS) {                            \
-            char _err_msg[1024];                                            \
-            snprintf(_err_msg, sizeof(_err_msg), "CUBLAS Error (%d): %s\n", \
-                     (int)(_error), cuda::errorString(_error));             \
-                                                                            \
-            AF_ERROR(_err_msg, AF_ERR_INTERNAL);                            \
-        }                                                                   \
+#define CUSOLVER_CHECK(fn)                                                    \
+    do {                                                                      \
+        cusolverStatus_t _error = fn;                                         \
+        if (_error != CUSOLVER_STATUS_SUCCESS) {                              \
+            char _err_msg[1024];                                              \
+            snprintf(_err_msg, sizeof(_err_msg), "CUSOLVER Error (%d): %s\n", \
+                     (int)(_error), cuda::errorString(_error));               \
+                                                                              \
+            AF_ERROR(_err_msg, AF_ERR_INTERNAL);                              \
+        }                                                                     \
     } while (0)
 
 }  // namespace cuda

--- a/src/backend/cuda/jit/kernel_generators.hpp
+++ b/src/backend/cuda/jit/kernel_generators.hpp
@@ -71,8 +71,9 @@ void generateBufferRead(std::stringstream& kerStream, int id,
               << "];\n";
 }
 
-void generateShiftNodeOffsets(std::stringstream& kerStream, int id,
-                              bool is_linear, const std::string& type_str) {
+inline void generateShiftNodeOffsets(std::stringstream& kerStream, int id,
+                                     bool is_linear,
+                                     const std::string& type_str) {
     UNUSED(is_linear);
     std::string idx_str   = std::string("idx") + std::to_string(id);
     std::string info_str  = std::string("in") + std::to_string(id);
@@ -99,8 +100,8 @@ void generateShiftNodeOffsets(std::stringstream& kerStream, int id,
     kerStream << type_str << " *in" << id << "_ptr = in" << id << ".ptr;\n";
 }
 
-void generateShiftNodeRead(std::stringstream& kerStream, int id,
-                           const std::string& type_str) {
+inline void generateShiftNodeRead(std::stringstream& kerStream, int id,
+                                  const std::string& type_str) {
     kerStream << type_str << " val" << id << " = in" << id << "_ptr[idx" << id
               << "];\n";
 }

--- a/src/backend/cuda/kernel/mean.hpp
+++ b/src/backend/cuda/kernel/mean.hpp
@@ -26,7 +26,7 @@
 
 namespace cuda {
 
-__host__ __device__ auto operator*(float lhs, __half rhs) -> __half {
+__device__ auto operator*(float lhs, __half rhs) -> __half {
     return __float2half(lhs * __half2float(rhs));
 }
 

--- a/src/backend/cuda/memory.cpp
+++ b/src/backend/cuda/memory.cpp
@@ -131,6 +131,8 @@ INSTANTIATE(short)
 INSTANTIATE(ushort)
 INSTANTIATE(half)
 
+template void memFree(void *ptr);
+
 Allocator::Allocator() { logger = common::loggerFactory("mem"); }
 
 void Allocator::shutdown() {

--- a/src/backend/cuda/types.hpp
+++ b/src/backend/cuda/types.hpp
@@ -47,69 +47,69 @@ using data_t = typename common::kernel_type<T>::data;
 #ifndef __CUDACC_RTC__
 namespace {
 template<typename T>
-const char *shortname(bool caps = false) {
+inline const char *shortname(bool caps = false) {
     return caps ? "Q" : "q";
 }
 template<>
-const char *shortname<float>(bool caps) {
+inline const char *shortname<float>(bool caps) {
     return caps ? "S" : "s";
 }
 template<>
-const char *shortname<double>(bool caps) {
+inline const char *shortname<double>(bool caps) {
     return caps ? "D" : "d";
 }
 template<>
-const char *shortname<cfloat>(bool caps) {
+inline const char *shortname<cfloat>(bool caps) {
     return caps ? "C" : "c";
 }
 template<>
-const char *shortname<cdouble>(bool caps) {
+inline const char *shortname<cdouble>(bool caps) {
     return caps ? "Z" : "z";
 }
 template<>
-const char *shortname<int>(bool caps) {
+inline const char *shortname<int>(bool caps) {
     return caps ? "I" : "i";
 }
 template<>
-const char *shortname<uint>(bool caps) {
+inline const char *shortname<uint>(bool caps) {
     return caps ? "U" : "u";
 }
 template<>
-const char *shortname<char>(bool caps) {
+inline const char *shortname<char>(bool caps) {
     return caps ? "J" : "j";
 }
 template<>
-const char *shortname<uchar>(bool caps) {
+inline const char *shortname<uchar>(bool caps) {
     return caps ? "V" : "v";
 }
 template<>
-const char *shortname<intl>(bool caps) {
+inline const char *shortname<intl>(bool caps) {
     return caps ? "X" : "x";
 }
 template<>
-const char *shortname<uintl>(bool caps) {
+inline const char *shortname<uintl>(bool caps) {
     return caps ? "Y" : "y";
 }
 template<>
-const char *shortname<short>(bool caps) {
+inline const char *shortname<short>(bool caps) {
     return caps ? "P" : "p";
 }
 template<>
-const char *shortname<ushort>(bool caps) {
+inline const char *shortname<ushort>(bool caps) {
     return caps ? "Q" : "q";
 }
 template<>
-const char *shortname<common::half>(bool caps) {
+inline const char *shortname<common::half>(bool caps) {
     return caps ? "H" : "h";
 }
 
 template<typename T>
-const char *getFullName();
+inline const char *getFullName();
 
-#define SPECIALIZE(T)              \
-    template<>                     \
-    const char *getFullName<T>() { \
-        return #T;                 \
+#define SPECIALIZE(T)                     \
+    template<>                            \
+    inline const char *getFullName<T>() { \
+        return #T;                        \
     }
 
 SPECIALIZE(float)
@@ -126,7 +126,7 @@ SPECIALIZE(unsigned long long)
 SPECIALIZE(long long)
 
 template<>
-const char *getFullName<common::half>() {
+inline const char *getFullName<common::half>() {
     return "half";
 }
 #undef SPECIALIZE


### PR DESCRIPTION
* The rdc and dlink flags are not required because they are added
  by CMake for separable compilation and static linking respectively
* Add guards around libs that are not included in the CUDA 9.0
  Toolkit
* Only link with OpenMP when linking with cuSOLVER dynamically
* Fix error message when CUDNN is not found
* Address casts from double to __half which are missing in 9.0
* Thrust return_temporary_buffer function can accept void* pointers
  in older versions of Thrust. Use raw_pointer_cast to pass the
  pointer to memFree
* cublasGemmEx doesn't exist in CUDA 9.0. Add ifdefs to guard
  against older builds
* __float2half is not a host function so it needs to be removed
  from mean
* Add template instantiation for memFree to accept void* pointers
* CUSOLVER_CHECK error message printed "CUBLAS Error" instead of
CUSOLVER Error