### PR TITLE
Create ASSERT_IMAGE_NEAR which compares two images for equality

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -128,6 +128,7 @@ endif()
 
 target_compile_definitions(arrayfire_test
   PRIVATE
+    TEST_RESULT_IMAGE_DIR="${CMAKE_BINARY_DIR}/test/"
     USE_MTX)
 
 # Creates tests for all backends

--- a/test/anisotropic_diffusion.cpp
+++ b/test/anisotropic_diffusion.cpp
@@ -125,14 +125,7 @@ void imageTest(string pTestFile, const float dt, const float K,
         ASSERT_SUCCESS(af_div(&divArray, numArray, denArray, false));
         ASSERT_SUCCESS(af_mul(&outArray, divArray, cstArray, false));
 
-        vector<OutType> outData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void *)outData.data(), outArray));
-
-        vector<OutType> goldData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void *)goldData.data(), goldArray));
-
-        ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(),
-                                          outData.data(), 0.025f));
+        ASSERT_IMAGES_NEAR(goldArray, outArray, 0.025);
 
         ASSERT_SUCCESS(af_release_array(_inArray));
         ASSERT_SUCCESS(af_release_array(_outArray));

--- a/test/bilateral.cpp
+++ b/test/bilateral.cpp
@@ -54,14 +54,7 @@ void bilateralTest(string pTestFile) {
         ASSERT_SUCCESS(
             af_bilateral(&outArray, inArray, 2.25f, 25.56f, isColor));
 
-        vector<T> outData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
-
-        vector<T> goldData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
-
-        ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(),
-                                          outData.data(), 0.02f));
+        ASSERT_IMAGES_NEAR(goldArray, outArray, 0.02f);
 
         ASSERT_SUCCESS(af_release_array(inArray));
         ASSERT_SUCCESS(af_release_array(outArray));

--- a/test/canny.cpp
+++ b/test/canny.cpp
@@ -147,14 +147,7 @@ void cannyImageOtsuTest(string pTestFile, bool isColor) {
         ASSERT_SUCCESS(af_mul(&mulArray, cstArray, _outArray, false));
         ASSERT_SUCCESS(af_cast(&outArray, mulArray, u8));
 
-        vector<unsigned char> outData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
-
-        vector<unsigned char> goldData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
-
-        ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(),
-                                          outData.data(), 1.0e-3));
+        ASSERT_IMAGES_NEAR(goldArray, outArray, 1.0e-3);
 
         ASSERT_SUCCESS(af_release_array(_inArray));
         ASSERT_SUCCESS(af_release_array(inArray));

--- a/test/inverse_deconv.cpp
+++ b/test/inverse_deconv.cpp
@@ -102,11 +102,7 @@ void invDeconvImageTest(string pTestFile, const float gamma,
         ASSERT_SUCCESS(af_div(&divArray, numArray, denArray, false));
         ASSERT_SUCCESS(af_mul(&outArray, divArray, cstArray, false));
 
-        std::vector<OutType> outData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
-
-        std::vector<OutType> goldData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
+        ASSERT_IMAGES_NEAR(goldArray, outArray, 0.03);
 
         ASSERT_SUCCESS(af_release_array(_inArray));
         ASSERT_SUCCESS(af_release_array(inArray));
@@ -120,9 +116,6 @@ void invDeconvImageTest(string pTestFile, const float gamma,
         ASSERT_SUCCESS(af_release_array(outArray));
         ASSERT_SUCCESS(af_release_array(_goldArray));
         ASSERT_SUCCESS(af_release_array(goldArray));
-
-        ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(),
-                                          outData.data(), 0.03));
     }
 }
 

--- a/test/iterative_deconv.cpp
+++ b/test/iterative_deconv.cpp
@@ -102,11 +102,7 @@ void iterDeconvImageTest(string pTestFile, const unsigned iters, const float rf,
         ASSERT_SUCCESS(af_div(&divArray, numArray, denArray, false));
         ASSERT_SUCCESS(af_mul(&outArray, divArray, cstArray, false));
 
-        std::vector<OutType> outData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
-
-        std::vector<OutType> goldData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
+        ASSERT_IMAGES_NEAR(goldArray, outArray, 0.03);
 
         ASSERT_SUCCESS(af_release_array(_inArray));
         ASSERT_SUCCESS(af_release_array(inArray));
@@ -120,9 +116,6 @@ void iterDeconvImageTest(string pTestFile, const unsigned iters, const float rf,
         ASSERT_SUCCESS(af_release_array(outArray));
         ASSERT_SUCCESS(af_release_array(_goldArray));
         ASSERT_SUCCESS(af_release_array(goldArray));
-
-        ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(),
-                                          outData.data(), 0.03));
     }
 }
 

--- a/test/meanshift.cpp
+++ b/test/meanshift.cpp
@@ -89,14 +89,7 @@ void meanshiftTest(string pTestFile, const float ss) {
 
         ASSERT_SUCCESS(af_mean_shift(&outArray, inArray, ss, 30.f, 5, isColor));
 
-        vector<T> outData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
-
-        vector<T> goldData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
-
-        ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(),
-                                          outData.data(), 0.02f));
+        ASSERT_IMAGES_NEAR(goldArray, outArray, 0.02f);
 
         ASSERT_SUCCESS(af_release_array(inArray));
         ASSERT_SUCCESS(af_release_array(inArray_f32));
@@ -159,14 +152,7 @@ TEST(Meanshift, Color_CPP) {
         dim_t nElems = gold.elements();
         array output = meanShift(img, 3.5f, 30.f, 5, true);
 
-        vector<float> outData(nElems);
-        output.host((void*)outData.data());
-
-        vector<float> goldData(nElems);
-        gold.host((void*)goldData.data());
-
-        ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(),
-                                          outData.data(), 0.02f));
+        ASSERT_IMAGES_NEAR(gold, output, 0.02f);
     }
 }
 

--- a/test/medfilt.cpp
+++ b/test/medfilt.cpp
@@ -195,14 +195,7 @@ void medfiltImageTest(string pTestFile, dim_t w_len, dim_t w_wid) {
         ASSERT_SUCCESS(
             af_medfilt2(&outArray, inArray, w_len, w_wid, AF_PAD_ZERO));
 
-        vector<T> outData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
-
-        vector<T> goldData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
-
-        ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(),
-                                          outData.data(), 0.018f));
+        ASSERT_IMAGES_NEAR(goldArray, outArray, 0.018f);
 
         ASSERT_SUCCESS(af_release_array(inArray));
         ASSERT_SUCCESS(af_release_array(outArray));

--- a/test/morph.cpp
+++ b/test/morph.cpp
@@ -183,20 +183,15 @@ void morphImageTest(string pTestFile, dim_t seLen) {
         }
 
 #if defined(AF_CPU)
-        ASSERT_EQ(error_code, AF_SUCCESS);
-
-        vector<T> outData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)outData.data(), outArray));
-
-        vector<T> goldData(nElems);
-        ASSERT_SUCCESS(af_get_data_ptr((void*)goldData.data(), goldArray));
-
-        ASSERT_EQ(true, compareArraysRMSD(nElems, goldData.data(),
-                                          outData.data(), 0.018f));
+        ASSERT_SUCCESS(error_code);
+        ASSERT_IMAGES_NEAR(goldArray, outArray, 0.018f);
 #else
         ASSERT_EQ(error_code,
                   (targetType != b8 && seLen > 19 ? AF_ERR_NOT_SUPPORTED
                                                   : AF_SUCCESS));
+        if (!(targetType != b8 && seLen > 19)) {
+            ASSERT_IMAGES_NEAR(goldArray, outArray, 0.018f);
+        }
 #endif
 
         ASSERT_SUCCESS(af_release_array(_inArray));

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -27,6 +27,8 @@
 
 #if defined(USE_MTX)
 #include <mmio.h>
+#include <cstdlib>
+
 #endif
 
 bool operator==(const af_half &lhs, const af_half &rhs);
@@ -129,6 +131,9 @@ void readImageFeaturesDescriptors(
  */
 template<typename T>
 bool compareArraysRMSD(dim_t data_size, T *gold, T *data, double tolerance);
+
+template<typename T>
+double computeArraysRMSD(dim_t data_size, T *gold, T *data);
 
 template<typename T, typename Other>
 struct is_same_type {
@@ -324,6 +329,17 @@ template<typename T>
                                            const af::array &b,
                                            float maxAbsDiff);
 
+::testing::AssertionResult assertImageNear(std::string aName, std::string bName,
+                                           std::string maxAbsDiffName,
+                                           const af_array &a, const af_array &b,
+                                           float maxAbsDiff);
+
+::testing::AssertionResult assertImageNear(std::string aName, std::string bName,
+                                           std::string maxAbsDiffName,
+                                           const af::array &a,
+                                           const af::array &b,
+                                           float maxAbsDiff);
+
 // Called by ASSERT_VEC_ARRAY_NEAR
 template<typename T>
 ::testing::AssertionResult assertArrayNear(
@@ -388,6 +404,18 @@ template<typename T>
 /// \NOTE: This macro will deallocate the af_arrays after the call
 #define ASSERT_ARRAYS_NEAR(EXPECTED, ACTUAL, MAX_ABSDIFF) \
     ASSERT_PRED_FORMAT3(assertArrayNear, EXPECTED, ACTUAL, MAX_ABSDIFF)
+
+/// Compares two af::array or af_arrays for their type, dims, and values (with a
+/// given tolerance).
+///
+/// \param[in] EXPECTED Expected value of the assertion
+/// \param[in] ACTUAL Actual value of the calculation
+/// \param[in] MAX_ABSDIFF Expected maximum absolute difference between
+///            elements of EXPECTED and ACTUAL
+///
+/// \NOTE: This macro will deallocate the af_arrays after the call
+#define ASSERT_IMAGES_NEAR(EXPECTED, ACTUAL, MAX_ABSDIFF) \
+    ASSERT_PRED_FORMAT3(assertImageNear, EXPECTED, ACTUAL, MAX_ABSDIFF)
 
 /// Compares a std::vector with an af::array for their dims and values (with a
 /// given tolerance).

--- a/test/threading.cpp
+++ b/test/threading.cpp
@@ -132,20 +132,12 @@ void morphTest(const array input, const array mask, const bool isDilation,
                const array gold, int targetDevice) {
     setDevice(targetDevice);
 
-    vector<float> goldData(gold.elements());
-    vector<float> outData(gold.elements());
-
-    gold.host((void*)goldData.data());
-
     array out;
 
     for (unsigned i = 0; i < ITERATION_COUNT; ++i)
         out = isDilation ? dilate(input, mask) : erode(input, mask);
 
-    out.host((void*)outData.data());
-
-    ASSERT_EQ(true, compareArraysRMSD(gold.elements(), goldData.data(),
-                                      outData.data(), 0.018f));
+    ASSERT_IMAGES_NEAR(gold, out, 0.018f);
 }
 
 TEST(Threading, SetPerThreadActiveDevice) {


### PR DESCRIPTION
Add an image comparison assertion to the tests that compares two images
and if there is an error, uploads the result and the gold image to CDash
for comparison. Useful for when image tests fail

Description
-----------
ASSERT_IMAGE_NEAR will compare two images for similarity and upload
the image to ci.arrayfire.org if the test fails. This allows us to quickly view
the errors by going to the site and viewing the differences to determine the
error.

This assertion works on both af::array and af_array objects. It currently
supports f32, f64, u8, and b8 images but can support additional types
fairly easily.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- [x] Functions documented
