### PR TITLE
Use older CLBlast to avoid DGEMM errors on Turing. Update FindOpenMP

### DIFF
--- a/CMakeModules/CMakeParseImplicitLinkInfo.cmake
+++ b/CMakeModules/CMakeParseImplicitLinkInfo.cmake
@@ -1,0 +1,271 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+cmake_policy(PUSH)
+cmake_policy(SET CMP0053 NEW)
+cmake_policy(SET CMP0054 NEW)
+
+# Function to parse implicit linker options.
+#
+# This is used internally by CMake and should not be included by user
+# code.
+#
+# Note: this function is leaked/exposed by FindOpenMP and therefore needs
+# to have a stable API so projects that copied `FindOpenMP` for backwards
+# compatibility don't break.
+#
+function(CMAKE_PARSE_IMPLICIT_LINK_INFO text lib_var dir_var fwk_var log_var obj_regex)
+  set(implicit_libs_tmp "")
+  set(implicit_objs_tmp "")
+  set(implicit_dirs_tmp)
+  set(implicit_fwks_tmp)
+  set(log "")
+
+  set(keywordArgs)
+  set(oneValueArgs COMPUTE_IMPLICIT_OBJECTS)
+  set(multiValueArgs )
+  cmake_parse_arguments(EXTRA_PARSE "${keywordArgs}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  # Parse implicit linker arguments.
+  set(linker "CMAKE_LINKER-NOTFOUND")
+  if(CMAKE_LINKER)
+    get_filename_component(linker ${CMAKE_LINKER} NAME)
+    string(REGEX REPLACE "([][+.*?()^$])" "\\\\\\1" linker "${linker}")
+  endif()
+  set(startfile "CMAKE_LINK_STARTFILE-NOTFOUND")
+  if(CMAKE_LINK_STARTFILE)
+    set(startfile "${CMAKE_LINK_STARTFILE}")
+  endif()
+  # Construct a regex to match linker lines.  It must match both the
+  # whole line and just the command (argv[0]).
+  set(linker_regex "^( *|.*[/\\])(${linker}|${startfile}|([^/\\]+-)?ld|collect2)[^/\\]*( |$)")
+  set(linker_exclude_regex "collect2 version |^[A-Za-z0-9_]+=|/ldfe ")
+  string(APPEND log "  link line regex: [${linker_regex}]\n")
+  string(REGEX REPLACE "\r?\n" ";" output_lines "${text}")
+  foreach(line IN LISTS output_lines)
+    set(cmd)
+    if("${line}" MATCHES "${linker_regex}" AND
+        NOT "${line}" MATCHES "${linker_exclude_regex}")
+      if(XCODE)
+        # Xcode unconditionally adds a path under the project build tree and
+        # on older versions it is not reported with proper quotes.  Remove it.
+        string(REGEX REPLACE "([][+.*()^])" "\\\\\\1" _dir_regex "${CMAKE_BINARY_DIR}")
+        string(REGEX REPLACE " -[FL]${_dir_regex}/([^ ]| [^-])+( |$)" " " xline "${line}")
+        if(NOT "x${xline}" STREQUAL "x${line}")
+          string(APPEND log "  reduced line: [${line}]\n            to: [${xline}]\n")
+          set(line "${xline}")
+        endif()
+      endif()
+      separate_arguments(args NATIVE_COMMAND "${line}")
+      list(GET args 0 cmd)
+    else()
+      #check to see if the link line is comma-separated instead of space separated
+      string(REGEX REPLACE "," " " line "${line}")
+      if("${line}" MATCHES "${linker_regex}" AND
+        NOT "${line}" MATCHES "${linker_exclude_regex}")
+        separate_arguments(args NATIVE_COMMAND "${line}")
+        list(GET args 0 cmd)
+        if("${cmd}" MATCHES "exec:")
+          # ibm xl sometimes has 'exec: ' in-front of the linker
+          list(GET args 1 cmd)
+        endif()
+      endif()
+    endif()
+    set(is_msvc 0)
+    set(search_static 0)
+    if("${cmd}" MATCHES "${linker_regex}")
+      string(APPEND log "  link line: [${line}]\n")
+      string(REGEX REPLACE ";-([LYz]);" ";-\\1" args "${args}")
+      set(skip_value_of "")
+      foreach(arg IN LISTS args)
+        if(skip_value_of)
+          string(APPEND log "    arg [${arg}] ==> skip value of ${skip_value_of}\n")
+          set(skip_value_of "")
+        elseif("${arg}" MATCHES "^-L(.:)?[/\\]")
+          # Unix search path.
+          string(REGEX REPLACE "^-L" "" dir "${arg}")
+          list(APPEND implicit_dirs_tmp ${dir})
+          string(APPEND log "    arg [${arg}] ==> dir [${dir}]\n")
+        elseif("${arg}" MATCHES "^[-/](LIBPATH|libpath):(.+)")
+          # MSVC search path.
+          set(dir "${CMAKE_MATCH_2}")
+          list(APPEND implicit_dirs_tmp ${dir})
+          string(APPEND log "    arg [${arg}] ==> dir [${dir}]\n")
+        elseif(is_msvc AND "${arg}" STREQUAL "-link")
+          string(APPEND log "    arg [${arg}] ==> ignore MSVC cl option\n")
+        elseif(is_msvc AND "${arg}" MATCHES "^(.*\\.[Ll][Ii][Bb])$")
+          set(lib "${CMAKE_MATCH_1}")
+          list(APPEND implicit_libs_tmp ${lib})
+          string(APPEND log "    arg [${arg}] ==> lib [${lib}]\n")
+        elseif("${arg}" STREQUAL "-lto_library")
+          # ld argument "-lto_library <path>"
+          set(skip_value_of "${arg}")
+          string(APPEND log "    arg [${arg}] ==> ignore, skip following value\n")
+        elseif("${arg}" MATCHES "^-l([^:].*)$")
+          # Unix library.
+          set(lib "${CMAKE_MATCH_1}")
+          if(search_static AND lib MATCHES "^(gfortran|stdc\\+\\+)$")
+            # Search for the static library later, once all link dirs are known.
+            set(lib "SEARCH_STATIC:${lib}")
+          endif()
+          list(APPEND implicit_libs_tmp ${lib})
+          string(APPEND log "    arg [${arg}] ==> lib [${lib}]\n")
+        elseif("${arg}" MATCHES "^(.:)?[/\\].*\\.a$")
+          # Unix library full path.
+          list(APPEND implicit_libs_tmp ${arg})
+          string(APPEND log "    arg [${arg}] ==> lib [${arg}]\n")
+        elseif("${arg}" MATCHES "^[-/](DEFAULTLIB|defaultlib):(.+)")
+          # Windows library.
+          set(lib "${CMAKE_MATCH_2}")
+          list(APPEND implicit_libs_tmp ${lib})
+          string(APPEND log "    arg [${arg}] ==> lib [${lib}]\n")
+        elseif("${arg}" MATCHES "^(.:)?[/\\].*\\.o$")
+          if(EXTRA_PARSE_COMPUTE_IMPLICIT_OBJECTS)
+            list(APPEND implicit_objs_tmp ${arg})
+            string(APPEND log "    arg [${arg}] ==> obj [${arg}]\n")
+          endif()
+          if(obj_regex AND "${arg}" MATCHES "${obj_regex}")
+            # Object file full path.
+            list(APPEND implicit_libs_tmp ${arg})
+          endif()
+        elseif("${arg}" MATCHES "^-Y(P,)?[^0-9]")
+          # Sun search path ([^0-9] avoids conflict with Mac -Y<num>).
+          string(REGEX REPLACE "^-Y(P,)?" "" dirs "${arg}")
+          string(REPLACE ":" ";" dirs "${dirs}")
+          list(APPEND implicit_dirs_tmp ${dirs})
+          string(APPEND log "    arg [${arg}] ==> dirs [${dirs}]\n")
+        elseif("${arg}" STREQUAL "-Bstatic")
+          set(search_static 1)
+          string(APPEND log "    arg [${arg}] ==> search static\n" )
+        elseif("${arg}" STREQUAL "-Bdynamic")
+          set(search_static 0)
+          string(APPEND log "    arg [${arg}] ==> search dynamic\n" )
+        elseif("${arg}" MATCHES "^-l:")
+          # HP named library.
+          list(APPEND implicit_libs_tmp ${arg})
+          string(APPEND log "    arg [${arg}] ==> lib [${arg}]\n")
+        elseif("${arg}" MATCHES "^-z(all|default|weak)extract")
+          # Link editor option.
+          list(APPEND implicit_libs_tmp ${arg})
+          string(APPEND log "    arg [${arg}] ==> opt [${arg}]\n")
+        elseif("${arg}" STREQUAL "cl.exe")
+          string(APPEND log "    arg [${arg}] ==> recognize MSVC cl\n")
+          set(is_msvc 1)
+        else()
+          string(APPEND log "    arg [${arg}] ==> ignore\n")
+        endif()
+      endforeach()
+      break()
+    elseif("${line}" MATCHES "LPATH(=| is:? *)(.*)$")
+      string(APPEND log "  LPATH line: [${line}]\n")
+      # HP search path.
+      string(REPLACE ":" ";" paths "${CMAKE_MATCH_2}")
+      list(APPEND implicit_dirs_tmp ${paths})
+      string(APPEND log "    dirs [${paths}]\n")
+    else()
+      string(APPEND log "  ignore line: [${line}]\n")
+    endif()
+  endforeach()
+
+  # Look for library search paths reported by linker.
+  if("${output_lines}" MATCHES ";Library search paths:((;\t[^;]+)+)")
+    string(REPLACE ";\t" ";" implicit_dirs_match "${CMAKE_MATCH_1}")
+    string(APPEND log "  Library search paths: [${implicit_dirs_match}]\n")
+    list(APPEND implicit_dirs_tmp ${implicit_dirs_match})
+  endif()
+  if("${output_lines}" MATCHES ";Framework search paths:((;\t[^;]+)+)")
+    string(REPLACE ";\t" ";" implicit_fwks_match "${CMAKE_MATCH_1}")
+    string(APPEND log "  Framework search paths: [${implicit_fwks_match}]\n")
+    list(APPEND implicit_fwks_tmp ${implicit_fwks_match})
+  endif()
+
+  # Cleanup list of libraries and flags.
+  # We remove items that are not language-specific.
+  set(implicit_libs "")
+  foreach(lib IN LISTS implicit_libs_tmp)
+    if("x${lib}" MATCHES "^xSEARCH_STATIC:(.*)")
+      set(search_static 1)
+      set(lib "${CMAKE_MATCH_1}")
+    else()
+      set(search_static 0)
+    endif()
+    if("x${lib}" MATCHES "^x(crt.*\\.o|gcc_eh.*|.*libgcc_eh.*|System.*|.*libclang_rt.*|msvcrt.*|libvcruntime.*|libucrt.*|libcmt.*)$")
+      string(APPEND log "  remove lib [${lib}]\n")
+    elseif(search_static)
+      # This library appears after a -Bstatic flag.  Due to ordering
+      # and filtering for mixed-language link lines, we do not preserve
+      # the -Bstatic flag itself.  Instead, use an absolute path.
+      # Search using a temporary variable with a distinct name
+      # so that our test suite does not depend on disk content.
+      find_library("CMAKE_${lang}_IMPLICIT_LINK_LIBRARY_${lib}" NO_CACHE NAMES "lib${lib}.a" NO_DEFAULT_PATH PATHS ${implicit_dirs_tmp})
+      set(_lib_static "${CMAKE_${lang}_IMPLICIT_LINK_LIBRARY_${lib}}")
+      if(_lib_static)
+        string(APPEND log "  search lib [SEARCH_STATIC:${lib}] ==> [${_lib_static}]\n")
+        list(APPEND implicit_libs "${_lib_static}")
+      else()
+        string(APPEND log "  search lib [SEARCH_STATIC:${lib}] ==> [${lib}]\n")
+        list(APPEND implicit_libs "${lib}")
+      endif()
+    elseif(IS_ABSOLUTE "${lib}")
+      get_filename_component(abs "${lib}" ABSOLUTE)
+      if(NOT "x${lib}" STREQUAL "x${abs}")
+        string(APPEND log "  collapse lib [${lib}] ==> [${abs}]\n")
+      endif()
+      list(APPEND implicit_libs "${abs}")
+    else()
+      list(APPEND implicit_libs "${lib}")
+    endif()
+  endforeach()
+
+  if(EXTRA_PARSE_COMPUTE_IMPLICIT_OBJECTS)
+    set(implicit_objs "")
+    foreach(obj IN LISTS implicit_objs_tmp)
+      if(IS_ABSOLUTE "${obj}")
+        get_filename_component(abs "${obj}" ABSOLUTE)
+        if(NOT "x${obj}" STREQUAL "x${abs}")
+          string(APPEND log "  collapse obj [${obj}] ==> [${abs}]\n")
+        endif()
+        list(APPEND implicit_objs "${abs}")
+      else()
+        list(APPEND implicit_objs "${obj}")
+      endif()
+    endforeach()
+  endif()
+
+  # Cleanup list of library and framework directories.
+  set(desc_dirs "library")
+  set(desc_fwks "framework")
+  foreach(t dirs fwks)
+    set(implicit_${t} "")
+    foreach(d IN LISTS implicit_${t}_tmp)
+      get_filename_component(dir "${d}" ABSOLUTE)
+      string(FIND "${dir}" "${CMAKE_FILES_DIRECTORY}/" pos)
+      if(NOT pos LESS 0)
+        set(msg ", skipping non-system directory")
+      else()
+        set(msg "")
+        list(APPEND implicit_${t} "${dir}")
+      endif()
+      string(APPEND log "  collapse ${desc_${t}} dir [${d}] ==> [${dir}]${msg}\n")
+    endforeach()
+    list(REMOVE_DUPLICATES implicit_${t})
+  endforeach()
+
+  # Log results.
+  string(APPEND log "  implicit libs: [${implicit_libs}]\n")
+  string(APPEND log "  implicit objs: [${implicit_objs}]\n")
+  string(APPEND log "  implicit dirs: [${implicit_dirs}]\n")
+  string(APPEND log "  implicit fwks: [${implicit_fwks}]\n")
+
+  # Return results.
+  set(${lib_var} "${implicit_libs}" PARENT_SCOPE)
+  set(${dir_var} "${implicit_dirs}" PARENT_SCOPE)
+  set(${fwk_var} "${implicit_fwks}" PARENT_SCOPE)
+  set(${log_var} "${log}" PARENT_SCOPE)
+
+  if(EXTRA_PARSE_COMPUTE_IMPLICIT_OBJECTS)
+    set(${EXTRA_PARSE_COMPUTE_IMPLICIT_OBJECTS} "${implicit_objs}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+cmake_policy(POP)

--- a/CMakeModules/FindOpenMP.cmake
+++ b/CMakeModules/FindOpenMP.cmake
@@ -1,77 +1,100 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 
-#.rst:
-# FindOpenMP
-# ----------
-#
-# Finds OpenMP support
-#
-# This module can be used to detect OpenMP support in a compiler.  If
-# the compiler supports OpenMP, the flags required to compile with
-# OpenMP support are returned in variables for the different languages.
-# The variables may be empty if the compiler does not need a special
-# flag to support OpenMP.
-#
-# Variables
-# ^^^^^^^^^
-#
-# This module will set the following variables per language in your
-# project, where ``<lang>`` is one of C, CXX, or Fortran:
-#
-# ``OpenMP_<lang>_FOUND``
-#   Variable indicating if OpenMP support for ``<lang>`` was detected.
-# ``OpenMP_<lang>_FLAGS``
-#   OpenMP compiler flags for ``<lang>``, separated by spaces.
-#
-# For linking with OpenMP code written in ``<lang>``, the following
-# variables are provided:
-#
-# ``OpenMP_<lang>_LIB_NAMES``
-#   :ref:`;-list <CMake Language Lists>` of libraries for OpenMP programs for ``<lang>``.
-# ``OpenMP_<libname>_LIBRARY``
-#   Location of the individual libraries needed for OpenMP support in ``<lang>``.
-# ``OpenMP_<lang>_LIBRARIES``
-#   A list of libraries needed to link with OpenMP code written in ``<lang>``.
-#
-# Additionally, the module provides :prop_tgt:`IMPORTED` targets:
-#
-# ``OpenMP::OpenMP_<lang>``
-#   Target for using OpenMP from ``<lang>``.
-#
-# Specifically for Fortran, the module sets the following variables:
-#
-# ``OpenMP_Fortran_HAVE_OMPLIB_HEADER``
-#   Boolean indicating if OpenMP is accessible through ``omp_lib.h``.
-# ``OpenMP_Fortran_HAVE_OMPLIB_MODULE``
-#   Boolean indicating if OpenMP is accessible through the ``omp_lib`` Fortran module.
-#
-# The module will also try to provide the OpenMP version variables:
-#
-# ``OpenMP_<lang>_SPEC_DATE``
-#   Date of the OpenMP specification implemented by the ``<lang>`` compiler.
-# ``OpenMP_<lang>_VERSION_MAJOR``
-#   Major version of OpenMP implemented by the ``<lang>`` compiler.
-# ``OpenMP_<lang>_VERSION_MINOR``
-#   Minor version of OpenMP implemented by the ``<lang>`` compiler.
-# ``OpenMP_<lang>_VERSION``
-#   OpenMP version implemented by the ``<lang>`` compiler.
-#
-# The specification date is formatted as given in the OpenMP standard:
-# ``yyyymm`` where ``yyyy`` and ``mm`` represents the year and month of
-# the OpenMP specification implemented by the ``<lang>`` compiler.
-#
-# Backward Compatibility
-# ^^^^^^^^^^^^^^^^^^^^^^
-#
-# For backward compatibility with older versions of FindOpenMP, these
-# variables are set, but deprecated::
-#
-#   OpenMP_FOUND
-#
-# In new projects, please use the ``OpenMP_<lang>_XXX`` equivalents.
+#[=======================================================================[.rst:
+FindOpenMP
+----------
+
+Finds Open Multi-Processing (OpenMP) support.
+
+This module can be used to detect OpenMP support in a compiler.  If
+the compiler supports OpenMP, the flags required to compile with
+OpenMP support are returned in variables for the different languages.
+The variables may be empty if the compiler does not need a special
+flag to support OpenMP.
+
+.. versionadded:: 3.5
+  Clang support.
+
+Variables
+^^^^^^^^^
+
+.. versionadded:: 3.10
+  The module exposes the components ``C``, ``CXX``, and ``Fortran``.
+  Each of these controls the various languages to search OpenMP support for.
+
+Depending on the enabled components the following variables will be set:
+
+``OpenMP_FOUND``
+  Variable indicating that OpenMP flags for all requested languages have been found.
+  If no components are specified, this is true if OpenMP settings for all enabled languages
+  were detected.
+``OpenMP_VERSION``
+  Minimal version of the OpenMP standard detected among the requested languages,
+  or all enabled languages if no components were specified.
+
+This module will set the following variables per language in your
+project, where ``<lang>`` is one of C, CXX, or Fortran:
+
+``OpenMP_<lang>_FOUND``
+  Variable indicating if OpenMP support for ``<lang>`` was detected.
+``OpenMP_<lang>_FLAGS``
+  OpenMP compiler flags for ``<lang>``, separated by spaces.
+``OpenMP_<lang>_INCLUDE_DIRS``
+  Directories that must be added to the header search path for ``<lang>``
+  when using OpenMP.
+
+For linking with OpenMP code written in ``<lang>``, the following
+variables are provided:
+
+``OpenMP_<lang>_LIB_NAMES``
+  :ref:`;-list <CMake Language Lists>` of libraries for OpenMP programs for ``<lang>``.
+``OpenMP_<libname>_LIBRARY``
+  Location of the individual libraries needed for OpenMP support in ``<lang>``.
+``OpenMP_<lang>_LIBRARIES``
+  A list of libraries needed to link with OpenMP code written in ``<lang>``.
+
+Additionally, the module provides :prop_tgt:`IMPORTED` targets:
+
+``OpenMP::OpenMP_<lang>``
+  Target for using OpenMP from ``<lang>``.
+
+Specifically for Fortran, the module sets the following variables:
+
+``OpenMP_Fortran_HAVE_OMPLIB_HEADER``
+  Boolean indicating if OpenMP is accessible through ``omp_lib.h``.
+``OpenMP_Fortran_HAVE_OMPLIB_MODULE``
+  Boolean indicating if OpenMP is accessible through the ``omp_lib`` Fortran module.
+
+The module will also try to provide the OpenMP version variables:
+
+``OpenMP_<lang>_SPEC_DATE``
+  .. versionadded:: 3.7
+
+  Date of the OpenMP specification implemented by the ``<lang>`` compiler.
+``OpenMP_<lang>_VERSION_MAJOR``
+  Major version of OpenMP implemented by the ``<lang>`` compiler.
+``OpenMP_<lang>_VERSION_MINOR``
+  Minor version of OpenMP implemented by the ``<lang>`` compiler.
+``OpenMP_<lang>_VERSION``
+  OpenMP version implemented by the ``<lang>`` compiler.
+
+The specification date is formatted as given in the OpenMP standard:
+``yyyymm`` where ``yyyy`` and ``mm`` represents the year and month of
+the OpenMP specification implemented by the ``<lang>`` compiler.
+
+For some compilers, it may be necessary to add a header search path to find
+the relevant OpenMP headers.  This location may be language-specific.  Where
+this is needed, the module may attempt to find the location, but it can be
+provided directly by setting the ``OpenMP_<lang>_INCLUDE_DIR`` cache variable.
+Note that this variable is an _input_ control to the module.  Project code
+should use the ``OpenMP_<lang>_INCLUDE_DIRS`` _output_ variable if it needs
+to know what include directories are needed.
+#]=======================================================================]
 
 cmake_policy(PUSH)
+cmake_policy(SET CMP0012 NEW) # if() recognizes numbers and booleans
+cmake_policy(SET CMP0054 NEW) # if() quoted variables not dereferenced
 cmake_policy(SET CMP0057 NEW) # if IN_LIST
 
 function(_OPENMP_FLAG_CANDIDATES LANG)
@@ -79,7 +102,8 @@ function(_OPENMP_FLAG_CANDIDATES LANG)
     unset(OpenMP_FLAG_CANDIDATES)
 
     set(OMP_FLAG_GNU "-fopenmp")
-    set(OMP_FLAG_Clang "-fopenmp=libomp" "-fopenmp=libiomp5" "-fopenmp")
+    set(OMP_FLAG_Clang "-fopenmp=libomp" "-fopenmp=libiomp5" "-fopenmp" "-Xclang -fopenmp")
+    set(OMP_FLAG_AppleClang "-Xclang -fopenmp")
     set(OMP_FLAG_HP "+Oopenmp")
     if(WIN32)
       set(OMP_FLAG_Intel "-Qopenmp")
@@ -89,16 +113,25 @@ function(_OPENMP_FLAG_CANDIDATES LANG)
     else()
       set(OMP_FLAG_Intel "-qopenmp")
     endif()
-    set(OMP_FLAG_MIPSpro "-mp")
+    if(CMAKE_${LANG}_COMPILER_ID STREQUAL "IntelLLVM" AND
+      "x${CMAKE_${LANG}_COMPILER_FRONTEND_VARIANT}" STREQUAL "xMSVC")
+      set(OMP_FLAG_IntelLLVM "-Qiopenmp")
+    else()
+      set(OMP_FLAG_IntelLLVM "-fiopenmp")
+    endif()
     set(OMP_FLAG_MSVC "-openmp")
     set(OMP_FLAG_PathScale "-openmp")
     set(OMP_FLAG_NAG "-openmp")
     set(OMP_FLAG_Absoft "-openmp")
+    set(OMP_FLAG_NVHPC "-mp")
     set(OMP_FLAG_PGI "-mp")
+    set(OMP_FLAG_Flang "-fopenmp")
     set(OMP_FLAG_SunPro "-xopenmp")
     set(OMP_FLAG_XL "-qsmp=omp")
-    # Cray compiles with OpenMP automatically
-    set(OMP_FLAG_Cray " ")
+    # Cray compiler activate OpenMP with -h omp, which is enabled by default.
+    set(OMP_FLAG_Cray " " "-h omp")
+    set(OMP_FLAG_Fujitsu "-Kopenmp" "-KOMP")
+    set(OMP_FLAG_FujitsuClang "-fopenmp" "-Kopenmp")
 
     # If we know the correct flags, use those
     if(DEFINED OMP_FLAG_${CMAKE_${LANG}_COMPILER_ID})
@@ -117,8 +150,13 @@ endfunction()
 set(OpenMP_C_CXX_TEST_SOURCE
 "
 #include <omp.h>
-int main() {
-#ifndef _OPENMP
+int main(void) {
+#ifdef _OPENMP
+  omp_get_max_threads();
+  return 0;
+#elif defined(__HIP_DEVICE_COMPILE__)
+  return 0;
+#else
   breaks_on_purpose
 #endif
 }
@@ -155,20 +193,29 @@ function(_OPENMP_WRITE_SOURCE_FILE LANG SRC_FILE_CONTENT_VAR SRC_FILE_NAME SRC_F
   set(${SRC_FILE_FULLPATH} "${SRC_FILE}" PARENT_SCOPE)
 endfunction()
 
-include(${CMAKE_ROOT}/Modules/CMakeParseImplicitLinkInfo.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/CMakeParseImplicitLinkInfo.cmake)
 
 function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
   _OPENMP_FLAG_CANDIDATES("${LANG}")
   _OPENMP_WRITE_SOURCE_FILE("${LANG}" "TEST_SOURCE" OpenMPTryFlag _OPENMP_TEST_SRC)
 
+  unset(OpenMP_VERBOSE_COMPILE_OPTIONS)
+  separate_arguments(OpenMP_VERBOSE_OPTIONS NATIVE_COMMAND "${CMAKE_${LANG}_VERBOSE_FLAG}")
+  foreach(_VERBOSE_OPTION IN LISTS OpenMP_VERBOSE_OPTIONS)
+    if(NOT _VERBOSE_OPTION MATCHES "^-Wl,")
+      list(APPEND OpenMP_VERBOSE_COMPILE_OPTIONS ${_VERBOSE_OPTION})
+    endif()
+  endforeach()
+
   foreach(OPENMP_FLAG IN LISTS OpenMP_${LANG}_FLAG_CANDIDATES)
     set(OPENMP_FLAGS_TEST "${OPENMP_FLAG}")
-    if(CMAKE_${LANG}_VERBOSE_FLAG)
-      string(APPEND OPENMP_FLAGS_TEST " ${CMAKE_${LANG}_VERBOSE_FLAG}")
+    if(OpenMP_VERBOSE_COMPILE_OPTIONS)
+      string(APPEND OPENMP_FLAGS_TEST " ${OpenMP_VERBOSE_COMPILE_OPTIONS}")
     endif()
     string(REGEX REPLACE "[-/=+]" "" OPENMP_PLAIN_FLAG "${OPENMP_FLAG}")
     try_compile( OpenMP_COMPILE_RESULT_${FLAG_MODE}_${OPENMP_PLAIN_FLAG} ${CMAKE_BINARY_DIR} ${_OPENMP_TEST_SRC}
       CMAKE_FLAGS "-DCOMPILE_DEFINITIONS:STRING=${OPENMP_FLAGS_TEST}"
+      LINK_LIBRARIES ${CMAKE_${LANG}_VERBOSE_FLAG}
       OUTPUT_VARIABLE OpenMP_TRY_COMPILE_OUTPUT
     )
 
@@ -197,34 +244,104 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
 
         unset(_OPENMP_LIB_NAMES)
         foreach(_OPENMP_IMPLICIT_LIB IN LISTS OpenMP_${LANG}_IMPLICIT_LIBRARIES)
-          if(NOT "${_OPENMP_IMPLICIT_LIB}" IN_LIST CMAKE_${LANG}_IMPLICIT_LINK_LIBRARIES)
-            find_library(OpenMP_${_OPENMP_IMPLICIT_LIB}_LIBRARY
-              NAMES "${_OPENMP_IMPLICIT_LIB}"
-              HINTS ${OpenMP_${LANG}_IMPLICIT_LINK_DIRS}
-            )
-            mark_as_advanced(OpenMP_${_OPENMP_IMPLICIT_LIB}_LIBRARY)
-            list(APPEND _OPENMP_LIB_NAMES ${_OPENMP_IMPLICIT_LIB})
+          get_filename_component(_OPENMP_IMPLICIT_LIB_DIR "${_OPENMP_IMPLICIT_LIB}" DIRECTORY)
+          get_filename_component(_OPENMP_IMPLICIT_LIB_NAME "${_OPENMP_IMPLICIT_LIB}" NAME)
+          get_filename_component(_OPENMP_IMPLICIT_LIB_PLAIN "${_OPENMP_IMPLICIT_LIB}" NAME_WE)
+          string(REGEX REPLACE "([][+.*?()^$])" "\\\\\\1" _OPENMP_IMPLICIT_LIB_PLAIN_ESC "${_OPENMP_IMPLICIT_LIB_PLAIN}")
+          string(REGEX REPLACE "([][+.*?()^$])" "\\\\\\1" _OPENMP_IMPLICIT_LIB_PATH_ESC "${_OPENMP_IMPLICIT_LIB}")
+          if(NOT ( "${_OPENMP_IMPLICIT_LIB}" IN_LIST CMAKE_${LANG}_IMPLICIT_LINK_LIBRARIES
+            OR "${CMAKE_${LANG}_STANDARD_LIBRARIES}" MATCHES "(^| )(-Wl,)?(-l)?(${_OPENMP_IMPLICIT_LIB_PLAIN_ESC}|${_OPENMP_IMPLICIT_LIB_PATH_ESC})( |$)"
+            OR "${CMAKE_${LANG}_LINK_EXECUTABLE}" MATCHES "(^| )(-Wl,)?(-l)?(${_OPENMP_IMPLICIT_LIB_PLAIN_ESC}|${_OPENMP_IMPLICIT_LIB_PATH_ESC})( |$)" ) )
+            if(_OPENMP_IMPLICIT_LIB_DIR)
+              set(OpenMP_${_OPENMP_IMPLICIT_LIB_PLAIN}_LIBRARY "${_OPENMP_IMPLICIT_LIB}" CACHE FILEPATH
+                "Path to the ${_OPENMP_IMPLICIT_LIB_PLAIN} library for OpenMP")
+            else()
+              find_library(OpenMP_${_OPENMP_IMPLICIT_LIB_PLAIN}_LIBRARY
+                NAMES "${_OPENMP_IMPLICIT_LIB_NAME}"
+                DOC "Path to the ${_OPENMP_IMPLICIT_LIB_PLAIN} library for OpenMP"
+                HINTS ${OpenMP_${LANG}_IMPLICIT_LINK_DIRS}
+                CMAKE_FIND_ROOT_PATH_BOTH
+                NO_DEFAULT_PATH
+              )
+            endif()
+            mark_as_advanced(OpenMP_${_OPENMP_IMPLICIT_LIB_PLAIN}_LIBRARY)
+            list(APPEND _OPENMP_LIB_NAMES ${_OPENMP_IMPLICIT_LIB_PLAIN})
           endif()
         endforeach()
         set("${OPENMP_LIB_NAMES_VAR}" "${_OPENMP_LIB_NAMES}" PARENT_SCOPE)
       else()
-        # The Intel compiler on windows has no verbose mode, so we need to treat it explicitly
-        if("${CMAKE_${LANG}_COMPILER_ID}" STREQUAL "Intel" AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-          set("${OPENMP_LIB_NAMES_VAR}" "libiomp5md" PARENT_SCOPE)
-          find_library(OpenMP_libiomp5md_LIBRARY
-            NAMES "libiomp5md"
-            HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}
-          )
-          mark_as_advanced(OpenMP_libiomp5md_LIBRARY)
-        else()
-          set("${OPENMP_LIB_NAMES_VAR}" "" PARENT_SCOPE)
-        endif()
+        # We do not know how to extract implicit OpenMP libraries for this compiler.
+        # Assume that it handles them automatically, e.g. the Intel Compiler on
+        # Windows should put the dependency in its object files.
+        set("${OPENMP_LIB_NAMES_VAR}" "" PARENT_SCOPE)
       endif()
       break()
+    elseif(CMAKE_${LANG}_COMPILER_ID STREQUAL "AppleClang"
+      AND CMAKE_${LANG}_COMPILER_VERSION VERSION_GREATER_EQUAL "7.0")
+
+      # Check for separate OpenMP library on AppleClang 7+
+      find_library(OpenMP_libomp_LIBRARY
+        NAMES omp gomp iomp5
+        HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}
+      )
+      mark_as_advanced(OpenMP_libomp_LIBRARY)
+
+      if(OpenMP_libomp_LIBRARY)
+        # Try without specifying include directory first. We only want to
+        # explicitly add a search path if the header can't be found on the
+        # default header search path already.
+        try_compile( OpenMP_COMPILE_RESULT_${FLAG_MODE}_${OPENMP_PLAIN_FLAG} ${CMAKE_BINARY_DIR} ${_OPENMP_TEST_SRC}
+          CMAKE_FLAGS "-DCOMPILE_DEFINITIONS:STRING=${OPENMP_FLAGS_TEST}"
+          LINK_LIBRARIES ${CMAKE_${LANG}_VERBOSE_FLAG} ${OpenMP_libomp_LIBRARY}
+          OUTPUT_VARIABLE OpenMP_TRY_COMPILE_OUTPUT
+        )
+        if(NOT OpenMP_COMPILE_RESULT_${FLAG_MODE}_${OPENMP_PLAIN_FLAG})
+          find_path(OpenMP_${LANG}_INCLUDE_DIR omp.h)
+          mark_as_advanced(OpenMP_${LANG}_INCLUDE_DIR)
+          set(OpenMP_${LANG}_INCLUDE_DIR "${OpenMP_${LANG}_INCLUDE_DIR}" PARENT_SCOPE)
+          if(OpenMP_${LANG}_INCLUDE_DIR)
+            try_compile( OpenMP_COMPILE_RESULT_${FLAG_MODE}_${OPENMP_PLAIN_FLAG} ${CMAKE_BINARY_DIR} ${_OPENMP_TEST_SRC}
+              CMAKE_FLAGS "-DCOMPILE_DEFINITIONS:STRING=${OPENMP_FLAGS_TEST}"
+                          "-DINCLUDE_DIRECTORIES:STRING=${OpenMP_${LANG}_INCLUDE_DIR}"
+              LINK_LIBRARIES ${CMAKE_${LANG}_VERBOSE_FLAG} ${OpenMP_libomp_LIBRARY}
+              OUTPUT_VARIABLE OpenMP_TRY_COMPILE_OUTPUT
+            )
+          endif()
+        endif()
+        if(OpenMP_COMPILE_RESULT_${FLAG_MODE}_${OPENMP_PLAIN_FLAG})
+          set("${OPENMP_FLAG_VAR}" "${OPENMP_FLAG}" PARENT_SCOPE)
+          set("${OPENMP_LIB_NAMES_VAR}" "libomp" PARENT_SCOPE)
+          break()
+        endif()
+      endif()
+    elseif(CMAKE_${LANG}_COMPILER_ID STREQUAL "Clang" AND WIN32)
+      # Check for separate OpenMP library for Clang on Windows
+      find_library(OpenMP_libomp_LIBRARY
+        NAMES libomp libgomp libiomp5
+        HINTS ${CMAKE_${LANG}_IMPLICIT_LINK_DIRECTORIES}
+      )
+      mark_as_advanced(OpenMP_libomp_LIBRARY)
+      if(OpenMP_libomp_LIBRARY)
+        try_compile( OpenMP_COMPILE_RESULT_${FLAG_MODE}_${OPENMP_PLAIN_FLAG} ${CMAKE_BINARY_DIR} ${_OPENMP_TEST_SRC}
+          CMAKE_FLAGS "-DCOMPILE_DEFINITIONS:STRING=${OPENMP_FLAGS_TEST}"
+          LINK_LIBRARIES ${CMAKE_${LANG}_VERBOSE_FLAG} ${OpenMP_libomp_LIBRARY}
+          OUTPUT_VARIABLE OpenMP_TRY_COMPILE_OUTPUT
+        )
+        if(OpenMP_COMPILE_RESULT_${FLAG_MODE}_${OPENMP_PLAIN_FLAG})
+          set("${OPENMP_FLAG_VAR}" "${OPENMP_FLAG}" PARENT_SCOPE)
+          set("${OPENMP_LIB_NAMES_VAR}" "libomp" PARENT_SCOPE)
+          break()
+        endif()
+      endif()
+    else()
+      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+        "Detecting ${LANG} OpenMP failed with the following output:\n${OpenMP_TRY_COMPILE_OUTPUT}\n\n")
     endif()
     set("${OPENMP_LIB_NAMES_VAR}" "NOTFOUND" PARENT_SCOPE)
     set("${OPENMP_FLAG_VAR}" "NOTFOUND" PARENT_SCOPE)
   endforeach()
+
+  unset(OpenMP_VERBOSE_COMPILE_OPTIONS)
 endfunction()
 
 set(OpenMP_C_CXX_CHECK_VERSION_SOURCE
@@ -240,9 +357,10 @@ const char ompver_str[] = { 'I', 'N', 'F', 'O', ':', 'O', 'p', 'e', 'n', 'M',
                             ('0' + ((_OPENMP/10)%10)),
                             ('0' + ((_OPENMP/1)%10)),
                             ']', '\\0' };
-int main()
+int main(void)
 {
   puts(ompver_str);
+  return 0;
 }
 ")
 
@@ -268,11 +386,17 @@ set(OpenMP_Fortran_CHECK_VERSION_SOURCE
 function(_OPENMP_GET_SPEC_DATE LANG SPEC_DATE)
   _OPENMP_WRITE_SOURCE_FILE("${LANG}" "CHECK_VERSION_SOURCE" OpenMPCheckVersion _OPENMP_TEST_SRC)
 
+  unset(_includeDirFlags)
+  if(OpenMP_${LANG}_INCLUDE_DIR)
+    set(_includeDirFlags "-DINCLUDE_DIRECTORIES:STRING=${OpenMP_${LANG}_INCLUDE_DIR}")
+  endif()
+
   set(BIN_FILE "${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/FindOpenMP/ompver_${LANG}.bin")
   string(REGEX REPLACE "[-/=+]" "" OPENMP_PLAIN_FLAG "${OPENMP_FLAG}")
   try_compile(OpenMP_SPECTEST_${LANG}_${OPENMP_PLAIN_FLAG} "${CMAKE_BINARY_DIR}" "${_OPENMP_TEST_SRC}"
-              CMAKE_FLAGS "-DCOMPILE_DEFINITIONS:STRING=${OpenMP_${LANG}_FLAGS}"
-              COPY_FILE ${BIN_FILE})
+              CMAKE_FLAGS "-DCOMPILE_DEFINITIONS:STRING=${OpenMP_${LANG}_FLAGS}" ${_includeDirFlags}
+              COPY_FILE ${BIN_FILE}
+              OUTPUT_VARIABLE OpenMP_TRY_COMPILE_OUTPUT)
 
   if(${OpenMP_SPECTEST_${LANG}_${OPENMP_PLAIN_FLAG}})
     file(STRINGS ${BIN_FILE} specstr LIMIT_COUNT 1 REGEX "INFO:OpenMP-date")
@@ -280,12 +404,18 @@ function(_OPENMP_GET_SPEC_DATE LANG SPEC_DATE)
     if("${specstr}" MATCHES "${regex_spec_date}")
       set(${SPEC_DATE} "${CMAKE_MATCH_1}" PARENT_SCOPE)
     endif()
+  else()
+    file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+        "Detecting ${LANG} OpenMP version failed with the following output:\n${OpenMP_TRY_COMPILE_OUTPUT}\n\n")
   endif()
 endfunction()
 
 macro(_OPENMP_SET_VERSION_BY_SPEC_DATE LANG)
   set(OpenMP_SPEC_DATE_MAP
+    # Preview versions
+    "201611=5.0" # OpenMP 5.0 preview 1
     # Combined versions, 2.5 onwards
+    "201811=5.0"
     "201511=4.5"
     "201307=4.0"
     "201107=3.1"
@@ -302,8 +432,15 @@ macro(_OPENMP_SET_VERSION_BY_SPEC_DATE LANG)
     # Fortran version 1.0
     "199710=1.0"
   )
+  if(MSVC)
+    list(APPEND OpenMP_SPEC_DATE_MAP "2019=2.0")
+  endif()
 
-  string(REGEX MATCHALL "${OpenMP_${LANG}_SPEC_DATE}=([0-9]+)\\.([0-9]+)" _version_match "${OpenMP_SPEC_DATE_MAP}")
+  if(OpenMP_${LANG}_SPEC_DATE)
+    string(REGEX MATCHALL "${OpenMP_${LANG}_SPEC_DATE}=([0-9]+)\\.([0-9]+)" _version_match "${OpenMP_SPEC_DATE_MAP}")
+  else()
+    set(_version_match "")
+  endif()
   if(NOT _version_match STREQUAL "")
     set(OpenMP_${LANG}_VERSION_MAJOR ${CMAKE_MATCH_1})
     set(OpenMP_${LANG}_VERSION_MINOR ${CMAKE_MATCH_2})
@@ -322,13 +459,12 @@ foreach(LANG IN ITEMS C CXX)
     if(NOT DEFINED OpenMP_${LANG}_FLAGS OR "${OpenMP_${LANG}_FLAGS}" STREQUAL "NOTFOUND"
       OR NOT DEFINED OpenMP_${LANG}_LIB_NAMES OR "${OpenMP_${LANG}_LIB_NAMES}" STREQUAL "NOTFOUND")
       _OPENMP_GET_FLAGS("${LANG}" "${LANG}" OpenMP_${LANG}_FLAGS_WORK OpenMP_${LANG}_LIB_NAMES_WORK)
+      set(OpenMP_${LANG}_FLAGS "${OpenMP_${LANG}_FLAGS_WORK}"
+        CACHE STRING "${LANG} compiler flags for OpenMP parallelization" FORCE)
+      set(OpenMP_${LANG}_LIB_NAMES "${OpenMP_${LANG}_LIB_NAMES_WORK}"
+        CACHE STRING "${LANG} compiler libraries for OpenMP parallelization" FORCE)
+      mark_as_advanced(OpenMP_${LANG}_FLAGS OpenMP_${LANG}_LIB_NAMES)
     endif()
-
-    set(OpenMP_${LANG}_FLAGS "${OpenMP_${LANG}_FLAGS_WORK}"
-      CACHE STRING "${LANG} compiler flags for OpenMP parallelization")
-    set(OpenMP_${LANG}_LIB_NAMES "${OpenMP_${LANG}_LIB_NAMES_WORK}"
-      CACHE STRING "${LANG} compiler libraries for OpenMP parallelization")
-    mark_as_advanced(OpenMP_${LANG}_FLAGS OpenMP_${LANG}_LIB_NAMES)
   endif()
 endforeach()
 
@@ -372,18 +508,24 @@ if(CMAKE_Fortran_COMPILER_LOADED)
   endif()
 endif()
 
-set(OPENMP_FOUND TRUE)
+if(NOT OpenMP_FIND_COMPONENTS)
+  set(OpenMP_FINDLIST C CXX Fortran)
+else()
+  set(OpenMP_FINDLIST ${OpenMP_FIND_COMPONENTS})
+endif()
 
-foreach(LANG IN ITEMS C CXX Fortran)
+unset(_OpenMP_MIN_VERSION)
+
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageHandleStandardArgs.cmake)
+
+foreach(LANG IN LISTS OpenMP_FINDLIST)
   if(CMAKE_${LANG}_COMPILER_LOADED)
-    if (NOT OpenMP_${LANG}_SPEC_DATE)
+    if (NOT OpenMP_${LANG}_SPEC_DATE AND OpenMP_${LANG}_FLAGS)
       _OPENMP_GET_SPEC_DATE("${LANG}" OpenMP_${LANG}_SPEC_DATE_INTERNAL)
       set(OpenMP_${LANG}_SPEC_DATE "${OpenMP_${LANG}_SPEC_DATE_INTERNAL}" CACHE
         INTERNAL "${LANG} compiler's OpenMP specification date")
-      _OPENMP_SET_VERSION_BY_SPEC_DATE("${LANG}")
     endif()
-
-    include(FindPackageHandleStandardArgs)
+    _OPENMP_SET_VERSION_BY_SPEC_DATE("${LANG}")
 
     set(OpenMP_${LANG}_FIND_QUIETLY ${OpenMP_FIND_QUIETLY})
     set(OpenMP_${LANG}_FIND_REQUIRED ${OpenMP_FIND_REQUIRED})
@@ -400,40 +542,65 @@ foreach(LANG IN ITEMS C CXX Fortran)
     endif()
 
     find_package_handle_standard_args(OpenMP_${LANG}
+      NAME_MISMATCHED
       REQUIRED_VARS OpenMP_${LANG}_FLAGS ${_OPENMP_${LANG}_REQUIRED_LIB_VARS}
       VERSION_VAR OpenMP_${LANG}_VERSION
     )
 
     if(OpenMP_${LANG}_FOUND)
+      if(DEFINED OpenMP_${LANG}_VERSION)
+        if(NOT _OpenMP_MIN_VERSION OR _OpenMP_MIN_VERSION VERSION_GREATER OpenMP_${LANG}_VERSION)
+          set(_OpenMP_MIN_VERSION OpenMP_${LANG}_VERSION)
+        endif()
+      endif()
       set(OpenMP_${LANG}_LIBRARIES "")
       foreach(_OPENMP_IMPLICIT_LIB IN LISTS OpenMP_${LANG}_LIB_NAMES)
         list(APPEND OpenMP_${LANG}_LIBRARIES "${OpenMP_${_OPENMP_IMPLICIT_LIB}_LIBRARY}")
       endforeach()
+      if(OpenMP_${LANG}_INCLUDE_DIR)
+        set(OpenMP_${LANG}_INCLUDE_DIRS ${OpenMP_${LANG}_INCLUDE_DIR})
+      else()
+        set(OpenMP_${LANG}_INCLUDE_DIRS "")
+      endif()
 
       if(NOT TARGET OpenMP::OpenMP_${LANG})
         add_library(OpenMP::OpenMP_${LANG} INTERFACE IMPORTED)
       endif()
       if(OpenMP_${LANG}_FLAGS)
-
-        if(UNIX)
-          separate_arguments(_OpenMP_${LANG}_OPTIONS UNIX_COMMAND "${OpenMP_${LANG}_FLAGS}")
-        elseif(WIN32)
-          separate_arguments(_OpenMP_${LANG}_OPTIONS WINDOWS_COMMAND "${OpenMP_${LANG}_FLAGS}")
-        endif()
-
+        separate_arguments(_OpenMP_${LANG}_OPTIONS NATIVE_COMMAND "${OpenMP_${LANG}_FLAGS}")
         set_property(TARGET OpenMP::OpenMP_${LANG} PROPERTY
-          INTERFACE_COMPILE_OPTIONS "${_OpenMP_${LANG}_OPTIONS}")
+          INTERFACE_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:${LANG}>:${_OpenMP_${LANG}_OPTIONS}>")
+        if(CMAKE_${LANG}_COMPILER_ID STREQUAL "Fujitsu")
+          set_property(TARGET OpenMP::OpenMP_${LANG} PROPERTY
+            INTERFACE_LINK_OPTIONS "${OpenMP_${LANG}_FLAGS}")
+        endif()
         unset(_OpenMP_${LANG}_OPTIONS)
+      endif()
+      if(OpenMP_${LANG}_INCLUDE_DIRS)
+        set_property(TARGET OpenMP::OpenMP_${LANG} PROPERTY
+          INTERFACE_INCLUDE_DIRECTORIES "$<BUILD_INTERFACE:${OpenMP_${LANG}_INCLUDE_DIRS}>")
       endif()
       if(OpenMP_${LANG}_LIBRARIES)
         set_property(TARGET OpenMP::OpenMP_${LANG} PROPERTY
           INTERFACE_LINK_LIBRARIES "${OpenMP_${LANG}_LIBRARIES}")
       endif()
-    else()
-      set(OPENMP_FOUND FALSE)
     endif()
   endif()
 endforeach()
+
+unset(_OpenMP_REQ_VARS)
+foreach(LANG IN ITEMS C CXX Fortran)
+  if((NOT OpenMP_FIND_COMPONENTS AND CMAKE_${LANG}_COMPILER_LOADED) OR LANG IN_LIST OpenMP_FIND_COMPONENTS)
+    list(APPEND _OpenMP_REQ_VARS "OpenMP_${LANG}_FOUND")
+  endif()
+endforeach()
+
+find_package_handle_standard_args(OpenMP
+    REQUIRED_VARS ${_OpenMP_REQ_VARS}
+    VERSION_VAR ${_OpenMP_MIN_VERSION}
+    HANDLE_COMPONENTS)
+
+set(OPENMP_FOUND ${OpenMP_FOUND})
 
 if(CMAKE_Fortran_COMPILER_LOADED AND OpenMP_Fortran_FOUND)
   if(NOT DEFINED OpenMP_Fortran_HAVE_OMPLIB_MODULE)

--- a/CMakeModules/FindPackageHandleStandardArgs.cmake
+++ b/CMakeModules/FindPackageHandleStandardArgs.cmake
@@ -1,0 +1,605 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindPackageHandleStandardArgs
+-----------------------------
+
+This module provides functions intended to be used in :ref:`Find Modules`
+implementing :command:`find_package(<PackageName>)` calls.
+
+.. command:: find_package_handle_standard_args
+
+  This command handles the ``REQUIRED``, ``QUIET`` and version-related
+  arguments of :command:`find_package`.  It also sets the
+  ``<PackageName>_FOUND`` variable.  The package is considered found if all
+  variables listed contain valid results, e.g. valid filepaths.
+
+  There are two signatures:
+
+  .. code-block:: cmake
+
+    find_package_handle_standard_args(<PackageName>
+      (DEFAULT_MSG|<custom-failure-message>)
+      <required-var>...
+      )
+
+    find_package_handle_standard_args(<PackageName>
+      [FOUND_VAR <result-var>]
+      [REQUIRED_VARS <required-var>...]
+      [VERSION_VAR <version-var>]
+      [HANDLE_VERSION_RANGE]
+      [HANDLE_COMPONENTS]
+      [CONFIG_MODE]
+      [NAME_MISMATCHED]
+      [REASON_FAILURE_MESSAGE <reason-failure-message>]
+      [FAIL_MESSAGE <custom-failure-message>]
+      )
+
+  The ``<PackageName>_FOUND`` variable will be set to ``TRUE`` if all
+  the variables ``<required-var>...`` are valid and any optional
+  constraints are satisfied, and ``FALSE`` otherwise.  A success or
+  failure message may be displayed based on the results and on
+  whether the ``REQUIRED`` and/or ``QUIET`` option was given to
+  the :command:`find_package` call.
+
+  The options are:
+
+  ``(DEFAULT_MSG|<custom-failure-message>)``
+    In the simple signature this specifies the failure message.
+    Use ``DEFAULT_MSG`` to ask for a default message to be computed
+    (recommended).  Not valid in the full signature.
+
+  ``FOUND_VAR <result-var>``
+    .. deprecated:: 3.3
+
+    Specifies either ``<PackageName>_FOUND`` or
+    ``<PACKAGENAME>_FOUND`` as the result variable.  This exists only
+    for compatibility with older versions of CMake and is now ignored.
+    Result variables of both names are always set for compatibility.
+
+  ``REQUIRED_VARS <required-var>...``
+    Specify the variables which are required for this package.
+    These may be named in the generated failure message asking the
+    user to set the missing variable values.  Therefore these should
+    typically be cache entries such as ``FOO_LIBRARY`` and not output
+    variables like ``FOO_LIBRARIES``.
+
+    .. versionchanged:: 3.18
+      If ``HANDLE_COMPONENTS`` is specified, this option can be omitted.
+
+  ``VERSION_VAR <version-var>``
+    Specify the name of a variable that holds the version of the package
+    that has been found.  This version will be checked against the
+    (potentially) specified required version given to the
+    :command:`find_package` call, including its ``EXACT`` option.
+    The default messages include information about the required
+    version and the version which has been actually found, both
+    if the version is ok or not.
+
+  ``HANDLE_VERSION_RANGE``
+    .. versionadded:: 3.19
+
+    Enable handling of a version range, if one is specified. Without this
+    option, a developer warning will be displayed if a version range is
+    specified.
+
+  ``HANDLE_COMPONENTS``
+    Enable handling of package components.  In this case, the command
+    will report which components have been found and which are missing,
+    and the ``<PackageName>_FOUND`` variable will be set to ``FALSE``
+    if any of the required components (i.e. not the ones listed after
+    the ``OPTIONAL_COMPONENTS`` option of :command:`find_package`) are
+    missing.
+
+  ``CONFIG_MODE``
+    Specify that the calling find module is a wrapper around a
+    call to ``find_package(<PackageName> NO_MODULE)``.  This implies
+    a ``VERSION_VAR`` value of ``<PackageName>_VERSION``.  The command
+    will automatically check whether the package configuration file
+    was found.
+
+  ``REASON_FAILURE_MESSAGE <reason-failure-message>``
+    .. versionadded:: 3.16
+
+    Specify a custom message of the reason for the failure which will be
+    appended to the default generated message.
+
+  ``FAIL_MESSAGE <custom-failure-message>``
+    Specify a custom failure message instead of using the default
+    generated message.  Not recommended.
+
+  ``NAME_MISMATCHED``
+    .. versionadded:: 3.17
+
+    Indicate that the ``<PackageName>`` does not match
+    ``${CMAKE_FIND_PACKAGE_NAME}``. This is usually a mistake and raises a
+    warning, but it may be intentional for usage of the command for components
+    of a larger package.
+
+Example for the simple signature:
+
+.. code-block:: cmake
+
+  find_package_handle_standard_args(LibXml2 DEFAULT_MSG
+    LIBXML2_LIBRARY LIBXML2_INCLUDE_DIR)
+
+The ``LibXml2`` package is considered to be found if both
+``LIBXML2_LIBRARY`` and ``LIBXML2_INCLUDE_DIR`` are valid.
+Then also ``LibXml2_FOUND`` is set to ``TRUE``.  If it is not found
+and ``REQUIRED`` was used, it fails with a
+:command:`message(FATAL_ERROR)`, independent whether ``QUIET`` was
+used or not.  If it is found, success will be reported, including
+the content of the first ``<required-var>``.  On repeated CMake runs,
+the same message will not be printed again.
+
+.. note::
+
+  If ``<PackageName>`` does not match ``CMAKE_FIND_PACKAGE_NAME`` for the
+  calling module, a warning that there is a mismatch is given. The
+  ``FPHSA_NAME_MISMATCHED`` variable may be set to bypass the warning if using
+  the old signature and the ``NAME_MISMATCHED`` argument using the new
+  signature. To avoid forcing the caller to require newer versions of CMake for
+  usage, the variable's value will be used if defined when the
+  ``NAME_MISMATCHED`` argument is not passed for the new signature (but using
+  both is an error)..
+
+Example for the full signature:
+
+.. code-block:: cmake
+
+  find_package_handle_standard_args(LibArchive
+    REQUIRED_VARS LibArchive_LIBRARY LibArchive_INCLUDE_DIR
+    VERSION_VAR LibArchive_VERSION)
+
+In this case, the ``LibArchive`` package is considered to be found if
+both ``LibArchive_LIBRARY`` and ``LibArchive_INCLUDE_DIR`` are valid.
+Also the version of ``LibArchive`` will be checked by using the version
+contained in ``LibArchive_VERSION``.  Since no ``FAIL_MESSAGE`` is given,
+the default messages will be printed.
+
+Another example for the full signature:
+
+.. code-block:: cmake
+
+  find_package(Automoc4 QUIET NO_MODULE HINTS /opt/automoc4)
+  find_package_handle_standard_args(Automoc4  CONFIG_MODE)
+
+In this case, a ``FindAutmoc4.cmake`` module wraps a call to
+``find_package(Automoc4 NO_MODULE)`` and adds an additional search
+directory for ``automoc4``.  Then the call to
+``find_package_handle_standard_args`` produces a proper success/failure
+message.
+
+.. command:: find_package_check_version
+
+  .. versionadded:: 3.19
+
+  Helper function which can be used to check if a ``<version>`` is valid
+  against version-related arguments of :command:`find_package`.
+
+  .. code-block:: cmake
+
+    find_package_check_version(<version> <result-var>
+      [HANDLE_VERSION_RANGE]
+      [RESULT_MESSAGE_VARIABLE <message-var>]
+      )
+
+  The ``<result-var>`` will hold a boolean value giving the result of the check.
+
+  The options are:
+
+  ``HANDLE_VERSION_RANGE``
+    Enable handling of a version range, if one is specified. Without this
+    option, a developer warning will be displayed if a version range is
+    specified.
+
+  ``RESULT_MESSAGE_VARIABLE <message-var>``
+    Specify a variable to get back a message describing the result of the check.
+
+Example for the usage:
+
+.. code-block:: cmake
+
+  find_package_check_version(1.2.3 result HANDLE_VERSION_RANGE
+    RESULT_MESSAGE_VARIABLE reason)
+  if (result)
+    message (STATUS "${reason}")
+  else()
+    message (FATAL_ERROR "${reason}")
+  endif()
+#]=======================================================================]
+
+include(${CMAKE_CURRENT_LIST_DIR}/FindPackageMessage.cmake)
+
+
+cmake_policy(PUSH)
+# numbers and boolean constants
+cmake_policy (SET CMP0012 NEW)
+# IN_LIST operator
+cmake_policy (SET CMP0057 NEW)
+
+
+# internal helper macro
+macro(_FPHSA_FAILURE_MESSAGE _msg)
+  set (__msg "${_msg}")
+  if (FPHSA_REASON_FAILURE_MESSAGE)
+    string(APPEND __msg "\n    Reason given by package: ${FPHSA_REASON_FAILURE_MESSAGE}\n")
+  endif()
+  if (${_NAME}_FIND_REQUIRED)
+    message(FATAL_ERROR "${__msg}")
+  else ()
+    if (NOT ${_NAME}_FIND_QUIETLY)
+      message(STATUS "${__msg}")
+    endif ()
+  endif ()
+endmacro()
+
+
+# internal helper macro to generate the failure message when used in CONFIG_MODE:
+macro(_FPHSA_HANDLE_FAILURE_CONFIG_MODE)
+  # <PackageName>_CONFIG is set, but FOUND is false, this means that some other of the REQUIRED_VARS was not found:
+  if(${_NAME}_CONFIG)
+    _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: missing:${MISSING_VARS} (found ${${_NAME}_CONFIG} ${VERSION_MSG})")
+  else()
+    # If _CONSIDERED_CONFIGS is set, the config-file has been found, but no suitable version.
+    # List them all in the error message:
+    if(${_NAME}_CONSIDERED_CONFIGS)
+      set(configsText "")
+      list(LENGTH ${_NAME}_CONSIDERED_CONFIGS configsCount)
+      math(EXPR configsCount "${configsCount} - 1")
+      foreach(currentConfigIndex RANGE ${configsCount})
+        list(GET ${_NAME}_CONSIDERED_CONFIGS ${currentConfigIndex} filename)
+        list(GET ${_NAME}_CONSIDERED_VERSIONS ${currentConfigIndex} version)
+        string(APPEND configsText "\n    ${filename} (version ${version})")
+      endforeach()
+      if (${_NAME}_NOT_FOUND_MESSAGE)
+        if (FPHSA_REASON_FAILURE_MESSAGE)
+          string(PREPEND FPHSA_REASON_FAILURE_MESSAGE "${${_NAME}_NOT_FOUND_MESSAGE}\n    ")
+        else()
+          set(FPHSA_REASON_FAILURE_MESSAGE "${${_NAME}_NOT_FOUND_MESSAGE}")
+        endif()
+      else()
+        string(APPEND configsText "\n")
+      endif()
+      _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE} ${VERSION_MSG}, checked the following files:${configsText}")
+
+    else()
+      # Simple case: No Config-file was found at all:
+      _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: found neither ${_NAME}Config.cmake nor ${_NAME_LOWER}-config.cmake ${VERSION_MSG}")
+    endif()
+  endif()
+endmacro()
+
+
+function(FIND_PACKAGE_CHECK_VERSION version result)
+  cmake_parse_arguments (PARSE_ARGV 2 FPCV "HANDLE_VERSION_RANGE;NO_AUTHOR_WARNING_VERSION_RANGE" "RESULT_MESSAGE_VARIABLE" "")
+
+  if (FPCV_UNPARSED_ARGUMENTS)
+    message (FATAL_ERROR "find_package_check_version(): ${FPCV_UNPARSED_ARGUMENTS}: unexpected arguments")
+  endif()
+  if ("RESULT_MESSAGE_VARIABLE" IN_LIST FPCV_KEYWORDS_MISSING_VALUES)
+    message (FATAL_ERROR "find_package_check_version(): RESULT_MESSAGE_VARIABLE expects an argument")
+  endif()
+
+  set (${result} FALSE PARENT_SCOPE)
+  if (FPCV_RESULT_MESSAGE_VARIABLE)
+    unset (${FPCV_RESULT_MESSAGE_VARIABLE} PARENT_SCOPE)
+  endif()
+
+  if (_CMAKE_FPHSA_PACKAGE_NAME)
+    set (package "${_CMAKE_FPHSA_PACKAGE_NAME}")
+  elseif (CMAKE_FIND_PACKAGE_NAME)
+    set (package "${CMAKE_FIND_PACKAGE_NAME}")
+  else()
+    message (FATAL_ERROR "find_package_check_version(): Cannot be used outside a 'Find Module'")
+  endif()
+
+  if (NOT FPCV_NO_AUTHOR_WARNING_VERSION_RANGE
+      AND ${package}_FIND_VERSION_RANGE AND NOT FPCV_HANDLE_VERSION_RANGE)
+    message(AUTHOR_WARNING
+      "`find_package()` specify a version range but the option "
+      "HANDLE_VERSION_RANGE` is not passed to `find_package_check_version()`. "
+      "Only the lower endpoint of the range will be used.")
+  endif()
+
+
+  set (version_ok FALSE)
+  unset (version_msg)
+
+  if (FPCV_HANDLE_VERSION_RANGE AND ${package}_FIND_VERSION_RANGE)
+    if ((${package}_FIND_VERSION_RANGE_MIN STREQUAL "INCLUDE"
+          AND version VERSION_GREATER_EQUAL ${package}_FIND_VERSION_MIN)
+        AND ((${package}_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE"
+            AND version VERSION_LESS_EQUAL ${package}_FIND_VERSION_MAX)
+          OR (${package}_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE"
+            AND version VERSION_LESS ${package}_FIND_VERSION_MAX)))
+      set (version_ok TRUE)
+      set(version_msg "(found suitable version \"${version}\", required range is \"${${package}_FIND_VERSION_RANGE}\")")
+    else()
+      set(version_msg "Found unsuitable version \"${version}\", required range is \"${${package}_FIND_VERSION_RANGE}\"")
+    endif()
+  elseif (DEFINED ${package}_FIND_VERSION)
+    if(${package}_FIND_VERSION_EXACT)       # exact version required
+      # count the dots in the version string
+      string(REGEX REPLACE "[^.]" "" version_dots "${version}")
+      # add one dot because there is one dot more than there are components
+      string(LENGTH "${version_dots}." version_dots)
+      if (version_dots GREATER ${package}_FIND_VERSION_COUNT)
+        # Because of the C++ implementation of find_package() ${package}_FIND_VERSION_COUNT
+        # is at most 4 here. Therefore a simple lookup table is used.
+        if (${package}_FIND_VERSION_COUNT EQUAL 1)
+          set(version_regex "[^.]*")
+        elseif (${package}_FIND_VERSION_COUNT EQUAL 2)
+          set(version_regex "[^.]*\\.[^.]*")
+        elseif (${package}_FIND_VERSION_COUNT EQUAL 3)
+          set(version_regex "[^.]*\\.[^.]*\\.[^.]*")
+        else()
+          set(version_regex "[^.]*\\.[^.]*\\.[^.]*\\.[^.]*")
+        endif()
+        string(REGEX REPLACE "^(${version_regex})\\..*" "\\1" version_head "${version}")
+        if (NOT ${package}_FIND_VERSION VERSION_EQUAL version_head)
+          set(version_msg "Found unsuitable version \"${version}\", but required is exact version \"${${package}_FIND_VERSION}\"")
+        else ()
+          set(version_ok TRUE)
+          set(version_msg "(found suitable exact version \"${_FOUND_VERSION}\")")
+        endif ()
+      else ()
+        if (NOT ${package}_FIND_VERSION VERSION_EQUAL version)
+          set(version_msg "Found unsuitable version \"${version}\", but required is exact version \"${${package}_FIND_VERSION}\"")
+        else ()
+          set(version_ok TRUE)
+          set(version_msg "(found suitable exact version \"${version}\")")
+        endif ()
+      endif ()
+    else()     # minimum version
+      if (${package}_FIND_VERSION VERSION_GREATER version)
+        set(version_msg "Found unsuitable version \"${version}\", but required is at least \"${${package}_FIND_VERSION}\"")
+      else()
+        set(version_ok TRUE)
+        set(version_msg "(found suitable version \"${version}\", minimum required is \"${${package}_FIND_VERSION}\")")
+      endif()
+    endif()
+  else ()
+    set(version_ok TRUE)
+    set(version_msg "(found version \"${version}\")")
+  endif()
+
+  set (${result} ${version_ok} PARENT_SCOPE)
+  if (FPCV_RESULT_MESSAGE_VARIABLE)
+    set (${FPCV_RESULT_MESSAGE_VARIABLE} "${version_msg}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+
+function(FIND_PACKAGE_HANDLE_STANDARD_ARGS _NAME _FIRST_ARG)
+
+  # Set up the arguments for `cmake_parse_arguments`.
+  set(options  CONFIG_MODE  HANDLE_COMPONENTS NAME_MISMATCHED HANDLE_VERSION_RANGE)
+  set(oneValueArgs  FAIL_MESSAGE  REASON_FAILURE_MESSAGE VERSION_VAR  FOUND_VAR)
+  set(multiValueArgs REQUIRED_VARS)
+
+  # Check whether we are in 'simple' or 'extended' mode:
+  set(_KEYWORDS_FOR_EXTENDED_MODE  ${options} ${oneValueArgs} ${multiValueArgs} )
+  list(FIND _KEYWORDS_FOR_EXTENDED_MODE "${_FIRST_ARG}" INDEX)
+
+  unset(FPHSA_NAME_MISMATCHED_override)
+  if (DEFINED FPHSA_NAME_MISMATCHED)
+    # If the variable NAME_MISMATCHED variable is set, error if it is passed as
+    # an argument. The former is for old signatures, the latter is for new
+    # signatures.
+    list(FIND ARGN "NAME_MISMATCHED" name_mismatched_idx)
+    if (NOT name_mismatched_idx EQUAL "-1")
+      message(FATAL_ERROR
+        "The `NAME_MISMATCHED` argument may only be specified by the argument or "
+        "the variable, not both.")
+    endif ()
+
+    # But use the variable if it is not an argument to avoid forcing minimum
+    # CMake version bumps for calling modules.
+    set(FPHSA_NAME_MISMATCHED_override "${FPHSA_NAME_MISMATCHED}")
+  endif ()
+
+  if(${INDEX} EQUAL -1)
+    set(FPHSA_FAIL_MESSAGE ${_FIRST_ARG})
+    set(FPHSA_REQUIRED_VARS ${ARGN})
+    set(FPHSA_VERSION_VAR)
+  else()
+    cmake_parse_arguments(FPHSA "${options}" "${oneValueArgs}" "${multiValueArgs}"  ${_FIRST_ARG} ${ARGN})
+
+    if(FPHSA_UNPARSED_ARGUMENTS)
+      message(FATAL_ERROR "Unknown keywords given to FIND_PACKAGE_HANDLE_STANDARD_ARGS(): \"${FPHSA_UNPARSED_ARGUMENTS}\"")
+    endif()
+
+    if(NOT FPHSA_FAIL_MESSAGE)
+      set(FPHSA_FAIL_MESSAGE  "DEFAULT_MSG")
+    endif()
+
+    # In config-mode, we rely on the variable <PackageName>_CONFIG, which is set by find_package()
+    # when it successfully found the config-file, including version checking:
+    if(FPHSA_CONFIG_MODE)
+      list(INSERT FPHSA_REQUIRED_VARS 0 ${_NAME}_CONFIG)
+      list(REMOVE_DUPLICATES FPHSA_REQUIRED_VARS)
+      set(FPHSA_VERSION_VAR ${_NAME}_VERSION)
+    endif()
+
+    if(NOT FPHSA_REQUIRED_VARS AND NOT FPHSA_HANDLE_COMPONENTS)
+      message(FATAL_ERROR "No REQUIRED_VARS specified for FIND_PACKAGE_HANDLE_STANDARD_ARGS()")
+    endif()
+  endif()
+
+  if (DEFINED FPHSA_NAME_MISMATCHED_override)
+    set(FPHSA_NAME_MISMATCHED "${FPHSA_NAME_MISMATCHED_override}")
+  endif ()
+
+  if (DEFINED CMAKE_FIND_PACKAGE_NAME
+      AND NOT FPHSA_NAME_MISMATCHED
+      AND NOT _NAME STREQUAL CMAKE_FIND_PACKAGE_NAME)
+    message(AUTHOR_WARNING
+      "The package name passed to `find_package_handle_standard_args` "
+      "(${_NAME}) does not match the name of the calling package "
+      "(${CMAKE_FIND_PACKAGE_NAME}). This can lead to problems in calling "
+      "code that expects `find_package` result variables (e.g., `_FOUND`) "
+      "to follow a certain pattern.")
+  endif ()
+
+  if (${_NAME}_FIND_VERSION_RANGE AND NOT FPHSA_HANDLE_VERSION_RANGE)
+    message(AUTHOR_WARNING
+      "`find_package()` specify a version range but the module ${_NAME} does "
+      "not support this capability. Only the lower endpoint of the range "
+      "will be used.")
+  endif()
+
+  # to propagate package name to FIND_PACKAGE_CHECK_VERSION
+  set(_CMAKE_FPHSA_PACKAGE_NAME "${_NAME}")
+
+  # now that we collected all arguments, process them
+
+  if("x${FPHSA_FAIL_MESSAGE}" STREQUAL "xDEFAULT_MSG")
+    set(FPHSA_FAIL_MESSAGE "Could NOT find ${_NAME}")
+  endif()
+
+  if (FPHSA_REQUIRED_VARS)
+    list(GET FPHSA_REQUIRED_VARS 0 _FIRST_REQUIRED_VAR)
+  endif()
+
+  string(TOUPPER ${_NAME} _NAME_UPPER)
+  string(TOLOWER ${_NAME} _NAME_LOWER)
+
+  if(FPHSA_FOUND_VAR)
+    set(_FOUND_VAR_UPPER ${_NAME_UPPER}_FOUND)
+    set(_FOUND_VAR_MIXED ${_NAME}_FOUND)
+    if(FPHSA_FOUND_VAR STREQUAL _FOUND_VAR_MIXED  OR  FPHSA_FOUND_VAR STREQUAL _FOUND_VAR_UPPER)
+      set(_FOUND_VAR ${FPHSA_FOUND_VAR})
+    else()
+      message(FATAL_ERROR "The argument for FOUND_VAR is \"${FPHSA_FOUND_VAR}\", but only \"${_FOUND_VAR_MIXED}\" and \"${_FOUND_VAR_UPPER}\" are valid names.")
+    endif()
+  else()
+    set(_FOUND_VAR ${_NAME_UPPER}_FOUND)
+  endif()
+
+  # collect all variables which were not found, so they can be printed, so the
+  # user knows better what went wrong (#6375)
+  set(MISSING_VARS "")
+  set(DETAILS "")
+  # check if all passed variables are valid
+  set(FPHSA_FOUND_${_NAME} TRUE)
+  foreach(_CURRENT_VAR ${FPHSA_REQUIRED_VARS})
+    if(NOT ${_CURRENT_VAR})
+      set(FPHSA_FOUND_${_NAME} FALSE)
+      string(APPEND MISSING_VARS " ${_CURRENT_VAR}")
+    else()
+      string(APPEND DETAILS "[${${_CURRENT_VAR}}]")
+    endif()
+  endforeach()
+  if(FPHSA_FOUND_${_NAME})
+    set(${_NAME}_FOUND TRUE)
+    set(${_NAME_UPPER}_FOUND TRUE)
+  else()
+    set(${_NAME}_FOUND FALSE)
+    set(${_NAME_UPPER}_FOUND FALSE)
+  endif()
+
+  # component handling
+  unset(FOUND_COMPONENTS_MSG)
+  unset(MISSING_COMPONENTS_MSG)
+
+  if(FPHSA_HANDLE_COMPONENTS)
+    foreach(comp ${${_NAME}_FIND_COMPONENTS})
+      if(${_NAME}_${comp}_FOUND)
+
+        if(NOT DEFINED FOUND_COMPONENTS_MSG)
+          set(FOUND_COMPONENTS_MSG "found components:")
+        endif()
+        string(APPEND FOUND_COMPONENTS_MSG " ${comp}")
+
+      else()
+
+        if(NOT DEFINED MISSING_COMPONENTS_MSG)
+          set(MISSING_COMPONENTS_MSG "missing components:")
+        endif()
+        string(APPEND MISSING_COMPONENTS_MSG " ${comp}")
+
+        if(${_NAME}_FIND_REQUIRED_${comp})
+          set(${_NAME}_FOUND FALSE)
+          string(APPEND MISSING_VARS " ${comp}")
+        endif()
+
+      endif()
+    endforeach()
+    set(COMPONENT_MSG "${FOUND_COMPONENTS_MSG} ${MISSING_COMPONENTS_MSG}")
+    string(APPEND DETAILS "[c${COMPONENT_MSG}]")
+  endif()
+
+  # version handling:
+  set(VERSION_MSG "")
+  set(VERSION_OK TRUE)
+
+  # check with DEFINED here as the requested or found version may be "0"
+  if (DEFINED ${_NAME}_FIND_VERSION)
+    if(DEFINED ${FPHSA_VERSION_VAR})
+      set(_FOUND_VERSION ${${FPHSA_VERSION_VAR}})
+      if (FPHSA_HANDLE_VERSION_RANGE)
+        set (FPCV_HANDLE_VERSION_RANGE HANDLE_VERSION_RANGE)
+      else()
+        set(FPCV_HANDLE_VERSION_RANGE NO_AUTHOR_WARNING_VERSION_RANGE)
+      endif()
+      find_package_check_version ("${_FOUND_VERSION}" VERSION_OK RESULT_MESSAGE_VARIABLE VERSION_MSG
+        ${FPCV_HANDLE_VERSION_RANGE})
+    else()
+      # if the package was not found, but a version was given, add that to the output:
+      if(${_NAME}_FIND_VERSION_EXACT)
+        set(VERSION_MSG "(Required is exact version \"${${_NAME}_FIND_VERSION}\")")
+      elseif (FPHSA_HANDLE_VERSION_RANGE AND ${_NAME}_FIND_VERSION_RANGE)
+        set(VERSION_MSG "(Required is version range \"${${_NAME}_FIND_VERSION_RANGE}\")")
+      else()
+        set(VERSION_MSG "(Required is at least version \"${${_NAME}_FIND_VERSION}\")")
+      endif()
+    endif()
+  else ()
+    # Check with DEFINED as the found version may be 0.
+    if(DEFINED ${FPHSA_VERSION_VAR})
+      set(VERSION_MSG "(found version \"${${FPHSA_VERSION_VAR}}\")")
+    endif()
+  endif ()
+
+  if(VERSION_OK)
+    string(APPEND DETAILS "[v${${FPHSA_VERSION_VAR}}(${${_NAME}_FIND_VERSION})]")
+  else()
+    set(${_NAME}_FOUND FALSE)
+  endif()
+
+
+  # print the result:
+  if (${_NAME}_FOUND)
+    FIND_PACKAGE_MESSAGE(${_NAME} "Found ${_NAME}: ${${_FIRST_REQUIRED_VAR}} ${VERSION_MSG} ${COMPONENT_MSG}" "${DETAILS}")
+  else ()
+
+    if(FPHSA_CONFIG_MODE)
+      _FPHSA_HANDLE_FAILURE_CONFIG_MODE()
+    else()
+      if(NOT VERSION_OK)
+        set(RESULT_MSG)
+        if (_FIRST_REQUIRED_VAR)
+          string (APPEND RESULT_MSG "found ${${_FIRST_REQUIRED_VAR}}")
+        endif()
+        if (COMPONENT_MSG)
+          if (RESULT_MSG)
+            string (APPEND RESULT_MSG ", ")
+          endif()
+          string (APPEND RESULT_MSG "${FOUND_COMPONENTS_MSG}")
+        endif()
+        _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE}: ${VERSION_MSG} (${RESULT_MSG})")
+      else()
+        _FPHSA_FAILURE_MESSAGE("${FPHSA_FAIL_MESSAGE} (missing:${MISSING_VARS}) ${VERSION_MSG}")
+      endif()
+    endif()
+
+  endif ()
+
+  set(${_NAME}_FOUND ${${_NAME}_FOUND} PARENT_SCOPE)
+  set(${_NAME_UPPER}_FOUND ${${_NAME}_FOUND} PARENT_SCOPE)
+endfunction()
+
+
+cmake_policy(POP)

--- a/CMakeModules/FindPackageMessage.cmake
+++ b/CMakeModules/FindPackageMessage.cmake
@@ -1,0 +1,48 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindPackageMessage
+------------------
+
+.. code-block:: cmake
+
+  find_package_message(<name> "message for user" "find result details")
+
+This function is intended to be used in FindXXX.cmake modules files.
+It will print a message once for each unique find result.  This is
+useful for telling the user where a package was found.  The first
+argument specifies the name (XXX) of the package.  The second argument
+specifies the message to display.  The third argument lists details
+about the find result so that if they change the message will be
+displayed again.  The macro also obeys the QUIET argument to the
+find_package command.
+
+Example:
+
+.. code-block:: cmake
+
+  if(X11_FOUND)
+    find_package_message(X11 "Found X11: ${X11_X11_LIB}"
+      "[${X11_X11_LIB}][${X11_INCLUDE_DIR}]")
+  else()
+   ...
+  endif()
+#]=======================================================================]
+
+function(find_package_message pkg msg details)
+  # Avoid printing a message repeatedly for the same find result.
+  if(NOT ${pkg}_FIND_QUIETLY)
+    string(REPLACE "\n" "" details "${details}")
+    set(DETAILS_VAR FIND_PACKAGE_MESSAGE_DETAILS_${pkg})
+    if(NOT "${details}" STREQUAL "${${DETAILS_VAR}}")
+      # The message has not yet been printed.
+      message(STATUS "${msg}")
+
+      # Save the find details in the cache to avoid printing the same
+      # message again.
+      set("${DETAILS_VAR}" "${details}"
+        CACHE INTERNAL "Details about finding ${pkg}")
+    endif()
+  endif()
+endfunction()

--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -8,7 +8,7 @@
 FetchContent_Declare(
   ${clblast_prefix}
   GIT_REPOSITORY    https://github.com/cnugteren/CLBlast.git
-  GIT_TAG           1.5.2
+  GIT_TAG           481d86665f1d79ce59e1677eea15d618f1ac62bf
 )
 af_dep_check_and_populate(${clblast_prefix})
 


### PR DESCRIPTION
This PR updates the tag for the CLBlast version to avoid failures in DGEMM on Turing GPUs. Also update the FindOpenMP the version found in CMake 3.21

Description
-----------
* Revert CLBlast to an older commit
* Update FindOpenMP.cmake

Changes to Users
----------------
None

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
