### PR TITLE
Cautionary notes about default random engine handle management

### DIFF
--- a/docs/details/random.dox
+++ b/docs/details/random.dox
@@ -67,6 +67,9 @@ an \ref af::randomEngine object as an argument.
 
 Returns the \ref af::randomEngine that is currently set as default.
 
+Note that there is no need to call \ref af_release_random_engine on the handle
+returned by \ref af_get_default_random_engine.
+
 \ingroup random_mat
 
 ===============================================================================


### PR DESCRIPTION
Description
-----------
Adds some cautionary notes on how to manage the handle returned by `af_get_default_random_engine`.
Fixes: #2940

Changes to Users
----------------
Documentation of [Default Random Engine Functions](http://arrayfire.org/docs/group__random__func__get__default__engine.htm) is changed.

Checklist
---------
- [x] ~Rebased on latest master~
- [x] ~Code compiles~
- [x] ~Tests pass~
- [x] ~Functions added to unified API~
- [x] ~Functions documented~
