### PR TITLE
Max parameter length fetched from device

### DIFF
--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -300,10 +300,6 @@ kJITHeuristics passesJitHeuristics(Node *root_node) {
     auto platform      = getActivePlatform();
 
     // The Apple platform can have the nvidia card or the AMD card
-    bool isNvidia =
-        platform == AFCL_PLATFORM_NVIDIA || platform == AFCL_PLATFORM_APPLE;
-    bool isAmd =
-        platform == AFCL_PLATFORM_AMD || platform == AFCL_PLATFORM_APPLE;
     bool isIntel = platform == AFCL_PLATFORM_INTEL;
 
     /// Intels param_size limit is much smaller than the other platforms


### PR DESCRIPTION
On some devices, the hard-coded maxima for the parameter length did not correspond.  This is solved by asking it to the device and using the returned value.

Description
-----------
* Fixes errors and crashes on iGPUs other than intel, which was also hard-coded.
* Noticed impact is a speed improvement for some devices.
* The hard-coded values are now removed, so this is not tested for other devices.
* If desired, this can be back-ported since the change is very limited.

Changes to Users
----------------
* No changes, except on improved stability.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
