### PR TITLE
Add support for versioned loading of libs at runtime; Fix cudnn cmake install command

### DIFF
--- a/src/backend/common/DependencyModule.hpp
+++ b/src/backend/common/DependencyModule.hpp
@@ -8,12 +8,14 @@
  ********************************************************/
 
 #pragma once
+
 #include <common/Logger.hpp>
 #include <common/defines.hpp>
 #include <common/module_loading.hpp>
 
 #include <memory>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -21,6 +23,8 @@ namespace spdlog {
 class logger;
 }
 namespace common {
+
+using Version = std::tuple<int, int, int>;  // major, minor, patch
 
 /// Allows you to create classes which dynamically load dependencies at runtime
 ///
@@ -39,7 +43,9 @@ class DependencyModule {
 
     DependencyModule(const std::vector<std::string>& plugin_base_file_name,
                      const std::vector<std::string>& suffixes,
-                     const std::vector<std::string>& paths);
+                     const std::vector<std::string>& paths,
+                     const size_t verListSize = 0,
+                     const Version* versions  = nullptr);
 
     ~DependencyModule() noexcept;
 

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -797,7 +797,14 @@ endfunction()
 
 if(AF_INSTALL_STANDALONE)
   if(AF_WITH_CUDNN)
-    afcu_collect_libs(cudnn)
+    if(WIN32)
+      set(cudnn_lib "${cuDNN_DLL_LIBRARY}")
+    else()
+      get_filename_component(cudnn_lib "${cuDNN_LINK_LIBRARY}" REALPATH)
+    endif()
+    install(FILES ${cudnn_lib}
+          DESTINATION ${AF_INSTALL_LIB_DIR}
+          COMPONENT   cuda_dependencies)
   endif()
 
   afcu_collect_libs(nvrtc FULL_VERSION)

--- a/src/backend/cuda/cudnnModule.cpp
+++ b/src/backend/cuda/cudnnModule.cpp
@@ -14,13 +14,31 @@
 #include <device_manager.hpp>
 #include <utility.hpp>
 
+#include <array>
 #include <string>
 #include <tuple>
 
+using common::Version;
 using std::make_tuple;
 using std::string;
 
 namespace cuda {
+
+// clang-format off
+// Latest version from each minor releases are enlisted below
+constexpr std::array<common::Version, 10> cudnnVersions = {
+    make_tuple(7, 6,  5),
+    make_tuple(7, 5,  1),
+    make_tuple(7, 4,  2),
+    make_tuple(7, 3,  1),
+    make_tuple(7, 2,  1),
+    make_tuple(7, 1,  4),
+    make_tuple(7, 0,  5),
+    make_tuple(6, 0, 21),
+    make_tuple(5, 1, 10),
+    make_tuple(4, 0,  7)
+};
+// clang-format on
 
 spdlog::logger* cudnnModule::getLogger() const noexcept {
     return module.getLogger();
@@ -34,7 +52,8 @@ auto cudnnVersionComponents(size_t version) {
 }
 
 cudnnModule::cudnnModule()
-    : module({"cudnn"}, {"", "64_7", "64_8", "64_6", "64_5", "64_4"}, {""}) {
+    : module({"cudnn"}, {"", "64_7", "64_8", "64_6", "64_5", "64_4"}, {""},
+             cudnnVersions.size(), cudnnVersions.data()) {
     if (!module.isLoaded()) {
         AF_TRACE(
             "WARNING: Unable to load cuDNN: {}"


### PR DESCRIPTION
Description
-----------
- Added support for loading versioned libraries by DependencyModule class. If versioned library is not found, the search will fallback to non versioned name lookup.
- Changed cudnn module to lookup latest minor releases for each major version available.
- Earlier to this change, cuDNN install command failed on windows. On Linux, it was packaged with incorrect version suffix.
After this change, cuDNN library will be installed as `<lib prefix>cudnn<lib suffix><soname>` on unix platform.

Changes to Users
----------------
None

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- ~[ ] Tests pass~
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
