### PR TITLE
Use ONEAPI_ROOT env variable also for looking up MKL Installation

### DIFF
--- a/CMakeModules/FindMKL.cmake
+++ b/CMakeModules/FindMKL.cmake
@@ -12,6 +12,9 @@
 # script is located in the bin folder of your mkl installation. This will set the
 # MKLROOT environment variable which will be used to find the libraries on your system.
 #
+# In case you have oneAPI base toolkit installed, having ONEAPI_ROOT environment variable available
+# also will enable picking Intel oneMKL automatically.
+#
 # Example:
 # set(MKL_THREAD_LAYER "TBB")
 # find_package(MKL)
@@ -101,6 +104,7 @@ find_path(MKL_INCLUDE_DIR
     /opt/intel
     /opt/intel/mkl
     $ENV{MKLROOT}
+    $ENV{ONEAPI_ROOT}/mkl/latest
     /opt/intel/compilers_and_libraries/linux/mkl
   PATH_SUFFIXES
     include
@@ -230,6 +234,7 @@ function(find_mkl_library)
         /opt/intel/tbb/lib
         /opt/intel/lib
         $ENV{MKLROOT}/lib
+        $ENV{ONEAPI_ROOT}/mkl/latest/lib
         ${ENV_LIBRARY_PATHS}
         /opt/intel/compilers_and_libraries/linux/mkl/lib
       PATH_SUFFIXES
@@ -259,6 +264,7 @@ function(find_mkl_library)
         /opt/intel/tbb/lib
         /opt/intel/lib
         $ENV{MKLROOT}/lib
+        $ENV{ONEAPI_ROOT}/mkl/latest/lib
         ${ENV_LIBRARY_PATHS}
         /opt/intel/compilers_and_libraries/linux/mkl/lib
       PATH_SUFFIXES


### PR DESCRIPTION
Description
-----------
If the user sets-up MKL using Intel provided setup scripts prior to building ArrayFire, all environment variables are taken care of by the Intel setup scripts. This change addresses the scenario where oneAPI basetoolkit is installed but the setup script is not run before building ArrayFire.

With this additional environment variable based lookup, in the case MKL setup script is not run, ArrayFire CMake tries to locate MKL based on ONEAPI installation root. This change essentially enables easier look up of MKL installation for building ArrayFire using oneMKL. However, note that to run the built tests/examples the user needs to make sure oneMKL libraries are available via PATH or LD_LIBRARY_PATH for runtime programs to find them.

Changes to Users
----------------
None to library users. An minor ease of use enabler for ArrayFire developers.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- ~[ ] Tests pass~
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
