### PR TITLE
Turn OFF cmake fetchcontent update step

### DIFF
--- a/CMakeModules/AFconfigure_deps_vars.cmake
+++ b/CMakeModules/AFconfigure_deps_vars.cmake
@@ -10,6 +10,12 @@ option(AF_BUILD_OFFLINE "Build ArrayFire assuming there is no network" OFF)
 # Override fetch content base dir before including AFfetch_content
 set(FETCHCONTENT_BASE_DIR "${ArrayFire_BINARY_DIR}/extern" CACHE PATH
     "Base directory where ArrayFire dependencies are downloaded and/or built" FORCE)
+# Override fetch content updates setting to let cmake run without internet connection
+# when cmake configure ran successfully once in the past. Developers who wish to
+# pull latest changes or make changes to dependencies using fetch content workflow
+# needs to turn this option ON as needed.
+set(FETCHCONTENT_UPDATES_DISCONNECTED ON CACHE BOOL
+    "Disable Update stage of FetchContent workflow")
 
 include(AFfetch_content)
 


### PR DESCRIPTION
Description
-----------

This was ON earlier which necessiated the need of an internet connection
while re-running cmake configure command after an initial successful
run.

This change eliminates the cloud connection requirement after the first
successful cmake configure run. Note, that changing certain options that
use fetchcontent workflow while there is no cloud connection may result
in failed cmake configure step due to change in options.

Changes to Users
----------------
None. Helps devs in a narrow use case where development is done on no network setup after running cmake configure.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
