### PR TITLE
Fix for CUDA 11 nvrtc-builtins shared lib packaging

### DIFF
--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -843,7 +843,7 @@ if(AF_INSTALL_STANDALONE)
 	  afcu_collect_cudnn_libs(ops_train)
 	endif()
   endif()
-  afcu_collect_libs(nvrtc FULL_VERSION)
+
   if(WIN32)
 	if(CUDA_VERSION_MAJOR VERSION_EQUAL 11)
       afcu_collect_libs(cufft LIB_MAJOR 10 LIB_MINOR 4)
@@ -860,22 +860,27 @@ if(AF_INSTALL_STANDALONE)
     afcu_collect_libs(cusolver)
   endif()
 
-  if(APPLE)
-    afcu_collect_libs(cudart)
-
-    get_filename_component(nvrtc_outpath "${dlib_path_prefix}/${PX}nvrtc-builtins.${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR}${SX}" REALPATH)
-    install(FILES       ${nvrtc_outpath}
-            DESTINATION ${AF_INSTALL_BIN_DIR}
-            RENAME      "${PX}nvrtc-builtins${SX}"
-            COMPONENT   cuda_dependencies)
-  elseif(UNIX)
-    get_filename_component(nvrtc_outpath "${dlib_path_prefix}/${PX}nvrtc-builtins${SX}" REALPATH)
-    install(FILES       ${nvrtc_outpath}
-            DESTINATION ${AF_INSTALL_LIB_DIR}
-            RENAME      "${PX}nvrtc-builtins${SX}"
-            COMPONENT   cuda_dependencies)
+  afcu_collect_libs(nvrtc FULL_VERSION)
+  if(CUDA_VERSION VERSION_GREATER 10.0)
+    afcu_collect_libs(nvrtc-builtins FULL_VERSION)
   else()
-    afcu_collect_libs(nvrtc-builtins)
+    if(APPLE)
+      afcu_collect_libs(cudart)
+
+      get_filename_component(nvrtc_outpath "${dlib_path_prefix}/${PX}nvrtc-builtins.${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR}${SX}" REALPATH)
+      install(FILES       ${nvrtc_outpath}
+              DESTINATION ${AF_INSTALL_BIN_DIR}
+              RENAME      "${PX}nvrtc-builtins${SX}"
+              COMPONENT   cuda_dependencies)
+    elseif(UNIX)
+      get_filename_component(nvrtc_outpath "${dlib_path_prefix}/${PX}nvrtc-builtins${SX}" REALPATH)
+      install(FILES       ${nvrtc_outpath}
+              DESTINATION ${AF_INSTALL_LIB_DIR}
+              RENAME      "${PX}nvrtc-builtins${SX}"
+              COMPONENT   cuda_dependencies)
+    else()
+      afcu_collect_libs(nvrtc-builtins)
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
Description
-----------
Linux Installer `.sh` needs fixing. As without this change, the current Linux Installer on our website is causing `libnvrtc-buitins.so.11.1` not found error when used with CUDA 11.2 runtime. I have verified this by using our current installer on a 11.2 runtime docker container. Issue was found via #3101 .

Prior to CUDA 11, I think the `nvrtc` shared library on Linux wasn't using any version suffixes to lookup for `nvrtc-builtins` shared library. This seems to have changed in CUDA 11(not sure if it changed right from 11.0 or not).

Changes to Users
------------------------
Users likely needs to reinstall 3.8 again on Linux.

A rename of `libnvrtc-builtins.so`(provided by ArrayFire Installation, not system one) to `libnvrtc-builtins.so.11.1` on user's system is the current work around until a fixed installer is uploaded.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
