### PR TITLE
Fix reference count if array used in JIT operations.

### DIFF
--- a/src/api/c/anisotropic_diffusion.cpp
+++ b/src/api/c/anisotropic_diffusion.cpp
@@ -11,7 +11,7 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <copy.hpp>
 #include <gradient.hpp>
@@ -24,9 +24,9 @@
 #include <type_traits>
 
 using af::dim4;
+using common::cast;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::createEmptyArray;
 using detail::gradient;
 using detail::reduce_all;

--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -27,6 +27,7 @@
 #include <common/half.hpp>
 
 using af::dim4;
+using af::dtype;
 using common::half;
 using detail::arithOp;
 using detail::arithOpD;
@@ -41,9 +42,17 @@ using detail::ushort;
 template<typename T, af_op_t op>
 static inline af_array arithOp(const af_array lhs, const af_array rhs,
                                const dim4 &odims) {
-    af_array res =
-        getHandle(arithOp<T, op>(castArray<T>(lhs), castArray<T>(rhs), odims));
-    return res;
+    const ArrayInfo &linfo = getInfo(lhs);
+    const ArrayInfo &rinfo = getInfo(rhs);
+
+    dtype type = static_cast<af::dtype>(af::dtype_traits<T>::af_type);
+
+    const detail::Array<T> &l =
+        linfo.getType() == type ? getArray<T>(lhs) : castArray<T>(lhs);
+    const detail::Array<T> &r =
+        rinfo.getType() == type ? getArray<T>(rhs) : castArray<T>(rhs);
+
+    return getHandle(arithOp<T, op>(l, r, odims));
 }
 
 template<typename T, af_op_t op>

--- a/src/api/c/canny.cpp
+++ b/src/api/c/canny.cpp
@@ -7,10 +7,12 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <canny.hpp>
+
 #include <Array.hpp>
 #include <arith.hpp>
 #include <backend.hpp>
-#include <canny.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <complex.hpp>
 #include <convolve.hpp>
@@ -34,9 +36,9 @@
 #include <vector>
 
 using af::dim4;
+using common::cast;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::convolve2;
 using detail::createEmptyArray;
 using detail::createHostDataArray;

--- a/src/api/c/cast.cpp
+++ b/src/api/c/cast.cpp
@@ -8,8 +8,8 @@
  ********************************************************/
 
 #include <backend.hpp>
-#include <cast.hpp>
 #include <common/ArrayInfo.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/half.hpp>
 #include <handle.hpp>

--- a/src/api/c/confidence_connected.cpp
+++ b/src/api/c/confidence_connected.cpp
@@ -10,7 +10,7 @@
 #include <af/image.h>
 
 #include <arith.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <flood_fill.hpp>
 #include <handle.hpp>
@@ -24,10 +24,10 @@
 #include <type_traits>
 
 using af::dim4;
+using common::cast;
 using common::createSpanIndex;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::createValueArray;
 using detail::reduce_all;
 using detail::uchar;

--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -10,7 +10,7 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/half.hpp>
 #include <fftconvolve.hpp>
@@ -25,10 +25,10 @@
 #include <cstdio>
 
 using af::dim4;
+using common::cast;
 using common::half;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::cdouble;
 using detail::cfloat;
 using detail::convolve;

--- a/src/api/c/corrcoef.cpp
+++ b/src/api/c/corrcoef.cpp
@@ -9,7 +9,7 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <handle.hpp>
 #include <math.hpp>
@@ -23,9 +23,9 @@
 #include <cmath>
 
 using af::dim4;
+using common::cast;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::intl;
 using detail::reduce_all;
 using detail::uchar;

--- a/src/api/c/covariance.cpp
+++ b/src/api/c/covariance.cpp
@@ -9,7 +9,7 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <handle.hpp>
 #include <math.hpp>
 #include <mean.hpp>
@@ -23,9 +23,9 @@
 #include "stats.h"
 
 using af::dim4;
+using common::cast;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::createValueArray;
 using detail::intl;
 using detail::mean;

--- a/src/api/c/deconvolution.cpp
+++ b/src/api/c/deconvolution.cpp
@@ -10,7 +10,7 @@
 #include <Array.hpp>
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/dispatch.hpp>
 #include <common/err_common.hpp>
 #include <complex.hpp>
@@ -32,9 +32,9 @@
 #include <vector>
 
 using af::dim4;
+using common::cast;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::cdouble;
 using detail::cfloat;
 using detail::createSubArray;

--- a/src/api/c/fftconvolve.cpp
+++ b/src/api/c/fftconvolve.cpp
@@ -7,13 +7,15 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <fftconvolve.hpp>
+
 #include <arith.hpp>
 #include <backend.hpp>
+#include <common/cast.hpp>
 #include <common/dispatch.hpp>
 #include <common/err_common.hpp>
 #include <complex.hpp>
 #include <fft_common.hpp>
-#include <fftconvolve.hpp>
 #include <handle.hpp>
 #include <af/defines.h>
 #include <af/dim4.hpp>
@@ -24,9 +26,9 @@
 #include <vector>
 
 using af::dim4;
+using common::cast;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::cdouble;
 using detail::cfloat;
 using detail::createSubArray;

--- a/src/api/c/handle.hpp
+++ b/src/api/c/handle.hpp
@@ -10,7 +10,6 @@
 #pragma once
 #include <Array.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
 #include <common/err_common.hpp>
 #include <common/half.hpp>
 #include <common/traits.hpp>
@@ -32,6 +31,9 @@ af::dim4 verifyDims(const unsigned ndims, const dim_t *const dims);
 af_array createHandle(const af::dim4 &d, af_dtype dtype);
 
 af_array createHandleFromValue(const af::dim4 &d, double val, af_dtype dtype);
+
+template<typename To>
+detail::Array<To> castArray(const af_array &in);
 
 namespace {
 
@@ -66,36 +68,6 @@ detail::Array<T> &getArray(af_array &arr) {
     if ((af_dtype)af::dtype_traits<T>::af_type != A->getType())
         AF_ERROR("Invalid type for input array.", AF_ERR_INTERNAL);
     return *A;
-}
-
-template<typename To>
-detail::Array<To> castArray(const af_array &in) {
-    using detail::cdouble;
-    using detail::cfloat;
-    using detail::intl;
-    using detail::uchar;
-    using detail::uint;
-    using detail::uintl;
-    using detail::ushort;
-
-    const ArrayInfo &info = getInfo(in);
-    switch (info.getType()) {
-        case f32: return detail::cast<To, float>(getArray<float>(in));
-        case f64: return detail::cast<To, double>(getArray<double>(in));
-        case c32: return detail::cast<To, cfloat>(getArray<cfloat>(in));
-        case c64: return detail::cast<To, cdouble>(getArray<cdouble>(in));
-        case s32: return detail::cast<To, int>(getArray<int>(in));
-        case u32: return detail::cast<To, uint>(getArray<uint>(in));
-        case u8: return detail::cast<To, uchar>(getArray<uchar>(in));
-        case b8: return detail::cast<To, char>(getArray<char>(in));
-        case s64: return detail::cast<To, intl>(getArray<intl>(in));
-        case u64: return detail::cast<To, uintl>(getArray<uintl>(in));
-        case s16: return detail::cast<To, short>(getArray<short>(in));
-        case u16: return detail::cast<To, ushort>(getArray<ushort>(in));
-        case f16:
-            return detail::cast<To, common::half>(getArray<common::half>(in));
-        default: TYPE_ERROR(1, info.getType());
-    }
 }
 
 template<typename T>

--- a/src/api/c/hist.cpp
+++ b/src/api/c/hist.cpp
@@ -8,8 +8,8 @@
  ********************************************************/
 
 #include <backend.hpp>
-#include <cast.hpp>
 #include <common/ArrayInfo.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/graphics_common.hpp>
 #include <handle.hpp>

--- a/src/api/c/histeq.cpp
+++ b/src/api/c/histeq.cpp
@@ -9,7 +9,7 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <handle.hpp>
 #include <lookup.hpp>
@@ -21,9 +21,9 @@
 #include <af/index.h>
 
 using af::dim4;
+using common::cast;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::createValueArray;
 using detail::intl;
 using detail::lookup;

--- a/src/api/c/image.cpp
+++ b/src/api/c/image.cpp
@@ -14,8 +14,8 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
 #include <common/ArrayInfo.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/graphics_common.hpp>
 #include <handle.hpp>
@@ -27,9 +27,9 @@
 #include <limits>
 
 using af::dim4;
+using common::cast;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::copy_image;
 using detail::createValueArray;
 using detail::forgeManager;

--- a/src/api/c/imgproc_common.hpp
+++ b/src/api/c/imgproc_common.hpp
@@ -11,7 +11,7 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <logic.hpp>
 #include <reduce.hpp>
 #include <scan.hpp>
@@ -22,7 +22,7 @@ namespace common {
 
 template<typename To, typename Ti = To>
 detail::Array<To> integralImage(const detail::Array<Ti>& in) {
-    auto input                       = detail::cast<To, Ti>(in);
+    auto input                       = common::cast<To, Ti>(in);
     detail::Array<To> horizontalScan = detail::scan<af_add_t, To, To>(input, 0);
     return detail::scan<af_add_t, To, To>(horizontalScan, 1);
 }
@@ -37,7 +37,7 @@ detail::Array<T> threshold(const detail::Array<T>& in, T min, T max) {
     auto above = detail::logicOp<T, af_ge_t>(in, MN, inDims);
     auto valid = detail::logicOp<char, af_and_t>(below, above, inDims);
 
-    return detail::arithOp<T, af_mul_t>(in, detail::cast<T, char>(valid),
+    return detail::arithOp<T, af_mul_t>(in, common::cast<T, char>(valid),
                                         inDims);
 }
 
@@ -45,7 +45,7 @@ template<typename To, typename Ti>
 detail::Array<To> convRange(const detail::Array<Ti>& in,
                             const To newLow = To(0), const To newHigh = To(1)) {
     auto dims  = in.dims();
-    auto input = detail::cast<To, Ti>(in);
+    auto input = common::cast<To, Ti>(in);
     To high    = detail::reduce_all<af_max_t, To, To>(input);
     To low     = detail::reduce_all<af_min_t, To, To>(input);
     To range   = high - low;

--- a/src/api/c/implicit.hpp
+++ b/src/api/c/implicit.hpp
@@ -9,8 +9,8 @@
 
 #pragma once
 #include <backend.hpp>
-#include <cast.hpp>
 #include <common/ArrayInfo.hpp>
+#include <common/cast.hpp>
 #include <handle.hpp>
 #include <optypes.hpp>
 #include <types.hpp>

--- a/src/api/c/mean.cpp
+++ b/src/api/c/mean.cpp
@@ -9,7 +9,7 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/half.hpp>
 #include <handle.hpp>

--- a/src/api/c/median.cpp
+++ b/src/api/c/median.cpp
@@ -8,7 +8,7 @@
  ********************************************************/
 
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <handle.hpp>
 #include <math.hpp>
@@ -36,7 +36,7 @@ static double median(const af_array& in) {
 
     af_array temp = 0;
     AF_CHECK(af_moddims(&temp, in, 1, dims.get()));
-    const Array<T> input = getArray<T>(temp);
+    const Array<T>& input = getArray<T>(temp);
 
     // Shortcut cases for 1 or 2 elements
     if (nElems == 1) {

--- a/src/api/c/moments.cpp
+++ b/src/api/c/moments.cpp
@@ -13,8 +13,8 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
 #include <common/ArrayInfo.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/graphics_common.hpp>
 #include <handle.hpp>

--- a/src/api/c/morph.cpp
+++ b/src/api/c/morph.cpp
@@ -9,7 +9,7 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/indexing_helpers.hpp>
 #include <copy.hpp>
@@ -24,10 +24,10 @@
 #include <af/image.h>
 
 using af::dim4;
+using common::cast;
 using common::flip;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::cdouble;
 using detail::cfloat;
 using detail::createEmptyArray;

--- a/src/api/c/pinverse.cpp
+++ b/src/api/c/pinverse.cpp
@@ -12,8 +12,8 @@
 
 #include <arith.hpp>
 #include <blas.hpp>
-#include <cast.hpp>
 #include <common/ArrayInfo.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <diagonal.hpp>
 #include <handle.hpp>
@@ -31,9 +31,9 @@
 
 using af::dim4;
 using af::dtype_traits;
+using common::cast;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::cdouble;
 using detail::cfloat;
 using detail::createEmptyArray;

--- a/src/api/c/rgb_gray.cpp
+++ b/src/api/c/rgb_gray.cpp
@@ -15,17 +15,17 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
 #include <common/ArrayInfo.hpp>
+#include <common/cast.hpp>
 #include <handle.hpp>
 #include <join.hpp>
 #include <math.hpp>
 #include <tile.hpp>
 
 using af::dim4;
+using common::cast;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::createValueArray;
 using detail::join;
 using detail::scalar;

--- a/src/api/c/sparse_handle.hpp
+++ b/src/api/c/sparse_handle.hpp
@@ -10,7 +10,7 @@
 #pragma once
 #include <Array.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <copy.hpp>
 #include <handle.hpp>
@@ -66,7 +66,7 @@ common::SparseArray<To> castSparse(const af_array &in) {
 #define CAST_SPARSE(Ti)                                                          \
     do {                                                                         \
         const SparseArray<Ti> sparse = getSparseArray<Ti>(in);                   \
-        detail::Array<To> values     = detail::cast<To, Ti>(sparse.getValues()); \
+        detail::Array<To> values     = common::cast<To, Ti>(sparse.getValues()); \
         return createArrayDataSparseArray(                                       \
             sparse.dims(), values, sparse.getRowIdx(), sparse.getColIdx(),       \
             sparse.getStorage());                                                \

--- a/src/api/c/stdev.cpp
+++ b/src/api/c/stdev.cpp
@@ -9,7 +9,7 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <handle.hpp>
 #include <math.hpp>
 #include <mean.hpp>
@@ -25,8 +25,8 @@
 #include "stats.h"
 
 using af::dim4;
+using common::cast;
 using detail::Array;
-using detail::cast;
 using detail::cdouble;
 using detail::cfloat;
 using detail::createValueArray;

--- a/src/api/c/unary.cpp
+++ b/src/api/c/unary.cpp
@@ -15,8 +15,8 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
 #include <common/ArrayInfo.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/half.hpp>
 #include <complex.hpp>

--- a/src/api/c/var.cpp
+++ b/src/api/c/var.cpp
@@ -9,7 +9,7 @@
 
 #include <arith.hpp>
 #include <backend.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/half.hpp>
 #include <handle.hpp>
@@ -25,10 +25,10 @@
 #include <tuple>
 
 using af::dim4;
+using common::cast;
 using common::half;
 using detail::arithOp;
 using detail::Array;
-using detail::cast;
 using detail::cdouble;
 using detail::cfloat;
 using detail::createEmptyArray;

--- a/src/backend/common/CMakeLists.txt
+++ b/src/backend/common/CMakeLists.txt
@@ -43,6 +43,8 @@ target_sources(afcommon_interface
     ${CMAKE_CURRENT_SOURCE_DIR}/TemplateArg.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/TemplateTypename.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/blas_headers.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cast.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/cast.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/cblas.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/compile_module.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/complex.hpp

--- a/src/backend/common/CMakeLists.txt
+++ b/src/backend/common/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(afcommon_interface INTERFACE)
 
 target_sources(afcommon_interface
   INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/jit/BinaryNode.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/jit/BinaryNode.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/jit/NaryNode.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/jit/Node.cpp

--- a/src/backend/common/cast.cpp
+++ b/src/backend/common/cast.cpp
@@ -1,0 +1,62 @@
+/*******************************************************
+ * Copyright (c) 2021, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <common/cast.hpp>
+#include <handle.hpp>
+
+using common::half;
+using detail::cdouble;
+using detail::cfloat;
+using detail::intl;
+using detail::uchar;
+using detail::uint;
+using detail::uintl;
+using detail::ushort;
+
+template<typename To>
+detail::Array<To> castArray(const af_array &in) {
+    const ArrayInfo &info = getInfo(in);
+
+    if (static_cast<af::dtype>(af::dtype_traits<To>::af_type) ==
+        info.getType()) {
+        return getArray<To>(in);
+    }
+
+    switch (info.getType()) {
+        case f32: return common::cast<To, float>(getArray<float>(in));
+        case f64: return common::cast<To, double>(getArray<double>(in));
+        case c32: return common::cast<To, cfloat>(getArray<cfloat>(in));
+        case c64: return common::cast<To, cdouble>(getArray<cdouble>(in));
+        case s32: return common::cast<To, int>(getArray<int>(in));
+        case u32: return common::cast<To, uint>(getArray<uint>(in));
+        case u8: return common::cast<To, uchar>(getArray<uchar>(in));
+        case b8: return common::cast<To, char>(getArray<char>(in));
+        case s64: return common::cast<To, intl>(getArray<intl>(in));
+        case u64: return common::cast<To, uintl>(getArray<uintl>(in));
+        case s16: return common::cast<To, short>(getArray<short>(in));
+        case u16: return common::cast<To, ushort>(getArray<ushort>(in));
+        case f16:
+            return common::cast<To, common::half>(getArray<common::half>(in));
+        default: TYPE_ERROR(1, info.getType());
+    }
+}
+
+template detail::Array<float> castArray(const af_array &in);
+template detail::Array<double> castArray(const af_array &in);
+template detail::Array<cfloat> castArray(const af_array &in);
+template detail::Array<cdouble> castArray(const af_array &in);
+template detail::Array<int> castArray(const af_array &in);
+template detail::Array<uint> castArray(const af_array &in);
+template detail::Array<uchar> castArray(const af_array &in);
+template detail::Array<char> castArray(const af_array &in);
+template detail::Array<intl> castArray(const af_array &in);
+template detail::Array<uintl> castArray(const af_array &in);
+template detail::Array<short> castArray(const af_array &in);
+template detail::Array<ushort> castArray(const af_array &in);
+template detail::Array<half> castArray(const af_array &in);

--- a/src/backend/common/cast.hpp
+++ b/src/backend/common/cast.hpp
@@ -22,12 +22,11 @@ template<typename To, typename Ti>
 struct CastWrapper {
     detail::Array<To> operator()(const detail::Array<Ti> &in) {
         using cpu::jit::UnaryNode;
+
         Node_ptr in_node = in.getNode();
-        UnaryNode<To, Ti, af_cast_t> *node =
-            new UnaryNode<To, Ti, af_cast_t>(in_node);
-        return detail::createNodeArray<To>(
-            in.dims(),
-            common::Node_ptr(reinterpret_cast<common::Node *>(node)));
+        auto node = std::make_shared<UnaryNode<To, Ti, af_cast_t>>(in_node);
+
+        return detail::createNodeArray<To>(in.dims(), move(node));
     }
 };
 #else

--- a/src/backend/common/cast.hpp
+++ b/src/backend/common/cast.hpp
@@ -1,0 +1,72 @@
+/*******************************************************
+ * Copyright (c) 2021, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+#include <Array.hpp>
+#include <cast.hpp>
+
+#ifdef AF_CPU
+#include <jit/UnaryNode.hpp>
+#endif
+
+namespace common {
+
+#ifdef AF_CPU
+template<typename To, typename Ti>
+struct CastWrapper {
+    detail::Array<To> operator()(const detail::Array<Ti> &in) {
+        using cpu::jit::UnaryNode;
+        Node_ptr in_node = in.getNode();
+        UnaryNode<To, Ti, af_cast_t> *node =
+            new UnaryNode<To, Ti, af_cast_t>(in_node);
+        return detail::createNodeArray<To>(
+            in.dims(),
+            common::Node_ptr(reinterpret_cast<common::Node *>(node)));
+    }
+};
+#else
+template<typename To, typename Ti>
+struct CastWrapper {
+    detail::Array<To> operator()(const detail::Array<Ti> &in) {
+        detail::CastOp<To, Ti> cop;
+        common::Node_ptr in_node = in.getNode();
+        common::UnaryNode *node  = new common::UnaryNode(
+            static_cast<af::dtype>(dtype_traits<To>::af_type), cop.name(),
+            in_node, af_cast_t);
+        return detail::createNodeArray<To>(in.dims(), common::Node_ptr(node));
+    }
+};
+#endif
+
+template<typename T>
+struct CastWrapper<T, T> {
+    detail::Array<T> operator()(const detail::Array<T> &in);
+};
+
+template<typename To, typename Ti>
+auto cast(detail::Array<Ti> &&in)
+    -> std::enable_if_t<std::is_same<Ti, To>::value, detail::Array<To>> {
+    return std::move(in);
+}
+
+template<typename To, typename Ti>
+auto cast(const detail::Array<Ti> &in)
+    -> std::enable_if_t<std::is_same<Ti, To>::value, detail::Array<To>> {
+    return in;
+}
+
+template<typename To, typename Ti>
+auto cast(const detail::Array<Ti> &in)
+    -> std::enable_if_t<std::is_same<Ti, To>::value == false,
+                        detail::Array<To>> {
+    CastWrapper<To, Ti> cast_op;
+    return cast_op(in);
+}
+
+}  // namespace common

--- a/src/backend/common/jit/BinaryNode.cpp
+++ b/src/backend/common/jit/BinaryNode.cpp
@@ -1,0 +1,149 @@
+
+#include <Array.hpp>
+#include <binary.hpp>
+#include <common/jit/BinaryNode.hpp>
+#include <complex.hpp>
+#include <types.hpp>
+
+using af::dim4;
+using af::dtype_traits;
+using detail::Array;
+using detail::BinOp;
+using detail::cdouble;
+using detail::cfloat;
+using detail::createNodeArray;
+
+namespace common {
+#ifdef AF_CPU
+template<typename To, typename Ti, af_op_t op>
+Array<To> createBinaryNode(const Array<Ti> &lhs, const Array<Ti> &rhs,
+                           const af::dim4 &odims) {
+    common::Node_ptr lhs_node = lhs.getNode();
+    common::Node_ptr rhs_node = rhs.getNode();
+
+    detail::jit::BinaryNode<To, Ti, op> *node =
+        new detail::jit::BinaryNode<To, Ti, op>(lhs_node, rhs_node);
+
+    return createNodeArray<To>(odims, common::Node_ptr(node));
+}
+
+#else
+
+template<typename To, typename Ti, af_op_t op>
+Array<To> createBinaryNode(const Array<Ti> &lhs, const Array<Ti> &rhs,
+                           const af::dim4 &odims) {
+    auto createBinary = [](std::array<Node_ptr, 2> &operands) -> Node_ptr {
+        BinOp<To, Ti, op> bop;
+        return Node_ptr(
+            new BinaryNode(static_cast<af::dtype>(dtype_traits<To>::af_type),
+                           bop.name(), operands[0], operands[1], (int)(op)));
+    };
+
+    Node_ptr out =
+        common::createNaryNode<Ti, 2>(odims, createBinary, {&lhs, &rhs});
+    return createNodeArray<To>(odims, out);
+}
+
+#endif
+
+#define INSTANTIATE(To, Ti, op)                      \
+    template Array<To> createBinaryNode<To, Ti, op>( \
+        const Array<Ti> &lhs, const Array<Ti> &rhs, const dim4 &odims)
+
+INSTANTIATE(cfloat, float, af_cplx2_t);
+INSTANTIATE(cdouble, double, af_cplx2_t);
+
+#define INSTANTIATE_ARITH(op)                                \
+    INSTANTIATE(float, float, op);                           \
+    INSTANTIATE(cfloat, cfloat, op);                         \
+    INSTANTIATE(double, double, op);                         \
+    INSTANTIATE(cdouble, cdouble, op);                       \
+    INSTANTIATE(unsigned, unsigned, op);                     \
+    INSTANTIATE(short, short, op);                           \
+    INSTANTIATE(unsigned short, unsigned short, op);         \
+    INSTANTIATE(unsigned long long, unsigned long long, op); \
+    INSTANTIATE(long long, long long, op);                   \
+    INSTANTIATE(unsigned char, unsigned char, op);           \
+    INSTANTIATE(char, char, op);                             \
+    INSTANTIATE(common::half, common::half, op);             \
+    INSTANTIATE(int, int, op)
+
+INSTANTIATE_ARITH(af_add_t);
+INSTANTIATE_ARITH(af_sub_t);
+INSTANTIATE_ARITH(af_mul_t);
+INSTANTIATE_ARITH(af_div_t);
+INSTANTIATE_ARITH(af_min_t);
+INSTANTIATE_ARITH(af_max_t);
+
+#undef INSTANTIATE_ARITH
+
+#define INSTANTIATE_ARITH_REAL(op)                           \
+    INSTANTIATE(float, float, op);                           \
+    INSTANTIATE(double, double, op);                         \
+    INSTANTIATE(unsigned, unsigned, op);                     \
+    INSTANTIATE(short, short, op);                           \
+    INSTANTIATE(unsigned short, unsigned short, op);         \
+    INSTANTIATE(unsigned long long, unsigned long long, op); \
+    INSTANTIATE(long long, long long, op);                   \
+    INSTANTIATE(unsigned char, unsigned char, op);           \
+    INSTANTIATE(char, char, op);                             \
+    INSTANTIATE(common::half, common::half, op);             \
+    INSTANTIATE(int, int, op)
+
+INSTANTIATE_ARITH_REAL(af_rem_t);
+INSTANTIATE_ARITH_REAL(af_pow_t);
+INSTANTIATE_ARITH_REAL(af_mod_t);
+
+#define INSTANTIATE_FLOATOPS(op)     \
+    INSTANTIATE(float, float, op);   \
+    INSTANTIATE(double, double, op); \
+    INSTANTIATE(common::half, common::half, op)
+
+INSTANTIATE_FLOATOPS(af_hypot_t);
+INSTANTIATE_FLOATOPS(af_atan2_t);
+
+#define INSTANTIATE_BITOP(op)                                \
+    INSTANTIATE(unsigned, unsigned, op);                     \
+    INSTANTIATE(short, short, op);                           \
+    INSTANTIATE(unsigned short, unsigned short, op);         \
+    INSTANTIATE(unsigned long long, unsigned long long, op); \
+    INSTANTIATE(long long, long long, op);                   \
+    INSTANTIATE(unsigned char, unsigned char, op);           \
+    INSTANTIATE(char, char, op);                             \
+    INSTANTIATE(int, int, op)
+
+INSTANTIATE_BITOP(af_bitshiftl_t);
+INSTANTIATE_BITOP(af_bitshiftr_t);
+INSTANTIATE_BITOP(af_bitor_t);
+INSTANTIATE_BITOP(af_bitand_t);
+INSTANTIATE_BITOP(af_bitxor_t);
+#undef INSTANTIATE_BITOP
+
+#define INSTANTIATE_LOGIC(op)                  \
+    INSTANTIATE(char, float, op);              \
+    INSTANTIATE(char, double, op);             \
+    INSTANTIATE(char, cfloat, op);             \
+    INSTANTIATE(char, cdouble, op);            \
+    INSTANTIATE(char, common::half, op);       \
+    INSTANTIATE(char, unsigned, op);           \
+    INSTANTIATE(char, short, op);              \
+    INSTANTIATE(char, unsigned short, op);     \
+    INSTANTIATE(char, unsigned long long, op); \
+    INSTANTIATE(char, long long, op);          \
+    INSTANTIATE(char, unsigned char, op);      \
+    INSTANTIATE(char, char, op);               \
+    INSTANTIATE(char, int, op)
+
+INSTANTIATE_LOGIC(af_and_t);
+INSTANTIATE_LOGIC(af_or_t);
+INSTANTIATE_LOGIC(af_eq_t);
+INSTANTIATE_LOGIC(af_neq_t);
+INSTANTIATE_LOGIC(af_lt_t);
+INSTANTIATE_LOGIC(af_le_t);
+INSTANTIATE_LOGIC(af_gt_t);
+INSTANTIATE_LOGIC(af_ge_t);
+
+#undef INSTANTIATE_LOGIC
+#undef INSTANTIATE
+
+}  // namespace common

--- a/src/backend/common/jit/BinaryNode.cpp
+++ b/src/backend/common/jit/BinaryNode.cpp
@@ -34,9 +34,9 @@ Array<To> createBinaryNode(const Array<Ti> &lhs, const Array<Ti> &rhs,
                            const af::dim4 &odims) {
     auto createBinary = [](std::array<Node_ptr, 2> &operands) -> Node_ptr {
         BinOp<To, Ti, op> bop;
-        return Node_ptr(
-            new BinaryNode(static_cast<af::dtype>(dtype_traits<To>::af_type),
-                           bop.name(), operands[0], operands[1], (int)(op)));
+        return std::make_shared<BinaryNode>(
+            static_cast<af::dtype>(dtype_traits<To>::af_type), bop.name(),
+            operands[0], operands[1], (int)(op));
     };
 
     Node_ptr out =

--- a/src/backend/common/jit/BinaryNode.cpp
+++ b/src/backend/common/jit/BinaryNode.cpp
@@ -5,6 +5,8 @@
 #include <complex.hpp>
 #include <types.hpp>
 
+#include <memory>
+
 using af::dim4;
 using af::dtype_traits;
 using detail::Array;
@@ -12,6 +14,8 @@ using detail::BinOp;
 using detail::cdouble;
 using detail::cfloat;
 using detail::createNodeArray;
+
+using std::make_shared;
 
 namespace common {
 #ifdef AF_CPU
@@ -21,10 +25,10 @@ Array<To> createBinaryNode(const Array<Ti> &lhs, const Array<Ti> &rhs,
     common::Node_ptr lhs_node = lhs.getNode();
     common::Node_ptr rhs_node = rhs.getNode();
 
-    detail::jit::BinaryNode<To, Ti, op> *node =
-        new detail::jit::BinaryNode<To, Ti, op>(lhs_node, rhs_node);
+    auto node =
+        make_shared<detail::jit::BinaryNode<To, Ti, op>>(lhs_node, rhs_node);
 
-    return createNodeArray<To>(odims, common::Node_ptr(node));
+    return createNodeArray<To>(odims, move(node));
 }
 
 #else

--- a/src/backend/common/jit/BinaryNode.hpp
+++ b/src/backend/common/jit/BinaryNode.hpp
@@ -7,6 +7,8 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#pragma once
+
 #include <common/jit/NaryNode.hpp>
 
 #include <cmath>
@@ -19,4 +21,10 @@ class BinaryNode : public NaryNode {
         : NaryNode(type, op_str, 2, {{lhs, rhs}}, op,
                    std::max(lhs->getHeight(), rhs->getHeight()) + 1) {}
 };
+
+template<typename To, typename Ti, af_op_t op>
+detail::Array<To> createBinaryNode(const detail::Array<Ti> &lhs,
+                                   const detail::Array<Ti> &rhs,
+                                   const af::dim4 &odims);
+
 }  // namespace common

--- a/src/backend/common/jit/BufferNodeBase.hpp
+++ b/src/backend/common/jit/BufferNodeBase.hpp
@@ -12,8 +12,6 @@
 #include <common/jit/Node.hpp>
 #include <jit/kernel_generators.hpp>
 
-#include <iomanip>
-#include <mutex>
 #include <sstream>
 
 namespace common {
@@ -24,25 +22,20 @@ class BufferNodeBase : public common::Node {
     DataType m_data;
     ParamType m_param;
     unsigned m_bytes;
-    std::once_flag m_set_data_flag;
     bool m_linear_buffer;
 
    public:
-    BufferNodeBase(af::dtype type) : Node(type, 0, {}) {
-        // This class is not movable because of std::once_flag
-    }
+    BufferNodeBase(af::dtype type)
+        : Node(type, 0, {}), m_bytes(0), m_linear_buffer(true) {}
 
     bool isBuffer() const final { return true; }
 
     void setData(ParamType param, DataType data, const unsigned bytes,
                  bool is_linear) {
-        std::call_once(m_set_data_flag,
-                       [this, param, data, bytes, is_linear]() {
-                           m_param         = param;
-                           m_data          = data;
-                           m_bytes         = bytes;
-                           m_linear_buffer = is_linear;
-                       });
+        m_param         = param;
+        m_data          = data;
+        m_bytes         = bytes;
+        m_linear_buffer = is_linear;
     }
 
     bool isLinear(dim_t dims[4]) const final {

--- a/src/backend/common/jit/BufferNodeBase.hpp
+++ b/src/backend/common/jit/BufferNodeBase.hpp
@@ -92,6 +92,29 @@ class BufferNodeBase : public common::Node {
     }
 
     size_t getBytes() const final { return m_bytes; }
+
+    size_t getHash() const noexcept {
+        size_t out = 0;
+        auto ptr   = m_data.get();
+        memcpy(&out, &ptr, std::max(sizeof(Node *), sizeof(size_t)));
+        return out;
+    }
+
+    /// Compares two BufferNodeBase objects for equality
+    bool operator==(
+        const BufferNodeBase<DataType, ParamType> &other) const noexcept;
+
+    /// Overloads the equality operator to call comparisons between Buffer
+    /// objects. Calls the BufferNodeBase equality operator if the other
+    /// object is also a Buffer Node
+    bool operator==(const common::Node &other) const noexcept final {
+        if (other.isBuffer()) {
+            return *this ==
+                   static_cast<const BufferNodeBase<DataType, ParamType> &>(
+                       other);
+        }
+        return false;
+    }
 };
 
 }  // namespace common

--- a/src/backend/common/jit/NaryNode.hpp
+++ b/src/backend/common/jit/NaryNode.hpp
@@ -94,7 +94,9 @@ common::Node_ptr createNaryNode(
     const af::dim4 &odims, FUNC createNode,
     std::array<const detail::Array<Ti> *, N> &&children) {
     std::array<common::Node_ptr, N> childNodes;
-    for (int i = 0; i < N; i++) { childNodes[i] = children[i]->getNode(); }
+    for (int i = 0; i < N; i++) {
+        childNodes[i] = move(children[i]->getNode());
+    }
 
     common::Node_ptr ptr = createNode(childNodes);
 

--- a/src/backend/common/jit/Node.cpp
+++ b/src/backend/common/jit/Node.cpp
@@ -57,4 +57,14 @@ std::string getFuncName(const vector<Node *> &output_nodes,
     return "KER" + std::to_string(deterministicHash(funcName));
 }
 
+bool NodePtr_equalto::operator()(const Node *l, const Node *r) const noexcept {
+    return *l == *r;
+}
+
 }  // namespace common
+
+size_t std::hash<common::Node *>::operator()(
+    common::Node *const node) const noexcept {
+    common::Node *const node_ptr = static_cast<common::Node *const>(node);
+    return node_ptr->getHash();
+}

--- a/src/backend/cpu/Array.cpp
+++ b/src/backend/cpu/Array.cpp
@@ -273,7 +273,7 @@ kJITHeuristics passesJitHeuristics(Node *root_node) {
 
 template<typename T>
 Array<T> createNodeArray(const dim4 &dims, Node_ptr node) {
-    Array<T> out = Array<T>(dims, node);
+    Array<T> out(dims, node);
     return out;
 }
 

--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -29,6 +29,7 @@ target_sources(afcpu
     assign.cpp
     assign.hpp
     backend.hpp
+    binary.hpp
     bilateral.cpp
     bilateral.hpp
     blas.cpp

--- a/src/backend/cpu/arith.hpp
+++ b/src/backend/cpu/arith.hpp
@@ -16,6 +16,12 @@
 namespace cpu {
 
 template<typename T, af_op_t op>
+Array<T> arithOp(const Array<T> &&lhs, const Array<T> &&rhs,
+                 const af::dim4 &odims) {
+    return common::createBinaryNode<T, T, op>(lhs, rhs, odims);
+}
+
+template<typename T, af_op_t op>
 Array<T> arithOp(const Array<T> &lhs, const Array<T> &rhs,
                  const af::dim4 &odims) {
     return common::createBinaryNode<T, T, op>(lhs, rhs, odims);

--- a/src/backend/cpu/binary.hpp
+++ b/src/backend/cpu/binary.hpp
@@ -8,6 +8,7 @@
  ********************************************************/
 #pragma once
 
+#include <jit/Node.hpp>
 #include <math.hpp>
 #include <optypes.hpp>
 #include <types.hpp>

--- a/src/backend/cpu/binary.hpp
+++ b/src/backend/cpu/binary.hpp
@@ -1,0 +1,152 @@
+/*******************************************************
+ * Copyright (c) 2021, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+#pragma once
+
+#include <math.hpp>
+#include <optypes.hpp>
+#include <types.hpp>
+#include <cmath>
+
+namespace cpu {
+
+template<typename To, typename Ti, af_op_t op>
+struct BinOp;
+
+#define ARITH_FN(OP, op)                                                 \
+    template<typename T>                                                 \
+    struct BinOp<T, T, OP> {                                             \
+        void eval(jit::array<compute_t<T>> &out,                         \
+                  const jit::array<compute_t<T>> &lhs,                   \
+                  const jit::array<compute_t<T>> &rhs, int lim) const {  \
+            for (int i = 0; i < lim; i++) { out[i] = lhs[i] op rhs[i]; } \
+        }                                                                \
+    };
+
+ARITH_FN(af_add_t, +)
+ARITH_FN(af_sub_t, -)
+ARITH_FN(af_mul_t, *)
+ARITH_FN(af_div_t, /)
+
+#undef ARITH_FN
+
+#define LOGIC_FN(OP, op)                                                      \
+    template<typename T>                                                      \
+    struct BinOp<char, T, OP> {                                               \
+        void eval(jit::array<char> &out, const jit::array<compute_t<T>> &lhs, \
+                  const jit::array<compute_t<T>> &rhs, int lim) {             \
+            for (int i = 0; i < lim; i++) { out[i] = lhs[i] op rhs[i]; }      \
+        }                                                                     \
+    };
+
+LOGIC_FN(af_eq_t, ==)
+LOGIC_FN(af_neq_t, !=)
+LOGIC_FN(af_lt_t, <)
+LOGIC_FN(af_gt_t, >)
+LOGIC_FN(af_le_t, <=)
+LOGIC_FN(af_ge_t, >=)
+LOGIC_FN(af_and_t, &&)
+LOGIC_FN(af_or_t, ||)
+
+#undef LOGIC_FN
+
+#define LOGIC_CPLX_FN(T, OP, op)                                               \
+    template<>                                                                 \
+    struct BinOp<char, std::complex<T>, OP> {                                  \
+        typedef std::complex<T> Ti;                                            \
+        void eval(jit::array<char> &out, const jit::array<compute_t<Ti>> &lhs, \
+                  const jit::array<compute_t<Ti>> &rhs, int lim) {             \
+            for (int i = 0; i < lim; i++) {                                    \
+                T lhs_mag = std::abs(lhs[i]);                                  \
+                T rhs_mag = std::abs(rhs[i]);                                  \
+                out[i]    = lhs_mag op rhs_mag;                                \
+            }                                                                  \
+        }                                                                      \
+    };
+
+LOGIC_CPLX_FN(float, af_lt_t, <)
+LOGIC_CPLX_FN(float, af_le_t, <=)
+LOGIC_CPLX_FN(float, af_gt_t, >)
+LOGIC_CPLX_FN(float, af_ge_t, >=)
+LOGIC_CPLX_FN(float, af_and_t, &&)
+LOGIC_CPLX_FN(float, af_or_t, ||)
+
+LOGIC_CPLX_FN(double, af_lt_t, <)
+LOGIC_CPLX_FN(double, af_le_t, <=)
+LOGIC_CPLX_FN(double, af_gt_t, >)
+LOGIC_CPLX_FN(double, af_ge_t, >=)
+LOGIC_CPLX_FN(double, af_and_t, &&)
+LOGIC_CPLX_FN(double, af_or_t, ||)
+
+#undef LOGIC_CPLX_FN
+
+template<typename T>
+static T __mod(T lhs, T rhs) {
+    T res = lhs % rhs;
+    return (res < 0) ? abs(rhs - res) : res;
+}
+
+template<typename T>
+static T __rem(T lhs, T rhs) {
+    return lhs % rhs;
+}
+
+template<>
+STATIC_ float __mod<float>(float lhs, float rhs) {
+    return fmod(lhs, rhs);
+}
+template<>
+STATIC_ double __mod<double>(double lhs, double rhs) {
+    return fmod(lhs, rhs);
+}
+template<>
+STATIC_ float __rem<float>(float lhs, float rhs) {
+    return remainder(lhs, rhs);
+}
+template<>
+STATIC_ double __rem<double>(double lhs, double rhs) {
+    return remainder(lhs, rhs);
+}
+
+#define BITWISE_FN(OP, op)                                               \
+    template<typename T>                                                 \
+    struct BinOp<T, T, OP> {                                             \
+        void eval(jit::array<compute_t<T>> &out,                         \
+                  const jit::array<compute_t<T>> &lhs,                   \
+                  const jit::array<compute_t<T>> &rhs, int lim) {        \
+            for (int i = 0; i < lim; i++) { out[i] = lhs[i] op rhs[i]; } \
+        }                                                                \
+    };
+
+BITWISE_FN(af_bitor_t, |)
+BITWISE_FN(af_bitand_t, &)
+BITWISE_FN(af_bitxor_t, ^)
+BITWISE_FN(af_bitshiftl_t, <<)
+BITWISE_FN(af_bitshiftr_t, >>)
+
+#undef BITWISE_FN
+
+#define NUMERIC_FN(OP, FN)                                                 \
+    template<typename T>                                                   \
+    struct BinOp<T, T, OP> {                                               \
+        void eval(jit::array<compute_t<T>> &out,                           \
+                  const jit::array<compute_t<T>> &lhs,                     \
+                  const jit::array<compute_t<T>> &rhs, int lim) {          \
+            for (int i = 0; i < lim; i++) { out[i] = FN(lhs[i], rhs[i]); } \
+        }                                                                  \
+    };
+
+NUMERIC_FN(af_max_t, max)
+NUMERIC_FN(af_min_t, min)
+NUMERIC_FN(af_mod_t, __mod)
+NUMERIC_FN(af_pow_t, pow)
+NUMERIC_FN(af_rem_t, __rem)
+NUMERIC_FN(af_atan2_t, atan2)
+NUMERIC_FN(af_hypot_t, hypot)
+
+}  // namespace cpu

--- a/src/backend/cpu/blas.cpp
+++ b/src/backend/cpu/blas.cpp
@@ -15,8 +15,8 @@
 
 #include <Array.hpp>
 #include <Param.hpp>
-#include <cast.hpp>
 #include <common/blas_headers.hpp>
+#include <common/cast.hpp>
 #include <common/complex.hpp>
 #include <common/err_common.hpp>
 #include <common/half.hpp>
@@ -34,6 +34,7 @@
 #include <vector>
 
 using af::dtype_traits;
+using common::cast;
 using common::half;
 using common::is_complex;
 using std::conditional;

--- a/src/backend/cpu/cast.hpp
+++ b/src/backend/cpu/cast.hpp
@@ -152,27 +152,4 @@ CAST_B8(int)
 CAST_B8(uchar)
 CAST_B8(char)
 
-template<typename To, typename Ti>
-struct CastWrapper {
-    Array<To> operator()(const Array<Ti> &in) {
-        common::Node_ptr in_node = in.getNode();
-        jit::UnaryNode<To, Ti, af_cast_t> *node =
-            new jit::UnaryNode<To, Ti, af_cast_t>(in_node);
-        return createNodeArray<To>(
-            in.dims(),
-            common::Node_ptr(reinterpret_cast<common::Node *>(node)));
-    }
-};
-
-template<typename T>
-struct CastWrapper<T, T> {
-    Array<T> operator()(const Array<T> &in) { return in; }
-};
-
-template<typename To, typename Ti>
-Array<To> cast(const Array<Ti> &in) {
-    CastWrapper<To, Ti> cast_op;
-    return cast_op(in);
-}
-
 }  // namespace cpu

--- a/src/backend/cpu/complex.hpp
+++ b/src/backend/cpu/complex.hpp
@@ -54,40 +54,32 @@ CPLX_UNARY_FN(abs)
 template<typename To, typename Ti>
 Array<To> real(const Array<Ti> &in) {
     common::Node_ptr in_node = in.getNode();
-    jit::UnaryNode<To, Ti, af_real_t> *node =
-        new jit::UnaryNode<To, Ti, af_real_t>(in_node);
+    auto node = std::make_shared<jit::UnaryNode<To, Ti, af_real_t>>(in_node);
 
-    return createNodeArray<To>(
-        in.dims(), common::Node_ptr(static_cast<common::Node *>(node)));
+    return createNodeArray<To>(in.dims(), move(node));
 }
 
 template<typename To, typename Ti>
 Array<To> imag(const Array<Ti> &in) {
     common::Node_ptr in_node = in.getNode();
-    jit::UnaryNode<To, Ti, af_imag_t> *node =
-        new jit::UnaryNode<To, Ti, af_imag_t>(in_node);
+    auto node = std::make_shared<jit::UnaryNode<To, Ti, af_imag_t>>(in_node);
 
-    return createNodeArray<To>(
-        in.dims(), common::Node_ptr(static_cast<common::Node *>(node)));
+    return createNodeArray<To>(in.dims(), move(node));
 }
 
 template<typename To, typename Ti>
 Array<To> abs(const Array<Ti> &in) {
     common::Node_ptr in_node = in.getNode();
-    jit::UnaryNode<To, Ti, af_abs_t> *node =
-        new jit::UnaryNode<To, Ti, af_abs_t>(in_node);
+    auto node = std::make_shared<jit::UnaryNode<To, Ti, af_abs_t>>(in_node);
 
-    return createNodeArray<To>(
-        in.dims(), common::Node_ptr(static_cast<common::Node *>(node)));
+    return createNodeArray<To>(in.dims(), move(node));
 }
 
 template<typename T>
 Array<T> conj(const Array<T> &in) {
     common::Node_ptr in_node = in.getNode();
-    jit::UnaryNode<T, T, af_conj_t> *node =
-        new jit::UnaryNode<T, T, af_conj_t>(in_node);
+    auto node = std::make_shared<jit::UnaryNode<T, T, af_conj_t>>(in_node);
 
-    return createNodeArray<T>(
-        in.dims(), common::Node_ptr(static_cast<common::Node *>(node)));
+    return createNodeArray<T>(in.dims(), move(node));
 }
 }  // namespace cpu

--- a/src/backend/cpu/jit/BinaryNode.hpp
+++ b/src/backend/cpu/jit/BinaryNode.hpp
@@ -9,16 +9,15 @@
 
 #pragma once
 
+#include <binary.hpp>
+#include <common/jit/Node.hpp>
 #include <math.hpp>
 #include <optypes.hpp>
+
 #include <array>
 #include <vector>
-#include "Node.hpp"
 
 namespace cpu {
-
-template<typename To, typename Ti, af_op_t op>
-struct BinOp;
 
 namespace jit {
 

--- a/src/backend/cpu/jit/BufferNode.hpp
+++ b/src/backend/cpu/jit/BufferNode.hpp
@@ -22,35 +22,35 @@ namespace cpu {
 
 namespace jit {
 
-using std::shared_ptr;
 template<typename T>
 class BufferNode : public TNode<T> {
    protected:
-    shared_ptr<T> m_sptr;
+    std::shared_ptr<T> m_data;
     T *m_ptr;
     unsigned m_bytes;
     dim_t m_strides[4];
     dim_t m_dims[4];
-    std::once_flag m_set_data_flag;
     bool m_linear_buffer;
 
    public:
-    BufferNode() : TNode<T>(T(0), 0, {}) {}
+    BufferNode()
+        : TNode<T>(T(0), 0, {})
+        , m_bytes(0)
+        , m_strides{0, 0, 0, 0}
+        , m_dims{0, 0, 0, 0}
+        , m_linear_buffer(true) {}
 
-    void setData(shared_ptr<T> data, unsigned bytes, dim_t data_off,
+    void setData(std::shared_ptr<T> data, unsigned bytes, dim_t data_off,
                  const dim_t *dims, const dim_t *strides,
                  const bool is_linear) {
-        std::call_once(m_set_data_flag, [this, data, bytes, data_off, dims,
-                                         strides, is_linear]() {
-            m_sptr          = data;
-            m_ptr           = data.get() + data_off;
-            m_bytes         = bytes;
-            m_linear_buffer = is_linear;
-            for (int i = 0; i < 4; i++) {
-                m_strides[i] = strides[i];
-                m_dims[i]    = dims[i];
-            }
-        });
+        m_data          = data;
+        m_ptr           = data.get() + data_off;
+        m_bytes         = bytes;
+        m_linear_buffer = is_linear;
+        for (int i = 0; i < 4; i++) {
+            m_strides[i] = strides[i];
+            m_dims[i]    = dims[i];
+        }
     }
 
     void calc(int x, int y, int z, int w, int lim) final {

--- a/src/backend/cpu/jit/Node.hpp
+++ b/src/backend/cpu/jit/Node.hpp
@@ -18,7 +18,6 @@
 #include <array>
 #include <memory>
 #include <unordered_map>
-#include <vector>
 
 namespace common {
 template<typename T>

--- a/src/backend/cpu/jit/Node.hpp
+++ b/src/backend/cpu/jit/Node.hpp
@@ -38,15 +38,17 @@ template<typename T>
 class TNode : public common::Node {
    public:
     alignas(16) jit::array<compute_t<T>> m_val;
+    using common::Node::m_children;
 
    public:
     TNode(T val, const int height,
-          const std::array<common::Node_ptr, kMaxChildren> children)
+          const std::array<common::Node_ptr, kMaxChildren> &&children)
         : Node(static_cast<af::dtype>(af::dtype_traits<T>::af_type), height,
-               children) {
+               move(children)) {
         using namespace common;
         m_val.fill(static_cast<compute_t<T>>(val));
     }
+
     virtual ~TNode() = default;
 };
 

--- a/src/backend/cpu/jit/UnaryNode.hpp
+++ b/src/backend/cpu/jit/UnaryNode.hpp
@@ -13,6 +13,7 @@
 #include <types.hpp>
 #include "Node.hpp"
 
+#include <jit/BufferNode.hpp>
 #include <vector>
 
 namespace cpu {
@@ -33,7 +34,12 @@ class UnaryNode : public TNode<To> {
    public:
     UnaryNode(common::Node_ptr child)
         : TNode<To>(To(0), child->getHeight() + 1, {{child}})
-        , m_child(reinterpret_cast<TNode<Ti> *>(child.get())) {}
+        , m_child(static_cast<TNode<Ti> *>(child.get())) {}
+
+    void replaceChild(int id, void *ptr) noexcept final {
+        auto nnode = static_cast<TNode<Ti> *>(ptr);
+        if (id == 0 && nnode->isBuffer() && m_child != ptr) { m_child = nnode; }
+    }
 
     void calc(int x, int y, int z, int w, int lim) final {
         UNUSED(x);

--- a/src/backend/cpu/logic.hpp
+++ b/src/backend/cpu/logic.hpp
@@ -8,102 +8,23 @@
  ********************************************************/
 
 #include <Array.hpp>
+#include <common/jit/BinaryNode.hpp>
 #include <err_cpu.hpp>
-#include <jit/BinaryNode.hpp>
 #include <optypes.hpp>
 #include <types.hpp>
 #include <af/dim4.hpp>
 
 namespace cpu {
 
-#define LOGIC_FN(OP, op)                                                 \
-    template<typename T>                                                 \
-    struct BinOp<char, T, OP> {                                          \
-        void eval(jit::array<char> &out, const jit::array<T> &lhs,       \
-                  const jit::array<T> &rhs, int lim) {                   \
-            for (int i = 0; i < lim; i++) { out[i] = lhs[i] op rhs[i]; } \
-        }                                                                \
-    };
-
-LOGIC_FN(af_eq_t, ==)
-LOGIC_FN(af_neq_t, !=)
-LOGIC_FN(af_lt_t, <)
-LOGIC_FN(af_gt_t, >)
-LOGIC_FN(af_le_t, <=)
-LOGIC_FN(af_ge_t, >=)
-LOGIC_FN(af_and_t, &&)
-LOGIC_FN(af_or_t, ||)
-
-#undef LOGIC_FN
-
-#define LOGIC_CPLX_FN(T, OP, op)                                    \
-    template<>                                                      \
-    struct BinOp<char, std::complex<T>, OP> {                       \
-        typedef std::complex<T> Ti;                                 \
-        void eval(jit::array<char> &out, const jit::array<Ti> &lhs, \
-                  const jit::array<Ti> &rhs, int lim) {             \
-            for (int i = 0; i < lim; i++) {                         \
-                T lhs_mag = std::abs(lhs[i]);                       \
-                T rhs_mag = std::abs(rhs[i]);                       \
-                out[i]    = lhs_mag op rhs_mag;                     \
-            }                                                       \
-        }                                                           \
-    };
-
-LOGIC_CPLX_FN(float, af_lt_t, <)
-LOGIC_CPLX_FN(float, af_le_t, <=)
-LOGIC_CPLX_FN(float, af_gt_t, >)
-LOGIC_CPLX_FN(float, af_ge_t, >=)
-LOGIC_CPLX_FN(float, af_and_t, &&)
-LOGIC_CPLX_FN(float, af_or_t, ||)
-
-LOGIC_CPLX_FN(double, af_lt_t, <)
-LOGIC_CPLX_FN(double, af_le_t, <=)
-LOGIC_CPLX_FN(double, af_gt_t, >)
-LOGIC_CPLX_FN(double, af_ge_t, >=)
-LOGIC_CPLX_FN(double, af_and_t, &&)
-LOGIC_CPLX_FN(double, af_or_t, ||)
-
-#undef LOGIC_CPLX_FN
-
 template<typename T, af_op_t op>
 Array<char> logicOp(const Array<T> &lhs, const Array<T> &rhs,
                     const af::dim4 &odims) {
-    common::Node_ptr lhs_node = lhs.getNode();
-    common::Node_ptr rhs_node = rhs.getNode();
-
-    jit::BinaryNode<char, T, op> *node =
-        new jit::BinaryNode<char, T, op>(lhs_node, rhs_node);
-
-    return createNodeArray<char>(odims, common::Node_ptr(node));
+    return common::createBinaryNode<char, T, op>(lhs, rhs, odims);
 }
-
-#define BITWISE_FN(OP, op)                                               \
-    template<typename T>                                                 \
-    struct BinOp<T, T, OP> {                                             \
-        void eval(jit::array<T> &out, const jit::array<T> &lhs,          \
-                  const jit::array<T> &rhs, int lim) {                   \
-            for (int i = 0; i < lim; i++) { out[i] = lhs[i] op rhs[i]; } \
-        }                                                                \
-    };
-
-BITWISE_FN(af_bitor_t, |)
-BITWISE_FN(af_bitand_t, &)
-BITWISE_FN(af_bitxor_t, ^)
-BITWISE_FN(af_bitshiftl_t, <<)
-BITWISE_FN(af_bitshiftr_t, >>)
-
-#undef BITWISE_FN
 
 template<typename T, af_op_t op>
 Array<T> bitOp(const Array<T> &lhs, const Array<T> &rhs,
                const af::dim4 &odims) {
-    common::Node_ptr lhs_node = lhs.getNode();
-    common::Node_ptr rhs_node = rhs.getNode();
-
-    jit::BinaryNode<T, T, op> *node =
-        new jit::BinaryNode<T, T, op>(lhs_node, rhs_node);
-
-    return createNodeArray<T>(odims, common::Node_ptr(node));
+    return common::createBinaryNode<T, T, op>(lhs, rhs, odims);
 }
 }  // namespace cpu

--- a/src/backend/cpu/sparse.cpp
+++ b/src/backend/cpu/sparse.cpp
@@ -14,7 +14,7 @@
 #include <string>
 
 #include <arith.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/complex.hpp>
 #include <common/err_common.hpp>
 #include <complex.hpp>
@@ -28,6 +28,7 @@
 
 #include <functional>
 
+using common::cast;
 using std::function;
 
 namespace cpu {

--- a/src/backend/cpu/unary.hpp
+++ b/src/backend/cpu/unary.hpp
@@ -88,10 +88,10 @@ Array<T> unaryOp(const Array<T> &in, dim4 outDim = dim4(-1, -1, -1, -1)) {
     using UnaryNode = jit::UnaryNode<T, T, op>;
 
     common::Node_ptr in_node = in.getNode();
-    UnaryNode *node          = new UnaryNode(in_node);
+    auto node                = std::make_shared<UnaryNode>(in_node);
 
     if (outDim == dim4(-1, -1, -1, -1)) { outDim = in.dims(); }
-    return createNodeArray<T>(outDim, common::Node_ptr(node));
+    return createNodeArray<T>(outDim, move(node));
 }
 
 #define iszero(a) ((a) == 0)
@@ -113,11 +113,10 @@ CHECK_FN(iszero, iszero)
 template<typename T, af_op_t op>
 Array<char> checkOp(const Array<T> &in, dim4 outDim = dim4(-1, -1, -1, -1)) {
     common::Node_ptr in_node = in.getNode();
-    jit::UnaryNode<char, T, op> *node =
-        new jit::UnaryNode<char, T, op>(in_node);
+    auto node = std::make_shared<jit::UnaryNode<char, T, op>>(in_node);
 
     if (outDim == dim4(-1, -1, -1, -1)) { outDim = in.dims(); }
-    return createNodeArray<char>(outDim, common::Node_ptr(node));
+    return createNodeArray<char>(outDim, move(node));
 }
 
 }  // namespace cpu

--- a/src/backend/cuda/arith.hpp
+++ b/src/backend/cuda/arith.hpp
@@ -10,14 +10,13 @@
 #pragma once
 
 #include <Array.hpp>
-#include <binary.hpp>
-#include <optypes.hpp>
+#include <common/jit/BinaryNode.hpp>
 #include <af/dim4.hpp>
 
 namespace cuda {
 template<typename T, af_op_t op>
 Array<T> arithOp(const Array<T> &lhs, const Array<T> &rhs,
                  const af::dim4 &odims) {
-    return createBinaryNode<T, T, op>(lhs, rhs, odims);
+    return common::createBinaryNode<T, T, op>(lhs, rhs, odims);
 }
 }  // namespace cuda

--- a/src/backend/cuda/arith.hpp
+++ b/src/backend/cuda/arith.hpp
@@ -14,6 +14,13 @@
 #include <af/dim4.hpp>
 
 namespace cuda {
+
+template<typename T, af_op_t op>
+Array<T> arithOp(const Array<T> &&lhs, const Array<T> &&rhs,
+                 const af::dim4 &odims) {
+    return common::createBinaryNode<T, T, op>(lhs, rhs, odims);
+}
+
 template<typename T, af_op_t op>
 Array<T> arithOp(const Array<T> &lhs, const Array<T> &rhs,
                  const af::dim4 &odims) {

--- a/src/backend/cuda/binary.hpp
+++ b/src/backend/cuda/binary.hpp
@@ -8,12 +8,8 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
-#include <common/jit/BinaryNode.hpp>
-#include <common/jit/NaryNode.hpp>
 #include <math.hpp>
 #include <optypes.hpp>
-#include <af/dim4.hpp>
 
 namespace cuda {
 
@@ -127,23 +123,5 @@ template<typename To, typename Ti>
 struct BinOp<To, Ti, af_hypot_t> {
     const char *name() { return "hypot"; }
 };
-
-template<typename To, typename Ti, af_op_t op>
-Array<To> createBinaryNode(const Array<Ti> &lhs, const Array<Ti> &rhs,
-                           const af::dim4 &odims) {
-    using common::Node;
-    using common::Node_ptr;
-
-    auto createBinary = [](std::array<Node_ptr, 2> &operands) -> Node_ptr {
-        BinOp<To, Ti, op> bop;
-        return Node_ptr(new common::BinaryNode(
-            static_cast<af::dtype>(dtype_traits<To>::af_type), bop.name(),
-            operands[0], operands[1], (int)(op)));
-    };
-
-    Node_ptr out =
-        common::createNaryNode<Ti, 2>(odims, createBinary, {&lhs, &rhs});
-    return createNodeArray<To>(odims, out);
-}
 
 }  // namespace cuda

--- a/src/backend/cuda/blas.cu
+++ b/src/backend/cuda/blas.cu
@@ -10,7 +10,7 @@
 #include <blas.hpp>
 
 #include <arith.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/half.hpp>
 #include <complex.hpp>

--- a/src/backend/cuda/cast.hpp
+++ b/src/backend/cuda/cast.hpp
@@ -84,27 +84,4 @@ struct CastOp<unsigned char, common::half> {
 #undef CAST_FN
 #undef CAST_CFN
 
-template<typename To, typename Ti>
-struct CastWrapper {
-    Array<To> operator()(const Array<Ti> &in) {
-        CastOp<To, Ti> cop;
-        common::Node_ptr in_node = in.getNode();
-        common::UnaryNode *node  = new common::UnaryNode(
-            static_cast<af::dtype>(dtype_traits<To>::af_type), cop.name(),
-            in_node, af_cast_t);
-        return createNodeArray<To>(in.dims(), common::Node_ptr(node));
-    }
-};
-
-template<typename T>
-struct CastWrapper<T, T> {
-    Array<T> operator()(const Array<T> &in) { return in; }
-};
-
-template<typename To, typename Ti>
-Array<To> cast(const Array<Ti> &in) {
-    CastWrapper<To, Ti> cast_op;
-    return cast_op(in);
-}
-
 }  // namespace cuda

--- a/src/backend/cuda/complex.hpp
+++ b/src/backend/cuda/complex.hpp
@@ -9,6 +9,7 @@
 
 #include <Array.hpp>
 #include <binary.hpp>
+#include <common/jit/BinaryNode.hpp>
 #include <common/jit/UnaryNode.hpp>
 #include <optypes.hpp>
 #include <af/dim4.hpp>
@@ -17,7 +18,7 @@ namespace cuda {
 template<typename To, typename Ti>
 Array<To> cplx(const Array<Ti> &lhs, const Array<Ti> &rhs,
                const af::dim4 &odims) {
-    return createBinaryNode<To, Ti, af_cplx2_t>(lhs, rhs, odims);
+    return common::createBinaryNode<To, Ti, af_cplx2_t>(lhs, rhs, odims);
 }
 
 template<typename To, typename Ti>

--- a/src/backend/cuda/convolveNN.cpp
+++ b/src/backend/cuda/convolveNN.cpp
@@ -11,7 +11,7 @@
 
 #include <Array.hpp>
 #include <blas.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/half.hpp>
 #include <common/indexing_helpers.hpp>
 #include <common/unique_handle.hpp>

--- a/src/backend/cuda/jit/BufferNode.hpp
+++ b/src/backend/cuda/jit/BufferNode.hpp
@@ -16,4 +16,19 @@ namespace jit {
 template<typename T>
 using BufferNode = common::BufferNodeBase<std::shared_ptr<T>, Param<T>>;
 }
+
 }  // namespace cuda
+
+namespace common {
+
+template<typename DataType, typename ParamType>
+bool BufferNodeBase<DataType, ParamType>::operator==(
+    const BufferNodeBase<DataType, ParamType> &other) const noexcept {
+    // clang-format off
+    return m_data.get() == other.m_data.get() &&
+           m_bytes == other.m_bytes &&
+           m_param.ptr == other.m_param.ptr;
+    // clang-format on
+}
+
+}  // namespace common

--- a/src/backend/cuda/logic.hpp
+++ b/src/backend/cuda/logic.hpp
@@ -8,22 +8,19 @@
  ********************************************************/
 
 #include <Array.hpp>
-#include <binary.hpp>
-#include <err_cuda.hpp>
-#include <optypes.hpp>
-#include <af/defines.h>
+#include <common/jit/BinaryNode.hpp>
 #include <af/dim4.hpp>
 
 namespace cuda {
 template<typename T, af_op_t op>
 Array<char> logicOp(const Array<T> &lhs, const Array<T> &rhs,
                     const af::dim4 &odims) {
-    return createBinaryNode<char, T, op>(lhs, rhs, odims);
+    return common::createBinaryNode<char, T, op>(lhs, rhs, odims);
 }
 
 template<typename T, af_op_t op>
 Array<T> bitOp(const Array<T> &lhs, const Array<T> &rhs,
                const af::dim4 &odims) {
-    return createBinaryNode<T, T, op>(lhs, rhs, odims);
+    return common::createBinaryNode<T, T, op>(lhs, rhs, odims);
 }
 }  // namespace cuda

--- a/src/backend/cuda/sparse.cu
+++ b/src/backend/cuda/sparse.cu
@@ -10,7 +10,7 @@
 #include <sparse.hpp>
 
 #include <arith.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <complex.hpp>
 #include <copy.hpp>

--- a/src/backend/cuda/sparse_arith.cu
+++ b/src/backend/cuda/sparse_arith.cu
@@ -10,7 +10,7 @@
 #include <sparse_arith.hpp>
 
 #include <arith.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/unique_handle.hpp>
 #include <complex.hpp>

--- a/src/backend/opencl/arith.hpp
+++ b/src/backend/opencl/arith.hpp
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <Array.hpp>
-#include <binary.hpp>
+#include <common/jit/BinaryNode.hpp>
 #include <optypes.hpp>
 #include <af/dim4.hpp>
 
@@ -18,6 +18,6 @@ namespace opencl {
 template<typename T, af_op_t op>
 Array<T> arithOp(const Array<T> &lhs, const Array<T> &rhs,
                  const af::dim4 &odims) {
-    return createBinaryNode<T, T, op>(lhs, rhs, odims);
+    return common::createBinaryNode<T, T, op>(lhs, rhs, odims);
 }
 }  // namespace opencl

--- a/src/backend/opencl/arith.hpp
+++ b/src/backend/opencl/arith.hpp
@@ -15,6 +15,13 @@
 #include <af/dim4.hpp>
 
 namespace opencl {
+
+template<typename T, af_op_t op>
+Array<T> arithOp(const Array<T> &&lhs, const Array<T> &&rhs,
+                 const af::dim4 &odims) {
+    return common::createBinaryNode<T, T, op>(lhs, rhs, odims);
+}
+
 template<typename T, af_op_t op>
 Array<T> arithOp(const Array<T> &lhs, const Array<T> &rhs,
                  const af::dim4 &odims) {

--- a/src/backend/opencl/binary.hpp
+++ b/src/backend/opencl/binary.hpp
@@ -8,11 +8,7 @@
  ********************************************************/
 
 #pragma once
-#include <Array.hpp>
-#include <common/jit/BinaryNode.hpp>
-#include <math.hpp>
 #include <optypes.hpp>
-#include <af/dim4.hpp>
 
 namespace opencl {
 
@@ -127,23 +123,5 @@ template<typename To, typename Ti>
 struct BinOp<To, Ti, af_hypot_t> {
     const char *name() { return "hypot"; }
 };
-
-template<typename To, typename Ti, af_op_t op>
-Array<To> createBinaryNode(const Array<Ti> &lhs, const Array<Ti> &rhs,
-                           const af::dim4 &odims) {
-    using common::Node;
-    using common::Node_ptr;
-
-    auto createBinary = [](std::array<Node_ptr, 2> &operands) -> Node_ptr {
-        BinOp<To, Ti, op> bop;
-        return Node_ptr(new common::BinaryNode(
-            static_cast<af::dtype>(dtype_traits<To>::af_type), bop.name(),
-            operands[0], operands[1], (int)(op)));
-    };
-
-    Node_ptr out =
-        common::createNaryNode<Ti, 2>(odims, createBinary, {&lhs, &rhs});
-    return createNodeArray<To>(odims, out);
-}
 
 }  // namespace opencl

--- a/src/backend/opencl/cast.hpp
+++ b/src/backend/opencl/cast.hpp
@@ -70,27 +70,4 @@ struct CastOp<cdouble, cdouble> {
 #undef CAST_FN
 #undef CAST_CFN
 
-template<typename To, typename Ti>
-struct CastWrapper {
-    Array<To> operator()(const Array<Ti> &in) {
-        CastOp<To, Ti> cop;
-        common::Node_ptr in_node = in.getNode();
-        common::UnaryNode *node  = new common::UnaryNode(
-            static_cast<af::dtype>(dtype_traits<To>::af_type), cop.name(),
-            in_node, af_cast_t);
-        return createNodeArray<To>(in.dims(), common::Node_ptr(node));
-    }
-};
-
-template<typename T>
-struct CastWrapper<T, T> {
-    Array<T> operator()(const Array<T> &in) { return in; }
-};
-
-template<typename To, typename Ti>
-Array<To> cast(const Array<Ti> &in) {
-    CastWrapper<To, Ti> cast_op;
-    return cast_op(in);
-}
-
 }  // namespace opencl

--- a/src/backend/opencl/complex.hpp
+++ b/src/backend/opencl/complex.hpp
@@ -9,6 +9,7 @@
 
 #include <Array.hpp>
 #include <binary.hpp>
+#include <common/jit/BinaryNode.hpp>
 #include <common/jit/UnaryNode.hpp>
 #include <optypes.hpp>
 #include <traits.hpp>
@@ -18,7 +19,7 @@ namespace opencl {
 template<typename To, typename Ti>
 Array<To> cplx(const Array<Ti> &lhs, const Array<Ti> &rhs,
                const af::dim4 &odims) {
-    return createBinaryNode<To, Ti, af_cplx2_t>(lhs, rhs, odims);
+    return common::createBinaryNode<To, Ti, af_cplx2_t>(lhs, rhs, odims);
 }
 
 template<typename To, typename Ti>

--- a/src/backend/opencl/jit/BufferNode.hpp
+++ b/src/backend/opencl/jit/BufferNode.hpp
@@ -20,3 +20,17 @@ namespace jit {
 using BufferNode = common::BufferNodeBase<std::shared_ptr<cl::Buffer>, KParam>;
 }
 }  // namespace opencl
+
+namespace common {
+
+template<typename DataType, typename ParamType>
+bool BufferNodeBase<DataType, ParamType>::operator==(
+    const BufferNodeBase<DataType, ParamType> &other) const noexcept {
+    // clang-format off
+    return m_data.get() == other.m_data.get() &&
+           m_bytes == other.m_bytes &&
+           m_param.offset == other.m_param.offset;
+    // clang-format on
+}
+
+}  // namespace common

--- a/src/backend/opencl/jit/BufferNode.hpp
+++ b/src/backend/opencl/jit/BufferNode.hpp
@@ -9,11 +9,9 @@
 
 #pragma once
 #include <common/jit/BufferNodeBase.hpp>
-#include <common/jit/Node.hpp>
-#include <af/defines.h>
-#include <iomanip>
-#include <mutex>
 #include "../kernel/KParam.hpp"
+
+#include <memory>
 
 namespace opencl {
 namespace jit {

--- a/src/backend/opencl/kernel/iir.hpp
+++ b/src/backend/opencl/kernel/iir.hpp
@@ -14,6 +14,7 @@
 #include <common/kernel_cache.hpp>
 #include <debug_opencl.hpp>
 #include <kernel_headers/iir.hpp>
+#include <math.hpp>
 #include <traits.hpp>
 
 #include <string>

--- a/src/backend/opencl/logic.hpp
+++ b/src/backend/opencl/logic.hpp
@@ -9,6 +9,7 @@
 
 #include <Array.hpp>
 #include <binary.hpp>
+#include <common/jit/BinaryNode.hpp>
 #include <err_opencl.hpp>
 #include <optypes.hpp>
 #include <af/defines.h>
@@ -18,12 +19,12 @@ namespace opencl {
 template<typename T, af_op_t op>
 Array<char> logicOp(const Array<T> &lhs, const Array<T> &rhs,
                     const af::dim4 &odims) {
-    return createBinaryNode<char, T, op>(lhs, rhs, odims);
+    return common::createBinaryNode<char, T, op>(lhs, rhs, odims);
 }
 
 template<typename T, af_op_t op>
 Array<T> bitOp(const Array<T> &lhs, const Array<T> &rhs,
                const af::dim4 &odims) {
-    return createBinaryNode<T, T, op>(lhs, rhs, odims);
+    return common::createBinaryNode<T, T, op>(lhs, rhs, odims);
 }
 }  // namespace opencl

--- a/src/backend/opencl/sparse.cpp
+++ b/src/backend/opencl/sparse.cpp
@@ -14,7 +14,7 @@
 #include <string>
 
 #include <arith.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <complex.hpp>
 #include <copy.hpp>
 #include <err_opencl.hpp>

--- a/src/backend/opencl/sparse_arith.cpp
+++ b/src/backend/opencl/sparse_arith.cpp
@@ -14,7 +14,7 @@
 #include <string>
 
 #include <arith.hpp>
-#include <cast.hpp>
+#include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <complex.hpp>
 #include <copy.hpp>

--- a/test/arrayfire_test.cpp
+++ b/test/arrayfire_test.cpp
@@ -1634,6 +1634,23 @@ template<typename T>
                            bbb, maxAbsDiff);
 }
 
+::testing::AssertionResult assertRefEq(std::string hA_name,
+                                       std::string expected_name,
+                                       const af::array &a, int expected) {
+    int count = 0;
+    af_get_data_ref_count(&count, a.get());
+    if (count != expected) {
+        std::stringstream ss;
+        ss << "Incorrect reference count:\nExpected: " << expected << "\n"
+           << std::setw(8) << hA_name << ": " << count;
+
+        return ::testing::AssertionFailure() << ss.str();
+
+    } else {
+        return ::testing::AssertionSuccess();
+    }
+}
+
 #define INSTANTIATE(To)                                                        \
     template std::string printContext(                                         \
         const std::vector<To> &hGold, std::string goldName,                    \

--- a/test/convolve.cpp
+++ b/test/convolve.cpp
@@ -672,8 +672,8 @@ TEST(Convolve, 1D_C32) {
 
     cfloat acc = sum<cfloat>(out - gld);
 
-    EXPECT_EQ(std::abs(real(acc)) < 1E-3, true);
-    EXPECT_EQ(std::abs(imag(acc)) < 1E-3, true);
+    EXPECT_LT(std::abs(real(acc)), 1E-3);
+    EXPECT_LT(std::abs(imag(acc)), 1E-3);
 }
 
 TEST(Convolve, 2D_C32) {
@@ -685,8 +685,8 @@ TEST(Convolve, 2D_C32) {
 
     cfloat acc = sum<cfloat>(out - gld);
 
-    EXPECT_EQ(std::abs(real(acc)) < 1E-3, true);
-    EXPECT_EQ(std::abs(imag(acc)) < 1E-3, true);
+    EXPECT_LT(std::abs(real(acc)), 1E-3);
+    EXPECT_LT(std::abs(imag(acc)), 1E-3);
 }
 
 TEST(Convolve, 3D_C32) {

--- a/test/jit.cpp
+++ b/test/jit.cpp
@@ -53,9 +53,10 @@ TEST(JIT, CPP_JIT_HASH) {
 
     // Creating a kernel
     {
-        array d    = a + b;
-        array e    = a + c;
-        array f1   = d * e - e;
+        array d  = a + b;
+        array e  = a + c;
+        array f1 = d * e - e;
+
         float* hF1 = f1.host<float>();
 
         for (int i = 0; i < num; i++) { ASSERT_EQ(hF1[i], valF1); }

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -360,6 +360,10 @@ template<typename T>
     std::string maxAbsDiffName, const std::vector<T> &hA, af::dim4 aDims,
     const af_array b, float maxAbsDiff);
 
+::testing::AssertionResult assertRefEq(std::string hA_name,
+                                       std::string expected_name,
+                                       const af::array &a, int expected);
+
 /// Checks if the C-API arrayfire function returns successfully
 ///
 /// \param[in] CALL This is the arrayfire C function
@@ -429,6 +433,9 @@ template<typename T>
                               MAX_ABSDIFF)                                 \
     ASSERT_PRED_FORMAT4(assertArrayNear, EXPECTED_VEC, EXPECTED_ARR_DIMS,  \
                         ACTUAL_ARR, MAX_ABSDIFF)
+
+#define ASSERT_REF(arr, expected) \
+    ASSERT_PRED_FORMAT2(assertRefEq, arr, expected)
 
 #if defined(USE_MTX)
 ::testing::AssertionResult mtxReadSparseMatrix(af::array &out,


### PR DESCRIPTION
Better manage the reference count of an Array<T> object when it is used in a JIT operation

Description
-----------
Previously when an af::array was used in a jit operation and it was backed by a
buffer, a buffer node was created and the internal shared_ptr was stored in the
Array for future use and returned when getNode was called. This increased the
reference count of the internal buffer. This reference count never decreased
because of the internal reference to the shared_ptr.

This commit changes this behavior by storing a weak_ptr instead of a
shared_ptr inernally to the Array<T> object. This change reduces the
reference count once the Array<T> is evaluated in an expression. If
the weak_ptr can be converted into a

Changes to Users
----------------
Enjoy lower reference counts. This may increase performance under certain scenarios

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- [x] Functions documented
