### PR TITLE
Add driver checks for CUDA 11.7, Add ccache support, cuSparse Fix

### DIFF
--- a/CMakeModules/config_ccache.cmake
+++ b/CMakeModules/config_ccache.cmake
@@ -1,42 +1,41 @@
 # picked up original content from https://crascit.com/2016/04/09/using-ccache-with-cmake/
 
-if (UNIX)
-  find_program(CCACHE_PROGRAM ccache)
+find_program(CCACHE_PROGRAM ccache)
 
-  set(CCACHE_FOUND OFF)
-  if(CCACHE_PROGRAM)
-    set(CCACHE_FOUND ON)
-  endif()
-
-  option(AF_USE_CCACHE "Use ccache when compiling" ${CCACHE_FOUND})
-
-  if(${AF_USE_CCACHE})
-    # Set up wrapper scripts
-    set(C_LAUNCHER   "${CCACHE_PROGRAM}")
-    set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
-    set(NVCC_LAUNCHER "${CCACHE_PROGRAM}")
-    configure_file(${ArrayFire_SOURCE_DIR}/CMakeModules/launch-c.in   launch-c)
-    configure_file(${ArrayFire_SOURCE_DIR}/CMakeModules/launch-cxx.in launch-cxx)
-    configure_file(${ArrayFire_SOURCE_DIR}/CMakeModules/launch-nvcc.in launch-nvcc)
-    execute_process(COMMAND chmod a+rx
-        "${ArrayFire_BINARY_DIR}/launch-c"
-        "${ArrayFire_BINARY_DIR}/launch-cxx"
-        "${ArrayFire_BINARY_DIR}/launch-nvcc"
-      )
-    if(CMAKE_GENERATOR STREQUAL "Xcode")
-      # Set Xcode project attributes to route compilation and linking
-      # through our scripts
-      set(CMAKE_XCODE_ATTRIBUTE_CC         "${ArrayFire_BINARY_DIR}/launch-c")
-      set(CMAKE_XCODE_ATTRIBUTE_CXX        "${ArrayFire_BINARY_DIR}/launch-cxx")
-      set(CMAKE_XCODE_ATTRIBUTE_LD         "${ArrayFire_BINARY_DIR}/launch-c")
-      set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${ArrayFire_BINARY_DIR}/launch-cxx")
-    else()
-      # Support Unix Makefiles and Ninja
-      set(CMAKE_C_COMPILER_LAUNCHER   "${ArrayFire_BINARY_DIR}/launch-c")
-      set(CMAKE_CXX_COMPILER_LAUNCHER "${ArrayFire_BINARY_DIR}/launch-cxx")
-      set(CUDA_NVCC_EXECUTABLE "${ArrayFire_BINARY_DIR}/launch-nvcc")
-    endif()
-  endif()
-  mark_as_advanced(CCACHE_PROGRAM)
-  mark_as_advanced(AF_USE_CCACHE)
+set(CCACHE_FOUND OFF)
+if(CCACHE_PROGRAM)
+  set(CCACHE_FOUND ON)
 endif()
+
+option(AF_USE_CCACHE "Use ccache when compiling" ${CCACHE_FOUND})
+
+if(${AF_USE_CCACHE})
+  message(STATUS "ccache FOUND: ${CCACHE_PROGRAM}")
+  # Set up wrapper scripts
+  set(C_LAUNCHER   "${CCACHE_PROGRAM}")
+  set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
+  set(NVCC_LAUNCHER "${CCACHE_PROGRAM}")
+  configure_file(${ArrayFire_SOURCE_DIR}/CMakeModules/launch-c.in   launch-c)
+  configure_file(${ArrayFire_SOURCE_DIR}/CMakeModules/launch-cxx.in launch-cxx)
+  configure_file(${ArrayFire_SOURCE_DIR}/CMakeModules/launch-nvcc.in launch-nvcc)
+  execute_process(COMMAND chmod a+rx
+      "${ArrayFire_BINARY_DIR}/launch-c"
+      "${ArrayFire_BINARY_DIR}/launch-cxx"
+      "${ArrayFire_BINARY_DIR}/launch-nvcc"
+    )
+  if(CMAKE_GENERATOR STREQUAL "Xcode")
+    # Set Xcode project attributes to route compilation and linking
+    # through our scripts
+    set(CMAKE_XCODE_ATTRIBUTE_CC         "${ArrayFire_BINARY_DIR}/launch-c")
+    set(CMAKE_XCODE_ATTRIBUTE_CXX        "${ArrayFire_BINARY_DIR}/launch-cxx")
+    set(CMAKE_XCODE_ATTRIBUTE_LD         "${ArrayFire_BINARY_DIR}/launch-c")
+    set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${ArrayFire_BINARY_DIR}/launch-cxx")
+  else()
+    # Support Unix Makefiles and Ninja
+    set(CMAKE_C_COMPILER_LAUNCHER   "${CCACHE_PROGRAM}")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    set(CUDA_NVCC_EXECUTABLE ${CCACHE_PROGRAM} "${CUDA_NVCC_EXECUTABLE}")
+  endif()
+endif()
+mark_as_advanced(CCACHE_PROGRAM)
+mark_as_advanced(AF_USE_CCACHE)

--- a/src/backend/cuda/cusparseModule.cpp
+++ b/src/backend/cuda/cusparseModule.cpp
@@ -22,7 +22,7 @@ cusparseModule::cusparseModule()
 #ifdef AF_cusparse_STATIC_LINKING
     module(nullptr, nullptr)
 #else
-    module("cusparse", nullptr)
+    module({"cusparse"}, {"64_11", "64_10", "64_9", "64_8"}, {""})
 #endif
 {
 #ifdef AF_cusparse_STATIC_LINKING

--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -86,6 +86,7 @@ struct ToolkitDriverVersions {
 
 // clang-format off
 static const int jetsonComputeCapabilities[] = {
+    8070,
     7020,
     6020,
     5030,
@@ -95,6 +96,7 @@ static const int jetsonComputeCapabilities[] = {
 
 // clang-format off
 static const cuNVRTCcompute Toolkit2MaxCompute[] = {
+    {11070, 8, 7, 0},
     {11060, 8, 6, 0},
     {11050, 8, 6, 0},
     {11040, 8, 6, 0},
@@ -129,13 +131,14 @@ struct ComputeCapabilityToStreamingProcessors {
 // clang-format off
 static const ToolkitDriverVersions
     CudaToDriverVersion[] = {
-        {11060, 510.39f, 511.23f},
-        {11050, 495.29f, 496.13f},
-        {11040, 470.42f, 471.11f},
-        {11030, 465.19f, 465.89f},
-        {11020, 460.27f, 460.82f},
-        {11010, 455.23f, 456.38f},
-        {11000, 450.51f, 451.48f},
+        {11070, 450.80f, 452.39f},
+        {11060, 450.80f, 452.39f},
+        {11050, 450.80f, 452.39f},
+        {11040, 450.80f, 452.39f},
+        {11030, 450.80f, 452.39f},
+        {11020, 450.80f, 452.39f},
+        {11010, 450.80f, 452.39f},
+        {11000, 450.36f, 451.22f},
         {10020, 440.33f, 441.22f},
         {10010, 418.39f, 418.96f},
         {10000, 410.48f, 411.31f},
@@ -156,7 +159,7 @@ static ComputeCapabilityToStreamingProcessors gpus[] = {
     {0x21, 48},  {0x30, 192}, {0x32, 192}, {0x35, 192}, {0x37, 192},
     {0x50, 128}, {0x52, 128}, {0x53, 128}, {0x60, 64},  {0x61, 128},
     {0x62, 128}, {0x70, 64},  {0x75, 64},  {0x80, 64},  {0x86, 128},
-    {-1, -1},
+    {0x87, 128}, {-1, -1},
 };
 
 // pulled from CUTIL from CUDA SDK

--- a/src/backend/opencl/jit.cpp
+++ b/src/backend/opencl/jit.cpp
@@ -288,7 +288,7 @@ void evalNodes(vector<Param> &outputs, const vector<Node *> &output_nodes) {
         uint out_elements = outDims[3] * out_info.strides[3];
         uint groups       = divup(out_elements, local_0);
 
-        global_1 = divup(groups, 1000) * local_1;
+        global_1 = divup(groups, work_group_size) * local_1;
         global_0 = divup(groups, global_1) * local_0;
 
     } else {

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -39,8 +39,7 @@
         "cuda": {
             "description": "Build CUDA backend",
             "dependencies": [
-                "cuda",
-                "cudnn"
+                "cuda"
             ]
         },
         "opencl": {
@@ -54,6 +53,12 @@
             "description": "Build with MKL",
             "dependencies": [
                 "intel-mkl"
+            ]
+        },
+        "cudnn": {
+            "description": "Build CUDA with support for cuDNN",
+            "dependencies": [
+                "cudnn"
             ]
         }
     },


### PR DESCRIPTION
This PR add checks for drivers in 11.7 and adds support for ccache on Windows

Description
-----------
* Fixes #3251 Add suffixes for cuSparse DLLs on Windows
* Add support for ccache on Windows
* Add driver checks for CUDA 11.7
* Fix work group calculation issue on OpenCL
* Catch errors when creating OpenCL contexts from Devices

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
