### PR TITLE
Fix incorrect macro and name in docs. Update links to https.

### DIFF
--- a/docs/footer.htm
+++ b/docs/footer.htm
@@ -7,13 +7,13 @@
 <!--Google Analytics-->
 <script type="text/javascript">
   var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-5076919-1']);
+  _gaq.push(['_setAccount', 'UA-130950618-1']);
   _gaq.push(['_setDomainName', '.arrayfire.com']);
   _gaq.push(['_trackPageview']);
 
   (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'https://www') + '.google-analytics.com/ga.js';
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
 </script>
@@ -26,7 +26,7 @@
   (function() {
     function async_load(){
       var s = document.createElement('script'); s.type = 'text/javascript';
-      s.src = (('https:' == document.location.protocol) ? "https://ssl" : "http://cdn") + ".spectate.com/s.js";
+      s.src = (('https:' == document.location.protocol) ? "https://ssl" : "https://cdn") + ".spectate.com/s.js";
       var c = document.getElementsByTagName('script')[0]; c.parentNode.insertBefore(s, c);
     }
     if(window.attachEvent) { window.attachEvent('onload', async_load); }
@@ -43,7 +43,7 @@ var oldonload = window.onload;
 window.onload = function(){
    __adroll_loaded=true;
    var scr = document.createElement("script");
-   var host = (("https:" == document.location.protocol) ? "https://s.adroll.com" : "http://a.adroll.com");
+   var host = (("https:" == document.location.protocol) ? "https://s.adroll.com" : "https://a.adroll.com");
    scr.setAttribute('async', 'true');
    scr.type = "text/javascript";
    scr.src = host + "/j/roundtrip.js";

--- a/docs/header.htm
+++ b/docs/header.htm
@@ -1,6 +1,6 @@
 <!-- HTML header for doxygen 1.8.17-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="https://www.w3.org/1999/xhtml">
 <head>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
 <meta http-equiv="X-UA-Compatible" content="IE=9"/>

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -20,48 +20,48 @@ v3.7.2
 
 Improvements
 ------------
-- Cache CUDA kernels to disk to improve load times(Thanks to \@cschreib-ibex) /PR{2848}
-- Staticly link against cuda libraries /PR{2785}
-- Make cuDNN an optional build dependency /PR{2836}
-- Improve support for different compilers and OS /PR{2876} /PR{2945} /PR{2925} /PR{2942} /PR{2943} /PR{2945} /PR{2958}
-- Improve performance of join and transpose on CPU /PR{2849}
-- Improve documentation /PR{2816} /PR{2821} /PR{2846} /PR{2918} /PR{2928} /PR{2947}
-- Reduce binary size using NVRTC and template reducing instantiations /PR{2849} /PR{2861} /PR{2890} /PR{2957}
-- reduceByKey performance improvements /PR{2851} /PR{2957}
-- Improve support for Intel OpenCL GPUs /PR{2855}
-- Allow staticly linking against MKL /PR{2877} (Sponsered by SDL)
-- Better support for older CUDA toolkits /PR{2923}
-- Add support for CUDA 11 /PR{2939}
-- Add support for ccache for faster builds /PR{2931}
-- Add support for the conan package manager on linux /PR{2875}
-- Propagate build errors up the stack in AFError exceptions /PR{2948} /PR{2957}
-- Improve runtime dependency library loading /PR{2954}
-- Improved cuDNN runtime checks and warnings /PR{2960}
-- Document af\_memory\_manager\_* native memory return values /PR{2911}
+- Cache CUDA kernels to disk to improve load times(Thanks to \@cschreib-ibex) \PR{2848}
+- Staticly link against cuda libraries \PR{2785}
+- Make cuDNN an optional build dependency \PR{2836}
+- Improve support for different compilers and OS \PR{2876} \PR{2945} \PR{2925} \PR{2942} \PR{2943} \PR{2945} \PR{2958}
+- Improve performance of join and transpose on CPU \PR{2849}
+- Improve documentation \PR{2816} \PR{2821} \PR{2846} \PR{2918} \PR{2928} \PR{2947}
+- Reduce binary size using NVRTC and template reducing instantiations \PR{2849} \PR{2861} \PR{2890} \PR{2957}
+- reduceByKey performance improvements \PR{2851} \PR{2957}
+- Improve support for Intel OpenCL GPUs \PR{2855}
+- Allow staticly linking against MKL \PR{2877} (Sponsered by SDL)
+- Better support for older CUDA toolkits \PR{2923}
+- Add support for CUDA 11 \PR{2939}
+- Add support for ccache for faster builds \PR{2931}
+- Add support for the conan package manager on linux \PR{2875}
+- Propagate build errors up the stack in AFError exceptions \PR{2948} \PR{2957}
+- Improve runtime dependency library loading \PR{2954}
+- Improved cuDNN runtime checks and warnings \PR{2960}
+- Document af\_memory\_manager\_* native memory return values \PR{2911}
 
 Fixes
 -----
-- Bug crash when allocating large arrays /PR{2827}
-- Fix various compiler warnings /PR{2827} /PR{2849} /PR{2872} /PR{2876}
-- Fix minor leaks in OpenCL functions /PR{2913}
-- Various continuous integration related fixes /PR{2819}
-- Fix zero padding with convolv2NN /PR{2820}
-- Fix af_get_memory_pressure_threshold return value /PR{2831}
+- Bug crash when allocating large arrays \PR{2827}
+- Fix various compiler warnings \PR{2827} \PR{2849} \PR{2872} \PR{2876}
+- Fix minor leaks in OpenCL functions \PR{2913}
+- Various continuous integration related fixes \PR{2819}
+- Fix zero padding with convolv2NN \PR{2820}
+- Fix af_get_memory_pressure_threshold return value \PR{2831}
 - Increased the max filter length for morph
-- Handle empty array inputs for LU, QR, and Rank functions /PR{2838}
-- Fix FindMKL.cmake script for sequential threading library /PR{2840} /PR{2952}
-- Various internal refactoring /PR{2839} /PR{2861} /PR{2864} /PR{2873} /PR{2890} /PR{2891} /PR{2913} /PR{2959}
-- Fix OpenCL 2.0 builtin function name conflict /PR{2851}
-- Fix error caused when releasing memory with multiple devices /PR{2867}
-- Fix missing set stacktrace symbol from unified API /PR{2915}
-- Fix zero padding issue in convolve2NN /PR{2820}
-- Fixed bugs in ReduceByKey /PR{2957}
+- Handle empty array inputs for LU, QR, and Rank functions \PR{2838}
+- Fix FindMKL.cmake script for sequential threading library \PR{2840} \PR{2952}
+- Various internal refactoring \PR{2839} \PR{2861} \PR{2864} \PR{2873} \PR{2890} \PR{2891} \PR{2913} \PR{2959}
+- Fix OpenCL 2.0 builtin function name conflict \PR{2851}
+- Fix error caused when releasing memory with multiple devices \PR{2867}
+- Fix missing set stacktrace symbol from unified API \PR{2915}
+- Fix zero padding issue in convolve2NN \PR{2820}
+- Fixed bugs in ReduceByKey \PR{2957}
 
 Contributions
 -------------
 Special thanks to our contributors:
 [Corentin Schreiber](https://github.com/cschreib-ibex)
-[Jacob Khan](https://github.com/jacobkahn)
+[Jacob Kahn](https://github.com/jacobkahn)
 [Paul Jurczak](https://github.com/pauljurczak)
 [Christoph Junghans](https://github.com/junghans)
 


### PR DESCRIPTION
Fixes minor issues in documentation

Description
-----------
* Fixes the `\PR` macro used in doxygen to create PR links
* Fixed an incorrectly spelled name in the release notes
* Change the http links to https links

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- [x] Functions documented
