### PR TITLE
Fix canny_opencl tests for Intel CPUs

### DIFF
--- a/src/backend/opencl/kernel/trace_edge.cl
+++ b/src/backend/opencl/kernel/trace_edge.cl
@@ -7,9 +7,9 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-__constant int STRONG = 1;
-__constant int WEAK   = 2;
-__constant int NOEDGE = 0;
+#define STRONG 1
+#define WEAK 2
+#define NOEDGE 0
 
 #if defined(INIT_EDGE_OUT)
 kernel void initEdgeOutKernel(global T* output, KParam oInfo,
@@ -154,7 +154,10 @@ kernel void edgeTrackKernel(global T* output, KParam oInfo, unsigned nBBS0,
         }
 
         continueIter = predicates[0];
-    };
+
+        // Needed for Intel OpenCL implementation targeting CPUs
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
 
     // Check if any 1-pixel border ring
     // has weak pixels with strong candidates


### PR DESCRIPTION
This PR fixes an error in the CannyEdgeDetector.OtsuThreshold test which appeared on the Intel CPU OpenCL implementation.

Description
-----------
Fixes an infinite loop error that occurred on Intel OpenCL platform targeting the CPU. The fix is to add a barrier at the end of the while loop in the edgeTrackKernel. I am not sure why this is necessary because there is sufficient synchronization there but this barrier fixes the issue.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
