### PR TITLE
Fix features copy constructor for multithreaded usage

### DIFF
--- a/include/af/features.h
+++ b/include/af/features.h
@@ -40,6 +40,19 @@ namespace af
         /// Copy assignment operator
         features& operator= (const features& other);
 
+#if AF_API_VERSION >= 38
+        /// Copy constructor
+        features(const features &other);
+
+#if AF_COMPILER_CXX_RVALUE_REFERENCES
+        /// Move constructor
+        features(features &&other);
+
+        /// Move assignment operator
+        features &operator=(features &&other);
+#endif
+#endif
+
         /// Returns  the number of features represented by this object
         size_t getNumFeatures() const;
 

--- a/src/api/cpp/features.cpp
+++ b/src/api/cpp/features.cpp
@@ -11,6 +11,8 @@
 #include <af/features.h>
 #include "error.hpp"
 
+#include <utility>
+
 namespace af {
 
 features::features() : feat{} { AF_THROW(af_create_features(&feat, 0)); }
@@ -21,11 +23,23 @@ features::features(const size_t n) : feat{} {
 
 features::features(af_features f) : feat(f) {}
 
+features::features(const features& other) {
+    if (this != &other) { AF_THROW(af_retain_features(&feat, other.get())); }
+}
+
 features& features::operator=(const features& other) {
     if (this != &other) {
         AF_THROW(af_release_features(feat));
         AF_THROW(af_retain_features(&feat, other.get()));
     }
+    return *this;
+}
+
+features::features(features&& other)
+    : feat(std::exchange(other.feat, nullptr)) {}
+
+features& features::operator=(features&& other) {
+    std::swap(feat, other.feat);
     return *this;
 }
 


### PR DESCRIPTION
Features class now uses rule of five guideline.

Description
-----------
Fixes: #2979

Changes to Users
----------------
Users will now be able to pass objects of Features class by value to other threads.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
