### PR TITLE
Free unlocked buffers before tests run in rng quality tests

### DIFF
--- a/test/rng_quality.cpp
+++ b/test/rng_quality.cpp
@@ -18,7 +18,7 @@ template<typename T>
 class RandomEngine : public ::testing::Test {
    public:
     virtual void SetUp() {
-        //Ensure all unlocked buffers are freed
+        // Ensure all unlocked buffers are freed
         deviceGC();
     }
 };

--- a/test/rng_quality.cpp
+++ b/test/rng_quality.cpp
@@ -7,6 +7,7 @@
 using af::allTrue;
 using af::array;
 using af::constant;
+using af::deviceGC;
 using af::dtype;
 using af::dtype_traits;
 using af::randomEngine;
@@ -16,7 +17,10 @@ using af::sum;
 template<typename T>
 class RandomEngine : public ::testing::Test {
    public:
-    virtual void SetUp() {}
+    virtual void SetUp() {
+        //Ensure all unlocked buffers are freed
+        deviceGC();
+    }
 };
 
 // create a list of types to be tested


### PR DESCRIPTION

Description
-----------

This is needed when running rng quality tests on lesser memory cards
where higher memory usage is causing out of memory issues.

Changes to Users
----------------
None

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
