### PR TITLE
Fix ccache launch scripts to use sh compatible syntax

### DIFF
--- a/CMakeModules/launch-c.in
+++ b/CMakeModules/launch-c.in
@@ -2,7 +2,7 @@
 
 # Xcode generator doesn't include the compiler as the
 # first argument, Ninja and Makefiles do. Handle both cases.
-if [[ "$1" = "${CMAKE_C_COMPILER}" ]] ; then
+if [ "$1" = "${CMAKE_C_COMPILER}" ] ; then
     shift
 fi
 

--- a/CMakeModules/launch-cxx.in
+++ b/CMakeModules/launch-cxx.in
@@ -2,7 +2,7 @@
 
 # Xcode generator doesn't include the compiler as the
 # first argument, Ninja and Makefiles do. Handle both cases.
-if [[ "$1" = "${CMAKE_CXX_COMPILER}" ]] ; then
+if [ "$1" = "${CMAKE_CXX_COMPILER}" ] ; then
     shift
 fi
 


### PR DESCRIPTION
Earlier to this change, I added bash based syntax which won't work
with /bin/sh or dash shells.

/usr/sh is available on most systems that use init.d scripts. So, it is
safe to assume it's availability on majority of linux distributions.