### PR TITLE
Fix failing sparse tests on CUDA 11

### DIFF
--- a/test/sparse_common.hpp
+++ b/test/sparse_common.hpp
@@ -120,21 +120,29 @@ static void sparseTransposeTester(const int m, const int n, const int k,
 
     // Result of GEMM
     af::array dRes2 = matmul(A, B, AF_MAT_TRANS, AF_MAT_NONE);
-    af::array dRes3 = matmul(A, B, AF_MAT_CTRANS, AF_MAT_NONE);
+    af::array dRes3;
+    if (IsComplex<T>::value) {
+        dRes3 = matmul(A, B, AF_MAT_CTRANS, AF_MAT_NONE);
+    }
 
     // Create Sparse Array From Dense
     af::array sA = af::sparse(A, AF_STORAGE_CSR);
 
     // Sparse Matmul
     af::array sRes2 = matmul(sA, B, AF_MAT_TRANS, AF_MAT_NONE);
-    af::array sRes3 = matmul(sA, B, AF_MAT_CTRANS, AF_MAT_NONE);
+    af::array sRes3;
+    if (IsComplex<T>::value) {
+        sRes3 = matmul(sA, B, AF_MAT_CTRANS, AF_MAT_NONE);
+    }
 
     // Verify Results
     ASSERT_NEAR(0, calc_norm(real(dRes2), real(sRes2)), eps);
     ASSERT_NEAR(0, calc_norm(imag(dRes2), imag(sRes2)), eps);
 
-    ASSERT_NEAR(0, calc_norm(real(dRes3), real(sRes3)), eps);
-    ASSERT_NEAR(0, calc_norm(imag(dRes3), imag(sRes3)), eps);
+    if (IsComplex<T>::value) {
+        ASSERT_NEAR(0, calc_norm(real(dRes3), real(sRes3)), eps);
+        ASSERT_NEAR(0, calc_norm(imag(dRes3), imag(sRes3)), eps);
+    }
 }
 
 template<typename T>

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -188,6 +188,12 @@ inline double imag<af::cfloat>(af::cfloat val) {
 }
 
 template<class T>
+struct IsComplex {
+    static const bool value = is_same_type<af::cfloat, T>::value ||
+                              is_same_type<af::cdouble, T>::value;
+};
+
+template<class T>
 struct IsFloatingPoint {
     static const bool value = is_same_type<half_float::half, T>::value ||
                               is_same_type<float, T>::value ||


### PR DESCRIPTION
Sparse tests were failing because we were trying to perform a conjugate transpose on doubles and floats. This throws an error on CUDA 11 so tests were failing.

Description
-----------
Sparse tests were failing because we were trying to perform a conjugate transpose on doubles and floats. This throws an error on CUDA 11 so tests were failing.

Changes to Users
----------------
None

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
