### PR TITLE
Fix barrierOR fn in confidence connected opencl kernel

### DIFF
--- a/src/api/c/confidence_connected.cpp
+++ b/src/api/c/confidence_connected.cpp
@@ -188,13 +188,6 @@ af_err af_confidence_cc(af_array* out, const af_array in, const af_array seedx,
                         const af_array seedy, const unsigned radius,
                         const unsigned multiplier, const int iter,
                         const double segmented_value) {
-#if defined(AF_OPENCL)
-    // FIXME OpenCL backend keeps running into indefinte loop for
-    // short bit size(16,8) types very often and occasionally
-    // with 32 bit types.
-    AF_ERROR("There is a known issue for OpenCL implementation",
-             AF_ERR_NOT_SUPPORTED);
-#endif
     try {
         const ArrayInfo& inInfo         = getInfo(in);
         const ArrayInfo& seedxInfo      = getInfo(seedx);

--- a/src/backend/opencl/kernel/flood_fill.cl
+++ b/src/backend/opencl/kernel/flood_fill.cl
@@ -41,8 +41,11 @@ int barrierOR(local int *predicates) {
         }
         barrier(CLK_LOCAL_MEM_FENCE);
     }
+    int retVal = predicates[0];
+#if AF_IS_PLATFORM_NVIDIA
     barrier(CLK_LOCAL_MEM_FENCE);
-    return predicates[0];
+#endif
+    return retVal;
 }
 
 kernel void flood_step(global T *out, KParam oInfo, global const T *img,

--- a/src/backend/opencl/kernel/flood_fill.cl
+++ b/src/backend/opencl/kernel/flood_fill.cl
@@ -43,6 +43,10 @@ int barrierOR(local int *predicates) {
     }
     int retVal = predicates[0];
 #if AF_IS_PLATFORM_NVIDIA
+    // Without the extra barrier sync after reading the reduction result,
+    // the caller's loop is going into infinite loop occasionally which is
+    // in turn randoms hangs. This doesn't seem to be an issue on non-nvidia
+    // hardware. Hence, the check.
     barrier(CLK_LOCAL_MEM_FENCE);
 #endif
     return retVal;

--- a/src/backend/opencl/kernel/flood_fill.hpp
+++ b/src/backend/opencl/kernel/flood_fill.hpp
@@ -92,6 +92,7 @@ void floodFill(Param out, const Param image, const Param seedsx,
         DefineKeyValue(LMEM_WIDTH, (THREADS_X + 2 * RADIUS)),
         DefineKeyValue(LMEM_HEIGHT, (THREADS_Y + 2 * RADIUS)),
         DefineKeyValue(GROUP_SIZE, (THREADS_Y * THREADS_X)),
+        DefineKeyValue(AF_IS_PLATFORM_NVIDIA, getActivePlatform()),
     };
     options.emplace_back(getTypeBuildDefinition<T>());
 

--- a/src/backend/opencl/kernel/flood_fill.hpp
+++ b/src/backend/opencl/kernel/flood_fill.hpp
@@ -92,7 +92,8 @@ void floodFill(Param out, const Param image, const Param seedsx,
         DefineKeyValue(LMEM_WIDTH, (THREADS_X + 2 * RADIUS)),
         DefineKeyValue(LMEM_HEIGHT, (THREADS_Y + 2 * RADIUS)),
         DefineKeyValue(GROUP_SIZE, (THREADS_Y * THREADS_X)),
-        DefineKeyValue(AF_IS_PLATFORM_NVIDIA, getActivePlatform()),
+        DefineKeyValue(AF_IS_PLATFORM_NVIDIA,
+                       (int)(AFCL_PLATFORM_NVIDIA == getActivePlatform())),
     };
     options.emplace_back(getTypeBuildDefinition<T>());
 

--- a/test/confidence_connected.cpp
+++ b/test/confidence_connected.cpp
@@ -160,8 +160,6 @@ void testData(CCCTestParams params) {
 class ConfidenceConnectedDataTest
     : public testing::TestWithParam<CCCTestParams> {};
 
-#if !defined(AF_OPENCL)
-
 TYPED_TEST(ConfidenceConnectedImageTest, DonutBackgroundExtraction) {
     const unsigned seedx = 10;
     const unsigned seedy = 10;
@@ -200,4 +198,3 @@ INSTANTIATE_TEST_CASE_P(
            << info.param.iterations << "_replace_" << info.param.replace;
         return ss.str();
     });
-#endif


### PR DESCRIPTION
Description
-----------
Enable confidence connected components function in OpenCL backend.

Changes to Users
----------------
The users can use confidence connected components in OpenCL backend from now on.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
