### PR TITLE
fix multiprocess filename collisions in imageio tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,10 +101,6 @@ add_library(arrayfire_test OBJECT
   testHelpers.hpp
   arrayfire_test.cpp)
 
-set_target_properties(arrayfire_test
-PROPERTIES
-    CXX_STANDARD 11)
-
 target_include_directories(arrayfire_test
   PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -101,6 +101,10 @@ add_library(arrayfire_test OBJECT
   testHelpers.hpp
   arrayfire_test.cpp)
 
+set_target_properties(arrayfire_test
+PROPERTIES
+    CXX_STANDARD 11)
+
 target_include_directories(arrayfire_test
   PRIVATE
     ${CMAKE_CURRENT_LIST_DIR}

--- a/test/arrayfire_test.cpp
+++ b/test/arrayfire_test.cpp
@@ -98,6 +98,22 @@ std::string readNextNonEmptyLine(std::ifstream &file) {
     return result;
 }
 
+std::string getBackendName() {
+    af::Backend backend = af::getActiveBackend();
+    if (backend == AF_BACKEND_OPENCL)
+        return std::string("opencl");
+    else if (backend == AF_BACKEND_CUDA)
+        return std::string("cuda");
+
+    return std::string("cpu");
+}
+
+std::string getTestName() {
+    std::string testname =
+        ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    return testname;
+}
+
 namespace half_float {
 std::ostream &operator<<(std::ostream &os, half_float::half val) {
     os << (float)val;

--- a/test/arrayfire_test.cpp
+++ b/test/arrayfire_test.cpp
@@ -29,7 +29,6 @@
 #include <iterator>
 #include <limits>
 #include <numeric>
-#include <random>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -1690,25 +1689,6 @@ INSTANTIATE(std::complex<float>);
 INSTANTIATE(std::complex<double>);
 INSTANTIATE(af_half);
 #undef INSTANTIATE
-
-unsigned int random_char() {
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<> dis(0, 255);
-    return dis(gen);
-}
-
-std::string generate_hex(const unsigned int len) {
-    std::stringstream ss;
-    for (auto i = 0; i < len; i++) {
-        const auto rc = random_char();
-        std::stringstream hexstream;
-        hexstream << std::hex << rc;
-        auto hex = hexstream.str();
-        ss << (hex.length() < 2 ? '0' + hex : hex);
-    }
-    return ss.str();
-}
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/arrayfire_test.cpp
+++ b/test/arrayfire_test.cpp
@@ -29,6 +29,7 @@
 #include <iterator>
 #include <limits>
 #include <numeric>
+#include <random>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -1689,6 +1690,25 @@ INSTANTIATE(std::complex<float>);
 INSTANTIATE(std::complex<double>);
 INSTANTIATE(af_half);
 #undef INSTANTIATE
+
+unsigned int random_char() {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dis(0, 255);
+    return dis(gen);
+}
+
+std::string generate_hex(const unsigned int len) {
+    std::stringstream ss;
+    for (auto i = 0; i < len; i++) {
+        const auto rc = random_char();
+        std::stringstream hexstream;
+        hexstream << std::hex << rc;
+        auto hex = hexstream.str();
+        ss << (hex.length() < 2 ? '0' + hex : hex);
+    }
+    return ss.str();
+}
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/imageio.cpp
+++ b/test/imageio.cpp
@@ -32,16 +32,6 @@ class ImageIO : public ::testing::Test {
 
 typedef ::testing::Types<float> TestTypes;
 
-std::string getBackendString() {
-    af::Backend backend = af::getActiveBackend();
-    if(backend == AF_BACKEND_OPENCL)
-        return std::string("opencl");
-    else if(backend == AF_BACKEND_CUDA)
-        return std::string("cuda");
-
-    return std::string("cpu");
-}
-
 // register the type list
 TYPED_TEST_CASE(ImageIO, TestTypes);
 
@@ -170,9 +160,7 @@ TEST(ImageIO, SavePNGCPP) {
     input(9, 0, 2)          = 255;
     input(9, 9, span)       = 255;
 
-    std::string testname =
-        ::testing::UnitTest::GetInstance()->current_test_info()->name();
-    testname = testname + "_" + getBackendString();
+    std::string testname  = getTestName() + "_" + getBackendName();
     std::string imagename = "SaveCPP_" + testname + ".png";
 
     saveImage(imagename.c_str(), input);
@@ -192,9 +180,7 @@ TEST(ImageIO, SaveBMPCPP) {
     input(9, 0, 2)          = 255;
     input(9, 9, span)       = 255;
 
-    std::string testname =
-        ::testing::UnitTest::GetInstance()->current_test_info()->name();
-    testname = testname + "_" + getBackendString();
+    std::string testname  = getTestName() + "_" + getBackendName();
     std::string imagename = "SaveCPP_" + testname + ".bmp";
 
     saveImage(imagename.c_str(), input);
@@ -305,9 +291,7 @@ TEST(ImageIO, SaveImage16CPP) {
     array input     = randu(dims, u16);
     array input_255 = (input / 257).as(u16);
 
-    std::string testname =
-        ::testing::UnitTest::GetInstance()->current_test_info()->name();
-    testname = testname + "_" + getBackendString();
+    std::string testname  = getTestName() + "_" + getBackendName();
     std::string imagename = "saveImage16CPP_" + testname + ".png";
 
     saveImage(imagename.c_str(), input);
@@ -382,9 +366,7 @@ void saveLoadImageNativeCPPTest(dim4 dims) {
 
     array input = randu(dims, (af_dtype)dtype_traits<T>::af_type);
 
-    std::string testname =
-        ::testing::UnitTest::GetInstance()->current_test_info()->name();
-    std::string imagename = testname + "_" + getBackendString() + ".png";
+    std::string imagename = getTestName() + "_" + getBackendName() + ".png";
 
     saveImageNative(imagename.c_str(), input);
 

--- a/test/imageio.cpp
+++ b/test/imageio.cpp
@@ -32,6 +32,16 @@ class ImageIO : public ::testing::Test {
 
 typedef ::testing::Types<float> TestTypes;
 
+std::string getBackendString() {
+    af::Backend backend = af::getActiveBackend();
+    if(backend == AF_BACKEND_OPENCL)
+        return std::string("opencl");
+    else if(backend == AF_BACKEND_CUDA)
+        return std::string("cuda");
+
+    return std::string("cpu");
+}
+
 // register the type list
 TYPED_TEST_CASE(ImageIO, TestTypes);
 
@@ -160,8 +170,10 @@ TEST(ImageIO, SavePNGCPP) {
     input(9, 0, 2)          = 255;
     input(9, 9, span)       = 255;
 
-    std::string uuid_str  = generate_hex(4);
-    std::string imagename = "SaveCPP-" + uuid_str + ".png";
+    std::string testname =
+        ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    testname = testname + "_" + getBackendString();
+    std::string imagename = "SaveCPP_" + testname + ".png";
 
     saveImage(imagename.c_str(), input);
     array out = loadImage(imagename.c_str(), true);
@@ -180,8 +192,10 @@ TEST(ImageIO, SaveBMPCPP) {
     input(9, 0, 2)          = 255;
     input(9, 9, span)       = 255;
 
-    std::string uuid_str  = generate_hex(4);
-    std::string imagename = "SaveCPP-" + uuid_str + ".bmp";
+    std::string testname =
+        ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    testname = testname + "_" + getBackendString();
+    std::string imagename = "SaveCPP_" + testname + ".bmp";
 
     saveImage(imagename.c_str(), input);
     array out = loadImage(imagename.c_str(), true);
@@ -291,8 +305,10 @@ TEST(ImageIO, SaveImage16CPP) {
     array input     = randu(dims, u16);
     array input_255 = (input / 257).as(u16);
 
-    std::string uuid_str  = generate_hex(4);
-    std::string imagename = "saveImage16CPP-" + uuid_str + ".png";
+    std::string testname =
+        ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    testname = testname + "_" + getBackendString();
+    std::string imagename = "saveImage16CPP_" + testname + ".png";
 
     saveImage(imagename.c_str(), input);
 
@@ -368,9 +384,7 @@ void saveLoadImageNativeCPPTest(dim4 dims) {
 
     std::string testname =
         ::testing::UnitTest::GetInstance()->current_test_info()->name();
-
-    std::string uuid_str  = generate_hex(4);
-    std::string imagename = testname + "-" + uuid_str + ".png";
+    std::string imagename = testname + "_" + getBackendString() + ".png";
 
     saveImageNative(imagename.c_str(), input);
 

--- a/test/imageio.cpp
+++ b/test/imageio.cpp
@@ -8,6 +8,9 @@
  ********************************************************/
 
 #include <arrayfire.h>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <gtest/gtest.h>
 #include <testHelpers.hpp>
 #include <af/dim4.hpp>
@@ -160,8 +163,13 @@ TEST(ImageIO, SavePNGCPP) {
     input(9, 0, 2)          = 255;
     input(9, 9, span)       = 255;
 
-    saveImage("SaveCPP.png", input);
-    array out = loadImage("SaveCPP.png", true);
+    boost::uuids::uuid uuid = boost::uuids::random_generator()();
+    std::string uuid_str    = to_string(uuid);
+
+    std::string imagename = "SaveCPP-" + uuid_str + ".png";
+
+    saveImage(imagename.c_str(), input);
+    array out = loadImage(imagename.c_str(), true);
 
     ASSERT_FALSE(anyTrue<bool>(out - input));
 }
@@ -177,8 +185,13 @@ TEST(ImageIO, SaveBMPCPP) {
     input(9, 0, 2)          = 255;
     input(9, 9, span)       = 255;
 
-    saveImage("SaveCPP.bmp", input);
-    array out = loadImage("SaveCPP.bmp", true);
+    boost::uuids::uuid uuid = boost::uuids::random_generator()();
+    std::string uuid_str    = to_string(uuid);
+
+    std::string imagename = "SaveCPP-" + uuid_str + ".bmp";
+
+    saveImage(imagename.c_str(), input);
+    array out = loadImage(imagename.c_str(), true);
 
     ASSERT_FALSE(anyTrue<bool>(out - input));
 }
@@ -285,9 +298,14 @@ TEST(ImageIO, SaveImage16CPP) {
     array input     = randu(dims, u16);
     array input_255 = (input / 257).as(u16);
 
-    saveImage("saveImage16CPP.png", input);
+    boost::uuids::uuid uuid = boost::uuids::random_generator()();
+    std::string uuid_str    = to_string(uuid);
 
-    array img = loadImage("saveImage16CPP.png", true);
+    std::string imagename = "saveImage16CPP-" + uuid_str + ".png";
+
+    saveImage(imagename.c_str(), input);
+
+    array img = loadImage(imagename.c_str(), true);
     ASSERT_EQ(img.type(), f32);  // loadImage should always return float
 
     ASSERT_FALSE(anyTrue<bool>(abs(img - input_255)));
@@ -357,9 +375,17 @@ void saveLoadImageNativeCPPTest(dim4 dims) {
 
     array input = randu(dims, (af_dtype)dtype_traits<T>::af_type);
 
-    saveImageNative("saveImageNative.png", input);
+    std::string testname =
+        ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
-    array loaded = loadImageNative("saveImageNative.png");
+    boost::uuids::uuid uuid = boost::uuids::random_generator()();
+    std::string uuid_str    = to_string(uuid);
+
+    std::string imagename = testname + "-" + uuid_str + ".png";
+
+    saveImageNative(imagename.c_str(), input);
+
+    array loaded = loadImageNative(imagename.c_str());
     ASSERT_EQ(loaded.type(), input.type());
 
     ASSERT_FALSE(anyTrue<bool>(input - loaded));

--- a/test/imageio.cpp
+++ b/test/imageio.cpp
@@ -8,9 +8,6 @@
  ********************************************************/
 
 #include <arrayfire.h>
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
 #include <gtest/gtest.h>
 #include <testHelpers.hpp>
 #include <af/dim4.hpp>
@@ -163,9 +160,7 @@ TEST(ImageIO, SavePNGCPP) {
     input(9, 0, 2)          = 255;
     input(9, 9, span)       = 255;
 
-    boost::uuids::uuid uuid = boost::uuids::random_generator()();
-    std::string uuid_str    = to_string(uuid);
-
+    std::string uuid_str  = generate_hex(4);
     std::string imagename = "SaveCPP-" + uuid_str + ".png";
 
     saveImage(imagename.c_str(), input);
@@ -185,9 +180,7 @@ TEST(ImageIO, SaveBMPCPP) {
     input(9, 0, 2)          = 255;
     input(9, 9, span)       = 255;
 
-    boost::uuids::uuid uuid = boost::uuids::random_generator()();
-    std::string uuid_str    = to_string(uuid);
-
+    std::string uuid_str  = generate_hex(4);
     std::string imagename = "SaveCPP-" + uuid_str + ".bmp";
 
     saveImage(imagename.c_str(), input);
@@ -298,9 +291,7 @@ TEST(ImageIO, SaveImage16CPP) {
     array input     = randu(dims, u16);
     array input_255 = (input / 257).as(u16);
 
-    boost::uuids::uuid uuid = boost::uuids::random_generator()();
-    std::string uuid_str    = to_string(uuid);
-
+    std::string uuid_str  = generate_hex(4);
     std::string imagename = "saveImage16CPP-" + uuid_str + ".png";
 
     saveImage(imagename.c_str(), input);
@@ -378,9 +369,7 @@ void saveLoadImageNativeCPPTest(dim4 dims) {
     std::string testname =
         ::testing::UnitTest::GetInstance()->current_test_info()->name();
 
-    boost::uuids::uuid uuid = boost::uuids::random_generator()();
-    std::string uuid_str    = to_string(uuid);
-
+    std::string uuid_str  = generate_hex(4);
     std::string imagename = testname + "-" + uuid_str + ".png";
 
     saveImageNative(imagename.c_str(), input);

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -69,6 +69,9 @@ typedef unsigned char uchar;
 typedef unsigned int uint;
 typedef unsigned short ushort;
 
+std::string getBackendName();
+std::string getTestName();
+
 std::string readNextNonEmptyLine(std::ifstream &file);
 
 namespace half_float {
@@ -553,7 +556,5 @@ void genTestOutputArray(af_array *out_ptr, double val, const unsigned ndims,
                                          std::string metadataName,
                                          const af_array a, const af_array b,
                                          TestOutputArrayInfo *metadata);
-
-std::string generate_hex(const unsigned int len);
 
 #pragma GCC diagnostic pop

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -554,4 +554,6 @@ void genTestOutputArray(af_array *out_ptr, double val, const unsigned ndims,
                                          const af_array a, const af_array b,
                                          TestOutputArrayInfo *metadata);
 
+std::string generate_hex(const unsigned int len);
+
 #pragma GCC diagnostic pop


### PR DESCRIPTION
This PR fixes test failures in imageio when using ctest.
Ctest creates multiple processes to run tests in parallel. In some cases, a collision between the filenames can occur due to parallel access and cause random failures.

Description
-----------
* Is this a new feature or a bug fix? 
  Bug fix
* More detail if necessary to describe all commits in pull request
  Fix added uuids to the filenames which collided 
* Why these changes are necessary
  These changes should allow the multiple processes of ctest to work in parallel without the chance of collision.

Changes to Users
----------------
Should reduce number of failures in CI

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
