### PR TITLE
adds missing WITH_CUDNN guard for cudnn.hpp

### DIFF
--- a/src/backend/cuda/convolveNN.cpp
+++ b/src/backend/cuda/convolveNN.cpp
@@ -15,7 +15,9 @@
 #include <common/half.hpp>
 #include <common/indexing_helpers.hpp>
 #include <common/unique_handle.hpp>
+#ifdef WITH_CUDNN
 #include <cudnn.hpp>
+#endif
 #include <err_cuda.hpp>
 #include <kernel/convolve.hpp>
 #include <platform.hpp>


### PR DESCRIPTION
Wraps cudnn.hpp header with an #ifdef that checks if the build is built with cudnn.
This is a bug fix that would cause compilation issues when trying to build without cudnn.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass