### PR TITLE
Forge dep install fix

### DIFF
--- a/.github/workflows/release_src_artifact.yml
+++ b/.github/workflows/release_src_artifact.yml
@@ -46,7 +46,7 @@ jobs:
               run: |
                   cd ${GITHUB_WORKSPACE}/arrayfire-full-${AF_VER}
                   mkdir build && cd build
-                  cmake .. -DAF_BUILD_FORGE:BOOL=ON
+                  cmake .. -DAF_BUILD_FORGE:BOOL=ON -DAF_COMPUTE_LIBRARY="FFTW/LAPACK/BLAS"
 
             - name: Create source tarball
               id: create-src-tarball

--- a/CMakeModules/AFconfigure_forge_dep.cmake
+++ b/CMakeModules/AFconfigure_forge_dep.cmake
@@ -61,8 +61,8 @@ if(AF_BUILD_FORGE)
     set_property(TARGET forge APPEND_STRING PROPERTY COMPILE_FLAGS " -w")
 else(AF_BUILD_FORGE)
     find_package(Forge
-	    ${FG_VERSION_MAJOR}.${FG_VERSION_MINOR}.${FG_VERSION_PATCH}
-	    QUIET
+        ${FG_VERSION_MAJOR}.${FG_VERSION_MINOR}.${FG_VERSION_PATCH}
+        QUIET
     )
 
     if(TARGET Forge::forge)
@@ -78,9 +78,14 @@ else(AF_BUILD_FORGE)
                     COMPONENT common_backend_dependencies)
         endif()
     else()
+        af_dep_check_and_populate(${forge_prefix}
+            URI https://github.com/arrayfire/forge.git
+            REF "v${FG_VERSION}"
+        )
+
         configure_file(
-		  ${${forge_prefix}_SOURCE_DIR}/CMakeModules/version.h.in
-		  ${${forge_prefix}_BINARY_DIR}/include/fg/version.h
-		  )
+            ${${forge_prefix}_SOURCE_DIR}/CMakeModules/version.h.in
+            ${${forge_prefix}_BINARY_DIR}/include/fg/version.h
+        )
     endif()
 endif(AF_BUILD_FORGE)

--- a/CMakeModules/AFconfigure_forge_dep.cmake
+++ b/CMakeModules/AFconfigure_forge_dep.cmake
@@ -51,13 +51,21 @@ if(AF_BUILD_FORGE)
     set(FETCHCONTENT_UPDATES_DISCONNECTED ${af_FETCHCONTENT_UPDATES_DISCONNECTED})
     install(FILES
         $<TARGET_FILE:forge>
-        $<TARGET_RUNTIME_DLLS:forge>
         $<$<PLATFORM_ID:Linux>:$<TARGET_SONAME_FILE:forge>>
         $<$<PLATFORM_ID:Darwin>:$<TARGET_SONAME_FILE:forge>>
         $<$<PLATFORM_ID:Linux>:$<TARGET_LINKER_FILE:forge>>
         $<$<PLATFORM_ID:Darwin>:$<TARGET_LINKER_FILE:forge>>
         DESTINATION "${AF_INSTALL_LIB_DIR}"
         COMPONENT common_backend_dependencies)
+
+    if(AF_INSTALL_STANDALONE)
+        cmake_minimum_required(VERSION 3.21)
+        install(FILES
+            $<TARGET_RUNTIME_DLLS:forge>
+            DESTINATION "${AF_INSTALL_LIB_DIR}"
+            COMPONENT common_backend_dependencies)
+    endif(AF_INSTALL_STANDALONE)
+
     set_property(TARGET forge APPEND_STRING PROPERTY COMPILE_FLAGS " -w")
 else(AF_BUILD_FORGE)
     find_package(Forge


### PR DESCRIPTION
If forge was found in vcpkg, AF_BUILD_FORGE would be ignored. This PR fixes that behavior.
This PR also fixes:
* missing glfw3.dll during AF_BUILD_FORGE standalone installation
* ci workflows for non-intel build during src_artifact_release

Is this a new feature or a bug fix?
bug fix  

Future changes not implemented in this PR.
glfw should also be installed if forge is prebuilt, can currently be done with X_VCPKG_APPLOCAL_DEPS_INTALL, perhaps there is an elegant way to do this in the CMakeModules.
AF_COMPUTE_BACKEND should have a default fallback if intel fails

Fixes: #3208


Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass