### PR TITLE
Build Unified backend without OpenCL or CUDA installed if necessary

### DIFF
--- a/src/api/unified/CMakeLists.txt
+++ b/src/api/unified/CMakeLists.txt
@@ -9,7 +9,6 @@ target_sources(af
     ${CMAKE_CURRENT_SOURCE_DIR}/arith.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/array.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/blas.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/cuda.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/device.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/error.cpp
@@ -23,7 +22,6 @@ target_sources(af
     ${CMAKE_CURRENT_SOURCE_DIR}/memory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ml.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/moments.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/opencl.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/random.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/signal.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sparse.cpp
@@ -33,6 +31,28 @@ target_sources(af
     ${CMAKE_CURRENT_SOURCE_DIR}/util.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/vision.cpp
   )
+
+if(OpenCL_FOUND)
+  target_sources(af
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/opencl.cpp
+  )
+
+  target_link_libraries(af
+    PRIVATE
+      OpenCL::OpenCL)
+
+endif()
+
+if(CUDA_FOUND)
+  target_sources(af
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/cuda.cpp)
+
+  target_include_directories(af
+    PRIVATE
+      ${CUDA_INCLUDE_DIRS})
+endif()
 
 target_sources(af
   PRIVATE


### PR DESCRIPTION
Allow the building of the unified backend even if OpenCL or CUDA headers are not available

Description
-----------

The unified backend required the CUDA and OpenCL headers but the end
user may not have either of those backend installed. This causes a
problem with building on CUDA only or OpenCL only systems.

Fixes: #2989


Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
