### PR TITLE
Fix bug in getMappedPtr in OpenCL due to invalid lambda capture

### DIFF
--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -261,6 +261,7 @@ class Array {
    public:
     mapped_ptr<T> getMappedPtr(cl_map_flags map_flags = CL_MAP_READ |
                                                         CL_MAP_WRITE) const {
+        if (!isReady()) eval();
         auto func = [data = data](void *ptr) {
             if (ptr != nullptr) {
                 cl_int err = getQueue().enqueueUnmapMemObject(*data, ptr);


### PR DESCRIPTION
This commit fixes a bug that was caused by an invalid capture of
the Array class in the destructor of the mapped_ptr function. This
caused intermittent errors when using the getMappedPtr function.

Description
-----------
This commit fixes a bug in the getMappedPtr function of the OpenCL
Array class. The bug was caused because we were capturing the
Array class using the `this` pointer instead of specifically capturing
the Buffer_ptr object. These changes are necessary because the
clEnqueueUnmap function failed to execute for CPU backends and
causes segfaults in certain scenarios. 

This PR can be backported to older versions.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
