### PR TITLE
JIT optimization for sequential casts that are idempotent

### DIFF
--- a/include/af/arith.h
+++ b/include/af/arith.h
@@ -822,6 +822,35 @@ extern "C" {
     /**
        C Interface for casting an array from one type to another
 
+       This function casts an af_array object from one type to another. If the
+       type of the original array is the same as \p type then the same array is
+       returned.
+
+       \note Consecitive casting operations may be may be optimized out if the
+       original type of the af_array is the same as the final type. For example
+       if the original type is f64 which is then cast to f32 and then back to
+       f64, then the cast to f32 will be skipped and that operation will *NOT*
+       be performed by ArrayFire. The following table shows which casts will
+       be optimized out. outer -> inner -> outer
+       | inner-> | f32 | f64 | c32 | c64 | s32 | u32 | u8 | b8 | s64 | u64 | s16 | u16 | f16 |
+       |---------|-----|-----|-----|-----|-----|-----|----|----|-----|-----|-----|-----|-----|
+       | f32     | x   | x   | x   | x   |     |     |    |    |     |     |     |     | x   |
+       | f64     | x   | x   | x   | x   |     |     |    |    |     |     |     |     | x   |
+       | c32     | x   | x   | x   | x   |     |     |    |    |     |     |     |     | x   |
+       | c64     | x   | x   | x   | x   |     |     |    |    |     |     |     |     | x   |
+       | s32     | x   | x   | x   | x   | x   | x   |    |    | x   | x   |     |     | x   |
+       | u32     | x   | x   | x   | x   | x   | x   |    |    | x   | x   |     |     | x   |
+       | u8      | x   | x   | x   | x   | x   | x   | x  | x  | x   | x   | x   | x   | x   |
+       | b8      | x   | x   | x   | x   | x   | x   | x  | x  | x   | x   | x   | x   | x   |
+       | s64     | x   | x   | x   | x   |     |     |    |    | x   | x   |     |     | x   |
+       | u64     | x   | x   | x   | x   |     |     |    |    | x   | x   |     |     | x   |
+       | s16     | x   | x   | x   | x   | x   | x   |    |    | x   | x   | x   | x   | x   |
+       | u16     | x   | x   | x   | x   | x   | x   |    |    | x   | x   | x   | x   | x   |
+       | f16     | x   | x   | x   | x   |     |     |    |    |     |     |     |     | x   |
+       If you want to avoid this behavior use af_eval after the first cast
+       operation. This will ensure that the cast operation is performed on the
+       af_array
+
        \param[out] out will contain the values in the specified type
        \param[in] in is the input
        \param[in] type is the target data type \ref af_dtype

--- a/include/af/array.h
+++ b/include/af/array.h
@@ -933,9 +933,34 @@ namespace af
         const array::array_proxy slices(int first, int last) const; ///< \copydoc slices
         /// @}
 
-        /// \brief Converts the array into another type
+        /// \brief Casts the array into another data type
         ///
-        ///  \param[in] type is the desired type(f32, s64, etc.)
+        /// \note Consecitive casting operations may be may be optimized out if
+        /// the original type of the af::array is the same as the final type.
+        /// For example if the original type is f64 which is then cast to f32
+        /// and then back to f64, then the cast to f32 will be skipped and that
+        /// operation will *NOT* be performed by ArrayFire. The following table
+        /// shows which casts will be optimized out. outer -> inner -> outer
+        /// | inner-> | f32 | f64 | c32 | c64 | s32 | u32 | u8 | b8 | s64 | u64 | s16 | u16 | f16 |
+        /// |---------|-----|-----|-----|-----|-----|-----|----|----|-----|-----|-----|-----|-----|
+        /// | f32     | x   | x   | x   | x   |     |     |    |    |     |     |     |     | x   |
+        /// | f64     | x   | x   | x   | x   |     |     |    |    |     |     |     |     | x   |
+        /// | c32     | x   | x   | x   | x   |     |     |    |    |     |     |     |     | x   |
+        /// | c64     | x   | x   | x   | x   |     |     |    |    |     |     |     |     | x   |
+        /// | s32     | x   | x   | x   | x   | x   | x   |    |    | x   | x   |     |     | x   |
+        /// | u32     | x   | x   | x   | x   | x   | x   |    |    | x   | x   |     |     | x   |
+        /// | u8      | x   | x   | x   | x   | x   | x   | x  | x  | x   | x   | x   | x   | x   |
+        /// | b8      | x   | x   | x   | x   | x   | x   | x  | x  | x   | x   | x   | x   | x   |
+        /// | s64     | x   | x   | x   | x   |     |     |    |    | x   | x   |     |     | x   |
+        /// | u64     | x   | x   | x   | x   |     |     |    |    | x   | x   |     |     | x   |
+        /// | s16     | x   | x   | x   | x   | x   | x   |    |    | x   | x   | x   | x   | x   |
+        /// | u16     | x   | x   | x   | x   | x   | x   |    |    | x   | x   | x   | x   | x   |
+        /// | f16     | x   | x   | x   | x   |     |     |    |    |     |     |     |     | x   |
+        /// If you want to avoid this behavior use af_eval after the first cast
+        /// operation. This will ensure that the cast operation is performed on
+        /// the af::array
+        ///
+        /// \param[in] type is the desired type(f32, s64, etc.)
         /// \returns an array with the type specified by \p type
         const array as(dtype type) const;
 

--- a/src/backend/common/ArrayInfo.cpp
+++ b/src/backend/common/ArrayInfo.cpp
@@ -9,6 +9,7 @@
 
 #include <common/ArrayInfo.hpp>
 #include <common/err_common.hpp>
+#include <common/traits.hpp>
 #include <algorithm>
 #include <functional>
 #include <numeric>
@@ -93,28 +94,23 @@ bool ArrayInfo::isVector() const {
     return singular_dims == AF_MAX_DIMS - 1 && non_singular_dims == 1;
 }
 
-bool ArrayInfo::isComplex() const { return ((type == c32) || (type == c64)); }
+bool ArrayInfo::isComplex() const { return common::isComplex(type); }
 
-bool ArrayInfo::isReal() const { return !isComplex(); }
+bool ArrayInfo::isReal() const { return common::isReal(type); }
 
-bool ArrayInfo::isDouble() const { return (type == f64 || type == c64); }
+bool ArrayInfo::isDouble() const { return common::isDouble(type); }
 
-bool ArrayInfo::isSingle() const { return (type == f32 || type == c32); }
+bool ArrayInfo::isSingle() const { return common::isSingle(type); }
 
-bool ArrayInfo::isHalf() const { return (type == f16); }
+bool ArrayInfo::isHalf() const { return common::isHalf(type); }
 
-bool ArrayInfo::isRealFloating() const {
-    return (type == f64 || type == f32 || type == f16);
-}
+bool ArrayInfo::isRealFloating() const { return common::isRealFloating(type); }
 
-bool ArrayInfo::isFloating() const { return (!isInteger() && !isBool()); }
+bool ArrayInfo::isFloating() const { return common::isFloating(type); }
 
-bool ArrayInfo::isInteger() const {
-    return (type == s32 || type == u32 || type == s64 || type == u64 ||
-            type == s16 || type == u16 || type == u8);
-}
+bool ArrayInfo::isInteger() const { return common::isInteger(type); }
 
-bool ArrayInfo::isBool() const { return (type == b8); }
+bool ArrayInfo::isBool() const { return common::isBool(type); }
 
 bool ArrayInfo::isLinear() const {
     if (ndims() == 1) { return dim_strides[0] == 1; }

--- a/src/backend/common/cast.hpp
+++ b/src/backend/common/cast.hpp
@@ -41,32 +41,15 @@ struct CastWrapper {
         // JIT optimization in the cast of multiple sequential casts that become
         // idempotent - check to see if the previous operation was also a cast
         // TODO: handle arbitrarily long chains of casts
-        auto in_node_nary =
-            std::dynamic_pointer_cast<common::NaryNode>(in_node);
-        if (in_node_nary && in_node_nary->getOp() == af_cast_t) {
-            // The only way to get the input type of the child node if it's a
-            // cast is to get the output type of the child's child.
-            auto in_node_children = in_node_nary->getChildren();
-            // Check if any children are casts with the same type - if so,
-            // insert a shortcut noop
-            for (size_t i = 0;
-                 i < in_node_children.size() && in_node_nary->getChildren()[i];
-                 ++i) {
-                // Found a node whose child can be fast-track noop-ed
-                common::Node_ptr in_in_node = in_node_nary->getChildren()[i];
-                if (in_in_node->getType() == to_dtype) {
-                    // If the output of the child's child is the same as the
-                    // output of this node, ignore the input node and simply
-                    // connect a noop node from the child's child to produce
-                    // this op's output
-
-                    // TODO: including unary.hpp to use
-                    // detail::unaryName<af_noop_t> breaks some other stuff
-                    return detail::createNodeArray<To>(
-                        in.dims(),
-                        common::Node_ptr(new common::UnaryNode(
-                            to_dtype, "__noop", in_in_node, af_noop_t)));
-                }
+        auto in_node_unary =
+            std::dynamic_pointer_cast<common::UnaryNode>(in_node);
+        if (in_node_unary && in_node_unary->getOp() == af_cast_t) {
+            // child child's output type is the input type of the child
+            auto in_in_node = in_node_unary->getChildren()[0];
+            if (in_in_node->getType() == to_dtype) {
+                // ignore the input node and simply connect a noop node from the
+                // child's child to produce this op's output
+                return detail::createNodeArray<To>(in.dims(), in_in_node);
             }
         }
 

--- a/src/backend/common/cast.hpp
+++ b/src/backend/common/cast.hpp
@@ -30,17 +30,52 @@ struct CastWrapper {
     }
 };
 #else
+
 template<typename To, typename Ti>
 struct CastWrapper {
     detail::Array<To> operator()(const detail::Array<Ti> &in) {
         detail::CastOp<To, Ti> cop;
         common::Node_ptr in_node = in.getNode();
-        common::UnaryNode *node  = new common::UnaryNode(
-            static_cast<af::dtype>(dtype_traits<To>::af_type), cop.name(),
-            in_node, af_cast_t);
+        af::dtype to_dtype = static_cast<af::dtype>(dtype_traits<To>::af_type);
+
+        // JIT optimization in the cast of multiple sequential casts that become
+        // idempotent - check to see if the previous operation was also a cast
+        // TODO: handle arbitrarily long chains of casts
+        auto in_node_nary =
+            std::dynamic_pointer_cast<common::NaryNode>(in_node);
+        if (in_node_nary && in_node_nary->getOp() == af_cast_t) {
+            // The only way to get the input type of the child node if it's a
+            // cast is to get the output type of the child's child.
+            auto in_node_children = in_node_nary->getChildren();
+            // Check if any children are casts with the same type - if so,
+            // insert a shortcut noop
+            for (size_t i = 0;
+                 i < in_node_children.size() && in_node_nary->getChildren()[i];
+                 ++i) {
+                // Found a node whose child can be fast-track noop-ed
+                common::Node_ptr in_in_node = in_node_nary->getChildren()[i];
+                if (in_in_node->getType() == to_dtype) {
+                    // If the output of the child's child is the same as the
+                    // output of this node, ignore the input node and simply
+                    // connect a noop node from the child's child to produce
+                    // this op's output
+
+                    // TODO: including unary.hpp to use
+                    // detail::unaryName<af_noop_t> breaks some other stuff
+                    return detail::createNodeArray<To>(
+                        in.dims(),
+                        common::Node_ptr(new common::UnaryNode(
+                            to_dtype, "__noop", in_in_node, af_noop_t)));
+                }
+            }
+        }
+
+        common::UnaryNode *node =
+            new common::UnaryNode(to_dtype, cop.name(), in_node, af_cast_t);
         return detail::createNodeArray<To>(in.dims(), common::Node_ptr(node));
     }
 };
+
 #endif
 
 template<typename T>

--- a/src/backend/common/cast.hpp
+++ b/src/backend/common/cast.hpp
@@ -11,20 +11,97 @@
 #include <Array.hpp>
 #include <cast.hpp>
 #include <common/Logger.hpp>
+#include <memory>
 
 #ifdef AF_CPU
 #include <jit/UnaryNode.hpp>
 #endif
 
 namespace common {
+/// This function determines if consecutive cast operations should be
+/// removed from a JIT AST.
+///
+/// This function returns true if consecutive cast operations in the JIT AST
+/// should be removed. Multiple cast operations are removed when going from
+/// a smaller type to a larger type and back again OR if the conversion is
+/// between two floating point types including complex types.
+///
+///                  Cast operations that will be removed
+///                        outer -> inner -> outer
+///
+///                                inner cast
+///           f32  f64  c32  c64  s32  u32   u8   b8  s64  u64  s16  u16  f16
+///     f32    x    x    x    x                                            x
+///     f64    x    x    x    x                                            x
+///  o  c32    x    x    x    x                                            x
+///  u  c64    x    x    x    x                                            x
+///  t  s32    x    x    x    x    x    x              x    x              x
+///  e  u32    x    x    x    x    x    x              x    x              x
+///  r   u8    x    x    x    x    x    x    x    x    x    x    x    x    x
+///      b8    x    x    x    x    x    x    x    x    x    x    x    x    x
+///  c  s64    x    x    x    x                        x    x              x
+///  a  u64    x    x    x    x                        x    x              x
+///  s  s16    x    x    x    x    x    x              x    x    x    x    x
+///  t  u16    x    x    x    x    x    x              x    x    x    x    x
+///     f16    x    x    x    x                                            x
+///
+/// \param[in] outer The type of the second cast and the child of the
+///            previous cast
+/// \param[in] inner  The type of the first cast
+///
+/// \returns True if the inner cast operation should be removed
+constexpr bool canOptimizeCast(af::dtype outer, af::dtype inner) {
+    if (isFloating(outer)) {
+        if (isFloating(inner)) { return true; }
+    } else {
+        if (isFloating(inner)) { return true; }
+        if (dtypeSize(inner) >= dtypeSize(outer)) { return true; }
+    }
+
+    return false;
+}
 
 #ifdef AF_CPU
 template<typename To, typename Ti>
 struct CastWrapper {
+    static spdlog::logger *getLogger() noexcept {
+        static std::shared_ptr<spdlog::logger> logger =
+            common::loggerFactory("ast");
+        return logger.get();
+    }
+
     detail::Array<To> operator()(const detail::Array<Ti> &in) {
         using cpu::jit::UnaryNode;
 
-        Node_ptr in_node = in.getNode();
+        common::Node_ptr in_node = in.getNode();
+        constexpr af::dtype to_dtype =
+            static_cast<af::dtype>(af::dtype_traits<To>::af_type);
+        constexpr af::dtype in_dtype =
+            static_cast<af::dtype>(af::dtype_traits<Ti>::af_type);
+
+        if (canOptimizeCast(to_dtype, in_dtype)) {
+            // JIT optimization in the cast of multiple sequential casts that
+            // become idempotent - check to see if the previous operation was
+            // also a cast
+            // TODO: handle arbitrarily long chains of casts
+            auto in_node_unary =
+                std::dynamic_pointer_cast<UnaryNode<To, Ti, af_cast_t>>(
+                    in_node);
+
+            if (in_node_unary && in_node_unary->getOp() == af_cast_t) {
+                // child child's output type is the input type of the child
+                AF_TRACE("Cast optimiztion performed by removing cast to {}",
+                         af::dtype_traits<Ti>::getName());
+                auto in_child_node = in_node_unary->getChildren()[0];
+                if (in_child_node->getType() == to_dtype) {
+                    // ignore the input node and simply connect a noop node from
+                    // the child's child to produce this op's output
+                    return detail::createNodeArray<To>(in.dims(),
+                                                       in_child_node);
+                }
+            }
+        }
+
         auto node = std::make_shared<UnaryNode<To, Ti, af_cast_t>>(in_node);
 
         return detail::createNodeArray<To>(in.dims(), move(node));
@@ -39,25 +116,35 @@ struct CastWrapper {
             common::loggerFactory("ast");
         return logger.get();
     }
+
     detail::Array<To> operator()(const detail::Array<Ti> &in) {
+        using common::UnaryNode;
         detail::CastOp<To, Ti> cop;
         common::Node_ptr in_node = in.getNode();
-        af::dtype to_dtype = static_cast<af::dtype>(dtype_traits<To>::af_type);
+        constexpr af::dtype to_dtype =
+            static_cast<af::dtype>(dtype_traits<To>::af_type);
+        constexpr af::dtype in_dtype =
+            static_cast<af::dtype>(af::dtype_traits<Ti>::af_type);
 
-        // JIT optimization in the cast of multiple sequential casts that become
-        // idempotent - check to see if the previous operation was also a cast
-        // TODO: handle arbitrarily long chains of casts
-        auto in_node_unary =
-            std::dynamic_pointer_cast<common::UnaryNode>(in_node);
-        if (in_node_unary && in_node_unary->getOp() == af_cast_t) {
-            // child child's output type is the input type of the child
-            AF_TRACE("Cast optimiztion performed by removing cast to {}",
-                     dtype_traits<Ti>::getName());
-            auto in_in_node = in_node_unary->getChildren()[0];
-            if (in_in_node->getType() == to_dtype) {
-                // ignore the input node and simply connect a noop node from the
-                // child's child to produce this op's output
-                return detail::createNodeArray<To>(in.dims(), in_in_node);
+        if (canOptimizeCast(to_dtype, in_dtype)) {
+            // JIT optimization in the cast of multiple sequential casts that
+            // become idempotent - check to see if the previous operation was
+            // also a cast
+            // TODO: handle arbitrarily long chains of casts
+            auto in_node_unary =
+                std::dynamic_pointer_cast<common::UnaryNode>(in_node);
+
+            if (in_node_unary && in_node_unary->getOp() == af_cast_t) {
+                // child child's output type is the input type of the child
+                AF_TRACE("Cast optimiztion performed by removing cast to {}",
+                         dtype_traits<Ti>::getName());
+                auto in_child_node = in_node_unary->getChildren()[0];
+                if (in_child_node->getType() == to_dtype) {
+                    // ignore the input node and simply connect a noop node from
+                    // the child's child to produce this op's output
+                    return detail::createNodeArray<To>(in.dims(),
+                                                       in_child_node);
+                }
             }
         }
 

--- a/src/backend/common/jit/BufferNodeBase.hpp
+++ b/src/backend/common/jit/BufferNodeBase.hpp
@@ -34,6 +34,8 @@ class BufferNodeBase : public common::Node {
         return std::make_unique<BufferNodeBase>(*this);
     }
 
+    DataType getDataPointer() const { return m_data; }
+
     void setData(ParamType param, DataType data, const unsigned bytes,
                  bool is_linear) {
         m_param         = param;

--- a/src/backend/common/jit/NaryNode.hpp
+++ b/src/backend/common/jit/NaryNode.hpp
@@ -26,8 +26,10 @@ namespace common {
 class NaryNode : public Node {
    private:
     int m_num_children;
-    af_op_t m_op;
     const char *m_op_str;
+
+   protected:
+    af_op_t m_op;
 
    public:
     NaryNode(const af::dtype type, const char *op_str, const int num_children,
@@ -39,8 +41,8 @@ class NaryNode : public Node {
                   const std::array<common::Node_ptr, Node::kMaxChildren>>(
                   children))
         , m_num_children(num_children)
-        , m_op(op)
-        , m_op_str(op_str) {
+        , m_op_str(op_str)
+        , m_op(op) {
         static_assert(std::is_nothrow_move_assignable<NaryNode>::value,
                       "NaryNode is not move assignable");
         static_assert(std::is_nothrow_move_constructible<NaryNode>::value,
@@ -61,8 +63,8 @@ class NaryNode : public Node {
         using std::swap;
         Node::swap(other);
         swap(m_num_children, other.m_num_children);
-        swap(m_op, other.m_op);
         swap(m_op_str, other.m_op_str);
+        swap(m_op, other.m_op);
     }
 
     af_op_t getOp() const noexcept final { return m_op; }

--- a/src/backend/common/jit/Node.hpp
+++ b/src/backend/common/jit/Node.hpp
@@ -181,6 +181,10 @@ class Node {
         UNUSED(lim);
     }
 
+    const std::array<Node_ptr, kMaxChildren> &getChildren() const {
+        return m_children;
+    }
+
     /// Generates the variable that stores the thread's/work-item's offset into
     /// the memory.
     ///
@@ -247,6 +251,7 @@ class Node {
     /// Returns true if the buffer is linear
     virtual bool isLinear(const dim_t dims[4]) const;
 
+    /// Returns the type
     af::dtype getType() const { return m_type; }
 
     /// Returns the string representation of the type

--- a/src/backend/common/traits.hpp
+++ b/src/backend/common/traits.hpp
@@ -8,6 +8,7 @@
  ********************************************************/
 #pragma once
 
+#include <common/err_common.hpp>
 #include <af/defines.h>
 
 namespace af {
@@ -17,13 +18,63 @@ struct dtype_traits;
 
 namespace common {
 class half;
+
+namespace {
+
+inline size_t dtypeSize(af::dtype type) {
+    switch (type) {
+        case u8:
+        case b8: return 1;
+        case s16:
+        case u16:
+        case f16: return 2;
+        case s32:
+        case u32:
+        case f32: return 4;
+        case u64:
+        case s64:
+        case c32:
+        case f64: return 8;
+        case c64: return 16;
+        default: AF_RETURN_ERROR("Unsupported type", AF_ERR_INTERNAL);
+    }
 }
+
+constexpr bool isComplex(af::dtype type) {
+    return ((type == c32) || (type == c64));
+}
+
+constexpr bool isReal(af::dtype type) { return !isComplex(type); }
+
+constexpr bool isDouble(af::dtype type) { return (type == f64 || type == c64); }
+
+constexpr bool isSingle(af::dtype type) { return (type == f32 || type == c32); }
+
+constexpr bool isHalf(af::dtype type) { return (type == f16); }
+
+constexpr bool isRealFloating(af::dtype type) {
+    return (type == f64 || type == f32 || type == f16);
+}
+
+constexpr bool isInteger(af::dtype type) {
+    return (type == s32 || type == u32 || type == s64 || type == u64 ||
+            type == s16 || type == u16 || type == u8);
+}
+
+constexpr bool isBool(af::dtype type) { return (type == b8); }
+
+constexpr bool isFloating(af::dtype type) {
+    return (!isInteger(type) && !isBool(type));
+}
+
+}  // namespace
+}  // namespace common
 
 namespace af {
 template<>
 struct dtype_traits<common::half> {
     enum { af_type = f16, ctype = f16 };
     typedef common::half base_type;
-    static const char* getName() { return "half"; }
+    static const char *getName() { return "half"; }
 };
 }  // namespace af

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -131,7 +131,7 @@ Array<T>::Array(const af::dim4 &dims, common::Node_ptr n)
     , node(move(n))
     , owner(true) {
     if (node->isBuffer()) {
-        data  = std::static_pointer_cast<BufferNode<T>>(node)->getDataPointer();
+        data = std::static_pointer_cast<BufferNode<T>>(node)->getDataPointer();
     }
 }
 

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -21,7 +21,7 @@
 #include <cstddef>
 #include <memory>
 #include <numeric>
-#include <utility>
+#include <vector>
 
 using af::dim4;
 using common::half;
@@ -129,7 +129,11 @@ Array<T>::Array(const af::dim4 &dims, common::Node_ptr n)
     , data()
     , data_dims(dims)
     , node(move(n))
-    , owner(true) {}
+    , owner(true) {
+    if (node->isBuffer()) {
+        data  = std::static_pointer_cast<BufferNode<T>>(node)->getDataPointer();
+    }
+}
 
 template<typename T>
 Array<T>::Array(const af::dim4 &dims, const af::dim4 &strides, dim_t offset_,

--- a/src/backend/cuda/cast.hpp
+++ b/src/backend/cuda/cast.hpp
@@ -16,7 +16,6 @@
 #include <optypes.hpp>
 #include <types.hpp>
 #include <af/dim4.hpp>
-#include <complex>
 
 namespace cuda {
 

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -102,7 +102,7 @@ Array<T>::Array(const dim4 &dims, Node_ptr n)
     , node(std::move(n))
     , owner(true) {
     if (node->isBuffer()) {
-        data  = std::static_pointer_cast<BufferNode>(node)->getDataPointer();
+        data = std::static_pointer_cast<BufferNode>(node)->getDataPointer();
     }
 }
 

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -100,7 +100,11 @@ Array<T>::Array(const dim4 &dims, Node_ptr n)
            static_cast<af_dtype>(dtype_traits<T>::af_type))
     , data_dims(dims)
     , node(std::move(n))
-    , owner(true) {}
+    , owner(true) {
+    if (node->isBuffer()) {
+        data  = std::static_pointer_cast<BufferNode>(node)->getDataPointer();
+    }
+}
 
 template<typename T>
 Array<T>::Array(const dim4 &dims, const T *const in_data)

--- a/test/cast.cpp
+++ b/test/cast.cpp
@@ -99,3 +99,27 @@ COMPLEX_REAL_TESTS(cfloat, float)
 COMPLEX_REAL_TESTS(cfloat, double)
 COMPLEX_REAL_TESTS(cdouble, float)
 COMPLEX_REAL_TESTS(cdouble, double)
+
+TEST(CAST_TEST, Test_JIT_DuplicateCastNoop) {
+    // Does a trivial cast - check JIT kernel trace to ensure a __noop is
+    // generated since we don't have a way to test it directly
+    af_dtype ta = (af_dtype)dtype_traits<float>::af_type;
+    af_dtype tb = (af_dtype)dtype_traits<double>::af_type;
+    dim4 dims(num, 1, 1, 1);
+    af_array a, b, c;
+    af_randu(&a, dims.ndims(), dims.get(), ta);
+
+    af_cast(&b, a, tb);
+    af_cast(&c, b, ta);
+
+    std::vector<float> a_vals(num);
+    std::vector<float> c_vals(num);
+    ASSERT_SUCCESS(af_get_data_ptr((void **)&a_vals[0], a));
+    ASSERT_SUCCESS(af_get_data_ptr((void **)&c_vals[0], c));
+
+    for (size_t i = 0; i < num; ++i) { ASSERT_FLOAT_EQ(a_vals[i], c_vals[i]); }
+
+    af_release_array(a);
+    af_release_array(b);
+    af_release_array(c);
+}

--- a/test/cast.cpp
+++ b/test/cast.cpp
@@ -14,6 +14,9 @@
 #include <af/array.h>
 #include <af/data.h>
 #include <af/random.h>
+#include <algorithm>
+#include <cstdlib>
+#include <vector>
 
 using af::cdouble;
 using af::cfloat;
@@ -122,4 +125,68 @@ TEST(CAST_TEST, Test_JIT_DuplicateCastNoop) {
     af_release_array(a);
     af_release_array(b);
     af_release_array(c);
+}
+
+TEST(Cast, ImplicitCast) {
+    using namespace af;
+    array a = randu(100, 100, f64);
+    array b = a.as(f32);
+
+    array c = max(abs(a - b));
+    ASSERT_ARRAYS_NEAR(constant(0, 1, 100, f64), c, 1e-7);
+}
+
+TEST(Cast, ConstantCast) {
+    using namespace af;
+    array a = constant(1, 100, f64);
+    array b = a.as(f32);
+
+    array c = max(abs(a - b));
+    ASSERT_ARRAYS_NEAR(c, constant(0, 1, f64), 1e-7);
+}
+
+TEST(Cast, OpCast) {
+    using namespace af;
+    array a = constant(1, 100, f64);
+    a       = a + a;
+    array b = a.as(f32);
+
+    array c = max(abs(a - b));
+    ASSERT_ARRAYS_NEAR(c, constant(0, 1, f64), 1e-7);
+}
+TEST(Cast, ImplicitCastIndexed) {
+    using namespace af;
+    array a = randu(100, 100, f64);
+    array b = a(span, 1).as(f32);
+    array c = max(abs(a(span, 1) - b));
+    ASSERT_ARRAYS_NEAR(constant(0, 1, 1, f64), c, 1e-7);
+}
+
+TEST(Cast, ImplicitCastIndexedNonLinear) {
+    using namespace af;
+    array a = randu(100, 100, f64);
+    array b = a(seq(10, 20, 2), 1).as(f32);
+    array c = max(abs(a(seq(10, 20, 2), 1) - b));
+    ASSERT_ARRAYS_NEAR(constant(0, 1, 1, f64), c, 1e-7);
+}
+
+TEST(Cast, ImplicitCastIndexedNonLinearArray) {
+    using namespace af;
+    array a   = randu(100, 100, f64);
+    array idx = seq(10, 20, 2);
+    array b   = a(idx, 1).as(f32);
+    array c   = max(abs(a(idx, 1) - b));
+    ASSERT_ARRAYS_NEAR(constant(0, 1, 1, f64), c, 1e-7);
+}
+
+TEST(Cast, ImplicitCastIndexedAndScoped) {
+    using namespace af;
+    array c;
+    {
+        array a = randu(100, 100, f64);
+        array b = a(span, 1).as(f32);
+        c       = abs(a(span, 1) - b);
+    }
+    c = max(c);
+    ASSERT_ARRAYS_NEAR(constant(0, 1, 1, f64), c, 1e-7);
 }


### PR DESCRIPTION
Adds a JIT optimization which does a NOOP in the case of sequential cases that don't result in a differently-typed result.

Description
-----------

The following code is technically a noop:
```c++
af::array a = af::randu(10, 1, 1, 1, af::dtype::f32);
af::array b = a.as(af::dtype::f64);
af::array c = b.as(af::dtype::f32);
```
No casting kernels should be generated for any of the above operations, especially for `c`, but they are. The solution here is to, when creating the `CastOp`/`CastWrapper` for `c`, to check to see if the previous operation was a cast. If it was, and the previous operation's previous operation's output type is the same output type as the current cast, create a `__noop` node between the prev-prev operation and the current one.

This also precludes tricky cases like:
```c++
af::array a = af::randu(10, 1, 1, 1, af::dtype::f32);
af::array b = a.as(af::dtype::f64);
af::array d = b + 2;
af::array c = b.as(af::dtype::f32);
c.eval();
d.eval();
```
where the result of `b` could be used, in which case the intermediate casting operation can't be discounted completely.

With the change, running `AF_JIT_KERNEL_TRACE=stderr ./test/cast_cuda --gtest_filter="*Test_JIT_DuplicateCastNoop"` produces the following kernels:
- CUDA: https://gist.github.com/jacobkahn/c59884ee1d64a996bf9e81002ed46c9f.
- OpenCL: https://gist.github.com/jacobkahn/628659c9d7adbfc7c713fb44b1afed4c

Before the change, the generated kernel used wasteful casts:
- CUDA: https://gist.github.com/jacobkahn/ec66b1645a5e7c69fbc457dd7b16461b,

This PR also adds op, type, and children accessors to `Node`/`NaryNode` to facilitate inspecting the JIT tree for optimization.

Further optimization could be had by recursively checking previous operations until an operation has no previous operations are casts - this would fix arbitrarily long chains of casts that were noops on a particular subtree of JIT operations.

Changes to Users
----------------
No changes to user behavior.

Checklist
---------
- [x] Rebased on latest master
- [X] Code compiles
- [X] Tests pass
- [X] Functions added to unified API
- [X] Functions documented
