### PR TITLE
Work around in floodfill for what seems to be bug in NVIDIA opencl

### DIFF
--- a/src/api/c/confidence_connected.cpp
+++ b/src/api/c/confidence_connected.cpp
@@ -188,13 +188,6 @@ af_err af_confidence_cc(af_array* out, const af_array in, const af_array seedx,
                         const af_array seedy, const unsigned radius,
                         const unsigned multiplier, const int iter,
                         const double segmented_value) {
-#if defined(AF_OPENCL)
-    // FIXME OpenCL backend keeps running into indefinte loop for
-    // short bit size(16,8) types very often and occasionally
-    // with 32 bit types.
-    AF_ERROR("There is a known issue for OpenCL implementation",
-             AF_ERR_NOT_SUPPORTED);
-#endif
     try {
         const ArrayInfo& inInfo         = getInfo(in);
         const ArrayInfo& seedxInfo      = getInfo(seedx);

--- a/src/backend/cuda/kernel/flood_fill.cuh
+++ b/src/backend/cuda/kernel/flood_fill.cuh
@@ -8,8 +8,8 @@
  ********************************************************/
 
 #include <Param.hpp>
-#include <af/defines.h>
 #include <math.hpp>
+#include <af/defines.h>
 
 /// doAnotherLaunch is a variable in kernel space
 /// used to track the convergence of
@@ -27,24 +27,33 @@ namespace cuda {
 ///
 /// Once, the algorithm is finished, output is reset
 /// to either zero or \p newValue for all valid pixels.
-template<typename T> constexpr T VALID() { return T(2); }
-template<typename T> constexpr T INVALID() { return T(1); }
-template<typename T> constexpr T ZERO() { return T(0); }
+template<typename T>
+constexpr T VALID() {
+    return T(2);
+}
+template<typename T>
+constexpr T INVALID() {
+    return T(1);
+}
+template<typename T>
+constexpr T ZERO() {
+    return T(0);
+}
 
 template<typename T>
-__global__
-void initSeeds(Param<T> out, CParam<uint> seedsx, CParam<uint> seedsy) {
+__global__ void initSeeds(Param<T> out, CParam<uint> seedsx,
+                          CParam<uint> seedsy) {
     uint idx = blockDim.x * blockIdx.x + threadIdx.x;
     if (idx < seedsx.elements()) {
-        uint x = seedsx.ptr[ idx ];
-        uint y = seedsy.ptr[ idx ];
-        out.ptr[ x + y * out.dims[0] ] = VALID<T>();
+        uint x                       = seedsx.ptr[idx];
+        uint y                       = seedsy.ptr[idx];
+        out.ptr[x + y * out.dims[0]] = VALID<T>();
     }
 }
 
 template<typename T>
-__global__
-void floodStep(Param<T> out, CParam<T> img, T lowValue, T highValue) {
+__global__ void floodStep(Param<T> out, CParam<T> img, T lowValue,
+                          T highValue) {
     constexpr int RADIUS      = 1;
     constexpr int SMEM_WIDTH  = THREADS_X + 2 * RADIUS;
     constexpr int SMEM_HEIGHT = THREADS_Y + 2 * RADIUS;
@@ -57,11 +66,10 @@ void floodStep(Param<T> out, CParam<T> img, T lowValue, T highValue) {
     const int gy = blockDim.y * blockIdx.y + ly;
     const int d0 = out.dims[0];
     const int d1 = out.dims[1];
-    const int s0 = out.strides[0];
     const int s1 = out.strides[1];
 
     const T *iptr = (const T *)img.ptr;
-          T *optr = (T *)out.ptr;
+    T *optr       = (T *)out.ptr;
 #pragma unroll
     for (int b = ly, gy2 = gy; b < SMEM_HEIGHT;
          b += blockDim.y, gy2 += blockDim.y) {
@@ -71,22 +79,23 @@ void floodStep(Param<T> out, CParam<T> img, T lowValue, T highValue) {
             int x      = gx2 - RADIUS;
             int y      = gy2 - RADIUS;
             bool inROI = (x >= 0 && x < d0 && y >= 0 && y < d1);
-            smem[b][a] = (inROI ? optr[ x*s0+y*s1 ] : INVALID<T>());
+            smem[b][a] = (inROI ? optr[x + y * s1] : INVALID<T>());
         }
     }
     int i = lx + RADIUS;
     int j = ly + RADIUS;
 
-    T tImgVal = iptr[(clamp(gx, 0, int(img.dims[0]-1)) * img.strides[0] +
-                      clamp(gy, 0, int(img.dims[1]-1)) * img.strides[1])];
+    T tImgVal = iptr[(clamp(gx, 0, int(img.dims[0] - 1)) * img.strides[0] +
+                      clamp(gy, 0, int(img.dims[1] - 1)) * img.strides[1])];
     const int isPxBtwnThresholds =
         (tImgVal >= lowValue && tImgVal <= highValue);
     __syncthreads();
 
     T origOutVal      = smem[j][i];
+    T centerVal       = origOutVal;
     bool blockChanged = false;
     bool isBorderPxl  = (lx == 0 || ly == 0 || lx == (blockDim.x - 1) ||
-                         ly == (blockDim.y - 1));
+                        ly == (blockDim.y - 1));
     do {
         int validNeighbors = 0;
 #pragma unroll
@@ -97,19 +106,18 @@ void floodStep(Param<T> out, CParam<T> img, T lowValue, T highValue) {
                 validNeighbors += (currVal == VALID<T>());
             }
         }
+        // Exempt current/center pixel from validNeighbors
+        validNeighbors -= (centerVal == VALID<T>());
         __syncthreads();
 
         bool outChanged = (smem[j][i] == ZERO<T>() && (validNeighbors > 0));
-        if (outChanged) {
-            smem[j][i] = T(isPxBtwnThresholds + INVALID<T>());
-        }
+        if (outChanged) { smem[j][i] = T(isPxBtwnThresholds + INVALID<T>()); }
         blockChanged = __syncthreads_or(int(outChanged));
+        centerVal    = smem[j][i];
     } while (blockChanged);
 
-    T newOutVal = smem[j][i];
-
-    bool borderChanged = (isBorderPxl &&
-                          newOutVal != origOutVal && newOutVal == VALID<T>());
+    bool borderChanged =
+        (isBorderPxl && centerVal != origOutVal && centerVal == VALID<T>());
 
     borderChanged = __syncthreads_or(int(borderChanged));
 
@@ -120,21 +128,18 @@ void floodStep(Param<T> out, CParam<T> img, T lowValue, T highValue) {
         doAnotherLaunch = 1;
     }
 
-    if (gx < d0 && gy < d1) {
-        optr[ (gx*s0 + gy*s1) ] = smem[j][i];
-    }
+    if (gx < d0 && gy < d1) { optr[(gx + gy * s1)] = smem[j][i]; }
 }
 
 template<typename T>
-__global__
-void finalizeOutput(Param<T> out, T newValue) {
+__global__ void finalizeOutput(Param<T> out, T newValue) {
     uint gx = blockDim.x * blockIdx.x + threadIdx.x;
     uint gy = blockDim.y * blockIdx.y + threadIdx.y;
     if (gx < out.dims[0] && gy < out.dims[1]) {
-        uint idx = gx * out.strides[0] + gy * out.strides[1];
-        T val = out.ptr[idx];
+        uint idx     = gx + gy * out.strides[1];
+        T val        = out.ptr[idx];
         out.ptr[idx] = (val == VALID<T>() ? newValue : ZERO<T>());
     }
 }
 
-} // namespace cuda
+}  // namespace cuda

--- a/src/backend/opencl/kernel/flood_fill.cl
+++ b/src/backend/opencl/kernel/flood_fill.cl
@@ -23,31 +23,37 @@ kernel void init_seeds(global T *out, KParam oInfo, global const uint *seedsx,
                        KParam syInfo) {
     uint tid = get_global_id(0);
     if (tid < sxInfo.dims[0]) {
-        uint x                                             = seedsx[tid];
-        uint y                                             = seedsy[tid];
-        out[(x * oInfo.strides[0] + y * oInfo.strides[1])] = VALID;
+        uint x                          = seedsx[tid];
+        uint y                          = seedsy[tid];
+        out[(x + y * oInfo.strides[1])] = VALID;
     }
 }
 #endif
 
 #if defined(FLOOD_FILL_STEP)
 
-int barrierOR(local int *predicates) {
+bool barrierOR(local int *predicates, const int workGroupSize) {
     int tid = get_local_id(0) + get_local_size(0) * get_local_id(1);
-    barrier(CLK_LOCAL_MEM_FENCE);
-    for (int nt = GROUP_SIZE / 2; nt > 0; nt >>= 1) {
-        if (tid < nt) {
-            predicates[tid] = (predicates[tid] | predicates[tid + nt]);
-        }
+    for (int nt = workGroupSize >> 1; nt > 0; nt >>= 1) {
         barrier(CLK_LOCAL_MEM_FENCE);
+        if (tid < nt) {
+            predicates[tid] = (predicates[tid] + predicates[tid + nt]);
+        }
     }
     barrier(CLK_LOCAL_MEM_FENCE);
-    return predicates[0];
+    return predicates[0] > 0;
 }
 
 kernel void flood_step(global T *out, KParam oInfo, global const T *img,
                        KParam iInfo, T lowValue, T highValue,
                        global volatile int *notFinished) {
+    const int wgsize0 = get_local_size(0);
+    const int wgsize1 = get_local_size(1);
+#if AF_PLATFORM_NVIDIA
+    const int FLOOD_LOOP_MAX_ITERATIONS =
+        ceil(sqrt((float)(wgsize0 * wgsize0) + (float)(wgsize1 * wgsize1)));
+#endif
+
     local T lmem[LMEM_HEIGHT][LMEM_WIDTH];
     local int predicates[GROUP_SIZE];
 
@@ -57,17 +63,15 @@ kernel void flood_step(global T *out, KParam oInfo, global const T *img,
     const int gy = get_global_id(1);
     const int d0 = oInfo.dims[0];
     const int d1 = oInfo.dims[1];
-    const int s0 = oInfo.strides[0];
     const int s1 = oInfo.strides[1];
 
-    for (int b = ly, gy2 = gy; b < LMEM_HEIGHT;
-         b += get_local_size(1), gy2 += get_local_size(1)) {
+    for (int b = ly, gy2 = gy; b < LMEM_HEIGHT; b += wgsize1, gy2 += wgsize1) {
         for (int a = lx, gx2 = gx; a < LMEM_WIDTH;
-             a += get_local_size(0), gx2 += get_local_size(0)) {
+             a += wgsize0, gx2 += wgsize0) {
             int x      = gx2 - RADIUS;
             int y      = gy2 - RADIUS;
             bool inROI = (x >= 0 && x < d0 && y >= 0 && y < d1);
-            lmem[b][a] = (inROI ? out[x * s0 + y * s1] : INVALID);
+            lmem[b][a] = (inROI ? out[x + y * s1] : INVALID);
         }
     }
     int i = lx + RADIUS;
@@ -75,19 +79,24 @@ kernel void flood_step(global T *out, KParam oInfo, global const T *img,
 
     T tImgVal =
         img[(clamp(gx, 0, (int)(iInfo.dims[0] - 1)) * iInfo.strides[0] +
-             clamp(gy, 0, (int)(iInfo.dims[1] - 1)) * iInfo.strides[1])];
+             clamp(gy, 0, (int)(iInfo.dims[1] - 1)) * iInfo.strides[1]) +
+            iInfo.offset];
     const int isPxBtwnThresholds =
         (tImgVal >= lowValue && tImgVal <= highValue);
 
-    int tid = lx + get_local_size(0) * ly;
+    int tid = lx + wgsize0 * ly;
+
+    predicates[tid] = 0;
 
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    T origOutVal     = lmem[j][i];
-    bool isBorderPxl = (lx == 0 || ly == 0 || lx == (get_local_size(0) - 1) ||
-                        ly == (get_local_size(1) - 1));
-
-    for (bool blkChngd = true; blkChngd; blkChngd = barrierOR(predicates)) {
+    T origOutVal      = lmem[j][i];
+    T centerVal       = origOutVal;
+    bool blockChanged = false;
+    bool isBorderPxl =
+        (lx == 0 || ly == 0 || lx == (wgsize0 - 1) || ly == (wgsize1 - 1));
+    int loopCount = 0;
+    do {
         int validNeighbors = 0;
         for (int no_j = -RADIUS; no_j <= RADIUS; ++no_j) {
             for (int no_i = -RADIUS; no_i <= RADIUS; ++no_i) {
@@ -95,29 +104,38 @@ kernel void flood_step(global T *out, KParam oInfo, global const T *img,
                 validNeighbors += (currVal == VALID);
             }
         }
-        bool outChanged = (lmem[j][i] == ZERO && (validNeighbors > 0));
-        predicates[tid] = outChanged;
+        // Exempt current/center pixel from validNeighbors
+        validNeighbors -= (centerVal == VALID);
         barrier(CLK_LOCAL_MEM_FENCE);
-        if (outChanged) { lmem[j][i] = (T)(isPxBtwnThresholds + INVALID); }
-    }
 
-    T newOutVal = lmem[j][i];
+        bool outChanged = (lmem[j][i] == ZERO && (validNeighbors > 0));
+        if (outChanged) { lmem[j][i] = (T)(isPxBtwnThresholds + INVALID); }
+        predicates[tid] = (int)(outChanged);
+        blockChanged    = barrierOR(predicates, GROUP_SIZE);
+        centerVal       = lmem[j][i];
+#if AF_PLATFORM_NVIDIA
+        // NVIDIA OpenCL seems to have a bug with while loop, where it
+        // is somehow going into infinite loop even if the loop should
+        // This isn't an issue on AMD as expected.
+    } while (blockChanged && (loopCount++ < FLOOD_LOOP_MAX_ITERATIONS));
+#else
+    } while (blockChanged);
+#endif
 
     bool brdrChngd =
-        (isBorderPxl && newOutVal != origOutVal && newOutVal == VALID);
-    predicates[tid] = brdrChngd;
+        (isBorderPxl && centerVal != origOutVal && centerVal == VALID);
+    predicates[tid] = (int)(brdrChngd);
 
-    brdrChngd = barrierOR(predicates) > 0;
+    brdrChngd = barrierOR(predicates, GROUP_SIZE);
 
-    if (gx < d0 && gy < d1) {
-        if (brdrChngd && lx == 0 && ly == 0) {
-            // Atleast one border pixel changed. Therefore, mark for
-            // another kernel launch to propogate changes beyond border
-            // of this block
-            atomic_inc(notFinished);
-        }
-        out[(gx * s0 + gy * s1)] = lmem[j][i];
+    if (brdrChngd && lx == 0 && ly == 0) {
+        // Atleast one border pixel changed. Therefore, mark for
+        // another kernel launch to propogate changes beyond border
+        // of this block
+        atomic_inc(notFinished);
     }
+
+    if (gx < d0 && gy < d1) { out[(gx + gy * s1)] = lmem[j][i]; }
 }
 #endif
 
@@ -126,7 +144,7 @@ kernel void finalize_output(global T *out, KParam oInfo, T newValue) {
     uint gx = get_global_id(0);
     uint gy = get_global_id(1);
     if (gx < oInfo.dims[0] && gy < oInfo.dims[1]) {
-        uint idx = gx * oInfo.strides[0] + gy * oInfo.strides[1];
+        uint idx = gx + gy * oInfo.strides[1];
         T val    = out[idx];
         out[idx] = (val == VALID ? newValue : ZERO);
     }

--- a/src/backend/opencl/kernel/flood_fill.hpp
+++ b/src/backend/opencl/kernel/flood_fill.hpp
@@ -92,6 +92,7 @@ void floodFill(Param out, const Param image, const Param seedsx,
         DefineKeyValue(LMEM_WIDTH, (THREADS_X + 2 * RADIUS)),
         DefineKeyValue(LMEM_HEIGHT, (THREADS_Y + 2 * RADIUS)),
         DefineKeyValue(GROUP_SIZE, (THREADS_Y * THREADS_X)),
+        DefineKeyValue(AF_PLATFORM_NVIDIA, getActivePlatform()),
     };
     options.emplace_back(getTypeBuildDefinition<T>());
 

--- a/test/confidence_connected.cpp
+++ b/test/confidence_connected.cpp
@@ -160,8 +160,6 @@ void testData(CCCTestParams params) {
 class ConfidenceConnectedDataTest
     : public testing::TestWithParam<CCCTestParams> {};
 
-#if !defined(AF_OPENCL)
-
 TYPED_TEST(ConfidenceConnectedImageTest, DonutBackgroundExtraction) {
     const unsigned seedx = 10;
     const unsigned seedy = 10;
@@ -200,4 +198,3 @@ INSTANTIATE_TEST_CASE_P(
            << info.param.iterations << "_replace_" << info.param.replace;
         return ss.str();
     });
-#endif


### PR DESCRIPTION
Description
-----------
* The kernel's while loop seems to go into an infinite loop for no apparent reason on NVIDIA
  platform which doesn't happen on AMD, BIEGNET and POCL. CCC Tests pass on AMD, BIEGNET but
  doesn't on POCL, fails with value difference errors.

* Also, cleaned up flood fill kernels in both CUDA and OpenCL backends.


Changes to Users
----------------
Confidence Connected Components is now enabled in OpenCL backend.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
