### PR TITLE
Deterministic topK

### DIFF
--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -508,8 +508,11 @@ typedef enum {
 } af_diffusion_eq;
 
 typedef enum {
-    AF_TOPK_MIN     = 1,  ///< Top k min values
-    AF_TOPK_MAX     = 2,  ///< Top k max values
+    AF_TOPK_MIN         = 1,  ///< Top k min values
+    AF_TOPK_MAX         = 2,  ///< Top k max values
+    AF_TOPK_STABLE      = 4,  ///< Preserve order of indices for equal values
+    AF_TOPK_STABLE_MIN  = AF_TOPK_STABLE | AF_TOPK_MIN,
+    AF_TOPK_STABLE_MAX  = AF_TOPK_STABLE | AF_TOPK_MAX,
     AF_TOPK_DEFAULT = 0   ///< Default option (max)
 } af_topk_function;
 #endif

--- a/include/af/defines.h
+++ b/include/af/defines.h
@@ -511,8 +511,8 @@ typedef enum {
     AF_TOPK_MIN         = 1,  ///< Top k min values
     AF_TOPK_MAX         = 2,  ///< Top k max values
     AF_TOPK_STABLE      = 4,  ///< Preserve order of indices for equal values
-    AF_TOPK_STABLE_MIN  = AF_TOPK_STABLE | AF_TOPK_MIN,
-    AF_TOPK_STABLE_MAX  = AF_TOPK_STABLE | AF_TOPK_MAX,
+    AF_TOPK_STABLE_MIN  = AF_TOPK_STABLE | AF_TOPK_MIN, ///< Top k min with stable indices
+    AF_TOPK_STABLE_MAX  = AF_TOPK_STABLE | AF_TOPK_MAX, ///< Top k max with stable indices
     AF_TOPK_DEFAULT = 0   ///< Default option (max)
 } af_topk_function;
 #endif

--- a/include/af/statistics.h
+++ b/include/af/statistics.h
@@ -320,7 +320,8 @@ AFAPI T corrcoef(const array& X, const array& Y);
 
    \note{This function is optimized for small values of k.}
    \note{The order of the returned keys may not be in the same order as the
-   appear in the input array}
+   appear in the input array, for a stable topk, set the AF_TOPK_STABLE flag
+   in the order param. These are equivalent to AF_TOPK_STABLE_MAX and AF_TOPK_STABLE_MIN}
    \ingroup stat_func_topk
 */
 AFAPI void topk(array &values, array &indices, const array& in, const int k,
@@ -673,7 +674,8 @@ AFAPI af_err af_corrcoef(double *realVal, double *imagVal, const af_array X, con
 
    \note{This function is optimized for small values of k.}
    \note{The order of the returned keys may not be in the same order as the
-         appear in the input array}
+   appear in the input array, for a stable topk, set the AF_TOPK_STABLE flag
+   in the order param. These are equivalent to AF_TOPK_STABLE_MAX and AF_TOPK_STABLE_MIN}
    \ingroup stat_func_topk
 */
 AFAPI af_err af_topk(af_array *values, af_array *indices, const af_array in,

--- a/src/backend/cpu/topk.cpp
+++ b/src/backend/cpu/topk.cpp
@@ -85,7 +85,7 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
                     partial_sort_copy(
                         idx_itr, idx_itr + in.strides()[1], kiptr, kiptr + k,
                         [ptr](const uint lhs, const uint rhs) -> bool {
-                            return compute_t<T>(ptr[lhs]) >= compute_t<T>(ptr[rhs]);
+                            return compute_t<T>(ptr[lhs]) > compute_t<T>(ptr[rhs]);
                         });
                 }
             }

--- a/src/backend/cpu/topk.cpp
+++ b/src/backend/cpu/topk.cpp
@@ -65,10 +65,10 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
                             return compute_t<T>(ptr[lhs]) <
                                            compute_t<T>(ptr[rhs])
                                        ? true
-                                       : compute_t<T>(ptr[lhs]) ==
-                                                 compute_t<T>(ptr[rhs])
-                                             ? (lhs < rhs)
-                                             : false;
+                                   : compute_t<T>(ptr[lhs]) ==
+                                           compute_t<T>(ptr[rhs])
+                                       ? (lhs < rhs)
+                                       : false;
                         });
                 } else {
                     partial_sort_copy(
@@ -87,10 +87,10 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
                             return compute_t<T>(ptr[lhs]) >
                                            compute_t<T>(ptr[rhs])
                                        ? true
-                                       : compute_t<T>(ptr[lhs]) ==
-                                                 compute_t<T>(ptr[rhs])
-                                             ? (lhs < rhs)
-                                             : false;
+                                   : compute_t<T>(ptr[lhs]) ==
+                                           compute_t<T>(ptr[rhs])
+                                       ? (lhs < rhs)
+                                       : false;
                         });
                 } else {
                     partial_sort_copy(

--- a/src/backend/cpu/topk.cpp
+++ b/src/backend/cpu/topk.cpp
@@ -62,14 +62,20 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
                     partial_sort_copy(
                         idx_itr, idx_itr + in.strides()[1], kiptr, kiptr + k,
                         [ptr](const uint lhs, const uint rhs) -> bool {
-                            return compute_t<T>(ptr[lhs]) < compute_t<T>(ptr[rhs]) ? true :
-                                   compute_t<T>(ptr[lhs]) == compute_t<T>(ptr[rhs]) ? (lhs < rhs) : false;
+                            return compute_t<T>(ptr[lhs]) <
+                                           compute_t<T>(ptr[rhs])
+                                       ? true
+                                       : compute_t<T>(ptr[lhs]) ==
+                                                 compute_t<T>(ptr[rhs])
+                                             ? (lhs < rhs)
+                                             : false;
                         });
                 } else {
                     partial_sort_copy(
                         idx_itr, idx_itr + in.strides()[1], kiptr, kiptr + k,
                         [ptr](const uint lhs, const uint rhs) -> bool {
-                            return compute_t<T>(ptr[lhs]) < compute_t<T>(ptr[rhs]);
+                            return compute_t<T>(ptr[lhs]) <
+                                   compute_t<T>(ptr[rhs]);
                         });
                     // Sort the top k values in each column
                 }
@@ -78,14 +84,20 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
                     partial_sort_copy(
                         idx_itr, idx_itr + in.strides()[1], kiptr, kiptr + k,
                         [ptr](const uint lhs, const uint rhs) -> bool {
-                            return compute_t<T>(ptr[lhs]) > compute_t<T>(ptr[rhs]) ? true :
-                            compute_t<T>(ptr[lhs]) == compute_t<T>(ptr[rhs]) ? (lhs < rhs) : false ;
+                            return compute_t<T>(ptr[lhs]) >
+                                           compute_t<T>(ptr[rhs])
+                                       ? true
+                                       : compute_t<T>(ptr[lhs]) ==
+                                                 compute_t<T>(ptr[rhs])
+                                             ? (lhs < rhs)
+                                             : false;
                         });
                 } else {
                     partial_sort_copy(
                         idx_itr, idx_itr + in.strides()[1], kiptr, kiptr + k,
                         [ptr](const uint lhs, const uint rhs) -> bool {
-                            return compute_t<T>(ptr[lhs]) > compute_t<T>(ptr[rhs]);
+                            return compute_t<T>(ptr[lhs]) >
+                                   compute_t<T>(ptr[rhs]);
                         });
                 }
             }

--- a/src/backend/opencl/kernel/sort_by_key_impl.hpp
+++ b/src/backend/opencl/kernel/sort_by_key_impl.hpp
@@ -222,10 +222,11 @@ void sort0ByKey(Param pKey, Param pVal, bool isAscending) {
     // But this is only useful before GPU is saturated
     // The GPU is saturated at around 1000,000 integers
     // Call batched sort only if both conditions are met
-    if (higherDims > 4 && pKey.info.dims[0] < 1000000)
+    if (higherDims > 4 && pKey.info.dims[0] < 1000000) {
         kernel::sortByKeyBatched<Tk, Tv>(pKey, pVal, 0, isAscending);
-    else
+    } else {
         kernel::sort0ByKeyIterative<Tk, Tv>(pKey, pVal, isAscending);
+    }
 }
 
 #define INSTANTIATE(Tk, Tv)                                           \

--- a/src/backend/opencl/topk.cpp
+++ b/src/backend/opencl/topk.cpp
@@ -128,7 +128,7 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
     } else {
         auto values  = createEmptyArray<T>(in.dims());
         auto indices = createEmptyArray<unsigned>(in.dims());
-        sort_index(values, indices, in, dim, order == AF_TOPK_MIN);
+        sort_index(values, indices, in, dim, order & AF_TOPK_MIN);
         auto indVec = indexForTopK(k);
         vals        = index<T>(values, indVec.data());
         idxs        = index<unsigned>(indices, indVec.data());

--- a/src/backend/opencl/topk.cpp
+++ b/src/backend/opencl/topk.cpp
@@ -102,10 +102,10 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
                             return (compute_t<T>(ptr[lhs]) <
                                     compute_t<T>(ptr[rhs]))
                                        ? true
-                                       : compute_t<T>(ptr[lhs]) ==
-                                                 compute_t<T>(ptr[rhs])
-                                             ? (lhs < rhs)
-                                             : false;
+                                   : compute_t<T>(ptr[lhs]) ==
+                                           compute_t<T>(ptr[rhs])
+                                       ? (lhs < rhs)
+                                       : false;
                         });
                 } else {
                     // Sort the top k values in each column
@@ -124,10 +124,10 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
                             return (compute_t<T>(ptr[lhs]) >
                                     compute_t<T>(ptr[rhs]))
                                        ? true
-                                       : compute_t<T>(ptr[lhs]) ==
-                                                 compute_t<T>(ptr[rhs])
-                                             ? (lhs < rhs)
-                                             : false;
+                                   : compute_t<T>(ptr[lhs]) ==
+                                           compute_t<T>(ptr[rhs])
+                                       ? (lhs < rhs)
+                                       : false;
                         });
                 } else {
                     partial_sort_copy(

--- a/src/backend/opencl/topk.cpp
+++ b/src/backend/opencl/topk.cpp
@@ -96,9 +96,9 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
 
             if (order & AF_TOPK_MIN) {
                 if (order & AF_TOPK_STABLE) {
-					partial_sort_copy(
-						idx_itr, idx_itr + in.strides()[1], kiptr, kiptr + k,
-						[ptr](const uint lhs, const uint rhs) -> bool {
+                    partial_sort_copy(
+                        idx_itr, idx_itr + in.strides()[1], kiptr, kiptr + k,
+                        [ptr](const uint lhs, const uint rhs) -> bool {
                             return (compute_t<T>(ptr[lhs]) <
                                     compute_t<T>(ptr[rhs]))
                                        ? true
@@ -106,14 +106,15 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
                                                  compute_t<T>(ptr[rhs])
                                              ? (lhs < rhs)
                                              : false;
-						});
+                        });
                 } else {
-					// Sort the top k values in each column
-					partial_sort_copy(
-						idx_itr, idx_itr + in.strides()[1], kiptr, kiptr + k,
-						[ptr](const uint lhs, const uint rhs) -> bool {
-							return compute_t<T>(ptr[lhs]) < compute_t<T>(ptr[rhs]);
-						});
+                    // Sort the top k values in each column
+                    partial_sort_copy(
+                        idx_itr, idx_itr + in.strides()[1], kiptr, kiptr + k,
+                        [ptr](const uint lhs, const uint rhs) -> bool {
+                            return compute_t<T>(ptr[lhs]) <
+                                   compute_t<T>(ptr[rhs]);
+                        });
                 }
             } else {
                 if (order & AF_TOPK_STABLE) {

--- a/test/topk.cpp
+++ b/test/topk.cpp
@@ -369,7 +369,7 @@ TEST(TopK, KLessThan0) {
 }
 
 TEST(TopK, DeterministicTies) {
-    af::array a = af::constant(1, 500);
+    af::array a           = af::constant(1, 500);
     a(af::seq(0, 499, 2)) = 7;
     af::array vals_max, idx_max;
     af::array vals_min, idx_min;
@@ -378,17 +378,17 @@ TEST(TopK, DeterministicTies) {
     topk(vals_max, idx_max, a, k, 0, AF_TOPK_STABLE_MAX);
     topk(vals_min, idx_min, a, k, 0, AF_TOPK_STABLE_MIN);
 
-    af::array expected_idx_max = af::seq(0, 499, 2);
-    af::array k_expected_idx_max = expected_idx_max(af::seq(0, k-1));
-    af::array expected_idx_min = af::seq(1, 499, 2);
-    af::array k_expected_idx_min = expected_idx_min(af::seq(0, k-1));
+    af::array expected_idx_max   = af::seq(0, 499, 2);
+    af::array k_expected_idx_max = expected_idx_max(af::seq(0, k - 1));
+    af::array expected_idx_min   = af::seq(1, 499, 2);
+    af::array k_expected_idx_min = expected_idx_min(af::seq(0, k - 1));
     ASSERT_ARRAYS_EQ(idx_max, k_expected_idx_max.as(u32));
     ASSERT_ARRAYS_EQ(idx_min, k_expected_idx_min.as(u32));
 }
 
 TEST(TopK, DeterministicTiesBatched) {
     const int nbatch = 10;
-    af::array a = af::constant(1, 500, nbatch, nbatch, nbatch);
+    af::array a      = af::constant(1, 500, nbatch, nbatch, nbatch);
     a(af::seq(0, 499, 2), af::span, af::span, af::span) = 7;
     af::array vals_max, idx_max;
     af::array vals_min, idx_min;
@@ -397,10 +397,14 @@ TEST(TopK, DeterministicTiesBatched) {
     topk(vals_max, idx_max, a, k, 0, AF_TOPK_STABLE_MAX);
     topk(vals_min, idx_min, a, k, 0, AF_TOPK_STABLE_MIN);
 
-    af::array expected_idx_max   = af::seq(0, 499, 2);
-    af::array k_expected_idx_max = af::tile(expected_idx_max(af::seq(0, k-1)), af::dim4(1, nbatch, nbatch, nbatch));
-    af::array expected_idx_min   = af::seq(1, 499, 2);
-    af::array k_expected_idx_min = af::tile(expected_idx_min(af::seq(0, k-1)), af::dim4(1, nbatch, nbatch, nbatch));
+    af::array expected_idx_max = af::seq(0, 499, 2);
+    af::array k_expected_idx_max =
+        af::tile(expected_idx_max(af::seq(0, k - 1)),
+                 af::dim4(1, nbatch, nbatch, nbatch));
+    af::array expected_idx_min = af::seq(1, 499, 2);
+    af::array k_expected_idx_min =
+        af::tile(expected_idx_min(af::seq(0, k - 1)),
+                 af::dim4(1, nbatch, nbatch, nbatch));
     ASSERT_ARRAYS_EQ(idx_max, k_expected_idx_max.as(u32));
     ASSERT_ARRAYS_EQ(idx_min, k_expected_idx_min.as(u32));
 }

--- a/test/topk.cpp
+++ b/test/topk.cpp
@@ -369,24 +369,28 @@ TEST(TopK, KLessThan0) {
 }
 
 TEST(TopK, DeterministicTies) {
-    //af::array a = af::constant(1, 500);
-    //a(af::seq(0, 499, 2)) = 7;
-    af::array a = af::constant(1, 257);
-    a(af::seq(0, 255, 2)) = 7;
+    af::info();
+    af::array a = af::constant(1, 500);
+    a(af::seq(0, 499, 2)) = 7;
+    //af::array a = af::constant(1, 500, 500, 500);
+    //a(af::seq(0, 499, 2), af::span, af::span, af::span) = 7;
     af::array vals_max, idx_max;
     af::array vals_min, idx_min;
 
     int k = 6;
-    //topk(vals_max, idx_max, a, k, 0, AF_TOPK_STABLE_MAX);
+    topk(vals_max, idx_max, a, k, 0, AF_TOPK_STABLE_MAX);
     topk(vals_min, idx_min, a, k, 0, AF_TOPK_STABLE_MIN);
 
-    af::array expected_idx_max{0, 2, 4, 6, 8, 10};
-    af::array expected_idx_min{1, 3, 5, 7, 9, 11};
+    af::array expected_idx_max = af::seq(0, 499, 2);
+    af::array k_expected_idx_max = expected_idx_max(af::seq(0, k-1));
+    af::array expected_idx_min = af::seq(1, 499, 2);
+    af::array k_expected_idx_min = expected_idx_min(af::seq(0, k-1));
     //af_print(idx_max)
     //af_print(expected_idx_max)
-    af_print(idx_min)
-    af_print(expected_idx_min)
-    //ASSERT_ARRAYS_EQ(idx_max, expected_idx_max.as(u32));
-    ASSERT_ARRAYS_EQ(idx_min, expected_idx_min.as(u32));
+    //af_print(idx_min)
+    //af_print(vals_min)
+    //af_print(expected_idx_min)
+    ASSERT_ARRAYS_EQ(idx_max, k_expected_idx_max.as(u32));
+    ASSERT_ARRAYS_EQ(idx_min, k_expected_idx_min.as(u32));
 
 }

--- a/test/topk.cpp
+++ b/test/topk.cpp
@@ -367,3 +367,26 @@ TEST(TopK, KLessThan0) {
     EXPECT_THROW(topk(vals, idx, a, k), af::exception)
         << "K cannot be less than 0";
 }
+
+TEST(TopK, DeterministicTies) {
+    //af::array a = af::constant(1, 500);
+    //a(af::seq(0, 499, 2)) = 7;
+    af::array a = af::constant(1, 257);
+    a(af::seq(0, 255, 2)) = 7;
+    af::array vals_max, idx_max;
+    af::array vals_min, idx_min;
+
+    int k = 6;
+    //topk(vals_max, idx_max, a, k, 0, AF_TOPK_STABLE_MAX);
+    topk(vals_min, idx_min, a, k, 0, AF_TOPK_STABLE_MIN);
+
+    af::array expected_idx_max{0, 2, 4, 6, 8, 10};
+    af::array expected_idx_min{1, 3, 5, 7, 9, 11};
+    //af_print(idx_max)
+    //af_print(expected_idx_max)
+    af_print(idx_min)
+    af_print(expected_idx_min)
+    //ASSERT_ARRAYS_EQ(idx_max, expected_idx_max.as(u32));
+    ASSERT_ARRAYS_EQ(idx_min, expected_idx_min.as(u32));
+
+}

--- a/test/topk.cpp
+++ b/test/topk.cpp
@@ -369,11 +369,8 @@ TEST(TopK, KLessThan0) {
 }
 
 TEST(TopK, DeterministicTies) {
-    af::info();
     af::array a = af::constant(1, 500);
     a(af::seq(0, 499, 2)) = 7;
-    //af::array a = af::constant(1, 500, 500, 500);
-    //a(af::seq(0, 499, 2), af::span, af::span, af::span) = 7;
     af::array vals_max, idx_max;
     af::array vals_min, idx_min;
 
@@ -385,12 +382,25 @@ TEST(TopK, DeterministicTies) {
     af::array k_expected_idx_max = expected_idx_max(af::seq(0, k-1));
     af::array expected_idx_min = af::seq(1, 499, 2);
     af::array k_expected_idx_min = expected_idx_min(af::seq(0, k-1));
-    //af_print(idx_max)
-    //af_print(expected_idx_max)
-    //af_print(idx_min)
-    //af_print(vals_min)
-    //af_print(expected_idx_min)
     ASSERT_ARRAYS_EQ(idx_max, k_expected_idx_max.as(u32));
     ASSERT_ARRAYS_EQ(idx_min, k_expected_idx_min.as(u32));
+}
 
+TEST(TopK, DeterministicTiesBatched) {
+    const int nbatch = 10;
+    af::array a = af::constant(1, 500, nbatch, nbatch, nbatch);
+    a(af::seq(0, 499, 2), af::span, af::span, af::span) = 7;
+    af::array vals_max, idx_max;
+    af::array vals_min, idx_min;
+
+    int k = 6;
+    topk(vals_max, idx_max, a, k, 0, AF_TOPK_STABLE_MAX);
+    topk(vals_min, idx_min, a, k, 0, AF_TOPK_STABLE_MIN);
+
+    af::array expected_idx_max   = af::seq(0, 499, 2);
+    af::array k_expected_idx_max = af::tile(expected_idx_max(af::seq(0, k-1)), af::dim4(1, nbatch, nbatch, nbatch));
+    af::array expected_idx_min   = af::seq(1, 499, 2);
+    af::array k_expected_idx_min = af::tile(expected_idx_min(af::seq(0, k-1)), af::dim4(1, nbatch, nbatch, nbatch));
+    ASSERT_ARRAYS_EQ(idx_max, k_expected_idx_max.as(u32));
+    ASSERT_ARRAYS_EQ(idx_min, k_expected_idx_min.as(u32));
 }


### PR DESCRIPTION
topK would not use a stable sort, so in the case of ties results would be non-deterministic.
This PR adds new topk function types AF_TOPK_STABLE_MIN, AF_TOPK_STABLE_MAX that will perform the topk search in a deterministic manner. 

* Is this a new feature or a bug fix?
 New feature
* More detail if necessary to describe all commits in pull request.
 The CPU and openCL backends needed tweaks to their comparator functions. Now the comparators will perform an additional index comparison if the values are equal to deterministically sort ties.
The cuda backend used radix sort which is stable, however the order of loading the data would assign each granule(n items per thread) with spread out data, resulting in an output depending on grid-size. Shared memory is now used to load data to specific threads.

* Potential impact on specific hardware, software or backends.
Cuda backend now uses more shared memory. Doesn't affect performance much since bottleneck is SMEM bandwidth in radix sort. CPU and OpenCL backends now need an extra comparison in some cases, shouldn't affect performance much.
* New functions and their functionality.
new options are  AF_TOPK_STABLE_MIN, AF_TOPK_STABLE_MAX, which are the previous AF_TOPK_MAX | AF_TOPK_STABLE and AF_TOPK_MIN | AF_TOPK_STABLE

Changes to Users
----------------
Updated API options

Checklist
---------
<!-- Check if done or not applicable -->
- [ ] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
