### PR TITLE
Add assert that check if topk is called with a negative value for k

### DIFF
--- a/src/api/c/topk.cpp
+++ b/src/api/c/topk.cpp
@@ -66,7 +66,8 @@ af_err af_topk(af_array *values, af_array *indices, const af_array in,
         }
 
         ARG_ASSERT(2, (inInfo.dims()[rdim] >= k));
-        ARG_ASSERT(4, (k <= 256));  // TODO(umar): Remove this limitation
+        ARG_ASSERT(
+            4, (k > 0) && (k <= 256));  // TODO(umar): Remove this limitation
 
         if (rdim != 0) {
             AF_ERROR("topk is supported along dimenion 0 only.",

--- a/test/topk.cpp
+++ b/test/topk.cpp
@@ -333,9 +333,37 @@ TEST_P(TopKParams, CPP) {
                 float gold  = static_cast<float>(ii * d0 + j);
                 int goldidx = j;
                 ASSERT_FLOAT_EQ(gold, hval[i])
-                    << print_context(i, 0, hval, hidx);
-                ASSERT_EQ(goldidx, hidx[i]) << print_context(i, 0, hval, hidx);
+                    << print_context(i, j, hval, hidx);
+                ASSERT_EQ(goldidx, hidx[i]) << print_context(i, j, hval, hidx);
             }
         }
     }
+}
+
+TEST(TopK, KGreaterThan256) {
+    af::array a = af::randu(500);
+    af::array vals, idx;
+
+    int k = 257;
+    EXPECT_THROW(topk(vals, idx, a, k), af::exception)
+        << "The current limitation of the K value as increased. Please check "
+           "or remove this test";
+}
+
+TEST(TopK, KEquals0) {
+    af::array a = af::randu(500);
+    af::array vals, idx;
+
+    int k = 0;
+    EXPECT_THROW(topk(vals, idx, a, k), af::exception)
+        << "K cannot be less than 1";
+}
+
+TEST(TopK, KLessThan0) {
+    af::array a = af::randu(500);
+    af::array vals, idx;
+
+    int k = -1;
+    EXPECT_THROW(topk(vals, idx, a, k), af::exception)
+        << "K cannot be less than 0";
 }


### PR DESCRIPTION
Add checks to make sure K is greater than 0 for topk

Description
-----------
TopK fails if k is negative. This is not a proper value for TopK so we are adding assertions to make sure K is grater than 0.

Changes to Users
----------------
* Users must make sure that k is greater than 0 for the topk function

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
