### PR TITLE
CMake presets to enable faster development cmake setup

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,9 +7,11 @@
   },
   "configurePresets": [
     {
-      "name": "all-off-debug",
+      "name": "ninja-all-off-debug",
       "hidden": true,
       "description": "Base preset with all backends off with Debug build configuration",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": {
           "type": "String",
@@ -56,9 +58,7 @@
     {
       "name": "ninja-cpu-debug",
       "description": "Build CPU Backend with FFTW and a BLAS library using Ninja Generator in Debug Configuration",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Ninja",
-      "inherits": "all-off-debug",
+      "inherits": "ninja-all-off-debug",
       "cacheVariables": {
         "AF_BUILD_CPU": "ON"
       }
@@ -66,43 +66,31 @@
     {
       "name": "ninja-cpu-relwithdebinfo",
       "description": "Build CPU Backend with FFTW and a BLAS library using Ninja Generator in RelWithDebInfo Configuration",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Ninja",
-      "inherits": "all-off-debug",
+      "inherits": "ninja-cpu-debug",
       "cacheVariables": {
-        "AF_BUILD_CPU": "ON",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     },
     {
       "name": "ninja-cpu-mkl-debug",
       "description": "Build CPU Backend using Intel MKL in Debug Configuration with Ninja Generator",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Ninja",
-      "inherits": "all-off-debug",
+      "inherits": "ninja-cpu-debug",
       "cacheVariables": {
-        "AF_BUILD_CPU": "ON",
         "USE_CPU_MKL": "ON"
       }
     },
     {
       "name": "ninja-cpu-mkl-relwithdebinfo",
       "description": "Build CPU Backend using Intel MKL in RelWithDebInfo Configuration with Ninja Generator",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Ninja",
-      "inherits": "all-off-debug",
+      "inherits": "ninja-cpu-mkl-debug",
       "cacheVariables": {
-        "AF_BUILD_CPU": "ON",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "USE_CPU_MKL": "ON"
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     },
     {
       "name": "ninja-cuda-debug",
       "description": "Build CUDA Backend in debug configuration using Ninja Generator",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Ninja",
-      "inherits": "all-off-debug",
+      "inherits": "ninja-all-off-debug",
       "cacheVariables": {
         "AF_BUILD_CUDA": "ON"
       }
@@ -110,20 +98,15 @@
     {
       "name": "ninja-cuda-relwithdebinfo",
       "description": "Build CUDA Backend in RelWithDebInfo configuration using Ninja Generator",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Ninja",
-      "inherits": "all-off-debug",
+      "inherits": "ninja-cuda-debug",
       "cacheVariables": {
-        "AF_BUILD_CUDA": "ON",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     },
     {
       "name": "ninja-opencl-debug",
       "description": "Build OpenCL Backend in debug configuration using Ninja Generator",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Ninja",
-      "inherits": "all-off-debug",
+      "inherits": "ninja-all-off-debug",
       "cacheVariables": {
         "AF_BUILD_OPENCL": "ON"
       }
@@ -131,35 +114,87 @@
     {
       "name": "ninja-opencl-mkl-debug",
       "description": "Build OpenCL Backend in debug configuration using Ninja Generator",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Ninja",
-      "inherits": "all-off-debug",
+      "inherits": "ninja-opencl-debug",
       "cacheVariables": {
-        "AF_BUILD_OPENCL": "ON",
         "USE_OPENCL_MKL": "ON"
       }
     },
     {
       "name": "ninja-opencl-relwithdebinfo",
       "description": "Build OpenCL Backend in RelWithDebInfo configuration using Ninja Generator",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Ninja",
-      "inherits": "all-off-debug",
+      "inherits": "ninja-opencl-debug",
       "cacheVariables": {
-        "AF_BUILD_OPENCL": "ON",
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     },
     {
       "name": "ninja-opencl-mkl-relwithdebinfo",
       "description": "Build OpenCL Backend in RelWithDebInfo configuration using Ninja Generator. This preset uses Intel MKL for CPU fallback code.",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Ninja",
-      "inherits": "all-off-debug",
+      "inherits": "ninja-opencl-mkl-debug",
       "cacheVariables": {
-        "AF_BUILD_OPENCL": "ON",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-        "USE_OPENCL_MKL": "ON"
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+        "name": "ninja-debug",
+        "description": "Build all feasible backends using Ninja Generator in Debug Configuraiton",
+        "inherits": "ninja-all-off-debug",
+        "cacheVariables": {
+            "AF_BUILD_CPU": "ON",
+            "AF_BUILD_CUDA": "ON",
+            "AF_BUILD_OPENCL": "ON",
+            "AF_BUILD_UNIFIED": "ON"
+        }
+    },
+    {
+        "name": "ninja-mkl-debug",
+        "description": "Build all feasible backends using Ninja Generator in Debug Configuraiton",
+        "inherits": "ninja-debug",
+        "cacheVariables": {
+            "USE_CPU_MKL": "ON",
+            "USE_OPENCL_MKL": "ON"
+        }
+    },
+    {
+        "name": "ninja-relwithdebinfo",
+        "description": "Build all feasible backends using Ninja Generator in RelWithDebInfo Configuraiton",
+        "inherits": "ninja-debug",
+        "cacheVariables": {
+            "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        }
+    },
+    {
+        "name": "ninja-mkl-relwithdebinfo",
+        "description": "Build all feasible backends using Ninja Generator in RelWithDebInfo Configuraiton",
+        "inherits": "ninja-mkl-debug",
+        "cacheVariables": {
+            "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        }
+    },
+    {
+        "name": "ninja-mkl-local-install",
+        "description": "Build all feasible backends using Ninja Generator in RelWithDebInfo Configuraiton",
+        "inherits": "ninja-mkl-relwithdebinfo",
+        "cacheVariables": {
+            "BUILD_TESTING": "OFF"
+        }
+    },
+    {
+        "name": "ninja-mkl-standalone-install",
+        "description": "Build all feasible backends using Ninja Generator in RelWithDebInfo Configuraiton",
+        "inherits": "ninja-mkl-local-install",
+        "cacheVariables": {
+            "AF_INSTALL_STANDALONE": "ON"
+        }
+    },
+    {
+      "name": "ninja-docs",
+      "description": "Build ArrayFire Documentation, needs doxygen installed",
+      "inherits": "ninja-all-off-debug",
+      "cacheVariables": {
+          "BUILD_TESTING": "OFF",
+          "AF_BUILD_FORGE": "OFF",
+          "AF_BUILD_DOCS": "ON"
       }
     }
   ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -136,7 +136,7 @@
       }
     },
     {
-        "name": "ninja-debug",
+        "name": "ninja-all-debug",
         "description": "Build all feasible backends using Ninja Generator in Debug Configuraiton",
         "inherits": "ninja-all-off-debug",
         "cacheVariables": {
@@ -147,42 +147,42 @@
         }
     },
     {
-        "name": "ninja-mkl-debug",
+        "name": "ninja-all-mkl-debug",
         "description": "Build all feasible backends using Ninja Generator in Debug Configuraiton",
-        "inherits": "ninja-debug",
+        "inherits": "ninja-all-debug",
         "cacheVariables": {
             "USE_CPU_MKL": "ON",
             "USE_OPENCL_MKL": "ON"
         }
     },
     {
-        "name": "ninja-relwithdebinfo",
+        "name": "ninja-all-relwithdebinfo",
         "description": "Build all feasible backends using Ninja Generator in RelWithDebInfo Configuraiton",
-        "inherits": "ninja-debug",
+        "inherits": "ninja-all-debug",
         "cacheVariables": {
             "CMAKE_BUILD_TYPE": "RelWithDebInfo"
         }
     },
     {
-        "name": "ninja-mkl-relwithdebinfo",
+        "name": "ninja-all-mkl-relwithdebinfo",
         "description": "Build all feasible backends using Ninja Generator in RelWithDebInfo Configuraiton",
-        "inherits": "ninja-mkl-debug",
+        "inherits": "ninja-all-mkl-debug",
         "cacheVariables": {
             "CMAKE_BUILD_TYPE": "RelWithDebInfo"
         }
     },
     {
-        "name": "ninja-mkl-local-install",
+        "name": "ninja-all-mkl-local-install",
         "description": "Build all feasible backends using Ninja Generator in RelWithDebInfo Configuraiton",
-        "inherits": "ninja-mkl-relwithdebinfo",
+        "inherits": "ninja-all-mkl-relwithdebinfo",
         "cacheVariables": {
             "BUILD_TESTING": "OFF"
         }
     },
     {
-        "name": "ninja-mkl-standalone-install",
+        "name": "ninja-all-mkl-standalone-install",
         "description": "Build all feasible backends using Ninja Generator in RelWithDebInfo Configuraiton",
-        "inherits": "ninja-mkl-local-install",
+        "inherits": "ninja-all-mkl-local-install",
         "cacheVariables": {
             "AF_INSTALL_STANDALONE": "ON"
         }
@@ -196,6 +196,24 @@
           "AF_BUILD_FORGE": "OFF",
           "AF_BUILD_DOCS": "ON"
       }
+    },
+    {
+        "name": "ninja-any-debug",
+        "description": "Build available backends in Debug configuration using Ninja Generator",
+        "binaryDir": "${sourceDir}/build/${presetName}",
+        "generator": "Ninja",
+        "cacheVariables": {
+            "CMAKE_BUILD_TYPE": "Debug",
+            "CMAKE_INSTALL_PREFIX": "${sourceDir}/build/${presetName}/pkg"
+        }
+    },
+    {
+        "name": "ninja-any-relwithdebinfo",
+        "description": "Build available backends in RelWithDebInfo configuration using Ninja Generator",
+        "inherits": "ninja-any-debug",
+        "cacheVariables": {
+            "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        }
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,166 @@
+{
+  "version": 2,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 20,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "all-off-debug",
+      "hidden": true,
+      "description": "Base preset with all backends off with Debug build configuration",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "type": "String",
+          "value": "Debug"
+        },
+        "AF_BUILD_CPU": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "AF_BUILD_CUDA": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "AF_BUILD_OPENCL": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "AF_BUILD_UNIFIED": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "AF_BUILD_FORGE": {
+          "type": "BOOL",
+          "value": "ON"
+        },
+        "AF_BUILD_DOCS": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "AF_BUILD_EXAMPLES": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "AF_TEST_WITH_MTX_FILES": {
+          "type": "BOOL",
+          "value": "OFF"
+        },
+        "CMAKE_INSTALL_PREFIX": {
+          "type": "PATH",
+          "value": "${sourceDir}/build/${presetName}/pkg"
+        }
+      }
+    },
+    {
+      "name": "ninja-cpu-debug",
+      "description": "Build CPU Backend with FFTW and a BLAS library using Ninja Generator in Debug Configuration",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
+      "inherits": "all-off-debug",
+      "cacheVariables": {
+        "AF_BUILD_CPU": "ON"
+      }
+    },
+    {
+      "name": "ninja-cpu-relwithdebinfo",
+      "description": "Build CPU Backend with FFTW and a BLAS library using Ninja Generator in RelWithDebInfo Configuration",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
+      "inherits": "all-off-debug",
+      "cacheVariables": {
+        "AF_BUILD_CPU": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "ninja-cpu-mkl-debug",
+      "description": "Build CPU Backend using Intel MKL in Debug Configuration with Ninja Generator",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
+      "inherits": "all-off-debug",
+      "cacheVariables": {
+        "AF_BUILD_CPU": "ON",
+        "USE_CPU_MKL": "ON"
+      }
+    },
+    {
+      "name": "ninja-cpu-mkl-relwithdebinfo",
+      "description": "Build CPU Backend using Intel MKL in RelWithDebInfo Configuration with Ninja Generator",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
+      "inherits": "all-off-debug",
+      "cacheVariables": {
+        "AF_BUILD_CPU": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "USE_CPU_MKL": "ON"
+      }
+    },
+    {
+      "name": "ninja-cuda-debug",
+      "description": "Build CUDA Backend in debug configuration using Ninja Generator",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
+      "inherits": "all-off-debug",
+      "cacheVariables": {
+        "AF_BUILD_CUDA": "ON"
+      }
+    },
+    {
+      "name": "ninja-cuda-relwithdebinfo",
+      "description": "Build CUDA Backend in RelWithDebInfo configuration using Ninja Generator",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
+      "inherits": "all-off-debug",
+      "cacheVariables": {
+        "AF_BUILD_CUDA": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "ninja-opencl-debug",
+      "description": "Build OpenCL Backend in debug configuration using Ninja Generator",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
+      "inherits": "all-off-debug",
+      "cacheVariables": {
+        "AF_BUILD_OPENCL": "ON"
+      }
+    },
+    {
+      "name": "ninja-opencl-mkl-debug",
+      "description": "Build OpenCL Backend in debug configuration using Ninja Generator",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
+      "inherits": "all-off-debug",
+      "cacheVariables": {
+        "AF_BUILD_OPENCL": "ON",
+        "USE_OPENCL_MKL": "ON"
+      }
+    },
+    {
+      "name": "ninja-opencl-relwithdebinfo",
+      "description": "Build OpenCL Backend in RelWithDebInfo configuration using Ninja Generator",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
+      "inherits": "all-off-debug",
+      "cacheVariables": {
+        "AF_BUILD_OPENCL": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "ninja-opencl-mkl-relwithdebinfo",
+      "description": "Build OpenCL Backend in RelWithDebInfo configuration using Ninja Generator. This preset uses Intel MKL for CPU fallback code.",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
+      "inherits": "all-off-debug",
+      "cacheVariables": {
+        "AF_BUILD_OPENCL": "ON",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "USE_OPENCL_MKL": "ON"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Description
-----------
Run `cmake .. --list-presets` to see the list of presets available.

Run `cmake .. --preset <name_of_preset>` to setup build folder using the
options in the particular preset.

Note that these presets feature will only work with cmake 3.20 or later. If it is earlier than cmake 3.20, then the all options need to be set the old way i.e. command line or ccmake or cmake-gui

Changes to Users
----------------
None

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- ~[ ] Tests pass~
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
