### PR TITLE
Use short function name in non-debug builds in error messages

### DIFF
--- a/src/api/cpp/error.hpp
+++ b/src/api/cpp/error.hpp
@@ -17,14 +17,13 @@
         if (__err == AF_SUCCESS) break;                                       \
         char *msg = NULL;                                                     \
         af_get_last_error(&msg, NULL);                                        \
-        af::exception ex(msg, __PRETTY_FUNCTION__, __AF_FILENAME__, __LINE__, \
-                         __err);                                              \
+        af::exception ex(msg, __AF_FUNC__, __AF_FILENAME__, __LINE__, __err); \
         af_free_host(msg);                                                    \
         throw std::move(ex);                                                  \
     } while (0)
 
-#define AF_THROW_ERR(__msg, __err)                                       \
-    do {                                                                 \
-        throw af::exception(__msg, __PRETTY_FUNCTION__, __AF_FILENAME__, \
-                            __LINE__, __err);                            \
+#define AF_THROW_ERR(__msg, __err)                                         \
+    do {                                                                   \
+        throw af::exception(__msg, __AF_FUNC__, __AF_FILENAME__, __LINE__, \
+                            __err);                                        \
     } while (0)

--- a/src/backend/common/defines.hpp
+++ b/src/backend/common/defines.hpp
@@ -36,11 +36,15 @@ inline std::string clipFilePath(std::string path, std::string str) {
 #define STATIC_ static
 #define __AF_FILENAME__ (clipFilePath(__FILE__, "src\\").c_str())
 #else
-//#ifndef __PRETTY_FUNCTION__
-//    #define __PRETTY_FUNCTION__ __func__ // __PRETTY_FUNCTION__ Fallback
-//#endif
 #define STATIC_ inline
 #define __AF_FILENAME__ (clipFilePath(__FILE__, "src/").c_str())
+#endif
+
+#if defined(NDEBUG)
+#define __AF_FUNC__ __FUNCTION__
+#else
+// Debug
+#define __AF_FUNC__ __PRETTY_FUNCTION__
 #endif
 
 #ifdef OS_WIN

--- a/src/backend/common/err_common.hpp
+++ b/src/backend/common/err_common.hpp
@@ -146,40 +146,39 @@ af_err processException();
 af_err set_global_error_string(const std::string& msg,
                                af_err err = AF_ERR_UNKNOWN);
 
-#define DIM_ASSERT(INDEX, COND)                                        \
-    do {                                                               \
-        if ((COND) == false) {                                         \
-            throw DimensionError(__PRETTY_FUNCTION__, __AF_FILENAME__, \
-                                 __LINE__, INDEX, #COND,               \
-                                 boost::stacktrace::stacktrace());     \
-        }                                                              \
+#define DIM_ASSERT(INDEX, COND)                                          \
+    do {                                                                 \
+        if ((COND) == false) {                                           \
+            throw DimensionError(__AF_FUNC__, __AF_FILENAME__, __LINE__, \
+                                 INDEX, #COND,                           \
+                                 boost::stacktrace::stacktrace());       \
+        }                                                                \
     } while (0)
 
-#define ARG_ASSERT(INDEX, COND)                                       \
-    do {                                                              \
-        if ((COND) == false) {                                        \
-            throw ArgumentError(__PRETTY_FUNCTION__, __AF_FILENAME__, \
-                                __LINE__, INDEX, #COND,               \
-                                boost::stacktrace::stacktrace());     \
-        }                                                             \
-    } while (0)
-
-#define TYPE_ERROR(INDEX, type)                                                \
+#define ARG_ASSERT(INDEX, COND)                                                \
     do {                                                                       \
-        throw TypeError(__PRETTY_FUNCTION__, __AF_FILENAME__, __LINE__, INDEX, \
-                        type, boost::stacktrace::stacktrace());                \
+        if ((COND) == false) {                                                 \
+            throw ArgumentError(__AF_FUNC__, __AF_FILENAME__, __LINE__, INDEX, \
+                                #COND, boost::stacktrace::stacktrace());       \
+        }                                                                      \
     } while (0)
 
-#define AF_ERROR(MSG, ERR_TYPE)                                            \
-    do {                                                                   \
-        throw AfError(__PRETTY_FUNCTION__, __AF_FILENAME__, __LINE__, MSG, \
-                      ERR_TYPE, boost::stacktrace::stacktrace());          \
+#define TYPE_ERROR(INDEX, type)                                              \
+    do {                                                                     \
+        throw TypeError(__AF_FUNC__, __AF_FILENAME__, __LINE__, INDEX, type, \
+                        boost::stacktrace::stacktrace());                    \
+    } while (0)
+
+#define AF_ERROR(MSG, ERR_TYPE)                                              \
+    do {                                                                     \
+        throw AfError(__AF_FUNC__, __AF_FILENAME__, __LINE__, MSG, ERR_TYPE, \
+                      boost::stacktrace::stacktrace());                      \
     } while (0)
 
 #define AF_RETURN_ERROR(MSG, ERR_TYPE)                                       \
     do {                                                                     \
         std::stringstream s;                                                 \
-        s << "Error in " << __PRETTY_FUNCTION__ << "\n"                      \
+        s << "Error in " << __AF_FUNC__ << "\n"                              \
           << "In file " << __AF_FILENAME__ << ":" << __LINE__ << ": " << MSG \
           << "\n"                                                            \
           << boost::stacktrace::stacktrace();                                \
@@ -200,12 +199,12 @@ af_err set_global_error_string(const std::string& msg,
         return processException(); \
     }
 
-#define AF_CHECK(fn)                                                        \
-    do {                                                                    \
-        af_err __err = fn;                                                  \
-        if (__err == AF_SUCCESS) break;                                     \
-        throw AfError(__PRETTY_FUNCTION__, __AF_FILENAME__, __LINE__, "\n", \
-                      __err, boost::stacktrace::stacktrace());              \
+#define AF_CHECK(fn)                                                       \
+    do {                                                                   \
+        af_err __err = fn;                                                 \
+        if (__err == AF_SUCCESS) break;                                    \
+        throw AfError(__AF_FUNC__, __AF_FILENAME__, __LINE__, "\n", __err, \
+                      boost::stacktrace::stacktrace());                    \
     } while (0)
 
 static const int MAX_ERR_SIZE = 1024;

--- a/src/backend/cpu/err_cpu.hpp
+++ b/src/backend/cpu/err_cpu.hpp
@@ -9,8 +9,8 @@
 
 #include <common/err_common.hpp>
 
-#define CPU_NOT_SUPPORTED(message)                                         \
-    do {                                                                   \
-        throw SupportError(__PRETTY_FUNCTION__, __AF_FILENAME__, __LINE__, \
-                           message, boost::stacktrace::stacktrace());      \
+#define CPU_NOT_SUPPORTED(message)                                          \
+    do {                                                                    \
+        throw SupportError(__AF_FUNC__, __AF_FILENAME__, __LINE__, message, \
+                           boost::stacktrace::stacktrace());                \
     } while (0)

--- a/src/backend/cuda/err_cuda.hpp
+++ b/src/backend/cuda/err_cuda.hpp
@@ -12,10 +12,10 @@
 #include <common/err_common.hpp>
 #include <stdio.h>
 
-#define CUDA_NOT_SUPPORTED(message)                                        \
-    do {                                                                   \
-        throw SupportError(__PRETTY_FUNCTION__, __AF_FILENAME__, __LINE__, \
-                           message, boost::stacktrace::stacktrace());      \
+#define CUDA_NOT_SUPPORTED(message)                                         \
+    do {                                                                    \
+        throw SupportError(__AF_FUNC__, __AF_FILENAME__, __LINE__, message, \
+                           boost::stacktrace::stacktrace());                \
     } while (0)
 
 #define CUDA_CHECK(fn)                                               \

--- a/src/backend/opencl/err_opencl.hpp
+++ b/src/backend/opencl/err_opencl.hpp
@@ -11,8 +11,8 @@
 
 #include <common/err_common.hpp>
 
-#define OPENCL_NOT_SUPPORTED(message)                                      \
-    do {                                                                   \
-        throw SupportError(__PRETTY_FUNCTION__, __AF_FILENAME__, __LINE__, \
-                           message, boost::stacktrace::stacktrace());      \
+#define OPENCL_NOT_SUPPORTED(message)                                       \
+    do {                                                                    \
+        throw SupportError(__AF_FUNC__, __AF_FILENAME__, __LINE__, message, \
+                           boost::stacktrace::stacktrace());                \
     } while (0)


### PR DESCRIPTION
Description
-----------
Prior to this, error message from an exception would look like below

    In function af_err af_transpose_inplace(af_array, bool)
    In file src/api/c/transpose.cpp:97

Earlier approach was hindering any useful log messages, especially from
runtime(like nvrtc) compilation phase, to be properly captured by
by the string returned by af_get_last_error function call.

Now it would look the same in debug builds but for release builds it
shall look like as following

    In function af_transpose_inplace
    In file src/api/c/transpose.cpp:97

Fixes: #3053 

Changes to Users
----------------
Issues such as the ones mentioned in #3053 will be fixed.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
