### PR TITLE
Add missing opencl-arrayfire interop fns in unified backend

### DIFF
--- a/src/api/unified/CMakeLists.txt
+++ b/src/api/unified/CMakeLists.txt
@@ -23,6 +23,7 @@ target_sources(af
     ${CMAKE_CURRENT_SOURCE_DIR}/memory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ml.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moments.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/opencl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/random.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/signal.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sparse.cpp

--- a/src/api/unified/opencl.cpp
+++ b/src/api/unified/opencl.cpp
@@ -1,0 +1,83 @@
+/*******************************************************
+ * Copyright (c) 2020, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <af/backend.h>
+#include "symbol_manager.hpp"
+
+#include <af/opencl.h>
+
+af_err afcl_get_device_type(afcl_device_type* res) {
+    af_backend backend;
+    af_get_active_backend(&backend);
+    if (backend == AF_BACKEND_OPENCL) { CALL(afcl_get_device_type, res); }
+    return AF_ERR_NOT_SUPPORTED;
+}
+
+af_err afcl_get_platform(afcl_platform* res) {
+    af_backend backend;
+    af_get_active_backend(&backend);
+    if (backend == AF_BACKEND_OPENCL) { CALL(afcl_get_platform, res); }
+    return AF_ERR_NOT_SUPPORTED;
+}
+
+af_err afcl_get_context(cl_context* ctx, const bool retain) {
+    af_backend backend;
+    af_get_active_backend(&backend);
+    if (backend == AF_BACKEND_OPENCL) { CALL(afcl_get_context, ctx, retain); }
+    return AF_ERR_NOT_SUPPORTED;
+}
+
+af_err afcl_get_queue(cl_command_queue* queue, const bool retain) {
+    af_backend backend;
+    af_get_active_backend(&backend);
+    if (backend == AF_BACKEND_OPENCL) { CALL(afcl_get_queue, queue, retain); }
+    return AF_ERR_NOT_SUPPORTED;
+}
+
+af_err afcl_get_device_id(cl_device_id* id) {
+    af_backend backend;
+    af_get_active_backend(&backend);
+    if (backend == AF_BACKEND_OPENCL) { CALL(afcl_get_device_id, id); }
+    return AF_ERR_NOT_SUPPORTED;
+}
+
+af_err afcl_set_device_id(cl_device_id id) {
+    af_backend backend;
+    af_get_active_backend(&backend);
+    if (backend == AF_BACKEND_OPENCL) { CALL(afcl_set_device_id, id); }
+    return AF_ERR_NOT_SUPPORTED;
+}
+
+af_err afcl_add_device_context(cl_device_id dev, cl_context ctx,
+                               cl_command_queue que) {
+    af_backend backend;
+    af_get_active_backend(&backend);
+    if (backend == AF_BACKEND_OPENCL) {
+        CALL(afcl_add_device_context, dev, ctx, que);
+    }
+    return AF_ERR_NOT_SUPPORTED;
+}
+
+af_err afcl_set_device_context(cl_device_id dev, cl_context ctx) {
+    af_backend backend;
+    af_get_active_backend(&backend);
+    if (backend == AF_BACKEND_OPENCL) {
+        CALL(afcl_set_device_context, dev, ctx);
+    }
+    return AF_ERR_NOT_SUPPORTED;
+}
+
+af_err afcl_delete_device_context(cl_device_id dev, cl_context ctx) {
+    af_backend backend;
+    af_get_active_backend(&backend);
+    if (backend == AF_BACKEND_OPENCL) {
+        CALL(afcl_delete_device_context, dev, ctx);
+    }
+    return AF_ERR_NOT_SUPPORTED;
+}


### PR DESCRIPTION
Description
-----------
API that is required for users to use OpenCL and ArrayFire simultaneously in their application were missing from unified backend. CUDA doesn't have this issue. Somehow, OpenCL wasn't added earlier and this change fixes that problem

Changes to Users
----------------
Users using unified backend will also be able to use Raw OpenCL and ArrayFire simultaneously. Earlier, they could do this only by directly using the OpenCL backend.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- ~[ ] Tests pass~
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
