### PR TITLE
Add functions to set and get the cache directory for runtime kernels

### DIFF
--- a/docs/pages/configuring_arrayfire_environment.md
+++ b/docs/pages/configuring_arrayfire_environment.md
@@ -223,7 +223,7 @@ AF_BUILD_LIB_CUSTOM_PATH {#af_build_lib_custom_path}
 -------------------------------------------------------------------------------
 
 When set, this environment variable specifies a custom path along which the
-symbol manager will search for dynamic (shared library) backends to load. This 
+symbol manager will search for dynamic (shared library) backends to load. This
 is useful for specialized build configurations that use the unified backend and
 build shared libraries separately.
 
@@ -243,3 +243,22 @@ three values:
 CUDA backend kernels are stored in files with cu file extension.
 
 OpenCL backend kernels are stored in files with cl file extension.
+
+AF_JIT_KERNEL_CACHE_DIRECTORY {#af_jit_kernel_cache_directory}
+-------------------------------------------------------------------------------
+
+This variable sets the path to the ArrayFire cache on the filesystem. If set
+ArrayFire will write the kernels that are compiled at runtime to this directory.
+If the path is not writeable, the default path is used.
+
+This path is different from AF_JIT_KERNEL_TRACE which stores strings. These
+kernels will store binaries and the content will be dependent on the
+backend and platforms used.
+
+The default path is determined in the following order:
+  Unix:
+      1. $HOME/.arrayfire
+      2. /tmp/arrayfire
+  Windows:
+      1. ArrayFire application Temp folder(Usually
+          C:\Users\<user_name>\AppData\Local\Temp\ArrayFire)

--- a/examples/machine_learning/naive_bayes.cpp
+++ b/examples/machine_learning/naive_bayes.cpp
@@ -39,7 +39,7 @@ void naive_bayes_train(float *priors, array &mu, array &sig2,
         mu(span, ii) = mean(train_feats_ii, 1);
 
         // Some pixels are always 0. Add a small variance.
-        sig2(span, ii) = var(train_feats_ii, 0, 1) + 0.01;
+        sig2(span, ii) = var(train_feats_ii, AF_VARIANCE_SAMPLE, 1) + 0.01;
 
         // Calculate priors
         priors[ii] = (float)idx.elements() / (float)num_samples;

--- a/include/af/device.h
+++ b/include/af/device.h
@@ -575,6 +575,49 @@ extern "C" {
     */
     AFAPI af_err af_get_device_ptr(void **ptr, const af_array arr);
 
+#if AF_API_VERSION >= 38
+    /**
+       Sets the path where the kernels generated at runtime will be cached
+
+       Sets the path where the kernels generated at runtime will be stored to
+       cache for later use. The files in this directory can be safely deleted.
+       The default location for these kernels is in $HOME/.arrayfire on Unix
+       systems and in the ArrayFire temp directory on Windows.
+
+       \param[in] path The location where the kernels will be stored
+       \param[in] override_env if true this path will take precedence over the
+                               AF_JIT_KERNEL_CACHE_DIRECTORY environment variable.
+                               If false, the environment variable takes precedence
+                               over this path.
+
+       \returns AF_SUCCESS if the variable is set. AF_ERR_ARG if path is NULL.
+       \ingroup device_func_mem
+    */
+    AFAPI af_err af_set_kernel_cache_directory(const char* path,
+                                               int override_env);
+
+    /**
+       Gets the path where the kernels generated at runtime will be cached
+
+       Gets the path where the kernels generated at runtime will be stored to
+       cache for later use. The files in this directory can be safely deleted.
+       The default location for these kernels is in $HOME/.arrayfire on Unix
+       systems and in the ArrayFire temp directory on Windows.
+
+       \param[out] length The length of the path array. If \p path is NULL, the
+                          length of the current path is assigned to this pointer
+       \param[out] path The path of the runtime generated kernel cache
+                         variable. If NULL, the current path length is assigned
+                         to \p length
+       \returns AF_SUCCESS if the variable is set.
+                AF_ERR_ARG if path and length are null at the same time.
+                AF_ERR_SIZE if \p length not sufficient enought to store the
+                            path
+       \ingroup device_func_mem
+    */
+    AFAPI af_err af_get_kernel_cache_directory(size_t *length, char *path);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/src/api/unified/device.cpp
+++ b/src/api/unified/device.cpp
@@ -179,3 +179,11 @@ af_err af_set_manual_eval_flag(bool flag) {
 af_err af_get_manual_eval_flag(bool *flag) {
     CALL(af_get_manual_eval_flag, flag);
 }
+
+af_err af_set_kernel_cache_directory(const char *path, int override_eval) {
+    CALL(af_set_kernel_cache_directory, path, override_eval);
+}
+
+af_err af_get_kernel_cache_directory(size_t *length, char *path) {
+    CALL(af_get_kernel_cache_directory, length, path);
+}

--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -14,6 +14,11 @@
 #include <string>
 #include <vector>
 
+/// The environment variable that determines where the runtime kernels
+/// will be stored on the file system
+constexpr const char* JIT_KERNEL_CACHE_DIRECTORY_ENV_NAME =
+    "AF_JIT_KERNEL_CACHE_DIRECTORY";
+
 std::string getEnvVar(const std::string& key);
 
 // Dump the kernel sources only if the environment variable is defined
@@ -22,7 +27,7 @@ void saveKernel(const std::string& funcName, const std::string& jit_ker,
 
 std::string int_version_to_string(int version);
 
-const std::string& getCacheDirectory();
+std::string& getCacheDirectory();
 
 bool directoryExists(const std::string& path);
 

--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -70,6 +70,22 @@ struct cuNVRTCcompute {
     int embedded_minor;
 };
 
+/// Struct represents the cuda toolkit version and its associated minimum
+/// required driver versions.
+struct ToolkitDriverVersions {
+    /// The CUDA Toolkit version returned by cudaDriverGetVersion or
+    /// cudaRuntimeGetVersion
+    int version;
+
+    /// The minimum GPU driver version required for the \p version toolkit on
+    /// Linux or macOS
+    float unix_min_version;
+
+    /// The minimum GPU driver version required for the \p version toolkit on
+    /// Windows
+    float windows_min_version;
+};
+
 // clang-format off
 static const int jetsonComputeCapabilities[] = {
     7020,
@@ -81,6 +97,7 @@ static const int jetsonComputeCapabilities[] = {
 
 // clang-format off
 static const cuNVRTCcompute Toolkit2MaxCompute[] = {
+    {11000, 8, 0, 0},
     {10020, 7, 5, 2},
     {10010, 7, 5, 2},
     {10000, 7, 0, 2},
@@ -90,6 +107,24 @@ static const cuNVRTCcompute Toolkit2MaxCompute[] = {
     { 8000, 5, 2, 3},
     { 7050, 5, 2, 3},
     { 7000, 5, 2, 3}};
+// clang-format on
+
+/// Map giving the minimum device driver needed in order to run a given version
+/// of CUDA for both Linux/Mac and Windows from:
+/// https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
+// clang-format off
+static const ToolkitDriverVersions
+    CudaToDriverVersion[] = {
+        {11000, 450.51f, 451.48f},
+        {10020, 440.33f, 441.22f},
+        {10010, 418.39f, 418.96f},
+        {10000, 410.48f, 411.31f},
+        {9020,  396.37f, 398.26f},
+        {9010,  390.46f, 391.29f},
+        {9000,  384.81f, 385.54f},
+        {8000,  375.26f, 376.51f},
+        {7050,  352.31f, 353.66f},
+        {7000,  346.46f, 347.62f}};
 // clang-format on
 
 bool isEmbedded(pair<int, int> compute) {
@@ -202,7 +237,7 @@ static inline int compute2cores(unsigned major, unsigned minor) {
         {0x10, 8},   {0x11, 8},   {0x12, 8},   {0x13, 8},   {0x20, 32},
         {0x21, 48},  {0x30, 192}, {0x32, 192}, {0x35, 192}, {0x37, 192},
         {0x50, 128}, {0x52, 128}, {0x53, 128}, {0x60, 64},  {0x61, 128},
-        {0x62, 128}, {0x70, 64},  {0x75, 64},  {-1, -1},
+        {0x62, 128}, {0x70, 64},  {0x75, 64},  {0x80, 64},  {-1, -1},
     };
 
     for (int i = 0; gpus[i].compute != -1; ++i) {
@@ -359,40 +394,6 @@ void DeviceManager::resetMemoryManagerPinned() {
                                          AF_MEM_DEBUG || AF_CUDA_MEM_DEBUG));
     setMemoryManagerPinned(std::move(mgr));
 }
-
-/// Struct represents the cuda toolkit version and its associated minimum
-/// required driver versions.
-struct ToolkitDriverVersions {
-    /// The CUDA Toolkit version returned by cudaDriverGetVersion or
-    /// cudaRuntimeGetVersion
-    int version;
-
-    /// The minimum GPU driver version required for the \p version toolkit on
-    /// Linux or macOS
-    float unix_min_version;
-
-    /// The minimum GPU driver version required for the \p version toolkit on
-    /// Windows
-    float windows_min_version;
-};
-
-/// Map giving the minimum device driver needed in order to run a given version
-/// of CUDA for both Linux/Mac and Windows from:
-/// https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
-// clang-format off
-static const ToolkitDriverVersions
-    CudaToDriverVersion[] = {
-        {11000, 450.51f, 451.48f},
-        {10020, 440.33f, 441.22f},
-        {10010, 418.39f, 418.96f},
-        {10000, 410.48f, 411.31f},
-        {9020,  396.37f, 398.26f},
-        {9010,  390.46f, 391.29f},
-        {9000,  384.81f, 385.54f},
-        {8000,  375.26f, 376.51f},
-        {7050,  352.31f, 353.66f},
-        {7000,  346.46f, 347.62f}};
-// clang-format on
 
 /// A debug only function that checks to see if the driver or runtime
 /// function is part of the CudaToDriverVersion array. If the runtime

--- a/test/jit.cpp
+++ b/test/jit.cpp
@@ -793,3 +793,38 @@ TEST(JIT, DISABLED_ManyConstants) {
     eval(res2, res4, res6);//, res8);
     af::sync();
 }
+
+TEST(JIT, getKernelCacheDirectory) {
+  size_t length = 0;
+  ASSERT_SUCCESS(af_get_kernel_cache_directory(&length, NULL));
+
+  std::string path;
+  path.resize(length);
+  ASSERT_SUCCESS(af_get_kernel_cache_directory(&length, &path.at(0)));
+}
+
+TEST(JIT, setKernelCacheDirectory) {
+  std::string path = ".";
+
+  // Get the old path so we can reset it after the test
+  size_t length = 0;
+  ASSERT_SUCCESS(af_get_kernel_cache_directory(&length, NULL));
+  std::string old_path;
+  old_path.resize(length);
+  ASSERT_SUCCESS(af_get_kernel_cache_directory(&length, &old_path.at(0)));
+
+  // Set cache directory to the new path
+  ASSERT_SUCCESS(af_set_kernel_cache_directory(path.c_str(), false));
+
+  // Get the new path for verification
+  size_t new_length = path.size();
+  std::string new_path;
+  new_path.resize(new_length);
+  ASSERT_SUCCESS(af_get_kernel_cache_directory(&new_length, &new_path.at(0)));
+
+  ASSERT_EQ(path, new_path);
+  ASSERT_EQ(path.size(), new_path.size());
+
+  // Reset to the old path
+  ASSERT_SUCCESS(af_set_kernel_cache_directory(old_path.c_str(), false));
+}


### PR DESCRIPTION
Add functions to set and get the cache directory for the kernels compiled at runtime.

Description
-----------
* Adds an enviornment variable AF_JIT_KERNEL_CACHE_DIRECTORY which
  can change the path where ArrayFire will store the runtime generated
  kernels. If the path is not writeable ArrayFire will fallback to defaults
* Add functions af_get_kernel_cache_directory and af_set_kernel_cache_directory
  which can also set the directory in the code.
* The set function is capablie of overriding the environment variable values
  based on the override_env variable
* Add CUDA 11 to Toolkit2MaxCompute. Add Ampere sm to compute2cores
* Fix variance warning in naive_bayes example 

Changes to Users
----------------
* Add the ability to set and get the directory where ArrayFire will store the kernels generated at runtime
* Add an environment variable that can set where ArrayFire will store the kernels generated at runtime

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
