### PR TITLE
Use normalized rng data for Large* tests of pinverse

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,7 +70,9 @@ else(${AF_USE_RELATIVE_TEST_DIR})
   FetchContent_Declare(
     ${testdata_prefix}
     GIT_REPOSITORY https://github.com/arrayfire/arrayfire-data.git
-    GIT_TAG        master
+
+    #pinv large data set update change
+    GIT_TAG        0144a599f913cc67c76c9227031b4100156abc25
   )
   af_dep_check_and_populate(${testdata_prefix})
   set(TESTDATA_SOURCE_DIR "${${testdata_prefix}_SOURCE_DIR}")

--- a/test/pinverse.cpp
+++ b/test/pinverse.cpp
@@ -159,7 +159,7 @@ TYPED_TEST(Pinverse, ApinvA_IsHermitian) {
 
 TYPED_TEST(Pinverse, Large) {
     array in = readTestInput<TypeParam>(
-        string(TEST_DIR "/pinverse/pinverse640x480.test"));
+        string(TEST_DIR "/pinverse/pinv_640x480_inputs.test"));
     array inpinv = pinverse(in);
     array out    = matmul(in, inpinv, in);
     ASSERT_ARRAYS_NEAR(in, out, relEps<TypeParam>(in));
@@ -167,7 +167,7 @@ TYPED_TEST(Pinverse, Large) {
 
 TYPED_TEST(Pinverse, LargeTall) {
     array in = readTestInput<TypeParam>(
-                   string(TEST_DIR "/pinverse/pinverse640x480.test"))
+                   string(TEST_DIR "/pinverse/pinv_640x480_inputs.test"))
                    .T();
     array inpinv = pinverse(in);
     array out    = matmul(in, inpinv, in);


### PR DESCRIPTION
Description
-----------

Float type has accuracy issues with large input values which is the case with current test data for Large & LargeTall test inputs.

Changes to Users
----------------
None

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
