### PR TITLE
Remove adv_infer and adv_train cudnn libs from install step

### DIFF
--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -834,8 +834,6 @@ if(AF_INSTALL_STANDALONE)
     if(cuDNN_VERSION_MAJOR VERSION_GREATER 8 OR cuDNN_VERSION_MAJOR VERSION_EQUAL 8)
       # cudnn changed how dlls are shipped starting major version 8
       # except the main dll a lot of the other DLLs are loaded upon demand
-      afcu_collect_cudnn_libs(adv_infer)
-      afcu_collect_cudnn_libs(adv_train)
       afcu_collect_cudnn_libs(cnn_infer)
       afcu_collect_cudnn_libs(cnn_train)
       afcu_collect_cudnn_libs(ops_infer)


### PR DESCRIPTION
Remove unused cudnn libs form installations

Description
-----------
Remove unused adv_infer and adv_train libs from the installs

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
