### PR TITLE
Add support to cuDNN Dependency module to load verion 8 when available

### DIFF
--- a/CMakeModules/FindcuDNN.cmake
+++ b/CMakeModules/FindcuDNN.cmake
@@ -54,8 +54,8 @@ find_package(CUDA QUIET)
 find_path(cuDNN_INCLUDE_DIRS
   NAMES cudnn.h
   HINTS
-    ${PC_CUDNN_INCLUDE_DIRS}
     ${cuDNN_ROOT_DIR}
+    ${PC_CUDNN_INCLUDE_DIRS}
     ${CUDA_TOOLKIT_INCLUDE}
   PATH_SUFFIXES include
   DOC "cuDNN include directory path." )
@@ -64,6 +64,12 @@ if(cuDNN_INCLUDE_DIRS)
   file(READ ${cuDNN_INCLUDE_DIRS}/cudnn.h CUDNN_VERSION_FILE_CONTENTS)
   string(REGEX MATCH "define CUDNN_MAJOR * +([0-9]+)"
     CUDNN_MAJOR_VERSION "${CUDNN_VERSION_FILE_CONTENTS}")
+  list(LENGTH CUDNN_MAJOR_VERSION cudnn_ver_matches)
+  if(${cudnn_ver_matches} EQUAL 0)
+    file(READ ${cuDNN_INCLUDE_DIRS}/cudnn_version.h CUDNN_VERSION_FILE_CONTENTS)
+    string(REGEX MATCH "define CUDNN_MAJOR * +([0-9]+)"
+      CUDNN_MAJOR_VERSION "${CUDNN_VERSION_FILE_CONTENTS}")
+  endif()
   string(REGEX REPLACE "define CUDNN_MAJOR * +([0-9]+)" "\\1"
       CUDNN_MAJOR_VERSION "${CUDNN_MAJOR_VERSION}")
   string(REGEX MATCH "define CUDNN_MINOR * +([0-9]+)"
@@ -94,10 +100,10 @@ if(cuDNN_INCLUDE_DIRS)
       libcudnn.${cudnn_ver_suffix}.dylib
       cudnn
     PATHS
-      $ENV{LD_LIBRARY_PATH}
-      ${libpath_cudart}
       ${cuDNN_ROOT_DIR}
       ${PC_CUDNN_LIBRARY_DIRS}
+      $ENV{LD_LIBRARY_PATH}
+      ${libpath_cudart}
       ${CMAKE_INSTALL_PREFIX}
     PATH_SUFFIXES lib lib64 bin lib/x64 bin/x64
     DOC "cuDNN link library." )
@@ -106,10 +112,10 @@ if(cuDNN_INCLUDE_DIRS)
     find_file(cuDNN_DLL_LIBRARY
     NAMES cudnn64_${cudnn_ver_suffix}${CMAKE_SHARED_LIBRARY_SUFFIX}
     PATHS
-      $ENV{PATH}
-      ${libpath_cudart}
       ${cuDNN_ROOT_DIR}
       ${PC_CUDNN_LIBRARY_DIRS}
+      $ENV{PATH}
+      ${libpath_cudart}
       ${CMAKE_INSTALL_PREFIX}
     PATH_SUFFIXES lib lib64 bin lib/x64 bin/x64
     DOC "cuDNN Windows DLL." )

--- a/src/backend/cuda/cudnn.hpp
+++ b/src/backend/cuda/cudnn.hpp
@@ -116,13 +116,11 @@ cudnnStatus_t cudnnGetConvolutionNdForwardOutputDim(
     const cudnnFilterDescriptor_t filterDesc, int nbDims,
     int tensorOuputDimA[]);
 
-cudnnStatus_t cudnnGetConvolutionForwardAlgorithm(
-    cudnnHandle_t handle, const cudnnTensorDescriptor_t xDesc,
-    const cudnnFilterDescriptor_t wDesc,
-    const cudnnConvolutionDescriptor_t convDesc,
-    const cudnnTensorDescriptor_t yDesc,
-    cudnnConvolutionFwdPreference_t preference, size_t memoryLimitInBytes,
-    cudnnConvolutionFwdAlgo_t *algo);
+cudnnStatus_t cudnnGetConvolutionForwardAlgorithmMaxCount(cudnnHandle_t handle,
+                                                          int *count);
+
+cudnnStatus_t cudnnGetConvolutionBackwardFilterAlgorithmMaxCount(
+    cudnnHandle_t handle, int *count);
 
 cudnnStatus_t cudnnGetConvolutionForwardWorkspaceSize(
     cudnnHandle_t handle, const cudnnTensorDescriptor_t xDesc,
@@ -131,13 +129,34 @@ cudnnStatus_t cudnnGetConvolutionForwardWorkspaceSize(
     const cudnnTensorDescriptor_t yDesc, cudnnConvolutionFwdAlgo_t algo,
     size_t *sizeInBytes);
 
-cudnnStatus_t cudnnConvolutionForward(
-    cudnnHandle_t handle, const void *alpha,
-    const cudnnTensorDescriptor_t xDesc, const void *x,
-    const cudnnFilterDescriptor_t wDesc, const void *w,
-    const cudnnConvolutionDescriptor_t convDesc, cudnnConvolutionFwdAlgo_t algo,
-    void *workSpace, size_t workSpaceSizeInBytes, const void *beta,
-    const cudnnTensorDescriptor_t yDesc, void *y);
+cudnnStatus_t cudnnGetConvolutionBackwardFilterWorkspaceSize(
+    cudnnHandle_t handle, const cudnnTensorDescriptor_t xDesc,
+    const cudnnTensorDescriptor_t dyDesc,
+    const cudnnConvolutionDescriptor_t convDesc,
+    const cudnnFilterDescriptor_t gradDesc,
+    cudnnConvolutionBwdFilterAlgo_t algo, size_t *sizeInBytes);
+
+cudnnStatus_t cudnnFindConvolutionForwardAlgorithm(
+    cudnnHandle_t handle, const cudnnTensorDescriptor_t xDesc,
+    const cudnnFilterDescriptor_t wDesc,
+    const cudnnConvolutionDescriptor_t convDesc,
+    const cudnnTensorDescriptor_t yDesc, const int requestedAlgoCount,
+    int *returnedAlgoCount, cudnnConvolutionFwdAlgoPerf_t *perfResults);
+
+cudnnStatus_t cudnnFindConvolutionBackwardFilterAlgorithm(
+    cudnnHandle_t handle, const cudnnTensorDescriptor_t xDesc,
+    const cudnnTensorDescriptor_t dyDesc,
+    const cudnnConvolutionDescriptor_t convDesc,
+    const cudnnFilterDescriptor_t dwDesc, const int requestedAlgoCount,
+    int *returnedAlgoCount, cudnnConvolutionBwdFilterAlgoPerf_t *perfResults);
+
+cudnnStatus_t cudnnGetConvolutionForwardAlgorithm(
+    cudnnHandle_t handle, const cudnnTensorDescriptor_t xDesc,
+    const cudnnFilterDescriptor_t wDesc,
+    const cudnnConvolutionDescriptor_t convDesc,
+    const cudnnTensorDescriptor_t yDesc,
+    cudnnConvolutionFwdPreference_t preference, size_t memoryLimitInBytes,
+    cudnnConvolutionFwdAlgo_t *algo);
 
 cudnnStatus_t cudnnGetConvolutionBackwardFilterAlgorithm(
     cudnnHandle_t handle, const cudnnTensorDescriptor_t xDesc,
@@ -147,12 +166,13 @@ cudnnStatus_t cudnnGetConvolutionBackwardFilterAlgorithm(
     cudnnConvolutionBwdFilterPreference_t preference, size_t memoryLimitInBytes,
     cudnnConvolutionBwdFilterAlgo_t *algo);
 
-cudnnStatus_t cudnnGetConvolutionBackwardFilterWorkspaceSize(
-    cudnnHandle_t handle, const cudnnTensorDescriptor_t xDesc,
-    const cudnnTensorDescriptor_t dyDesc,
-    const cudnnConvolutionDescriptor_t convDesc,
-    const cudnnFilterDescriptor_t gradDesc,
-    cudnnConvolutionBwdFilterAlgo_t algo, size_t *sizeInBytes);
+cudnnStatus_t cudnnConvolutionForward(
+    cudnnHandle_t handle, const void *alpha,
+    const cudnnTensorDescriptor_t xDesc, const void *x,
+    const cudnnFilterDescriptor_t wDesc, const void *w,
+    const cudnnConvolutionDescriptor_t convDesc, cudnnConvolutionFwdAlgo_t algo,
+    void *workSpace, size_t workSpaceSizeInBytes, const void *beta,
+    const cudnnTensorDescriptor_t yDesc, void *y);
 
 cudnnStatus_t cudnnConvolutionBackwardFilter(
     cudnnHandle_t handle, const void *alpha,

--- a/src/backend/cuda/cudnnModule.cpp
+++ b/src/backend/cuda/cudnnModule.cpp
@@ -26,7 +26,8 @@ namespace cuda {
 
 // clang-format off
 // Latest version from each minor releases are enlisted below
-constexpr std::array<common::Version, 10> cudnnVersions = {
+constexpr std::array<common::Version, 11> cudnnVersions = {
+    make_tuple(8, 0,  1),
     make_tuple(7, 6,  5),
     make_tuple(7, 5,  1),
     make_tuple(7, 4,  2),
@@ -130,10 +131,16 @@ cudnnModule::cudnnModule()
     MODULE_FUNCTION_INIT(cudnnDestroyFilterDescriptor);
     MODULE_FUNCTION_INIT(cudnnDestroyTensorDescriptor);
     MODULE_FUNCTION_INIT(cudnnGetConvolutionBackwardDataWorkspaceSize);
-    MODULE_FUNCTION_INIT(cudnnGetConvolutionBackwardFilterAlgorithm);
-    MODULE_FUNCTION_INIT(cudnnGetConvolutionBackwardFilterWorkspaceSize);
-    MODULE_FUNCTION_INIT(cudnnGetConvolutionForwardAlgorithm);
+    MODULE_FUNCTION_INIT(cudnnGetConvolutionForwardAlgorithmMaxCount);
+    MODULE_FUNCTION_INIT(cudnnGetConvolutionBackwardFilterAlgorithmMaxCount);
     MODULE_FUNCTION_INIT(cudnnGetConvolutionForwardWorkspaceSize);
+    MODULE_FUNCTION_INIT(cudnnGetConvolutionBackwardFilterWorkspaceSize);
+    MODULE_FUNCTION_INIT(cudnnFindConvolutionForwardAlgorithm);
+    MODULE_FUNCTION_INIT(cudnnFindConvolutionBackwardFilterAlgorithm);
+    if (major < 8) {
+        MODULE_FUNCTION_INIT(cudnnGetConvolutionForwardAlgorithm);
+        MODULE_FUNCTION_INIT(cudnnGetConvolutionBackwardFilterAlgorithm);
+    }
     MODULE_FUNCTION_INIT(cudnnGetConvolutionNdForwardOutputDim);
     MODULE_FUNCTION_INIT(cudnnSetConvolution2dDescriptor);
     MODULE_FUNCTION_INIT(cudnnSetFilter4dDescriptor);

--- a/src/backend/cuda/cudnnModule.hpp
+++ b/src/backend/cuda/cudnnModule.hpp
@@ -31,6 +31,36 @@ cudnnStatus_t cudnnSetFilter4dDescriptor_v4(
 size_t cudnnGetCudartVersion(void);
 #endif
 
+#if CUDNN_VERSION >= 8000
+typedef enum {
+    CUDNN_CONVOLUTION_FWD_NO_WORKSPACE            = 0,
+    CUDNN_CONVOLUTION_FWD_PREFER_FASTEST          = 1,
+    CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT = 2,
+} cudnnConvolutionFwdPreference_t;
+
+typedef enum {
+    CUDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE            = 0,
+    CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST          = 1,
+    CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT = 2,
+} cudnnConvolutionBwdFilterPreference_t;
+
+cudnnStatus_t cudnnGetConvolutionForwardAlgorithm(
+    cudnnHandle_t handle, const cudnnTensorDescriptor_t xDesc,
+    const cudnnFilterDescriptor_t wDesc,
+    const cudnnConvolutionDescriptor_t convDesc,
+    const cudnnTensorDescriptor_t yDesc,
+    cudnnConvolutionFwdPreference_t preference, size_t memoryLimitInBytes,
+    cudnnConvolutionFwdAlgo_t* algo);
+
+cudnnStatus_t cudnnGetConvolutionBackwardFilterAlgorithm(
+    cudnnHandle_t handle, const cudnnTensorDescriptor_t xDesc,
+    const cudnnTensorDescriptor_t dyDesc,
+    const cudnnConvolutionDescriptor_t convDesc,
+    const cudnnFilterDescriptor_t dwDesc,
+    cudnnConvolutionBwdFilterPreference_t preference, size_t memoryLimitInBytes,
+    cudnnConvolutionBwdFilterAlgo_t* algo);
+#endif
+
 namespace cuda {
 
 class cudnnModule {
@@ -51,10 +81,14 @@ class cudnnModule {
     MODULE_MEMBER(cudnnDestroyFilterDescriptor);
     MODULE_MEMBER(cudnnDestroyTensorDescriptor);
     MODULE_MEMBER(cudnnGetConvolutionBackwardDataWorkspaceSize);
-    MODULE_MEMBER(cudnnGetConvolutionBackwardFilterAlgorithm);
+    MODULE_MEMBER(cudnnGetConvolutionForwardAlgorithmMaxCount);
+    MODULE_MEMBER(cudnnGetConvolutionBackwardFilterAlgorithmMaxCount);
+    MODULE_MEMBER(cudnnFindConvolutionForwardAlgorithm);
+    MODULE_MEMBER(cudnnFindConvolutionBackwardFilterAlgorithm);
+    MODULE_MEMBER(cudnnGetConvolutionForwardWorkspaceSize);
     MODULE_MEMBER(cudnnGetConvolutionBackwardFilterWorkspaceSize);
     MODULE_MEMBER(cudnnGetConvolutionForwardAlgorithm);
-    MODULE_MEMBER(cudnnGetConvolutionForwardWorkspaceSize);
+    MODULE_MEMBER(cudnnGetConvolutionBackwardFilterAlgorithm);
     MODULE_MEMBER(cudnnGetConvolutionNdForwardOutputDim);
     MODULE_MEMBER(cudnnSetConvolution2dDescriptor);
     MODULE_MEMBER(cudnnSetFilter4dDescriptor);


### PR DESCRIPTION
Description
-----------
Fixes: #2935 

Changes to Users
----------------
None

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass - Locally yes with CUDA 10.2 and cuDNN 8.0.1.
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~