### PR TITLE
OPT: eliminating temp buffer in cascading joins

### DIFF
--- a/src/api/c/rgb_gray.cpp
+++ b/src/api/c/rgb_gray.cpp
@@ -96,8 +96,7 @@ static af_array gray2rgb(const af_array& in, const float r, const float g,
     AF_CHECK(af_release_array(mod_input));
 
     // join channels
-    Array<cType> expr4 = join<cType>(2, expr1, expr2);
-    return getHandle(join<cType>(2, expr3, expr4));
+    return getHandle(join<cType>(2, {expr3, expr1, expr2}));
 }
 
 template<typename T, typename cType, bool isRGB2GRAY>

--- a/src/api/c/ycbcr_rgb.cpp
+++ b/src/api/c/ycbcr_rgb.cpp
@@ -108,8 +108,7 @@ static af_array convert(const af_array& in, const af_ycc_std standard) {
                    INV_112 * (kb - 1) * kb * invKl);
         Array<T> B = mix<T>(Y_, Cb_, INV_219, INV_112 * (1 - kb));
         // join channels
-        Array<T> RG = join<T>(2, R, G);
-        return getHandle(join<T>(2, RG, B));
+        return getHandle(join<T>(2, {R, G, B}));
     }
     Array<T> Ey = mix<T>(X, Y, Z, kr, kl, kb);
     Array<T> Ecr =
@@ -120,8 +119,7 @@ static af_array convert(const af_array& in, const af_ycc_std standard) {
     Array<T> Cr = digitize<T>(Ecr, 224.0, 128.0);
     Array<T> Cb = digitize<T>(Ecb, 224.0, 128.0);
     // join channels
-    Array<T> YCb = join<T>(2, Y_, Cb);
-    return getHandle(join<T>(2, YCb, Cr));
+    return getHandle(join<T>(2, {Y_, Cb, Cr}));
 }
 
 template<bool isYCbCr2RGB>


### PR DESCRIPTION
It is faster to join multiple array's directly into the final buffer, iso using temp buffers with cascading joins
Previous flow:
- join (array A & array B) into temp buffer
- join (temp & array C) into final buffer
New flow:
- join (array A, array B & array C) into final buffer

Performance improvement for gray2rgb & ycbr2rgb are:
  - vector [16M,1,1,1] --> 1.5x (OCL) & 2.0x (CUDA)
  - vector [1,16M,1,1] --> 1.7x (OCL) & 1.7x (CUDA)
When combined with PR#3144 (join optimization)
  - vector [16M,1,1,1] --> 4.1x (OCL) & 3.3x (CUDA)
  - vector [1,16M,1,1] --> 59x (OCL) & 75x (CUDA)

Description
-----------
Performance improvement for gray2rgb & ycbr2rgb functions.
Less memory consumption, since 1 intermediate buffer is eliminated by this PR, and 3 extra intermediate buffers by PR3144.

Changes to Users
----------------
No functional changes.

Checklist
---------
<!-- Check if done or not applicable -->
- [ x ] Rebased on latest master
- [ x ] Code compiles
- [ x ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
