### PR TITLE
Add RPM support to cpack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,7 +284,7 @@ foreach(backend CPU CUDA OpenCL Unified)
     install(EXPORT ArrayFire${backend}Targets
             NAMESPACE ArrayFire::
             DESTINATION ${AF_INSTALL_CMAKE_DIR}
-            COMPONENT ${lower_backend})
+            COMPONENT ${lower_backend}-cmake)
 
     export( EXPORT ArrayFire${backend}Targets
             NAMESPACE ArrayFire::

--- a/CMakeModules/CPackConfig.RPM.cmake
+++ b/CMakeModules/CPackConfig.RPM.cmake
@@ -1,0 +1,147 @@
+##
+# RPM package
+##
+
+include(CMakeParseArguments)
+
+#TODO(umar): remove, should be set form command line
+# set(CPACK_RPM_PACKAGE_RELEASE 1)
+
+set(CPACK_RPM_FILE_NAME "%{name}-%{version}-%{release}%{?dist}.%{_arch}.rpm")
+set(CPACK_RPM_COMPONENT_INSTALL ON)
+set(CPACK_RPM_PACKAGE_LICENSE "BSD")
+set(CPACK_RPM_PACKAGE_GROUP "Development/Libraries")
+set(CPACK_RPM_PACKAGE_URL "${SITE_URL}")
+#set(CPACK_RPM_CHANGELOG_FILE "${ArrayFire_SOURCE_DIR}/docs/pages/release_notes.md")
+
+set(CPACK_COMPONENTS_ALL
+  arrayfire
+  cpu
+  cpu-dev
+  cpu-cmake
+  cuda
+  cuda-dev
+  cuda-cmake
+  opencl
+  opencl-dev
+  opencl-cmake
+  unified
+  unified-dev
+  unified-cmake
+  headers
+  cmake
+  examples
+  documentation
+  )
+
+macro(af_rpm_component)
+  cmake_parse_arguments(RC "" "COMPONENT;NAME;SUMMARY;DESCRIPTION" "REQUIRES;OPTIONAL" ${ARGN})
+  cpack_add_component(${RC_COMPONENT}
+    #DISPLAY_NAME
+    DESCRIPTION ${RC_DESCRIPTION})
+
+  string(REPLACE ";" ", " REQ "${RC_REQUIRES}")
+  string(REPLACE ";" ", " OPT "${RC_OPTIONAL}")
+  string(TOUPPER ${RC_COMPONENT} COMPONENT_UPPER)
+
+  if(RC_NAME)
+      set(CPACK_RPM_${COMPONENT_UPPER}_PACKAGE_NAME "${RC_NAME}")
+  endif()
+  # NOTE: Does not work in CentOS 6
+  #set(CPACK_RPM_${COMPONENT_UPPER}_PACKAGE_SUGGESTS ${OPT})
+  set(CPACK_RPM_${COMPONENT_UPPER}_SUMMARY ${SUMMARY})
+  set(CPACK_RPM_${COMPONENT_UPPER}_PACKAGE_REQUIRES "${REQ}")
+endmacro()
+
+set(CPACK_RPM_MAIN_COMPONENT arrayfire)
+af_rpm_component(
+  COMPONENT arrayfire
+  REQUIRES arrayfire-cpu-dev arrayfire-cuda-dev arrayfire-opencl-dev arrayfire-examples
+  SUMMARY  "ArrayFire high performance library"
+  DESCRIPTION  "ArrayFire
+ArrayFire is a general-purpose library that simplifies software
+development that targets parallel and massively-parallel architectures
+including CPUs, GPUs, and other hardware acceleration devices.")
+
+af_rpm_component(
+  COMPONENT cpu
+  NAME arrayfire-cpu-runtime
+  SUMMARY "ArrayFire CPU backend shared libraries"
+  DESCRIPTION "ArrayFire CPU backend shared libraries")
+
+af_rpm_component(
+  COMPONENT cpu-dev
+  REQUIRES arrayfire-cpu-runtime arrayfire-headers arrayfire-cmake arrayfire-cpu-cmake
+  SUMMARY  "ArrayFire CPU Backend development files"
+  DESCRIPTION  "ArrayFire CPU Backend development files")
+
+af_rpm_component(
+  COMPONENT cuda
+  NAME arrayfire-cuda-runtime
+  OPTIONAL forge-runtime
+  SUMMARY "ArrayFire CUDA backend shared libraries"
+  DESCRIPTION "ArrayFire CUDA backend shared libraries")
+
+af_rpm_component(
+  COMPONENT cuda-dev
+  REQUIRES arrayfire-cuda-runtime arrayfire-headers arrayfire-cmake arrayfire-cuda-cmake
+  SUMMARY  "ArrayFire CUDA Backend development files"
+  DESCRIPTION  "ArrayFire CUDA Backend development files")
+
+af_rpm_component(
+  COMPONENT opencl
+  NAME arrayfire-opencl-runtime
+  OPTIONAL forge-runtime
+  SUMMARY "ArrayFire OpenCL backend shared libraries"
+  DESCRIPTION "ArrayFire OpenCL backend shared libraries")
+
+af_rpm_component(
+  COMPONENT opencl-dev
+  REQUIRES arrayfire-opencl-runtime arrayfire-headers arrayfire-cmake arrayfire-opencl-cmake
+  SUMMARY  "ArrayFire OpenCL Backend development files"
+  DESCRIPTION  "ArrayFire OpenCL Backend development files")
+
+af_rpm_component(
+  COMPONENT unified
+  NAME arrayfire-unified-runtime
+  OPTIONAL forge-runtime
+  SUMMARY "ArrayFire Unified backend shared libraries."
+  DESCRIPTION "ArrayFire Unified backend shared libraries. Requires other backends to function.")
+
+af_rpm_component(
+  COMPONENT unified-dev
+  REQUIRES arrayfire-unified-runtime arrayfire-headers arrayfire-cmake arrayfire-unified-cmake
+  OPTIONAL forge-runtime
+  SUMMARY  "ArrayFire Unified Backend development files"
+  DESCRIPTION  "ArrayFire Unified Backend development files")
+
+af_rpm_component(
+  COMPONENT documentation
+  NAME arrayfire-doc
+  SUMMARY  "ArrayFire Documentation"
+  DESCRIPTION  "ArrayFire Doxygen Documentation")
+
+# NOTE: These commands do not work well for forge. The
+# version or the package name is incorrect when you perform
+# the package creation this way. The CPACK_PACKAGE_VERSION
+# does not extend to components. The forge rpm package will
+# need to be created in the forge project.
+
+#af_rpm_component(
+#  COMPONENT forge-lib
+#  NAME forge-runtime
+#  DESCRIPTION  )
+
+#cpack_add_component(forge-lib
+#    DESCRIPTION "Forge runtime libraries")
+#
+#set(CPACK_RPM_FORGE-LIB_PACKAGE_NAME "forge-runtime")
+#get_target_property(Forge_VERSION forge VERSION)
+##set(CPACK_RPM_FORGE-RUNTIME_FILE_NAME "forge-runtime-${Forge_VERSION}-%{release}%{?dist}.%{_arch}.rpm")
+#set(CPACK_RPM_FORGE-LIB_FILE_NAME "forge-runtime-${Forge_VERSION}-%{release}%{?dist}.%{_arch}.rpm")
+
+# Does not work in CentOS 6
+#set(CPACK_RPM_${COMPONENT_UPPER}_PACKAGE_SUGGESTS ${OPT})
+#set(CPACK_RPM_FORGE-LIB_SUMMARY "Forge runtime librariers")
+#set(CPACK_RPM_FORGE-LIB_VERSION ${Forge_VERSION})
+#set(CPACK_RPM_FORGE-LIB_PACKAGE_REQUIRES "${REQ}")

--- a/CMakeModules/CPackConfig.cmake
+++ b/CMakeModules/CPackConfig.cmake
@@ -338,17 +338,7 @@ set(CPACK_DEB_COMPONENT_INSTALL ON)
 #set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 set(CPACK_DEBIAN_PACKAGE_HOMEPAGE http://www.arrayfire.com)
 
-##
-# RPM package
-##
-set(CPACK_RPM_PACKAGE_ARCHITECTURE "x86_64")
-set(CPACK_RPM_PACKAGE_AUTOREQPROV " no")
-set(CPACK_RPM_PACKAGE_GROUP "Development/Libraries")
-set(CPACK_RPM_PACKAGE_LICENSE "BSD")
-set(CPACK_RPM_PACKAGE_URL "${SITE_URL}")
-if(AF_BUILD_FORGE)
-    set(CPACK_RPM_PACKAGE_SUGGESTS "fontconfig-devel, libX11, libXrandr, libXinerama, libXxf86vm, libXcursor, mesa-libGL-devel")
-endif()
+include(CPackConfig.RPM)
 
 ##
 # Source package


### PR DESCRIPTION
Create RPM packages using CPack

Description
-----------
This PR allows you to add RPM packages which can be used in CentOS and Fedora distros. The following packages are created:

```
-rw-r--r-- 1 root root 2.1K Aug 14 06:02 arrayfire-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 5.5K Aug 14 06:02 arrayfire-cmake-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 4.3K Aug 14 06:02 arrayfire-cpu-cmake-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 2.0K Aug 14 06:02 arrayfire-cpu-dev-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 4.8M Aug 14 06:02 arrayfire-cpu-runtime-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 4.3K Aug 14 06:02 arrayfire-cuda-cmake-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 2.0K Aug 14 06:02 arrayfire-cuda-dev-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 119M Aug 14 06:02 arrayfire-cuda-runtime-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root  19M Aug 14 06:02 arrayfire-doc-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root  13M Aug 14 06:02 arrayfire-examples-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root  91K Aug 14 06:02 arrayfire-headers-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root  16K Aug 13 22:27 arrayfire-licenses-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 4.3K Aug 14 06:02 arrayfire-opencl-cmake-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 2.0K Aug 14 06:02 arrayfire-opencl-dev-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 6.9M Aug 14 06:02 arrayfire-opencl-runtime-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 4.3K Aug 14 06:02 arrayfire-unified-cmake-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 2.0K Aug 14 06:02 arrayfire-unified-dev-3.8.0-1.el6.x86_64.rpm
-rw-r--r-- 1 root root 615K Aug 14 06:02 arrayfire-unified-runtime-3.8.0-1.el6.x86_64.rpm
```
Each package is organized so that they libraries and headers can be installed independently of each other if necessary.

Changes to Users
----------------
Users can install ArrayFire using RPM packages.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
