### PR TITLE
Remove cuDNN compute capablity check as its inaccurate

### DIFF
--- a/src/backend/cuda/cudnnModule.cpp
+++ b/src/backend/cuda/cudnnModule.cpp
@@ -135,16 +135,6 @@ cudnnModule::cudnnModule()
     MODULE_FUNCTION_INIT(cudnnSetStream);
     MODULE_FUNCTION_INIT(cudnnSetTensor4dDescriptor);
 
-    // Check to see if the cuDNN runtime is compatible with the current device
-    cudaDeviceProp prop = getDeviceProp(getActiveDeviceId());
-    if (!checkDeviceWithRuntime(cudnn_rtversion, {prop.major, prop.minor})) {
-        string error_message = fmt::format(
-            "Error: cuDNN CUDA Runtime({}.{}) does not support the "
-            "current device's compute capability(sm_{}{}).",
-            rtmajor, rtminor, prop.major, prop.minor);
-        AF_ERROR(error_message, AF_ERR_RUNTIME);
-    }
-
     if (!module.symbolsLoaded()) {
         string error_message =
             "Error loading cuDNN symbols. ArrayFire was unable to load some "


### PR DESCRIPTION
The version check for the compute capability is inaccurate. The version capability are too difficult to maintain for cudnn as they are changing with every minor release.

Description
-----------
The compute capability and cuda runtime version checking was based on NVRTC. cuDNN version checking is more complicated and we should not try to maintain error messages based on that. The current version fails to target Turing cards with cudnn 7.6.5.

Changes to Users
----------------
None

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
