### PR TITLE
Add CUDA 11.5 to max compute and compute capability arrays

### DIFF
--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -95,6 +95,7 @@ static const int jetsonComputeCapabilities[] = {
 
 // clang-format off
 static const cuNVRTCcompute Toolkit2MaxCompute[] = {
+    {11050, 8, 6, 0},
     {11040, 8, 6, 0},
     {11030, 8, 6, 0},
     {11020, 8, 6, 0},
@@ -127,6 +128,7 @@ struct ComputeCapabilityToStreamingProcessors {
 // clang-format off
 static const ToolkitDriverVersions
     CudaToDriverVersion[] = {
+        {11050, 495.29f, 496.13f},
         {11040, 470.42f, 471.11f},
         {11030, 465.19f, 465.89f},
         {11020, 460.27f, 460.82f},

--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -95,6 +95,7 @@ static const int jetsonComputeCapabilities[] = {
 
 // clang-format off
 static const cuNVRTCcompute Toolkit2MaxCompute[] = {
+    {11060, 8, 6, 0},
     {11050, 8, 6, 0},
     {11040, 8, 6, 0},
     {11030, 8, 6, 0},
@@ -128,6 +129,7 @@ struct ComputeCapabilityToStreamingProcessors {
 // clang-format off
 static const ToolkitDriverVersions
     CudaToDriverVersion[] = {
+        {11060, 510.39f, 511.23f},
         {11050, 495.29f, 496.13f},
         {11040, 470.42f, 471.11f},
         {11030, 465.19f, 465.89f},


### PR DESCRIPTION
Add CUDA 11.5 to the MaxCompute and compute capability array in device_manager

Description
-----------
N/A

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
