### PR TITLE
Set AF_COMPUTE_LIBRARY to MKL only if found.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,12 @@ option(AF_WITH_STACKTRACE  "Add stacktraces to the error messages." ON)
 option(AF_CACHE_KERNELS_TO_DISK "Enable caching kernels to disk" ON)
 option(AF_WITH_STATIC_MKL "Link against static Intel MKL libraries" OFF)
 
-set(AF_COMPUTE_LIBRARY "Intel-MKL"
+set(default_compute_library "FFTW/LAPACK/BLAS")
+if(MKL_FOUND)
+  set(default_compute_library "Intel-MKL")
+endif()
+
+set(AF_COMPUTE_LIBRARY ${default_compute_library}
     CACHE STRING "Compute library for signal processing and linear algebra routines")
 set_property(CACHE AF_COMPUTE_LIBRARY
     PROPERTY STRINGS "Intel-MKL" "FFTW/LAPACK/BLAS")


### PR DESCRIPTION
Fixes errors if MKL is not found on the system

Description
-----------
By default we set the AF_COMPUTE_LIBRARY to MKL only if MKL was found on
the system. If MKL was not found it will be set to FFTW/LAPACK/BLAS instead.

Changes to Users
----------------
Users will not need to set AF_COMPUTE_LIBRARY by default.

Checklist
---------

- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
