### PR TITLE
Create a more portable macro that disables deprecated warnings

### DIFF
--- a/src/api/cpp/device.cpp
+++ b/src/api/cpp/device.cpp
@@ -7,6 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <common/deprecated.hpp>
 #include <af/array.h>
 #include <af/backend.h>
 #include <af/compatible.h>
@@ -102,10 +103,9 @@ void sync(int device) { AF_THROW(af_sync(device)); }
 // Alloc device memory
 void *alloc(const size_t elements, const af::dtype type) {
     void *ptr;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    AF_DEPRECATED_WARNINGS_OFF
     AF_THROW(af_alloc_device(&ptr, elements * size_of(type)));
-#pragma GCC diagnostic pop
+    AF_DEPRECATED_WARNINGS_ON
     // FIXME: Add to map
     return ptr;
 }
@@ -127,10 +127,9 @@ void *pinned(const size_t elements, const af::dtype type) {
 
 void free(const void *ptr) {
     // FIXME: look up map and call the right free
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    AF_DEPRECATED_WARNINGS_OFF
     AF_THROW(af_free_device(const_cast<void *>(ptr)));
-#pragma GCC diagnostic pop
+    AF_DEPRECATED_WARNINGS_ON
 }
 
 void freeV2(const void *ptr) {
@@ -172,8 +171,7 @@ size_t getMemStepSize() {
     return size_bytes;
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+AF_DEPRECATED_WARNINGS_OFF
 #define INSTANTIATE(T)                                                        \
     template<>                                                                \
     AFAPI T *alloc(const size_t elements) {                                   \
@@ -200,6 +198,6 @@ INSTANTIATE(short)
 INSTANTIATE(unsigned short)
 INSTANTIATE(long long)
 INSTANTIATE(unsigned long long)
-#pragma GCC diagnostic pop
+AF_DEPRECATED_WARNINGS_ON
 
 }  // namespace af

--- a/src/api/unified/CMakeLists.txt
+++ b/src/api/unified/CMakeLists.txt
@@ -65,6 +65,7 @@ target_sources(af
     ${ArrayFire_SOURCE_DIR}/src/backend/common/err_common.cpp
     ${ArrayFire_SOURCE_DIR}/src/backend/common/util.cpp
     ${ArrayFire_SOURCE_DIR}/src/backend/common/util.hpp
+    ${ArrayFire_SOURCE_DIR}/src/backend/common/deprecated.hpp
   )
 
 arrayfire_set_default_cxx_flags(af)

--- a/src/api/unified/device.cpp
+++ b/src/api/unified/device.cpp
@@ -7,6 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <common/deprecated.hpp>
 #include <af/array.h>
 #include <af/backend.h>
 #include <af/device.h>
@@ -74,10 +75,9 @@ af_err af_get_device(int *device) { CALL(af_get_device, device); }
 af_err af_sync(const int device) { CALL(af_sync, device); }
 
 af_err af_alloc_device(void **ptr, const dim_t bytes) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    AF_DEPRECATED_WARNINGS_OFF
     CALL(af_alloc_device, ptr, bytes);
-#pragma GCC diagnostic pop
+    AF_DEPRECATED_WARNINGS_ON
 }
 
 af_err af_alloc_device_v2(void **ptr, const dim_t bytes) {
@@ -89,10 +89,9 @@ af_err af_alloc_pinned(void **ptr, const dim_t bytes) {
 }
 
 af_err af_free_device(void *ptr) {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    AF_DEPRECATED_WARNINGS_OFF
     CALL(af_free_device, ptr);
-#pragma GCC diagnostic pop
+    AF_DEPRECATED_WARNINGS_ON
 }
 
 af_err af_free_device_v2(void *ptr) { CALL(af_free_device_v2, ptr); }
@@ -136,18 +135,16 @@ af_err af_get_mem_step_size(size_t *step_bytes) {
 
 af_err af_lock_device_ptr(const af_array arr) {
     CHECK_ARRAYS(arr);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    AF_DEPRECATED_WARNINGS_OFF
     CALL(af_lock_device_ptr, arr);
-#pragma GCC diagnostic pop
+    AF_DEPRECATED_WARNINGS_ON
 }
 
 af_err af_unlock_device_ptr(const af_array arr) {
     CHECK_ARRAYS(arr);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    AF_DEPRECATED_WARNINGS_OFF
     CALL(af_unlock_device_ptr, arr);
-#pragma GCC diagnostic pop
+    AF_DEPRECATED_WARNINGS_ON
 }
 
 af_err af_lock_array(const af_array arr) {

--- a/src/api/unified/graphics.cpp
+++ b/src/api/unified/graphics.cpp
@@ -7,6 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <common/deprecated.hpp>
 #include <af/array.h>
 #include <af/graphics.h>
 #include "symbol_manager.hpp"
@@ -38,19 +39,17 @@ af_err af_draw_image(const af_window wind, const af_array in,
 af_err af_draw_plot(const af_window wind, const af_array X, const af_array Y,
                     const af_cell* const props) {
     CHECK_ARRAYS(X, Y);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    AF_DEPRECATED_WARNINGS_OFF
     CALL(af_draw_plot, wind, X, Y, props);
-#pragma GCC diagnostic pop
+    AF_DEPRECATED_WARNINGS_ON
 }
 
 af_err af_draw_plot3(const af_window wind, const af_array P,
                      const af_cell* const props) {
     CHECK_ARRAYS(P);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    AF_DEPRECATED_WARNINGS_OFF
     CALL(af_draw_plot3, wind, P, props);
-#pragma GCC diagnostic pop
+    AF_DEPRECATED_WARNINGS_ON
 }
 
 af_err af_draw_plot_nd(const af_window wind, const af_array in,
@@ -75,20 +74,18 @@ af_err af_draw_scatter(const af_window wind, const af_array X, const af_array Y,
                        const af_marker_type marker,
                        const af_cell* const props) {
     CHECK_ARRAYS(X, Y);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    AF_DEPRECATED_WARNINGS_OFF
     CALL(af_draw_scatter, wind, X, Y, marker, props);
-#pragma GCC diagnostic pop
+    AF_DEPRECATED_WARNINGS_ON
 }
 
 af_err af_draw_scatter3(const af_window wind, const af_array P,
                         const af_marker_type marker,
                         const af_cell* const props) {
     CHECK_ARRAYS(P);
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    AF_DEPRECATED_WARNINGS_OFF
     CALL(af_draw_scatter3, wind, P, marker, props);
-#pragma GCC diagnostic pop
+    AF_DEPRECATED_WARNINGS_ON
 }
 
 af_err af_draw_scatter_nd(const af_window wind, const af_array in,

--- a/src/api/unified/statistics.cpp
+++ b/src/api/unified/statistics.cpp
@@ -7,6 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <common/deprecated.hpp>
 #include <af/array.h>
 #include <af/statistics.h>
 #include "symbol_manager.hpp"
@@ -22,11 +23,13 @@ af_err af_mean_weighted(af_array *out, const af_array in,
     CALL(af_mean_weighted, out, in, weights, dim);
 }
 
+AF_DEPRECATED_WARNINGS_OFF
 af_err af_var(af_array *out, const af_array in, const bool isbiased,
               const dim_t dim) {
     CHECK_ARRAYS(in);
     CALL(af_var, out, in, isbiased, dim);
 }
+AF_DEPRECATED_WARNINGS_ON
 
 af_err af_var_weighted(af_array *out, const af_array in, const af_array weights,
                        const dim_t dim) {
@@ -41,6 +44,7 @@ af_err af_meanvar(af_array *mean, af_array *var, const af_array in,
     CALL(af_meanvar, mean, var, in, weights, bias, dim);
 }
 
+AF_DEPRECATED_WARNINGS_OFF
 af_err af_stdev(af_array *out, const af_array in, const dim_t dim) {
     CHECK_ARRAYS(in);
     CALL(af_stdev, out, in, dim);
@@ -51,6 +55,7 @@ af_err af_cov(af_array *out, const af_array X, const af_array Y,
     CHECK_ARRAYS(X, Y);
     CALL(af_cov, out, X, Y, isbiased);
 }
+AF_DEPRECATED_WARNINGS_ON
 
 af_err af_median(af_array *out, const af_array in, const dim_t dim) {
     CHECK_ARRAYS(in);
@@ -68,11 +73,13 @@ af_err af_mean_all_weighted(double *real, double *imag, const af_array in,
     CALL(af_mean_all_weighted, real, imag, in, weights);
 }
 
+AF_DEPRECATED_WARNINGS_OFF
 af_err af_var_all(double *realVal, double *imagVal, const af_array in,
                   const bool isbiased) {
     CHECK_ARRAYS(in);
     CALL(af_var_all, realVal, imagVal, in, isbiased);
 }
+AF_DEPRECATED_WARNINGS_ON
 
 af_err af_var_all_weighted(double *realVal, double *imagVal, const af_array in,
                            const af_array weights) {
@@ -80,10 +87,12 @@ af_err af_var_all_weighted(double *realVal, double *imagVal, const af_array in,
     CALL(af_var_all_weighted, realVal, imagVal, in, weights);
 }
 
+AF_DEPRECATED_WARNINGS_OFF
 af_err af_stdev_all(double *real, double *imag, const af_array in) {
     CHECK_ARRAYS(in);
     CALL(af_stdev_all, real, imag, in);
 }
+AF_DEPRECATED_WARNINGS_ON
 
 af_err af_median_all(double *realVal, double *imagVal, const af_array in) {
     CHECK_ARRAYS(in);

--- a/src/backend/common/deprecated.hpp
+++ b/src/backend/common/deprecated.hpp
@@ -1,0 +1,27 @@
+/*******************************************************
+ * Copyright (c) 2020, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+#include <af/compilers.h>
+
+// clang-format off
+#if AF_COMPILER_IS_MSVC
+#define AF_DEPRECATED_WARNINGS_OFF  \
+    __pragma(warning(push))         \
+    __pragma(warning(disable:4996))
+
+#define AF_DEPRECATED_WARNINGS_ON \
+    __pragma(warning(pop))
+#else
+#define AF_DEPRECATED_WARNINGS_OFF                                  \
+  _Pragma("GCC diagnostic push")                                 \
+  _Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+
+#define AF_DEPRECATED_WARNINGS_ON                                   \
+  _Pragma("GCC diagnostic pop")
+#endif
+// clang-format on

--- a/src/backend/opencl/cl2hpp.hpp
+++ b/src/backend/opencl/cl2hpp.hpp
@@ -9,13 +9,16 @@
 
 #pragma once
 
+#include <common/deprecated.hpp>
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wignored-qualifiers"
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+AF_DEPRECATED_WARNINGS_OFF
 #if __GNUC__ >= 8
 #pragma GCC diagnostic ignored "-Wcatch-value="
 #endif
 #include <CL/cl2.hpp>
+AF_DEPRECATED_WARNINGS_ON
 #pragma GCC diagnostic pop

--- a/src/backend/opencl/kernel/regions.hpp
+++ b/src/backend/opencl/kernel/regions.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <Param.hpp>
+#include <common/deprecated.hpp>
 #include <common/dispatch.hpp>
 #include <common/kernel_cache.hpp>
 #include <debug_opencl.hpp>
@@ -19,9 +20,7 @@
 #include <traits.hpp>
 #include <af/defines.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
+AF_DEPRECATED_WARNINGS_OFF
 #include <boost/compute/algorithm/adjacent_difference.hpp>
 #include <boost/compute/algorithm/exclusive_scan.hpp>
 #include <boost/compute/algorithm/sort.hpp>
@@ -30,8 +29,7 @@
 #include <boost/compute/iterator/counting_iterator.hpp>
 #include <boost/compute/lambda.hpp>
 #include <boost/compute/lambda/placeholders.hpp>
-
-#pragma GCC diagnostic pop
+AF_DEPRECATED_WARNINGS_ON
 
 #include <array>
 #include <string>

--- a/src/backend/opencl/kernel/sift_nonfree.hpp
+++ b/src/backend/opencl/kernel/sift_nonfree.hpp
@@ -70,6 +70,7 @@
 // NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 // SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#include <common/deprecated.hpp>
 #include <common/dispatch.hpp>
 #include <common/kernel_cache.hpp>
 #include <debug_opencl.hpp>
@@ -80,16 +81,13 @@
 #include <memory.hpp>
 #include <af/defines.h>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
+AF_DEPRECATED_WARNINGS_OFF
 #include <boost/compute/algorithm/gather.hpp>
 #include <boost/compute/algorithm/iota.hpp>
 #include <boost/compute/algorithm/sort_by_key.hpp>
 #include <boost/compute/core.hpp>
 #include <boost/compute/iterator/buffer_iterator.hpp>
-
-#pragma GCC diagnostic pop
+AF_DEPRECATED_WARNINGS_ON
 
 #include <vector>
 

--- a/src/backend/opencl/kernel/sort.hpp
+++ b/src/backend/opencl/kernel/sort.hpp
@@ -16,14 +16,13 @@
 #include <kernel/sort_helper.hpp>
 #include <traits.hpp>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
+AF_DEPRECATED_WARNINGS_OFF
 #include <boost/compute/algorithm/sort.hpp>
 #include <boost/compute/algorithm/sort_by_key.hpp>
 #include <boost/compute/core.hpp>
 #include <boost/compute/functional/operator.hpp>
 #include <boost/compute/iterator/buffer_iterator.hpp>
+AF_DEPRECATED_WARNINGS_ON
 
 namespace compute = boost::compute;
 
@@ -129,5 +128,3 @@ void sort0(Param val, bool isAscending) {
 }
 }  // namespace kernel
 }  // namespace opencl
-
-#pragma GCC diagnostic pop

--- a/src/backend/opencl/kernel/sort_by_key_impl.hpp
+++ b/src/backend/opencl/kernel/sort_by_key_impl.hpp
@@ -21,9 +21,7 @@
 #include <memory.hpp>
 #include <traits.hpp>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
+AF_DEPRECATED_WARNINGS_OFF
 #include <boost/compute/algorithm/copy.hpp>
 #include <boost/compute/algorithm/sort_by_key.hpp>
 #include <boost/compute/algorithm/transform.hpp>
@@ -34,6 +32,7 @@
 #include <boost/compute/functional/operator.hpp>
 #include <boost/compute/iterator/buffer_iterator.hpp>
 #include <boost/compute/types/pair.hpp>
+AF_DEPRECATED_WARNINGS_ON
 
 namespace compute = boost::compute;
 
@@ -254,5 +253,3 @@ void sort0ByKey(Param pKey, Param pVal, bool isAscending) {
 
 }  // namespace kernel
 }  // namespace opencl
-
-#pragma GCC diagnostic pop

--- a/src/backend/opencl/set.cpp
+++ b/src/backend/opencl/set.cpp
@@ -14,14 +14,13 @@
 #include <sort.hpp>
 #include <af/dim4.hpp>
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-
+AF_DEPRECATED_WARNINGS_OFF
 #include <boost/compute/algorithm/set_intersection.hpp>
 #include <boost/compute/algorithm/set_union.hpp>
 #include <boost/compute/algorithm/sort.hpp>
 #include <boost/compute/algorithm/unique.hpp>
 #include <boost/compute/iterator/buffer_iterator.hpp>
+AF_DEPRECATED_WARNINGS_ON
 
 namespace compute = boost::compute;
 
@@ -153,5 +152,3 @@ INSTANTIATE(ushort)
 INSTANTIATE(intl)
 INSTANTIATE(uintl)
 }  // namespace opencl
-
-#pragma GCC diagnostic pop

--- a/test/random.cpp
+++ b/test/random.cpp
@@ -317,12 +317,12 @@ void testRandomEngineUniform(randomEngineType type) {
     if (af::isDoubleAvailable(af::getDevice())) {
         array Ad = A.as(f64);
         double m = mean<double>(Ad);
-        double s = stdev<double>(Ad);
+        double s = stdev<double>(Ad, AF_VARIANCE_POPULATION);
         ASSERT_NEAR(m, 0.5, 1e-3);
         ASSERT_NEAR(s, 0.2887, 1e-2);
     } else {
         T m = mean<T>(A);
-        T s = stdev<T>(A);
+        T s = stdev<T>(A, AF_VARIANCE_POPULATION);
         ASSERT_NEAR(m, 0.5, 1e-3);
         ASSERT_NEAR(s, 0.2887, 1e-2);
     }
@@ -337,7 +337,7 @@ void testRandomEngineNormal(randomEngineType type) {
     randomEngine r(type, 0);
     array A = randn(elem, ty, r);
     T m     = mean<T>(A);
-    T s     = stdev<T>(A);
+    T s     = stdev<T>(A, AF_VARIANCE_POPULATION);
     ASSERT_NEAR(m, 0, 1e-1);
     ASSERT_NEAR(s, 1, 1e-1);
 }


### PR DESCRIPTION
Create a more portable macro that disables deprecated warnings

Description
-----------
There are several functions that are deprecated in ArrayFire. We need to disable these warnings when we need to use these functions in our backend code. We had used gcc specific flags to achieve this but these warnings still appeared in MSVC compilers. This PR creates a macro that works across those two compilers and can be expanded to target others.

Also fixes some deprecated warnings in tests and unified backend code.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x]  Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
