### PR TITLE
reduce all -> array

### DIFF
--- a/include/af/algorithm.h
+++ b/include/af/algorithm.h
@@ -674,6 +674,19 @@ extern "C" {
     */
     AFAPI af_err af_sum(af_array *out, const af_array in, const int dim);
 
+#if AF_API_VERSION >= 39
+    /**
+       C Interface for sum of all elements in an array, resulting in an array
+
+       \param[out] out will contain the sum of all values in \p in
+       \param[in] in is the input array
+       \return \ref AF_SUCCESS if the execution completes properly
+
+       \ingroup reduce_func_sum
+    */
+    AFAPI af_err af_sum_all_array(af_array *out, const af_array in);
+#endif
+
 #if AF_API_VERSION >= 31
     /**
        C Interface for sum of elements in an array while replacing nans
@@ -688,6 +701,21 @@ extern "C" {
     */
     AFAPI af_err af_sum_nan(af_array *out, const af_array in,
                             const int dim, const double nanval);
+#endif
+
+#if AF_API_VERSION >= 39
+    /**
+       C Interface for sum of all elements in an array, resulting in an array with
+       nan substitution
+
+       \param[out] out will contain the sum of all values in \p in
+       \param[in] in is the input array
+       \param[in] nanval  The value that will replace the NaNs in \p in
+       \return \ref AF_SUCCESS if the execution completes properly
+
+       \ingroup reduce_func_sum
+    */
+    AFAPI af_err af_sum_nan_all_array(af_array *out, const af_array in, const double nanval);
 #endif
 
 #if AF_API_VERSION >= 37
@@ -741,6 +769,19 @@ extern "C" {
     */
     AFAPI af_err af_product(af_array *out, const af_array in, const int dim);
 
+#if AF_API_VERSION >= 39
+    /**
+       C Interface for product of elements in an array, resulting in an array
+
+       \param[out] out will contain the product of all values in \p in
+       \param[in] in is the input array
+       \return \ref AF_SUCCESS if the execution completes properly
+
+       \ingroup reduce_func_product
+    */
+    AFAPI af_err af_product_all_array(af_array *out, const af_array in);
+#endif
+
 #if AF_API_VERSION >= 31
     /**
        C Interface for product of elements in an array while replacing nans
@@ -755,6 +796,21 @@ extern "C" {
        \ingroup reduce_func_product
     */
     AFAPI af_err af_product_nan(af_array *out, const af_array in, const int dim, const double nanval);
+#endif
+
+#if AF_API_VERSION >= 39
+    /**
+       C Interface for product of elements in an array, resulting in an array
+       while replacing nans
+
+       \param[out] out will contain the product of all values in \p in
+       \param[in] in   is the input array
+       \param[in] nanval  The value that will replace the NaNs in \p in
+       \return \ref AF_SUCCESS if the execution completes properly
+
+       \ingroup reduce_func_product
+    */
+    AFAPI af_err af_product_nan_all_array(af_array *out, const af_array in, const double nanval);
 #endif
 
 #if AF_API_VERSION >= 37
@@ -1052,6 +1108,19 @@ extern "C" {
     */
     AFAPI af_err af_min_all(double *real, double *imag, const af_array in);
 
+#if AF_API_VERSION >= 39
+    /**
+       C Interface for minimum values in an array, returning an array
+
+       \param[out] out will contain the minimum of all values in \p in
+       \param[in] in is the input array
+       \return \ref AF_SUCCESS if the execution completes properly
+
+       \ingroup reduce_func_min
+    */
+    AFAPI af_err af_min_all_array(af_array *out, const af_array in);
+#endif
+
     /**
        C Interface for getting maximum value of an array
 
@@ -1065,6 +1134,21 @@ extern "C" {
        \ingroup reduce_func_max
     */
     AFAPI af_err af_max_all(double *real, double *imag, const af_array in);
+
+#if AF_API_VERSION >= 39
+    /**
+       C Interface for getting maximum value of an array, returning an array
+
+       \param[out] out will contain the maximum of all values in \p in
+       \param[in] in is the input array
+       \return \ref AF_SUCCESS if the execution completes properly
+
+       \note \p imag is always set to 0 when \p in is real.
+
+       \ingroup reduce_func_max
+    */
+    AFAPI af_err af_max_all_array(af_array *out, const af_array in);
+#endif
 
     /**
        C Interface for checking if all values in an array are true
@@ -1080,6 +1164,22 @@ extern "C" {
     */
     AFAPI af_err af_all_true_all(double *real, double *imag, const af_array in);
 
+#if AF_API_VERSION >= 39
+    /**
+       C Interface for checking if all values in an array are true,
+       while returning an af_array
+
+       \param[out] out will contain 1 if all values of input \p in are true, 0 otherwise
+       \param[in] in is the input array
+       \return \ref AF_SUCCESS if the execution completes properly
+
+       \note \p imag is always set to 0.
+
+       \ingroup reduce_func_all_true
+    */
+    AFAPI af_err af_all_true_all_array(af_array *out, const af_array in);
+#endif
+
     /**
        C Interface for checking if any values in an array are true
 
@@ -1094,6 +1194,22 @@ extern "C" {
     */
     AFAPI af_err af_any_true_all(double *real, double *imag, const af_array in);
 
+#if AF_API_VERSION >= 39
+    /**
+       C Interface for checking if any values in an array are true,
+       while returning an af_array
+
+       \param[out] out will contain 1 if any value of input \p in is true, 0 otherwise
+       \param[in] in is the input array
+       \return \ref AF_SUCCESS if the execution completes properly
+
+       \note \p imag is always set to 0.
+
+       \ingroup reduce_func_any_true
+    */
+    AFAPI af_err af_any_true_all_array(af_array *out, const af_array in);
+#endif
+
     /**
        C Interface for counting total number of non-zero values in an array
 
@@ -1107,6 +1223,20 @@ extern "C" {
        \ingroup reduce_func_count
     */
     AFAPI af_err af_count_all(double *real, double *imag, const af_array in);
+
+#if AF_API_VERSION >= 39
+    /**
+       C Interface for counting total number of non-zero values in an array,
+       while returning an af_array
+
+       \param[out] out contain the number of non-zero values in \p in.
+       \param[in] in is the input array
+       \return \ref AF_SUCCESS if the execution completes properly
+
+       \ingroup reduce_func_count
+    */
+    AFAPI af_err af_count_all_array(af_array *out, const af_array in);
+#endif
 
     /**
        C Interface for getting minimum values and their locations in an array

--- a/src/api/c/anisotropic_diffusion.cpp
+++ b/src/api/c/anisotropic_diffusion.cpp
@@ -28,6 +28,7 @@ using common::cast;
 using detail::arithOp;
 using detail::Array;
 using detail::createEmptyArray;
+using detail::getScalar;
 using detail::gradient;
 using detail::reduce_all;
 
@@ -48,7 +49,8 @@ af_array diffusion(const Array<float>& in, const float dt, const float K,
         auto g0Sqr = arithOp<float, af_mul_t>(g0, g0, dims);
         auto g1Sqr = arithOp<float, af_mul_t>(g1, g1, dims);
         auto sumd  = arithOp<float, af_add_t>(g0Sqr, g1Sqr, dims);
-        float avg  = reduce_all<af_add_t, float, float>(sumd, true, 0);
+        float avg =
+            getScalar<float>(reduce_all<af_add_t, float, float>(sumd, true, 0));
 
         anisotropicDiffusion(out, dt, 1.0f / (cnst * avg), fftype, eq);
     }

--- a/src/api/c/canny.cpp
+++ b/src/api/c/canny.cpp
@@ -44,6 +44,7 @@ using detail::createEmptyArray;
 using detail::createHostDataArray;
 using detail::createSubArray;
 using detail::createValueArray;
+using detail::getScalar;
 using detail::histogram;
 using detail::iota;
 using detail::ireduce;
@@ -151,7 +152,9 @@ pair<Array<char>, Array<char>> computeCandidates(const Array<float>& supEdges,
                                                  const float t1,
                                                  const af_canny_threshold ct,
                                                  const float t2) {
-    float maxVal  = reduce_all<af_max_t, float, float>(supEdges);
+    float maxVal =
+        getScalar<float>(reduce_all<af_max_t, float, float>(supEdges));
+    ;
     auto NUM_BINS = static_cast<unsigned>(maxVal);
 
     auto lowRatio = createValueArray<float>(supEdges.dims(), t1);
@@ -171,10 +174,11 @@ pair<Array<char>, Array<char>> computeCandidates(const Array<float>& supEdges,
             return make_pair(strong, weak);
         };
         default: {
-            float minVal = reduce_all<af_min_t, float, float>(supEdges);
-            auto normG   = normalize(supEdges, minVal, maxVal);
-            auto T2      = createValueArray<float>(supEdges.dims(), t2);
-            auto T1      = createValueArray<float>(supEdges.dims(), t1);
+            float minVal =
+                getScalar<float>(reduce_all<af_min_t, float, float>(supEdges));
+            auto normG = normalize(supEdges, minVal, maxVal);
+            auto T2    = createValueArray<float>(supEdges.dims(), t2);
+            auto T1    = createValueArray<float>(supEdges.dims(), t1);
             Array<char> weak1 =
                 logicOp<float, af_ge_t>(normG, T1, normG.dims());
             Array<char> weak2 =

--- a/src/api/c/corrcoef.cpp
+++ b/src/api/c/corrcoef.cpp
@@ -11,6 +11,7 @@
 #include <backend.hpp>
 #include <common/cast.hpp>
 #include <common/err_common.hpp>
+#include <copy.hpp>
 #include <handle.hpp>
 #include <math.hpp>
 #include <reduce.hpp>
@@ -26,6 +27,7 @@ using af::dim4;
 using common::cast;
 using detail::arithOp;
 using detail::Array;
+using detail::getScalar;
 using detail::intl;
 using detail::reduce_all;
 using detail::uchar;
@@ -41,16 +43,16 @@ static To corrcoef(const af_array& X, const af_array& Y) {
     const dim4& dims = xIn.dims();
     dim_t n          = xIn.elements();
 
-    To xSum = reduce_all<af_add_t, To, To>(xIn);
-    To ySum = reduce_all<af_add_t, To, To>(yIn);
+    To xSum = getScalar<To>(reduce_all<af_add_t, To, To>(xIn));
+    To ySum = getScalar<To>(reduce_all<af_add_t, To, To>(yIn));
 
     Array<To> xSq = arithOp<To, af_mul_t>(xIn, xIn, dims);
     Array<To> ySq = arithOp<To, af_mul_t>(yIn, yIn, dims);
     Array<To> xy  = arithOp<To, af_mul_t>(xIn, yIn, dims);
 
-    To xSqSum = reduce_all<af_add_t, To, To>(xSq);
-    To ySqSum = reduce_all<af_add_t, To, To>(ySq);
-    To xySum  = reduce_all<af_add_t, To, To>(xy);
+    To xSqSum = getScalar<To>(reduce_all<af_add_t, To, To>(xSq));
+    To ySqSum = getScalar<To>(reduce_all<af_add_t, To, To>(ySq));
+    To xySum  = getScalar<To>(reduce_all<af_add_t, To, To>(xy));
 
     To result =
         (n * xySum - xSum * ySum) / (std::sqrt(n * xSqSum - xSum * xSum) *

--- a/src/api/c/gaussian_kernel.cpp
+++ b/src/api/c/gaussian_kernel.cpp
@@ -10,6 +10,7 @@
 #include <arith.hpp>
 #include <backend.hpp>
 #include <common/err_common.hpp>
+#include <copy.hpp>
 #include <handle.hpp>
 #include <math.hpp>
 #include <range.hpp>
@@ -24,6 +25,7 @@ using af::dim4;
 using detail::arithOp;
 using detail::Array;
 using detail::createValueArray;
+using detail::getScalar;
 using detail::range;
 using detail::reduce_all;
 using detail::scalar;
@@ -77,7 +79,7 @@ Array<T> gaussianKernel(const int rows, const int cols, const double sigma_r,
 
     // Use this instead of (2 * pi * sig^2);
     // This ensures the window adds up to 1
-    T norm_factor = reduce_all<af_add_t, T, T>(tmp);
+    T norm_factor = getScalar<T>(reduce_all<af_add_t, T, T>(tmp));
 
     Array<T> norm = createValueArray(odims, norm_factor);
     Array<T> res  = arithOp<T, af_div_t>(tmp, norm, odims);

--- a/src/api/c/hist.cpp
+++ b/src/api/c/hist.cpp
@@ -12,6 +12,7 @@
 #include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/graphics_common.hpp>
+#include <copy.hpp>
 #include <handle.hpp>
 #include <hist_graphics.hpp>
 #include <reduce.hpp>
@@ -20,6 +21,7 @@
 using detail::Array;
 using detail::copy_histogram;
 using detail::forgeManager;
+using detail::getScalar;
 using detail::uchar;
 using detail::uint;
 using detail::ushort;
@@ -57,7 +59,8 @@ fg_chart setup_histogram(fg_window const window, const af_array in,
         float xMin, xMax, yMin, yMax, zMin, zMax;
         FG_CHECK(_.fg_get_chart_axes_limits(&xMin, &xMax, &yMin, &yMax, &zMin,
                                             &zMax, chart));
-        T freqMax = detail::reduce_all<af_max_t, T, T>(histogramInput);
+        T freqMax =
+            getScalar<T>(detail::reduce_all<af_max_t, T, T>(histogramInput));
 
         if (xMin == 0 && xMax == 0 && yMin == 0 && yMax == 0) {
             // No previous limits. Set without checking

--- a/src/api/c/histeq.cpp
+++ b/src/api/c/histeq.cpp
@@ -12,6 +12,7 @@
 #include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/moddims.hpp>
+#include <copy.hpp>
 #include <handle.hpp>
 #include <lookup.hpp>
 #include <reduce.hpp>
@@ -27,6 +28,7 @@ using common::modDims;
 using detail::arithOp;
 using detail::Array;
 using detail::createValueArray;
+using detail::getScalar;
 using detail::intl;
 using detail::lookup;
 using detail::reduce_all;
@@ -50,8 +52,8 @@ static af_array hist_equal(const af_array& in, const af_array& hist) {
 
     Array<float> cdf = scan<af_add_t, float, float>(fHist, 0);
 
-    float minCdf = reduce_all<af_min_t, float, float>(cdf);
-    float maxCdf = reduce_all<af_max_t, float, float>(cdf);
+    float minCdf = getScalar<float>(reduce_all<af_min_t, float, float>(cdf));
+    float maxCdf = getScalar<float>(reduce_all<af_max_t, float, float>(cdf));
     float factor = static_cast<float>(grayLevels - 1) / (maxCdf - minCdf);
 
     // constant array of min value from cdf

--- a/src/api/c/imgproc_common.hpp
+++ b/src/api/c/imgproc_common.hpp
@@ -12,6 +12,7 @@
 #include <arith.hpp>
 #include <backend.hpp>
 #include <common/cast.hpp>
+#include <copy.hpp>
 #include <logic.hpp>
 #include <reduce.hpp>
 #include <scan.hpp>
@@ -46,9 +47,10 @@ detail::Array<To> convRange(const detail::Array<Ti>& in,
                             const To newLow = To(0), const To newHigh = To(1)) {
     auto dims  = in.dims();
     auto input = common::cast<To, Ti>(in);
-    To high    = detail::reduce_all<af_max_t, To, To>(input);
-    To low     = detail::reduce_all<af_min_t, To, To>(input);
-    To range   = high - low;
+    To high =
+        detail::getScalar<To>(detail::reduce_all<af_max_t, To, To>(input));
+    To low = detail::getScalar<To>(detail::reduce_all<af_min_t, To, To>(input));
+    To range = high - low;
 
     if (std::abs(range) < 1.0e-6) {
         if (low == To(0) && newLow == To(0)) {

--- a/src/api/c/rank.cpp
+++ b/src/api/c/rank.cpp
@@ -11,6 +11,7 @@
 #include <common/ArrayInfo.hpp>
 #include <common/err_common.hpp>
 #include <complex.hpp>
+#include <copy.hpp>
 #include <handle.hpp>
 #include <logic.hpp>
 #include <qr.hpp>
@@ -25,6 +26,7 @@ using detail::cdouble;
 using detail::cfloat;
 using detail::createEmptyArray;
 using detail::createValueArray;
+using detail::getScalar;
 using detail::logicOp;
 using detail::reduce;
 using detail::reduce_all;
@@ -52,7 +54,7 @@ static inline uint rank(const af_array in, double tol) {
     Array<BT> val  = createValueArray<BT>(R.dims(), scalar<BT>(tol));
     Array<char> gt = logicOp<BT, af_gt_t>(R, val, val.dims());
     Array<char> at = reduce<af_or_t, char, char>(gt, 1);
-    return reduce_all<af_notzero_t, char, uint>(at);
+    return getScalar<uint>(reduce_all<af_notzero_t, char, uint>(at));
 }
 
 af_err af_rank(uint* out, const af_array in, const double tol) {

--- a/src/api/c/stdev.cpp
+++ b/src/api/c/stdev.cpp
@@ -10,6 +10,7 @@
 #include <arith.hpp>
 #include <backend.hpp>
 #include <common/cast.hpp>
+#include <copy.hpp>
 #include <handle.hpp>
 #include <math.hpp>
 #include <mean.hpp>
@@ -31,6 +32,7 @@ using detail::cdouble;
 using detail::cfloat;
 using detail::createValueArray;
 using detail::division;
+using detail::getScalar;
 using detail::intl;
 using detail::mean;
 using detail::reduce;
@@ -52,9 +54,9 @@ static outType stdev(const af_array& in, const af_var_bias bias) {
         detail::arithOp<outType, af_sub_t>(input, meanCnst, input.dims());
     Array<outType> diffSq =
         detail::arithOp<outType, af_mul_t>(diff, diff, diff.dims());
-    outType result =
-        division(reduce_all<af_add_t, outType, outType>(diffSq),
-                 (input.elements() - (bias == AF_VARIANCE_SAMPLE)));
+    outType result = division(
+        getScalar<outType>(reduce_all<af_add_t, outType, outType>(diffSq)),
+        (input.elements() - (bias == AF_VARIANCE_SAMPLE)));
     return sqrt(result);
 }
 

--- a/src/api/c/surface.cpp
+++ b/src/api/c/surface.cpp
@@ -15,6 +15,7 @@
 #include <common/err_common.hpp>
 #include <common/graphics_common.hpp>
 #include <common/moddims.hpp>
+#include <copy.hpp>
 #include <handle.hpp>
 #include <join.hpp>
 #include <reduce.hpp>
@@ -28,6 +29,7 @@ using detail::Array;
 using detail::copy_surface;
 using detail::createEmptyArray;
 using detail::forgeManager;
+using detail::getScalar;
 using detail::reduce_all;
 using detail::uchar;
 using detail::uint;
@@ -101,12 +103,12 @@ fg_chart setup_surface(fg_window window, const af_array xVals,
         T dmin[3], dmax[3];
         FG_CHECK(_.fg_get_chart_axes_limits(
             &cmin[0], &cmax[0], &cmin[1], &cmax[1], &cmin[2], &cmax[2], chart));
-        dmin[0] = reduce_all<af_min_t, T, T>(xIn);
-        dmax[0] = reduce_all<af_max_t, T, T>(xIn);
-        dmin[1] = reduce_all<af_min_t, T, T>(yIn);
-        dmax[1] = reduce_all<af_max_t, T, T>(yIn);
-        dmin[2] = reduce_all<af_min_t, T, T>(zIn);
-        dmax[2] = reduce_all<af_max_t, T, T>(zIn);
+        dmin[0] = getScalar<T>(reduce_all<af_min_t, T, T>(xIn));
+        dmax[0] = getScalar<T>(reduce_all<af_max_t, T, T>(xIn));
+        dmin[1] = getScalar<T>(reduce_all<af_min_t, T, T>(yIn));
+        dmax[1] = getScalar<T>(reduce_all<af_max_t, T, T>(yIn));
+        dmin[2] = getScalar<T>(reduce_all<af_min_t, T, T>(zIn));
+        dmax[2] = getScalar<T>(reduce_all<af_max_t, T, T>(zIn));
 
         if (cmin[0] == 0 && cmax[0] == 0 && cmin[1] == 0 && cmax[1] == 0 &&
             cmin[2] == 0 && cmax[2] == 0) {

--- a/src/api/c/var.cpp
+++ b/src/api/c/var.cpp
@@ -12,6 +12,7 @@
 #include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/half.hpp>
+#include <copy.hpp>
 #include <handle.hpp>
 #include <math.hpp>
 #include <mean.hpp>
@@ -34,6 +35,7 @@ using detail::cfloat;
 using detail::createEmptyArray;
 using detail::createValueArray;
 using detail::division;
+using detail::getScalar;
 using detail::imag;
 using detail::intl;
 using detail::mean;
@@ -64,9 +66,9 @@ static outType varAll(const af_array& in, const af_var_bias bias) {
 
     Array<outType> diffSq = arithOp<outType, af_mul_t>(diff, diff, diff.dims());
 
-    outType result =
-        division(reduce_all<af_add_t, outType, outType>(diffSq),
-                 (input.elements() - (bias == AF_VARIANCE_SAMPLE)));
+    outType result = division(
+        getScalar<outType>(reduce_all<af_add_t, outType, outType>(diffSq)),
+        (input.elements() - (bias == AF_VARIANCE_SAMPLE)));
 
     return result;
 }
@@ -78,7 +80,8 @@ static outType varAll(const af_array& in, const af_array weights) {
     Array<outType> input = cast<outType>(getArray<inType>(in));
     Array<outType> wts   = cast<outType>(getArray<bType>(weights));
 
-    bType wtsSum = reduce_all<af_add_t, bType, bType>(getArray<bType>(weights));
+    bType wtsSum = getScalar<bType>(
+        reduce_all<af_add_t, bType, bType>(getArray<bType>(weights)));
     auto wtdMean = mean<outType, bType>(input, getArray<bType>(weights));
 
     Array<outType> meanArr = createValueArray<outType>(input.dims(), wtdMean);
@@ -89,8 +92,9 @@ static outType varAll(const af_array& in, const af_array weights) {
     Array<outType> accDiffSq =
         arithOp<outType, af_mul_t>(diffSq, wts, diffSq.dims());
 
-    outType result =
-        division(reduce_all<af_add_t, outType, outType>(accDiffSq), wtsSum);
+    outType result = division(
+        getScalar<outType>(reduce_all<af_add_t, outType, outType>(accDiffSq)),
+        wtsSum);
 
     return result;
 }

--- a/src/api/cpp/reduce.cpp
+++ b/src/api/cpp/reduce.cpp
@@ -212,6 +212,14 @@ void max(array &val, array &idx, const array &in, const int dim) {
         return out;                                       \
     }
 
+#define INSTANTIATE_ARRAY(fnC, fnCPP)                   \
+    template<>                                          \
+    AFAPI af::array fnCPP(const array &in) {            \
+        af_array out = 0;                               \
+        AF_THROW(af_##fnC##_all_array(&out, in.get())); \
+        return array(out);                              \
+    }
+
 INSTANTIATE(sum, sum)
 INSTANTIATE(product, product)
 INSTANTIATE(min, min)
@@ -223,8 +231,17 @@ INSTANTIATE(count, count)
 INSTANTIATE_REAL(all_true, allTrue, bool);
 INSTANTIATE_REAL(any_true, anyTrue, bool);
 
+INSTANTIATE_ARRAY(sum, sum)
+INSTANTIATE_ARRAY(product, product)
+INSTANTIATE_ARRAY(min, min)
+INSTANTIATE_ARRAY(max, max)
+INSTANTIATE_ARRAY(all_true, allTrue)
+INSTANTIATE_ARRAY(any_true, anyTrue)
+INSTANTIATE_ARRAY(count, count)
+
 #undef INSTANTIATE_REAL
 #undef INSTANTIATE_CPLX
+#undef INSTANTIATE_ARRAY
 
 #define INSTANTIATE_REAL(fnC, fnCPP, T)                           \
     template<>                                                    \
@@ -243,12 +260,23 @@ INSTANTIATE_REAL(any_true, anyTrue, bool);
         return out;                                               \
     }
 
+#define INSTANTIATE_ARRAY(fnC, fnCPP)                             \
+    template<>                                                    \
+    AFAPI af::array fnCPP(const array &in, const double nanval) { \
+        af_array out = 0;                                         \
+        AF_THROW(af_##fnC##_all_array(&out, in.get(), nanval));   \
+        return array(out);                                        \
+    }
+INSTANTIATE_ARRAY(sum_nan, sum)
+INSTANTIATE_ARRAY(product_nan, product)
+
 INSTANTIATE(sum_nan, sum)
 INSTANTIATE(product_nan, product)
 
 #undef INSTANTIATE_REAL
 #undef INSTANTIATE_CPLX
 #undef INSTANTIATE
+#undef INSTANTIATE_ARRAY
 
 #define INSTANTIATE_COMPAT(fnCPP, fnCompat, T) \
     template<>                                 \

--- a/src/api/unified/algorithm.cpp
+++ b/src/api/unified/algorithm.cpp
@@ -124,6 +124,33 @@ ALGO_HAPI_DEF(af_imax_all)
 
 #undef ALGO_HAPI_DEF
 
+#define ALGO_HAPI_DEF(af_func)                         \
+    af_err af_func(af_array *out, const af_array in) { \
+        CHECK_ARRAYS(in);                              \
+        CALL(af_func, out, in);                        \
+    }
+
+ALGO_HAPI_DEF(af_sum_all_array)
+ALGO_HAPI_DEF(af_product_all_array)
+ALGO_HAPI_DEF(af_min_all_array)
+ALGO_HAPI_DEF(af_max_all_array)
+ALGO_HAPI_DEF(af_count_all_array)
+ALGO_HAPI_DEF(af_any_true_all_array)
+ALGO_HAPI_DEF(af_all_true_all_array)
+
+#undef ALGO_HAPI_DEF
+
+#define ALGO_HAPI_DEF(af_func)                                              \
+    af_err af_func(af_array *out, const af_array in, const double nanval) { \
+        CHECK_ARRAYS(in);                                                   \
+        CALL(af_func, out, in, nanval);                                     \
+    }
+
+ALGO_HAPI_DEF(af_sum_nan_all_array)
+ALGO_HAPI_DEF(af_product_nan_all_array)
+
+#undef ALGO_HAPI_DEF
+
 af_err af_where(af_array *idx, const af_array in) {
     CHECK_ARRAYS(in);
     CALL(af_where, idx, in);

--- a/src/api/unified/symbol_manager.hpp
+++ b/src/api/unified/symbol_manager.hpp
@@ -144,6 +144,11 @@ bool checkArrays(af_backend activeBackend, T a, Args... arg) {
     if (unified::getActiveHandle()) {                                            \
         thread_local af_func func = (af_func)common::getFunctionPointer(         \
             unified::getActiveHandle(), __func__);                               \
+        if (!func) {                                                             \
+            AF_RETURN_ERROR(                                                     \
+                "requested symbol name could not be found in loaded library.",   \
+                AF_ERR_LOAD_LIB);                                                \
+        }                                                                        \
         if (index_ != unified::getActiveBackend()) {                             \
             index_ = unified::getActiveBackend();                                \
             func   = (af_func)common::getFunctionPointer(                        \

--- a/src/backend/cpu/reduce.cpp
+++ b/src/backend/cpu/reduce.cpp
@@ -115,9 +115,6 @@ template<af_op_t op, typename Ti, typename To>
 Array<To> reduce_all(const Array<Ti> &in, bool change_nan, double nanval) {
     in.eval();
 
-    Transform<Ti, compute_t<To>, op> transform;
-    Binary<compute_t<To>, op> reduce;
-
     Array<To> out = createEmptyArray<To>(1);
     static const reduce_all_func<op, Ti, To> reduce_all_kernel =
         kernel::reduce_all<op, Ti, To>();

--- a/src/backend/cpu/reduce.hpp
+++ b/src/backend/cpu/reduce.hpp
@@ -21,5 +21,6 @@ void reduce_by_key(Array<Tk> &keys_out, Array<To> &vals_out,
                    bool change_nan = false, double nanval = 0);
 
 template<af_op_t op, typename Ti, typename To>
-To reduce_all(const Array<Ti> &in, bool change_nan = false, double nanval = 0);
+Array<To> reduce_all(const Array<Ti> &in, bool change_nan = false,
+                     double nanval = 0);
 }  // namespace cpu

--- a/src/backend/cpu/sparse.cpp
+++ b/src/backend/cpu/sparse.cpp
@@ -40,7 +40,7 @@ using common::SparseArray;
 template<typename T, af_storage stype>
 SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in) {
     if (stype == AF_STORAGE_CSR) {
-        uint nNZ = reduce_all<af_notzero_t, T, uint>(in);
+        uint nNZ = getScalar<uint>(reduce_all<af_notzero_t, T, uint>(in));
 
         auto sparse = createEmptySparseArray<T>(in.dims(), nNZ, stype);
         sparse.eval();

--- a/src/backend/cuda/reduce.hpp
+++ b/src/backend/cuda/reduce.hpp
@@ -21,5 +21,6 @@ void reduce_by_key(Array<Tk> &keys_out, Array<To> &vals_out,
                    bool change_nan = false, double nanval = 0);
 
 template<af_op_t op, typename Ti, typename To>
-To reduce_all(const Array<Ti> &in, bool change_nan = false, double nanval = 0);
+Array<To> reduce_all(const Array<Ti> &in, bool change_nan = false,
+                     double nanval = 0);
 }  // namespace cuda

--- a/src/backend/cuda/reduce_impl.hpp
+++ b/src/backend/cuda/reduce_impl.hpp
@@ -353,9 +353,12 @@ void reduce_by_key(Array<Tk> &keys_out, Array<To> &vals_out,
 }
 
 template<af_op_t op, typename Ti, typename To>
-To reduce_all(const Array<Ti> &in, bool change_nan, double nanval) {
-    return kernel::reduce_all<Ti, To, op>(in, change_nan, nanval);
+Array<To> reduce_all(const Array<Ti> &in, bool change_nan, double nanval) {
+    Array<To> out = createEmptyArray<To>(1);
+    kernel::reduce_all<Ti, To, op>(out, in, change_nan, nanval);
+    return out;
 }
+
 }  // namespace cuda
 
 #define INSTANTIATE(Op, Ti, To)                                                \
@@ -367,5 +370,5 @@ To reduce_all(const Array<Ti> &in, bool change_nan, double nanval) {
     template void reduce_by_key<Op, Ti, uint, To>(                             \
         Array<uint> & keys_out, Array<To> & vals_out, const Array<uint> &keys, \
         const Array<Ti> &vals, const int dim, bool change_nan, double nanval); \
-    template To reduce_all<Op, Ti, To>(const Array<Ti> &in, bool change_nan,   \
-                                       double nanval);
+    template Array<To> reduce_all<Op, Ti, To>(const Array<Ti> &in,             \
+                                              bool change_nan, double nanval);

--- a/src/backend/opencl/kernel/reduce_all.cl
+++ b/src/backend/opencl/kernel/reduce_all.cl
@@ -1,0 +1,160 @@
+/*******************************************************
+ * Copyright (c) 2021, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+// careful w/__threadfence substitution!
+// http://www.whatmannerofburgeristhis.com/blog/opencl-vs-cuda-gpu-memory-fences/
+
+kernel void reduce_all_kernel(global To *oData, KParam oInfo,
+                              global int* retirementCount, global To *tmp, KParam tmpInfo,
+                              const global Ti *iData, KParam iInfo,
+                              uint groups_x, uint groups_y, uint repeat,
+                              int change_nan, To nanval) {
+
+    const uint tidx = get_local_id(0);
+    const uint tidy = get_local_id(1);
+    const uint tid  = tidy * DIMX + tidx;
+
+    const uint zid       = get_group_id(0) / groups_x;
+    const uint groupId_x = get_group_id(0) - (groups_x)*zid;
+    const uint xid       = groupId_x * get_local_size(0) * repeat + tidx;
+
+    const uint wid       = get_group_id(1) / groups_y;
+    const uint groupId_y = get_group_id(1) - (groups_y)*wid;
+    const uint yid       = groupId_y * get_local_size(1) + tidy;
+
+    local To s_val[THREADS_PER_GROUP];
+
+    iData += wid * iInfo.strides[3] + zid * iInfo.strides[2] +
+             yid * iInfo.strides[1] + iInfo.offset;
+
+    bool cond =
+        (yid < iInfo.dims[1]) && (zid < iInfo.dims[2]) && (wid < iInfo.dims[3]);
+
+
+    int last   = (xid + repeat * DIMX);
+    int lim    = last > iInfo.dims[0] ? iInfo.dims[0] : last;
+
+    To out_val = init;
+    for (int id = xid; cond && id < lim; id += DIMX) {
+        To in_val = transform(iData[id]);
+        if (change_nan) in_val = !IS_NAN(in_val) ? in_val : nanval;
+        out_val = binOp(in_val, out_val);
+    }
+
+    s_val[tid] = out_val;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (THREADS_PER_GROUP == 256) {
+        if (tid < 128) s_val[tid] = binOp(s_val[tid], s_val[tid + 128]);
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (THREADS_PER_GROUP >= 128) {
+        if (tid < 64) s_val[tid] = binOp(s_val[tid], s_val[tid + 64]);
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (THREADS_PER_GROUP >= 64) {
+        if (tid < 32) s_val[tid] = binOp(s_val[tid], s_val[tid + 32]);
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (tid < 16) s_val[tid] = binOp(s_val[tid], s_val[tid + 16]);
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (tid < 8) s_val[tid] = binOp(s_val[tid], s_val[tid + 8]);
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (tid < 4) s_val[tid] = binOp(s_val[tid], s_val[tid + 4]);
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (tid < 2) s_val[tid] = binOp(s_val[tid], s_val[tid + 2]);
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (tid < 1) s_val[tid] = binOp(s_val[tid], s_val[tid + 1]);
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+
+    const unsigned total_blocks = (get_num_groups(0) * get_num_groups(1) * get_num_groups(2));
+    const int uubidx = (get_num_groups(0) * get_num_groups(1)) * get_group_id(2)
+                       + (get_num_groups(0) * get_group_id(1)) + get_group_id(0);
+    if (cond && tid == 0) {
+        if(total_blocks != 1) {
+            tmp[uubidx] = s_val[0];
+        } else {
+            oData[0] = s_val[0];
+        }
+    }
+
+    // Last block to perform final reduction
+    if (total_blocks > 1) {
+        local bool amLast;
+
+        mem_fence(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE);
+
+        // Thread 0 takes a ticket
+        if (tid == 0) {
+            unsigned int ticket = atomic_inc(retirementCount);
+            // If the ticket ID == number of blocks, we are the last block
+            amLast = (ticket == (total_blocks - 1));
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        if (amLast) {
+            int i = tid;
+            To fout_val = init;
+
+            while (i < total_blocks) {
+                To in_val = tmp[i];
+                fout_val = binOp(in_val, fout_val);
+                i += THREADS_PER_GROUP;
+            }
+
+            s_val[tid] = fout_val;
+            barrier(CLK_LOCAL_MEM_FENCE);
+
+            // reduce final block
+            if (THREADS_PER_GROUP == 256) {
+                if (tid < 128) s_val[tid] = binOp(s_val[tid], s_val[tid + 128]);
+                barrier(CLK_LOCAL_MEM_FENCE);
+            }
+
+            if (THREADS_PER_GROUP >= 128) {
+                if (tid < 64) s_val[tid] = binOp(s_val[tid], s_val[tid + 64]);
+                barrier(CLK_LOCAL_MEM_FENCE);
+            }
+
+            if (THREADS_PER_GROUP >= 64) {
+                if (tid < 32) s_val[tid] = binOp(s_val[tid], s_val[tid + 32]);
+                barrier(CLK_LOCAL_MEM_FENCE);
+            }
+
+            if (tid < 16) s_val[tid] = binOp(s_val[tid], s_val[tid + 16]);
+            barrier(CLK_LOCAL_MEM_FENCE);
+
+            if (tid < 8) s_val[tid] = binOp(s_val[tid], s_val[tid + 8]);
+            barrier(CLK_LOCAL_MEM_FENCE);
+
+            if (tid < 4) s_val[tid] = binOp(s_val[tid], s_val[tid + 4]);
+            barrier(CLK_LOCAL_MEM_FENCE);
+
+            if (tid < 2) s_val[tid] = binOp(s_val[tid], s_val[tid + 2]);
+            barrier(CLK_LOCAL_MEM_FENCE);
+
+            if (tid < 1) s_val[tid] = binOp(s_val[tid], s_val[tid + 1]);
+            barrier(CLK_LOCAL_MEM_FENCE);
+
+            if (tid == 0) {
+                oData[0] = s_val[0];
+
+                // reset retirement count so that next run succeeds
+                retirementCount[0] = 0;
+            }
+        }
+    }
+}

--- a/src/backend/opencl/kernel/reduce_all.cl
+++ b/src/backend/opencl/kernel/reduce_all.cl
@@ -28,6 +28,7 @@ kernel void reduce_all_kernel(global To *oData, KParam oInfo,
     const uint yid       = groupId_y * get_local_size(1) + tidy;
 
     local To s_val[THREADS_PER_GROUP];
+    local bool amLast;
 
     iData += wid * iInfo.strides[3] + zid * iInfo.strides[2] +
              yid * iInfo.strides[1] + iInfo.offset;
@@ -93,7 +94,6 @@ kernel void reduce_all_kernel(global To *oData, KParam oInfo,
 
     // Last block to perform final reduction
     if (total_blocks > 1) {
-        local bool amLast;
 
         mem_fence(CLK_LOCAL_MEM_FENCE | CLK_GLOBAL_MEM_FENCE);
 

--- a/src/backend/opencl/reduce.hpp
+++ b/src/backend/opencl/reduce.hpp
@@ -22,5 +22,6 @@ void reduce_by_key(Array<Tk> &keys_out, Array<To> &vals_out,
                    bool change_nan = false, double nanval = 0);
 
 template<af_op_t op, typename Ti, typename To>
-To reduce_all(const Array<Ti> &in, bool change_nan = false, double nanval = 0);
+Array<To> reduce_all(const Array<Ti> &in, bool change_nan = false,
+                     double nanval = 0);
 }  // namespace opencl

--- a/src/backend/opencl/reduce_impl.hpp
+++ b/src/backend/opencl/reduce_impl.hpp
@@ -37,9 +37,12 @@ void reduce_by_key(Array<Tk> &keys_out, Array<To> &vals_out,
 }
 
 template<af_op_t op, typename Ti, typename To>
-To reduce_all(const Array<Ti> &in, bool change_nan, double nanval) {
-    return kernel::reduceAll<Ti, To, op>(in, change_nan, nanval);
+Array<To> reduce_all(const Array<Ti> &in, bool change_nan, double nanval) {
+    Array<To> out = createEmptyArray<To>(1);
+    kernel::reduceAll<Ti, To, op>(out, in, change_nan, nanval);
+    return out;
 }
+
 }  // namespace opencl
 
 #define INSTANTIATE(Op, Ti, To)                                                \
@@ -51,5 +54,5 @@ To reduce_all(const Array<Ti> &in, bool change_nan, double nanval) {
     template void reduce_by_key<Op, Ti, uint, To>(                             \
         Array<uint> & keys_out, Array<To> & vals_out, const Array<uint> &keys, \
         const Array<Ti> &vals, const int dim, bool change_nan, double nanval); \
-    template To reduce_all<Op, Ti, To>(const Array<Ti> &in, bool change_nan,   \
-                                       double nanval);
+    template Array<To> reduce_all<Op, Ti, To>(const Array<Ti> &in,             \
+                                              bool change_nan, double nanval);

--- a/src/backend/opencl/sparse.cpp
+++ b/src/backend/opencl/sparse.cpp
@@ -61,7 +61,7 @@ template<typename T, af_storage stype>
 SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in_) {
     in_.eval();
 
-    uint nNZ = reduce_all<af_notzero_t, T, uint>(in_);
+    uint nNZ = getScalar<uint>(reduce_all<af_notzero_t, T, uint>(in_));
 
     SparseArray<T> sparse_ = createEmptySparseArray<T>(in_.dims(), nNZ, stype);
     sparse_.eval();

--- a/src/backend/opencl/svd.cpp
+++ b/src/backend/opencl/svd.cpp
@@ -87,7 +87,7 @@ void svd(Array<T> &arrU, Array<Tr> &arrS, Array<T> &arrVT, Array<T> &arrA,
     static const double smlnum = std::sqrt(cpu_lapack_lamch('S')) / eps;
     static const double bignum = 1. / smlnum;
 
-    Tr anrm = abs(reduce_all<af_max_t, T, T>(arrA));
+    Tr anrm = abs(getScalar<T>(reduce_all<af_max_t, T, T>(arrA)));
 
     T scale                = scalar<T>(1);
     static const int ione  = 1;

--- a/test/mean.cpp
+++ b/test/mean.cpp
@@ -362,8 +362,9 @@ TEST(MeanAll, SubArray) {
     array in  = randu(inDims);
     array sub = in(0, span, span, span);
 
-    size_t nElems = sub.elements();
-    ASSERT_FLOAT_EQ(mean<float>(sub), sum<float>(sub) / nElems);
+    size_t nElems   = sub.elements();
+    float max_error = std::numeric_limits<float>::epsilon() * nElems;
+    ASSERT_NEAR(mean<float>(sub), sum<float>(sub) / nElems, max_error);
 }
 
 TEST(MeanHalf, dim0) {


### PR DESCRIPTION
This PR adds af::array as a return type to the reduction functions. ( reduce<af::array>(arr); ) 

Description
Previously, the reduce all functions would return a scalar value. The return of an af::array type was missing. Furthermore, the return of a scalar causes a mandatory synchronization at the function call.

* Is this a new feature or a bug fix?
New feature
* More detail if necessary to describe all commits in pull request.
Partial commits contain separate API changes, kernels for each backend, and tests as described in each commit message. Will be squashed before merging.
* Why these changes are necessary.
To improve performance by avoiding unnecessary synchronization at each reduce<>() call.
* Potential impact on specific hardware, software or backends.

* New functions and their functionality.
Adds af_sum_array, af_sum_nan_array, af_product_array, af_product_nan_array, af_min_array, af_max_array, af_count_array, af_all_true_array, af_any_true_array,  and the corresponding C++ versions such as af::max<af::array>(arr);
* Can this PR be backported to older versions?
 No, breaks API


Changes to Users
----------------
Existing code should be compatible. Users can now specify <af::array> as a template argument for reduction functions.

Checklist
---------
<!-- Check if done or not applicable -->
- [ ] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
