### PR TITLE
Fix ccache configuration issue because it was configured before CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ project(ArrayFire VERSION 3.9.0 LANGUAGES C CXX)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
 include(AFconfigure_deps_vars)
-include(config_ccache)
 include(AFBuildConfigurations)
 include(AFInstallDirs)
 include(CMakeDependentOption)
@@ -58,6 +57,7 @@ find_package(MKL)
 find_package(spdlog 1.8.5 QUIET)
 
 include(boost_package)
+include(config_ccache)
 
 option(AF_BUILD_CPU      "Build ArrayFire with a CPU backend"        ON)
 option(AF_BUILD_CUDA     "Build ArrayFire with a CUDA backend"       ${CUDA_FOUND})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,7 +430,7 @@ write_basic_package_version_file(
 set(INCLUDE_DIRS include)
 set(CMAKE_DIR ${AF_INSTALL_CMAKE_DIR})
 configure_package_config_file(
-  ${CMAKE_MODULE_PATH}/ArrayFireConfig.cmake.in
+  ${ArrayFire_SOURCE_DIR}/CMakeModules/ArrayFireConfig.cmake.in
   cmake/install/ArrayFireConfig.cmake
   INSTALL_DESTINATION "${AF_INSTALL_CMAKE_DIR}"
   PATH_VARS INCLUDE_DIRS CMAKE_DIR
@@ -488,7 +488,7 @@ endif()
 set(INCLUDE_DIRS "${ArrayFire_SOURCE_DIR}/include" "${ArrayFire_BINARY_DIR}/include")
 set(CMAKE_DIR "${ArrayFire_BINARY_DIR}/cmake")
 configure_package_config_file(
-  ${CMAKE_MODULE_PATH}/ArrayFireConfig.cmake.in
+  ${ArrayFire_SOURCE_DIR}/CMakeModules/ArrayFireConfig.cmake.in
   ArrayFireConfig.cmake
   INSTALL_DESTINATION "${ArrayFire_BINARY_DIR}"
   PATH_VARS INCLUDE_DIRS CMAKE_DIR
@@ -506,7 +506,7 @@ configure_package_config_file(
 unset(CMAKE_CXX_VISIBILITY_PRESET)
 
 configure_file(
-  ${CMAKE_MODULE_PATH}/CTestCustom.cmake
+  ${ArrayFire_SOURCE_DIR}/CMakeModules/CTestCustom.cmake
   ${ArrayFire_BINARY_DIR}/CTestCustom.cmake)
 
 include(CTest)

--- a/CMakeModules/InternalUtils.cmake
+++ b/CMakeModules/InternalUtils.cmake
@@ -205,7 +205,7 @@ macro(arrayfire_set_cmake_default_variables)
   #          EPILOG ${compiler_header_epilogue}
   #          )
   configure_file(
-    ${CMAKE_MODULE_PATH}/compilers.h
+    ${ArrayFire_SOURCE_DIR}/CMakeModules/compilers.h
     ${ArrayFire_BINARY_DIR}/include/af/compilers.h)
 endmacro()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -372,7 +372,9 @@ if(CUDA_FOUND)
         FOLDER "Tests"
         OUTPUT_NAME "cuda_${backend}")
 
-      add_test(NAME ${target} COMMAND ${target})
+      if(NOT ${backend} STREQUAL "unified")
+        add_test(NAME ${target} COMMAND ${target})
+      endif()
     endif()
   endforeach()
 endif()


### PR DESCRIPTION
Ccache was configured before CUDA was setup. This caused the launch-nvcc
script to include an empty CUDA_NVCC_EXECUTABLE variable.

Description
-----------
Ccache was configured before CUDA was setup. This caused the launch-nvcc
script to include an empty CUDA_NVCC_EXECUTABLE variable.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
