### PR TITLE
Address perf regression in approx after dim based interop was introduced

### DIFF
--- a/src/backend/cuda/kernel/approx.hpp
+++ b/src/backend/cuda/kernel/approx.hpp
@@ -31,9 +31,10 @@ void approx1(Param<Ty> yo, CParam<Ty> yi, CParam<Tp> xo, const int xdim,
              const af::interpType method, const int order) {
     static const std::string source(approx1_cuh, approx1_cuh_len);
 
-    auto approx1 = common::getKernel(
-        "cuda::approx1", {source},
-        {TemplateTypename<Ty>(), TemplateTypename<Tp>(), TemplateArg(order)});
+    auto approx1 =
+        common::getKernel("cuda::approx1", {source},
+                          {TemplateTypename<Ty>(), TemplateTypename<Tp>(),
+                           TemplateArg(xdim), TemplateArg(order)});
 
     dim3 threads(THREADS, 1, 1);
     int blocksPerMat = divup(yo.dims[0], threads.x);
@@ -48,7 +49,7 @@ void approx1(Param<Ty> yo, CParam<Ty> yi, CParam<Tp> xo, const int xdim,
 
     EnqueueArgs qArgs(blocks, threads, getActiveStream());
 
-    approx1(qArgs, yo, yi, xo, xdim, xi_beg, xi_step, offGrid, blocksPerMat,
+    approx1(qArgs, yo, yi, xo, xi_beg, Tp(1) / xi_step, offGrid, blocksPerMat,
             batch, method);
 
     POST_LAUNCH_CHECK();
@@ -63,7 +64,8 @@ void approx2(Param<Ty> zo, CParam<Ty> zi, CParam<Tp> xo, const int xdim,
 
     auto approx2 = common::getKernel(
         "cuda::approx2", {source},
-        {TemplateTypename<Ty>(), TemplateTypename<Tp>(), TemplateArg(order)});
+        {TemplateTypename<Ty>(), TemplateTypename<Tp>(), TemplateArg(xdim),
+         TemplateArg(ydim), TemplateArg(order)});
 
     dim3 threads(TX, TY, 1);
     int blocksPerMatX = divup(zo.dims[0], threads.x);
@@ -79,8 +81,9 @@ void approx2(Param<Ty> zo, CParam<Ty> zi, CParam<Tp> xo, const int xdim,
 
     EnqueueArgs qArgs(blocks, threads, getActiveStream());
 
-    approx2(qArgs, zo, zi, xo, xdim, xi_beg, xi_step, yo, ydim, yi_beg, yi_step,
-            offGrid, blocksPerMatX, blocksPerMatY, batch, method);
+    approx2(qArgs, zo, zi, xo, xi_beg, Tp(1) / xi_step, yo, yi_beg,
+            Tp(1) / yi_step, offGrid, blocksPerMatX, blocksPerMatY, batch,
+            method);
 
     POST_LAUNCH_CHECK();
 }

--- a/src/backend/cuda/kernel/approx1.cuh
+++ b/src/backend/cuda/kernel/approx1.cuh
@@ -14,13 +14,11 @@
 
 namespace cuda {
 
-template<typename Ty, typename Tp, int order>
-__global__
-void approx1(Param<Ty> yo, CParam<Ty> yi, CParam<Tp> xo,
-             const int xdim, const Tp xi_beg,
-             const Tp xi_step, const float offGrid,
-             const int blocksMatX, const bool batch,
-             af::interpType method) {
+template<typename Ty, typename Tp, int xdim, int order>
+__global__ void approx1(Param<Ty> yo, CParam<Ty> yi, CParam<Tp> xo,
+                        const Tp xi_beg, const Tp xi_step_reproc,
+                        const float offGrid, const int blocksMatX,
+                        const bool batch, af::interpType method) {
     const int idy        = blockIdx.x / blocksMatX;
     const int blockIdx_x = blockIdx.x - idy * blocksMatX;
     const int idx        = blockIdx_x * blockDim.x + threadIdx.x;
@@ -32,36 +30,42 @@ void approx1(Param<Ty> yo, CParam<Ty> yi, CParam<Tp> xo,
         idw >= yo.dims[3])
         return;
 
-    bool is_xo_off[] = {xo.dims[0] > 1, xo.dims[1] > 1, xo.dims[2] > 1,
-                        xo.dims[3] > 1};
-    bool is_yi_off[] = {true, true, true, true};
-    is_yi_off[xdim]  = false;
+    // FIXME: Only cubic interpolation is doing clamping
+    // We need to make it consistent across all methods
+    // Not changing the behavior because tests will fail
+    const bool clamp = order == 3;
+
+    bool is_off[] = {xo.dims[0] > 1, xo.dims[1] > 1, xo.dims[2] > 1,
+                     xo.dims[3] > 1};
+
+    int xo_idx = idx * is_off[0];
+    if (batch) {
+        xo_idx += idw * xo.strides[3] * is_off[3];
+        xo_idx += idz * xo.strides[2] * is_off[2];
+        xo_idx += idy * xo.strides[1] * is_off[1];
+    }
+
+    const Tp x = (xo.ptr[xo_idx] - xi_beg) * xi_step_reproc;
 
     const int yo_idx =
         idw * yo.strides[3] + idz * yo.strides[2] + idy * yo.strides[1] + idx;
-    int xo_idx = idx * is_xo_off[0];
-    xo_idx += idw * xo.strides[3] * is_xo_off[3];
-    xo_idx += idz * xo.strides[2] * is_xo_off[2];
-    xo_idx += idy * xo.strides[1] * is_xo_off[1];
 
-    const Tp x = (xo.ptr[xo_idx] - xi_beg) / xi_step;
+#pragma unroll
+    for (int flagIdx = 0; flagIdx < 4; ++flagIdx) { is_off[flagIdx] = true; }
+    is_off[xdim] = false;
+
     if (x < 0 || yi.dims[xdim] < x + 1) {
         yo.ptr[yo_idx] = scalar<Ty>(offGrid);
         return;
     }
 
-    int yi_idx = idx * is_yi_off[0];
-    yi_idx += idw * yi.strides[3] * is_yi_off[3];
-    yi_idx += idz * yi.strides[2] * is_yi_off[2];
-    yi_idx += idy * yi.strides[1] * is_yi_off[1];
+    int yi_idx = idx * is_off[0];
+    yi_idx += idw * yi.strides[3] * is_off[3];
+    yi_idx += idz * yi.strides[2] * is_off[2];
+    yi_idx += idy * yi.strides[1] * is_off[1];
 
-    // FIXME: Only cubic interpolation is doing clamping
-    // We need to make it consistent across all methods
-    // Not changing the behavior because tests will fail
-    bool clamp = order == 3;
-
-    Interp1<Ty, Tp, order> interp;
-    interp(yo, yo_idx, yi, yi_idx, x, method, 1, clamp, xdim);
+    Interp1<Ty, Tp, xdim, order> interp;
+    interp(yo, yo_idx, yi, yi_idx, x, method, 1, clamp);
 }
 
-}
+}  // namespace cuda

--- a/src/backend/cuda/kernel/approx2.cuh
+++ b/src/backend/cuda/kernel/approx2.cuh
@@ -14,15 +14,13 @@
 
 namespace cuda {
 
-template<typename Ty, typename Tp, int order>
-__global__
-void approx2(Param<Ty> zo, CParam<Ty> zi, CParam<Tp> xo,
-             const int xdim, const Tp xi_beg,
-             const Tp xi_step, CParam<Tp> yo, const int ydim,
-             const Tp yi_beg, const Tp yi_step,
-             const float offGrid, const int blocksMatX,
-             const int blocksMatY, const bool batch,
-             af::interpType method) {
+template<typename Ty, typename Tp, int xdim, int ydim, int order>
+__global__ void approx2(Param<Ty> zo, CParam<Ty> zi, CParam<Tp> xo,
+                        const Tp xi_beg, const Tp xi_step_reproc, CParam<Tp> yo,
+                        const Tp yi_beg, const Tp yi_step_reproc,
+                        const float offGrid, const int blocksMatX,
+                        const int blocksMatY, const bool batch,
+                        af::interpType method) {
     const int idz        = blockIdx.x / blocksMatX;
     const int blockIdx_x = blockIdx.x - idz * blocksMatX;
     const int idx        = threadIdx.x + blockIdx_x * blockDim.x;
@@ -36,39 +34,43 @@ void approx2(Param<Ty> zo, CParam<Ty> zi, CParam<Tp> xo,
         idw >= zo.dims[3])
         return;
 
-    bool is_xo_off[] = {xo.dims[0] > 1, xo.dims[1] > 1, xo.dims[2] > 1,
-                        xo.dims[3] > 1};
-    bool is_zi_off[] = {true, true, true, true};
-    is_zi_off[xdim]  = false;
-    is_zi_off[ydim]  = false;
+    // FIXME: Only cubic interpolation is doing clamping
+    // We need to make it consistent across all methods
+    // Not changing the behavior because tests will fail
+    const bool clamp = order == 3;
+
+    bool is_off[] = {xo.dims[0] > 1, xo.dims[1] > 1, xo.dims[2] > 1,
+                     xo.dims[3] > 1};
 
     const int zo_idx =
         idw * zo.strides[3] + idz * zo.strides[2] + idy * zo.strides[1] + idx;
-    int xo_idx = idy * xo.strides[1] * is_xo_off[1] + idx * is_xo_off[0];
-    int yo_idx = idy * yo.strides[1] * is_xo_off[1] + idx * is_xo_off[0];
-    xo_idx +=
-        idw * xo.strides[3] * is_xo_off[3] + idz * xo.strides[2] * is_xo_off[2];
-    yo_idx +=
-        idw * yo.strides[3] * is_xo_off[3] + idz * yo.strides[2] * is_xo_off[2];
+    int xo_idx = idy * xo.strides[1] * is_off[1] + idx * is_off[0];
+    int yo_idx = idy * yo.strides[1] * is_off[1] + idx * is_off[0];
+    if (batch) {
+        xo_idx +=
+            idw * xo.strides[3] * is_off[3] + idz * xo.strides[2] * is_off[2];
+        yo_idx +=
+            idw * yo.strides[3] * is_off[3] + idz * yo.strides[2] * is_off[2];
+    }
 
-    const Tp x = (xo.ptr[xo_idx] - xi_beg) / xi_step;
-    const Tp y = (yo.ptr[yo_idx] - yi_beg) / yi_step;
+    const Tp x = (xo.ptr[xo_idx] - xi_beg) * xi_step_reproc;
+    const Tp y = (yo.ptr[yo_idx] - yi_beg) * yi_step_reproc;
+
+#pragma unroll
+    for (int flagIdx = 0; flagIdx < 4; ++flagIdx) { is_off[flagIdx] = true; }
+    is_off[xdim] = false;
+    is_off[ydim] = false;
+
     if (x < 0 || y < 0 || zi.dims[xdim] < x + 1 || zi.dims[ydim] < y + 1) {
         zo.ptr[zo_idx] = scalar<Ty>(offGrid);
         return;
     }
 
-    int zi_idx = idy * zi.strides[1] * is_zi_off[1] + idx * is_zi_off[0];
-    zi_idx +=
-        idw * zi.strides[3] * is_zi_off[3] + idz * zi.strides[2] * is_zi_off[2];
+    int zi_idx = idy * zi.strides[1] * is_off[1] + idx * is_off[0];
+    zi_idx += idw * zi.strides[3] * is_off[3] + idz * zi.strides[2] * is_off[2];
 
-    // FIXME: Only cubic interpolation is doing clamping
-    // We need to make it consistent across all methods
-    // Not changing the behavior because tests will fail
-    bool clamp = order == 3;
-
-    Interp2<Ty, Tp, order> interp;
-    interp(zo, zo_idx, zi, zi_idx, x, y, method, 1, clamp, xdim, ydim);
+    Interp2<Ty, Tp, xdim, ydim, order> interp;
+    interp(zo, zo_idx, zi, zi_idx, x, y, method, 1, clamp);
 }
 
-}
+}  // namespace cuda

--- a/src/backend/cuda/kernel/interp.hpp
+++ b/src/backend/cuda/kernel/interp.hpp
@@ -85,14 +85,14 @@ __device__ inline static Ty bicubicInterpFunc(Ty val[4][4], Tp xratio,
     return cubicInterpFunc(res, yratio, spline);
 }
 
-template<typename Ty, typename Tp, int order>
+template<typename Ty, typename Tp, int xdim, int order>
 struct Interp1 {};
 
-template<typename Ty, typename Tp>
-struct Interp1<Ty, Tp, 1> {
+template<typename Ty, typename Tp, int xdim>
+struct Interp1<Ty, Tp, xdim, 1> {
     __device__ void operator()(Param<Ty> out, int ooff, CParam<Ty> in, int ioff,
                                Tp x, af::interpType method, int batch,
-                               bool clamp, int xdim = 0, int batch_dim = 1) {
+                               bool clamp, int batch_dim = 1) {
         Ty zero = scalar<Ty>(0);
 
         const int x_lim    = in.dims[xdim];
@@ -113,11 +113,11 @@ struct Interp1<Ty, Tp, 1> {
     }
 };
 
-template<typename Ty, typename Tp>
-struct Interp1<Ty, Tp, 2> {
+template<typename Ty, typename Tp, int xdim>
+struct Interp1<Ty, Tp, xdim, 2> {
     __device__ void operator()(Param<Ty> out, int ooff, CParam<Ty> in, int ioff,
                                Tp x, af::interpType method, int batch,
-                               bool clamp, int xdim = 0, int batch_dim = 1) {
+                               bool clamp, int batch_dim = 1) {
         typedef typename itype_t<Tp>::wtype WT;
         typedef typename itype_t<Ty>::vtype VT;
 
@@ -149,11 +149,11 @@ struct Interp1<Ty, Tp, 2> {
     }
 };
 
-template<typename Ty, typename Tp>
-struct Interp1<Ty, Tp, 3> {
+template<typename Ty, typename Tp, int xdim>
+struct Interp1<Ty, Tp, xdim, 3> {
     __device__ void operator()(Param<Ty> out, int ooff, CParam<Ty> in, int ioff,
                                Tp x, af::interpType method, int batch,
-                               bool clamp, int xdim = 0, int batch_dim = 1) {
+                               bool clamp, int batch_dim = 1) {
         typedef typename itype_t<Tp>::wtype WT;
         typedef typename itype_t<Ty>::vtype VT;
 
@@ -184,15 +184,14 @@ struct Interp1<Ty, Tp, 3> {
     }
 };
 
-template<typename Ty, typename Tp, int order>
+template<typename Ty, typename Tp, int xdim, int ydim, int order>
 struct Interp2 {};
 
-template<typename Ty, typename Tp>
-struct Interp2<Ty, Tp, 1> {
+template<typename Ty, typename Tp, int xdim, int ydim>
+struct Interp2<Ty, Tp, xdim, ydim, 1> {
     __device__ void operator()(Param<Ty> out, int ooff, CParam<Ty> in, int ioff,
                                Tp x, Tp y, af::interpType method, int batch,
-                               bool clamp, int xdim = 0, int ydim = 1,
-                               int batch_dim = 2) {
+                               bool clamp, int batch_dim = 2) {
         int xid = (method == AF_INTERP_LOWER ? floor(x) : round(x));
         int yid = (method == AF_INTERP_LOWER ? floor(y) : round(y));
 
@@ -222,12 +221,11 @@ struct Interp2<Ty, Tp, 1> {
     }
 };
 
-template<typename Ty, typename Tp>
-struct Interp2<Ty, Tp, 2> {
+template<typename Ty, typename Tp, int xdim, int ydim>
+struct Interp2<Ty, Tp, xdim, ydim, 2> {
     __device__ void operator()(Param<Ty> out, int ooff, CParam<Ty> in, int ioff,
                                Tp x, Tp y, af::interpType method, int batch,
-                               bool clamp, int xdim = 0, int ydim = 1,
-                               int batch_dim = 2) {
+                               bool clamp, int batch_dim = 2) {
         typedef typename itype_t<Tp>::wtype WT;
         typedef typename itype_t<Ty>::vtype VT;
 
@@ -275,12 +273,11 @@ struct Interp2<Ty, Tp, 2> {
     }
 };
 
-template<typename Ty, typename Tp>
-struct Interp2<Ty, Tp, 3> {
+template<typename Ty, typename Tp, int xdim, int ydim>
+struct Interp2<Ty, Tp, xdim, ydim, 3> {
     __device__ void operator()(Param<Ty> out, int ooff, CParam<Ty> in, int ioff,
                                Tp x, Tp y, af::interpType method, int batch,
-                               bool clamp, int xdim = 0, int ydim = 1,
-                               int batch_dim = 2) {
+                               bool clamp, int batch_dim = 2) {
         typedef typename itype_t<Tp>::wtype WT;
         typedef typename itype_t<Ty>::vtype VT;
 

--- a/src/backend/cuda/kernel/rotate.cuh
+++ b/src/backend/cuda/kernel/rotate.cuh
@@ -19,8 +19,7 @@ typedef struct {
 template<typename T, int order>
 __global__ void rotate(Param<T> out, CParam<T> in, const tmat_t t,
                        const int nimages, const int nbatches,
-                       const int blocksXPerImage,
-                       const int blocksYPerImage,
+                       const int blocksXPerImage, const int blocksYPerImage,
                        af::interpType method) {
     // Compute which image set
     const int setId      = blockIdx.x / blocksXPerImage;
@@ -62,7 +61,7 @@ __global__ void rotate(Param<T> out, CParam<T> in, const tmat_t t,
         }
     }
 
-    Interp2<T, WT, order> interp;
+    Interp2<T, WT, 0, 1, order> interp;
     // FIXME: Nearest and lower do not do clamping, but other methods do
     // Make it consistent
     bool clamp = order != 1;

--- a/src/backend/cuda/kernel/transform.cuh
+++ b/src/backend/cuda/kernel/transform.cuh
@@ -164,7 +164,7 @@ void transform(Param<T> out, CParam<T> in,
         return;
     }
 
-    Interp2<T, WT, order> interp;
+    Interp2<T, WT, 0, 1, order> interp;
     // FIXME: Nearest and lower do not do clamping, but other methods do
     // Make it consistent
     bool clamp = order != 1;

--- a/src/backend/opencl/kernel/approx1.cl
+++ b/src/backend/opencl/kernel/approx1.cl
@@ -9,9 +9,8 @@
 
 kernel void approx1(global Ty *d_yo, const KParam yo, global const Ty *d_yi,
                     const KParam yi, global const Tp *d_xo, const KParam xo,
-                    const int xdim, const Tp xi_beg, const Tp xi_step,
-                    const Ty offGrid, const int blocksMatX, const int batch,
-                    const int method) {
+                    const Tp xi_beg, const Tp xi_step_reproc, const Ty offGrid,
+                    const int blocksMatX, const int batch, const int method) {
     const int idw = get_group_id(1) / yo.dims[2];
     const int idz = get_group_id(1) - idw * yo.dims[2];
 
@@ -23,34 +22,39 @@ kernel void approx1(global Ty *d_yo, const KParam yo, global const Ty *d_yi,
         idw >= yo.dims[3])
         return;
 
-    bool is_xo_off[] = {xo.dims[0] > 1, xo.dims[1] > 1, xo.dims[2] > 1,
-                        xo.dims[3] > 1};
-    bool is_yi_off[] = {true, true, true, true};
-    is_yi_off[xdim]  = false;
+    // FIXME: Only cubic interpolation is doing clamping
+    // We need to make it consistent across all methods
+    // Not changing the behavior because tests will fail
+    const bool doclamp = INTERP_ORDER == 3;
+
+    bool is_off[] = {xo.dims[0] > 1, xo.dims[1] > 1, xo.dims[2] > 1,
+                     xo.dims[3] > 1};
 
     const int yo_idx = idw * yo.strides[3] + idz * yo.strides[2] +
                        idy * yo.strides[1] + idx + yo.offset;
 
-    int xo_idx = idx * is_xo_off[0] + xo.offset;
-    xo_idx += idw * xo.strides[3] * is_xo_off[3];
-    xo_idx += idz * xo.strides[2] * is_xo_off[2];
-    xo_idx += idy * xo.strides[1] * is_xo_off[1];
+    int xo_idx = idx * is_off[0] + xo.offset;
+    if (batch) {
+        xo_idx += idw * xo.strides[3] * is_off[3];
+        xo_idx += idz * xo.strides[2] * is_off[2];
+        xo_idx += idy * xo.strides[1] * is_off[1];
+    }
 
-    const Tp x = (d_xo[xo_idx] - xi_beg) / xi_step;
-    if (x < 0 || yi.dims[xdim] < x + 1) {
+    const Tp x = (d_xo[xo_idx] - xi_beg) * xi_step_reproc;
+
+#pragma unroll
+    for (int flagIdx = 0; flagIdx < 4; ++flagIdx) { is_off[flagIdx] = true; }
+    is_off[XDIM] = false;
+
+    if (x < 0 || yi.dims[XDIM] < x + 1) {
         d_yo[yo_idx] = offGrid;
         return;
     }
 
-    int yi_idx = idx * is_yi_off[0] + yi.offset;
-    yi_idx += idw * yi.strides[3] * is_yi_off[3];
-    yi_idx += idz * yi.strides[2] * is_yi_off[2];
-    yi_idx += idy * yi.strides[1] * is_yi_off[1];
+    int yi_idx = idx * is_off[0] + yi.offset;
+    yi_idx += idw * yi.strides[3] * is_off[3];
+    yi_idx += idz * yi.strides[2] * is_off[2];
+    yi_idx += idy * yi.strides[1] * is_off[1];
 
-    // FIXME: Only cubic interpolation is doing clamping
-    // We need to make it consistent across all methods
-    // Not changing the behavior because tests will fail
-    bool clamp = INTERP_ORDER == 3;
-
-    interp1_dim(d_yo, yo, yo_idx, d_yi, yi, yi_idx, x, method, 1, clamp, xdim);
+    interp1(d_yo, yo, yo_idx, d_yi, yi, yi_idx, x, method, 1, doclamp, 1);
 }

--- a/src/backend/opencl/kernel/rotate.cl
+++ b/src/backend/opencl/kernel/rotate.cl
@@ -62,7 +62,7 @@ kernel void rotateKernel(global T *d_out, const KParam out,
 
     // FIXME: Nearest and lower do not do clamping, but other methods do
     // Make it consistent
-    bool clamp = INTERP_ORDER != 1;
+    const bool doclamp = INTERP_ORDER != 1;
     interp2(d_out, out, loco, d_in, in, inoff, xidi, yidi, method, limages,
-            clamp);
+            doclamp, 2);
 }

--- a/src/backend/opencl/kernel/rotate.hpp
+++ b/src/backend/opencl/kernel/rotate.hpp
@@ -70,6 +70,8 @@ void rotate(Param out, const Param in, const float theta, af_interp_type method,
         DefineKeyValue(InterpInTy, dtype_traits<T>::getName()),
         DefineKeyValue(InterpValTy, dtype_traits<vtype_t<T>>::getName()),
         DefineKeyValue(InterpPosTy, dtype_traits<wtype_t<BT>>::getName()),
+        DefineKeyValue(XDIM, 0),
+        DefineKeyValue(YDIM, 1),
         DefineKeyValue(INTERP_ORDER, order),
         DefineKeyValue(IS_CPLX, (isComplex ? 1 : 0)),
     };

--- a/src/backend/opencl/kernel/transform.cl
+++ b/src/backend/opencl/kernel/transform.cl
@@ -155,7 +155,7 @@ kernel void transformKernel(global T *d_out, const KParam out,
     const int loco = outoff + (yido * out.strides[1] + xido);
     // FIXME: Nearest and lower do not do clamping, but other methods do
     // Make it consistent
-    bool clamp = INTERP_ORDER != 1;
+    const bool doclamp = INTERP_ORDER != 1;
 
     T zero = ZERO;
     if (xidi < (InterpPosTy)-0.0001 || yidi < (InterpPosTy)-0.0001 ||
@@ -167,5 +167,5 @@ kernel void transformKernel(global T *d_out, const KParam out,
     }
 
     interp2(d_out, out, loco, d_in, in, inoff, xidi, yidi, method, limages,
-            clamp);
+            doclamp, 2);
 }

--- a/src/backend/opencl/kernel/transform.hpp
+++ b/src/backend/opencl/kernel/transform.hpp
@@ -70,6 +70,8 @@ void transform(Param out, const Param in, const Param tf, bool isInverse,
         DefineKeyValue(InterpInTy, dtype_traits<T>::getName()),
         DefineKeyValue(InterpValTy, dtype_traits<vtype_t<T>>::getName()),
         DefineKeyValue(InterpPosTy, dtype_traits<wtype_t<BT>>::getName()),
+        DefineKeyValue(XDIM, 0),
+        DefineKeyValue(YDIM, 1),
         DefineKeyValue(INTERP_ORDER, order),
         DefineKeyValue(IS_CPLX, (isComplex ? 1 : 0)),
     };


### PR DESCRIPTION
Description
-----------
Fixes: #2975 

Changes to Users
----------------
The performance of approx1 and approx2 should be back to what it was prior to 3.7.* releases.

Checklist
---------

- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
