### PR TITLE
Fix cmake arguments for external projects for msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,15 +9,6 @@ cmake_minimum_required(VERSION 3.5)
 
 project(ArrayFire VERSION 3.8.0 LANGUAGES C CXX)
 
-if(NOT CMAKE_VERSION VERSION_LESS 3.9)
-  get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
-elseif(CMAKE_CONFIGURATION_TYPES)
-  # CMAKE_CONFIGURATION_TYPES is set by project() call
-  set(isMultiConfig True)
-else()
-  set(isMultiConfig False)
-endif()
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
 include(config_ccache)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,15 @@ cmake_minimum_required(VERSION 3.5)
 
 project(ArrayFire VERSION 3.8.0 LANGUAGES C CXX)
 
+if(NOT CMAKE_VERSION VERSION_LESS 3.9)
+  get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+elseif(CMAKE_CONFIGURATION_TYPES)
+  # CMAKE_CONFIGURATION_TYPES is set by project() call
+  set(isMultiConfig True)
+else()
+  set(isMultiConfig False)
+endif()
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
 include(config_ccache)

--- a/CMakeModules/AFBuildConfigurations.cmake
+++ b/CMakeModules/AFBuildConfigurations.cmake
@@ -2,15 +2,15 @@
 # or single-config generator. Before 3.9, the defintion of CMAKE_CONFIGURATION_TYPES
 # variable indicated multi-config, but developers might modify.
 if(NOT CMAKE_VERSION VERSION_LESS 3.9)
-  get_property(_isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 elseif(CMAKE_CONFIGURATION_TYPES)
   # CMAKE_CONFIGURATION_TYPES is set by project() call for multi-config generators
-  set(_isMultiConfig True)
+  set(isMultiConfig True)
 else()
-  set(_isMultiConfig False)
+  set(isMultiConfig False)
 endif()
 
-if(_isMultiConfig)
+if(isMultiConfig)
   set(CMAKE_CONFIGURATION_TYPES
     "Coverage;Debug;MinSizeRel;Release;RelWithDebInfo"
     CACHE STRING "Configurations for Multi-Config CMake Generator" FORCE)

--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -6,22 +6,27 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 include(ExternalProject)
-
 find_program(GIT git)
 
 set(prefix ${PROJECT_BINARY_DIR}/third_party/CLBlast)
 set(CLBlast_location ${prefix}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}clblast${CMAKE_STATIC_LIBRARY_SUFFIX})
 
+set(extproj_gen_opts "-G${CMAKE_GENERATOR}")
 if(WIN32 AND CMAKE_GENERATOR_PLATFORM AND NOT CMAKE_GENERATOR MATCHES "Ninja")
-  set(extproj_gen_opts "-G${CMAKE_GENERATOR}" "-A${CMAKE_GENERATOR_PLATFORM}")
-else()
-  set(extproj_gen_opts "-G${CMAKE_GENERATOR}")
+  list(APPEND extproj_gen_opts "-A${CMAKE_GENERATOR_PLATFORM}")
+  if(CMAKE_GENERATOR_TOOLSET)
+    list(APPEND extproj_gen_opts "-T${CMAKE_GENERATOR_TOOLSET}")
+  endif()
 endif()
 
-if("${CMAKE_BUILD_TYPE}" MATCHES "Release|RelWithDebInfo")
-  set(extproj_build_type "Release")
-else()
-  set(extproj_build_type ${CMAKE_BUILD_TYPE})
+set(extproj_build_type_option "")
+if(NOT isMultiConfig)
+  if("${CMAKE_BUILD_TYPE}" MATCHES "Release|RelWithDebInfo")
+    set(extproj_build_type "Release")
+  else()
+    set(extproj_build_type ${CMAKE_BUILD_TYPE})
+  endif()
+  set(extproj_build_type_option "-DCMAKE_BUILD_TYPE:STRING=${extproj_build_type}")
 endif()
 
 ExternalProject_Add(
@@ -40,7 +45,7 @@ ExternalProject_Add(
       -DOVERRIDE_MSVC_FLAGS_TO_MT:BOOL=OFF
       -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
       "-DCMAKE_C_FLAGS:STRING=${CMAKE_C_FLAGS} -w -fPIC"
-      -DCMAKE_BUILD_TYPE:STRING=${extproj_build_type}
+      ${extproj_build_type_option}
       -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
       -DCMAKE_INSTALL_LIBDIR:PATH=lib
       -DBUILD_SHARED_LIBS:BOOL=OFF


### PR DESCRIPTION
Without the additional toolset argument being forwarded to msvc
toolchain, cmake/msvc is free to choose a toolset as per their
respective logic. This causes build issues.

Also fixed some conditions that are based on CMakeBuildType variable -
not recommended to use checks based on that variable and often resulted
in issues when used with untested multi-config generators.


Changes to Users
----------------
None unless it is an user building ArrayFire on Windows platform.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
