### PR TITLE
Backport 37 compilefixes

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -1,6 +1,96 @@
 Release Notes {#releasenotes}
 ==============
 
+v3.8.0
+======
+
+Major Updates
+-------------
+- Ragged max
+- Bitwise not
+- Updated alloc and free
+- Initializer list for af::array
+
+Improvements
+------------
+
+v3.7.2
+======
+
+Improvements
+------------
+- Cache CUDA kernels to disk to improve load times(Thanks to \@cschreib-ibex) /PR{2848}
+- Staticly link against cuda libraries /PR{2785}
+- Make cuDNN an optional build dependency /PR{2836}
+- Improve support for different compilers and OS /PR{2876} /PR{2945} /PR{2925} /PR{2942} /PR{2943} /PR{2945}
+- Improve performance of join and transpose on CPU /PR{2849}
+- Improve documentation /PR{2816} /PR{2821} /PR{2846} /PR{2918} /PR{2928} /PR{2947}
+- Reduce binary size using NVRTC and template reducing instantiations /PR{2849} /PR{2861} /PR{2890}
+- Improve reduceByKey performance on OpenCL by using builtin functions /PR{2851}
+- Improve support for Intel OpenCL GPUs /PR{2855}
+- Allow staticly linking against MKL /PR{2877} (Sponsered by SDL)
+- Better support for older CUDA toolkits /PR{2923}
+- Add support for CUDA 11 /PR{2939}
+- Add support for ccache for faster builds /PR{2931}
+- Add support for the conan package manager on linux /PR{2875}
+
+Fixes
+-----
+- Bug crash when allocating large arrays /PR{2827}
+- Fix various compiler warnings /PR{2827} /PR{2849} /PR{2872} /PR{2876}
+- Fix minor leaks in OpenCL functions /PR{2913}
+- Various continuous integration related fixes /PR{2819}
+- Fix zero padding with convolv2NN /PR{2820}
+- Fix af_get_memory_pressure_threshold return value /PR{2831}
+- Increased the max filter length for morph
+- Handle empty array inputs for LU, QR, and Rank functions /PR{2838}
+- Fix FindMKL.cmake script for sequential threading library /PR{2840}
+- Various internal refactoring /PR{2839} /PR{2861} /PR{2864} /PR{2873} /PR{2890} /PR{2891} /PR{2913}
+- Fix OpenCL 2.0 builtin function name conflict /PR{2851}
+- Fix error caused when releasing memory with multiple devices /PR{2867}
+
+Contributions
+-------------
+Special thanks to our contributors:
+[Corentin Schreiber](https://github.com/cschreib-ibex)
+[Jacob Khan](https://github.com/jacobkahn)
+[Paul Jurczak](https://github.com/pauljurczak)
+
+v3.7.1
+======
+
+Improvements
+------------
+
+- Improve mtx download for test data \PR{2742}
+- Documentation improvements \PR{2754} \PR{2792} \PR{2797}
+- Remove verbose messages in older CMake versions \PR{2773}
+- Reduce binary size with the use of nvrtc  \PR{2790}
+- Use texture memory to load LUT in orb and fast \PR{2791}
+- Add missing print function for f16 \PR{2784}
+- Add checks for f16 support in the CUDA backend \PR{2784}
+- Create a thrust policy to intercept tmp buffer allocations \PR{2806}
+
+Fixes
+-----
+
+- Fix segfault on exit when ArrayFire is not initialized in the main thread
+- Fix support for CMake 3.5.1 \PR{2771} \PR{2772} \PR{2760}
+- Fix evalMultiple if the input array sizes aren't the same \PR{2766}
+- Fix error when AF_BACKEND_DEFAULT is passed directly to backend \PR{2769}
+- Workaround name collision with AMD OpenCL implementation \PR{2802}
+- Fix on-exit errors with the unified backend \PR{2769}
+- Fix check for f16 compatibility in OpenCL \PR{2773}
+- Fix matmul on Intel OpenCL when passing same array as input \PR{2774}
+- Fix CPU OpenCL blas batching \PR{2774}
+- Fix memory pressure in the default memory manager \PR{2801}
+
+Contributions
+-------------
+Special thanks to our contributors:
+[padentomasello](https://github.com/padentomasello)
+[glavaux2](https://github.com/glavaux2)
+
 v3.7.0
 ======
 
@@ -205,7 +295,7 @@ Misc
 Contributions
 -------------
 Special thanks to our contributors: [Jacob Kahn](https://github.com/jacobkahn),
-[Vardan Akopian](https://github.com/vakopian)  
+[Vardan Akopian](https://github.com/vakopian)
 
 v3.6.1
 ======

--- a/src/backend/common/half.hpp
+++ b/src/backend/common/half.hpp
@@ -832,7 +832,10 @@ class alignas(2) half {
 #endif
 
    public:
-    AF_CONSTEXPR half() = default;
+#if CUDA_VERSION >= 10000
+    AF_CONSTEXPR
+#endif
+    half() = default;
 
     /// Constructor.
     /// \param bits binary representation to set half to

--- a/src/backend/common/jit/NaryNode.hpp
+++ b/src/backend/common/jit/NaryNode.hpp
@@ -26,7 +26,7 @@ class NaryNode : public Node {
    private:
     int m_num_children;
     int m_op;
-    std::string m_op_str;
+    const char *m_op_str;
 
    public:
     NaryNode(const af::dtype type, const char *op_str, const int num_children,
@@ -46,7 +46,7 @@ class NaryNode : public Node {
                       "NaryNode is not move constructible");
     }
 
-    NaryNode(NaryNode &&other) = default;
+    NaryNode(NaryNode &&other) noexcept = default;
 
     NaryNode(const NaryNode &other) = default;
 

--- a/src/backend/common/jit/Node.hpp
+++ b/src/backend/common/jit/Node.hpp
@@ -106,11 +106,17 @@ class Node {
                       "Node is not move assignable");
     }
 
+    /// Default move constructor operator
+    Node(Node &&node) noexcept = default;
+
     /// Default copy constructor operator
     Node(const Node &node) = default;
 
     /// Default copy assignment operator
     Node &operator=(const Node &node) = default;
+
+    /// Default move assignment operator
+    Node &operator=(Node &&node) noexcept = default;
 
     int getNodesMap(Node_map_t &node_map, std::vector<Node *> &full_nodes,
                     std::vector<Node_ids> &full_ids);

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -54,7 +54,10 @@ if(UNIX)
   # use ${CMAKE_*_LIBRARY} variables in the following flags.
   set(af_cuda_static_flags "${af_cuda_static_flags};-lculibos")
   set(af_cuda_static_flags "${af_cuda_static_flags};-lcublas_static")
-  set(af_cuda_static_flags "${af_cuda_static_flags};-lcublasLt_static")
+
+  if(CUDA_VERSION VERSION_GREATER 10.0)
+    set(af_cuda_static_flags "${af_cuda_static_flags};-lcublasLt_static")
+  endif()
   set(af_cuda_static_flags "${af_cuda_static_flags};-lcufft_static")
   set(af_cuda_static_flags "${af_cuda_static_flags};-lcusparse_static")
 
@@ -323,10 +326,14 @@ if(UNIX)
       ${END_GROUP}
   )
 
+  if(CUDA_VERSION VERSION_GREATER 10.0)
+    target_link_libraries(af_cuda_static_cuda_library
+      PRIVATE
+        ${CUDA_cublasLt_static_LIBRARY})
+  endif()
   if(CUDA_VERSION VERSION_GREATER 9.5)
     target_link_libraries(af_cuda_static_cuda_library
       PRIVATE
-        ${CUDA_cublasLt_static_LIBRARY}
         ${CUDA_lapack_static_LIBRARY})
   endif()
 
@@ -798,7 +805,9 @@ if(AF_INSTALL_STANDALONE)
   if(WIN32)
     afcu_collect_libs(cufft)
     afcu_collect_libs(cublas)
-    afcu_collect_libs(cublasLt)
+    if(CUDA_VERSION VERSION_GREATER 10.0)
+      afcu_collect_libs(cublasLt)
+    endif()
     afcu_collect_libs(cusolver)
     afcu_collect_libs(cusparse)
   elseif(NOT ${use_static_cuda_lapack})

--- a/src/backend/cuda/kernel/random_engine.hpp
+++ b/src/backend/cuda/kernel/random_engine.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <common/dispatch.hpp>
+#include <common/half.hpp>
 #include <debug_cuda.hpp>
 #include <err_cuda.hpp>
 #include <kernel/random_engine_mersenne.hpp>
@@ -597,7 +598,7 @@ __device__ static void partialWriteOut128Bytes(common::half *out,
 __device__ static void partialBoxMullerWriteOut128Bytes(
     common::half *out, const uint &index, const uint &r1, const uint &r2,
     const uint &r3, const uint &r4, const uint &elements) {
-    common::half n[8];
+    __half n[8];
     boxMullerTransform(n + 0, n + 1, getHalf(r1), getHalf(r1 >> 16));
     boxMullerTransform(n + 2, n + 3, getHalf(r2), getHalf(r2 >> 16));
     boxMullerTransform(n + 4, n + 5, getHalf(r3), getHalf(r3 >> 16));

--- a/src/backend/cuda/kernel/reduce_by_key.hpp
+++ b/src/backend/cuda/kernel/reduce_by_key.hpp
@@ -106,9 +106,6 @@ __global__ void compact(int *reduced_block_sizes, Param<Tk> keys_out,
     const int bidz = blockIdx.z % nBlocksZ;
     const int bidw = blockIdx.z / nBlocksZ;
 
-    Tk k;
-    To v;
-
     // reduced_block_sizes should have inclusive sum of block sizes
     int nwrite = (blockIdx.x == 0) ? reduced_block_sizes[0]
                                    : reduced_block_sizes[blockIdx.x] -
@@ -117,8 +114,8 @@ __global__ void compact(int *reduced_block_sizes, Param<Tk> keys_out,
 
     const int bOffset = bidw * vals_in.strides[3] + bidz * vals_in.strides[2] +
                         bidy * vals_in.strides[1];
-    k = keys_in.ptr[tidx];
-    v = vals_in.ptr[bOffset + tidx];
+    Tk k = keys_in.ptr[tidx];
+    To v = vals_in.ptr[bOffset + tidx];
 
     if (threadIdx.x < nwrite) {
         keys_out.ptr[writeloc + threadIdx.x]           = k;
@@ -147,9 +144,6 @@ __global__ void compact_dim(int *reduced_block_sizes, Param<Tk> keys_out,
     const int bidz = blockIdx.z % nBlocksZ;
     const int bidw = blockIdx.z / nBlocksZ;
 
-    Tk k;
-    To v;
-
     // reduced_block_sizes should have inclusive sum of block sizes
     int nwrite = (blockIdx.x == 0) ? reduced_block_sizes[0]
                                    : reduced_block_sizes[blockIdx.x] -
@@ -160,8 +154,8 @@ __global__ void compact_dim(int *reduced_block_sizes, Param<Tk> keys_out,
                     bidz * vals_in.strides[dim_ordering[2]] +
                     bidy * vals_in.strides[dim_ordering[1]] +
                     tidx * vals_in.strides[dim];
-    k = keys_in.ptr[tidx];
-    v = vals_in.ptr[tid];
+    Tk k = keys_in.ptr[tidx];
+    To v = vals_in.ptr[tid];
 
     if (threadIdx.x < nwrite) {
         keys_out.ptr[writeloc + threadIdx.x] = k;


### PR DESCRIPTION
Fixes for compilation on CUDA 9.0 and 10.0. Updated release notes in master.

Fixes #2951 

Description
-----------
* Use const char* instead of std::string in NaryNode.
* Add version guards around cublasLT
  cublasLT was added to 10.1.
* Add release notes from v3.7 branch to master
* Fixes to half default constructor for CUDA 9.0

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
