### PR TITLE
Add new standard deviation APIs with bias parameter control

### DIFF
--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -516,9 +516,9 @@ typedef enum {
 
 #if AF_API_VERSION >= 37
 typedef enum {
-              AF_VARIANCE_DEFAULT    = 0, ///< Default (Population) variance
-              AF_VARIANCE_SAMPLE     = 1, ///< Sample variance
-              AF_VARIANCE_POPULATION = 2  ///< Population variance
+    AF_VARIANCE_DEFAULT    = 0, ///< Default (Population) variance
+    AF_VARIANCE_SAMPLE     = 1, ///< Sample variance
+    AF_VARIANCE_POPULATION = 2  ///< Population variance
 } af_var_bias;
 
 typedef enum {

--- a/include/af/statistics.h
+++ b/include/af/statistics.h
@@ -121,18 +121,36 @@ AFAPI void meanvar(array& mean, array& var, const array& in, const array& weight
 */
 AFAPI array stdev(const array& in, const dim_t dim=-1);
 
-
 /**
    C++ Interface for covariance
 
    \param[in] X is the first input array
    \param[in] Y is the second input array
-   \param[in] isbiased is boolean specifying if biased estimate should be taken (default: false)
+   \param[in] isbiased is boolean specifying if biased estimate should be
+              taken (default: false)
    \return    the covariance of the input arrays
 
    \ingroup stat_func_cov
+
+   \deprecated Use af::cov(const array&, const array& const af_var_bias)
 */
+AF_DEPRECATED("Use af::cov(const af::array&, const array&, conv af_var_bias)")
 AFAPI array cov(const array& X, const array& Y, const bool isbiased=false);
+
+#if AF_API_VERSION >= 38
+/**
+   C++ Interface for covariance
+
+   \param[in] X is the first input array
+   \param[in] Y is the second input array
+   \param[in] bias The type of bias used for variance calculation. Takes of
+              value of type \ref af_var_bias.
+   \return the covariance of the input arrays
+
+   \ingroup stat_func_cov
+*/
+AFAPI array cov(const array &X, const array &Y, const af_var_bias bias);
+#endif
 
 /**
    C++ Interface for median
@@ -270,7 +288,6 @@ AFAPI T corrcoef(const array& X, const array& Y);
 AFAPI void topk(array &values, array &indices, const array& in, const int k,
                 const int dim = -1, const topkFunction order = AF_TOPK_MAX);
 #endif
-
 }
 #endif
 
@@ -399,8 +416,29 @@ AFAPI af_err af_stdev(af_array *out, const af_array in, const dim_t dim);
    otherwise an appropriate error code is returned.
 
    \ingroup stat_func_cov
+
+   \deprecated Use \ref af_cov_v2 instead
 */
+AF_DEPRECATED("Use af_cov_v2")
 AFAPI af_err af_cov(af_array* out, const af_array X, const af_array Y, const bool isbiased);
+
+#if AF_API_VERSION >= 38
+/**
+   C Interface for covariance
+
+   \param[out] out will the covariance of the input arrays
+   \param[in] X is the first input array
+   \param[in] Y is the second input array
+   \param[in] bias The type of bias used for variance calculation. Takes of
+              value of type \ref af_var_bias
+   \return \ref AF_SUCCESS if the operation is successful, otherwise an
+           appropriate error code is returned.
+
+   \ingroup stat_func_cov
+*/
+AFAPI af_err af_cov_v2(af_array *out, const af_array X, const af_array Y,
+                       const af_var_bias bias);
+#endif
 
 /**
    C Interface for median

--- a/include/af/statistics.h
+++ b/include/af/statistics.h
@@ -46,15 +46,36 @@ AFAPI array mean(const array& in, const array& weights, const dim_t dim=-1);
    C++ Interface for variance
 
    \param[in] in is the input array
-   \param[in] isbiased is boolean denoting Population variance (false) or Sample Variance (true)
+   \param[in] isbiased is boolean denoting Population variance (false) or Sample
+              Variance (true)
    \param[in] dim the dimension along which the variance is extracted
-   \return    the variance of the input array along dimension \p dim
+   \return the variance of the input array along dimension \p dim
+
+   \ingroup stat_func_var
+
+   \note \p dim is -1 by default. -1 denotes the first non-singleton dimension.
+
+   \deprecated Use \ref af::var that takes \ref af_var_bias instead
+*/
+AF_DEPRECATED("Use \ref af::var(const array&, const af_var_bias, const dim_t)")
+AFAPI array var(const array& in, const bool isbiased=false, const dim_t dim=-1);
+
+#if AF_API_VERSION >= 38
+/**
+   C++ Interface for variance
+
+   \param[in] in is the input array
+   \param[in] bias The type of bias used for variance calculation. Takes o
+              value of type \ref af_var_bias.
+   \param[in] dim the dimension along which the variance is extracted
+   \return the variance of the input array along dimension \p dim
 
    \ingroup stat_func_var
 
    \note \p dim is -1 by default. -1 denotes the first non-singleton dimension.
 */
-AFAPI array var(const array& in, const bool isbiased=false, const dim_t dim=-1);
+AFAPI array var(const array &in, const af_var_bias bias, const dim_t dim = -1);
+#endif
 
 /**
    C++ Interface for variance of weighted inputs
@@ -153,13 +174,31 @@ AFAPI T mean(const array& in, const array& weights);
    C++ Interface for variance of all elements
 
    \param[in] in is the input array
-   \param[in] isbiased is boolean denoting Population variance (false) or Sample Variance (true)
-   \return    variance of the entire input array
+   \param[in] isbiased is boolean denoting Population variance (false) or Sample
+              Variance (true)
+   \return variance of the entire input array
+
+   \ingroup stat_func_var
+
+   \deprecated Use \ref af::var that takes \ref af_var_bias instead
+*/
+template <typename T>
+AF_DEPRECATED("Use af::var(const af::array&, const af_var_bias)")
+AFAPI T var(const array &in, const bool isbiased = false);
+
+#if AF_API_VERSION >= 38
+/**
+   C++ Interface for variance of all elements
+
+   \param[in] in is the input array
+   \param[in] bias The type of bias used for variance calculation. Takes of
+              value of type \ref af_var_bias.
+   \return variance of the \p in array
 
    \ingroup stat_func_var
 */
-template<typename T>
-AFAPI T var(const array& in, const bool isbiased=false);
+template <typename T> AFAPI T var(const array &in, const af_var_bias bias);
+#endif
 
 /**
    C++ Interface for variance of all elements in weighted input
@@ -278,8 +317,30 @@ AFAPI af_err af_mean_weighted(af_array *out, const af_array in, const af_array w
 
    \ingroup stat_func_var
 
+   \deprecated Use \ref af_var_v2 instead
 */
+AF_DEPRECATED("Use af_var_v2")
 AFAPI af_err af_var(af_array *out, const af_array in, const bool isbiased, const dim_t dim);
+
+#if AF_API_VERSION >= 38
+/**
+   C Interface for variance
+
+   \param[out] out will contain the variance of the input array along dimension
+               \p dim
+   \param[in] in is the input array
+   \param[in] bias The type of bias used for variance calculation. Takes of
+              value of type \ref af_var_bias
+   \param[in] dim the dimension along which the variance is extracted
+   \return \ref AF_SUCCESS if the operation is successful, otherwise an
+           appropriate error code is returned.
+
+   \ingroup stat_func_var
+
+*/
+AFAPI af_err af_var_v2(af_array *out, const af_array in, const af_var_bias bias,
+                       const dim_t dim);
+#endif
 
 /**
    C Interface for variance of weighted input array
@@ -393,8 +454,31 @@ AFAPI af_err af_mean_all_weighted(double *real, double *imag, const af_array in,
    otherwise an appropriate error code is returned.
 
    \ingroup stat_func_var
+
+   \deprecated Use \ref af_var_all_v2 instead
 */
+AF_DEPRECATED("Use af_var_all_v2")
 AFAPI af_err af_var_all(double *realVal, double *imagVal, const af_array in, const bool isbiased);
+
+#if AF_API_VERSION >= 38
+/**
+   C Interface for variance of all elements
+
+   \param[out] realVal will contain the real part of variance of the entire
+               input array
+   \param[out] imagVal will contain the imaginary part of variance
+               of the entire input array
+   \param[in] in is the input array
+   \param[in] bias The type of bias used for variance calculation. Takes of
+              value of type \ref af_var_bias
+   \return \ref AF_SUCCESS if the operation is successful, otherwise an
+           appropriate error code is returned.
+
+   \ingroup stat_func_var
+*/
+AFAPI af_err af_var_all_v2(double *realVal, double *imagVal, const af_array in,
+                           const af_var_bias bias);
+#endif
 
 /**
    C Interface for variance of all elements in weighted input

--- a/include/af/statistics.h
+++ b/include/af/statistics.h
@@ -118,8 +118,29 @@ AFAPI void meanvar(array& mean, array& var, const array& in, const array& weight
    \ingroup stat_func_stdev
 
    \note \p dim is -1 by default. -1 denotes the first non-singleton dimension.
+
+   \deprecated Use \ref af::stdev that takes \ref af_var_bias instead
 */
+AF_DEPRECATED("Use af::stdev(const array&, const af_var_bias, const dim_t)")
 AFAPI array stdev(const array& in, const dim_t dim=-1);
+
+#if AF_API_VERSION >= 38
+/**
+   C++ Interface for standard deviation
+
+   \param[in] in is the input array
+   \param[in] bias The type of bias used for variance calculation. Takes of
+              value of type \ref af_var_bias.
+   \param[in] dim the dimension along which the standard deviation is extracted
+   \return    the standard deviation of the input array along dimension \p dim
+
+   \ingroup stat_func_stdev
+
+   \note \p dim is -1 by default. -1 denotes the first non-singleton dimension.
+*/
+AFAPI array stdev(const array &in, const af_var_bias bias,
+                  const dim_t dim = -1);
+#endif
 
 /**
    C++ Interface for covariance
@@ -237,9 +258,26 @@ AFAPI T var(const array& in, const array& weights);
    \return    standard deviation of the entire input array
 
    \ingroup stat_func_stdev
+
+   \deprecated Use \ref af::stdev that takes \ref af_var_bias instead
 */
-template<typename T>
-AFAPI T stdev(const array& in);
+template <typename T>
+AF_DEPRECATED("Use af::stdev(const array&, const af_var_bias)")
+AFAPI T stdev(const array &in);
+
+#if AF_API_VERSION >= 38
+/**
+   C++ Interface for standard deviation of all elements
+
+   \param[in] in is the input array
+   \param[in] bias The type of bias used for variance calculation. Takes of
+              value of type \ref af_var_bias.
+   \return    standard deviation of the entire input array
+
+   \ingroup stat_func_stdev
+*/
+template <typename T> AFAPI T stdev(const array &in, const af_var_bias bias);
+#endif
 
 /**
    C++ Interface for median of all elements
@@ -402,8 +440,30 @@ AFAPI af_err af_meanvar(af_array *mean, af_array *var, const af_array in,
 
    \ingroup stat_func_stdev
 
+   \deprecated Use \ref af_stdev_v2 instead
 */
+AF_DEPRECATED("Use af_stdev_v2")
 AFAPI af_err af_stdev(af_array *out, const af_array in, const dim_t dim);
+
+#if AF_API_VERSION >= 38
+/**
+   C Interface for standard deviation
+
+   \param[out] out will contain the standard deviation of the input array along
+               dimension \p dim
+   \param[in] in is the input array
+   \param[in] bias The type of bias used for variance calculation. Takes of
+              value of type \ref af_var_bias
+   \param[in] dim the dimension along which the standard deviation is extracted
+   \return \ref AF_SUCCESS if the operation is successful, otherwise an
+           appropriate error code is returned.
+
+   \ingroup stat_func_stdev
+
+*/
+AFAPI af_err af_stdev_v2(af_array *out, const af_array in,
+                         const af_var_bias bias, const dim_t dim);
+#endif
 
 /**
    C Interface for covariance
@@ -542,8 +602,31 @@ AFAPI af_err af_var_all_weighted(double *realVal, double *imagVal, const af_arra
    otherwise an appropriate error code is returned.
 
    \ingroup stat_func_stdev
+
+   \deprecated Use \ref af_stdev_all_v2 instead
 */
+AF_DEPRECATED("Use af_stdev_all_v2")
 AFAPI af_err af_stdev_all(double *real, double *imag, const af_array in);
+
+#if AF_API_VERSION >= 38
+/**
+   C Interface for standard deviation of all elements
+
+   \param[out] real will contain the real part of standard deviation of the
+               entire input array
+   \param[out] imag will contain the imaginary part of standard deviation
+               of the entire input array
+   \param[in] in is the input array
+   \param[in] bias The type of bias used for variance calculation. Takes of
+              value of type \ref af_var_bias
+   \return     \ref AF_SUCCESS if the operation is successful,
+   otherwise an appropriate error code is returned.
+
+   \ingroup stat_func_stdev
+*/
+AFAPI af_err af_stdev_all_v2(double *real, double *imag, const af_array in,
+                             const af_var_bias bias);
+#endif
 
 /**
    C Interface for median

--- a/src/api/c/covariance.cpp
+++ b/src/api/c/covariance.cpp
@@ -46,7 +46,7 @@ static af_array cov(const af_array& X, const af_array& Y,
     Array<cType> yArr = cast<cType>(_y);
 
     dim4 xDims = xArr.dims();
-    dim_t N    = (bias == AF_VARIANCE_SAMPLE ? xDims[0] : xDims[0] - 1);
+    dim_t N    = (bias == AF_VARIANCE_SAMPLE ? xDims[0] - 1 : xDims[0]);
 
     Array<cType> xmArr =
         createValueArray<cType>(xDims, mean<T, weightType, cType>(_x));

--- a/src/api/c/stdev.cpp
+++ b/src/api/c/stdev.cpp
@@ -42,7 +42,7 @@ using detail::uintl;
 using detail::ushort;
 
 template<typename inType, typename outType>
-static outType stdev(const af_array& in) {
+static outType stdev(const af_array& in, const af_var_bias bias) {
     using weightType        = typename baseOutType<outType>::type;
     const Array<inType> _in = getArray<inType>(in);
     Array<outType> input    = cast<outType>(_in);
@@ -52,14 +52,14 @@ static outType stdev(const af_array& in) {
         detail::arithOp<outType, af_sub_t>(input, meanCnst, input.dims());
     Array<outType> diffSq =
         detail::arithOp<outType, af_mul_t>(diff, diff, diff.dims());
-    outType result = division(reduce_all<af_add_t, outType, outType>(diffSq),
-                              input.elements());
-
+    outType result =
+        division(reduce_all<af_add_t, outType, outType>(diffSq),
+                 (input.elements() - (bias == AF_VARIANCE_SAMPLE)));
     return sqrt(result);
 }
 
 template<typename inType, typename outType>
-static af_array stdev(const af_array& in, int dim) {
+static af_array stdev(const af_array& in, int dim, const af_var_bias bias) {
     using weightType        = typename baseOutType<outType>::type;
     const Array<inType> _in = getArray<inType>(in);
     Array<outType> input    = cast<outType>(_in);
@@ -80,8 +80,8 @@ static af_array stdev(const af_array& in, int dim) {
     Array<outType> redDiff = reduce<af_add_t, outType, outType>(diffSq, dim);
     const dim4& oDims      = redDiff.dims();
 
-    Array<outType> divArr =
-        createValueArray<outType>(oDims, scalar<outType>(iDims[dim]));
+    Array<outType> divArr = createValueArray<outType>(
+        oDims, scalar<outType>((iDims[dim] - (bias == AF_VARIANCE_SAMPLE))));
     Array<outType> varArr =
         detail::arithOp<outType, af_div_t>(redDiff, divArr, redDiff.dims());
     Array<outType> result = detail::unaryOp<outType, af_sqrt_t>(varArr);
@@ -91,21 +91,26 @@ static af_array stdev(const af_array& in, int dim) {
 
 // NOLINTNEXTLINE(readability-non-const-parameter)
 af_err af_stdev_all(double* realVal, double* imagVal, const af_array in) {
+    return af_stdev_all_v2(realVal, imagVal, in, AF_VARIANCE_POPULATION);
+}
+
+af_err af_stdev_all_v2(double* realVal, double* imagVal, const af_array in,
+                       const af_var_bias bias) {
     UNUSED(imagVal);  // TODO implement for complex values
     try {
         const ArrayInfo& info = getInfo(in);
         af_dtype type         = info.getType();
         switch (type) {
-            case f64: *realVal = stdev<double, double>(in); break;
-            case f32: *realVal = stdev<float, float>(in); break;
-            case s32: *realVal = stdev<int, float>(in); break;
-            case u32: *realVal = stdev<uint, float>(in); break;
-            case s16: *realVal = stdev<short, float>(in); break;
-            case u16: *realVal = stdev<ushort, float>(in); break;
-            case s64: *realVal = stdev<intl, double>(in); break;
-            case u64: *realVal = stdev<uintl, double>(in); break;
-            case u8: *realVal = stdev<uchar, float>(in); break;
-            case b8: *realVal = stdev<char, float>(in); break;
+            case f64: *realVal = stdev<double, double>(in, bias); break;
+            case f32: *realVal = stdev<float, float>(in, bias); break;
+            case s32: *realVal = stdev<int, float>(in, bias); break;
+            case u32: *realVal = stdev<uint, float>(in, bias); break;
+            case s16: *realVal = stdev<short, float>(in, bias); break;
+            case u16: *realVal = stdev<ushort, float>(in, bias); break;
+            case s64: *realVal = stdev<intl, double>(in, bias); break;
+            case u64: *realVal = stdev<uintl, double>(in, bias); break;
+            case u8: *realVal = stdev<uchar, float>(in, bias); break;
+            case b8: *realVal = stdev<char, float>(in, bias); break;
             // TODO(umar): FIXME: sqrt(complex) is not present in cuda/opencl
             // backend case c32: {
             //    cfloat tmp = stdev<cfloat,cfloat>(in);
@@ -125,6 +130,11 @@ af_err af_stdev_all(double* realVal, double* imagVal, const af_array in) {
 }
 
 af_err af_stdev(af_array* out, const af_array in, const dim_t dim) {
+    return af_stdev_v2(out, in, AF_VARIANCE_POPULATION, dim);
+}
+
+af_err af_stdev_v2(af_array* out, const af_array in, const af_var_bias bias,
+                   const dim_t dim) {
     try {
         ARG_ASSERT(2, (dim >= 0 && dim <= 3));
 
@@ -132,16 +142,16 @@ af_err af_stdev(af_array* out, const af_array in, const dim_t dim) {
         const ArrayInfo& info = getInfo(in);
         af_dtype type         = info.getType();
         switch (type) {
-            case f64: output = stdev<double, double>(in, dim); break;
-            case f32: output = stdev<float, float>(in, dim); break;
-            case s32: output = stdev<int, float>(in, dim); break;
-            case u32: output = stdev<uint, float>(in, dim); break;
-            case s16: output = stdev<short, float>(in, dim); break;
-            case u16: output = stdev<ushort, float>(in, dim); break;
-            case s64: output = stdev<intl, double>(in, dim); break;
-            case u64: output = stdev<uintl, double>(in, dim); break;
-            case u8: output = stdev<uchar, float>(in, dim); break;
-            case b8: output = stdev<char, float>(in, dim); break;
+            case f64: output = stdev<double, double>(in, dim, bias); break;
+            case f32: output = stdev<float, float>(in, dim, bias); break;
+            case s32: output = stdev<int, float>(in, dim, bias); break;
+            case u32: output = stdev<uint, float>(in, dim, bias); break;
+            case s16: output = stdev<short, float>(in, dim, bias); break;
+            case u16: output = stdev<ushort, float>(in, dim, bias); break;
+            case s64: output = stdev<intl, double>(in, dim, bias); break;
+            case u64: output = stdev<uintl, double>(in, dim, bias); break;
+            case u8: output = stdev<uchar, float>(in, dim, bias); break;
+            case b8: output = stdev<char, float>(in, dim, bias); break;
             // TODO(umar): FIXME: sqrt(complex) is not present in cuda/opencl
             // backend case c32: output = stdev<cfloat,  cfloat>(in, dim);
             // break; case c64: output = stdev<cdouble,cdouble>(in, dim); break;

--- a/src/api/c/var.cpp
+++ b/src/api/c/var.cpp
@@ -64,9 +64,9 @@ static outType varAll(const af_array& in, const af_var_bias bias) {
 
     Array<outType> diffSq = arithOp<outType, af_mul_t>(diff, diff, diff.dims());
 
-    outType result = division(
-        reduce_all<af_add_t, outType, outType>(diffSq),
-        bias == AF_VARIANCE_SAMPLE ? input.elements() : input.elements() - 1);
+    outType result =
+        division(reduce_all<af_add_t, outType, outType>(diffSq),
+                 (input.elements() - (bias == AF_VARIANCE_SAMPLE)));
 
     return result;
 }

--- a/src/api/cpp/covariance.cpp
+++ b/src/api/cpp/covariance.cpp
@@ -14,8 +14,14 @@
 namespace af {
 
 array cov(const array& X, const array& Y, const bool isbiased) {
+    const af_var_bias bias =
+        (isbiased ? AF_VARIANCE_SAMPLE : AF_VARIANCE_POPULATION);
+    return cov(X, Y, bias);
+}
+
+array cov(const array& X, const array& Y, const af_var_bias bias) {
     af_array temp = 0;
-    AF_THROW(af_cov(&temp, X.get(), Y.get(), isbiased));
+    AF_THROW(af_cov_v2(&temp, X.get(), Y.get(), bias));
     return array(temp);
 }
 

--- a/src/api/cpp/stdev.cpp
+++ b/src/api/cpp/stdev.cpp
@@ -15,26 +15,40 @@
 
 namespace af {
 
-#define INSTANTIATE_STDEV(T)                              \
-    template<>                                            \
-    AFAPI T stdev(const array& in) {                      \
-        double ret_val;                                   \
-        AF_THROW(af_stdev_all(&ret_val, NULL, in.get())); \
-        return (T)ret_val;                                \
+#define INSTANTIATE_STDEV(T)                                       \
+    template<>                                                     \
+    AFAPI T stdev(const array& in, const af_var_bias bias) {       \
+        double ret_val;                                            \
+        AF_THROW(af_stdev_all_v2(&ret_val, NULL, in.get(), bias)); \
+        return (T)ret_val;                                         \
+    }                                                              \
+    template<>                                                     \
+    AFAPI T stdev(const array& in) {                               \
+        return stdev<T>(in, AF_VARIANCE_POPULATION);               \
     }
 
 template<>
-AFAPI af_cfloat stdev(const array& in) {
+AFAPI af_cfloat stdev(const array& in, const af_var_bias bias) {
     double real, imag;
-    AF_THROW(af_stdev_all(&real, &imag, in.get()));
+    AF_THROW(af_stdev_all_v2(&real, &imag, in.get(), bias));
     return {static_cast<float>(real), static_cast<float>(imag)};
 }
 
 template<>
-AFAPI af_cdouble stdev(const array& in) {
+AFAPI af_cdouble stdev(const array& in, const af_var_bias bias) {
     double real, imag;
-    AF_THROW(af_stdev_all(&real, &imag, in.get()));
+    AF_THROW(af_stdev_all_v2(&real, &imag, in.get(), bias));
     return {real, imag};
+}
+
+template<>
+AFAPI af_cfloat stdev(const array& in) {
+    return stdev<af_cfloat>(in, AF_VARIANCE_POPULATION);
+}
+
+template<>
+AFAPI af_cdouble stdev(const array& in) {
+    return stdev<af_cdouble>(in, AF_VARIANCE_POPULATION);
 }
 
 INSTANTIATE_STDEV(float);
@@ -50,10 +64,14 @@ INSTANTIATE_STDEV(unsigned char);
 
 #undef INSTANTIATE_STDEV
 
-array stdev(const array& in, const dim_t dim) {
+array stdev(const array& in, const af_var_bias bias, const dim_t dim) {
     af_array temp = 0;
-    AF_THROW(af_stdev(&temp, in.get(), getFNSD(dim, in.dims())));
+    AF_THROW(af_stdev_v2(&temp, in.get(), bias, getFNSD(dim, in.dims())));
     return array(temp);
+}
+
+array stdev(const array& in, const dim_t dim) {
+    return stdev(in, AF_VARIANCE_POPULATION, dim);
 }
 
 }  // namespace af

--- a/src/api/unified/statistics.cpp
+++ b/src/api/unified/statistics.cpp
@@ -119,3 +119,15 @@ af_err af_cov_v2(af_array *out, const af_array X, const af_array Y,
     CHECK_ARRAYS(X, Y);
     CALL(af_cov_v2, out, X, Y, bias);
 }
+
+af_err af_stdev_v2(af_array *out, const af_array in, const af_var_bias bias,
+                   const dim_t dim) {
+    CHECK_ARRAYS(in);
+    CALL(af_stdev_v2, out, in, bias, dim);
+}
+
+af_err af_stdev_all_v2(double *real, double *imag, const af_array in,
+                       const af_var_bias bias) {
+    CHECK_ARRAYS(in);
+    CALL(af_stdev_all_v2, real, imag, in, bias);
+}

--- a/src/api/unified/statistics.cpp
+++ b/src/api/unified/statistics.cpp
@@ -101,3 +101,15 @@ af_err af_topk(af_array *values, af_array *indices, const af_array in,
     CHECK_ARRAYS(in);
     CALL(af_topk, values, indices, in, k, dim, order);
 }
+
+af_err af_var_v2(af_array *out, const af_array in, const af_var_bias bias,
+                 const dim_t dim) {
+    CHECK_ARRAYS(in);
+    CALL(af_var_v2, out, in, bias, dim);
+}
+
+af_err af_var_all_v2(double *realVal, double *imagVal, const af_array in,
+                     const af_var_bias bias) {
+    CHECK_ARRAYS(in);
+    CALL(af_var_all_v2, realVal, imagVal, in, bias);
+}

--- a/src/api/unified/statistics.cpp
+++ b/src/api/unified/statistics.cpp
@@ -113,3 +113,9 @@ af_err af_var_all_v2(double *realVal, double *imagVal, const af_array in,
     CHECK_ARRAYS(in);
     CALL(af_var_all_v2, realVal, imagVal, in, bias);
 }
+
+af_err af_cov_v2(af_array *out, const af_array X, const af_array Y,
+                 const af_var_bias bias) {
+    CHECK_ARRAYS(X, Y);
+    CALL(af_cov_v2, out, X, Y, bias);
+}

--- a/test/covariance.cpp
+++ b/test/covariance.cpp
@@ -72,7 +72,7 @@ struct covOutType {
 };
 
 template<typename T>
-void covTest(string pFileName, bool isbiased = false,
+void covTest(string pFileName, bool isbiased = true,
              const bool useDeprecatedAPI = false) {
     typedef typename covOutType<T>::type outType;
     SUPPORTED_TYPE_CHECK(T);
@@ -119,16 +119,13 @@ void covTest(string pFileName, bool isbiased = false,
 }
 
 TYPED_TEST(Covariance, Vector) {
-    covTest<TypeParam>(string(TEST_DIR "/covariance/vec_size60.test"), false);
-    covTest<TypeParam>(string(TEST_DIR "/covariance/vec_size60.test"), false,
-                       true);
+    covTest<TypeParam>(string(TEST_DIR "/covariance/vec_size60.test"));
+    covTest<TypeParam>(string(TEST_DIR "/covariance/vec_size60.test"), true);
 }
 
 TYPED_TEST(Covariance, Matrix) {
-    covTest<TypeParam>(string(TEST_DIR "/covariance/matrix_65x121.test"),
-                       false);
-    covTest<TypeParam>(string(TEST_DIR "/covariance/matrix_65x121.test"), false,
-                       true);
+    covTest<TypeParam>(string(TEST_DIR "/covariance/matrix_65x121.test"));
+    covTest<TypeParam>(string(TEST_DIR "/covariance/matrix_65x121.test"), true);
 }
 
 TEST(Covariance, c32) {

--- a/test/stdev.cpp
+++ b/test/stdev.cpp
@@ -74,7 +74,8 @@ struct sdOutType {
 };
 
 template<typename T>
-void stdevDimTest(string pFileName, dim_t dim = -1) {
+void stdevDimTest(string pFileName, dim_t dim,
+                  const bool useDeprecatedAPI = false) {
     typedef typename sdOutType<T>::type outType;
     SUPPORTED_TYPE_CHECK(T);
     SUPPORTED_TYPE_CHECK(outType);
@@ -90,7 +91,11 @@ void stdevDimTest(string pFileName, dim_t dim = -1) {
 
     array a(dims, &(input.front()));
 
-    array b = stdev(a, dim);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    array b = (useDeprecatedAPI ? stdev(a, dim)
+                                : stdev(a, AF_VARIANCE_POPULATION, dim));
+#pragma GCC diagnostic pop
 
     vector<outType> currGoldBar(tests[0].begin(), tests[0].end());
 
@@ -111,30 +116,42 @@ void stdevDimTest(string pFileName, dim_t dim = -1) {
 
 TYPED_TEST(StandardDev, Dim0) {
     stdevDimTest<TypeParam>(string(TEST_DIR "/stdev/mat_10x10_dim0.test"), 0);
+    stdevDimTest<TypeParam>(string(TEST_DIR "/stdev/mat_10x10_dim0.test"), 0,
+                            true);
 }
 
 TYPED_TEST(StandardDev, Dim1) {
     stdevDimTest<TypeParam>(string(TEST_DIR "/stdev/mat_10x10_dim1.test"), 1);
+    stdevDimTest<TypeParam>(string(TEST_DIR "/stdev/mat_10x10_dim1.test"), 1,
+                            true);
 }
 
 TYPED_TEST(StandardDev, Dim2) {
     stdevDimTest<TypeParam>(
         string(TEST_DIR "/stdev/hypercube_10x10x5x5_dim2.test"), 2);
+    stdevDimTest<TypeParam>(
+        string(TEST_DIR "/stdev/hypercube_10x10x5x5_dim2.test"), 2, true);
 }
 
 TYPED_TEST(StandardDev, Dim3) {
     stdevDimTest<TypeParam>(
         string(TEST_DIR "/stdev/hypercube_10x10x5x5_dim3.test"), 3);
+    stdevDimTest<TypeParam>(
+        string(TEST_DIR "/stdev/hypercube_10x10x5x5_dim3.test"), 3, true);
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST(StandardDev, InvalidDim) { ASSERT_THROW(stdev(array(), 5), exception); }
 
 TEST(StandardDev, InvalidType) {
     ASSERT_THROW(stdev(constant(cdouble(1.0, -1.0), 10)), exception);
 }
+#pragma GCC diagnostic pop
 
 template<typename T>
-void stdevDimIndexTest(string pFileName, dim_t dim = -1) {
+void stdevDimIndexTest(string pFileName, dim_t dim,
+                       const bool useDeprecatedAPI = false) {
     typedef typename sdOutType<T>::type outType;
     SUPPORTED_TYPE_CHECK(T);
     SUPPORTED_TYPE_CHECK(outType);
@@ -151,7 +168,11 @@ void stdevDimIndexTest(string pFileName, dim_t dim = -1) {
     array a(dims, &(input.front()));
     array b = a(seq(2, 6), seq(1, 7));
 
-    array c = stdev(b, dim);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    array c = (useDeprecatedAPI ? stdev(b, dim)
+                                : stdev(b, AF_VARIANCE_POPULATION, dim));
+#pragma GCC diagnostic pop
 
     vector<outType> currGoldBar(tests[0].begin(), tests[0].end());
 
@@ -173,32 +194,39 @@ void stdevDimIndexTest(string pFileName, dim_t dim = -1) {
 TYPED_TEST(StandardDev, IndexedArrayDim0) {
     stdevDimIndexTest<TypeParam>(
         string(TEST_DIR "/stdev/mat_10x10_seq2_6x1_7_dim0.test"), 0);
+    stdevDimIndexTest<TypeParam>(
+        string(TEST_DIR "/stdev/mat_10x10_seq2_6x1_7_dim0.test"), 0);
 }
 
 TYPED_TEST(StandardDev, IndexedArrayDim1) {
     stdevDimIndexTest<TypeParam>(
-        string(TEST_DIR "/stdev/mat_10x10_seq2_6x1_7_dim1.test"), 1);
+        string(TEST_DIR "/stdev/mat_10x10_seq2_6x1_7_dim1.test"), 1, true);
+    stdevDimIndexTest<TypeParam>(
+        string(TEST_DIR "/stdev/mat_10x10_seq2_6x1_7_dim1.test"), 1, true);
 }
 
-TYPED_TEST(StandardDev, All) {
-    typedef typename sdOutType<TypeParam>::type outType;
-    SUPPORTED_TYPE_CHECK(TypeParam);
+template<typename T>
+void stdevAllTest(string pFileName, const bool useDeprecatedAPI = false) {
+    typedef typename sdOutType<T>::type outType;
+    SUPPORTED_TYPE_CHECK(T);
     SUPPORTED_TYPE_CHECK(outType);
 
     vector<dim4> numDims;
     vector<vector<int> > in;
     vector<vector<float> > tests;
 
-    readTestsFromFile<int, float>(
-        string(TEST_DIR "/stdev/mat_10x10_scalar.test"), numDims, in, tests);
+    readTestsFromFile<int, float>(pFileName, numDims, in, tests);
 
     dim4 dims = numDims[0];
-    vector<TypeParam> input(in[0].size());
-    transform(in[0].begin(), in[0].end(), input.begin(),
-              convert_to<TypeParam, int>);
+    vector<T> input(in[0].size());
+    transform(in[0].begin(), in[0].end(), input.begin(), convert_to<T, int>);
 
     array a(dims, &(input.front()));
-    outType b = stdev<outType>(a);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    outType b = (useDeprecatedAPI ? stdev<outType>(a)
+                                  : stdev<outType>(a, AF_VARIANCE_POPULATION));
+#pragma GCC diagnostic pop
 
     vector<outType> currGoldBar(tests[0].size());
     transform(tests[0].begin(), tests[0].end(), currGoldBar.begin(),
@@ -206,4 +234,10 @@ TYPED_TEST(StandardDev, All) {
 
     ASSERT_NEAR(::real(currGoldBar[0]), ::real(b), 1.0e-3);
     ASSERT_NEAR(::imag(currGoldBar[0]), ::imag(b), 1.0e-3);
+}
+
+TYPED_TEST(StandardDev, All) {
+    stdevAllTest<TypeParam>(string(TEST_DIR "/stdev/mat_10x10_scalar.test"));
+    stdevAllTest<TypeParam>(string(TEST_DIR "/stdev/mat_10x10_scalar.test"),
+                            true);
 }

--- a/test/var.cpp
+++ b/test/var.cpp
@@ -80,17 +80,18 @@ void testCPPVar(T const_value, dim4 dims, const bool useDeprecatedAPI = false) {
     ASSERT_NEAR(::real(output), ::real(gold), 1.0e-3);
     ASSERT_NEAR(::imag(output), ::imag(gold), 1.0e-3);
 
-    gold          = outType(2.5);
+    gold          = outType(2);
     outType tmp[] = {outType(0), outType(1), outType(2), outType(3),
                      outType(4)};
     array b(5, tmp);
+    af_print(b);
     output = (useDeprecatedAPI ? var<outType>(b, false)
                                : var<outType>(b, AF_VARIANCE_POPULATION));
 
     ASSERT_NEAR(::real(output), ::real(gold), 1.0e-3);
     ASSERT_NEAR(::imag(output), ::imag(gold), 1.0e-3);
 
-    gold   = outType(2);
+    gold   = outType(2.5);
     output = (useDeprecatedAPI ? var<outType>(b, true)
                                : var<outType>(b, AF_VARIANCE_SAMPLE));
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Description
---------------
- Add new std dev APIs with bias parameter
- Add new covariance APIs with bias enum instead of bool
- Add new variance APIs with bias enum argument instead of bool

Fixes: #2881 

Changes to Users
----------------
New APIs to control bias for variance, covariance and standard deviation functions.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
- [x] Test deprecated API of new API