### PR TITLE
oneMKL related fixes and increase CLBLast dependency version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,21 +349,31 @@ install(FILES ${ArrayFire_BINARY_DIR}/cmake/install/ArrayFireConfig.cmake
 
 if((USE_CPU_MKL OR USE_OPENCL_MKL) AND AF_INSTALL_STANDALONE)
   if(TARGET MKL::ThreadingLibrary)
+    get_filename_component(mkl_tl ${MKL_ThreadingLibrary_LINK_LIBRARY} REALPATH)
     install(FILES
       $<TARGET_FILE:MKL::ThreadingLibrary>
+      ${mkl_tl}
       DESTINATION ${AF_INSTALL_LIB_DIR}
       COMPONENT mkl_dependencies)
   endif()
 
   if(NOT AF_WITH_STATIC_MKL AND TARGET MKL::Shared)
     if(NOT WIN32)
+      get_filename_component(mkl_int ${MKL_Interface_LINK_LIBRARY} REALPATH)
       install(FILES
         $<TARGET_FILE:MKL::Interface>
+        ${mkl_int}
         DESTINATION ${AF_INSTALL_LIB_DIR}
         COMPONENT mkl_dependencies)
     endif()
 
+    get_filename_component(mkl_rnt ${MKL_RT_LINK_LIBRARY} REALPATH)
+    get_filename_component(mkl_shd ${MKL_Core_LINK_LIBRARY} REALPATH)
+    get_filename_component(mkl_tly ${MKL_ThreadLayer_LINK_LIBRARY} REALPATH)
     install(FILES
+      ${mkl_rnt}
+      ${mkl_shd}
+      ${mkl_tly}
       $<TARGET_FILE:MKL::RT>
       $<TARGET_FILE:MKL::Shared>
       $<TARGET_FILE:MKL::ThreadLayer>

--- a/CMakeModules/FindMKL.cmake
+++ b/CMakeModules/FindMKL.cmake
@@ -393,6 +393,12 @@ if(NOT WIN32)
   mark_as_advanced(M_LIB)
 endif()
 
+if(TARGET MKL::RT)
+  set_target_properties(MKL::RT
+  PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${MKL_INCLUDE_DIR};${MKL_FFTW_INCLUDE_DIR}")
+endif()
+
 if(MKL_Shared_FOUND AND NOT TARGET MKL::Shared)
   add_library(MKL::Shared SHARED IMPORTED)
   if(MKL_THREAD_LAYER STREQUAL "Sequential")

--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -8,7 +8,7 @@
 FetchContent_Declare(
   ${clblast_prefix}
   GIT_REPOSITORY    https://github.com/cnugteren/CLBlast.git
-  GIT_TAG           41f344d1a6f2d149bba02a6615292e99b50f4856
+  GIT_TAG           1.5.2
 )
 af_dep_check_and_populate(${clblast_prefix})
 


### PR DESCRIPTION
Description
-----------

-   Fix Install commands when oneMKL is used
-   Bump up CLBlast dependency version to 1.5.2
-   Fix missing fftw include dir to MKL::RT imported target

Changes to Users
----------------
No code changes to users. These build improvements.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~