### PR TITLE
Several address sanitizer fixes

### DIFF
--- a/CMakeModules/LSANSuppression.txt
+++ b/CMakeModules/LSANSuppression.txt
@@ -2,11 +2,11 @@
 leak:libnvidia-ptxjitcompile
 leak:tbb::internal::task_stream
 leak:libnvidia-opencl.so
-leak:FFTRepo::FFTRepoKey::privatizeData
 
 # Allocated by Intel's OpenMP implementation during inverse_dense_cpu
 # This is not something we can control in ArrayFire
 leak:kmp_alloc_cpp*::bget
+leak:kmp_b_alloc
 
 # ArrayFire leaks the default random engine on each thread. This is to avoid
 # errors on exit on Windows.

--- a/CMakeModules/build_clFFT.cmake
+++ b/CMakeModules/build_clFFT.cmake
@@ -7,7 +7,7 @@
 
 af_dep_check_and_populate(${clfft_prefix}
   URI https://github.com/arrayfire/clFFT.git
-  REF cmake_fixes
+  REF arrayfire-release
 )
 
 set(current_build_type ${BUILD_SHARED_LIBS})

--- a/src/backend/opencl/memory.hpp
+++ b/src/backend/opencl/memory.hpp
@@ -24,9 +24,10 @@ namespace opencl {
 cl::Buffer *bufferAlloc(const size_t &bytes);
 void bufferFree(cl::Buffer *buf);
 
+using bufptr = std::unique_ptr<cl::Buffer, std::function<void(cl::Buffer *)>>;
+
 template<typename T>
-std::unique_ptr<cl::Buffer, std::function<void(cl::Buffer *)>> memAlloc(
-    const size_t &elements);
+bufptr memAlloc(const size_t &elements);
 void *memAllocUser(const size_t &bytes);
 
 // Need these as 2 separate function and not a default argument

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -432,7 +432,7 @@ make_test(SRC write.cpp)
 make_test(SRC ycbcr_rgb.cpp)
 
 foreach(backend ${enabled_backends})
-  set(target "test_basic_c_${backend}")
+  set(target "basic_c_${backend}")
   add_executable(${target} basic_c.c)
   if(${backend} STREQUAL "unified")
     target_link_libraries(${target}
@@ -443,7 +443,7 @@ foreach(backend ${enabled_backends})
       PRIVATE
       ArrayFire::af${backend})
   endif()
-  add_test(NAME ${target} COMMAND ${target})
+  add_test(NAME test_${target} COMMAND ${target})
 endforeach()
 
 if(AF_TEST_WITH_MTX_FILES)

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -584,14 +584,10 @@ TEST(Array, CopyListInitializerListDim4Assignment) {
 }
 
 TEST(Array, EmptyArrayHostCopy) {
-    EXPECT_EXIT(
-        {
-            af::array empty;
-            std::vector<float> hdata(100);
-            empty.host(hdata.data());
-            exit(0);
-        },
-        ::testing::ExitedWithCode(0), ".*");
+    af::array empty;
+    std::vector<float> hdata(100);
+    empty.host(hdata.data());
+    SUCCEED();
 }
 
 TEST(Array, ReferenceCount1) {

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -2303,10 +2303,14 @@ TEST(Reduce, nanval_issue_3255) {
         af_product_by_key_nan(&okeys, &ovals, ikeys, ivals, 0, 1.0);
         af::array ovals_cpp(ovals);
         ASSERT_FALSE(af::anyTrue<bool>(af::isNaN(ovals_cpp)));
+        ASSERT_SUCCESS(af_release_array(okeys));
 
         af_sum_by_key_nan(&okeys, &ovals, ikeys, ivals, 0, 1.0);
         ovals_cpp = af::array(ovals);
 
         ASSERT_FALSE(af::anyTrue<bool>(af::isNaN(ovals_cpp)));
+        ASSERT_SUCCESS(af_release_array(ivals));
+        ASSERT_SUCCESS(af_release_array(okeys));
     }
+    ASSERT_SUCCESS(af_release_array(ikeys));
 }


### PR DESCRIPTION
This PR addresses several issues found using the Address Sanitizer flag

Description
-----------
* Add missing af_release_array calls in the reduce tests
* Remove an unnecessary death test in array.cpp
* Refactor SIFT to use the memAlloc funciton instead of bufferAlloc function. The new function returns a unique pointer so that RAII handles the releasing of memory
* Rename a test to better align with the other tests
* Fixed a leak in clFFT. This PR updates the reference to the commit of the clFFT project

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
