### PR TITLE
Add clblast patch to handle custom context with multiple devices

### DIFF
--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -12,7 +12,7 @@ find_program(GIT git)
 set(prefix ${PROJECT_BINARY_DIR}/third_party/CLBlast)
 set(CLBlast_location ${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}clblast${CMAKE_STATIC_LIBRARY_SUFFIX})
 
-set(CLBLAST_PATCH_COMMAND ${GIT} apply ${ArrayFire_SOURCE_DIR}/CMakeModules/clblast_program_getIR.patch)
+set(CLBLAST_PATCH_COMMAND ${GIT} apply --whitespace=fix ${ArrayFire_SOURCE_DIR}/CMakeModules/clblast_program_getIR.patch)
 
 if(WIN32 AND CMAKE_GENERATOR_PLATFORM AND NOT CMAKE_GENERATOR MATCHES "Ninja")
   set(extproj_gen_opts "-G${CMAKE_GENERATOR}" "-A${CMAKE_GENERATOR_PLATFORM}")
@@ -33,7 +33,7 @@ ExternalProject_Add(
     PREFIX "${prefix}"
     INSTALL_DIR "${prefix}"
     UPDATE_COMMAND ""
-    PATCH_COMMAND ${CLBLAST_PATCH_COMMAND}
+    PATCH_COMMAND "${CLBLAST_PATCH_COMMAND}"
     BUILD_BYPRODUCTS ${CLBlast_location}
     CONFIGURE_COMMAND ${CMAKE_COMMAND} ${extproj_gen_opts}
       -Wno-dev <SOURCE_DIR>

--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -12,6 +12,8 @@ find_program(GIT git)
 set(prefix ${PROJECT_BINARY_DIR}/third_party/CLBlast)
 set(CLBlast_location ${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}clblast${CMAKE_STATIC_LIBRARY_SUFFIX})
 
+set(CLBLAST_PATCH_COMMAND ${GIT} apply ${ArrayFire_SOURCE_DIR}/CMakeModules/clblast_program_getIR.patch)
+
 if(WIN32 AND CMAKE_GENERATOR_PLATFORM AND NOT CMAKE_GENERATOR MATCHES "Ninja")
   set(extproj_gen_opts "-G${CMAKE_GENERATOR}" "-A${CMAKE_GENERATOR_PLATFORM}")
 else()
@@ -31,6 +33,7 @@ ExternalProject_Add(
     PREFIX "${prefix}"
     INSTALL_DIR "${prefix}"
     UPDATE_COMMAND ""
+    PATCH_COMMAND ${CLBLAST_PATCH_COMMAND}
     BUILD_BYPRODUCTS ${CLBlast_location}
     CONFIGURE_COMMAND ${CMAKE_COMMAND} ${extproj_gen_opts}
       -Wno-dev <SOURCE_DIR>

--- a/CMakeModules/clblast_program_getIR.patch
+++ b/CMakeModules/clblast_program_getIR.patch
@@ -1,0 +1,44 @@
+diff --git a/src/clpp11.hpp b/src/clpp11.hpp
+index 4ed157ea..2a25606c 100644
+--- a/src/clpp11.hpp
++++ b/src/clpp11.hpp
+@@ -509,12 +509,35 @@ class Program {
+ 
+   // Retrieves a binary or an intermediate representation of the compiled program
+   std::string GetIR() const {
+-    auto bytes = size_t{0};
+-    CheckError(clGetProgramInfo(program_, CL_PROGRAM_BINARY_SIZES, sizeof(size_t), &bytes, nullptr));
++    cl_uint num_devices = 0;
++    CheckError(clGetProgramInfo(program_, CL_PROGRAM_NUM_DEVICES,
++                sizeof(cl_uint), &num_devices, nullptr));
++
++    std::vector<size_t> binSizesInBytes(num_devices, 0);
++    CheckError(clGetProgramInfo(program_, CL_PROGRAM_BINARY_SIZES,
++                num_devices * sizeof(size_t), binSizesInBytes.data(), nullptr));
++
++    auto bytes       = size_t{0};
++    auto binSizeIter = size_t{0};
++    // Loop over the program binary sizes to find a binary whose size is > 0.
++    // The current logic assumes that there ever is only one valid program binary
++    // in a given cl_program. This should be the case unless the cl_program
++    // is built for all or a subset of devices associated to a given cl_program
++    for (; binSizeIter < binSizesInBytes.size(); ++binSizeIter) {
++        if (binSizesInBytes[binSizeIter] > 0) {
++            bytes = binSizesInBytes[binSizeIter];
++            break;
++        }
++    }
+     auto result = std::string{};
+     result.resize(bytes);
+-    auto result_ptr = result.data();
+-    CheckError(clGetProgramInfo(program_, CL_PROGRAM_BINARIES, sizeof(char*), &result_ptr, nullptr));
++
++    std::vector<char*> out(num_devices, nullptr);
++    out[binSizeIter] = const_cast<char*>(result.data());
++
++    CheckError(clGetProgramInfo(program_, CL_PROGRAM_BINARIES,
++                                num_devices * sizeof(char*),
++                                out.data(), nullptr));
+     return result;
+   }
+ 


### PR DESCRIPTION
Description
-----------
Fixes: #2919 

Patch has been pulled from https://github.com/CNugteren/CLBlast/pull/392

Changes to Users
----------------
Crash while using blas function with custom context constituting multiple devices is resolved.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
