### PR TITLE
Fix glad add_subdirectory to fix out of tree builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,7 +193,7 @@ if(NOT LAPACK_FOUND)
     endif()
 endif()
 
-add_subdirectory(${${glad_prefix}_SOURCE_DIR})
+add_subdirectory(${${glad_prefix}_SOURCE_DIR} ${${glad_prefix}_BINARY_DIR})
 
 add_subdirectory(src/backend/common)
 add_subdirectory(src/api/c)


### PR DESCRIPTION
This was a problem on the arrayfire-benchmark repo where the repository
is built as a subproject

Description
-----------
Add the binary directory to the add_subdirectory command that adds the glad repository.
This was causing errors with the arrayfire-benchmark repository when building master.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
