### PR TITLE
Canny empty array fix

### DIFF
--- a/src/api/c/canny.cpp
+++ b/src/api/c/canny.cpp
@@ -89,6 +89,7 @@ Array<float> otsuThreshold(const Array<float>& supEdges,
 
     vector<af_seq> seqBegin(4, af_span);
     vector<af_seq> seqRest(4, af_span);
+    vector<af_seq> sliceIndex(4, af_span);
 
     seqBegin[0] = af_make_seq(0, static_cast<double>(hDims[0] - 1), 1);
     seqRest[0]  = af_make_seq(0, static_cast<double>(hDims[0] - 1), 1);
@@ -129,11 +130,8 @@ Array<float> otsuThreshold(const Array<float>& supEdges,
         auto op2   = arithOp<float, af_mul_t>(qL, qH, tdims);
         auto sigma = arithOp<float, af_mul_t>(sqrd, op2, tdims);
 
-        vector<af_seq> sliceIndex(4, af_span);
         sliceIndex[0] = {double(b), double(b), 1};
-
-        auto binRes = createSubArray<float>(sigmas, sliceIndex, false);
-
+        auto binRes   = createSubArray<float>(sigmas, sliceIndex, false);
         copyArray(binRes, sigma);
     }
 

--- a/src/api/c/canny.cpp
+++ b/src/api/c/canny.cpp
@@ -95,8 +95,8 @@ Array<float> otsuThreshold(const Array<float>& supEdges,
 
     const dim4& iDims = supEdges.dims();
 
-    Array<float> sigmas = createEmptyArray<float>(hDims);
-
+    dim4 sigmaDims(NUM_BINS - 1, hDims[1], hDims[2], hDims[3]);
+    Array<float> sigmas = createEmptyArray<float>(sigmaDims);
     for (unsigned b = 0; b < (NUM_BINS - 1); ++b) {
         seqBegin[0].end  = static_cast<double>(b);
         seqRest[0].begin = static_cast<double>(b + 1);


### PR DESCRIPTION
The otsuThreshold function was creating an empty Array for the sigmas variable
and this sometimes failed because the last value was not always written to. This
PR adjusts the size of the array so that the extra element is not used.

Description
-----------
The otsuThreshold function was creating an empty Array for the sigmas variable
and this sometimes failed because the last value was not always written to. This
PR adjusts the size of the array so that the extra element is not used.

This PR also removes a couple of reductions in the otsuThreshold function. These
reductions are replaced by a scan.

Changes to Users
----------------
<!--
* Additional options added to the build.
* What changes will existing users have to make to their code or build steps?
Refer to [wiki](https://github.com/arrayfire/arrayfire/wiki) for development guidelines
-->

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- [x] Functions documented
