### PR TITLE
Use boost's epsilon difference when comparing floating point values

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,6 +108,7 @@ target_include_directories(arrayfire_test
     ${ArrayFire_BINARY_DIR}/include
     ${ArrayFire_SOURCE_DIR}/extern/half/include
     mmio
+    $<TARGET_PROPERTY:Boost::boost,INTERFACE_INCLUDE_DIRECTORIES>
     ${${gtest_prefix}_SOURCE_DIR}/googletest/include)
 
 if(WIN32)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,7 +61,7 @@ if(NOT TARGET mmio)
 endif()
 
 # Reset the CXX flags for tests
-set(CMAKE_CXX_STANDARD 98)
+set(CMAKE_CXX_STANDARD 11)
 
 # TODO(pradeep) perhaps rename AF_USE_RELATIVE_TEST_DIR to AF_WITH_TEST_DATA_DIR
 #               with empty default value

--- a/test/dot.cpp
+++ b/test/dot.cpp
@@ -47,8 +47,14 @@ typedef ::testing::Types<cfloat, cdouble> TestTypesC;
 TYPED_TEST_CASE(DotF, TestTypesF);
 TYPED_TEST_CASE(DotC, TestTypesC);
 
-bool isinf(af::af_cfloat val) { return isinf(val.real) || isinf(val.imag); }
-bool isinf(af::af_cdouble val) { return isinf(val.real) || isinf(val.imag); }
+bool isinf(af::af_cfloat val) {
+    using std::isinf;
+    return isinf(val.real) || isinf(val.imag);
+}
+bool isinf(af::af_cdouble val) {
+    using std::isinf;
+    return isinf(val.real) || isinf(val.imag);
+}
 
 template<typename T>
 void dotTest(string pTestFile, const int resultIdx,
@@ -135,6 +141,8 @@ void dotAllTest(string pTestFile, const int resultIdx,
 
     vector<T> goldData = tests[resultIdx];
 
+    using ::isinf;
+    using std::isinf;
     if (false == (isinf(rval) && isinf(goldData[0]))) {
         compare<T>(rval, ival, goldData[0]);
     }

--- a/test/join.cpp
+++ b/test/join.cpp
@@ -48,7 +48,7 @@ class Join : public ::testing::Test {
 // create a list of types to be tested
 typedef ::testing::Types<float, double, cfloat, cdouble, int, unsigned int,
                          intl, uintl, char, unsigned char, short, ushort,
-                         af_half>
+                         half_float::half>
     TestTypes;
 
 // register the type list

--- a/test/relative_difference.hpp
+++ b/test/relative_difference.hpp
@@ -1,0 +1,135 @@
+//  (C) Copyright John Maddock 2006, 2015
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MATH_RELATIVE_ERROR
+#define BOOST_MATH_RELATIVE_ERROR
+
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/math/tools/precision.hpp>
+#include <boost/math/tools/promotion.hpp>
+
+namespace boost {
+namespace math {
+
+template<class T, class U>
+typename boost::math::tools::promote_args<T, U>::type relative_difference(
+    const T& arg_a, const U& arg_b) {
+    typedef typename boost::math::tools::promote_args<T, U>::type result_type;
+    result_type a = arg_a;
+    result_type b = arg_b;
+    BOOST_MATH_STD_USING
+#ifdef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
+    //
+    // If math.h has no long double support we can't rely
+    // on the math functions generating exponents outside
+    // the range of a double:
+    //
+    result_type min_val = (std::max)(
+        tools::min_value<result_type>(),
+        static_cast<result_type>((std::numeric_limits<double>::min)()));
+    result_type max_val = (std::min)(
+        tools::max_value<result_type>(),
+        static_cast<result_type>((std::numeric_limits<double>::max)()));
+#else
+    result_type min_val = tools::min_value<result_type>();
+    result_type max_val = tools::max_value<result_type>();
+#endif
+    // Screen out NaN's first, if either value is a NaN then the distance is
+    // "infinite":
+    if ((boost::math::isnan)(a) || (boost::math::isnan)(b)) return max_val;
+    // Screen out infinities:
+    if (fabs(b) > max_val) {
+        if (fabs(a) > max_val)
+            return (a < 0) == (b < 0)
+                       ? result_type(0)
+                       : max_val;  // one infinity is as good as another!
+        else
+            return max_val;  // one infinity and one finite value implies
+                             // infinite difference
+    } else if (fabs(a) > max_val)
+        return max_val;  // one infinity and one finite value implies infinite
+                         // difference
+
+    //
+    // If the values have different signs, treat as infinite difference:
+    //
+    if (((a < 0) != (b < 0)) && (a != 0) && (b != 0)) return max_val;
+    a = fabs(a);
+    b = fabs(b);
+    //
+    // Now deal with zero's, if one value is zero (or denorm) then treat it the
+    // same as min_val for the purposes of the calculation that follows:
+    //
+    if (a < min_val) a = min_val;
+    if (b < min_val) b = min_val;
+
+    return (std::max)(fabs((a - b) / a), fabs((a - b) / b));
+}
+
+#if (defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)) && \
+    (LDBL_MAX_EXP <= DBL_MAX_EXP)
+template<>
+inline boost::math::tools::promote_args<double, double>::type
+relative_difference(const double& arg_a, const double& arg_b) {
+    BOOST_MATH_STD_USING
+    double a = arg_a;
+    double b = arg_b;
+    //
+    // On Mac OS X we evaluate "double" functions at "long double" precision,
+    // but "long double" actually has a very slightly narrower range than
+    // "double"! Therefore use the range of "long double" as our limits since
+    // results outside that range may have been truncated to 0 or INF:
+    //
+    double min_val = (std::max)((double)tools::min_value<long double>(),
+                                tools::min_value<double>());
+    double max_val = (std::min)((double)tools::max_value<long double>(),
+                                tools::max_value<double>());
+
+    // Screen out NaN's first, if either value is a NaN then the distance is
+    // "infinite":
+    if ((boost::math::isnan)(a) || (boost::math::isnan)(b)) return max_val;
+    // Screen out infinities:
+    if (fabs(b) > max_val) {
+        if (fabs(a) > max_val)
+            return 0;  // one infinity is as good as another!
+        else
+            return max_val;  // one infinity and one finite value implies
+                             // infinite difference
+    } else if (fabs(a) > max_val)
+        return max_val;  // one infinity and one finite value implies infinite
+                         // difference
+
+    //
+    // If the values have different signs, treat as infinite difference:
+    //
+    if (((a < 0) != (b < 0)) && (a != 0) && (b != 0)) return max_val;
+    a = fabs(a);
+    b = fabs(b);
+    //
+    // Now deal with zero's, if one value is zero (or denorm) then treat it the
+    // same as min_val for the purposes of the calculation that follows:
+    //
+    if (a < min_val) a = min_val;
+    if (b < min_val) b = min_val;
+
+    return (std::max)(fabs((a - b) / a), fabs((a - b) / b));
+}
+#endif
+
+template<class T, class U>
+inline typename boost::math::tools::promote_args<T, U>::type epsilon_difference(
+    const T& arg_a, const U& arg_b) {
+    typedef typename boost::math::tools::promote_args<T, U>::type result_type;
+    result_type r = relative_difference(arg_a, arg_b);
+    if (tools::max_value<result_type>() *
+            boost::math::tools::epsilon<result_type>() <
+        r)
+        return tools::max_value<result_type>();
+    return r / boost::math::tools::epsilon<result_type>();
+}
+}  // namespace math
+}  // namespace boost
+
+#endif

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -273,19 +273,6 @@ template<typename T>
                                       const std::vector<T> &b, af::dim4 bDims,
                                       float maxAbsDiff, IntegerTag);
 
-struct absMatch {
-    float diff_;
-    absMatch(float diff) : diff_(diff) {}
-
-    template<typename T>
-    bool operator()(T lhs, T rhs) {
-        using af::abs;
-        using half_float::abs;
-        using std::abs;
-        return abs(rhs - lhs) <= diff_;
-    }
-};
-
 template<typename T>
 ::testing::AssertionResult elemWiseEq(std::string aName, std::string bName,
                                       const std::vector<T> &a, af::dim4 aDims,


### PR DESCRIPTION
Use epsilon difference to compare floating point values in tests


Description
-----------
This commit changes the way we compare floating point values in the
tests to use the boost math's epsilon difference to compare two floating
point values for equality. This is a more accurate form of equality and
handles differences in half float values when the values reach a
certain threshold.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
