### PR TITLE
Add some debugging macros

### DIFF
--- a/src/backend/common/ArrayFireTypesIO.hpp
+++ b/src/backend/common/ArrayFireTypesIO.hpp
@@ -1,0 +1,37 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+#include <spdlog/fmt/bundled/ranges.h>
+#include <spdlog/fmt/ostr.h>
+#include <af/seq.h>
+
+template<>
+struct fmt::formatter<af_seq> {
+    // Parses format specifications of the form ['f' | 'e'].
+    constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+        return ctx.begin();
+    }
+
+    // Formats the point p using the parsed format specification (presentation)
+    // stored in this formatter.
+    template<typename FormatContext>
+    auto format(const af_seq& p, FormatContext& ctx) -> decltype(ctx.out()) {
+        // ctx.out() is an output iterator to write to.
+        if (p.begin == af_span.begin && p.end == af_span.end &&
+            p.step == af_span.step) {
+            return format_to(ctx.out(), "span");
+        }
+        if (p.begin == p.end) { return format_to(ctx.out(), "{}", p.begin); }
+        if (p.step == 1) {
+            return format_to(ctx.out(), "({} -> {})", p.begin, p.end);
+        }
+        return format_to(ctx.out(), "({} -({})-> {})", p.begin, p.step, p.end);
+    }
+};

--- a/src/backend/common/CMakeLists.txt
+++ b/src/backend/common/CMakeLists.txt
@@ -15,6 +15,7 @@ target_sources(afcommon_interface
     ${CMAKE_CURRENT_SOURCE_DIR}/jit/NaryNode.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/jit/Node.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/jit/Node.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/jit/NodeIO.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/jit/NodeIterator.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/jit/ScalarNode.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/jit/UnaryNode.hpp
@@ -25,6 +26,7 @@ target_sources(afcommon_interface
     ${CMAKE_CURRENT_SOURCE_DIR}/AllocatorInterface.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ArrayInfo.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ArrayInfo.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ArrayFireTypesIO.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/DefaultMemoryManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/DefaultMemoryManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/DependencyModule.cpp

--- a/src/backend/common/debug.hpp
+++ b/src/backend/common/debug.hpp
@@ -1,0 +1,62 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#define FMT_HEADER_ONLY
+#include <boost/stacktrace.hpp>
+#include <common/ArrayFireTypesIO.hpp>
+#include <common/jit/NodeIO.hpp>
+#include <spdlog/fmt/bundled/format.h>
+#include <iostream>
+
+#define DBGTRACE(msg)                                              \
+    fmt::print(std::cout, __FILE__ ":{}:{}\n{}\n", __LINE__, #msg, \
+               boost::stacktrace::stacktrace())
+
+namespace debugging {
+
+template<typename first>
+void print(const char *F, const first &FF) {
+    fmt::print(std::cout, "{} = {}", F, FF);
+}
+
+template<typename first, typename... ARGS>
+void print(const char *F, const first &FF, ARGS... args) {
+    fmt::print(std::cout, "{} = {} | ", F, FF);
+    print(args...);
+}
+}  // namespace debugging
+
+#define SHOW1(val1) debugging::print(#val1, val1)
+#define SHOW2(val1, val2) debugging::print(#val1, val1, #val2, val2)
+#define SHOW3(val1, val2, val3) \
+    debugging::print(#val1, val1, #val2, val2, #val3, val3)
+
+#define SHOW4(val1, val2, val3, val4) \
+    debugging::print(#val1, val1, #val2, val2, #val3, val3, #val4, val4)
+#define SHOW5(val1, val2, val3, val4, val5)                              \
+    debugging::print(#val1, val1, #val2, val2, #val3, val3, #val4, val4, \
+                     #val5, val5)
+
+#define GET_MACRO(_1, _2, _3, _4, _5, NAME, ...) NAME
+
+#define SHOW(...)                                                 \
+    do {                                                          \
+        fmt::print(std::cout, "{}:({}): ", __FILE__, __LINE__);   \
+        GET_MACRO(__VA_ARGS__, SHOW5, SHOW4, SHOW3, SHOW2, SHOW1) \
+        (__VA_ARGS__);                                            \
+        fmt::print(std::cout, "\n");                              \
+    } while (0)
+
+#define PRINTVEC(val)                                                        \
+    do {                                                                     \
+        fmt::print(std::cout, "{}:({}):{} [{}]\n", __FILE__, __LINE__, #val, \
+                   fmt::join(val, ", "));                                    \
+    } while (0)

--- a/src/backend/common/jit/Node.cpp
+++ b/src/backend/common/jit/Node.cpp
@@ -63,6 +63,8 @@ bool NodePtr_equalto::operator()(const Node *l, const Node *r) const noexcept {
 
 auto isBuffer(const Node &ptr) -> bool { return ptr.isBuffer(); }
 
+auto isScalar(const Node &ptr) -> bool { return ptr.isScalar(); }
+
 /// Returns true if the buffer is linear
 bool Node::isLinear(const dim_t dims[4]) const { return true; }
 

--- a/src/backend/common/jit/Node.hpp
+++ b/src/backend/common/jit/Node.hpp
@@ -241,6 +241,9 @@ class Node {
     // Returns true if this node is a Buffer
     virtual bool isBuffer() const { return false; }
 
+    // Returns true if this node is a Buffer
+    virtual bool isScalar() const { return false; }
+
     /// Returns true if the buffer is linear
     virtual bool isLinear(const dim_t dims[4]) const;
 
@@ -299,5 +302,7 @@ std::string getFuncName(const std::vector<Node *> &output_nodes,
                         const std::vector<Node_ids> &full_ids, bool is_linear);
 
 auto isBuffer(const Node &ptr) -> bool;
+
+auto isScalar(const Node &ptr) -> bool;
 
 }  // namespace common

--- a/src/backend/common/jit/NodeIO.hpp
+++ b/src/backend/common/jit/NodeIO.hpp
@@ -66,8 +66,10 @@ struct fmt::formatter<common::Node> {
         format_to(ctx.out(), "{{");
         if (pointer) format_to(ctx.out(), "{} ", (void*)&node);
         if (op) {
-            if (node.isBuffer()) {
+            if (isBuffer(node)) {
                 format_to(ctx.out(), "buffer ");
+            } else if (isScalar(node)) {
+                format_to(ctx.out(), "scalar ", getOpEnumStr(node.getOp()));
             } else {
                 format_to(ctx.out(), "{} ", getOpEnumStr(node.getOp()));
             }

--- a/src/backend/common/jit/NodeIO.hpp
+++ b/src/backend/common/jit/NodeIO.hpp
@@ -1,0 +1,93 @@
+/*******************************************************
+ * Copyright (c) 2021, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+#include <common/jit/Node.hpp>
+#include <common/util.hpp>
+#include <spdlog/fmt/bundled/format.h>
+
+#include <common/TemplateArg.hpp>
+
+template<>
+struct fmt::formatter<af::dtype> : fmt::formatter<char> {
+    template<typename FormatContext>
+    auto format(const af::dtype& p, FormatContext& ctx) -> decltype(ctx.out()) {
+        format_to(ctx.out(), "{}", getName(p));
+        return ctx.out();
+    }
+};
+
+template<>
+struct fmt::formatter<common::Node> {
+    // Presentation format: 'p' - pointer, 't' - type.
+    // char presentation;
+    bool pointer;
+    bool type;
+    bool children;
+    bool op;
+
+    // Parses format specifications of the form ['f' | 'e'].
+    constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+        auto it = ctx.begin(), end = ctx.end();
+
+        if (it == end || *it == '}') {
+            pointer = type = children = op = true;
+            return it;
+        }
+
+        while (it != end && *it != '}') {
+            switch (*it) {
+                case 'p': pointer = true; break;
+                case 't': type = true; break;
+                case 'c': children = true; break;
+                case 'o': op = true; break;
+                default: throw format_error("invalid format");
+            }
+            ++it;
+        }
+
+        // Return an iterator past the end of the parsed range:
+        return it;
+    }
+
+    // Formats the point p using the parsed format specification (presentation)
+    // stored in this formatter.
+    template<typename FormatContext>
+    auto format(const common::Node& node, FormatContext& ctx)
+        -> decltype(ctx.out()) {
+        // ctx.out() is an output iterator to write to.
+
+        format_to(ctx.out(), "{{");
+        if (pointer) format_to(ctx.out(), "{} ", (void*)&node);
+        if (op) {
+            if (node.isBuffer()) {
+                format_to(ctx.out(), "buffer ");
+            } else {
+                format_to(ctx.out(), "{} ", getOpEnumStr(node.getOp()));
+            }
+        }
+        if (type) format_to(ctx.out(), "{} ", node.getType());
+        if (children) {
+            int count;
+            for (count = 0; count < common::Node::kMaxChildren &&
+                            node.m_children[count].get() != nullptr;
+                 count++) {}
+            if (count > 0) {
+                format_to(ctx.out(), "children: {{ ");
+                for (int i = 0; i < count; i++) {
+                    format_to(ctx.out(), "{} ", *(node.m_children[i].get()));
+                }
+                format_to(ctx.out(), "\b}} ");
+            }
+        }
+        format_to(ctx.out(), "\b}}");
+
+        return ctx.out();
+    }
+};

--- a/src/backend/common/jit/ScalarNode.hpp
+++ b/src/backend/common/jit/ScalarNode.hpp
@@ -84,6 +84,9 @@ class ScalarNode : public common::Node {
                   << ";\n";
     }
 
+    // Returns true if this node is a Buffer
+    virtual bool isScalar() const { return false; }
+
     std::string getNameStr() const final { return detail::shortname<T>(false); }
 
     // Return the info for the params and the size of the buffers

--- a/src/backend/cpu/jit/ScalarNode.hpp
+++ b/src/backend/cpu/jit/ScalarNode.hpp
@@ -58,6 +58,8 @@ class ScalarNode : public TNode<T> {
         UNUSED(kerStream);
         UNUSED(ids);
     }
+
+    bool isScalar() const final { return true; }
 };
 }  // namespace jit
 


### PR DESCRIPTION
Add debugging macros to make it easier to view the values of variables in the project

Description
-----------
* Add the SHOW macro. Allows you to view multiple values in a given location of a program

```
int vala = 5;
float valb = 3.14;
af_seq s = span;
af::seq ss(3, 5, 1);

SHOW(vala, valb, s, ss);
```

```
/data/devel/arrayfire/src/backend/cpu/Array.cpp:(141): vala = 5 | valb = 3.14 | s = span | ss = (3 -> 5)
```

Changes to Users
----------------
This is an internal change.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
