### PR TITLE
Workaround for bug in Apple's OpenCL, a missing definition

### DIFF
--- a/src/backend/opencl/device_manager.cpp
+++ b/src/backend/opencl/device_manager.cpp
@@ -181,14 +181,20 @@ DeviceManager::DeviceManager()
     try {
         Platform::get(&platforms);
     } catch (const cl::Error& err) {
+#if !defined(OS_MAC)
+        // CL_PLATFORM_NOT_FOUND_KHR is not defined in Apple's OpenCL
+        // implementation. Thus, it requires this ugly check.
         if (err.err() == CL_PLATFORM_NOT_FOUND_KHR) {
+#endif
             AF_ERROR(
                 "No OpenCL platforms found on this system. Ensure you have "
                 "installed the device driver as well as the OpenCL runtime and "
                 "ICD from your device vendor. You can use the clinfo utility "
                 "to debug OpenCL installation issues.",
                 AF_ERR_RUNTIME);
+#if !defined(OS_MAC)
         }
+#endif
     }
     fgMngr = std::make_unique<graphics::ForgeManager>();
 


### PR DESCRIPTION
Description
-----------
`CL_PLATFORM_NOT_FOUND_KHR` definition is missing in Apple's OpenCL implementation. This change is a work around for that bug in OSX OpenCL.

Changes to Users
----------------
None

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
- [ ] ~Functions added to unified API~
- [ ] ~Functions documented~
