### PR TITLE
Fix comment in CUDA interop code example

### DIFF
--- a/docs/pages/interop_cuda.md
+++ b/docs/pages/interop_cuda.md
@@ -84,7 +84,7 @@ int main() {
     cudaStream_t af_cuda_stream = afcu::getStream(cuda_id);
 
     // 6. Set arguments and run your kernel in ArrayFire's stream
-    //    Here launch with 10 blocks of 10 threads
+    //    Here launch with 1 block of 10 threads
     increment<<<1, num, 0, af_cuda_stream>>>(d_x);
 
     // 7. Return control of af::array memory to ArrayFire using


### PR DESCRIPTION
The code example had a comment that incorrectly stated that 10 blocks
were being launched instead of the actual one. This PR fixes that comment

Description
-----------
The code example had a comment that incorrectly stated that 10 blocks
were being launched instead of the actual one. This PR fixes that comment

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
