### PR TITLE
Add support for ccache to the CUDA backend

### DIFF
--- a/CMakeModules/config_ccache.cmake
+++ b/CMakeModules/config_ccache.cmake
@@ -14,11 +14,14 @@ if (UNIX)
     # Set up wrapper scripts
     set(C_LAUNCHER   "${CCACHE_PROGRAM}")
     set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
+    set(NVCC_LAUNCHER "${CCACHE_PROGRAM}")
     configure_file(${ArrayFire_SOURCE_DIR}/CMakeModules/launch-c.in   launch-c)
     configure_file(${ArrayFire_SOURCE_DIR}/CMakeModules/launch-cxx.in launch-cxx)
+    configure_file(${ArrayFire_SOURCE_DIR}/CMakeModules/launch-nvcc.in launch-nvcc)
     execute_process(COMMAND chmod a+rx
         "${ArrayFire_BINARY_DIR}/launch-c"
         "${ArrayFire_BINARY_DIR}/launch-cxx"
+        "${ArrayFire_BINARY_DIR}/launch-nvcc"
       )
     if(CMAKE_GENERATOR STREQUAL "Xcode")
       # Set Xcode project attributes to route compilation and linking
@@ -31,6 +34,7 @@ if (UNIX)
       # Support Unix Makefiles and Ninja
       set(CMAKE_C_COMPILER_LAUNCHER   "${ArrayFire_BINARY_DIR}/launch-c")
       set(CMAKE_CXX_COMPILER_LAUNCHER "${ArrayFire_BINARY_DIR}/launch-cxx")
+      set(CUDA_NVCC_EXECUTABLE "${ArrayFire_BINARY_DIR}/launch-nvcc")
     endif()
   endif()
   mark_as_advanced(CCACHE_PROGRAM)

--- a/CMakeModules/launch-nvcc.in
+++ b/CMakeModules/launch-nvcc.in
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Xcode generator doesn't include the compiler as the
+# first argument, Ninja and Makefiles do. Handle both cases.
+if [ "$1" = "${CUDA_NVCC_EXECUTABLE}" ] ; then
+    shift
+fi
+
+export CCACHE_CPP2=true
+exec "${NVCC_LAUNCHER}" "${CUDA_NVCC_EXECUTABLE}" "$@"


### PR DESCRIPTION
Adds ccache support for the CUDA backend

Description
-----------
Add ccache support for NVCC for the CUDA backend. Makes compilation significantly faster when compiling the same configuration on a system.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
