### PR TITLE
Add missing batch support check in sparse-dense arith ops

### DIFF
--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -164,6 +164,12 @@ static af_err af_arith_sparse_dense(af_array *out, const af_array lhs,
                                     const bool reverse = false) {
     try {
         const common::SparseArrayBase linfo = getSparseArrayBase(lhs);
+        if (linfo.ndims() > 2) {
+            AF_ERROR(
+                "Sparse-Dense arithmetic operations cannot be used in batch "
+                "mode",
+                AF_ERR_BATCH);
+        }
         const ArrayInfo &rinfo              = getInfo(rhs);
 
         const af_dtype otype = implicit(linfo.getType(), rinfo.getType());

--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -170,7 +170,7 @@ static af_err af_arith_sparse_dense(af_array *out, const af_array lhs,
                 "mode",
                 AF_ERR_BATCH);
         }
-        const ArrayInfo &rinfo              = getInfo(rhs);
+        const ArrayInfo &rinfo = getInfo(rhs);
 
         const af_dtype otype = implicit(linfo.getType(), rinfo.getType());
         af_array res;


### PR DESCRIPTION
Description
-----------
Fixes: #1988 

Changes to Users
----------------
Prior to this change, sparse-dense arithmetic API calls incorrectly continued with the operation where batch support was in fact not yet available. Until such support is added later, we need correctly return an appropriate error code. 

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
