### PR TITLE
Update GitHub workflows away from set-env

### DIFF
--- a/.github/workflows/cpu_build.yml
+++ b/.github/workflows/cpu_build.yml
@@ -59,13 +59,13 @@ jobs:
                   cmake_lnx_dir=$(echo "${cmake_install_dir}/bin")
                   cmake_osx_dir=$(echo "${cmake_install_dir}/CMake.app/Contents/bin")
                   cmake_dir=$(if [ $OS_NAME == 'macos-latest' ]; then echo "${cmake_osx_dir}"; else echo "${cmake_lnx_dir}"; fi)
-                  echo "::set-env name=CMAKE_PROGRAM::$(pwd)/${cmake_dir}/cmake"
+                  echo "CMAKE_PROGRAM=$(pwd)/${cmake_dir}/cmake" >> $GITHUB_ENV
 
             - name: Install Dependencies for Macos
               if: matrix.os == 'macos-latest'
               run: |
                   brew install boost fontconfig glfw freeimage fftw lapack openblas
-                  echo "::set-env name=CMAKE_PROGRAM::cmake"
+                  echo "CMAKE_PROGRAM=cmake" >> $GITHUB_ENV
 
             - name: Install Common Dependencies for Ubuntu
               if: matrix.os == 'ubuntu-16.04' || matrix.os == 'ubuntu-18.04'
@@ -114,7 +114,7 @@ jobs:
                       -DUSE_CPU_MKL:BOOL=$USE_MKL \
                       -DBUILDNAME:STRING=${buildname} \
                       ..
-                  echo "::set-env name=CTEST_DASHBOARD::${dashboard}"
+                  echo "CTEST_DASHBOARD=${dashboard}" >> $GITHUB_ENV
 
             - name: Build and Test
               run: |
@@ -176,7 +176,7 @@ jobs:
                       -DAF_BUILD_CUDA:BOOL=OFF -DAF_BUILD_OPENCL:BOOL=OFF `
                       -DAF_BUILD_UNIFIED:BOOL=OFF -DAF_BUILD_FORGE:BOOL=ON `
                       -DBUILDNAME:STRING="$buildname"
-                  echo "::set-env name=CTEST_DASHBOARD::${dashboard}"
+                  echo "CTEST_DASHBOARD=${dashboard}" >> $GITHUB_ENV
 
             - name: Build and Test
               run: |

--- a/.github/workflows/release_src_artifact.yml
+++ b/.github/workflows/release_src_artifact.yml
@@ -19,9 +19,9 @@ jobs:
                   id_line=$(echo "${response}" | grep -m 1 "id.:")
                   rel_id=$(echo "${id_line}" | awk '{split($0, a, ":"); split(a[2], b, ","); print b[1]}')
                   trimmed_rel_id=$(echo "${rel_id}" | awk '{gsub(/^[ \t]+/,""); print $0 }')
-                  echo "::set-env name=RELEASE_ID::${trimmed_rel_id}"
-                  echo "::set-env name=AF_TAG::${tag}"
-                  echo "::set-env name=AF_VER::${ver}"
+                  echo "RELEASE_ID=${trimmed_rel_id}" >> $GITHUB_ENV
+                  echo "AF_TAG=${tag}" >> $GITHUB_ENV
+                  echo "AF_VER=${ver}" >> $GITHUB_ENV
 
             - name: Checkout with Submodules
               run: |
@@ -37,7 +37,7 @@ jobs:
                   rm -rf arrayfire-full-${AF_VER}/.github
                   rm arrayfire-full-${AF_VER}/.gitmodules
                   tar -cjf arrayfire-full-${AF_VER}.tar.bz2 arrayfire-full-${AF_VER}/
-                  echo "::set-env name=UPLOAD_FILE::arrayfire-full-${AF_VER}.tar.bz2"
+                  echo "UPLOAD_FILE=arrayfire-full-${AF_VER}.tar.bz2" >> $GITHUB_ENV
 
             - name: Upload source tarball
               uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Update set-env syntax to use GitHub environment variable files

Description
-----------
The GitHub workflows were throwing warnings about the set-env syntax for setting environment variables. This PR updates it to use the new environment file syntax.

Changes to Users
----------------
N/A

Checklist
---------

- [x] Rebased on latest master
- ~[ ] Code compiles~
- ~[ ] Tests pass~
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
