### PR TITLE
Restrict initializer list to fundamental types

### DIFF
--- a/include/af/array.h
+++ b/include/af/array.h
@@ -522,7 +522,9 @@ namespace af
 #if AF_API_VERSION >= 38
 #if AF_COMPILER_CXX_GENERALIZED_INITIALIZERS
         /// \brief Initializer list constructor
-        template <typename T> array(std::initializer_list<T> list)
+        template <typename T, typename = typename std::enable_if<
+                                  std::is_fundamental<T>::value, void>::type>
+        array(std::initializer_list<T> list)
         : arr(nullptr) {
           dim_t size = list.size();
           if (af_err __aferr = af_create_array(&arr, list.begin(), 1, &size,
@@ -537,7 +539,8 @@ namespace af
         }
 
         /// \brief Initializer list constructor
-        template <typename T>
+        template <typename T, typename = typename std::enable_if<
+                                  std::is_fundamental<T>::value, void>::type>
         array(const af::dim4 &dims, std::initializer_list<T> list)
             : arr(nullptr) {
           const dim_t *size = dims.get();

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -640,3 +640,24 @@ TEST(Array, ReferenceCount2) {
         ASSERT_REF(d, 0) << "After d = c;";
     }
 }
+
+// This tests situations where the compiler incorrectly assumes the initializer
+// list constructor instead of the regular constructor when using the uniform
+// initilization syntax
+TEST(Array, InitializerListFixAFArray) {
+    array a = randu(1);
+    array b{a};
+
+    ASSERT_ARRAYS_EQ(a, b);
+}
+
+// This tests situations where the compiler incorrectly assumes the initializer
+// list constructor instead of the regular constructor when using the uniform
+// initilization syntax
+TEST(Array, InitializerListFixDim4) {
+    array a            = randu(1);
+    vector<float> data = {3.14f, 3.14f, 3.14f, 3.14f, 3.14f,
+                          3.14f, 3.14f, 3.14f, 3.14f};
+    array b{dim4(3, 3), data.data()};
+    ASSERT_ARRAYS_EQ(constant(3.14, 3, 3), b);
+}


### PR DESCRIPTION
This commit limits the types that can be used in the initializer
list to fundamental types. This change is necessary because when
we use the uniform initialization syntax and pass in an array, the
compiler incorrectly uses the initialization list constructor instead
of the other array constructor.

Description
-----------
Previously the following code was not able to compile:

```
array a = randu(10, 10);
array b{a};
```

This was incorrectly using the initializer list syntax instead of the `af::array(af::array other)` constructor.

Changes to Users
----------------
Users can now use the universal syntax to initialize ArrayFire arrays

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
