### PR TITLE
Use sourceforge to download doxygen

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -14,7 +14,7 @@ jobs:
         runs-on: ubuntu-18.04
         env:
             NINJA_VER: 1.9.0
-            DOXYGEN_VER: 1.8.17
+            DOXYGEN_VER: 1.8.18
         steps:
             - name: Checkout Repository
               uses: actions/checkout@master
@@ -29,7 +29,7 @@ jobs:
 
             - name: Install Doxygen
               run: |
-                  wget --quiet http://doxygen.nl/files/doxygen-${DOXYGEN_VER}.linux.bin.tar.gz
+                  wget --quiet https://sourceforge.net/projects/doxygen/files/rel-${DOXYGEN_VER}/doxygen-${DOXYGEN_VER}.linux.bin.tar.gz
                   mkdir doxygen
                   tar -xf doxygen-${DOXYGEN_VER}.linux.bin.tar.gz -C doxygen --strip 1
 

--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -13,19 +13,10 @@ jobs:
         name: Documentation
         runs-on: ubuntu-18.04
         env:
-            NINJA_VER: 1.9.0
             DOXYGEN_VER: 1.8.18
         steps:
             - name: Checkout Repository
               uses: actions/checkout@master
-
-            - name: Download Ninja
-              id: ninja
-              run: |
-                  wget --quiet "https://github.com/ninja-build/ninja/releases/download/v${NINJA_VER}/ninja-linux.zip"
-                  unzip ./ninja-linux.zip
-                  chmod +x ninja
-                  ${GITHUB_WORKSPACE}/ninja --version
 
             - name: Install Doxygen
               run: |
@@ -37,14 +28,12 @@ jobs:
               run: |
                   git submodule update --init --recursive
                   mkdir build && cd build
-                  cmake -G Ninja \
-                      -DCMAKE_MAKE_PROGRAM:FILEPATH=${GITHUB_WORKSPACE}/ninja \
-                      -DAF_BUILD_CPU:BOOL=OFF -DAF_BUILD_CUDA:BOOL=OFF \
-                      -DAF_BUILD_OPENCL:BOOL=OFF -DAF_BUILD_UNIFIED:BOOL=OFF \
-                      -DAF_BUILD_EXAMPLES:BOOL=OFF -DBUILD_TESTING:BOOL=OFF \
-                      -DBOOST_ROOT:PATH=${BOOST_ROOT_1_72_0} \
-                      -DDOXYGEN_EXECUTABLE:FILEPATH=${GITHUB_WORKSPACE}/doxygen/bin/doxygen \
-                      ..
+                  cmake -DAF_BUILD_CPU:BOOL=OFF -DAF_BUILD_CUDA:BOOL=OFF \
+                        -DAF_BUILD_OPENCL:BOOL=OFF -DAF_BUILD_UNIFIED:BOOL=OFF \
+                        -DAF_BUILD_EXAMPLES:BOOL=OFF -DBUILD_TESTING:BOOL=OFF \
+                        -DBOOST_ROOT:PATH=${BOOST_ROOT_1_72_0} \
+                        -DDOXYGEN_EXECUTABLE:FILEPATH=${GITHUB_WORKSPACE}/doxygen/bin/doxygen \
+                        ..
 
             - name: Build
               run: |


### PR DESCRIPTION
Use Sourceforge to download doxygen instead of doxygen.nl

Description
-----------
It seems that the doxygen.nl site removes the older versions of
doxygen once they move to a newer version. This will cause faulures
when a new version is released. This commit uses the source forge
site to download the bin because they keep older versions on their
servers


Changes to Users
----------------
None

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- ~[ ] Code compiles~
- ~[ ] Tests pass~
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
