### PR TITLE
Fix deps cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,21 +351,31 @@ install(FILES ${ArrayFire_BINARY_DIR}/cmake/install/ArrayFireConfig.cmake
 
 if((AF_CPU_WITH_MKL OR AF_OPENCL_WITH_MKL) AND AF_INSTALL_STANDALONE)
   if(TARGET MKL::ThreadingLibrary)
+    get_filename_component(mkl_tl ${MKL_ThreadingLibrary_LINK_LIBRARY} REALPATH)
     install(FILES
       $<TARGET_FILE:MKL::ThreadingLibrary>
+      ${mkl_tl}
       DESTINATION ${AF_INSTALL_LIB_DIR}
       COMPONENT mkl_dependencies)
   endif()
 
   if(NOT AF_WITH_STATIC_MKL AND TARGET MKL::Shared)
     if(NOT WIN32)
+      get_filename_component(mkl_int ${MKL_Interface_LINK_LIBRARY} REALPATH)
       install(FILES
         $<TARGET_FILE:MKL::Interface>
+        ${mkl_int}
         DESTINATION ${AF_INSTALL_LIB_DIR}
         COMPONENT mkl_dependencies)
     endif()
 
+    get_filename_component(mkl_rnt ${MKL_RT_LINK_LIBRARY} REALPATH)
+    get_filename_component(mkl_shd ${MKL_Core_LINK_LIBRARY} REALPATH)
+    get_filename_component(mkl_tly ${MKL_ThreadLayer_LINK_LIBRARY} REALPATH)
     install(FILES
+      ${mkl_rnt}
+      ${mkl_shd}
+      ${mkl_tly}
       $<TARGET_FILE:MKL::RT>
       $<TARGET_FILE:MKL::Shared>
       $<TARGET_FILE:MKL::ThreadLayer>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,8 @@ option(AF_WITH_LOGGING  "Build ArrayFire with logging support" ON)
 option(AF_WITH_STACKTRACE  "Add stacktraces to the error messages." ON)
 option(AF_CACHE_KERNELS_TO_DISK "Enable caching kernels to disk" ON)
 option(AF_WITH_STATIC_MKL "Link against static Intel MKL libraries" OFF)
+option(AF_CPU_WITH_MKL "Use MKL for CPU backend" ${MKL_FOUND})
+option(AF_OPENCL_WITH_MKL "Use MKL for OpenCL backend" ${MKL_FOUND})
 
 if(WIN32)
   set(AF_STACKTRACE_TYPE "Windbg" CACHE STRING "The type of backtrace features. Windbg(simple), None")
@@ -347,7 +349,7 @@ install(FILES ${ArrayFire_BINARY_DIR}/cmake/install/ArrayFireConfig.cmake
               DESTINATION ${AF_INSTALL_CMAKE_DIR}
               COMPONENT cmake)
 
-if((USE_CPU_MKL OR USE_OPENCL_MKL) AND AF_INSTALL_STANDALONE)
+if((AF_CPU_WITH_MKL OR AF_OPENCL_WITH_MKL) AND AF_INSTALL_STANDALONE)
   if(TARGET MKL::ThreadingLibrary)
     install(FILES
       $<TARGET_FILE:MKL::ThreadingLibrary>

--- a/CMakeModules/FindMKL.cmake
+++ b/CMakeModules/FindMKL.cmake
@@ -393,6 +393,12 @@ if(NOT WIN32)
   mark_as_advanced(M_LIB)
 endif()
 
+if(TARGET MKL::RT)
+  set_target_properties(MKL::RT
+  PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${MKL_INCLUDE_DIR};${MKL_FFTW_INCLUDE_DIR}")
+endif()
+
 if(MKL_Shared_FOUND AND NOT TARGET MKL::Shared)
   add_library(MKL::Shared SHARED IMPORTED)
   if(MKL_THREAD_LAYER STREQUAL "Sequential")

--- a/CMakeModules/FindMKL.cmake
+++ b/CMakeModules/FindMKL.cmake
@@ -461,3 +461,8 @@ if(MKL_Static_FOUND AND NOT TARGET MKL::Static)
     endif()
   endif()
 endif()
+
+set(MKL_FOUND OFF)
+if(MKL_Shared_FOUND OR MKL_Static_FOUND)
+  set(MKL_FOUND ON)
+endif()

--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -8,7 +8,7 @@
 FetchContent_Declare(
   ${clblast_prefix}
   GIT_REPOSITORY    https://github.com/cnugteren/CLBlast.git
-  GIT_TAG           41f344d1a6f2d149bba02a6615292e99b50f4856
+  GIT_TAG           1.5.2
 )
 af_dep_check_and_populate(${clblast_prefix})
 

--- a/src/api/c/CMakeLists.txt
+++ b/src/api/c/CMakeLists.txt
@@ -184,7 +184,7 @@ if(FreeImage_FOUND AND AF_WITH_IMAGEIO)
   endif ()
 endif()
 
-if(USE_CPU_MKL OR USE_OPENCL_MKL)
+if(AF_CPU_WITH_MKL OR AF_OPENCL_WITH_MKL)
   target_compile_definitions(c_api_interface
     INTERFACE
       AF_MKL_INTERFACE_SIZE=${MKL_INTERFACE_INTEGER_SIZE}

--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -304,7 +304,7 @@ target_compile_definitions(afcpu
     AF_CPU
   )
 
-if(USE_CPU_MKL)
+if(AF_CPU_WITH_MKL)
   dependency_check(MKL_Shared_FOUND "MKL not found")
   target_compile_definitions(afcpu PRIVATE USE_MKL)
   target_link_libraries(afcpu
@@ -345,10 +345,8 @@ else()
   endif()
 endif()
 
-if(LAPACK_FOUND OR (USE_CPU_MKL AND MKL_Shared_FOUND))
-  target_compile_definitions(afcpu
-    PRIVATE
-      WITH_LINEAR_ALGEBRA)
+if(LAPACK_FOUND OR AF_CPU_WITH_MKL)
+  target_compile_definitions(afcpu PRIVATE WITH_LINEAR_ALGEBRA)
 endif()
 
 af_split_debug_info(afcpu ${AF_INSTALL_LIB_DIR})

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -429,7 +429,7 @@ if(APPLE)
   target_link_libraries(afopencl PRIVATE OpenGL::GL)
 endif()
 
-if(LAPACK_FOUND OR (USE_OPENCL_MKL AND MKL_Shared_FOUND))
+if(LAPACK_FOUND OR AF_OPENCL_WITH_MKL)
   target_sources(afopencl
     PRIVATE
       magma/gebrd.cpp
@@ -462,7 +462,7 @@ if(LAPACK_FOUND OR (USE_OPENCL_MKL AND MKL_Shared_FOUND))
       #magma/unmqr2.cpp
       )
 
-  if(USE_OPENCL_MKL)
+  if(AF_OPENCL_WITH_MKL)
     dependency_check(MKL_Shared_FOUND "MKL not found")
     target_compile_definitions(afopencl PRIVATE USE_MKL)
 


### PR DESCRIPTION
Description
-----------

-   Expose MKL cmake option for CPU/OpenCL backends
-   Bump up CLBlast dependency version to 1.5.2
-   Fix missing fftw include dir to MKL::RT imported target

Changes to Users
----------------
No code changes to users. These build improvements.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
