### PR TITLE
Improve offline build experience for developers

### DIFF
--- a/.github/workflows/release_src_artifact.yml
+++ b/.github/workflows/release_src_artifact.yml
@@ -70,7 +70,14 @@ jobs:
                   done
                   shopt -u extglob
                   rm -rf matrixmarket
-                  cd ../../..
+                  cp -r ./* ../../extern/
+                  cd ..
+                  wget https://github.com/arrayfire/forge/releases/download/v1.0.8/forge-full-1.0.8.tar.bz2
+                  tar -xf forge-full-1.0.8.tar.bz2
+                  mv forge-full-1.0.8 ../extern/af_forge-src
+                  cd ..
+                  rm -rf build
+                  cd ..
                   tar -cjf arrayfire-full-${AF_VER}.tar.bz2 arrayfire-full-${AF_VER}/
                   echo "UPLOAD_FILE=arrayfire-full-${AF_VER}.tar.bz2" >> $GITHUB_ENV
 

--- a/.github/workflows/win_cpu_build.yml
+++ b/.github/workflows/win_cpu_build.yml
@@ -13,7 +13,9 @@ jobs:
         name: CPU (fftw, OpenBLAS, windows-latest)
         runs-on: windows-latest
         env:
-          VCPKG_HASH: 5568f110b509a9fd90711978a7cb76bae75bb092 # vcpkg release tag 2021.05.12 with Forge v1.0.7 update
+
+          VCPKG_HASH: 4428702c1c56fdb7cb779584efdcba254d7b57ca #[neon2sse] create a new port; Has forge v1.0.8 and other cmake/vcpkg fixes
+
           VCPKG_DEFAULT_TRIPLET: x64-windows
         steps:
             - name: Checkout Repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,6 @@ endif()
 
 mark_as_advanced(
   AF_BUILD_FRAMEWORK
-  AF_BUILD_OFFLINE
   AF_CACHE_KERNELS_TO_DISK
   AF_INSTALL_STANDALONE
   AF_WITH_CPUID
@@ -194,22 +193,18 @@ if(TARGET spdlog::spdlog_header_only)
     $<TARGET_PROPERTY:spdlog::spdlog_header_only,INTERFACE_INCLUDE_DIRECTORIES>
     )
 else()
-  FetchContent_Declare(
-    ${spdlog_prefix}
-    GIT_REPOSITORY https://github.com/gabime/spdlog.git
-    GIT_TAG        v1.8.5
+  af_dep_check_and_populate(${spdlog_prefix}
+    URI https://github.com/gabime/spdlog.git
+    REF v1.8.5
   )
-  af_dep_check_and_populate(${spdlog_prefix})
   target_include_directories(af_spdlog INTERFACE "${${spdlog_prefix}_SOURCE_DIR}/include")
 endif()
 
 if(NOT TARGET glad::glad)
-  FetchContent_Declare(
-    ${glad_prefix}
-    GIT_REPOSITORY https://github.com/arrayfire/glad.git
-    GIT_TAG main
-    )
-  af_dep_check_and_populate(${glad_prefix})
+  af_dep_check_and_populate(${glad_prefix}
+    URI https://github.com/arrayfire/glad.git
+    REF main
+  )
   add_subdirectory(${${glad_prefix}_SOURCE_DIR} ${${glad_prefix}_BINARY_DIR})
 
   add_library(af_glad STATIC $<TARGET_OBJECTS:af_glad_obj_lib>)
@@ -220,12 +215,10 @@ if(NOT TARGET glad::glad)
     )
 endif()
 
-FetchContent_Declare(
-  ${assets_prefix}
-  GIT_REPOSITORY https://github.com/arrayfire/assets.git
-  GIT_TAG        master
+af_dep_check_and_populate(${assets_prefix}
+  URI https://github.com/arrayfire/assets.git
+  REF master
 )
-af_dep_check_and_populate(${assets_prefix})
 set(ASSETS_DIR ${${assets_prefix}_SOURCE_DIR})
 
 configure_file(

--- a/CMakeModules/AFconfigure_deps_vars.cmake
+++ b/CMakeModules/AFconfigure_deps_vars.cmake
@@ -5,7 +5,37 @@
 # The complete license agreement can be obtained at:
 # http://arrayfire.com/licenses/BSD-3-Clause
 
-option(AF_BUILD_OFFLINE "Build ArrayFire assuming there is no network" OFF)
+file(DOWNLOAD
+  "https://github.com/arrayfire/arrayfire/blob/v3.0.0/CMakeLists.txt"
+  "${ArrayFire_BINARY_DIR}/download_copy_cmakelists.stamp"
+  STATUS af_check_result
+  TIMEOUT 4
+)
+list(GET af_check_result 0 af_is_connected)
+if(${af_is_connected})
+  set(BUILD_OFFLINE ON)
+  # Turn ON disconnected flag when connected to cloud
+  set(FETCHCONTENT_FULLY_DISCONNECTED ON CACHE BOOL
+      "Disable Download/Update stages of FetchContent workflow" FORCE)
+
+  message(STATUS "No cloud connection. Attempting offline build if dependencies are available")
+else()
+  set(BUILD_OFFLINE OFF)
+  # Turn OFF disconnected flag when connected to cloud
+  # This is required especially in the following scenario:
+  # - cmake run successfully first
+  # - lost connection, but development can still be done
+  # - Now, connection regained. Hence updates should be allowed
+  set(FETCHCONTENT_FULLY_DISCONNECTED OFF CACHE BOOL
+      "Disable Download/Update stages of FetchContent workflow" FORCE)
+endif()
+
+# Track dependencies download persistently across multiple
+# cmake configure runs. *_POPULATED variables are reset for each
+# cmake run to 0. Hence, this internal cache value is needed to
+# check for already (from previous cmake run's) populated data
+# during the current cmake run if it looses network connection.
+set(AF_INTERNAL_DOWNLOAD_FLAG OFF CACHE BOOL "Deps Download Flag")
 
 # Override fetch content base dir before including AFfetch_content
 set(FETCHCONTENT_BASE_DIR "${ArrayFire_BINARY_DIR}/extern" CACHE PATH
@@ -13,7 +43,15 @@ set(FETCHCONTENT_BASE_DIR "${ArrayFire_BINARY_DIR}/extern" CACHE PATH
 
 include(AFfetch_content)
 
-macro(set_and_mark_depname var name)
+mark_as_advanced(
+  AF_INTERNAL_DOWNLOAD_FLAG
+  FETCHCONTENT_BASE_DIR
+  FETCHCONTENT_QUIET
+  FETCHCONTENT_FULLY_DISCONNECTED
+  FETCHCONTENT_UPDATES_DISCONNECTED
+)
+
+macro(set_and_mark_depnames_advncd var name)
   string(TOLOWER ${name} ${var})
   string(TOUPPER ${name} ${var}_ucname)
   mark_as_advanced(
@@ -22,51 +60,89 @@ macro(set_and_mark_depname var name)
   )
 endmacro()
 
-mark_as_advanced(
-  FETCHCONTENT_BASE_DIR
-  FETCHCONTENT_QUIET
-  FETCHCONTENT_FULLY_DISCONNECTED
-  FETCHCONTENT_UPDATES_DISCONNECTED
-)
+set_and_mark_depnames_advncd(assets_prefix "af_assets")
+set_and_mark_depnames_advncd(testdata_prefix "af_test_data")
+set_and_mark_depnames_advncd(gtest_prefix "googletest")
+set_and_mark_depnames_advncd(glad_prefix "af_glad")
+set_and_mark_depnames_advncd(forge_prefix "af_forge")
+set_and_mark_depnames_advncd(spdlog_prefix "spdlog")
+set_and_mark_depnames_advncd(threads_prefix "af_threads")
+set_and_mark_depnames_advncd(cub_prefix "nv_cub")
+set_and_mark_depnames_advncd(cl2hpp_prefix "ocl_cl2hpp")
+set_and_mark_depnames_advncd(clblast_prefix "ocl_clblast")
+set_and_mark_depnames_advncd(clfft_prefix "ocl_clfft")
+set_and_mark_depnames_advncd(boost_prefix "boost_compute")
 
-set_and_mark_depname(assets_prefix "af_assets")
-set_and_mark_depname(testdata_prefix "af_test_data")
-set_and_mark_depname(gtest_prefix "googletest")
-set_and_mark_depname(glad_prefix "af_glad")
-set_and_mark_depname(forge_prefix "af_forge")
-set_and_mark_depname(spdlog_prefix "spdlog")
-set_and_mark_depname(threads_prefix "af_threads")
-set_and_mark_depname(cub_prefix "nv_cub")
-set_and_mark_depname(cl2hpp_prefix "ocl_cl2hpp")
-set_and_mark_depname(clblast_prefix "ocl_clblast")
-set_and_mark_depname(clfft_prefix "ocl_clfft")
-set_and_mark_depname(boost_prefix "boost_compute")
+macro(af_dep_check_and_populate dep_prefix)
+  set(single_args URI REF)
+  cmake_parse_arguments(adcp_args "" "${single_args}" "" ${ARGN})
 
-if(AF_BUILD_OFFLINE)
-  macro(set_fetchcontent_src_dir prefix_var dep_name)
-    set(FETCHCONTENT_SOURCE_DIR_${${prefix_var}_ucname}
-        "${FETCHCONTENT_BASE_DIR}/${${prefix_var}}-src" CACHE PATH
-        "Source directory for ${dep_name} dependency")
-    mark_as_advanced(FETCHCONTENT_SOURCE_DIR_${${prefix_var}_ucname})
-  endmacro()
+  if("${adcp_args_URI}" STREQUAL "")
+    message(FATAL_ERROR [=[
+        Cannot check requested dependency source's availability.
+        Please provide a valid URI(almost always a URL to a github repo).
+        Note that the above error message if for developers of ArrayFire.
+        ]=])
+  endif()
 
-  set_fetchcontent_src_dir(assets_prefix "Assets")
-  set_fetchcontent_src_dir(testdata_prefix "Test Data")
-  set_fetchcontent_src_dir(gtest_prefix "googletest")
-  set_fetchcontent_src_dir(glad_prefix "glad")
-  set_fetchcontent_src_dir(forge_prefix "forge")
-  set_fetchcontent_src_dir(spdlog_prefix "spdlog")
-  set_fetchcontent_src_dir(threads_prefix "threads")
-  set_fetchcontent_src_dir(cub_prefix "NVIDIA CUB")
-  set_fetchcontent_src_dir(cl2hpp_prefix "OpenCL cl2 hpp header")
-  set_fetchcontent_src_dir(clblast_prefix "CLBlast library")
-  set_fetchcontent_src_dir(clfft_prefix "clFFT library")
-  set_fetchcontent_src_dir(boost_prefix "boost-compute headers")
-endif()
+  string(FIND "${adcp_args_REF}" "=" adcp_has_algo_id)
 
-macro(af_dep_check_and_populate prefix)
-  FetchContent_GetProperties(${prefix})
-  if(NOT ${prefix}_POPULATED)
-    FetchContent_Populate(${prefix})
+  if(${BUILD_OFFLINE} AND NOT ${AF_INTERNAL_DOWNLOAD_FLAG})
+    if(NOT ${adcp_has_algo_id} EQUAL -1)
+      FetchContent_Populate(${dep_prefix}
+        QUIET
+        URL            ${adcp_args_URI}
+        URL_HASH       ${adcp_args_REF}
+        DOWNLOAD_COMMAND \"\"
+        UPDATE_DISCONNECTED ON
+        SOURCE_DIR     "${ArrayFire_SOURCE_DIR}/extern/${dep_prefix}-src"
+        BINARY_DIR     "${ArrayFire_BINARY_DIR}/extern/${dep_prefix}-build"
+        SUBBUILD_DIR   "${ArrayFire_BINARY_DIR}/extern/${dep_prefix}-subbuild"
+      )
+    elseif("${adcp_args_REF}" STREQUAL "")
+      FetchContent_Populate(${dep_prefix}
+        QUIET
+        URL            ${adcp_args_URI}
+        DOWNLOAD_COMMAND \"\"
+        UPDATE_DISCONNECTED ON
+        SOURCE_DIR     "${ArrayFire_SOURCE_DIR}/extern/${dep_prefix}-src"
+        BINARY_DIR     "${ArrayFire_BINARY_DIR}/extern/${dep_prefix}-build"
+        SUBBUILD_DIR   "${ArrayFire_BINARY_DIR}/extern/${dep_prefix}-subbuild"
+      )
+    else()
+      # The left over alternative is assumed to be a cloud hosted git repository
+      FetchContent_Populate(${dep_prefix}
+        QUIET
+        GIT_REPOSITORY ${adcp_args_URI}
+        GIT_TAG        ${adcp_args_REF}
+        DOWNLOAD_COMMAND \"\"
+        UPDATE_DISCONNECTED ON
+        SOURCE_DIR     "${ArrayFire_SOURCE_DIR}/extern/${dep_prefix}-src"
+        BINARY_DIR     "${ArrayFire_BINARY_DIR}/extern/${dep_prefix}-build"
+        SUBBUILD_DIR   "${ArrayFire_BINARY_DIR}/extern/${dep_prefix}-subbuild"
+      )
+    endif()
+  else()
+    if(NOT ${adcp_has_algo_id} EQUAL -1)
+      FetchContent_Declare(${dep_prefix}
+        URL            ${adcp_args_URI}
+        URL_HASH       ${adcp_args_REF}
+      )
+    elseif("${adcp_args_REF}" STREQUAL "")
+      FetchContent_Declare(${dep_prefix}
+        URL            ${adcp_args_URI}
+      )
+    else()
+      # The left over alternative is assumed to be a cloud hosted git repository
+      FetchContent_Declare(${dep_prefix}
+        GIT_REPOSITORY ${adcp_args_URI}
+        GIT_TAG        ${adcp_args_REF}
+      )
+    endif()
+    FetchContent_GetProperties(${dep_prefix})
+    if(NOT ${dep_prefix}_POPULATED)
+      FetchContent_Populate(${dep_prefix})
+    endif()
+    set(AF_INTERNAL_DOWNLOAD_FLAG ON CACHE BOOL "Deps Download Flag" FORCE)
   endif()
 endmacro()

--- a/CMakeModules/AFconfigure_forge_dep.cmake
+++ b/CMakeModules/AFconfigure_forge_dep.cmake
@@ -7,7 +7,7 @@
 
 set(FG_VERSION_MAJOR 1)
 set(FG_VERSION_MINOR 0)
-set(FG_VERSION_PATCH 7)
+set(FG_VERSION_PATCH 8)
 
 find_package(Forge
   ${FG_VERSION_MAJOR}.${FG_VERSION_MINOR}.${FG_VERSION_PATCH}
@@ -30,12 +30,10 @@ else()
   set(FG_VERSION "${FG_VERSION_MAJOR}.${FG_VERSION_MINOR}.${FG_VERSION_PATCH}")
   set(FG_API_VERSION_CURRENT ${FG_VERSION_MAJOR}${FG_VERSION_MINOR})
 
-  FetchContent_Declare(
-    ${forge_prefix}
-    GIT_REPOSITORY https://github.com/arrayfire/forge.git
-    GIT_TAG        "v${FG_VERSION}"
+  af_dep_check_and_populate(${forge_prefix}
+    URI https://github.com/arrayfire/forge.git
+    REF "v${FG_VERSION}"
   )
-  af_dep_check_and_populate(${forge_prefix})
 
   if(AF_BUILD_FORGE)
     set(af_FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR})
@@ -58,8 +56,6 @@ else()
         FG_BUILD_DOCS
         FG_WITH_FREEIMAGE
         FG_USE_WINDOW_TOOLKIT
-        FG_USE_SYSTEM_CL2HPP
-        FG_ENABLE_HUNTER
         FG_RENDERING_BACKEND
         SPHINX_EXECUTABLE
         glfw3_DIR

--- a/CMakeModules/boost_package.cmake
+++ b/CMakeModules/boost_package.cmake
@@ -21,12 +21,11 @@ if(NOT
   message(WARNING
       "WARN: Found Boost v${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}."
       "Minimum required ${VER}. Build will download Boost Compute.")
-  FetchContent_Declare(
-    ${boost_prefix}
-    URL https://github.com/boostorg/compute/archive/boost-${VER}.tar.gz
-    URL_HASH MD5=e160ec0ff825fc2850ea4614323b1fb5
+  af_dep_check_and_populate(${boost_prefix}
+    URL_AND_HASH
+    URI https://github.com/boostorg/compute/archive/boost-${VER}.tar.gz
+    REF MD5=e160ec0ff825fc2850ea4614323b1fb5
   )
-  af_dep_check_and_populate(${boost_prefix})
   if(NOT TARGET Boost::boost)
     add_library(Boost::boost IMPORTED INTERFACE GLOBAL)
   endif()

--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -5,12 +5,10 @@
 # The complete license agreement can be obtained at:
 # http://arrayfire.com/licenses/BSD-3-Clause
 
-FetchContent_Declare(
-  ${clblast_prefix}
-  GIT_REPOSITORY    https://github.com/cnugteren/CLBlast.git
-  GIT_TAG           1.5.2
+af_dep_check_and_populate(${clblast_prefix}
+  URI https://github.com/cnugteren/CLBlast.git
+  REF 1.5.2
 )
-af_dep_check_and_populate(${clblast_prefix})
 
 include(ExternalProject)
 find_program(GIT git)

--- a/CMakeModules/build_cl2hpp.cmake
+++ b/CMakeModules/build_cl2hpp.cmake
@@ -13,12 +13,10 @@
 
 find_package(OpenCL)
 
-FetchContent_Declare(
-  ${cl2hpp_prefix}
-  GIT_REPOSITORY https://github.com/KhronosGroup/OpenCL-CLHPP.git
-  GIT_TAG v2.0.12
+af_dep_check_and_populate(${cl2hpp_prefix}
+  URI https://github.com/KhronosGroup/OpenCL-CLHPP.git
+  REF v2.0.12
 )
-af_dep_check_and_populate(${cl2hpp_prefix})
 
 if (NOT TARGET OpenCL::cl2hpp OR NOT TARGET cl2hpp)
   add_library(cl2hpp IMPORTED INTERFACE GLOBAL)

--- a/CMakeModules/build_clFFT.cmake
+++ b/CMakeModules/build_clFFT.cmake
@@ -5,12 +5,10 @@
 # The complete license agreement can be obtained at:
 # http://arrayfire.com/licenses/BSD-3-Clause
 
-FetchContent_Declare(
-  ${clfft_prefix}
-  GIT_REPOSITORY    https://github.com/arrayfire/clFFT.git
-  GIT_TAG           cmake_fixes
+af_dep_check_and_populate(${clfft_prefix}
+  URI https://github.com/arrayfire/clFFT.git
+  REF cmake_fixes
 )
-af_dep_check_and_populate(${clfft_prefix})
 
 set(current_build_type ${BUILD_SHARED_LIBS})
 set(BUILD_SHARED_LIBS OFF)

--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -272,12 +272,10 @@ if (AF_WITH_CPUID)
   target_compile_definitions(afcpu PRIVATE -DAF_WITH_CPUID)
 endif(AF_WITH_CPUID)
 
-FetchContent_Declare(
-  ${threads_prefix}
-  GIT_REPOSITORY https://github.com/arrayfire/threads.git
-  GIT_TAG        b666773940269179f19ef11c8f1eb77005e85d9a
+af_dep_check_and_populate(${threads_prefix}
+  URI https://github.com/arrayfire/threads.git
+  REF b666773940269179f19ef11c8f1eb77005e85d9a
 )
-af_dep_check_and_populate(${threads_prefix})
 
 target_sources(afcpu
   PRIVATE

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -116,12 +116,10 @@ cuda_include_directories(
   $<TARGET_PROPERTY:af_spdlog,INTERFACE_INCLUDE_DIRECTORIES>
   )
 if(CUDA_VERSION_MAJOR VERSION_LESS 11)
-  FetchContent_Declare(
-    ${cub_prefix}
-    GIT_REPOSITORY https://github.com/NVIDIA/cub.git
-    GIT_TAG        1.10.0
+  af_dep_check_and_populate(${cub_prefix}
+    URI https://github.com/NVIDIA/cub.git
+    REF 1.10.0
   )
-  af_dep_check_and_populate(${cub_prefix})
   cuda_include_directories(${${cub_prefix}_SOURCE_DIR})
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,13 +15,11 @@ if(AF_TEST_WITH_MTX_FILES)
   include(download_sparse_datasets)
 endif()
 
-FetchContent_Declare(
-  ${gtest_prefix}
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG        release-1.8.1
-)
 if(NOT TARGET gtest)
-  af_dep_check_and_populate(${gtest_prefix})
+  af_dep_check_and_populate(${gtest_prefix}
+    URI https://github.com/google/googletest.git
+    REF release-1.8.1
+  )
 
   # gtest targets cmake version 2.6 which throws warnings for policy CMP0042 on
   # newer cmakes. This sets the default global setting for that policy.
@@ -74,14 +72,11 @@ if(${AF_USE_RELATIVE_TEST_DIR})
       STRING "Relative Test Data Directory")
   set(TESTDATA_SOURCE_DIR ${RELATIVE_TEST_DATA_DIR})
 else(${AF_USE_RELATIVE_TEST_DIR})
-  FetchContent_Declare(
-    ${testdata_prefix}
-    GIT_REPOSITORY https://github.com/arrayfire/arrayfire-data.git
-
+  af_dep_check_and_populate(${testdata_prefix}
+    URI https://github.com/arrayfire/arrayfire-data.git
     #pinv large data set update change
-    GIT_TAG        0144a599f913cc67c76c9227031b4100156abc25
+    REF 0144a599f913cc67c76c9227031b4100156abc25
   )
-  af_dep_check_and_populate(${testdata_prefix})
   set(TESTDATA_SOURCE_DIR "${${testdata_prefix}_SOURCE_DIR}")
 endif(${AF_USE_RELATIVE_TEST_DIR})
 

--- a/test/CMakeModules/download_sparse_datasets.cmake
+++ b/test/CMakeModules/download_sparse_datasets.cmake
@@ -12,15 +12,12 @@ function(mtxDownload name group)
   set(target_dir ${root_dir}/${group}/${name})
   set(mtx_name mtxDownload_${group}_${name})
   string(TOLOWER ${mtx_name} mtx_name)
-  FetchContent_Declare(
-    ${mtx_name}
-    URL ${URL}/MM/${group}/${name}.tar.gz
+
+  set_and_mark_depnames_advncd(mtx_prefix ${mtx_name})
+  af_dep_check_and_populate(${mtx_name}
+    URI ${URL}/MM/${group}/${name}.tar.gz
   )
-  af_dep_check_and_populate(${mtx_name})
-  set_and_mark_depname(mtx_prefix ${mtx_name})
-  if(AF_BUILD_OFFLINE)
-    set_fetchcontent_src_dir(mtx_prefix "{name}.mtx file from {group} group")
-  endif()
+
   if(NOT EXISTS "${target_dir}/${name}.mtx")
     file(MAKE_DIRECTORY ${target_dir})
     file(COPY ${${mtx_name}_SOURCE_DIR}/${name}.mtx DESTINATION ${target_dir})

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,7 +10,7 @@
         "boost-stacktrace",
         {
             "name": "forge",
-            "version>=": "1.0.7",
+            "version>=": "1.0.8",
             "platform": "windows"
         },
         "freeimage",


### PR DESCRIPTION
Description
-----------
The following common scenarios(majority we think) are covered with this change.
- Developer has cloud connection always.
- Developer has cloud connection for initial cmake run, but not later.
- Developer has lost cloud connection for a while after the initial successful cmake run but regained the connection later.
- Developer is doing an completely disconnected build using the source tarball we generate and attach to our release assets.

When the developer wants to do an offline build for a specific commit other than release tags, they would have to generate the relevant source tarball themselves. The commands required to do the same can be found from the following ci workflow file in our repository.
```
.github/workflows/release_src_artifact.yml
```

The source tarball generation CI job has also been changed to reflect the change in external dependencies location.

Changes to Users
----------------
None to users, but Offline development made more easy for developers.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
