### PR TITLE
Fix prune

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,10 @@ option(AF_CACHE_KERNELS_TO_DISK "Enable caching kernels to disk" ON)
 option(AF_WITH_STATIC_MKL "Link against static Intel MKL libraries" OFF)
 option(AF_WITH_STATIC_CUDA_NUMERIC_LIBS "Link libafcuda with static numeric libraries(cublas, cufft, etc.)" OFF)
 
+if(AF_WITH_STATIC_CUDA_NUMERIC_LIBS)
+  option(AF_WITH_PRUNE_STATIC_CUDA_NUMERIC_LIBS "Prune CUDA static libraries to reduce binary size.(WARNING: May break some libs on older CUDA toolkits for some compute arch)" OFF)
+endif()
+
 set(default_compute_library "FFTW/LAPACK/BLAS")
 if(MKL_FOUND)
   set(default_compute_library "Intel-MKL")

--- a/CMakeModules/AFcuda_helpers.cmake
+++ b/CMakeModules/AFcuda_helpers.cmake
@@ -27,11 +27,11 @@ function(af_find_static_cuda_libs libname)
       MAIN_DEPENDENCY ${CUDA_${libname}_LIBRARY}
       COMMENT "Pruning ${CUDA_${libname}_LIBRARY} for ${cuda_build_targets}"
       VERBATIM)
-    add_custom_target(AF_CUDA_${libname}_LIBRARY_TARGET
+    add_custom_target(prune_${libname}
       DEPENDS ${liboutput}.depend)
-    list(APPEND cuda_pruned_libraries AF_CUDA_${libname}_LIBRARY_TARGET PARENT_SCOPE)
+    set(cuda_pruned_library_targets ${cuda_pruned_library_targets};prune_${libname} PARENT_SCOPE)
 
-    set(AF_CUDA_${libname}_LIBRARY ${liboutput} PARENT_SCOPE)
+    set(AF_CUDA_${libname}_LIBRARY "${liboutput}" PARENT_SCOPE)
     mark_as_advanced(AF_CUDA_${libname}_LIBRARY)
   else()
     set(AF_CUDA_${libname}_LIBRARY ${CUDA_${libname}_LIBRARY} PARENT_SCOPE)

--- a/CMakeModules/AFcuda_helpers.cmake
+++ b/CMakeModules/AFcuda_helpers.cmake
@@ -6,6 +6,7 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 find_program(NVPRUNE NAMES nvprune)
+
 # The following macro uses a macro defined by
 # FindCUDA module from cmake.
 function(af_find_static_cuda_libs libname)
@@ -16,7 +17,7 @@ function(af_find_static_cuda_libs libname)
   cuda_find_library_local_first(CUDA_${libname}_LIBRARY
     ${search_name} "${libname} static library")
 
-  if(fscl_PRUNE)
+  if(fscl_PRUNE AND AF_WITH_PRUNE_STATIC_CUDA_NUMERIC_LIBS)
     get_filename_component(af_${libname} ${CUDA_${libname}_LIBRARY} NAME)
 
     set(liboutput ${CMAKE_CURRENT_BINARY_DIR}/${af_${libname}})
@@ -32,7 +33,6 @@ function(af_find_static_cuda_libs libname)
     set(cuda_pruned_library_targets ${cuda_pruned_library_targets};prune_${libname} PARENT_SCOPE)
 
     set(AF_CUDA_${libname}_LIBRARY "${liboutput}" PARENT_SCOPE)
-    mark_as_advanced(AF_CUDA_${libname}_LIBRARY)
   else()
     set(AF_CUDA_${libname}_LIBRARY ${CUDA_${libname}_LIBRARY} PARENT_SCOPE)
   endif()

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -688,8 +688,9 @@ add_library(ArrayFire::afcuda ALIAS afcuda)
 
 add_dependencies(afcuda ${jit_kernel_targets} ${nvrtc_kernel_targets})
 add_dependencies(af_cuda_static_cuda_library ${nvrtc_kernel_targets})
-if(cuda_pruned_libraries)
-  add_dependencies(afcuda ${cuda_pruned_libraries})
+
+if(UNIX AND AF_WITH_STATIC_CUDA_NUMERIC_LIBS)
+  add_dependencies(afcuda ${cuda_pruned_library_targets})
 endif()
 
 target_include_directories (afcuda

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -689,7 +689,7 @@ add_library(ArrayFire::afcuda ALIAS afcuda)
 add_dependencies(afcuda ${jit_kernel_targets} ${nvrtc_kernel_targets})
 add_dependencies(af_cuda_static_cuda_library ${nvrtc_kernel_targets})
 
-if(UNIX AND AF_WITH_STATIC_CUDA_NUMERIC_LIBS)
+if(UNIX AND AF_WITH_PRUNE_STATIC_CUDA_NUMERIC_LIBS)
   add_dependencies(afcuda ${cuda_pruned_library_targets})
 endif()
 


### PR DESCRIPTION
Fix pruning option and set to off by default because of some failures in some combination of compute capabilities and cuda toolkits

Description
-----------
list(APPEND ...) in CMake cannot use the PARENT_SCOPE attribute. This caused an error when setting the cuda_pruned_library_targets variable which didn't propagate to the parent scope.

This PR also makes pruning optional because it fails for some compute capabilities and cuda toolkits. For example, it seemed to be working fine with 11.5 and compute capability 7.0 but not 7.5. It was failing for both computes in CUDA toolkit 10.2. It would be difficult to maintain and test all toolkits and compute combinations so I am setting it to off by default.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
