### PR TITLE
Add shortcut check for zero elements in af_write_array

### DIFF
--- a/src/api/c/array.cpp
+++ b/src/api/c/array.cpp
@@ -343,6 +343,9 @@ void write_array(af_array arr, const T *const data, const size_t bytes,
 
 af_err af_write_array(af_array arr, const void *data, const size_t bytes,
                       af_source src) {
+    if (bytes == 0) {
+        return AF_SUCCESS;
+    }
     try {
         af_dtype type = getInfo(arr).getType();
         // DIM_ASSERT(2, bytes <= getInfo(arr).bytes());


### PR DESCRIPTION
Description
-----------
Followup on https://github.com/arrayfire/arrayfire/issues/3058
Tested with 3.7.1 with OpenCL backend

Changes to Users
----------------
None

Checklist
---------
- [ ] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
