### PR TITLE
fixes nanval substitution on new keys

### DIFF
--- a/src/backend/cpu/kernel/reduce.hpp
+++ b/src/backend/cpu/kernel/reduce.hpp
@@ -147,6 +147,7 @@ struct reduce_dim_by_key<op, Ti, Tk, To, 0> {
 
                 current_key = keyval;
                 out_val     = transform(inValsPtr[vOffset + (i * istride)]);
+                if (change_nan) out_val = IS_NAN(out_val) ? nanval : out_val;
                 ++keyidx;
             }
 

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -2285,3 +2285,28 @@ TEST(Reduce, Test_Sum_Global_Array_nanval) {
     ASSERT_NEAR(res, full_reduce.scalar<float>(), max_error);
     freeHost(h_a);
 }
+
+TEST(Reduce, nanval_issue_3255) {
+    char *info_str;
+    af_array  ikeys, ivals, okeys, ovals;
+    dim_t dims[1] = {8};
+
+    int ikeys_src[8] = {0, 0,  1, 1, 1,  2, 2,  0};
+    af_create_array(&ikeys, ikeys_src, 1, dims, u32);
+
+    int i;
+    for (i=0; i<8; i++) {
+        double ivals_src[8] = {1, 2,  3, 4, 5,  6, 7,  8};
+        ivals_src[i] = NAN;
+        af_create_array(&ivals, ivals_src, 1, dims, f64);
+
+        af_product_by_key_nan(&okeys, &ovals, ikeys, ivals, 0, 1.0);
+        af::array ovals_cpp(ovals);
+        ASSERT_FALSE(af::anyTrue<bool>(af::isNaN(ovals_cpp)));
+
+        af_sum_by_key_nan(&okeys, &ovals, ikeys, ivals, 0, 1.0);
+        ovals_cpp = af::array(ovals);
+
+        ASSERT_FALSE(af::anyTrue<bool>(af::isNaN(ovals_cpp)));
+    }
+}


### PR DESCRIPTION
Bugfix PR fixing nanval substitution on new keys.
Previously, nan values would not be replaced if they fell on a key boundary for the CPU backend

* Is this a new feature or a bug fix?
Bug fix
* More detail if necessary to describe all commits in pull request.
Commit includes fix and test
* Potential impact on specific hardware, software or backends.
Fix for CPU backend only, others worked before
* Can this PR be backported to older versions?
Yes


Fixes: #3255 

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass

