### PR TITLE
fix transform operator for countByKey

### DIFF
--- a/src/backend/cuda/reduce_impl.hpp
+++ b/src/backend/cuda/reduce_impl.hpp
@@ -99,8 +99,9 @@ void reduce_by_key_dim(Array<Tk> &keys_out, Array<To> &vals_out,
             POST_LAUNCH_CHECK();
             first_pass = false;
         } else {
+            constexpr af_op_t op2 = op == af_notzero_t ? af_add_t : op;
             CUDA_LAUNCH(
-                (kernel::reduce_blocks_dim_by_key<To, Tk, To, op, numThreads>),
+                (kernel::reduce_blocks_dim_by_key<To, Tk, To, op2, numThreads>),
                 blocks, numThreads, reduced_block_sizes.get(), reduced_keys,
                 reduced_vals, t_reduced_keys, t_reduced_vals, n_reduced_host,
                 change_nan, scalar<To>(nanval), dim, folded_dim_sz);
@@ -245,8 +246,9 @@ void reduce_by_key_first(Array<Tk> &keys_out, Array<To> &vals_out,
             POST_LAUNCH_CHECK();
             first_pass = false;
         } else {
+            constexpr af_op_t op2 = op == af_notzero_t ? af_add_t : op;
             CUDA_LAUNCH(
-                (kernel::reduce_blocks_by_key<To, Tk, To, op, numThreads>),
+                (kernel::reduce_blocks_by_key<To, Tk, To, op2, numThreads>),
                 blocks, numThreads, reduced_block_sizes.get(), reduced_keys,
                 reduced_vals, t_reduced_keys, t_reduced_vals, n_reduced_host,
                 change_nan, scalar<To>(nanval), odims[2]);

--- a/src/backend/opencl/kernel/reduce_by_key.hpp
+++ b/src/backend/opencl/kernel/reduce_by_key.hpp
@@ -338,7 +338,8 @@ int reduceByKeyFirst(Array<Tk> &keys_out, Array<To> &vals_out, const Param keys,
                 vals, change_nan, nanval, n_reduced_host, numThreads);
             first_pass = false;
         } else {
-            reduceBlocksByKey<To, Tk, To, op>(
+            constexpr af_op_t op2 = op == af_notzero_t ? af_add_t : op;
+            reduceBlocksByKey<To, Tk, To, op2>(
                 reduced_block_sizes.get(), reduced_keys, reduced_vals,
                 t_reduced_keys, t_reduced_vals, change_nan, nanval,
                 n_reduced_host, numThreads);
@@ -458,7 +459,8 @@ int reduceByKeyDim(Array<Tk> &keys_out, Array<To> &vals_out, const Param keys,
                 dim_ordering);
             first_pass = false;
         } else {
-            reduceBlocksByKeyDim<To, Tk, To, op>(
+            constexpr af_op_t op2 = op == af_notzero_t ? af_add_t : op;
+            reduceBlocksByKeyDim<To, Tk, To, op2>(
                 reduced_block_sizes.get(), reduced_keys, reduced_vals,
                 t_reduced_keys, t_reduced_vals, change_nan, nanval,
                 n_reduced_host, numThreads, dim, dim_ordering);

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -2066,7 +2066,7 @@ TEST(ReduceByKey, ISSUE_2955_dim) {
     ASSERT_EQ(ov.dims(1), 128);
 }
 
-TEST(ReduceByKey, ISSUE_3602) {
+TEST(ReduceByKey, ISSUE_3062) {
     size_t N = 129;
 
     af::array ones = af::constant(1, N, u32);

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -2065,3 +2065,29 @@ TEST(ReduceByKey, ISSUE_2955_dim) {
     ASSERT_EQ(ok.dims(0), 128);
     ASSERT_EQ(ov.dims(1), 128);
 }
+
+TEST(ReduceByKey, ISSUE_3602) {
+    size_t N = 129;
+
+    af::array ones = af::constant(1, N, u32);
+    af::array zeros = af::constant(0, N, u32);
+
+    af::array okeys;
+    af::array ovalues;
+
+    af::sumByKey(okeys, ovalues, zeros, ones);
+    ASSERT_EQ(ovalues.scalar<unsigned>(), 129);
+
+    af::countByKey(okeys, ovalues, zeros, ones);
+    ASSERT_EQ(ovalues.scalar<unsigned>(), 129);
+
+    // test reduction on non-zero dimension as well
+    ones = af::constant(1, 2, N, u32);
+    zeros = af::constant(0, N, u32);
+
+    af::sumByKey(okeys, ovalues, zeros, ones, 1);
+    ASSERT_EQ(ovalues.scalar<unsigned>(), 129);
+
+    af::countByKey(okeys, ovalues, zeros, ones, 1);
+    ASSERT_EQ(ovalues.scalar<unsigned>(), 129);
+}


### PR DESCRIPTION
Fixes Issue #3062  where countByKey would give incorrect results for any n > 128 (block size). When there is more than one block's worth of reduction, multiple reduction iterations occur.
The af_nonzero_t  transformation would reset the reduced values back to a non-zero flag (1) instead of the actual count between reduction iterations. This operator is now replaced with the af_add_t operator in consequent iterations.

- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
