### PR TITLE
Fix the svd ndims check to limit inputs to 2D arrays

### DIFF
--- a/src/api/c/svd.cpp
+++ b/src/api/c/svd.cpp
@@ -75,7 +75,7 @@ af_err af_svd(af_array *u, af_array *s, af_array *vt, const af_array in) {
         const ArrayInfo &info = getInfo(in);
         dim4 dims             = info.dims();
 
-        ARG_ASSERT(3, (dims.ndims() >= 0 && dims.ndims() <= 3));
+        ARG_ASSERT(3, (dims.ndims() >= 0 && dims.ndims() <= 2));
         af_dtype type = info.getType();
 
         if (dims.ndims() == 0) {
@@ -102,7 +102,7 @@ af_err af_svd_inplace(af_array *u, af_array *s, af_array *vt, af_array in) {
         const ArrayInfo &info = getInfo(in);
         dim4 dims             = info.dims();
 
-        ARG_ASSERT(3, (dims.ndims() >= 0 && dims.ndims() <= 3));
+        ARG_ASSERT(3, (dims.ndims() >= 0 && dims.ndims() <= 2));
         af_dtype type = info.getType();
 
         if (dims.ndims() == 0) {


### PR DESCRIPTION
Limit linear algebra functions input array dimension validation

Description
-----------
Earlier to this change: `lu`, `qr`, `cholesky` and `solve` are correctly validation input array dimension to be 2d array. However, solve wasn't doing it for some reason. This fixes that.

Note that, there is another issue(#483 ) in place that is related to adding batch support for the above mentioned linear algebra functions.

Fixes: #1748 

Changes to Users
----------------
Correct input validation in `svd` functions.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
