### PR TITLE
Replace underscores with dashes in package names

### DIFF
--- a/CMakeModules/CPackConfig.cmake
+++ b/CMakeModules/CPackConfig.cmake
@@ -131,15 +131,15 @@ cpack_add_component_group(backends
   DISPLAY_NAME "ArrayFire"
   DESCRIPTION "ArrayFire backend libraries"
   EXPANDED)
-cpack_add_component_group(cpu_backend
+cpack_add_component_group(cpu-backend
   DISPLAY_NAME "CPU backend"
   DESCRIPTION "Libraries and dependencies of the CPU backend."
   PARENT_GROUP backends)
-cpack_add_component_group(cuda_backend
+cpack_add_component_group(cuda-backend
   DISPLAY_NAME "CUDA backend"
   DESCRIPTION "Libraries and dependencies of the CUDA backend."
   PARENT_GROUP backends)
-cpack_add_component_group(opencl_backend
+cpack_add_component_group(opencl-backend
   DISPLAY_NAME "OpenCL backend"
   DESCRIPTION "Libraries and dependencies of the OpenCL backend."
   PARENT_GROUP backends)
@@ -164,13 +164,13 @@ cpack_add_component(common_backend_dependencies
 cpack_add_component(opencl_dependencies
   DISPLAY_NAME "OpenCL Dependencies"
   DESCRIPTION "Libraries required by the OpenCL backend."
-  GROUP opencl_backend
+  GROUP opencl-backend
   INSTALL_TYPES All Development Runtime)
 if (NOT APPLE) #TODO(pradeep) Remove check after OSX support addition
   cpack_add_component(afopencl_debug_symbols
     DISPLAY_NAME "OpenCL Backend Debug Symbols"
     DESCRIPTION "File containing debug symbols for afopencl dll/so/dylib file"
-    GROUP opencl_backend
+    GROUP opencl-backend
     DISABLED
     INSTALL_TYPES Development)
 endif ()
@@ -178,13 +178,13 @@ endif ()
 cpack_add_component(cuda_dependencies
   DISPLAY_NAME "CUDA Dependencies"
   DESCRIPTION "CUDA runtime and libraries required by the CUDA backend."
-  GROUP cuda_backend
+  GROUP cuda-backend
   INSTALL_TYPES All Development Runtime)
 if (NOT APPLE) #TODO(pradeep) Remove check after OSX support addition
   cpack_add_component(afcuda_debug_symbols
     DISPLAY_NAME "CUDA Backend Debug Symbols"
     DESCRIPTION "File containing debug symbols for afcuda dll/so/dylib file"
-    GROUP cuda_backend
+    GROUP cuda-backend
     DISABLED
     INSTALL_TYPES Development)
 endif ()
@@ -193,7 +193,7 @@ if (NOT APPLE) #TODO(pradeep) Remove check after OSX support addition
   cpack_add_component(afcpu_debug_symbols
     DISPLAY_NAME "CPU Backend Debug Symbols"
     DESCRIPTION "File containing debug symbols for afcpu dll/so/dylib file"
-    GROUP cpu_backend
+    GROUP cpu-backend
     DISABLED
     INSTALL_TYPES Development)
 endif ()
@@ -201,7 +201,7 @@ endif ()
 cpack_add_component(cuda
   DISPLAY_NAME "CUDA Backend"
   DESCRIPTION "The CUDA backend allows you to run ArrayFire code on CUDA-enabled GPUs. Verify that you have the CUDA toolkit installed or install the CUDA dependencies component."
-  GROUP cuda_backend
+  GROUP cuda-backend
   DEPENDS common_backend_dependencies cuda_dependencies
   INSTALL_TYPES All Development Runtime)
 
@@ -220,14 +220,14 @@ endif ()
 cpack_add_component(cpu
   DISPLAY_NAME "CPU Backend"
   DESCRIPTION "The CPU backend allows you to run ArrayFire code on your CPU."
-  GROUP cpu_backend
+  GROUP cpu-backend
   DEPENDS ${cpu_deps_comps}
   INSTALL_TYPES All Development Runtime)
 
 cpack_add_component(opencl
   DISPLAY_NAME "OpenCL Backend"
   DESCRIPTION "The OpenCL backend allows you to run ArrayFire code on OpenCL-capable GPUs. Note: ArrayFire does not currently support OpenCL for Intel CPUs on OSX."
-  GROUP opencl_backend
+  GROUP opencl-backend
   DEPENDS ${ocl_deps_comps}
   INSTALL_TYPES All Development Runtime)
 
@@ -301,9 +301,9 @@ get_native_path(bsd3_lic_path "${CMAKE_SOURCE_DIR}/LICENSES/BSD 3-Clause.txt")
 get_native_path(issl_lic_path "${CMAKE_SOURCE_DIR}/LICENSES/ISSL License.txt")
 
 cpack_ifw_configure_component_group(backends)
-cpack_ifw_configure_component_group(cpu_backend)
-cpack_ifw_configure_component_group(cuda_backend)
-cpack_ifw_configure_component_group(opencl_backend)
+cpack_ifw_configure_component_group(cpu-backend)
+cpack_ifw_configure_component_group(cuda-backend)
+cpack_ifw_configure_component_group(opencl-backend)
 if (PACKAGE_MKL_DEPS)
   cpack_ifw_configure_component(mkl_dependencies)
 endif ()

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,10 +19,10 @@ class ArrayFireConan(ConanFile):
               "hpc", "performance", "scientific-computing")
     settings = "os", "compiler", "build_type", "arch"
     options = {
-        "cpu_backend": [True, False],
-        "cuda_backend": [True, False],
-        "opencl_backend": [True, False],
-        "unified_backend": [True, False],
+        "cpu-backend": [True, False],
+        "cuda-backend": [True, False],
+        "opencl-backend": [True, False],
+        "unified-backend": [True, False],
         "graphics": [True, False],
     }
     generators = "cmake"  # unused

--- a/conanfile.py
+++ b/conanfile.py
@@ -19,10 +19,10 @@ class ArrayFireConan(ConanFile):
               "hpc", "performance", "scientific-computing")
     settings = "os", "compiler", "build_type", "arch"
     options = {
-        "cpu-backend": [True, False],
-        "cuda-backend": [True, False],
-        "opencl-backend": [True, False],
-        "unified-backend": [True, False],
+        "cpu_backend": [True, False],
+        "cuda_backend": [True, False],
+        "opencl_backend": [True, False],
+        "unified_backend": [True, False],
         "graphics": [True, False],
     }
     generators = "cmake"  # unused


### PR DESCRIPTION
Previously, CPack would create Debian packages that have underscores in the package names (`arrayfire-cpu_backend`, `arrayfire-cuda_backend`, and `arrayfire-opencl_backend`).  Underscores are not allowed in Debian package names (see https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-source) and will break tools that attempt to parse them correctly.  This replaces the underscores with dashes.

Description
-----------
* Is this a new feature or a bug fix?
   * New feature.
* Why these changes are necessary.
   * Without this change, tools that parse Debian package information, such as `dpkg-shlibdeps`, may break when parsing metadata from these packages; this in particular makes it impossible to build other Debian packages that depend on these using traditional tools such as debhelper.
* Potential impact on specific hardware, software or backends.
   * No impact or hardware or software functionality, but anybody who was building and using the Debian packages will need to be aware that the package names for the backends have changed.
* Can this PR be backported to older versions?
   * Yes.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[] Functions added to unified API~
- ~[] Functions documented~
