### PR TITLE
Compute capability fix

### DIFF
--- a/src/backend/common/half.hpp
+++ b/src/backend/common/half.hpp
@@ -832,9 +832,7 @@ class alignas(2) half {
 #endif
 
    public:
-#if CUDA_VERSION >= 10000
     AF_CONSTEXPR
-#endif
     half() = default;
 
     /// Constructor.

--- a/src/backend/cuda/compile_module.cpp
+++ b/src/backend/cuda/compile_module.cpp
@@ -401,8 +401,8 @@ Module loadModuleFromDisk(const int device, const string &moduleKey,
     Module retVal{nullptr};
     try {
         std::ifstream in(cacheFile, std::ios::binary);
-        if (!in.is_open()) {
-            AF_TRACE("{{{:<30} : Unable to open {} for {}}}", moduleKey,
+        if (!in) {
+            AF_TRACE("{{{:<20} : Unable to open {} for {}}}", moduleKey,
                      cacheFile, getDeviceProp(device).name);
             removeFile(cacheFile);  // Remove if exists
             return Module{nullptr};
@@ -448,23 +448,23 @@ Module loadModuleFromDisk(const int device, const string &moduleKey,
 
         CU_CHECK(cuModuleLoadData(&modOut, cubin.data()));
 
-        AF_TRACE("{{{:<30} : loaded from {} for {} }}", moduleKey, cacheFile,
+        AF_TRACE("{{{:<20} : loaded from {} for {} }}", moduleKey, cacheFile,
                  getDeviceProp(device).name);
 
         retVal.set(modOut);
     } catch (const std::ios_base::failure &e) {
-        AF_TRACE("{{{:<30} : Unable to read {} for {}}}", moduleKey, cacheFile,
+        AF_TRACE("{{{:<20} : Unable to read {} for {}}}", moduleKey, cacheFile,
                  getDeviceProp(device).name);
         removeFile(cacheFile);
     } catch (const AfError &e) {
         if (e.getError() == AF_ERR_LOAD_SYM) {
             AF_TRACE(
-                "{{{:<30} : Corrupt binary({}) found on disk for {}, removed}}",
+                "{{{:<20} : Corrupt binary({}) found on disk for {}, removed}}",
                 moduleKey, cacheFile, getDeviceProp(device).name);
         } else {
             if (modOut != nullptr) { CU_CHECK(cuModuleUnload(modOut)); }
             AF_TRACE(
-                "{{{:<30} : cuModuleLoadData failed with content from {} for "
+                "{{{:<20} : cuModuleLoadData failed with content from {} for "
                 "{}, {}}}",
                 moduleKey, cacheFile, getDeviceProp(device).name, e.what());
         }

--- a/src/backend/cuda/kernel/random_engine.hpp
+++ b/src/backend/cuda/kernel/random_engine.hpp
@@ -134,12 +134,10 @@ __device__ static double getDouble01(uint num1, uint num2) {
     uint64_t n2 = num2;
     n1 <<= 32;
     uint64_t num = n1 | n2;
-#pragma diag_suppress 3245
     constexpr double factor =
         ((1.0) / (std::numeric_limits<unsigned long long>::max() +
-                  static_cast<long double>(1.0l)));
+                  static_cast<double>(1.0)));
     constexpr double half_factor((0.5) * factor);
-#pragma diag_default 3245
 
     return fma(static_cast<double>(num), factor, half_factor);
 }

--- a/src/backend/opencl/compile_module.cpp
+++ b/src/backend/opencl/compile_module.cpp
@@ -194,12 +194,12 @@ Module compileModule(const string &moduleKey, const vector<string> &sources,
             // before the current thread.
             if (!renameFile(tempFile, cacheFile)) { removeFile(tempFile); }
         } catch (const cl::Error &e) {
-            AF_TRACE("{{{:<30} : Failed to fetch opencl binary for {}, {}}}",
+            AF_TRACE("{{{:<20} : Failed to fetch opencl binary for {}, {}}}",
                      moduleKey,
                      opencl::getDevice(device).getInfo<CL_DEVICE_NAME>(),
                      e.what());
         } catch (const std::ios_base::failure &e) {
-            AF_TRACE("{{{:<30} : Failed writing binary to {} for {}, {}}}",
+            AF_TRACE("{{{:<20} : Failed writing binary to {} for {}, {}}}",
                      moduleKey, cacheFile,
                      opencl::getDevice(device).getInfo<CL_DEVICE_NAME>(),
                      e.what());
@@ -207,7 +207,7 @@ Module compileModule(const string &moduleKey, const vector<string> &sources,
     }
 #endif
 
-    AF_TRACE("{{{:<30} : {{ compile:{:>5} ms, {{ {} }}, {} }}}}", moduleKey,
+    AF_TRACE("{{{:<20} : {{ compile:{:>5} ms, {{ {} }}, {} }}}}", moduleKey,
              duration_cast<milliseconds>(compileEnd - compileBegin).count(),
              fmt::join(options, " "),
              getDevice(getActiveDeviceId()).getInfo<CL_DEVICE_NAME>());
@@ -250,26 +250,26 @@ Module loadModuleFromDisk(const int device, const string &moduleKey,
         program = Program(opencl::getContext(), {dev}, {clbin});
         program.build();
 
-        AF_TRACE("{{{:<30} : loaded from {} for {} }}", moduleKey, cacheFile,
+        AF_TRACE("{{{:<20} : loaded from {} for {} }}", moduleKey, cacheFile,
                  dev.getInfo<CL_DEVICE_NAME>());
         retVal.set(program);
     } catch (const AfError &e) {
         if (e.getError() == AF_ERR_LOAD_SYM) {
             AF_TRACE(
-                "{{{:<30} : Corrupt binary({}) found on disk for {}, removed}}",
+                "{{{:<20} : Corrupt binary({}) found on disk for {}, removed}}",
                 moduleKey, cacheFile, dev.getInfo<CL_DEVICE_NAME>());
         } else {
-            AF_TRACE("{{{:<30} : Unable to open {} for {}}}", moduleKey,
+            AF_TRACE("{{{:<20} : Unable to open {} for {}}}", moduleKey,
                      cacheFile, dev.getInfo<CL_DEVICE_NAME>());
         }
         removeFile(cacheFile);
     } catch (const std::ios_base::failure &e) {
-        AF_TRACE("{{{:<30} : IO failure while loading {} for {}; {}}}",
+        AF_TRACE("{{{:<20} : IO failure while loading {} for {}; {}}}",
                  moduleKey, cacheFile, dev.getInfo<CL_DEVICE_NAME>(), e.what());
         removeFile(cacheFile);
     } catch (const cl::Error &e) {
         AF_TRACE(
-            "{{{:<30} : Loading OpenCL binary({}) failed for {}; {}, Build "
+            "{{{:<20} : Loading OpenCL binary({}) failed for {}; {}, Build "
             "Log: {}}}",
             moduleKey, cacheFile, dev.getInfo<CL_DEVICE_NAME>(), e.what(),
             getProgramBuildLog(program));


### PR DESCRIPTION
Fixes checkAndSet

Description
-----------
Fixes an issue where the device compute capability is larger than
the supported maximum of the CUDA runtime used to build ArrayFire.
This happens for example when you run the Turing card with a CUDA
runtime of 9.0. The compute capability of Turing is 7.5 and the
maximum supported by the runtime is 7.0/7.2. Before this change
we were only checking the major compute capability and not checking
the minor version to set the max compute capability of the device.
This caused errors like:

```
In file src/backend/cuda/compile_module.cpp:266
NVRTC Error(5): NVRTC_ERROR_INVALID_OPTION
Log:
nvrtc: error: invalid value for --gpu-architecture (-arch)
```
This PR also updates the error messages for failure cases.

The utility header in cuda_fp16.hpp is not included automatically
in CUDA 9. Additionally we need to pass the
--device-as-default-execution-space flag to nvrtc for JIT and
non-JIT kernels

* The moduleKey is an size_t object so the maximum number of digits
  it can have is 20 so the format length for that value is updated
* The runtime check messages are always logged (but not displayed)
  Errors are still only thrown in debug modes
* Display the compute capability of the CUDA device along with
  its name and other stats

  example:
```
  Found device: Quadro T2000 (sm_75) (3.82 GB | ~3164.06 GFLOPs | 16 SMs)
```

Changes to Users
----------------
Better error messages and better support for newer devices with older CUDA toolkits

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
