### PR TITLE
Static MKL build fixes

### DIFF
--- a/src/api/c/device.cpp
+++ b/src/api/c/device.cpp
@@ -108,7 +108,7 @@ af_err af_init() {
         thread_local std::once_flag flag;
         std::call_once(flag, []() {
             getDeviceInfo();
-#if defined(USE_MKL)
+#if defined(USE_MKL) && !defined(USE_STATIC_MKL)
             int errCode = -1;
             // Have used the AF_MKL_INTERFACE_SIZE as regular if's so that
             // we will know if these are not defined when using MKL when a

--- a/src/api/unified/CMakeLists.txt
+++ b/src/api/unified/CMakeLists.txt
@@ -43,9 +43,9 @@ if(OpenCL_FOUND)
     ${CMAKE_CURRENT_SOURCE_DIR}/opencl.cpp
   )
 
-  target_link_libraries(af
+  target_include_directories(af
     PRIVATE
-      OpenCL::OpenCL)
+      $<TARGET_PROPERTY:OpenCL::OpenCL,INTERFACE_INCLUDE_DIRECTORIES>)
 
 endif()
 

--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -320,6 +320,7 @@ if(BUILD_WITH_MKL)
 
   if(AF_WITH_STATIC_MKL)
       target_link_libraries(afcpu PRIVATE MKL::Static)
+      target_compile_definitions(afcpu PRIVATE USE_STATIC_MKL)
   else()
       target_link_libraries(afcpu PRIVATE MKL::RT)
   endif()

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -472,6 +472,7 @@ if(LAPACK_FOUND OR BUILD_WITH_MKL)
 
     if(AF_WITH_STATIC_MKL)
         target_link_libraries(afopencl PRIVATE MKL::Static)
+        target_compile_definitions(afopencl PRIVATE USE_STATIC_MKL)
     else()
         target_link_libraries(afopencl PRIVATE MKL::RT)
     endif()


### PR DESCRIPTION
Fix build when AF_WITH_STATIC_MKL is set to ON. 

Description
-----------
* These errors appeared when we were calling the mkl_set_*_layer functions
to setup the libmkl_rt libray. These functions are not required for static versions of the 
library.
* Remove linking of OpenCL to the unified backend library
Fixes: #3242

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
