### PR TITLE
Fix empty array to host copy seg fault

### DIFF
--- a/src/backend/cpu/copy.cpp
+++ b/src/backend/cpu/copy.cpp
@@ -48,7 +48,7 @@ void copyData(T *to, const Array<T> &from) {
 template<typename T>
 Array<T> copyArray(const Array<T> &A) {
     Array<T> out = createEmptyArray<T>(A.dims());
-    getQueue().enqueue(kernel::copy<T, T>, out, A);
+    if (A.elements() > 0) { getQueue().enqueue(kernel::copy<T, T>, out, A); }
     return out;
 }
 

--- a/src/backend/cpu/copy.cpp
+++ b/src/backend/cpu/copy.cpp
@@ -30,6 +30,8 @@ namespace cpu {
 
 template<typename T>
 void copyData(T *to, const Array<T> &from) {
+    if (from.elements() == 0) { return; }
+
     from.eval();
     // Ensure all operations on 'from' are complete before copying data to host.
     getQueue().sync();

--- a/src/backend/cuda/copy.cpp
+++ b/src/backend/cuda/copy.cpp
@@ -23,6 +23,8 @@ namespace cuda {
 
 template<typename T>
 void copyData(T *dst, const Array<T> &src) {
+    if (src.elements() == 0) { return; }
+
     // FIXME: Merge this with copyArray
     src.eval();
 

--- a/src/backend/cuda/copy.cpp
+++ b/src/backend/cuda/copy.cpp
@@ -51,6 +51,7 @@ void copyData(T *dst, const Array<T> &src) {
 template<typename T>
 Array<T> copyArray(const Array<T> &src) {
     Array<T> out = createEmptyArray<T>(src.dims());
+    if (src.elements() == 0) { return out; }
 
     if (src.isLinear()) {
         CUDA_CHECK(

--- a/src/backend/opencl/copy.cpp
+++ b/src/backend/opencl/copy.cpp
@@ -51,8 +51,9 @@ void copyData(T *data, const Array<T> &A) {
 template<typename T>
 Array<T> copyArray(const Array<T> &A) {
     Array<T> out = createEmptyArray<T>(A.dims());
-    dim_t offset = A.getOffset();
+    if (A.elements() == 0) { return out; }
 
+    dim_t offset = A.getOffset();
     if (A.isLinear()) {
         // FIXME: Add checks
         getQueue().enqueueCopyBuffer(*A.get(), *out.get(), sizeof(T) * offset,

--- a/src/backend/opencl/copy.cpp
+++ b/src/backend/opencl/copy.cpp
@@ -22,6 +22,8 @@ namespace opencl {
 
 template<typename T>
 void copyData(T *data, const Array<T> &A) {
+    if (A.elements() == 0) { return; }
+
     // FIXME: Merge this with copyArray
     A.eval();
 

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -618,3 +618,14 @@ TEST(Array, CopyListInitializerListDim4Assignment) {
 
     ASSERT_ARRAYS_EQ(A, B);
 }
+
+TEST(Array, EmptyArrayHostCopy) {
+    EXPECT_EXIT(
+        {
+            af::array empty;
+            std::vector<float> hdata(100);
+            empty.host(hdata.data());
+            exit(0);
+        },
+        ::testing::ExitedWithCode(0), ".*");
+}


### PR DESCRIPTION
Description
-----------
Fixes: #3058 

Changes to Users
----------------
Calls to copy empty array to host pointer won't seg-fault on OpenCL backend anymore.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
