### PR TITLE
Add missing non-const Array::getNode method in CPU/OpenCL backends

### DIFF
--- a/src/backend/cpu/Array.cpp
+++ b/src/backend/cpu/Array.cpp
@@ -208,13 +208,19 @@ void evalMultiple(vector<Array<T> *> array_ptrs) {
 }
 
 template<typename T>
-Node_ptr Array<T>::getNode() const {
+Node_ptr Array<T>::getNode() {
     if (node->isBuffer()) {
         auto *bufNode  = reinterpret_cast<BufferNode<T> *>(node.get());
         unsigned bytes = this->getDataDims().elements() * sizeof(T);
         bufNode->setData(data, bytes, getOffset(), dims().get(),
                          strides().get(), isLinear());
     }
+    return node;
+}
+
+template<typename T>
+Node_ptr Array<T>::getNode() const {
+    if (node->isBuffer()) { return const_cast<Array<T> *>(this)->getNode(); }
     return node;
 }
 
@@ -351,6 +357,7 @@ void Array<T>::setDataDims(const dim4 &new_dims) {
                              bool is_device, bool copy_device);               \
     template Array<T>::Array(const af::dim4 &dims, const af::dim4 &strides,   \
                              dim_t offset, T *const in_data, bool is_device); \
+    template Node_ptr Array<T>::getNode();                                    \
     template Node_ptr Array<T>::getNode() const;                              \
     template void writeHostDataArray<T>(Array<T> & arr, const T *const data,  \
                                         const size_t bytes);                  \

--- a/src/backend/cpu/Array.hpp
+++ b/src/backend/cpu/Array.hpp
@@ -246,6 +246,7 @@ class Array {
     }
 
     common::Node_ptr getNode() const;
+    common::Node_ptr getNode();
 
     friend void evalMultiple<T>(std::vector<Array<T> *> arrays);
 

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -439,6 +439,7 @@ void Array<T>::setDataDims(const dim4 &new_dims) {
                              bool is_device);                                 \
     template Array<T>::Array(const af::dim4 &dims, const T *const in_data,    \
                              bool is_device, bool copy_device);               \
+    template Node_ptr Array<T>::getNode();                                    \
     template Node_ptr Array<T>::getNode() const;                              \
     template void Array<T>::eval();                                           \
     template void Array<T>::eval() const;                                     \

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -520,6 +520,7 @@ size_t Array<T>::getAllocatedBytes() const {
                              bool is_device);                                 \
     template Array<T>::Array(const dim4 &dims, cl_mem mem, size_t src_offset, \
                              bool copy);                                      \
+    template Node_ptr Array<T>::getNode();                                    \
     template Node_ptr Array<T>::getNode() const;                              \
     template void Array<T>::eval();                                           \
     template void Array<T>::eval() const;                                     \


### PR DESCRIPTION
Description
-----------
The missing methods are causing link issues with Intel compiler only. Nevertheless, it is an issue that needs to be fixed.

Fixes: #2272 

Changes to Users
----------------
None.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
