### PR TITLE
Fix half explicit constructor argument type

### DIFF
--- a/src/backend/common/half.hpp
+++ b/src/backend/common/half.hpp
@@ -879,22 +879,14 @@ class alignas(2) half {
         return *this;
     }
 
-#if defined(NVCC) || defined(__CUDACC_RTC__)
-    AF_CONSTEXPR __DH__ explicit half(__half value) noexcept
-#ifdef __CUDA_ARCH__
+    AF_CONSTEXPR __DH__ explicit half(native_half_t value) noexcept
         : data_(value) {
     }
-#else
-        : data_(*reinterpret_cast<native_half_t*>(&value)) {
-    }
-#endif
-    AF_CONSTEXPR __DH__ half& operator=(__half value) noexcept {
-        // NOTE Assignment to ushort from __half only works with device code.
-        // using memcpy instead
-        data_ = *reinterpret_cast<native_half_t*>(&value);
+
+    AF_CONSTEXPR __DH__ half& operator=(native_half_t value) noexcept {
+        data_ = value;
         return *this;
     }
-#endif
 
     __DH__ explicit operator float() const noexcept {
         return half2float(data_);


### PR DESCRIPTION
Description
-----------
This essentially fixes CUDA build related to invalid constexpr usage
on half constructor having reinterpret_cast call.

Changes to Users
----------------
Users building ArrayFire with clang/vs2019 should be able to build CUDA backend successfully.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
