### PR TITLE
Reduce synchronized initialization of OpenCL Buffers

### DIFF
--- a/src/backend/opencl/Kernel.cpp
+++ b/src/backend/opencl/Kernel.cpp
@@ -28,8 +28,8 @@ void Kernel::copyToReadOnly(Kernel::DevPtrType dst, Kernel::DevPtrType src,
 
 void Kernel::setFlag(Kernel::DevPtrType dst, int* scalarValPtr,
                      const bool syncCopy) {
-    getQueue().enqueueWriteBuffer(*dst, (syncCopy ? CL_TRUE : CL_FALSE), 0,
-                                  sizeof(int), scalarValPtr);
+    UNUSED(syncCopy);
+    getQueue().enqueueFillBuffer(*dst, *scalarValPtr, 0, sizeof(int));
 }
 
 int Kernel::getFlag(Kernel::DevPtrType src) {

--- a/src/backend/opencl/kernel/fast.hpp
+++ b/src/backend/opencl/kernel/fast.hpp
@@ -59,10 +59,8 @@ void fast(const unsigned arc_length, unsigned *out_feat, Param &x_out,
     // same coordinates as features, dimensions should be equal to in.
     cl::Buffer *d_score =
         bufferAlloc(in.info.dims[0] * in.info.dims[1] * sizeof(float));
-    std::vector<float> score_init(in.info.dims[0] * in.info.dims[1], (float)0);
-    getQueue().enqueueWriteBuffer(
-        *d_score, CL_FALSE, 0,
-        in.info.dims[0] * in.info.dims[1] * sizeof(float), &score_init[0]);
+    getQueue().enqueueFillBuffer(
+        *d_score, 0.0F, 0, in.info.dims[0] * in.info.dims[1] * sizeof(float));
 
     cl::Buffer *d_flags = d_score;
     if (nonmax) {
@@ -91,10 +89,8 @@ void fast(const unsigned arc_length, unsigned *out_feat, Param &x_out,
     const cl::NDRange global_nonmax(blk_nonmax_x * FAST_THREADS_NONMAX_X,
                                     blk_nonmax_y * FAST_THREADS_NONMAX_Y);
 
-    unsigned count_init = 0;
     cl::Buffer *d_total = bufferAlloc(sizeof(unsigned));
-    getQueue().enqueueWriteBuffer(*d_total, CL_FALSE, 0, sizeof(unsigned),
-                                  &count_init);
+    getQueue().enqueueFillBuffer(*d_total, 0U, 0, sizeof(unsigned));
 
     // size_t *global_nonmax_dims = global_nonmax();
     size_t blocks_sz = blk_nonmax_x * FAST_THREADS_NONMAX_X * blk_nonmax_y *

--- a/src/backend/opencl/kernel/harris.hpp
+++ b/src/backend/opencl/kernel/harris.hpp
@@ -162,8 +162,8 @@ void harris(unsigned *corners_out, Param &x_out, Param &y_out, Param &resp_out,
 
     unsigned corners_found      = 0;
     cl::Buffer *d_corners_found = bufferAlloc(sizeof(unsigned));
-    getQueue().enqueueWriteBuffer(*d_corners_found, CL_TRUE, 0,
-                                  sizeof(unsigned), &corners_found);
+    getQueue().enqueueFillBuffer(*d_corners_found, corners_found, 0,
+                                 sizeof(unsigned));
 
     cl::Buffer *d_x_corners    = bufferAlloc(corner_lim * sizeof(float));
     cl::Buffer *d_y_corners    = bufferAlloc(corner_lim * sizeof(float));

--- a/src/backend/opencl/kernel/orb.hpp
+++ b/src/backend/opencl/kernel/orb.hpp
@@ -208,8 +208,8 @@ void orb(unsigned* out_feat, Param& x_out, Param& y_out, Param& score_out,
 
         unsigned usable_feat  = 0;
         Buffer* d_usable_feat = bufferAlloc(sizeof(unsigned));
-        getQueue().enqueueWriteBuffer(*d_usable_feat, CL_FALSE, 0,
-                                      sizeof(unsigned), &usable_feat);
+        getQueue().enqueueFillBuffer(*d_usable_feat, usable_feat, 0,
+                                     sizeof(unsigned));
 
         Buffer* d_x_harris     = bufferAlloc(lvl_feat * sizeof(float));
         Buffer* d_y_harris     = bufferAlloc(lvl_feat * sizeof(float));
@@ -364,12 +364,8 @@ void orb(unsigned* out_feat, Param& x_out, Param& y_out, Param& score_out,
 
         // Compute ORB descriptors
         Buffer* d_desc_lvl = bufferAlloc(usable_feat * 8 * sizeof(unsigned));
-        vector<unsigned> h_desc_lvl(usable_feat * 8, 0);
-        {
-            getQueue().enqueueWriteBuffer(*d_desc_lvl, CL_FALSE, 0,
-                                          usable_feat * 8 * sizeof(unsigned),
-                                          h_desc_lvl.data());
-        }
+        getQueue().enqueueFillBuffer(*d_desc_lvl, 0U, 0,
+                                     usable_feat * 8 * sizeof(unsigned));
         auto eoOp = kernels[3];
         if (blur_img) {
             eoOp(EnqueueArgs(getQueue(), global_centroid, local_centroid),

--- a/src/backend/opencl/kernel/regions.hpp
+++ b/src/backend/opencl/kernel/regions.hpp
@@ -104,8 +104,7 @@ void regions(Param out, Param in, const bool full_conn,
 
     while (h_continue) {
         h_continue = 0;
-        getQueue().enqueueWriteBuffer(*d_continue, CL_FALSE, 0, sizeof(int),
-                                      &h_continue);
+        getQueue().enqueueFillBuffer(*d_continue, h_continue, 0, sizeof(int));
         ueOp(EnqueueArgs(getQueue(), global, local), *out.data, out.info,
              *d_continue);
         CL_DEBUG_FINISH(getQueue());

--- a/src/backend/opencl/kernel/sparse.hpp
+++ b/src/backend/opencl/kernel/sparse.hpp
@@ -117,10 +117,10 @@ void dense2csr(Param values, Param rowIdx, Param colIdx, const Param dense) {
     scanFirst<int, int, af_add_t>(rowIdx, rd1, false);
 
     int nnz = values.info.dims[0];
-    getQueue().enqueueWriteBuffer(
-        *rowIdx.data, CL_TRUE,
+    getQueue().enqueueFillBuffer(
+        *rowIdx.data, nnz,
         rowIdx.info.offset + (rowIdx.info.dims[0] - 1) * sizeof(int),
-        sizeof(int), (void *)&nnz);
+        sizeof(int));
 
     cl::NDRange local(THREADS_X, THREADS_Y);
     int groups_x = divup(dense.info.dims[0], local[0]);

--- a/src/backend/opencl/kernel/sparse_arith.hpp
+++ b/src/backend/opencl/kernel/sparse_arith.hpp
@@ -150,7 +150,7 @@ static void csrCalcOutNNZ(Param outRowIdx, unsigned &nnzC, const uint M,
 
     nnzC     = 0;
     auto out = memAlloc<unsigned>(1);
-    getQueue().enqueueWriteBuffer(*out, CL_TRUE, 0, sizeof(unsigned), &nnzC);
+    getQueue().enqueueFillBuffer(*out, nnzC, 0, sizeof(unsigned));
 
     calcNNZ(cl::EnqueueArgs(getQueue(), global, local), *out, *outRowIdx.data,
             M, *lrowIdx.data, *lcolIdx.data, *rrowIdx.data, *rcolIdx.data,

--- a/src/backend/opencl/kernel/susan.hpp
+++ b/src/backend/opencl/kernel/susan.hpp
@@ -79,8 +79,8 @@ unsigned nonMaximal(cl::Buffer* x_out, cl::Buffer* y_out, cl::Buffer* resp_out,
 
     unsigned corners_found = 0;
     auto d_corners_found   = memAlloc<unsigned>(1);
-    getQueue().enqueueWriteBuffer(*d_corners_found, CL_FALSE, 0,
-                                  sizeof(unsigned), &corners_found);
+    getQueue().enqueueFillBuffer(*d_corners_found, corners_found, 0,
+                                 sizeof(unsigned));
 
     cl::NDRange local(SUSAN_THREADS_X, SUSAN_THREADS_Y);
     cl::NDRange global(divup(idim0 - 2 * edge, local[0]) * local[0],


### PR DESCRIPTION
All OpenCL Buffers are now initialized in an synchronize way.

Short description of change
--------------
All blocking EnqueueWriteBuffers are replaced by non-blocking ones, resulting in performance improvement and/or extra stability.

Description
-----------
EnqueueWriteBuffer copies a buffer from Host memory into the device Buffer.  We have 2 issues with the Host memory, being:
- memory gets out of scope when created on the stack.
When the values are fixed (ex: always 0), a static variable can be used who remains always available, independent when the kernel executes.  Since it is a constant, the static does not pose problems with thread-safety.
When the value is a calculated value.  The scope of the variable has to be extended as long as possible, meaning that the variable declaration is performed in the highest function (no sub section) and an event is checked before destruction the variable.  When extra enqueue commands are issued between the writeBuffer and the event check, the GPU will continue having commands.
- large vectors are constructed and initialized to 0, before the copying. 
This construction takes much time on the Host thread so that the no new commands are available in the queue, resulting in low utilization on the GPU.
An extra kernel is added to the corresponding OpenCL program, which initializes the Buffer with the provided value.

Impact on the updated files:
Stability: orb.hpp (Line 366: vector h_desc_lvl could be destructed before execution)  --> intermittent failures
Performance: Kernel.cpp, csrmm.hpp, csrmv.hpp, fast.hpp, harris.hpp, regions.hpp, sparse.hpp, sparse_arith.hpp:, susan.hpp

Additional information about the PR answering following questions:

* Is this a new feature or a bug fix?  No
* Why these changes are necessary: Stability & Performance
* Potential impact on specific hardware, software or backends: None
* New functions and their functionality: None
-->
Fixes: #2937 partially, since this is not the main bottleneck.

Changes to Users
----------------
None

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
