### PR TITLE
Fix constexpr error with vs2019 with half

### DIFF
--- a/src/backend/common/half.hpp
+++ b/src/backend/common/half.hpp
@@ -879,15 +879,9 @@ class alignas(2) half {
         return *this;
     }
 
-#if defined(NVCC) || defined(__CUDACC_RTC__)
-    AF_CONSTEXPR __DH__ explicit half(__half value) noexcept
 #ifdef __CUDA_ARCH__
-        : data_(value) {
-    }
-#else
-        : data_(*reinterpret_cast<native_half_t*>(&value)) {
-    }
-#endif
+    AF_CONSTEXPR __DH__ explicit half(__half value) noexcept : data_(value) {}
+
     AF_CONSTEXPR __DH__ half& operator=(__half value) noexcept {
         // NOTE Assignment to ushort from __half only works with device code.
         // using memcpy instead


### PR DESCRIPTION
fix constexpr error with the half class in vs2019 and clang

Description
-----------
Fix constexpr error with vs2019 and clang. This was fixed by remove older versions of the __half constructor. 

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass

