### PR TITLE
Build option AF_COMPUTE_LIBRARY to select CPU backend dependencies

### DIFF
--- a/.github/workflows/unix_cpu_build.yml
+++ b/.github/workflows/unix_cpu_build.yml
@@ -99,6 +99,7 @@ jobs:
                   branch=$(git rev-parse --abbrev-ref HEAD)
                   buildname=$(if [ -z "$prnum" ]; then echo "$branch"; else echo "PR-$prnum"; fi)
                   dashboard=$(if [ -z "$prnum" ]; then echo "Continuous"; else echo "Experimental"; fi)
+                  backend=$(if [ "$USE_MKL" == 1 ]; then echo "Intel-MKL"; else echo "FFTW/LAPACK/BLAS"; fi)
                   buildname="$buildname-cpu-$BLAS_BACKEND"
                   mkdir build && cd build
                   ${CMAKE_PROGRAM} -G Ninja \
@@ -106,7 +107,7 @@ jobs:
                       -DAF_BUILD_CUDA:BOOL=OFF -DAF_BUILD_OPENCL:BOOL=OFF \
                       -DAF_BUILD_UNIFIED:BOOL=OFF -DAF_BUILD_EXAMPLES:BOOL=ON \
                       -DAF_BUILD_FORGE:BOOL=ON \
-                      -DUSE_CPU_MKL:BOOL=$USE_MKL \
+                      -DAF_COMPUTE_LIBRARY:STRING=$backend \
                       -DBUILDNAME:STRING=${buildname} ..
                   echo "CTEST_DASHBOARD=${dashboard}" >> $GITHUB_ENV
 

--- a/.github/workflows/win_cpu_build.yml
+++ b/.github/workflows/win_cpu_build.yml
@@ -14,25 +14,31 @@ jobs:
         runs-on: windows-latest
         env:
           VCPKG_HASH: 5568f110b509a9fd90711978a7cb76bae75bb092 # vcpkg release tag 2021.05.12 with Forge v1.0.7 update
+          VCPKG_DEFAULT_TRIPLET: x64-windows
         steps:
             - name: Checkout Repository
               uses: actions/checkout@master
 
-            - name: VCPKG Binary Cache
+            - name: VCPKG Cache
               uses: actions/cache@v2
-              id: vcpkg-bin-cache
+              id: vcpkg-cache
               with:
-                path: vcpkg_cache
-                key: vcpkg_bin_cache_${{ env.VCPKG_HASH }} # vcpkg manifest baseline
+                path: ~/vcpkg
+                key: vcpkg-deps-${{ env.VCPKG_HASH }}
+
+            - name: Install VCPKG Dependencies
+              if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+              run: |
+                cd ~
+                git clone --quiet --recursive https://github.com/microsoft/vcpkg.git
+                cd vcpkg
+                git checkout $env:VCPKG_HASH
+                .\bootstrap-vcpkg.bat
+                .\vcpkg.exe install boost-compute boost-functional boost-stacktrace fftw3 forge freeimage freetype glfw3 openblas
+                Remove-Item .\downloads,.\buildtrees,.\packages -Recurse -Force
 
             - name: CMake Configure
               run: |
-                  $cwd = (Get-Item -Path ".\").FullName
-                  Set-Location -Path ${env:VCPKG_INSTALLATION_ROOT}
-                  git pull
-                  .\bootstrap-vcpkg.bat
-                  .\vcpkg.exe install --triplet x64-windows boost-compute boost-functional boost-stacktrace fftw3 forge freeimage freetype glfw3 openblas
-                  Set-Location -Path $cwd
                   $ref = $env:GITHUB_REF | %{ if ($_ -match "refs/pull/[0-9]+/merge") { $_;} }
                   $prnum = $ref | %{$_.Split("/")[2]}
                   $branch = git branch --show-current
@@ -40,18 +46,18 @@ jobs:
                   $dashboard = if($prnum -eq $null) { "Continuous" } else { "Experimental" }
                   $buildname = "$buildname-cpu-openblas"
                   mkdir build && cd build
-                  New-Item -Path "${cwd}/vcpkg_cache" -ItemType "directory" -Force
-                  $env:VCPKG_DEFAULT_BINARY_CACHE="${cwd}/vcpkg_cache"
                   cmake .. -G "Visual Studio 16 2019" -A x64 `
+                      -DVCPKG_ROOT:PATH="~/vcpkg" `
+                      -DVCPKG_MANIFEST_MODE:BOOL=OFF `
                       -DAF_BUILD_CUDA:BOOL=OFF -DAF_BUILD_OPENCL:BOOL=OFF `
                       -DAF_BUILD_UNIFIED:BOOL=OFF -DAF_BUILD_FORGE:BOOL=ON `
                       -DBUILDNAME:STRING="$buildname" `
-                      -DVCPKG_ROOT:PATH="${env:VCPKG_INSTALLATION_ROOT}" `
-                      -DVCPKG_MANIFEST_MODE:BOOL=OFF
+                      -DAF_COMPUTE_LIBRARY:STRING="FFTW/LAPACK/BLAS"
                   echo "CTEST_DASHBOARD=${dashboard}" >> $env:GITHUB_ENV
 
             - name: Build and Test
               run: |
-                  Set-Location -Path .\build
-                  $Env:PATH += ";${env:VCPKG_INSTALLATION_ROOT}/installed/x64-windows/bin"
-                  ctest -D Experimental --track ${CTEST_DASHBOARD} -T Test -T Submit -C Release -R cpu -E pinverse -j2
+                  cd build
+                  $vcpkg_path = (Resolve-Path ~).Path
+                  $Env:PATH += ";${vcpkg_path}/vcpkg/installed/x64-windows/bin"
+                  ctest -D Experimental --track ${CTEST_DASHBOARD} -T Test -T Submit -C RelWithDebInfo -R cpu -E pinverse -j2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,11 @@ option(AF_WITH_STACKTRACE  "Add stacktraces to the error messages." ON)
 option(AF_CACHE_KERNELS_TO_DISK "Enable caching kernels to disk" ON)
 option(AF_WITH_STATIC_MKL "Link against static Intel MKL libraries" OFF)
 
+set(AF_COMPUTE_LIBRARY "Intel-MKL"
+    CACHE STRING "Compute library for signal processing and linear algebra routines")
+set_property(CACHE AF_COMPUTE_LIBRARY
+    PROPERTY STRINGS "Intel-MKL" "FFTW/LAPACK/BLAS")
+
 if(WIN32)
   set(AF_STACKTRACE_TYPE "Windbg" CACHE STRING "The type of backtrace features. Windbg(simple), None")
   set_property(CACHE AF_STACKTRACE_TYPE PROPERTY STRINGS "Windbg" "None")
@@ -105,6 +110,21 @@ af_deprecate(BUILD_EXAMPLES        AF_BUILD_EXAMPLES)
 af_deprecate(USE_RELATIVE_TEST_DIR AF_WITH_RELATIVE_TEST_DIR)
 af_deprecate(USE_FREEIMAGE_STATIC  AF_WITH_STATIC_FREEIMAGE)
 af_deprecate(USE_CPUID             AF_WITH_CPUID)
+if(DEFINED USE_CPU_MKL OR DEFINED USE_OPENCL_MKL)
+  # Cannot use af_deprecated as it expects the new and old variables to store values of
+  # same type. In this case, USE_*_MKL variables are BOOLs and AF_COMPUTE_LIBRARY is a STRING
+  message(DEPRECATION
+    "Variables USE_CPU_MKL/USE_OPENCL_MKL are deprecated. Use AF_COMPUTE_LIBRARY instead.")
+  message(WARNING
+    "USE_CPU_MKL/USE_OPENCL_MKL defined. These values take precendence over the value of
+    AF_COMPUTE_LIBRARY until they are removed to preserve existing build behavior.")
+  # Until USE_CPU_MKL and USE_OPENCL_MKL are removed, if they are defined, they take
+  # precendence and cmake will check and report error if Intel-MKL is not found
+  if(USE_CPU_MKL OR USE_OPENCL_MKL)
+    get_property(doc CACHE AF_COMPUTE_LIBRARY PROPERTY HELPSTRING)
+    set(AF_COMPUTE_LIBRARY "Intel-MKL" CACHE STRING "${doc}" FORCE)
+  endif()
+endif()
 
 mark_as_advanced(
   AF_BUILD_FRAMEWORK
@@ -117,6 +137,7 @@ mark_as_advanced(
   AF_WITH_STATIC_FREEIMAGE
   AF_WITH_NONFREE
   AF_WITH_IMAGEIO
+  AF_WITH_RELATIVE_TEST_DIR
   AF_TEST_WITH_MTX_FILES
   ArrayFire_DIR
   Boost_INCLUDE_DIR
@@ -135,6 +156,27 @@ mark_as_advanced(
   FG_BUILD_OFFLINE
   )
 mark_as_advanced(CLEAR CUDA_VERSION)
+
+# IF: the old USE_CPU_MKL/USE_OPENCL_MKL flags are present,
+# THEN Irrespective of AF_COMPUTE_LIBRARY value, continue with MKL to preserve old
+#      behavior. Once the deprecated USE_CPU_MKL/USE_OPENCL_MKL are removed in later
+#      versions AF_COMPUTE_LIBRARY will take over total control of selecting CPU
+#      compute backend.
+#
+# Note that the default value of AF_COMPUTE_LIBRARY is Intel-MKL.
+# Also, cmake doesn't have short-circuit of OR/AND conditions in if
+if(${AF_BUILD_CPU} OR ${AF_BUILD_OPENCL})
+  if("${AF_COMPUTE_LIBRARY}" STREQUAL "Intel-MKL")
+    dependency_check(MKL_FOUND "Please ensure Intel-MKL / oneAPI-oneMKL is installed")
+    set(BUILD_WITH_MKL ON)
+  elseif("${AF_COMPUTE_LIBRARY}" STREQUAL "FFTW/LAPACK/BLAS")
+    dependency_check(FFTW_FOUND "FFTW not found")
+    dependency_check(CBLAS_FOUND "CBLAS not found")
+    if(UNIX AND NOT APPLE)
+      dependency_check(LAPACK_FOUND "LAPACK not found")
+    endif()
+  endif()
+endif()
 
 #Configure forge submodule
 #forge is included in ALL target if AF_BUILD_FORGE is ON
@@ -373,7 +415,7 @@ install(FILES ${ArrayFire_BINARY_DIR}/cmake/install/ArrayFireConfig.cmake
               DESTINATION ${AF_INSTALL_CMAKE_DIR}
               COMPONENT cmake)
 
-if((USE_CPU_MKL OR USE_OPENCL_MKL) AND AF_INSTALL_STANDALONE)
+if(BUILD_WITH_MKL AND AF_INSTALL_STANDALONE)
   if(TARGET MKL::ThreadingLibrary)
     get_filename_component(mkl_tl ${MKL_ThreadingLibrary_LINK_LIBRARY} REALPATH)
     install(FILES

--- a/CMakeModules/FindMKL.cmake
+++ b/CMakeModules/FindMKL.cmake
@@ -461,3 +461,8 @@ if(MKL_Static_FOUND AND NOT TARGET MKL::Static)
     endif()
   endif()
 endif()
+
+set(MKL_FOUND OFF)
+if(MKL_Shared_FOUND OR MKL_Static_FOUND)
+  set(MKL_FOUND ON)
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,6 +17,10 @@
           "type": "String",
           "value": "Debug"
         },
+        "AF_COMPUTE_LIBRARY": {
+          "type": "String",
+          "value": "Intel-MKL"
+        },
         "AF_BUILD_CPU": {
           "type": "BOOL",
           "value": "OFF"
@@ -56,33 +60,33 @@
       }
     },
     {
-      "name": "ninja-cpu-debug",
-      "description": "Build CPU Backend with FFTW and a BLAS library using Ninja Generator in Debug Configuration",
+      "name": "ninja-cpu-mkl-debug",
+      "description": "Build CPU Backend using Intel MKL in Debug Configuration with Ninja Generator",
       "inherits": "ninja-all-off-debug",
       "cacheVariables": {
         "AF_BUILD_CPU": "ON"
       }
     },
     {
-      "name": "ninja-cpu-relwithdebinfo",
-      "description": "Build CPU Backend with FFTW and a BLAS library using Ninja Generator in RelWithDebInfo Configuration",
-      "inherits": "ninja-cpu-debug",
+      "name": "ninja-cpu-mkl-relwithdebinfo",
+      "description": "Build CPU Backend using Intel MKL in RelWithDebInfo Configuration with Ninja Generator",
+      "inherits": "ninja-cpu-mkl-debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     },
     {
-      "name": "ninja-cpu-mkl-debug",
-      "description": "Build CPU Backend using Intel MKL in Debug Configuration with Ninja Generator",
-      "inherits": "ninja-cpu-debug",
+      "name": "ninja-cpu-debug",
+      "description": "Build CPU Backend with FFTW and a BLAS library using Ninja Generator in Debug Configuration",
+      "inherits": "ninja-cpu-mkl-debug",
       "cacheVariables": {
-        "USE_CPU_MKL": "ON"
+        "AF_COMPUTE_LIBRARY": "FFTW/LAPCK/BLAS"
       }
     },
     {
-      "name": "ninja-cpu-mkl-relwithdebinfo",
-      "description": "Build CPU Backend using Intel MKL in RelWithDebInfo Configuration with Ninja Generator",
-      "inherits": "ninja-cpu-mkl-debug",
+      "name": "ninja-cpu-relwithdebinfo",
+      "description": "Build CPU Backend with FFTW and a BLAS library using Ninja Generator in RelWithDebInfo Configuration",
+      "inherits": "ninja-cpu-debug",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
@@ -104,27 +108,11 @@
       }
     },
     {
-      "name": "ninja-opencl-debug",
+      "name": "ninja-opencl-mkl-debug",
       "description": "Build OpenCL Backend in debug configuration using Ninja Generator",
       "inherits": "ninja-all-off-debug",
       "cacheVariables": {
         "AF_BUILD_OPENCL": "ON"
-      }
-    },
-    {
-      "name": "ninja-opencl-mkl-debug",
-      "description": "Build OpenCL Backend in debug configuration using Ninja Generator",
-      "inherits": "ninja-opencl-debug",
-      "cacheVariables": {
-        "USE_OPENCL_MKL": "ON"
-      }
-    },
-    {
-      "name": "ninja-opencl-relwithdebinfo",
-      "description": "Build OpenCL Backend in RelWithDebInfo configuration using Ninja Generator",
-      "inherits": "ninja-opencl-debug",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       }
     },
     {
@@ -136,7 +124,23 @@
       }
     },
     {
-        "name": "ninja-all-debug",
+      "name": "ninja-opencl-debug",
+      "description": "Build OpenCL Backend in debug configuration using Ninja Generator",
+      "inherits": "ninja-opencl-mkl-debug",
+      "cacheVariables": {
+        "AF_COMPUTE_LIBRARY": "FFTW/LAPCK/BLAS"
+      }
+    },
+    {
+      "name": "ninja-opencl-relwithdebinfo",
+      "description": "Build OpenCL Backend in RelWithDebInfo configuration using Ninja Generator",
+      "inherits": "ninja-opencl-debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+        "name": "ninja-all-mkl-debug",
         "description": "Build all feasible backends using Ninja Generator in Debug Configuraiton",
         "inherits": "ninja-all-off-debug",
         "cacheVariables": {
@@ -147,26 +151,25 @@
         }
     },
     {
-        "name": "ninja-all-mkl-debug",
-        "description": "Build all feasible backends using Ninja Generator in Debug Configuraiton",
-        "inherits": "ninja-all-debug",
+        "name": "ninja-all-mkl-relwithdebinfo",
+        "description": "Build all feasible backends using Ninja Generator in RelWithDebInfo Configuraiton",
+        "inherits": "ninja-all-mkl-debug",
         "cacheVariables": {
-            "USE_CPU_MKL": "ON",
-            "USE_OPENCL_MKL": "ON"
+            "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        }
+    },
+    {
+        "name": "ninja-all-debug",
+        "description": "Build all feasible backends using Ninja Generator in Debug Configuraiton",
+        "inherits": "ninja-all-mkl-debug",
+        "cacheVariables": {
+            "AF_COMPUTE_LIBRARY": "FFTW/LAPCK/BLAS"
         }
     },
     {
         "name": "ninja-all-relwithdebinfo",
         "description": "Build all feasible backends using Ninja Generator in RelWithDebInfo Configuraiton",
         "inherits": "ninja-all-debug",
-        "cacheVariables": {
-            "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-        }
-    },
-    {
-        "name": "ninja-all-mkl-relwithdebinfo",
-        "description": "Build all feasible backends using Ninja Generator in RelWithDebInfo Configuraiton",
-        "inherits": "ninja-all-mkl-debug",
         "cacheVariables": {
             "CMAKE_BUILD_TYPE": "RelWithDebInfo"
         }

--- a/src/api/c/CMakeLists.txt
+++ b/src/api/c/CMakeLists.txt
@@ -184,7 +184,7 @@ if(FreeImage_FOUND AND AF_WITH_IMAGEIO)
   endif ()
 endif()
 
-if(USE_CPU_MKL OR USE_OPENCL_MKL)
+if(BUILD_WITH_MKL)
   target_compile_definitions(c_api_interface
     INTERFACE
       AF_MKL_INTERFACE_SIZE=${MKL_INTERFACE_INTEGER_SIZE}

--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -304,51 +304,36 @@ target_compile_definitions(afcpu
     AF_CPU
   )
 
-if(USE_CPU_MKL)
-  dependency_check(MKL_Shared_FOUND "MKL not found")
+target_link_libraries(afcpu
+  PRIVATE
+    c_api_interface
+    cpp_api_interface
+    afcommon_interface
+    cpu_sort_by_key
+    Threads::Threads
+  )
+if(BUILD_WITH_MKL)
   target_compile_definitions(afcpu PRIVATE USE_MKL)
-  target_link_libraries(afcpu
-    PRIVATE
-      c_api_interface
-      cpp_api_interface
-      afcommon_interface
-      cpu_sort_by_key
-      Threads::Threads
-    )
   if(AF_WITH_STATIC_MKL)
       target_link_libraries(afcpu PRIVATE MKL::Static)
   else()
       target_link_libraries(afcpu PRIVATE MKL::RT)
   endif()
 else()
-  dependency_check(FFTW_FOUND "FFTW not found")
-  dependency_check(CBLAS_FOUND "CBLAS not found")
-
   target_link_libraries(afcpu
     PRIVATE
-      c_api_interface
-      cpp_api_interface
-      afcommon_interface
-      cpu_sort_by_key
       ${CBLAS_LIBRARIES}
       FFTW::FFTW
       FFTW::FFTWF
-      Threads::Threads
     )
   if(LAPACK_FOUND)
-    target_link_libraries(afcpu
-      PRIVATE
-        ${LAPACK_LIBRARIES})
-    target_include_directories(afcpu
-      PRIVATE
-        ${LAPACK_INCLUDE_DIR})
+    target_link_libraries(afcpu PRIVATE ${LAPACK_LIBRARIES})
+    target_include_directories(afcpu PRIVATE ${LAPACK_INCLUDE_DIR})
   endif()
 endif()
 
-if(LAPACK_FOUND OR (USE_CPU_MKL AND MKL_Shared_FOUND))
-  target_compile_definitions(afcpu
-    PRIVATE
-      WITH_LINEAR_ALGEBRA)
+if(LAPACK_FOUND OR BUILD_WITH_MKL)
+  target_compile_definitions(afcpu PRIVATE WITH_LINEAR_ALGEBRA)
 endif()
 
 af_split_debug_info(afcpu ${AF_INSTALL_LIB_DIR})

--- a/src/backend/cpu/homography.cpp
+++ b/src/backend/cpu/homography.cpp
@@ -16,9 +16,9 @@
 #include <af/dim4.hpp>
 
 #include <array>
-#include <cfloat>
 #include <cmath>
 #include <cstring>
+#include <limits>
 #include <vector>
 
 using af::dim4;
@@ -27,6 +27,7 @@ using std::array;
 using std::log;
 using std::max;
 using std::min;
+using std::numeric_limits;
 using std::pow;
 using std::round;
 using std::sqrt;
@@ -47,17 +48,17 @@ static const float LMEDSOutlierRatio = 0.4f;
 
 template<typename T>
 struct EPS {
-    T eps() { return FLT_EPSILON; }
+    T eps() { return numeric_limits<float>::epsilon(); }
 };
 
 template<>
 struct EPS<float> {
-    static float eps() { return FLT_EPSILON; }
+    static float eps() { return numeric_limits<float>::epsilon(); }
 };
 
 template<>
 struct EPS<double> {
-    static double eps() { return DBL_EPSILON; }
+    static double eps() { return numeric_limits<double>::epsilon(); }
 };
 
 template<typename T, int M, int N>
@@ -138,7 +139,7 @@ unsigned updateIterations(float inlier_ratio, unsigned iter) {
     float wn = pow(1 - w, 4.f);
 
     float d = 1.f - wn;
-    if (d < FLT_MIN) { return 0; }
+    if (d < numeric_limits<float>::min()) { return 0; }
 
     d = log(d);
 
@@ -284,7 +285,7 @@ int findBestHomography(Array<T>& bestH, const Array<float>& x_src,
     unsigned iter    = iterations;
     unsigned bestIdx = 0;
     int bestInliers  = 0;
-    float minMedian  = FLT_MAX;
+    float minMedian  = numeric_limits<float>::max();
 
     for (unsigned i = 0; i < iter; i++) {
         const unsigned Hidx = Hdims[0] * i;
@@ -344,7 +345,8 @@ int findBestHomography(Array<T>& bestH, const Array<float>& x_src,
                 median = (median + err[nsamples / 2 - 1]) * 0.5f;
             }
 
-            if (median < minMedian && median > FLT_EPSILON) {
+            if (median < minMedian &&
+                median > numeric_limits<float>::epsilon()) {
                 minMedian = median;
                 bestIdx   = i;
             }

--- a/src/backend/cpu/kernel/sift.hpp
+++ b/src/backend/cpu/kernel/sift.hpp
@@ -20,8 +20,8 @@
 #include <resize.hpp>
 #include <sort_index.hpp>
 
-#include <cfloat>
 #include <cstring>
+#include <limits>
 #include <vector>
 
 using af::dim4;
@@ -330,8 +330,9 @@ void interpolateExtrema(float* x_out, float* y_out, unsigned* layer_out,
         float det = dxx * dyy - dxy * dxy;
 
         // add FLT_EPSILON for double-precision compatibility
-        if (det <= 0 || tr * tr * edge_thr >=
-                            (edge_thr + 1) * (edge_thr + 1) * det + FLT_EPSILON)
+        if (det <= 0 ||
+            tr * tr * edge_thr >= (edge_thr + 1) * (edge_thr + 1) * det +
+                                      std::numeric_limits<float>::epsilon())
             continue;
 
         if (*counter < max_feat) {
@@ -692,7 +693,7 @@ void computeGLOHDescriptor(float* desc_out, const unsigned desc_len,
                                      (float)(GLOHRadii[1] - GLOHRadii[0])
                            : min(2 + (r - GLOHRadii[1]) /
                                          (float)(GLOHRadii[2] - GLOHRadii[1]),
-                                 3.f - FLT_EPSILON));
+                                 3.f - std::numeric_limits<float>::epsilon()));
 
             if (r <= GLOHRadii[rb - 1] && y > 0 && y < idims[0] - 1 && x > 0 &&
                 x < idims[1] - 1) {

--- a/src/backend/cuda/homography.cu
+++ b/src/backend/cuda/homography.cu
@@ -14,7 +14,7 @@
 #include <af/dim4.hpp>
 #include <algorithm>
 
-#include <cfloat>
+#include <limits>
 
 using af::dim4;
 
@@ -39,7 +39,8 @@ int homography(Array<T> &bestH, const Array<float> &x_src,
         iter = ::std::min(
             iter, (unsigned)(log(1.f - LMEDSConfidence) /
                              log(1.f - pow(1.f - LMEDSOutlierRatio, 4.f))));
-        err = createValueArray<float>(af::dim4(nsamples, iter), FLT_MAX);
+        err = createValueArray<float>(af::dim4(nsamples, iter),
+                                      std::numeric_limits<float>::max());
     }
 
     af::dim4 rdims(4, iter);

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -5,6 +5,8 @@
 # The complete license agreement can be obtained at:
 # http://arrayfire.com/licenses/BSD-3-Clause
 
+dependency_check(OpenCL_FOUND "OpenCL not found.")
+
 include(InternalUtils)
 include(build_cl2hpp)
 include(build_CLBlast)
@@ -429,7 +431,7 @@ if(APPLE)
   target_link_libraries(afopencl PRIVATE OpenGL::GL)
 endif()
 
-if(LAPACK_FOUND OR (USE_OPENCL_MKL AND MKL_Shared_FOUND))
+if(LAPACK_FOUND OR BUILD_WITH_MKL)
   target_sources(afopencl
     PRIVATE
       magma/gebrd.cpp
@@ -462,8 +464,7 @@ if(LAPACK_FOUND OR (USE_OPENCL_MKL AND MKL_Shared_FOUND))
       #magma/unmqr2.cpp
       )
 
-  if(USE_OPENCL_MKL)
-    dependency_check(MKL_Shared_FOUND "MKL not found")
+  if(BUILD_WITH_MKL)
     target_compile_definitions(afopencl PRIVATE USE_MKL)
 
     if(AF_WITH_STATIC_MKL)
@@ -472,13 +473,10 @@ if(LAPACK_FOUND OR (USE_OPENCL_MKL AND MKL_Shared_FOUND))
         target_link_libraries(afopencl PRIVATE MKL::RT)
     endif()
   else()
-    dependency_check(OpenCL_FOUND "OpenCL not found.")
-
     if(USE_CPU_F77_BLAS)
       target_compile_definitions(afopencl PRIVATE USE_F77_BLAS)
     endif()
 
-    dependency_check(CBLAS_LIBRARIES "CBLAS not found.")
     target_include_directories(afopencl
       PRIVATE
         ${CBLAS_INCLUDE_DIR}
@@ -489,10 +487,7 @@ if(LAPACK_FOUND OR (USE_OPENCL_MKL AND MKL_Shared_FOUND))
         ${LAPACK_LIBRARIES})
   endif()
 
-  target_compile_definitions(
-    afopencl
-    PRIVATE
-      WITH_LINEAR_ALGEBRA)
+  target_compile_definitions(afopencl PRIVATE WITH_LINEAR_ALGEBRA)
 endif()
 
 af_split_debug_info(afopencl ${AF_INSTALL_LIB_DIR})

--- a/src/backend/opencl/homography.cpp
+++ b/src/backend/opencl/homography.cpp
@@ -14,8 +14,10 @@
 #include <af/dim4.hpp>
 
 #include <algorithm>
+#include <limits>
 
 using af::dim4;
+using std::numeric_limits;
 
 namespace opencl {
 
@@ -39,7 +41,8 @@ int homography(Array<T> &bestH, const Array<float> &x_src,
             ::std::min(iter, static_cast<unsigned>(
                                  log(1.f - LMEDSConfidence) /
                                  log(1.f - pow(1.f - LMEDSOutlierRatio, 4.f))));
-        err = createValueArray<float>(af::dim4(nsamples, iter), FLT_MAX);
+        err = createValueArray<float>(af::dim4(nsamples, iter),
+                                      numeric_limits<float>::max());
     } else {
         // Avoid passing "null" cl_mem object to kernels
         err = createEmptyArray<float>(af::dim4(1));

--- a/src/backend/opencl/kernel/homography.hpp
+++ b/src/backend/opencl/kernel/homography.hpp
@@ -19,6 +19,7 @@
 #include <memory.hpp>
 #include <af/defines.h>
 
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -36,8 +37,10 @@ std::array<Kernel, 5> getHomographyKernels(const af_homography_type htype) {
         DefineKeyValue(T, dtype_traits<T>::getName()),
     };
     options.emplace_back(getTypeBuildDefinition<T>());
-    options.emplace_back(DefineKeyValue(
-        EPS, (std::is_same<T, double>::value ? DBL_EPSILON : FLT_EPSILON)));
+    options.emplace_back(
+        DefineKeyValue(EPS, (std::is_same<T, double>::value
+                                 ? std::numeric_limits<double>::epsilon()
+                                 : std::numeric_limits<float>::epsilon())));
     if (htype == AF_HOMOGRAPHY_RANSAC) {
         options.emplace_back(DefineKey(RANSAC));
     }


### PR DESCRIPTION
Description
-----------
Build option AF_COMPUTE_LIBRARY to select CPU compute dependency
    
This new cmake option can take the following values
- `Intel-MKL` - Intel MKL is used for blas, fft and sparse related routines
- `FFTW/LAPACK/BLAS` - OpenBLAS for blas routines; fftw for fft routines; netlib compatible lapack library for lapack routines
- `Intel-MKL` is the default value of this option.
    
We intend to add AMD-AOCL as the third option.
    
To preserve the behavior provided by the old flags, USE_CPU_MKL & USE_OPENCL_MKL, if provided(command-line/cmake-gui) will take precedence even if `AF_COMPUTE_LIBRARY` has `FFTW/LAPACK/BLAS`.

Changes to Users
----------------
None

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
