### PR TITLE
Update CUDA maps for newer version 11.2

### DIFF
--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -97,6 +97,7 @@ static const int jetsonComputeCapabilities[] = {
 
 // clang-format off
 static const cuNVRTCcompute Toolkit2MaxCompute[] = {
+    {11020, 8, 0, 0},
     {11010, 8, 0, 0},
     {11000, 8, 0, 0},
     {10020, 7, 5, 2},
@@ -116,6 +117,7 @@ static const cuNVRTCcompute Toolkit2MaxCompute[] = {
 // clang-format off
 static const ToolkitDriverVersions
     CudaToDriverVersion[] = {
+        {11020, 460.27f, 460.89f},
         {11010, 455.23f, 456.38f},
         {11000, 450.51f, 451.48f},
         {10020, 440.33f, 441.22f},


### PR DESCRIPTION
Changes to Users
----------------
Developers trying to build using CUDA 11 wouldn't have warnings when building with CUDA 11.2

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- ~[ ] Tests pass~
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
