### PR TITLE
Make cuSparse a runtime dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,17 +85,21 @@ if(MKL_FOUND)
   set(default_compute_library "Intel-MKL")
 endif()
 
-set(AF_COMPUTE_LIBRARY ${default_compute_library}
-    CACHE STRING "Compute library for signal processing and linear algebra routines")
-set_property(CACHE AF_COMPUTE_LIBRARY
-    PROPERTY STRINGS "Intel-MKL" "FFTW/LAPACK/BLAS")
+af_multiple_option(NAME        AF_COMPUTE_LIBRARY
+                   DEFAULT     ${default_compute_library}
+                   DESCRIPTION "Compute library for signal processing and linear algebra routines"
+                   OPTIONS     "Intel-MKL" "FFTW/LAPACK/BLAS")
 
 if(WIN32)
-  set(AF_STACKTRACE_TYPE "Windbg" CACHE STRING "The type of backtrace features. Windbg(simple), None")
-  set_property(CACHE AF_STACKTRACE_TYPE PROPERTY STRINGS "Windbg" "None")
+  af_multiple_option(NAME         AF_STACKTRACE_TYPE
+                     DEFAULT      "Windbg"
+                     DESCRIPTION  "The type of backtrace features. Windbg(simple), None"
+                     OPTIONS       "Windbg" "None")
 else()
-  set(AF_STACKTRACE_TYPE "Basic" CACHE STRING "The type of backtrace features. Basic(simple), libbacktrace(fancy), addr2line(fancy), None")
-  set_property(CACHE AF_STACKTRACE_TYPE PROPERTY STRINGS "Basic" "libbacktrace" "addr2line" "None")
+  af_multiple_option(NAME         AF_STACKTRACE_TYPE
+                     DEFAULT      "Basic"
+                     DESCRIPTION  "The type of backtrace features. Basic(simple), libbacktrace(fancy), addr2line(fancy), None"
+                     OPTIONS       "Basic" "libbacktrace" "addr2line" "None")
 endif()
 
 option(AF_INSTALL_STANDALONE "Build installers that include all dependencies" OFF)

--- a/CMakeModules/InternalUtils.cmake
+++ b/CMakeModules/InternalUtils.cmake
@@ -223,6 +223,25 @@ macro(af_mkl_batch_check)
   check_symbol_exists(sgetrf_batch_strided "mkl_lapack.h" MKL_BATCH)
 endmacro()
 
+# Creates a CACHEd CMake variable which has limited set of possible string values
+# Argumehts:
+#   NAME: The name of the variable
+#   DEFAULT: The default value of the variable
+#   DESCRIPTION: The description of the variable
+#   OPTIONS: The possible set of values for the option
+#
+# Example:
+#
+# af_multiple_option(NAME        AF_COMPUTE_LIBRARY
+#                    DEFAULT     "Intel-MKL"
+#                    DESCRIPTION "Compute library for signal processing and linear algebra routines"
+#                    OPTIONS     "Intel-MKL" "FFTW/LAPACK/BLAS")
+macro(af_multiple_option)
+  cmake_parse_arguments(opt "" "NAME;DEFAULT;DESCRIPTION" "OPTIONS" ${ARGN})
+  set(${opt_NAME} ${opt_DEFAULT} CACHE STRING ${opt_DESCRIPTION})
+  set_property(CACHE ${opt_NAME} PROPERTY STRINGS ${opt_OPTIONS})
+endmacro()
+
 mark_as_advanced(
     pkgcfg_lib_PC_CBLAS_cblas
     pkgcfg_lib_PC_LAPACKE_lapacke

--- a/src/backend/common/DependencyModule.hpp
+++ b/src/backend/common/DependencyModule.hpp
@@ -38,6 +38,11 @@ class DependencyModule {
     std::vector<void*> functions;
 
    public:
+    /// Loads the library \p plugin_file_name from the \p paths locations
+    /// \param plugin_file_name  The name of the library without any prefix or
+    ///                          extensions
+    /// \param paths             The locations to search for the libraries if
+    ///                          not found in standard locations
     DependencyModule(const char* plugin_file_name,
                      const char** paths = nullptr);
 

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -63,11 +63,23 @@ find_cuda_helper_libs(nvrtc-builtins)
 list(APPEND nvrtc_libs ${CUDA_nvrtc_LIBRARY})
 
 if(UNIX AND AF_WITH_STATIC_CUDA_NUMERIC_LIBS)
+  # The libraries that may be staticly linked or may be loaded at runtime
+  set(AF_CUDA_optionally_static_libraries)
+
+  af_multiple_option(NAME        AF_cusparse_LINK_LOADING
+    DEFAULT     "Module"
+    DESCRIPTION "The approach to load the cusparse library. Static linking(Static) or Dynamic runtime loading(Module) of the module"
+    OPTIONS     "Module" "Static")
+
+  if(AF_cusparse_LINK_LOADING STREQUAL "Static")
+    af_find_static_cuda_libs(cusparse_static PRUNE)
+    list(APPEND AF_CUDA_optionally_static_libraries ${AF_CUDA_cusparse_static_LIBRARY})
+  endif()
+
   af_find_static_cuda_libs(culibos)
   af_find_static_cuda_libs(cublas_static PRUNE)
   af_find_static_cuda_libs(cublasLt_static PRUNE)
   af_find_static_cuda_libs(cufft_static)
-  af_find_static_cuda_libs(cusparse_static PRUNE)
 
   if(CUDA_VERSION VERSION_GREATER 11.4)
     af_find_static_cuda_libs(nvrtc_static)
@@ -88,7 +100,6 @@ if(UNIX AND AF_WITH_STATIC_CUDA_NUMERIC_LIBS)
     set(af_cuda_static_flags "${af_cuda_static_flags};-lcublasLt_static")
   endif()
   set(af_cuda_static_flags "${af_cuda_static_flags};-lcufft_static")
-  set(af_cuda_static_flags "${af_cuda_static_flags};-lcusparse_static")
 
   if(${use_static_cuda_lapack})
     af_find_static_cuda_libs(cusolver_static PRUNE)
@@ -341,11 +352,10 @@ if(UNIX AND AF_WITH_STATIC_CUDA_NUMERIC_LIBS)
       ${AF_CUDA_cublas_static_LIBRARY}
       ${AF_CUDA_cublasLt_static_LIBRARY}
       ${AF_CUDA_cufft_static_LIBRARY}
-      ${AF_CUDA_cusparse_static_LIBRARY}
+      ${AF_CUDA_optionally_static_libraries}
       ${nvrtc_libs}
       ${cusolver_static_lib}
-      ${END_GROUP}
-  )
+      ${END_GROUP})
 
   if(CUDA_VERSION VERSION_GREATER 10.0)
     target_link_libraries(af_cuda_static_cuda_library
@@ -367,7 +377,6 @@ else()
       ${CUDA_CUBLAS_LIBRARIES}
       ${CUDA_CUFFT_LIBRARIES}
       ${CUDA_cusolver_LIBRARY}
-      ${CUDA_cusparse_LIBRARY}
       ${nvrtc_libs}
   )
 endif()
@@ -536,6 +545,8 @@ cuda_add_library(afcuda
     cusolverDn.hpp
     cusparse.cpp
     cusparse.hpp
+    cusparseModule.cpp
+    cusparseModule.hpp
     device_manager.cpp
     device_manager.hpp
     debug_cuda.hpp
@@ -689,6 +700,13 @@ if(AF_WITH_CUDNN)
       ${cuDNN_INCLUDE_DIRS}
     )
 endif()
+
+if(UNIX AND AF_WITH_STATIC_CUDA_NUMERIC_LIBS AND AF_cusparse_LINK_LOADING STREQUAL "Static")
+  target_compile_definitions(afcuda
+    PRIVATE
+      AF_cusparse_STATIC_LINKING)
+endif()
+
 
 arrayfire_set_default_cxx_flags(afcuda)
 

--- a/src/backend/cuda/cusparse.hpp
+++ b/src/backend/cuda/cusparse.hpp
@@ -12,15 +12,16 @@
 #include <common/defines.hpp>
 #include <common/err_common.hpp>
 #include <common/unique_handle.hpp>
+#include <cusparseModule.hpp>
 #include <cusparse_v2.h>
 
 // clang-format off
-DEFINE_HANDLER(cusparseHandle_t, cusparseCreate, cusparseDestroy);
-DEFINE_HANDLER(cusparseMatDescr_t, cusparseCreateMatDescr, cusparseDestroyMatDescr);
+DEFINE_HANDLER(cusparseHandle_t, cuda::getCusparsePlugin().cusparseCreate, cuda::getCusparsePlugin().cusparseDestroy);
+DEFINE_HANDLER(cusparseMatDescr_t, cuda::getCusparsePlugin().cusparseCreateMatDescr, cuda::getCusparsePlugin().cusparseDestroyMatDescr);
 #if defined(AF_USE_NEW_CUSPARSE_API)
-DEFINE_HANDLER(cusparseSpMatDescr_t, cusparseCreateCsr, cusparseDestroySpMat);
-DEFINE_HANDLER(cusparseDnVecDescr_t, cusparseCreateDnVec, cusparseDestroyDnVec);
-DEFINE_HANDLER(cusparseDnMatDescr_t, cusparseCreateDnMat, cusparseDestroyDnMat);
+DEFINE_HANDLER(cusparseSpMatDescr_t, cuda::getCusparsePlugin().cusparseCreateCsr, cuda::getCusparsePlugin().cusparseDestroySpMat);
+DEFINE_HANDLER(cusparseDnVecDescr_t, cuda::getCusparsePlugin().cusparseCreateDnVec, cuda::getCusparsePlugin().cusparseDestroyDnVec);
+DEFINE_HANDLER(cusparseDnMatDescr_t, cuda::getCusparsePlugin().cusparseCreateDnMat, cuda::getCusparsePlugin().cusparseDestroyDnMat);
 #endif
 // clang-format on
 

--- a/src/backend/cuda/cusparseModule.cpp
+++ b/src/backend/cuda/cusparseModule.cpp
@@ -1,0 +1,135 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <cusparseModule.hpp>
+
+#include <common/err_common.hpp>
+#include <af/defines.h>
+
+#include <cuda.h>
+#include <string>
+
+namespace cuda {
+
+cusparseModule::cusparseModule()
+    :
+#ifdef AF_cusparse_STATIC_LINKING
+    module(nullptr, nullptr)
+#else
+    module("cusparse", nullptr)
+#endif
+{
+#ifdef AF_cusparse_STATIC_LINKING
+    AF_TRACE("CuSparse linked staticly.");
+#undef MODULE_FUNCTION_INIT
+#define MODULE_FUNCTION_INIT(NAME) NAME = &::NAME
+#else
+    if (!module.isLoaded()) {
+        AF_TRACE(
+            "WARNING: Unable to load cuSparse: {}\n"
+            "cuSparse failed to load. Try installing cuSparse or check if\n"
+            "cuSparse is in the search path. On Linux, you can set the\n"
+            "LD_DEBUG=libs environment variable to debug loading issues.\n"
+            "Falling back to matmul based implementation",
+            module.getErrorMessage());
+
+        return;
+    }
+#endif
+
+    MODULE_FUNCTION_INIT(cusparseCcsc2dense);
+    MODULE_FUNCTION_INIT(cusparseCcsr2dense);
+    MODULE_FUNCTION_INIT(cusparseCdense2csc);
+    MODULE_FUNCTION_INIT(cusparseCdense2csr);
+    MODULE_FUNCTION_INIT(cusparseCgthr);
+    MODULE_FUNCTION_INIT(cusparseCnnz);
+    MODULE_FUNCTION_INIT(cusparseCreateCsr);
+    MODULE_FUNCTION_INIT(cusparseCreateDnMat);
+    MODULE_FUNCTION_INIT(cusparseCreateDnVec);
+    MODULE_FUNCTION_INIT(cusparseCreateIdentityPermutation);
+    MODULE_FUNCTION_INIT(cusparseCreate);
+    MODULE_FUNCTION_INIT(cusparseCreateMatDescr);
+    MODULE_FUNCTION_INIT(cusparseDcsc2dense);
+    MODULE_FUNCTION_INIT(cusparseDcsr2dense);
+    MODULE_FUNCTION_INIT(cusparseDdense2csc);
+    MODULE_FUNCTION_INIT(cusparseDdense2csr);
+    MODULE_FUNCTION_INIT(cusparseDestroyDnMat);
+    MODULE_FUNCTION_INIT(cusparseDestroyDnVec);
+    MODULE_FUNCTION_INIT(cusparseDestroy);
+    MODULE_FUNCTION_INIT(cusparseDestroyMatDescr);
+    MODULE_FUNCTION_INIT(cusparseDestroySpMat);
+    MODULE_FUNCTION_INIT(cusparseDgthr);
+    MODULE_FUNCTION_INIT(cusparseDnnz);
+    MODULE_FUNCTION_INIT(cusparseScsc2dense);
+    MODULE_FUNCTION_INIT(cusparseScsr2dense);
+    MODULE_FUNCTION_INIT(cusparseSdense2csc);
+    MODULE_FUNCTION_INIT(cusparseSdense2csr);
+    MODULE_FUNCTION_INIT(cusparseSetMatIndexBase);
+    MODULE_FUNCTION_INIT(cusparseSetMatType);
+    MODULE_FUNCTION_INIT(cusparseSetStream);
+    MODULE_FUNCTION_INIT(cusparseSgthr);
+    MODULE_FUNCTION_INIT(cusparseSnnz);
+    MODULE_FUNCTION_INIT(cusparseSpMM_bufferSize);
+    MODULE_FUNCTION_INIT(cusparseSpMM);
+    MODULE_FUNCTION_INIT(cusparseSpMV_bufferSize);
+    MODULE_FUNCTION_INIT(cusparseSpMV);
+    MODULE_FUNCTION_INIT(cusparseXcoo2csr);
+    MODULE_FUNCTION_INIT(cusparseXcoosort_bufferSizeExt);
+    MODULE_FUNCTION_INIT(cusparseXcoosortByColumn);
+    MODULE_FUNCTION_INIT(cusparseXcoosortByRow);
+    MODULE_FUNCTION_INIT(cusparseXcsr2coo);
+#if CUDA_VERSION >= 11000
+    MODULE_FUNCTION_INIT(cusparseXcsrgeam2Nnz);
+#else
+    MODULE_FUNCTION_INIT(cusparseXcsrgeamNnz);
+#endif
+    MODULE_FUNCTION_INIT(cusparseZcsc2dense);
+    MODULE_FUNCTION_INIT(cusparseZcsr2dense);
+#if CUDA_VERSION >= 11000
+    MODULE_FUNCTION_INIT(cusparseScsrgeam2_bufferSizeExt);
+    MODULE_FUNCTION_INIT(cusparseScsrgeam2);
+    MODULE_FUNCTION_INIT(cusparseDcsrgeam2_bufferSizeExt);
+    MODULE_FUNCTION_INIT(cusparseDcsrgeam2);
+    MODULE_FUNCTION_INIT(cusparseCcsrgeam2_bufferSizeExt);
+    MODULE_FUNCTION_INIT(cusparseCcsrgeam2);
+    MODULE_FUNCTION_INIT(cusparseZcsrgeam2_bufferSizeExt);
+    MODULE_FUNCTION_INIT(cusparseZcsrgeam2);
+#else
+    MODULE_FUNCTION_INIT(cusparseScsrgeam);
+    MODULE_FUNCTION_INIT(cusparseDcsrgeam);
+    MODULE_FUNCTION_INIT(cusparseCcsrgeam);
+    MODULE_FUNCTION_INIT(cusparseZcsrgeam);
+#endif
+    MODULE_FUNCTION_INIT(cusparseZdense2csc);
+    MODULE_FUNCTION_INIT(cusparseZdense2csr);
+    MODULE_FUNCTION_INIT(cusparseZgthr);
+    MODULE_FUNCTION_INIT(cusparseZnnz);
+
+#ifndef AF_cusparse_STATIC_LINKING
+    if (!module.symbolsLoaded()) {
+        std::string error_message =
+            "Error loading cuSparse symbols. ArrayFire was unable to load some "
+            "symbols from the cuSparse library. Please create an issue on the "
+            "ArrayFire repository with information about the installed "
+            "cuSparse and ArrayFire on your system.";
+        AF_ERROR(error_message, AF_ERR_LOAD_LIB);
+    }
+#endif
+}
+
+spdlog::logger* cusparseModule::getLogger() const noexcept {
+    return module.getLogger();
+}
+
+cusparseModule& getCusparsePlugin() noexcept {
+    static auto* plugin = new cusparseModule();
+    return *plugin;
+}
+
+}  // namespace cuda

--- a/src/backend/cuda/cusparseModule.hpp
+++ b/src/backend/cuda/cusparseModule.hpp
@@ -1,0 +1,96 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <common/DependencyModule.hpp>
+#include <cuda.h>
+#include <cusparse_v2.h>
+
+namespace cuda {
+class cusparseModule {
+    common::DependencyModule module;
+
+   public:
+    cusparseModule();
+    ~cusparseModule() = default;
+
+    MODULE_MEMBER(cusparseCcsc2dense);
+    MODULE_MEMBER(cusparseCcsr2dense);
+    MODULE_MEMBER(cusparseCdense2csc);
+    MODULE_MEMBER(cusparseCdense2csr);
+    MODULE_MEMBER(cusparseCgthr);
+    MODULE_MEMBER(cusparseCnnz);
+    MODULE_MEMBER(cusparseCreateCsr);
+    MODULE_MEMBER(cusparseCreateDnMat);
+    MODULE_MEMBER(cusparseCreateDnVec);
+    MODULE_MEMBER(cusparseCreateIdentityPermutation);
+    MODULE_MEMBER(cusparseCreate);
+    MODULE_MEMBER(cusparseCreateMatDescr);
+    MODULE_MEMBER(cusparseDcsc2dense);
+    MODULE_MEMBER(cusparseDcsr2dense);
+    MODULE_MEMBER(cusparseDdense2csc);
+    MODULE_MEMBER(cusparseDdense2csr);
+    MODULE_MEMBER(cusparseDestroyDnMat);
+    MODULE_MEMBER(cusparseDestroyDnVec);
+    MODULE_MEMBER(cusparseDestroy);
+    MODULE_MEMBER(cusparseDestroyMatDescr);
+    MODULE_MEMBER(cusparseDestroySpMat);
+    MODULE_MEMBER(cusparseDgthr);
+    MODULE_MEMBER(cusparseDnnz);
+    MODULE_MEMBER(cusparseScsc2dense);
+    MODULE_MEMBER(cusparseScsr2dense);
+    MODULE_MEMBER(cusparseSdense2csc);
+    MODULE_MEMBER(cusparseSdense2csr);
+    MODULE_MEMBER(cusparseSetMatIndexBase);
+    MODULE_MEMBER(cusparseSetMatType);
+    MODULE_MEMBER(cusparseSetStream);
+    MODULE_MEMBER(cusparseSgthr);
+    MODULE_MEMBER(cusparseSnnz);
+    MODULE_MEMBER(cusparseSpMM_bufferSize);
+    MODULE_MEMBER(cusparseSpMM);
+    MODULE_MEMBER(cusparseSpMV_bufferSize);
+    MODULE_MEMBER(cusparseSpMV);
+    MODULE_MEMBER(cusparseXcoo2csr);
+    MODULE_MEMBER(cusparseXcoosort_bufferSizeExt);
+    MODULE_MEMBER(cusparseXcoosortByColumn);
+    MODULE_MEMBER(cusparseXcoosortByRow);
+    MODULE_MEMBER(cusparseXcsr2coo);
+    MODULE_MEMBER(cusparseZcsc2dense);
+    MODULE_MEMBER(cusparseZcsr2dense);
+
+#if CUDA_VERSION >= 11000
+    MODULE_MEMBER(cusparseXcsrgeam2Nnz);
+    MODULE_MEMBER(cusparseCcsrgeam2_bufferSizeExt);
+    MODULE_MEMBER(cusparseCcsrgeam2);
+    MODULE_MEMBER(cusparseDcsrgeam2_bufferSizeExt);
+    MODULE_MEMBER(cusparseDcsrgeam2);
+    MODULE_MEMBER(cusparseScsrgeam2_bufferSizeExt);
+    MODULE_MEMBER(cusparseScsrgeam2);
+    MODULE_MEMBER(cusparseZcsrgeam2_bufferSizeExt);
+    MODULE_MEMBER(cusparseZcsrgeam2);
+#else
+    MODULE_MEMBER(cusparseXcsrgeamNnz);
+    MODULE_MEMBER(cusparseCcsrgeam);
+    MODULE_MEMBER(cusparseDcsrgeam);
+    MODULE_MEMBER(cusparseScsrgeam);
+    MODULE_MEMBER(cusparseZcsrgeam);
+#endif
+
+    MODULE_MEMBER(cusparseZdense2csc);
+    MODULE_MEMBER(cusparseZdense2csr);
+    MODULE_MEMBER(cusparseZgthr);
+    MODULE_MEMBER(cusparseZnnz);
+
+    spdlog::logger* getLogger() const noexcept;
+};
+
+cusparseModule& getCusparsePlugin() noexcept;
+
+}  // namespace cuda

--- a/src/backend/cuda/platform.cpp
+++ b/src/backend/cuda/platform.cpp
@@ -29,6 +29,7 @@
 #include <cufft.hpp>
 #include <cusolverDn.hpp>
 #include <cusparse.hpp>
+#include <cusparseModule.hpp>
 #include <device_manager.hpp>
 #include <driver.h>
 #include <err_cuda.hpp>
@@ -84,7 +85,7 @@ unique_handle<cublasHandle_t> *cublasManager(const int deviceId) {
     thread_local once_flag initFlags[DeviceManager::MAX_DEVICES];
 
     call_once(initFlags[deviceId], [&] {
-        handles[deviceId].create();
+        CUBLAS_CHECK((cublasStatus_t)handles[deviceId].create());
         // TODO(pradeep) When multiple streams per device
         // is added to CUDA backend, move the cublasSetStream
         // call outside of call_once scope.
@@ -159,12 +160,13 @@ unique_handle<cusparseHandle_t> *cusparseManager(const int deviceId) {
         handles[DeviceManager::MAX_DEVICES];
     thread_local once_flag initFlags[DeviceManager::MAX_DEVICES];
     call_once(initFlags[deviceId], [&] {
+        auto &_ = getCusparsePlugin();
         handles[deviceId].create();
         // TODO(pradeep) When multiple streams per device
         // is added to CUDA backend, move the cublasSetStream
         // call outside of call_once scope.
         CUSPARSE_CHECK(
-            cusparseSetStream(handles[deviceId], cuda::getStream(deviceId)));
+            _.cusparseSetStream(handles[deviceId], cuda::getStream(deviceId)));
     });
     return &handles[deviceId];
 }

--- a/src/backend/cuda/sparse.cu
+++ b/src/backend/cuda/sparse.cu
@@ -15,6 +15,7 @@
 #include <complex.hpp>
 #include <copy.hpp>
 #include <cusparse.hpp>
+#include <cusparseModule.hpp>
 #include <kernel/sparse.hpp>
 #include <lookup.hpp>
 #include <math.hpp>
@@ -122,8 +123,9 @@ struct gthr_func_def_t {
 #define SPARSE_FUNC(FUNC, TYPE, PREFIX)                                     \
     template<>                                                              \
     typename FUNC##_func_def_t<TYPE>::FUNC##_func_def FUNC##_func<TYPE>() { \
-        return (FUNC##_func_def_t<TYPE>::FUNC##_func_def) &                 \
-               cusparse##PREFIX##FUNC;                                      \
+        cusparseModule &_ = getCusparsePlugin();                            \
+        return (FUNC##_func_def_t<TYPE>::FUNC##_func_def)(                  \
+            _.cusparse##PREFIX##FUNC);                                      \
     }
 
 SPARSE_FUNC_DEF(dense2csr)
@@ -194,11 +196,12 @@ SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in) {
     const int M = in.dims()[0];
     const int N = in.dims()[1];
 
+    cusparseModule &_ = getCusparsePlugin();
     // Create Sparse Matrix Descriptor
     cusparseMatDescr_t descr = 0;
-    CUSPARSE_CHECK(cusparseCreateMatDescr(&descr));
-    cusparseSetMatType(descr, CUSPARSE_MATRIX_TYPE_GENERAL);
-    cusparseSetMatIndexBase(descr, CUSPARSE_INDEX_BASE_ZERO);
+    CUSPARSE_CHECK(_.cusparseCreateMatDescr(&descr));
+    _.cusparseSetMatType(descr, CUSPARSE_MATRIX_TYPE_GENERAL);
+    _.cusparseSetMatIndexBase(descr, CUSPARSE_INDEX_BASE_ZERO);
 
     int d                   = -1;
     cusparseDirection_t dir = CUSPARSE_DIRECTION_ROW;
@@ -238,7 +241,7 @@ SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in) {
             nnzPerDir.get(), values.get(), rowIdx.get(), colIdx.get()));
 
     // Destory Sparse Matrix Descriptor
-    CUSPARSE_CHECK(cusparseDestroyMatDescr(descr));
+    CUSPARSE_CHECK(_.cusparseDestroyMatDescr(descr));
 
     return createArrayDataSparseArray<T>(in.dims(), values, rowIdx, colIdx,
                                          stype);
@@ -262,10 +265,11 @@ Array<T> sparseConvertCOOToDense(const SparseArray<T> &in) {
 template<typename T, af_storage stype>
 Array<T> sparseConvertStorageToDense(const SparseArray<T> &in) {
     // Create Sparse Matrix Descriptor
+    cusparseModule &_        = getCusparsePlugin();
     cusparseMatDescr_t descr = 0;
-    CUSPARSE_CHECK(cusparseCreateMatDescr(&descr));
-    cusparseSetMatType(descr, CUSPARSE_MATRIX_TYPE_GENERAL);
-    cusparseSetMatIndexBase(descr, CUSPARSE_INDEX_BASE_ZERO);
+    CUSPARSE_CHECK(_.cusparseCreateMatDescr(&descr));
+    _.cusparseSetMatType(descr, CUSPARSE_MATRIX_TYPE_GENERAL);
+    _.cusparseSetMatIndexBase(descr, CUSPARSE_INDEX_BASE_ZERO);
 
     int M          = in.dims()[0];
     int N          = in.dims()[1];
@@ -284,7 +288,7 @@ Array<T> sparseConvertStorageToDense(const SparseArray<T> &in) {
                                 in.getColIdx().get(), dense.get(), d_strides1));
 
     // Destory Sparse Matrix Descriptor
-    CUSPARSE_CHECK(cusparseDestroyMatDescr(descr));
+    CUSPARSE_CHECK(_.cusparseDestroyMatDescr(descr));
 
     return dense;
 }
@@ -297,6 +301,7 @@ SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in) {
     int nNZ                  = in.getNNZ();
     SparseArray<T> converted = createEmptySparseArray<T>(in.dims(), nNZ, dest);
 
+    cusparseModule &_ = getCusparsePlugin();
     if (src == AF_STORAGE_CSR && dest == AF_STORAGE_COO) {
         // Copy colIdx as is
         CUDA_CHECK(
@@ -305,13 +310,13 @@ SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in) {
                             cudaMemcpyDeviceToDevice, cuda::getActiveStream()));
 
         // cusparse function to expand compressed row into coordinate
-        CUSPARSE_CHECK(cusparseXcsr2coo(
+        CUSPARSE_CHECK(_.cusparseXcsr2coo(
             sparseHandle(), in.getRowIdx().get(), nNZ, in.dims()[0],
             converted.getRowIdx().get(), CUSPARSE_INDEX_BASE_ZERO));
 
         // Call sort
         size_t pBufferSizeInBytes = 0;
-        CUSPARSE_CHECK(cusparseXcoosort_bufferSizeExt(
+        CUSPARSE_CHECK(_.cusparseXcoosort_bufferSizeExt(
             sparseHandle(), in.dims()[0], in.dims()[1], nNZ,
             converted.getRowIdx().get(), converted.getColIdx().get(),
             &pBufferSizeInBytes));
@@ -320,9 +325,9 @@ SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in) {
 
         shared_ptr<int> P(memAlloc<int>(nNZ).release(), memFree<int>);
         CUSPARSE_CHECK(
-            cusparseCreateIdentityPermutation(sparseHandle(), nNZ, P.get()));
+            _.cusparseCreateIdentityPermutation(sparseHandle(), nNZ, P.get()));
 
-        CUSPARSE_CHECK(cusparseXcoosortByColumn(
+        CUSPARSE_CHECK(_.cusparseXcoosortByColumn(
             sparseHandle(), in.dims()[0], in.dims()[1], nNZ,
             converted.getRowIdx().get(), converted.getColIdx().get(), P.get(),
             (void *)pBuffer.get()));
@@ -344,7 +349,7 @@ SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in) {
         // Call sort to convert column major to row major
         {
             size_t pBufferSizeInBytes = 0;
-            CUSPARSE_CHECK(cusparseXcoosort_bufferSizeExt(
+            CUSPARSE_CHECK(_.cusparseXcoosort_bufferSizeExt(
                 sparseHandle(), cooT.dims()[0], cooT.dims()[1], nNZ,
                 cooT.getRowIdx().get(), cooT.getColIdx().get(),
                 &pBufferSizeInBytes));
@@ -352,10 +357,10 @@ SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in) {
                 memAlloc<char>(pBufferSizeInBytes).release(), memFree<char>);
 
             shared_ptr<int> P(memAlloc<int>(nNZ).release(), memFree<int>);
-            CUSPARSE_CHECK(cusparseCreateIdentityPermutation(sparseHandle(),
-                                                             nNZ, P.get()));
+            CUSPARSE_CHECK(_.cusparseCreateIdentityPermutation(sparseHandle(),
+                                                               nNZ, P.get()));
 
-            CUSPARSE_CHECK(cusparseXcoosortByRow(
+            CUSPARSE_CHECK(_.cusparseXcoosortByRow(
                 sparseHandle(), cooT.dims()[0], cooT.dims()[1], nNZ,
                 cooT.getRowIdx().get(), cooT.getColIdx().get(), P.get(),
                 (void *)pBuffer.get()));
@@ -376,7 +381,7 @@ SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in) {
                             cudaMemcpyDeviceToDevice, cuda::getActiveStream()));
 
         // cusparse function to compress row from coordinate
-        CUSPARSE_CHECK(cusparseXcoo2csr(
+        CUSPARSE_CHECK(_.cusparseXcoo2csr(
             sparseHandle(), cooT.getRowIdx().get(), nNZ, cooT.dims()[0],
             converted.getRowIdx().get(), CUSPARSE_INDEX_BASE_ZERO));
 

--- a/src/backend/cuda/sparse_arith.cu
+++ b/src/backend/cuda/sparse_arith.cu
@@ -115,10 +115,11 @@ SparseArray<T> arithOp(const SparseArray<T> &lhs, const Array<T> &rhs,
     template<typename T>               \
     FUNC##_def<T> FUNC##_func();
 
-#define SPARSE_ARITH_OP_FUNC(FUNC, TYPE, INFIX) \
-    template<>                                  \
-    FUNC##_def<TYPE> FUNC##_func<TYPE>() {      \
-        return cusparse##INFIX##FUNC;           \
+#define SPARSE_ARITH_OP_FUNC(FUNC, TYPE, INFIX)  \
+    template<>                                   \
+    FUNC##_def<TYPE> FUNC##_func<TYPE>() {       \
+        cusparseModule &_ = getCusparsePlugin(); \
+        return _.cusparse##INFIX##FUNC;          \
     }
 
 #if CUDA_VERSION >= 11000
@@ -139,7 +140,8 @@ SPARSE_ARITH_OP_BUFFER_SIZE_FUNC_DEF(csrgeam2);
 #define SPARSE_ARITH_OP_BUFFER_SIZE_FUNC(FUNC, TYPE, INFIX)        \
     template<>                                                     \
     FUNC##_buffer_size_def<TYPE> FUNC##_buffer_size_func<TYPE>() { \
-        return cusparse##INFIX##FUNC##_bufferSizeExt;              \
+        cusparseModule &_ = getCusparsePlugin();                   \
+        return _.cusparse##INFIX##FUNC##_bufferSizeExt;            \
     }
 
 SPARSE_ARITH_OP_BUFFER_SIZE_FUNC(csrgeam2, float, S);
@@ -206,8 +208,9 @@ SparseArray<T> arithOp(const SparseArray<T> &lhs, const SparseArray<T> &rhs) {
     int baseC, nnzC;
     int *nnzcDevHostPtr = &nnzC;
 
-    T alpha = scalar<T>(1);
-    T beta  = op == af_sub_t ? scalar<T>(-1) : alpha;
+    T alpha           = scalar<T>(1);
+    T beta            = op == af_sub_t ? scalar<T>(-1) : alpha;
+    cusparseModule &_ = getCusparsePlugin();
 
 #if CUDA_VERSION >= 11000
     size_t pBufferSize = 0;
@@ -219,12 +222,12 @@ SparseArray<T> arithOp(const SparseArray<T> &lhs, const SparseArray<T> &rhs) {
 
     auto tmpBuffer = createEmptyArray<char>(dim4(pBufferSize));
 
-    CUSPARSE_CHECK(cusparseXcsrgeam2Nnz(
+    CUSPARSE_CHECK(_.cusparseXcsrgeam2Nnz(
         sparseHandle(), M, N, desc, nnzA, csrRowPtrA, csrColPtrA, desc, nnzB,
         csrRowPtrB, csrColPtrB, desc, csrRowPtrC, nnzcDevHostPtr,
         tmpBuffer.get()));
 #else
-    CUSPARSE_CHECK(cusparseXcsrgeamNnz(
+    CUSPARSE_CHECK(_.cusparseXcsrgeamNnz(
         sparseHandle(), M, N, desc, nnzA, csrRowPtrA, csrColPtrA, desc, nnzB,
         csrRowPtrB, csrColPtrB, desc, csrRowPtrC, nnzcDevHostPtr));
 #endif


### PR DESCRIPTION
Load cuSparse at runtime instead of at link time.

Description
-----------
This PR makes cuSparse a runtime dependency. You do not need the library
to the installed on the system to run ArrayFire code. You only need to have it
in the load path when you use any of the cusparse functions.

Changes to Users
----------------
* This could reduce the install size of the CUDA backend

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
