### PR TITLE
Fix the extra braces in cuda compile log message

### DIFF
--- a/src/backend/cuda/compile_module.cpp
+++ b/src/backend/cuda/compile_module.cpp
@@ -382,7 +382,8 @@ Module compileModule(const string &moduleKey, const vector<string> &sources,
                               return lhs + ", " + rhs;
                           });
     };
-    AF_TRACE("{{{compile:{:>5} ms, link:{:>4} ms, {{ {} }}, {} }}}",
+    AF_TRACE("{{ {:<20} : compile:{:>5} ms, link:{:>4} ms, {{ {} }}, {} }}",
+             moduleKey,
              duration_cast<milliseconds>(compile_end - compile).count(),
              duration_cast<milliseconds>(link_end - link).count(),
              listOpts(compiler_options), getDeviceProp(device).name);

--- a/src/backend/opencl/compile_module.cpp
+++ b/src/backend/opencl/compile_module.cpp
@@ -207,7 +207,7 @@ Module compileModule(const string &moduleKey, const vector<string> &sources,
     }
 #endif
 
-    AF_TRACE("{{{:<20} : {{ compile:{:>5} ms, {{ {} }}, {} }}}}", moduleKey,
+    AF_TRACE("{{ {:<20} : {{ compile:{:>5} ms, {{ {} }}, {} }} }}", moduleKey,
              duration_cast<milliseconds>(compileEnd - compileBegin).count(),
              fmt::join(options, " "),
              getDevice(getActiveDeviceId()).getInfo<CL_DEVICE_NAME>());


### PR DESCRIPTION
Formatted opencl compile log message braces for a slightly better
readability.

The extra braces seem to work fine when local tests are run fine, but for some unknown reason the same formatting gives invalid error when used via a wrapper for example rust wrapper.