### PR TITLE
Fix a infinite recursion bug in NaryNode JIT Node

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,9 @@ mark_as_advanced(
   AF_BUILD_FRAMEWORK
   AF_INSTALL_STANDALONE
   AF_WITH_CPUID
+  Boost_INCLUDE_DIR
   CUDA_HOST_COMPILER
+  CUDA_SDK_ROOT_DIR
   CUDA_USE_STATIC_CUDA_RUNTIME
   CUDA_rt_LIBRARY
   SPDLOG_BUILD_EXAMPLES
@@ -115,7 +117,9 @@ mark_as_advanced(
   ADDR2LINE_PROGRAM
   Backtrace_LIBRARY
   AF_WITH_STATIC_MKL
+  GIT
   )
+mark_as_advanced(CLEAR CUDA_VERSION)
 
 #Configure forge submodule
 #forge is included in ALL target if AF_BUILD_FORGE is ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, ArrayFire
+# Copyright (c) 2021, ArrayFire
 # All rights reserved.
 #
 # This file is distributed under 3-clause BSD license.
@@ -7,7 +7,7 @@
 
 cmake_minimum_required(VERSION 3.5)
 
-project(ArrayFire VERSION 3.8.0 LANGUAGES C CXX)
+project(ArrayFire VERSION 3.9.0 LANGUAGES C CXX)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 

--- a/CMakeModules/FindMKL.cmake
+++ b/CMakeModules/FindMKL.cmake
@@ -265,8 +265,8 @@ function(find_mkl_library)
         if (CMAKE_VERSION VERSION_GREATER 3.14)
           message(VERBOSE "MKL_${mkl_args_NAME}_STATIC_LINK_LIBRARY: ${MKL_${mkl_args_NAME}_STATIC_LINK_LIBRARY}")
         endif()
-        mark_as_advanced(MKL_${mkl_args_NAME}_STATIC_LINK_LIBRARY)
       endif()
+      mark_as_advanced(MKL_${mkl_args_NAME}_STATIC_LINK_LIBRARY)
     endif()
 
     set_target_properties(MKL::${mkl_args_NAME}

--- a/CMakeModules/FindcuDNN.cmake
+++ b/CMakeModules/FindcuDNN.cmake
@@ -151,6 +151,7 @@ if(cuDNN_INCLUDE_DIRS)
         ${CMAKE_INSTALL_PREFIX}
       PATH_SUFFIXES lib lib64 bin lib/x64 bin/x64
       DOC "cudnn${cudnn_lib_name_infix} link library." )
+    mark_as_advanced(cuDNN${LIB_INFIX}_LINK_LIBRARY)
 
     if(WIN32 AND cuDNN_LINK_LIBRARY)
       find_file(cuDNN${LIB_INFIX}_DLL_LIBRARY

--- a/src/api/c/CMakeLists.txt
+++ b/src/api/c/CMakeLists.txt
@@ -105,6 +105,8 @@ target_sources(c_api_interface
     ${CMAKE_CURRENT_SOURCE_DIR}/index.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/internal.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/inverse.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/jit_test_api.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/jit_test_api.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/join.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lu.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/match_template.cpp

--- a/src/api/c/jit_test_api.cpp
+++ b/src/api/c/jit_test_api.cpp
@@ -1,0 +1,28 @@
+/*******************************************************
+ * Copyright (c) 2021, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <jit_test_api.h>
+
+#include <backend.hpp>
+#include <common/err_common.hpp>
+#include <platform.hpp>
+
+af_err af_get_max_jit_len(int *jitLen) {
+    *jitLen = detail::getMaxJitSize();
+    return AF_SUCCESS;
+}
+
+af_err af_set_max_jit_len(const int maxJitLen) {
+    try {
+        ARG_ASSERT(1, maxJitLen > 0);
+        detail::getMaxJitSize() = maxJitLen;
+    }
+    CATCHALL;
+    return AF_SUCCESS;
+}

--- a/src/api/c/jit_test_api.h
+++ b/src/api/c/jit_test_api.h
@@ -1,0 +1,51 @@
+/*******************************************************
+ * Copyright (c) 2021, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <af/defines.h>
+
+#ifdef __cplusplus
+namespace af {
+/// Get the maximum jit tree length for active backend
+///
+/// \returns the maximum length of jit tree from root to any leaf
+AFAPI int getMaxJitLen(void);
+
+/// Set the maximum jit tree length for active backend
+///
+/// \param[in] jit_len is the maximum length of jit tree from root to any
+/// leaf
+AFAPI void setMaxJitLen(const int jitLen);
+}  // namespace af
+#endif  //__cplusplus
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Get the maximum jit tree length for active backend
+///
+/// \param[out] jit_len is the maximum length of jit tree from root to any
+/// leaf
+///
+/// \returns Always returns AF_SUCCESS
+AFAPI af_err af_get_max_jit_len(int *jit_len);
+
+/// Set the maximum jit tree length for active backend
+///
+/// \param[in] jit_len is the maximum length of jit tree from root to any
+/// leaf
+///
+/// \returns Always returns AF_SUCCESS
+AFAPI af_err af_set_max_jit_len(const int jit_len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/api/cpp/CMakeLists.txt
+++ b/src/api/cpp/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(cpp_api_interface
     ${CMAKE_CURRENT_SOURCE_DIR}/imageio.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/index.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/internal.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/jit_test_api.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lapack.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/matchTemplate.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/mean.cpp

--- a/src/api/cpp/jit_test_api.cpp
+++ b/src/api/cpp/jit_test_api.cpp
@@ -1,0 +1,21 @@
+/*******************************************************
+ * Copyright (c) 2021, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <jit_test_api.h>
+#include "error.hpp"
+
+namespace af {
+int getMaxJitLen(void) {
+    int retVal = 0;
+    AF_THROW(af_get_max_jit_len(&retVal));
+    return retVal;
+}
+
+void setMaxJitLen(const int jitLen) { AF_THROW(af_set_max_jit_len(jitLen)); }
+}  // namespace af

--- a/src/api/unified/CMakeLists.txt
+++ b/src/api/unified/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(af
     ${CMAKE_CURRENT_SOURCE_DIR}/image.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/index.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/internal.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/jit_test_api.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/lapack.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/memory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ml.cpp

--- a/src/api/unified/jit_test_api.cpp
+++ b/src/api/unified/jit_test_api.cpp
@@ -1,0 +1,18 @@
+/*******************************************************
+ * Copyright (c) 2021, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <jit_test_api.h>
+
+#include "symbol_manager.hpp"
+
+af_err af_get_max_jit_len(int *jitLen) { CALL(af_get_max_jit_len, jitLen); }
+
+af_err af_set_max_jit_len(const int jitLen) {
+    CALL(af_set_max_jit_len, jitLen);
+}

--- a/src/backend/common/jit/NaryNode.hpp
+++ b/src/backend/common/jit/NaryNode.hpp
@@ -98,8 +98,7 @@ common::Node_ptr createNaryNode(
 
     common::Node_ptr ptr = createNode(childNodes);
 
-    switch (static_cast<kJITHeuristics>(
-        detail::passesJitHeuristics<Ti>(ptr.get()))) {
+    switch (detail::passesJitHeuristics<Ti>(ptr.get())) {
         case kJITHeuristics::Pass: {
             return ptr;
         }
@@ -113,7 +112,6 @@ common::Node_ptr createNaryNode(
                     max_height       = childNodes[i]->getHeight();
                 }
             }
-
             children[max_height_index]->eval();
             return createNaryNode<Ti, N>(odims, createNode, move(children));
         }

--- a/src/backend/cpu/Array.cpp
+++ b/src/backend/cpu/Array.cpp
@@ -248,7 +248,7 @@ Array<T> createEmptyArray(const dim4 &dims) {
 template<typename T>
 kJITHeuristics passesJitHeuristics(Node *root_node) {
     if (!evalFlag()) { return kJITHeuristics::Pass; }
-    if (root_node->getHeight() >= static_cast<int>(getMaxJitSize())) {
+    if (root_node->getHeight() > static_cast<int>(getMaxJitSize())) {
         return kJITHeuristics::TreeHeight;
     }
 

--- a/src/backend/cpu/platform.cpp
+++ b/src/backend/cpu/platform.cpp
@@ -104,14 +104,14 @@ void devprop(char* d_name, char* d_platform, char* d_toolkit, char* d_compute) {
     snprintf(d_compute, 10, "%s", "0.0");
 }
 
-unsigned getMaxJitSize() {
-    const int MAX_JIT_LEN = 100;
-
-    thread_local int length = 0;
-    if (length == 0) {
+int& getMaxJitSize() {
+    constexpr int MAX_JIT_LEN = 100;
+    thread_local int length   = 0;
+    if (length <= 0) {
         string env_var = getEnvVar("AF_CPU_MAX_JIT_LEN");
         if (!env_var.empty()) {
-            length = stoi(env_var);
+            int input_len = std::stoi(env_var);
+            length        = input_len > 0 ? input_len : MAX_JIT_LEN;
         } else {
             length = MAX_JIT_LEN;
         }

--- a/src/backend/cpu/platform.hpp
+++ b/src/backend/cpu/platform.hpp
@@ -36,7 +36,7 @@ bool isHalfSupported(int device);
 
 void devprop(char* d_name, char* d_platform, char* d_toolkit, char* d_compute);
 
-unsigned getMaxJitSize();
+int& getMaxJitSize();
 
 int getDeviceCount();
 

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -254,7 +254,7 @@ Node_ptr Array<T>::getNode() const {
 template<typename T>
 kJITHeuristics passesJitHeuristics(Node *root_node) {
     if (!evalFlag()) { return kJITHeuristics::Pass; }
-    if (root_node->getHeight() >= static_cast<int>(getMaxJitSize())) {
+    if (root_node->getHeight() > static_cast<int>(getMaxJitSize())) {
         return kJITHeuristics::TreeHeight;
     }
 

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -325,14 +325,14 @@ string getCUDARuntimeVersion() noexcept {
     }
 }
 
-unsigned getMaxJitSize() {
-    const int MAX_JIT_LEN = 100;
-
-    thread_local int length = 0;
-    if (length == 0) {
+int &getMaxJitSize() {
+    constexpr int MAX_JIT_LEN = 100;
+    thread_local int length   = 0;
+    if (length <= 0) {
         std::string env_var = getEnvVar("AF_CUDA_MAX_JIT_LEN");
         if (!env_var.empty()) {
-            length = std::stoi(env_var);
+            int input_len = std::stoi(env_var);
+            length        = input_len > 0 ? input_len : MAX_JIT_LEN;
         } else {
             length = MAX_JIT_LEN;
         }

--- a/src/backend/cuda/platform.hpp
+++ b/src/backend/cuda/platform.hpp
@@ -76,7 +76,7 @@ bool isHalfSupported(int device);
 
 void devprop(char* d_name, char* d_platform, char* d_toolkit, char* d_compute);
 
-unsigned getMaxJitSize();
+int& getMaxJitSize();
 
 int getDeviceCount();
 

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -293,7 +293,7 @@ Node_ptr Array<T>::getNode() const {
 template<typename T>
 kJITHeuristics passesJitHeuristics(Node *root_node) {
     if (!evalFlag()) { return kJITHeuristics::Pass; }
-    if (root_node->getHeight() >= static_cast<int>(getMaxJitSize())) {
+    if (root_node->getHeight() > static_cast<int>(getMaxJitSize())) {
         return kJITHeuristics::TreeHeight;
     }
 

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -571,18 +571,18 @@ bool synchronize_calls() {
     return sync;
 }
 
-unsigned getMaxJitSize() {
+int& getMaxJitSize() {
 #if defined(OS_MAC)
-    const int MAX_JIT_LEN = 50;
+    constexpr int MAX_JIT_LEN = 50;
 #else
-    const int MAX_JIT_LEN = 100;
+    constexpr int MAX_JIT_LEN = 100;
 #endif
-
     thread_local int length = 0;
-    if (length == 0) {
+    if (length <= 0) {
         string env_var = getEnvVar("AF_OPENCL_MAX_JIT_LEN");
         if (!env_var.empty()) {
-            length = stoi(env_var);
+            int input_len = std::stoi(env_var);
+            length        = input_len > 0 ? input_len : MAX_JIT_LEN;
         } else {
             length = MAX_JIT_LEN;
         }

--- a/src/backend/opencl/platform.hpp
+++ b/src/backend/opencl/platform.hpp
@@ -57,7 +57,7 @@ int getDeviceCount() noexcept;
 
 unsigned getActiveDeviceId();
 
-unsigned getMaxJitSize();
+int& getMaxJitSize();
 
 const cl::Context& getContext();
 

--- a/src/backend/opencl/select.cpp
+++ b/src/backend/opencl/select.cpp
@@ -29,56 +29,59 @@ namespace opencl {
 template<typename T>
 Array<T> createSelectNode(const Array<char> &cond, const Array<T> &a,
                           const Array<T> &b, const dim4 &odims) {
-    auto cond_node = cond.getNode();
-    auto a_node    = a.getNode();
-    auto b_node    = b.getNode();
-    int height     = max(a_node->getHeight(), b_node->getHeight());
-    height         = max(height, cond_node->getHeight()) + 1;
-    auto node      = make_shared<NaryNode>(NaryNode(
+    auto cond_node   = cond.getNode();
+    auto a_node      = a.getNode();
+    auto b_node      = b.getNode();
+    auto a_height    = a_node->getHeight();
+    auto b_height    = b_node->getHeight();
+    auto cond_height = cond_node->getHeight();
+    const int height = max(max(a_height, b_height), cond_height) + 1;
+
+    auto node = make_shared<NaryNode>(NaryNode(
         static_cast<af::dtype>(dtype_traits<T>::af_type), "__select", 3,
         {{cond_node, a_node, b_node}}, static_cast<int>(af_select_t), height));
 
-    if (detail::passesJitHeuristics<T>(node.get()) == kJITHeuristics::Pass) {
-        return createNodeArray<T>(odims, node);
-    } else {
-        if (a_node->getHeight() >
-            max(b_node->getHeight(), cond_node->getHeight())) {
+    if (detail::passesJitHeuristics<T>(node.get()) != kJITHeuristics::Pass) {
+        if (a_height > max(b_height, cond_height)) {
             a.eval();
-        } else if (b_node->getHeight() > cond_node->getHeight()) {
+        } else if (b_height > cond_height) {
             b.eval();
         } else {
             cond.eval();
         }
         return createSelectNode<T>(cond, a, b, odims);
     }
+    return createNodeArray<T>(odims, node);
 }
 
 template<typename T, bool flip>
 Array<T> createSelectNode(const Array<char> &cond, const Array<T> &a,
                           const double &b_val, const dim4 &odims) {
-    auto cond_node = cond.getNode();
-    auto a_node    = a.getNode();
-    Array<T> b     = createScalarNode<T>(odims, scalar<T>(b_val));
-    auto b_node    = b.getNode();
-    int height     = max(a_node->getHeight(), b_node->getHeight());
-    height         = max(height, cond_node->getHeight()) + 1;
+    auto cond_node   = cond.getNode();
+    auto a_node      = a.getNode();
+    Array<T> b       = createScalarNode<T>(odims, scalar<T>(b_val));
+    auto b_node      = b.getNode();
+    auto a_height    = a_node->getHeight();
+    auto b_height    = b_node->getHeight();
+    auto cond_height = cond_node->getHeight();
+    const int height = max(max(a_height, b_height), cond_height) + 1;
 
     auto node = make_shared<NaryNode>(NaryNode(
         static_cast<af::dtype>(dtype_traits<T>::af_type),
         (flip ? "__not_select" : "__select"), 3, {{cond_node, a_node, b_node}},
         static_cast<int>(flip ? af_not_select_t : af_select_t), height));
 
-    if (detail::passesJitHeuristics<T>(node.get()) == kJITHeuristics::Pass) {
-        return createNodeArray<T>(odims, node);
-    } else {
-        if (a_node->getHeight() >
-            max(b_node->getHeight(), cond_node->getHeight())) {
+    if (detail::passesJitHeuristics<T>(node.get()) != kJITHeuristics::Pass) {
+        if (a_height > max(b_height, cond_height)) {
             a.eval();
+        } else if (b_height > cond_height) {
+            b.eval();
         } else {
             cond.eval();
         }
         return createSelectNode<T, flip>(cond, a, b_val, odims);
     }
+    return createNodeArray<T>(odims, node);
 }
 
 template<typename T>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -450,3 +450,5 @@ elseif(AF_BUILD_CUDA)
 elseif(AF_BUILD_CPU)
   target_link_libraries(print_info ArrayFire::afcpu)
 endif()
+
+make_test(SRC jit_test_api.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -40,6 +40,8 @@ if(NOT TARGET gtest)
   # Hide gtest project variables
   mark_as_advanced(
     BUILD_SHARED_LIBS
+    BUILD_GMOCK
+    INSTALL_GTEST
     gmock_build_tests
     gtest_build_samples
     gtest_build_tests

--- a/test/jit_test_api.cpp
+++ b/test/jit_test_api.cpp
@@ -1,0 +1,34 @@
+/*******************************************************
+ * Copyright (c) 2021, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <gtest/gtest.h>
+#include <testHelpers.hpp>
+#include <af/data.h>
+
+namespace af {
+int getMaxJitLen(void);
+
+void setMaxJitLen(const int jitLen);
+}  // namespace af
+
+TEST(JIT, UnitMaxHeight) {
+    const int oldMaxJitLen = af::getMaxJitLen();
+    af::setMaxJitLen(1);
+    af::array a = af::constant(1, 10);
+    af::array b = af::constant(2, 10);
+    af::array c = a * b;
+    af::array d = b * c;
+    c.eval();
+    d.eval();
+    af::setMaxJitLen(oldMaxJitLen);
+}
+
+TEST(JIT, ZeroMaxHeight) {
+    EXPECT_THROW({ af::setMaxJitLen(0); }, af::exception);
+}


### PR DESCRIPTION
Description
-----------
When the maximum JIT tree height is two, createNaryNode goes into
infinite recursion due to missing base case check inside the function.
Fixes: #3065 

Changes to Users
----------------
Fixes the infinite recursion bug when maximum jit length is set to 2.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
