### PR TITLE
Fix const array indexing inside gfor

### DIFF
--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -732,22 +732,6 @@ array::array_proxy::operator array() const {
     AF_THROW(af_index_gen(&tmp, arr, AF_MAX_DIMS, impl->indices_));
     if (impl->is_linear_) { AF_THROW(af_release_array(arr)); }
 
-    return array(tmp);
-}
-
-array::array_proxy::operator array() {
-    af_array tmp = nullptr;
-    af_array arr = nullptr;
-
-    if (impl->is_linear_) {
-        AF_THROW(af_flat(&arr, impl->parent_->get()));
-    } else {
-        arr = impl->parent_->get();
-    }
-
-    AF_THROW(af_index_gen(&tmp, arr, AF_MAX_DIMS, impl->indices_));
-    if (impl->is_linear_) { AF_THROW(af_release_array(arr)); }
-
     int dim = gforDim(impl->indices_);
     if (tmp && dim >= 0) {
         arr = gforReorder(tmp, dim);
@@ -757,6 +741,10 @@ array::array_proxy::operator array() {
     }
 
     return array(arr);
+}
+
+array::array_proxy::operator array() {
+    return const_cast<const array::array_proxy *>(this)->operator array();
 }
 
 #define MEM_INDEX(FUNC_SIG, USAGE)                                \

--- a/test/gfor.cpp
+++ b/test/gfor.cpp
@@ -20,8 +20,10 @@ using af::array;
 using af::cdouble;
 using af::cfloat;
 using af::constant;
+using af::dim4;
 using af::freeHost;
 using af::gforSet;
+using af::iota;
 using af::randu;
 using af::seq;
 using af::span;
@@ -542,4 +544,23 @@ TEST(GFOR, MatmulLoopWithNonUnitIncrSeq) {
         C(span, span, ii) = matmul(A(span, span, ii), B);
     }
     ASSERT_ARRAYS_NEAR(C, G, 1E-03);
+}
+
+TEST(GFOR, ConstArrayIndexing) {
+    const std::size_t dim = 4;
+
+    array m        = iota(dim4(1, dim), dim4(dim));
+    const array cm = iota(dim4(1, dim), dim4(dim));
+
+    array out_cm(dim), out_m(dim);
+
+    EXPECT_NO_THROW({
+        gfor(seq i, static_cast<double>(dim)) {
+            out_cm(i) = af::sum(cm(span,i) * cm(span,i));
+}
+});
+gfor(seq i, static_cast<double>(dim)) {
+    out_m(i) = af::sum(m(span, i) * m(span, i));
+}
+ASSERT_ARRAYS_EQ(out_cm, out_m);
 }


### PR DESCRIPTION
Description
-----------
Indexing a const array inside GFOR produced results which aren't identical to results generated from indexing a non-const array. 
Fixes: #3073 

Changes to Users
----------------
Identical behavior when indexing const vs non-const array inside gfor.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass - `test_inverse_dense_opencl` seems to fail after this change, looking into it why, although the specific failing test seems to run fine if run via filter argument to the test program.
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
