### PR TITLE
Fix issue where ndims was incorrectly used to calculate shape of input

### DIFF
--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -344,13 +344,16 @@ af_err af_convolve2_nn(af_array *out, const af_array signal,
 
         const af_dtype signalType = sInfo.getType();
 
-        ARG_ASSERT(3, stride_dims > 0 && stride_dims <= 2);
-        ARG_ASSERT(5, padding_dims > 0 && padding_dims <= 2);
-        ARG_ASSERT(7, dilation_dims > 0 && dilation_dims <= 2);
-
         dim4 stride(stride_dims, strides);
         dim4 padding(padding_dims, paddings);
         dim4 dilation(dilation_dims, dilations);
+
+        size_t stride_ndims   = stride.ndims();
+        size_t padding_ndims  = padding.ndims();
+        size_t dilation_ndims = dilation.ndims();
+        ARG_ASSERT(3, stride_ndims > 0 && stride_ndims <= 2);
+        ARG_ASSERT(5, padding_ndims >= 0 && padding_ndims <= 2);
+        ARG_ASSERT(7, dilation_ndims > 0 && dilation_ndims <= 2);
 
         // assert number of features matches between signal and filter
         DIM_ASSERT(1, sDims[2] == fDims[2]);
@@ -424,13 +427,16 @@ af_err af_convolve2_gradient_nn(
 
         af_array output;
 
-        ARG_ASSERT(3, stride_dims > 0 && stride_dims <= 2);
-        ARG_ASSERT(5, padding_dims > 0 && padding_dims <= 2);
-        ARG_ASSERT(7, dilation_dims > 0 && dilation_dims <= 2);
-
         af::dim4 stride(stride_dims, strides);
         af::dim4 padding(padding_dims, paddings);
         af::dim4 dilation(dilation_dims, dilations);
+
+        size_t stride_ndims   = stride.ndims();
+        size_t padding_ndims  = padding.ndims();
+        size_t dilation_ndims = dilation.ndims();
+        ARG_ASSERT(3, stride_ndims > 0 && stride_ndims <= 2);
+        ARG_ASSERT(5, padding_ndims > 0 && padding_ndims <= 2);
+        ARG_ASSERT(7, dilation_ndims > 0 && dilation_ndims <= 2);
 
         af_dtype type = oinfo.getType();
         switch (type) {


### PR DESCRIPTION
Fix the assertion to validate the input shape of the stride, padding and dilation array

Description
-----------
In C functions, the way the shapes of the input shapes are passed into functions is
using  an array of dim_t values and an unsigned integer. The unsigned integer is used
to indicate how many values are in the input array. It does not indicate the number of
axis of the resulting dim4 object. This distinction caused an error with the new
convolve functions.

Changes to Users
----------------
Users will be able to pass any values to the stride_dims, padding_dims and dilation_dims
values.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
