### PR TITLE
Move tile function to common namespace. Avoid calling tile from the detail namespace

### DIFF
--- a/src/api/c/assign.cpp
+++ b/src/api/c/assign.cpp
@@ -15,11 +15,11 @@
 #include <common/err_common.hpp>
 #include <common/half.hpp>
 #include <common/moddims.hpp>
+#include <common/tile.hpp>
 #include <copy.hpp>
 #include <handle.hpp>
 #include <indexing_common.hpp>
 #include <math.hpp>
-#include <tile.hpp>
 #include <af/data.h>
 #include <af/defines.h>
 #include <af/dim4.hpp>
@@ -78,7 +78,7 @@ static void assign(Array<Tout>& out, const vector<af_seq> seqs,
         // If both out and in are vectors of equal elements,
         // reshape in to out dims
         Array<Tin> in_ =
-            in.elements() == 1 ? tile(in, oDims) : modDims(in, oDims);
+            in.elements() == 1 ? common::tile(in, oDims) : modDims(in, oDims);
         auto dst = createSubArray<Tout>(out, seqs, false);
 
         copyArray<Tin, Tout>(dst, in_);

--- a/src/api/c/canny.cpp
+++ b/src/api/c/canny.cpp
@@ -14,6 +14,7 @@
 #include <backend.hpp>
 #include <common/cast.hpp>
 #include <common/err_common.hpp>
+#include <common/tile.hpp>
 #include <complex.hpp>
 #include <convolve.hpp>
 #include <copy.hpp>
@@ -25,7 +26,6 @@
 #include <reduce.hpp>
 #include <scan.hpp>
 #include <sobel.hpp>
-#include <tile.hpp>
 #include <transpose.hpp>
 #include <unary.hpp>
 #include <af/defines.h>
@@ -37,6 +37,7 @@
 
 using af::dim4;
 using common::cast;
+using common::tile;
 using detail::arithOp;
 using detail::Array;
 using detail::convolve2;
@@ -137,7 +138,7 @@ Array<float> otsuThreshold(const Array<float>& in, const unsigned NUM_BINS,
 
     ireduce<af_max_t, float>(thresh, locs, sigmas, 0);
 
-    return cast<float, uint>(tile(locs, dim4(inDims[0], inDims[1])));
+    return cast<float, uint>(common::tile(locs, dim4(inDims[0], inDims[1])));
 }
 
 Array<float> normalize(const Array<float>& supEdges, const float minVal,

--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -13,9 +13,9 @@
 #include <common/cast.hpp>
 #include <common/err_common.hpp>
 #include <common/half.hpp>
+#include <common/tile.hpp>
 #include <fftconvolve.hpp>
 #include <handle.hpp>
-#include <tile.hpp>
 #include <af/data.h>
 #include <af/defines.h>
 #include <af/dim4.hpp>
@@ -54,8 +54,8 @@ inline af_array convolve2(const af_array &s, const af_array &c_f,
     const Array<accT> signal    = castArray<accT>(s);
 
     if (colFilter.isScalar() && rowFilter.isScalar()) {
-        Array<accT> colArray = detail::tile(colFilter, signal.dims());
-        Array<accT> rowArray = detail::tile(rowFilter, signal.dims());
+        Array<accT> colArray = common::tile(colFilter, signal.dims());
+        Array<accT> rowArray = common::tile(rowFilter, signal.dims());
 
         Array<accT> filter =
             arithOp<accT, af_mul_t>(colArray, rowArray, signal.dims());

--- a/src/api/c/rgb_gray.cpp
+++ b/src/api/c/rgb_gray.cpp
@@ -17,10 +17,10 @@
 #include <backend.hpp>
 #include <common/ArrayInfo.hpp>
 #include <common/cast.hpp>
+#include <common/tile.hpp>
 #include <handle.hpp>
 #include <join.hpp>
 #include <math.hpp>
-#include <tile.hpp>
 
 using af::dim4;
 using common::cast;
@@ -75,7 +75,7 @@ static af_array gray2rgb(const af_array& in, const float r, const float g,
                          const float b) {
     if (r == 1.0 && g == 1.0 && b == 1.0) {
         dim4 tileDims(1, 1, 3, 1);
-        return getHandle(tile(getArray<T>(in), tileDims));
+        return getHandle(common::tile(getArray<T>(in), tileDims));
     }
 
     af_array mod_input = 0;

--- a/src/api/c/surface.cpp
+++ b/src/api/c/surface.cpp
@@ -15,13 +15,13 @@
 #include <common/err_common.hpp>
 #include <common/graphics_common.hpp>
 #include <common/moddims.hpp>
+#include <common/tile.hpp>
 #include <copy.hpp>
 #include <handle.hpp>
 #include <join.hpp>
 #include <reduce.hpp>
 #include <reorder.hpp>
 #include <surface.hpp>
-#include <tile.hpp>
 
 using af::dim4;
 using common::modDims;
@@ -58,13 +58,13 @@ fg_chart setup_surface(fg_window window, const af_array xVals,
         xIn = modDims(xIn, xIn.elements());
         // Now tile along second dimension
         dim4 x_tdims(1, Y_dims[0], 1, 1);
-        xIn = tile(xIn, x_tdims);
+        xIn = common::tile(xIn, x_tdims);
 
         // Convert yIn to a row vector
         yIn = modDims(yIn, dim4(1, yIn.elements()));
         // Now tile along first dimension
         dim4 y_tdims(X_dims[0], 1, 1, 1);
-        yIn = tile(yIn, y_tdims);
+        yIn = common::tile(yIn, y_tdims);
     }
 
     // Flatten xIn, yIn and zIn into row vectors

--- a/src/api/c/tile.cpp
+++ b/src/api/c/tile.cpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-#include <tile.hpp>
+#include <common/tile.hpp>
 
 #include <arith.hpp>
 #include <backend.hpp>
@@ -33,30 +33,7 @@ using detail::ushort;
 
 template<typename T>
 static inline af_array tile(const af_array in, const af::dim4 &tileDims) {
-    const Array<T> inArray = getArray<T>(in);
-    const dim4 &inDims     = inArray.dims();
-
-    // FIXME: Always use JIT instead of checking for the condition.
-    // The current limitation exists for performance reasons. it should change
-    // in the future.
-
-    bool take_jit_path = true;
-    dim4 outDims(1, 1, 1, 1);
-
-    // Check if JIT path can be taken. JIT path can only be taken if tiling a
-    // singleton dimension.
-    for (int i = 0; i < 4; i++) {
-        take_jit_path &= (inDims[i] == 1 || tileDims[i] == 1);
-        outDims[i] = inDims[i] * tileDims[i];
-    }
-
-    af_array out = nullptr;
-    if (take_jit_path) {
-        out = getHandle(unaryOp<T, af_noop_t>(inArray, outDims));
-    } else {
-        out = getHandle(tile<T>(inArray, tileDims));
-    }
-    return out;
+    return getHandle(common::tile<T>(getArray<T>(in), tileDims));
 }
 
 af_err af_tile(af_array *out, const af_array in, const af::dim4 &tileDims) {

--- a/src/backend/common/tile.hpp
+++ b/src/backend/common/tile.hpp
@@ -1,0 +1,48 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <tile.hpp>
+
+#include <Array.hpp>
+#include <arith.hpp>
+#include <backend.hpp>
+#include <optypes.hpp>
+#include <unary.hpp>
+
+#include <af/dim4.hpp>
+
+namespace common {
+
+/// duplicates the elements of an Array<T> array.
+template<typename T>
+detail::Array<T> tile(const detail::Array<T> &in, const af::dim4 tileDims) {
+    const af::dim4 &inDims = in.dims();
+
+    // FIXME: Always use JIT instead of checking for the condition.
+    // The current limitation exists for performance reasons. it should change
+    // in the future.
+
+    bool take_jit_path = true;
+    af::dim4 outDims(1, 1, 1, 1);
+
+    // Check if JIT path can be taken. JIT path can only be taken if tiling a
+    // singleton dimension.
+    for (int i = 0; i < 4; i++) {
+        take_jit_path &= (inDims[i] == 1 || tileDims[i] == 1);
+        outDims[i] = inDims[i] * tileDims[i];
+    }
+
+    if (take_jit_path) {
+        return detail::unaryOp<T, af_noop_t>(in, outDims);
+    } else {
+        return detail::tile<T>(in, tileDims);
+    }
+}
+
+}  // namespace common


### PR DESCRIPTION
Move the tile function to the common namespace.

Description
-----------
This commit moves the implementation of the tile funciton to the common
namespace. This is done because the tile funciton in detail does not perform JIT
optimization. It instead calls the tile kernel directly. This is undesirable
because there are some instances where tile funciton can be performed by
indexing. This commit also updates several calls to tile in the codebase
to use this new version.

It is still fairly easy to call the detail::tile function and we need to address
this at some point. Perhaps it should be deprecated and only called by the
common::tile function. This commit does not address this issue.


Changes to Users
----------------
<!--
* Additional options added to the build.
* What changes will existing users have to make to their code or build steps?
Refer to [wiki](https://github.com/arrayfire/arrayfire/wiki) for development guidelines
-->

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
