### PR TITLE
Enable disk caching support for OpenCL kernel binaries

### DIFF
--- a/src/backend/cuda/compile_module.cpp
+++ b/src/backend/cuda/compile_module.cpp
@@ -131,7 +131,7 @@ string getKernelCacheFilename(const int device, const string &key) {
         to_string(computeFlag.first) + to_string(computeFlag.second);
 
     return "KER" + key + "_CU_" + computeVersion + "_AF_" +
-           to_string(AF_API_VERSION_CURRENT) + ".cubin";
+           to_string(AF_API_VERSION_CURRENT) + ".bin";
 }
 
 namespace common {

--- a/src/backend/opencl/compile_module.cpp
+++ b/src/backend/opencl/compile_module.cpp
@@ -20,7 +20,10 @@
 #include <platform.hpp>
 #include <traits.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <cstdio>
+#include <fstream>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -37,9 +40,12 @@ using spdlog::logger;
 
 using std::begin;
 using std::end;
+using std::ofstream;
 using std::ostringstream;
 using std::shared_ptr;
 using std::string;
+using std::to_string;
+using std::transform;
 using std::vector;
 using std::chrono::duration_cast;
 using std::chrono::high_resolution_clock;
@@ -50,21 +56,30 @@ logger *getLogger() {
     return logger.get();
 }
 
-#define THROW_BUILD_LOG_EXCEPTION(PROG)                                     \
-    do {                                                                    \
-        string build_error;                                                 \
-        build_error.reserve(4096);                                          \
-        auto devices = PROG.getInfo<CL_PROGRAM_DEVICES>();                  \
-        for (auto &device : PROG.getInfo<CL_PROGRAM_DEVICES>()) {           \
-            build_error +=                                                  \
-                format("OpenCL Device: {}\n\tOptions: {}\n\tLog:\n{}\n",    \
-                       device.getInfo<CL_DEVICE_NAME>(),                    \
-                       PROG.getBuildInfo<CL_PROGRAM_BUILD_OPTIONS>(device), \
-                       PROG.getBuildInfo<CL_PROGRAM_BUILD_LOG>(device));    \
-        }                                                                   \
-        string info = getEnvVar("AF_OPENCL_SHOW_BUILD_INFO");               \
-        if (!info.empty() && info != "0") puts(build_error.c_str());        \
-        AF_ERROR(build_error, AF_ERR_INTERNAL);                             \
+string getProgramBuildLog(const Program &prog) {
+    string build_error("");
+    try {
+        build_error.reserve(4096);
+        auto devices = prog.getInfo<CL_PROGRAM_DEVICES>();
+        for (auto &device : prog.getInfo<CL_PROGRAM_DEVICES>()) {
+            build_error +=
+                format("OpenCL Device: {}\n\tOptions: {}\n\tLog:\n{}\n",
+                       device.getInfo<CL_DEVICE_NAME>(),
+                       prog.getBuildInfo<CL_PROGRAM_BUILD_OPTIONS>(device),
+                       prog.getBuildInfo<CL_PROGRAM_BUILD_LOG>(device));
+        }
+    } catch (const cl::Error &e) {
+        build_error = format("Failed to fetch build log: {}", e.what());
+    }
+    return build_error;
+}
+
+#define THROW_BUILD_LOG_EXCEPTION(PROG)                              \
+    do {                                                             \
+        string build_error = getProgramBuildLog(PROG);               \
+        string info        = getEnvVar("AF_OPENCL_SHOW_BUILD_INFO"); \
+        if (!info.empty() && info != "0") puts(build_error.c_str()); \
+        AF_ERROR(build_error, AF_ERR_INTERNAL);                      \
     } while (0)
 
 namespace opencl {
@@ -119,6 +134,21 @@ Program buildProgram(const vector<string> &kernelSources,
 
 }  // namespace opencl
 
+string getKernelCacheFilename(const int device, const string &key) {
+    auto &dev = opencl::getDevice(device);
+
+    unsigned vendorId = dev.getInfo<CL_DEVICE_VENDOR_ID>();
+    auto devName      = dev.getInfo<CL_DEVICE_NAME>();
+    string infix      = to_string(vendorId) + "_" + devName;
+
+    transform(infix.begin(), infix.end(), infix.begin(),
+              [](unsigned char c) { return std::toupper(c); });
+    std::replace(infix.begin(), infix.end(), ' ', '_');
+
+    return "KER" + key + "_CL_" + infix + "_AF_" +
+           to_string(AF_API_VERSION_CURRENT) + ".clbin";
+}
+
 namespace common {
 
 Module compileModule(const string &moduleKey, const vector<string> &sources,
@@ -131,6 +161,52 @@ Module compileModule(const string &moduleKey, const vector<string> &sources,
     auto program      = opencl::buildProgram(sources, options);
     auto compileEnd   = high_resolution_clock::now();
 
+#ifdef AF_CACHE_KERNELS_TO_DISK
+    const int device             = opencl::getActiveDeviceId();
+    const string &cacheDirectory = getCacheDirectory();
+    if (!cacheDirectory.empty()) {
+        const string cacheFile = cacheDirectory + AF_PATH_SEPARATOR +
+                                 getKernelCacheFilename(device, moduleKey);
+        const string tempFile =
+            cacheDirectory + AF_PATH_SEPARATOR + makeTempFilename();
+        try {
+            auto binaries = program.getInfo<CL_PROGRAM_BINARIES>();
+
+            // TODO Handle cases where program objects are created from contexts
+            // having multiple devices
+            const size_t clbinSize = binaries[0].size();
+            const char *clbin =
+                reinterpret_cast<const char *>(binaries[0].data());
+            const size_t clbinHash = deterministicHash(clbin, clbinSize);
+
+            // write module hash and binary data to file
+            ofstream out(tempFile, std::ios::binary);
+
+            out.write(reinterpret_cast<const char *>(&clbinHash),
+                      sizeof(clbinHash));
+            out.write(reinterpret_cast<const char *>(&clbinSize),
+                      sizeof(clbinSize));
+            out.write(static_cast<const char *>(clbin), clbinSize);
+            out.close();
+
+            // try to rename temporary file into final cache file, if this fails
+            // this means another thread has finished compiling this kernel
+            // before the current thread.
+            if (!renameFile(tempFile, cacheFile)) { removeFile(tempFile); }
+        } catch (const cl::Error &e) {
+            AF_TRACE("{{{:<30} : Failed to fetch opencl binary for {}, {}}}",
+                     moduleKey,
+                     opencl::getDevice(device).getInfo<CL_DEVICE_NAME>(),
+                     e.what());
+        } catch (const std::ios_base::failure &e) {
+            AF_TRACE("{{{:<30} : Failed writing binary to {} for {}, {}}}",
+                     moduleKey, cacheFile,
+                     opencl::getDevice(device).getInfo<CL_DEVICE_NAME>(),
+                     e.what());
+        }
+    }
+#endif
+
     AF_TRACE("{{{:<30} : {{ compile:{:>5} ms, {{ {} }}, {} }}}}", moduleKey,
              duration_cast<milliseconds>(compileEnd - compileBegin).count(),
              fmt::join(options, " "),
@@ -141,10 +217,65 @@ Module compileModule(const string &moduleKey, const vector<string> &sources,
 
 Module loadModuleFromDisk(const int device, const string &moduleKey,
                           const bool isJIT) {
-    UNUSED(device);
-    UNUSED(moduleKey);
-    UNUSED(isJIT);
-    return {};
+    const string &cacheDirectory = getCacheDirectory();
+    if (cacheDirectory.empty()) return Module{};
+
+    auto &dev              = opencl::getDevice(device);
+    const string cacheFile = cacheDirectory + AF_PATH_SEPARATOR +
+                             getKernelCacheFilename(device, moduleKey);
+    Program program;
+    Module retVal{};
+    try {
+        std::ifstream in(cacheFile, std::ios::binary);
+        if (!in.is_open()) {
+            AF_ERROR("Unable to open binary cache file", AF_ERR_INTERNAL);
+        }
+        in.exceptions(std::ios::failbit | std::ios::badbit);
+
+        // TODO Handle cases where program objects are created from contexts
+        // having multiple devices
+        size_t clbinHash = 0;
+        in.read(reinterpret_cast<char *>(&clbinHash), sizeof(clbinHash));
+        size_t clbinSize = 0;
+        in.read(reinterpret_cast<char *>(&clbinSize), sizeof(clbinSize));
+        vector<unsigned char> clbin(clbinSize);
+        in.read(reinterpret_cast<char *>(clbin.data()), clbinSize);
+        in.close();
+
+        const size_t recomputedHash =
+            deterministicHash(clbin.data(), clbinSize);
+        if (recomputedHash != clbinHash) {
+            AF_ERROR("Binary on disk seems to be corrupted", AF_ERR_LOAD_SYM);
+        }
+        program = Program(opencl::getContext(), {dev}, {clbin});
+        program.build();
+
+        AF_TRACE("{{{:<30} : loaded from {} for {} }}", moduleKey, cacheFile,
+                 dev.getInfo<CL_DEVICE_NAME>());
+        retVal.set(program);
+    } catch (const AfError &e) {
+        if (e.getError() == AF_ERR_LOAD_SYM) {
+            AF_TRACE(
+                "{{{:<30} : Corrupt binary({}) found on disk for {}, removed}}",
+                moduleKey, cacheFile, dev.getInfo<CL_DEVICE_NAME>());
+        } else {
+            AF_TRACE("{{{:<30} : Unable to open {} for {}}}", moduleKey,
+                     cacheFile, dev.getInfo<CL_DEVICE_NAME>());
+        }
+        removeFile(cacheFile);
+    } catch (const std::ios_base::failure &e) {
+        AF_TRACE("{{{:<30} : IO failure while loading {} for {}; {}}}",
+                 moduleKey, cacheFile, dev.getInfo<CL_DEVICE_NAME>(), e.what());
+        removeFile(cacheFile);
+    } catch (const cl::Error &e) {
+        AF_TRACE(
+            "{{{:<30} : Loading OpenCL binary({}) failed for {}; {}, Build "
+            "Log: {}}}",
+            moduleKey, cacheFile, dev.getInfo<CL_DEVICE_NAME>(), e.what(),
+            getProgramBuildLog(program));
+        removeFile(cacheFile);
+    }
+    return retVal;
 }
 
 Kernel getKernel(const Module &mod, const string &nameExpr,

--- a/src/backend/opencl/compile_module.cpp
+++ b/src/backend/opencl/compile_module.cpp
@@ -146,7 +146,7 @@ string getKernelCacheFilename(const int device, const string &key) {
     std::replace(infix.begin(), infix.end(), ' ', '_');
 
     return "KER" + key + "_CL_" + infix + "_AF_" +
-           to_string(AF_API_VERSION_CURRENT) + ".clbin";
+           to_string(AF_API_VERSION_CURRENT) + ".bin";
 }
 
 namespace common {


### PR DESCRIPTION
Description
-----------
Fixes: #2857 

Changes to Users
----------------
OpenCL kernel binaries are loaded from disk if available instead compiling from scratch on initialization of the library. In the tests with nvidia opencl implementation, observed a speedup of 2x loading vs compile time.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
