### PR TITLE
Fix lapack support check in CPU/OpenCL backend CMakeLists

### DIFF
--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -336,7 +336,7 @@ else()
   endif()
 endif()
 
-if(LAPACK_FOUND OR MKL_Shared_FOUND)
+if(LAPACK_FOUND OR (USE_CPU_MKL AND MKL_Shared_FOUND))
   target_compile_definitions(afcpu
     PRIVATE
       WITH_LINEAR_ALGEBRA)

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -449,7 +449,7 @@ if(APPLE)
   target_link_libraries(afopencl PRIVATE OpenGL::GL)
 endif()
 
-if(LAPACK_FOUND OR MKL_Shared_FOUND)
+if(LAPACK_FOUND OR (USE_OPENCL_MKL AND MKL_Shared_FOUND))
   target_sources(afopencl
     PRIVATE
       magma/gebrd.cpp


### PR DESCRIPTION
Description
-----------
Prior to this change, if the build environment doesn't have non-MKL LAPACK libraries installed while Intel MKL is installed, then even when the user didn't turn ON using MKL due to the current check, LAPACK was enabled which resulted in build failure with missing headers/libraries.

Changes to Users
----------------
None to Application developers unless they are building ArrayFire themselves. In which case, they would now be able to build ArrayFire without linear algebra routines support in the above specified scenario.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
