### PR TITLE
Fix ocl mem regression

### DIFF
--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -120,8 +120,9 @@ template<typename T>
 Array<T>::Array(const dim4 &dims, cl_mem mem, size_t src_offset, bool copy)
     : info(getActiveDeviceId(), dims, 0, calcStrides(dims),
            static_cast<af_dtype>(dtype_traits<T>::af_type))
-    , data(copy ? memAlloc<T>(info.elements()).release() : new Buffer(mem),
-           bufferFree)
+    , data(
+          copy ? memAlloc<T>(info.elements()).release() : new Buffer(mem, true),
+          bufferFree)
     , data_dims(dims)
     , node(bufferNodePtr<T>())
     , ready(true)

--- a/src/backend/opencl/Kernel.hpp
+++ b/src/backend/opencl/Kernel.hpp
@@ -19,7 +19,7 @@ namespace opencl {
 struct Enqueuer {
     template<typename... Args>
     void operator()(cl::Kernel ker, const cl::EnqueueArgs& qArgs,
-                    Args... args) {
+                    Args&&... args) {
         auto launchOp = cl::KernelFunctor<Args...>(ker);
         launchOp(qArgs, std::forward<Args>(args)...);
     }


### PR DESCRIPTION
Originally reported via rust wrapper https://github.com/arrayfire/arrayfire-rust/issues/282

Description
-----------
Fixes a double free regression in OpenCL backend. This happens particularly when ArrayFire is used in interop mode with custom kernels.

Changes to Users
----------------
None in terms of code but fixes a bug in terms of OpenCL interop behavior.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
