### PR TITLE
Remove assert that check that signal/filter types have to be the same

### DIFF
--- a/src/api/c/fftconvolve.cpp
+++ b/src/api/c/fftconvolve.cpp
@@ -162,14 +162,12 @@ af_err fft_convolve(af_array *out, const af_array signal, const af_array filter,
         const ArrayInfo &fInfo = getInfo(filter);
 
         af_dtype signalType = sInfo.getType();
-        af_dtype filterType = fInfo.getType();
 
         const dim4 &sdims = sInfo.dims();
         const dim4 &fdims = fInfo.dims();
 
         AF_BATCH_KIND convBT = identifyBatchKind(sdims, fdims, baseDim);
 
-        ARG_ASSERT(1, (signalType == filterType));
         ARG_ASSERT(1, (convBT != AF_BATCH_UNSUPPORTED));
 
         af_array output;


### PR DESCRIPTION
Remove the check that ensures that the filter type and signal type have to be the same.

Description
-----------
The filter and signal type need to be the same to function properly but ArrayFire used to perform implicit conversions if the filter type does not match the signal type. A check was added in the previous release that added an assert to enforce the same type which broke some code. This PR removes that check.

This sort of thing should warn the user in case this is being performed. We can also add a flag that does perform these checks for users who are concerned about these types of conversions. Although the performance impact of performing these types of conversions are minimal.

Changes to Users
----------------
Users do not explicitly have to convert the filter to the signal type before calling fftconvolve

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
