### PR TITLE
The compare function should return false, for equal elements.

### DIFF
--- a/src/backend/cpu/kernel/sift.hpp
+++ b/src/backend/cpu/kernel/sift.hpp
@@ -91,7 +91,7 @@ bool feat_cmp(feat_t i, feat_t j) {
         if (i.f[k] != j.f[k]) return (i.f[k] < j.f[k]);
     if (i.l != j.l) return (i.l < j.l);
 
-    return true;
+    return false;
 }
 
 void array_to_feat(std::vector<feat_t>& feat, float* x, float* y,

--- a/test/gloh.cpp
+++ b/test/gloh.cpp
@@ -46,7 +46,7 @@ static bool feat_cmp(feat_desc_t i, feat_desc_t j) {
         if (round(i.f[k] * 1e1f) != round(j.f[k] * 1e1f))
             return (round(i.f[k] * 1e1f) < round(j.f[k] * 1e1f));
 
-    return true;
+    return false;
 }
 
 static void array_to_feat_desc(vector<feat_desc_t>& feat, float* x, float* y,

--- a/test/orb.cpp
+++ b/test/orb.cpp
@@ -45,7 +45,7 @@ static bool feat_cmp(feat_desc_t i, feat_desc_t j) {
     for (int k = 0; k < 5; k++)
         if (i.f[k] != j.f[k]) return (i.f[k] < j.f[k]);
 
-    return true;
+    return false;
 }
 
 static void array_to_feat_desc(vector<feat_desc_t>& feat, float* x, float* y,

--- a/test/sift.cpp
+++ b/test/sift.cpp
@@ -46,7 +46,7 @@ static bool feat_cmp(feat_desc_t i, feat_desc_t j) {
         if (round(i.f[k] * 1e1f) != round(j.f[k] * 1e1f))
             return (round(i.f[k] * 1e1f) < round(j.f[k] * 1e1f));
 
-    return true;
+    return false;
 }
 
 static void array_to_feat_desc(vector<feat_desc_t>& feat, float* x, float* y,

--- a/test/topk.cpp
+++ b/test/topk.cpp
@@ -121,7 +121,7 @@ void topkTest(const int ndims, const dim_t* dims, const unsigned k,
         } else {
             stable_sort(kvPairs.begin(), kvPairs.end(),
                         [](const KeyValuePair& lhs, const KeyValuePair& rhs) {
-                            return lhs.first >= rhs.first;
+                            return lhs.first > rhs.first;
                         });
         }
 


### PR DESCRIPTION
When compiling in debug mode, the MSVC compiler returns an non-compliance error.
The provided method should simulate the '<' function, not '<='.


Description
-----------
bug fix, could result in increase sort time or even incorrect results.

Changes to Users
----------------
None

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
