### PR TITLE
minor error in doc

### DIFF
--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -210,7 +210,7 @@ typedef enum {
 typedef enum {
     f32,    ///< 32-bit floating point values
     c32,    ///< 32-bit complex floating point values
-    f64,    ///< 64-bit complex floating point values
+    f64,    ///< 64-bit floating point values
     c64,    ///< 64-bit complex floating point values
     b8 ,    ///< 8-bit boolean values
     s32,    ///< 32-bit signed integral values


### PR DESCRIPTION
f64 is 64-bit floating point values, not _complex_ floating point values.

Description
-----------
The documentation contained a table in which f64 was described as "64-bit complex floating point values" which was erroneous. This PR does not contain any new feature nor bug fix but corrects that point in the doc.
<!--
Additional information about the PR answering following questions:

Changes to Users
----------------
Allegedly none.

Checklist
---------
- [ ] Rebased on latest master
- [ ] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
