### PR TITLE
JIT optimization: Faster generation of an unique funcName

### DIFF
--- a/src/backend/common/jit/BufferNodeBase.hpp
+++ b/src/backend/common/jit/BufferNodeBase.hpp
@@ -53,11 +53,11 @@ class BufferNodeBase : public common::Node {
         return m_linear_buffer && same_dims;
     }
 
-    void genKerName(std::stringstream &kerStream,
+    void genKerName(std::string &kerString,
                     const common::Node_ids &ids) const final {
-        kerStream << "_" << getNameStr();
-        kerStream << std::setw(3) << std::setfill('0') << std::dec << ids.id
-                  << std::dec;
+        kerString += '_';
+        kerString += getNameStr();
+        kerString += std::to_string(ids.id);
     }
 
     void genParams(std::stringstream &kerStream, int id,

--- a/src/backend/common/jit/BufferNodeBase.hpp
+++ b/src/backend/common/jit/BufferNodeBase.hpp
@@ -57,6 +57,7 @@ class BufferNodeBase : public common::Node {
                     const common::Node_ids &ids) const final {
         kerString += '_';
         kerString += getNameStr();
+        kerString += ',';
         kerString += std::to_string(ids.id);
     }
 

--- a/src/backend/common/jit/NaryNode.hpp
+++ b/src/backend/common/jit/NaryNode.hpp
@@ -68,7 +68,7 @@ class NaryNode : public Node {
                     const common::Node_ids &ids) const final {
         // Make the dec representation of enum part of the Kernel name
         kerString += '_';
-        kerString += m_op_str;
+        kerString += std::to_string(m_op);
         kerString += ',';
         for (int i = 0; i < m_num_children; i++) {
             kerString += std::to_string(ids.child_ids[i]);

--- a/src/backend/common/jit/NaryNode.hpp
+++ b/src/backend/common/jit/NaryNode.hpp
@@ -64,17 +64,16 @@ class NaryNode : public Node {
         swap(m_op_str, other.m_op_str);
     }
 
-    void genKerName(std::stringstream &kerStream,
+    void genKerName(std::string &kerString,
                     const common::Node_ids &ids) const final {
         // Make the dec representation of enum part of the Kernel name
-        kerStream << "_" << std::setw(3) << std::setfill('0') << std::dec
-                  << m_op;
+        kerString += '_';
+        kerString += m_op_str;
         for (int i = 0; i < m_num_children; i++) {
-            kerStream << std::setw(3) << std::setfill('0') << std::dec
-                      << ids.child_ids[i];
+            kerString += std::to_string(ids.child_ids[i]);
+            kerString += ',';
         }
-        kerStream << std::setw(3) << std::setfill('0') << std::dec << ids.id
-                  << std::dec;
+        kerString += std::to_string(ids.id);
     }
 
     void genFuncs(std::stringstream &kerStream,

--- a/src/backend/common/jit/NaryNode.hpp
+++ b/src/backend/common/jit/NaryNode.hpp
@@ -69,6 +69,7 @@ class NaryNode : public Node {
         // Make the dec representation of enum part of the Kernel name
         kerString += '_';
         kerString += m_op_str;
+        kerString += ',';
         for (int i = 0; i < m_num_children; i++) {
             kerString += std::to_string(ids.child_ids[i]);
             kerString += ',';

--- a/src/backend/common/jit/Node.cpp
+++ b/src/backend/common/jit/Node.cpp
@@ -43,11 +43,11 @@ std::string getFuncName(const vector<Node *> &output_nodes,
                         const vector<Node_ids> &full_ids, bool is_linear) {
     std::string funcName;
     funcName.reserve(512);
-    funcName = is_linear ? 'L' : 'G';
+    funcName = (is_linear ? 'L' : 'G');
 
-    for (const auto &node : output_nodes) { 
+    for (const auto &node : output_nodes) {
         funcName += '_';
-        funcName += node->getNameStr(); 
+        funcName += node->getNameStr();
     }
 
     for (int i = 0; i < static_cast<int>(full_nodes.size()); i++) {

--- a/src/backend/common/jit/Node.cpp
+++ b/src/backend/common/jit/Node.cpp
@@ -45,7 +45,10 @@ std::string getFuncName(const vector<Node *> &output_nodes,
     funcName.reserve(512);
     funcName = is_linear ? 'L' : 'G';
 
-    for (const auto &node : output_nodes) { funcName += node->getNameStr(); }
+    for (const auto &node : output_nodes) { 
+        funcName += '_';
+        funcName += node->getNameStr(); 
+    }
 
     for (int i = 0; i < static_cast<int>(full_nodes.size()); i++) {
         full_nodes[i]->genKerName(funcName, full_ids[i]);

--- a/src/backend/common/jit/Node.cpp
+++ b/src/backend/common/jit/Node.cpp
@@ -41,26 +41,17 @@ int Node::getNodesMap(Node_map_t &node_map, vector<Node *> &full_nodes,
 std::string getFuncName(const vector<Node *> &output_nodes,
                         const vector<Node *> &full_nodes,
                         const vector<Node_ids> &full_ids, bool is_linear) {
-    std::stringstream funcName;
-    std::stringstream hashName;
+    std::string funcName;
+    funcName.reserve(512);
+    funcName = is_linear ? 'L' : 'G';
 
-    if (is_linear) {
-        funcName << "L_";  // Kernel Linear
-    } else {
-        funcName << "G_";  // Kernel General
-    }
-
-    for (const auto &node : output_nodes) {
-        funcName << node->getNameStr() << "_";
-    }
+    for (const auto &node : output_nodes) { funcName += node->getNameStr(); }
 
     for (int i = 0; i < static_cast<int>(full_nodes.size()); i++) {
         full_nodes[i]->genKerName(funcName, full_ids[i]);
     }
 
-    hashName << "KER";
-    hashName << deterministicHash(funcName.str());
-    return hashName.str();
+    return "KER" + std::to_string(deterministicHash(funcName));
 }
 
 }  // namespace common

--- a/src/backend/common/jit/Node.hpp
+++ b/src/backend/common/jit/Node.hpp
@@ -122,7 +122,7 @@ class Node {
                     std::vector<Node_ids> &full_ids);
 
     /// Generates the string that will be used to hash the kernel
-    virtual void genKerName(std::stringstream &kerStream,
+    virtual void genKerName(std::string &kerString,
                             const Node_ids &ids) const = 0;
 
     /// Generates the function parameters for the node.

--- a/src/backend/common/jit/ScalarNode.hpp
+++ b/src/backend/common/jit/ScalarNode.hpp
@@ -56,6 +56,7 @@ class ScalarNode : public common::Node {
                     const common::Node_ids& ids) const final {
         kerString += '_';
         kerString += getTypeStr();
+        kerString += ',';
         kerString += std::to_string(ids.id);
     }
 

--- a/src/backend/common/jit/ScalarNode.hpp
+++ b/src/backend/common/jit/ScalarNode.hpp
@@ -52,11 +52,11 @@ class ScalarNode : public common::Node {
         swap(m_val, other.m_val);
     }
 
-    void genKerName(std::stringstream& kerStream,
+    void genKerName(std::string& kerString,
                     const common::Node_ids& ids) const final {
-        kerStream << "_" << getTypeStr();
-        kerStream << std::setw(3) << std::setfill('0') << std::dec << ids.id
-                  << std::dec;
+        kerString += '_';
+        kerString += getTypeStr();
+        kerString += std::to_string(ids.id);
     }
 
     void genParams(std::stringstream& kerStream, int id,

--- a/src/backend/common/jit/ShiftNodeBase.hpp
+++ b/src/backend/common/jit/ShiftNodeBase.hpp
@@ -67,6 +67,7 @@ class ShiftNodeBase : public Node {
                     const common::Node_ids &ids) const final {
         kerString += '_';
         kerString += getNameStr();
+        kerString += ',';
         kerString += std::to_string(ids.id);
     }
 

--- a/src/backend/common/jit/ShiftNodeBase.hpp
+++ b/src/backend/common/jit/ShiftNodeBase.hpp
@@ -63,11 +63,11 @@ class ShiftNodeBase : public Node {
         return false;
     }
 
-    void genKerName(std::stringstream &kerStream,
+    void genKerName(std::string &kerString,
                     const common::Node_ids &ids) const final {
-        kerStream << "_" << getNameStr();
-        kerStream << std::setw(3) << std::setfill('0') << std::dec << ids.id
-                  << std::dec;
+        kerString += '_';
+        kerString += getNameStr();
+        kerString += std::to_string(ids.id);
     }
 
     void genParams(std::stringstream &kerStream, int id,

--- a/src/backend/cpu/jit/BinaryNode.hpp
+++ b/src/backend/cpu/jit/BinaryNode.hpp
@@ -49,9 +49,9 @@ class BinaryNode : public TNode<compute_t<To>> {
         m_op.eval(this->m_val, m_lhs->m_val, m_rhs->m_val, lim);
     }
 
-    void genKerName(std::stringstream &kerStream,
+    void genKerName(std::string &kerString,
                     const common::Node_ids &ids) const final {
-        UNUSED(kerStream);
+        UNUSED(kerString);
         UNUSED(ids);
     }
 

--- a/src/backend/cpu/jit/BufferNode.hpp
+++ b/src/backend/cpu/jit/BufferNode.hpp
@@ -85,9 +85,9 @@ class BufferNode : public TNode<T> {
 
     size_t getBytes() const final { return m_bytes; }
 
-    void genKerName(std::stringstream &kerStream,
+    void genKerName(std::string &kerString,
                     const common::Node_ids &ids) const final {
-        UNUSED(kerStream);
+        UNUSED(kerString);
         UNUSED(ids);
     }
 

--- a/src/backend/cpu/jit/ScalarNode.hpp
+++ b/src/backend/cpu/jit/ScalarNode.hpp
@@ -21,9 +21,9 @@ class ScalarNode : public TNode<T> {
    public:
     ScalarNode(T val) : TNode<T>(val, 0, {}) {}
 
-    void genKerName(std::stringstream &kerStream,
+    void genKerName(std::string &kerString,
                     const common::Node_ids &ids) const final {
-        UNUSED(kerStream);
+        UNUSED(kerString);
         UNUSED(ids);
     }
 

--- a/src/backend/cpu/jit/UnaryNode.hpp
+++ b/src/backend/cpu/jit/UnaryNode.hpp
@@ -48,9 +48,9 @@ class UnaryNode : public TNode<To> {
         m_op.eval(TNode<To>::m_val, m_child->m_val, lim);
     }
 
-    void genKerName(std::stringstream &kerStream,
+    void genKerName(std::string &kerString,
                     const common::Node_ids &ids) const final {
-        UNUSED(kerStream);
+        UNUSED(kerString);
         UNUSED(ids);
     }
 


### PR DESCRIPTION
The performance of JIT commands are improved up to 2x, dependent on the length of the JIT tree.
The difference is more pronounced for cached JIT kernels.

Description
-----------
The unique funcName is used to identify a JIT tree combination.  This name is generated, even when the corresponding kernel is cached.
The usage of std::string and eliminating of unnecessary formatting is a few times faster than the std::streamstring (which is very slow at construction).

Since some formatting is changed, the resulting KER number will be different resulting in a once recompilation of the kernel and a new cache file.

* Is this a new feature or a bug fix? NO, Performance improvement
* More detail if necessary to describe all commits in pull request: Each Node type has its virtual function to generate this part of the name, so they are all updated.
* Why these changes are necessary: With the improved GPU speed, the bottleneck is shifting to the CPU.  The GPU utilization increases.
* Potential impact on specific hardware, software or backends: The faster the connected GPU, the bigger the speed improvement.
* New functions and their functionality: None
* Future changes not implemented in this PR: A new PR will be launched to improve the caching/hashing mechanism for all kernels.

Changes to Users
----------------
No changes, except on the clean-up of the caching directory.
Perhaps a note necessary in the documentation??

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
