### PR TITLE
Make constructors that accept simple types explicit

### DIFF
--- a/examples/machine_learning/geneticalgorithm.cpp
+++ b/examples/machine_learning/geneticalgorithm.cpp
@@ -123,8 +123,8 @@ void reproducePrint(float& currentMax, array& searchSpace, array& sampleX,
 }
 
 void geneticSearch(bool console, const int nSamples, const int n) {
-    array searchSpaceXDisplay = 0;
-    array searchSpaceYDisplay = 0;
+    array searchSpaceXDisplay;
+    array searchSpaceYDisplay;
     array searchSpace;
     array sampleX;
     array sampleY;
@@ -170,17 +170,18 @@ int main(int argc, char** argv) {
 
     try {
         af::info();
-        printf("** ArrayFire Genetic Algorithm Search Demo **\n\n");
         printf(
-            "Search for trueMax in a search space where the objective function "
-            "is defined as :\n\n");
-        printf("SS(x ,y) = min(x, n - (x + 1)) + min(y, n - (y + 1))\n\n");
-        printf("(x, y) belongs to RxR; R = [0, n); n = %d\n\n", n);
+            "** ArrayFire Genetic Algorithm Search Demo **\n\n"
+            "Search for trueMax in a search space where the objective "
+            "function is defined as :\n\n"
+            "SS(x ,y) = min(x, n - (x + 1)) + min(y, n - (y + 1))\n\n"
+            "(x, y) belongs to RxR; R = [0, n); n = %d\n\n",
+            n);
         if (!console) {
-            printf("The left figure shows the objective function.\n");
             printf(
-                "The figure on the right shows current generation's parameters "
-                "and function values.\n\n");
+                "The left figure shows the objective function.\n"
+                "The right figure shows current generation's "
+                "parameters and function values.\n\n");
         }
         geneticSearch(console, nSamples, n);
     } catch (af::exception& e) { fprintf(stderr, "%s\n", e.what()); }

--- a/include/af/array.h
+++ b/include/af/array.h
@@ -246,6 +246,7 @@ namespace af
                        (default is f32)
 
         */
+        explicit
         array(dim_t dim0, dtype ty = f32);
 
         /**
@@ -271,6 +272,7 @@ namespace af
                        (default is f32)
 
         */
+        explicit
         array(dim_t dim0, dim_t dim1, dtype ty = f32);
 
         /**
@@ -297,6 +299,7 @@ namespace af
                        (default is f32)
 
         */
+        explicit
         array(dim_t dim0, dim_t dim1, dim_t dim2, dtype ty = f32);
 
         /**
@@ -324,6 +327,7 @@ namespace af
                        (default is f32)
 
         */
+        explicit
         array(dim_t dim0, dim_t dim1, dim_t dim2, dim_t dim3, dtype ty = f32);
 
         /**
@@ -368,10 +372,10 @@ namespace af
 
             array A(4, h_buffer);   // copy host data to device
                                     //
-                                    // A = 23
-                                    //   = 34
-                                    //   = 18
-                                    //   = 99
+                                    // A = [23]
+                                    //     [34]
+                                    //     [18]
+                                    //     [99]
 
             \endcode
 
@@ -382,6 +386,7 @@ namespace af
 
         */
         template<typename T>
+        explicit
         array(dim_t dim0,
               const T *pointer, af::source src=afHost);
 
@@ -409,6 +414,7 @@ namespace af
                   format when performing linear algebra operations.
         */
         template<typename T>
+        explicit
         array(dim_t dim0, dim_t dim1,
               const T *pointer, af::source src=afHost);
 
@@ -440,6 +446,7 @@ namespace af
             \image html 3dArray.png
         */
         template<typename T>
+        explicit
         array(dim_t dim0, dim_t dim1, dim_t dim2,
               const T *pointer, af::source src=afHost);
 
@@ -473,6 +480,7 @@ namespace af
 
         */
         template<typename T>
+        explicit
         array(dim_t dim0, dim_t dim1, dim_t dim2, dim_t dim3,
               const T *pointer, af::source src=afHost);
 


### PR DESCRIPTION
Some of the ArrayFire constructors that accept the dim_t type are not
marked explicit. this allows the initialization of the ArrayFire's array
using integer types.

Description
-----------
Some of the ArrayFire constructors that accept the dim_t type are not
marked explicit. this allows the initialization of the ArrayFire's array
using integer types. For example

```
af::array a = 5
```

will create an af::array with 5 elements. This is not intended behavior.

I have looked into the ABI for this change and it doesn't seem to
be affected on GCC. I have to still test this on MSVC. This CAN
break some existing code because it does change the API but ArrayFire
was never designed with this code in mind.

Changes to Users
----------------

This change CAN break some user code.  The following code will break

- Initialize `af::array` using an integer or float
```
array a = 5;
array b = 5.0;
```

- Pass an integer to a function that accepts an array
```
void func(af::array a) {
    ...
}

func(5);
```

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
