### PR TITLE
Update CLBlast to fix some errors on Turing cards

### DIFF
--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -7,7 +7,7 @@
 
 af_dep_check_and_populate(${clblast_prefix}
   URI https://github.com/cnugteren/CLBlast.git
-  REF 1.5.2
+  REF 4500a03440e2cc54998c0edab366babf5e504d67
 )
 
 include(ExternalProject)


### PR DESCRIPTION
This change updates the CLBlast reference to fix issues with Turing cards and some linear algebra functions and doubles

Description
-----------
Fixes several issues brought up in linear algebra functions when using Turing cards and doubles.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
