### PR TITLE
Added device_pointer, a class to encapsulate device data passed to a CUDA kernel.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ conan.lock
 graph_info.json
 .ccls-cache
 .projectile
+/.vs/arrayfire/FileContentIndex
+/.vs/arrayfire/v17
+/.vs

--- a/include/af/array.h
+++ b/include/af/array.h
@@ -11,6 +11,7 @@
 #include <af/compilers.h>
 #include <af/defines.h>
 #include <af/device.h>
+#include <af/device_pointer.h>
 #include <af/dim4.hpp>
 #include <af/exception.h>
 #include <af/index.h>
@@ -967,6 +968,7 @@ namespace af
         /// \returns an array with the type specified by \p type
         const array as(dtype type) const;
 
+        template<typename Type> operator af::device_pointer<Type>() { return af::device_pointer<Type>(this, dims(), device<Type>()); }
 
         ~array();
 

--- a/include/af/device_pointer.h
+++ b/include/af/device_pointer.h
@@ -1,0 +1,34 @@
+#include<arrayfire.h>
+#include<cuda_runtime.h>
+
+namespace af
+{
+	template<typename Type>
+	class device_pointer {
+
+		af::array* parent;
+
+	public:
+
+		int cols;
+		int rows;
+
+		Type* data;
+
+		device_pointer(af::array* _parent, dim4 _dims, Type* _data) {
+			parent = _parent;
+			cols = _dims[0];
+			rows = _dims[1];
+			data = _data;
+		}
+
+		__device__ Type& operator ()(int col, int row = 0) { return data[(col * rows) + row]; }
+
+		//parent array unlocks once the device_pointer falls out of scope
+		~device_pointer() {
+			parent->unlock();
+		}
+
+	};
+
+}


### PR DESCRIPTION
adds device_pointer, a class which encapsulates device data to be accessed inside of a CUDA kernel. The class allows use of the parenthetical operator to access data, and calls array.device() and array.unlock() automatically.


Description
-----------

This is the first PR I've submitted to an open source project, so I know there's a lot I will need to correct before it can be accepted. The issues that I'm aware of: The includes are incorrect, and the code is probably not situated correctly within the project. At the moment, the code doesn't compile. It does compile without the \_\_device__ macro, however, so I believe it is close to compilation. Either way, I've brought it as far as I can without further guidance (particularly in regards to the project structure). 

This is a new feature. I decided to add it while using arrayfire alongside CUDA kernels. I based the functionality off of OpenCV's GpuMat and PtrStepSz classes, which do more or less the same thing (i.e. allow the matrix container to be passed directly to a CUDA kernel). I hope this feature will make CUDA interoperability smoother and more intuitive for the user. I suspect this change will not play nice with the backend (especially calling unlock() for the parent array), but I don't know enough about the backend to anticipate exactly what could go wrong. I plan to dive further into how it interacts with the backend once I get the code properly situated within the project. 

The feature itself: device_pointer is a class which encapsulates a pointer to device data, and allows access to that data using the parenthetical operators (x, y). At the moment it can only handle 1d and 2d arrays. The class works by overloading the typecast operator between af::array and device_pointer. The typecast is called automatically when the array is passed into a CUDA kernel which is expecting a device_pointer as an argument. The array is locked automatically during the typecast, by calling array.device() as one of its arguments. I tried naively to make it unlock the array automatically as well, when the pointer falls out of scope. I'm not extremely confident that this last part will work, and I will need to perform further testing before the code is ready to merge.


Changes to Users
----------------

user now has the option to use device_pointer to access device data within CUDA kernels.


Checklist
---------
<!-- Check if done or not applicable -->
- [X] Rebased on latest master
- [ ] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
