### PR TITLE
Change backend Kernel::setScalar to be async by default

### DIFF
--- a/src/backend/common/KernelInterface.hpp
+++ b/src/backend/common/KernelInterface.hpp
@@ -70,8 +70,8 @@ class KernelInterface {
     /// \param[in] syncCopy will indicate if the backend call to upload the
     ///            scalar value to GPU memory has to wait for copy to finish
     ///            or proceed ahead without wait
-    virtual void setScalar(DevPtrType dst, int* scalarValPtr,
-                           const bool syncCopy = false) = 0;
+    virtual void setFlag(DevPtrType dst, int* scalarValPtr,
+                         const bool syncCopy = false) = 0;
 
     /// \brief Fetch a scalar from device memory
     ///
@@ -80,7 +80,7 @@ class KernelInterface {
     /// \param[in] src is the device pointer from which data will be copied
     ///
     /// \returns the integer scalar
-    virtual int getScalar(DevPtrType src) = 0;
+    virtual int getFlag(DevPtrType src) = 0;
 
     /// \brief Enqueue Kernel per queueing criteria forwarding other parameters
     ///

--- a/src/backend/common/KernelInterface.hpp
+++ b/src/backend/common/KernelInterface.hpp
@@ -65,8 +65,13 @@ class KernelInterface {
     /// to the device memory pointed by `dst`
     ///
     /// \param[in] dst is the device pointer to which data will be copied
-    /// \param[in] value is the integer scalar to set at device pointer
-    virtual void setScalar(DevPtrType dst, int value) = 0;
+    /// \param[in] value is a poiner to the scalar value that is set at device
+    ///            pointer
+    /// \param[in] syncCopy will indicate if the backend call to upload the
+    ///            scalar value to GPU memory has to wait for copy to finish
+    ///            or proceed ahead without wait
+    virtual void setScalar(DevPtrType dst, int* scalarValPtr,
+                           const bool syncCopy = false) = 0;
 
     /// \brief Fetch a scalar from device memory
     ///

--- a/src/backend/cuda/Kernel.cpp
+++ b/src/backend/cuda/Kernel.cpp
@@ -13,7 +13,7 @@
 
 namespace cuda {
 
-Kernel::DevPtrType Kernel::getDevPtr(const char *name) {
+Kernel::DevPtrType Kernel::getDevPtr(const char* name) {
     Kernel::DevPtrType out = 0;
     size_t size            = 0;
     CU_CHECK(cuModuleGetGlobal(&out, &size, this->getModuleHandle(), name));
@@ -25,10 +25,11 @@ void Kernel::copyToReadOnly(Kernel::DevPtrType dst, Kernel::DevPtrType src,
     CU_CHECK(cuMemcpyDtoDAsync(dst, src, bytes, cuda::getActiveStream()));
 }
 
-void Kernel::setScalar(Kernel::DevPtrType dst, int value) {
-    CU_CHECK(
-        cuMemcpyHtoDAsync(dst, &value, sizeof(int), cuda::getActiveStream()));
-    CU_CHECK(cuStreamSynchronize(cuda::getActiveStream()));
+void Kernel::setScalar(Kernel::DevPtrType dst, int* scalarValPtr,
+                       const bool syncCopy) {
+    CU_CHECK(cuMemcpyHtoDAsync(dst, scalarValPtr, sizeof(int),
+                               cuda::getActiveStream()));
+    if (syncCopy) { CU_CHECK(cuStreamSynchronize(cuda::getActiveStream())); }
 }
 
 int Kernel::getScalar(Kernel::DevPtrType src) {

--- a/src/backend/cuda/Kernel.cpp
+++ b/src/backend/cuda/Kernel.cpp
@@ -25,14 +25,14 @@ void Kernel::copyToReadOnly(Kernel::DevPtrType dst, Kernel::DevPtrType src,
     CU_CHECK(cuMemcpyDtoDAsync(dst, src, bytes, cuda::getActiveStream()));
 }
 
-void Kernel::setScalar(Kernel::DevPtrType dst, int* scalarValPtr,
-                       const bool syncCopy) {
+void Kernel::setFlag(Kernel::DevPtrType dst, int* scalarValPtr,
+                     const bool syncCopy) {
     CU_CHECK(cuMemcpyHtoDAsync(dst, scalarValPtr, sizeof(int),
                                cuda::getActiveStream()));
     if (syncCopy) { CU_CHECK(cuStreamSynchronize(cuda::getActiveStream())); }
 }
 
-int Kernel::getScalar(Kernel::DevPtrType src) {
+int Kernel::getFlag(Kernel::DevPtrType src) {
     int retVal = 0;
     CU_CHECK(
         cuMemcpyDtoHAsync(&retVal, src, sizeof(int), cuda::getActiveStream()));

--- a/src/backend/cuda/Kernel.hpp
+++ b/src/backend/cuda/Kernel.hpp
@@ -49,10 +49,10 @@ class Kernel
 
     void copyToReadOnly(DevPtrType dst, DevPtrType src, size_t bytes) final;
 
-    void setScalar(DevPtrType dst, int* scalarValPtr,
-                   const bool syncCopy = false) final;
+    void setFlag(DevPtrType dst, int* scalarValPtr,
+                 const bool syncCopy = false) final;
 
-    int getScalar(DevPtrType src) final;
+    int getFlag(DevPtrType src) final;
 };
 
 }  // namespace cuda

--- a/src/backend/cuda/Kernel.hpp
+++ b/src/backend/cuda/Kernel.hpp
@@ -49,7 +49,8 @@ class Kernel
 
     void copyToReadOnly(DevPtrType dst, DevPtrType src, size_t bytes) final;
 
-    void setScalar(DevPtrType dst, int value) final;
+    void setScalar(DevPtrType dst, int* scalarValPtr,
+                   const bool syncCopy = false) final;
 
     int getScalar(DevPtrType src) final;
 };

--- a/src/backend/cuda/kernel/canny.hpp
+++ b/src/backend/cuda/kernel/canny.hpp
@@ -84,7 +84,7 @@ void edgeTrackingHysteresis(Param<T> output, CParam<T> strong, CParam<T> weak) {
     int notFinished = 1;
     while (notFinished) {
         notFinished = 0;
-        edgeTrack.setScalar(flagPtr, notFinished);
+        edgeTrack.setScalar(flagPtr, &notFinished);
         edgeTrack(qArgs, output, blk_x, blk_y);
         POST_LAUNCH_CHECK();
         notFinished = edgeTrack.getScalar(flagPtr);

--- a/src/backend/cuda/kernel/canny.hpp
+++ b/src/backend/cuda/kernel/canny.hpp
@@ -84,10 +84,10 @@ void edgeTrackingHysteresis(Param<T> output, CParam<T> strong, CParam<T> weak) {
     int notFinished = 1;
     while (notFinished) {
         notFinished = 0;
-        edgeTrack.setScalar(flagPtr, &notFinished);
+        edgeTrack.setFlag(flagPtr, &notFinished);
         edgeTrack(qArgs, output, blk_x, blk_y);
         POST_LAUNCH_CHECK();
-        notFinished = edgeTrack.getScalar(flagPtr);
+        notFinished = edgeTrack.getFlag(flagPtr);
     }
     suppressLeftOver(qArgs, output, blk_x, blk_y);
     POST_LAUNCH_CHECK();

--- a/src/backend/cuda/kernel/flood_fill.hpp
+++ b/src/backend/cuda/kernel/flood_fill.hpp
@@ -71,7 +71,7 @@ void floodFill(Param<T> out, CParam<T> image, CParam<uint> seedsx,
 
     for (int doAnotherLaunch = 1; doAnotherLaunch > 0;) {
         doAnotherLaunch = 0;
-        floodStep.setScalar(continueFlagPtr, doAnotherLaunch);
+        floodStep.setScalar(continueFlagPtr, &doAnotherLaunch);
         floodStep(fQArgs, out, image, lowValue, highValue);
         POST_LAUNCH_CHECK();
         doAnotherLaunch = floodStep.getScalar(continueFlagPtr);

--- a/src/backend/cuda/kernel/flood_fill.hpp
+++ b/src/backend/cuda/kernel/flood_fill.hpp
@@ -71,10 +71,10 @@ void floodFill(Param<T> out, CParam<T> image, CParam<uint> seedsx,
 
     for (int doAnotherLaunch = 1; doAnotherLaunch > 0;) {
         doAnotherLaunch = 0;
-        floodStep.setScalar(continueFlagPtr, &doAnotherLaunch);
+        floodStep.setFlag(continueFlagPtr, &doAnotherLaunch);
         floodStep(fQArgs, out, image, lowValue, highValue);
         POST_LAUNCH_CHECK();
-        doAnotherLaunch = floodStep.getScalar(continueFlagPtr);
+        doAnotherLaunch = floodStep.getFlag(continueFlagPtr);
     }
     finalizeOutput(fQArgs, out, newValue);
     POST_LAUNCH_CHECK();

--- a/src/backend/opencl/Kernel.cpp
+++ b/src/backend/opencl/Kernel.cpp
@@ -26,8 +26,10 @@ void Kernel::copyToReadOnly(Kernel::DevPtrType dst, Kernel::DevPtrType src,
     getQueue().enqueueCopyBuffer(*src, *dst, 0, 0, bytes);
 }
 
-void Kernel::setScalar(Kernel::DevPtrType dst, int value) {
-    getQueue().enqueueWriteBuffer(*dst, CL_FALSE, 0, sizeof(int), &value);
+void Kernel::setScalar(Kernel::DevPtrType dst, int* scalarValPtr,
+                       const bool syncCopy) {
+    getQueue().enqueueWriteBuffer(*dst, (syncCopy ? CL_TRUE : CL_FALSE), 0,
+                                  sizeof(int), scalarValPtr);
 }
 
 int Kernel::getScalar(Kernel::DevPtrType src) {

--- a/src/backend/opencl/Kernel.cpp
+++ b/src/backend/opencl/Kernel.cpp
@@ -26,13 +26,13 @@ void Kernel::copyToReadOnly(Kernel::DevPtrType dst, Kernel::DevPtrType src,
     getQueue().enqueueCopyBuffer(*src, *dst, 0, 0, bytes);
 }
 
-void Kernel::setScalar(Kernel::DevPtrType dst, int* scalarValPtr,
-                       const bool syncCopy) {
+void Kernel::setFlag(Kernel::DevPtrType dst, int* scalarValPtr,
+                     const bool syncCopy) {
     getQueue().enqueueWriteBuffer(*dst, (syncCopy ? CL_TRUE : CL_FALSE), 0,
                                   sizeof(int), scalarValPtr);
 }
 
-int Kernel::getScalar(Kernel::DevPtrType src) {
+int Kernel::getFlag(Kernel::DevPtrType src) {
     int retVal = 0;
     getQueue().enqueueReadBuffer(*src, CL_TRUE, 0, sizeof(int), &retVal);
     return retVal;

--- a/src/backend/opencl/Kernel.hpp
+++ b/src/backend/opencl/Kernel.hpp
@@ -40,14 +40,15 @@ class Kernel
 
     // clang-format off
     [[deprecated("OpenCL backend doesn't need Kernel::getDevPtr method")]]
-    DevPtrType getDevPtr(const char* name) override;
+    DevPtrType getDevPtr(const char* name) final;
     // clang-format on
 
-    void copyToReadOnly(DevPtrType dst, DevPtrType src, size_t bytes) override;
+    void copyToReadOnly(DevPtrType dst, DevPtrType src, size_t bytes) final;
 
-    void setScalar(DevPtrType dst, int value) override;
+    void setScalar(DevPtrType dst, int* scalarValPtr,
+                   const bool syncCopy = false) final;
 
-    int getScalar(DevPtrType src) override;
+    int getScalar(DevPtrType src) final;
 };
 
 }  // namespace opencl

--- a/src/backend/opencl/Kernel.hpp
+++ b/src/backend/opencl/Kernel.hpp
@@ -45,10 +45,10 @@ class Kernel
 
     void copyToReadOnly(DevPtrType dst, DevPtrType src, size_t bytes) final;
 
-    void setScalar(DevPtrType dst, int* scalarValPtr,
-                   const bool syncCopy = false) final;
+    void setFlag(DevPtrType dst, int* scalarValPtr,
+                 const bool syncCopy = false) final;
 
-    int getScalar(DevPtrType src) final;
+    int getFlag(DevPtrType src) final;
 };
 
 }  // namespace opencl

--- a/src/backend/opencl/kernel/canny.hpp
+++ b/src/backend/opencl/kernel/canny.hpp
@@ -167,11 +167,11 @@ void edgeTrackingHysteresis(Param output, const Param strong,
 
     while (notFinished > 0) {
         notFinished = 0;
-        edgeTraceOp.setScalar(dContinue.get(), &notFinished);
+        edgeTraceOp.setFlag(dContinue.get(), &notFinished);
         edgeTraceOp(EnqueueArgs(getQueue(), global, threads), *output.data,
                     output.info, blk_x, blk_y, *dContinue);
         CL_DEBUG_FINISH(getQueue());
-        notFinished = edgeTraceOp.getScalar(dContinue.get());
+        notFinished = edgeTraceOp.getFlag(dContinue.get());
     }
     suppressLeftOver<T>(output);
 }

--- a/src/backend/opencl/kernel/canny.hpp
+++ b/src/backend/opencl/kernel/canny.hpp
@@ -167,7 +167,7 @@ void edgeTrackingHysteresis(Param output, const Param strong,
 
     while (notFinished > 0) {
         notFinished = 0;
-        edgeTraceOp.setScalar(dContinue.get(), notFinished);
+        edgeTraceOp.setScalar(dContinue.get(), &notFinished);
         edgeTraceOp(EnqueueArgs(getQueue(), global, threads), *output.data,
                     output.info, blk_x, blk_y, *dContinue);
         CL_DEBUG_FINISH(getQueue());

--- a/src/backend/opencl/kernel/flood_fill.hpp
+++ b/src/backend/opencl/kernel/flood_fill.hpp
@@ -108,12 +108,12 @@ void floodFill(Param out, const Param image, const Param seedsx,
 
     while (notFinished) {
         notFinished = 0;
-        floodStep.setScalar(dContinue, &notFinished);
+        floodStep.setFlag(dContinue, &notFinished);
         floodStep(cl::EnqueueArgs(getQueue(), global, local), *out.data,
                   out.info, *image.data, image.info, lowValue, highValue,
                   *dContinue);
         CL_DEBUG_FINISH(getQueue());
-        notFinished = floodStep.getScalar(dContinue);
+        notFinished = floodStep.getFlag(dContinue);
     }
     bufferFree(dContinue);
     finalizeOutput<T>(out, newValue);

--- a/src/backend/opencl/kernel/flood_fill.hpp
+++ b/src/backend/opencl/kernel/flood_fill.hpp
@@ -108,16 +108,12 @@ void floodFill(Param out, const Param image, const Param seedsx,
 
     while (notFinished) {
         notFinished = 0;
-        getQueue().enqueueWriteBuffer(*dContinue, CL_FALSE, 0, sizeof(int),
-                                      &notFinished);
-
+        floodStep.setScalar(dContinue, &notFinished);
         floodStep(cl::EnqueueArgs(getQueue(), global, local), *out.data,
                   out.info, *image.data, image.info, lowValue, highValue,
                   *dContinue);
         CL_DEBUG_FINISH(getQueue());
-
-        getQueue().enqueueReadBuffer(*dContinue, CL_TRUE, 0, sizeof(int),
-                                     &notFinished);
+        notFinished = floodStep.getScalar(dContinue);
     }
     bufferFree(dContinue);
     finalizeOutput<T>(out, newValue);


### PR DESCRIPTION
Description
-----------
Added an additional boolean argument to `Kernel::setScalar` method that defaults to `false`. This argument indicates if the caller wants `setScalar` to synchronize the upload to GPU memory or not.

Prior to this change, CUDA backend was always synchronizing within setScalar call.

Changes to Users
----------------
None

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
