### PR TITLE
Avoid overriding `CMAKE_INSTALL_RPATH` on macOS.

### DIFF
--- a/.github/workflows/unix_cpu_build.yml
+++ b/.github/workflows/unix_cpu_build.yml
@@ -102,6 +102,7 @@ jobs:
                   dashboard=$(if [ -z "$prnum" ]; then echo "Continuous"; else echo "Experimental"; fi)
                   backend=$(if [ "$USE_MKL" == 1 ]; then echo "Intel-MKL"; else echo "FFTW/LAPACK/BLAS"; fi)
                   buildname="$buildname-cpu-$BLAS_BACKEND"
+                  cmake_rpath=$(if [ $OS_NAME == 'macos-latest' ]; then echo "-DCMAKE_INSTALL_RPATH=/opt/arrayfire/lib"; fi)
                   mkdir build && cd build
                   ${CMAKE_PROGRAM} -G Ninja \
                       -DCMAKE_MAKE_PROGRAM:FILEPATH=${GITHUB_WORKSPACE}/ninja \
@@ -109,6 +110,7 @@ jobs:
                       -DAF_BUILD_UNIFIED:BOOL=OFF -DAF_BUILD_EXAMPLES:BOOL=ON \
                       -DAF_BUILD_FORGE:BOOL=ON \
                       -DAF_COMPUTE_LIBRARY:STRING=${backend} \
+                      "$cmake_rpath" \
                       -DBUILDNAME:STRING=${buildname} ..
                   echo "CTEST_DASHBOARD=${dashboard}" >> $GITHUB_ENV
 

--- a/CMakeModules/InternalUtils.cmake
+++ b/CMakeModules/InternalUtils.cmake
@@ -177,8 +177,8 @@ macro(arrayfire_set_cmake_default_variables)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${ArrayFire_BINARY_DIR}/bin)
   endif()
 
-  if(APPLE)
-    list(APPEND CMAKE_INSTALL_RPATH "/opt/arrayfire/lib")
+  if(APPLE AND (NOT DEFINED CMAKE_INSTALL_RPATH))
+      message(WARNING "CMAKE_INSTALL_RPATH is required when installing ArrayFire to the local system. Set it to /opt/arrayfire/lib if making the installer or your own custom install path.")
   endif()
 
   # This code is used to generate the compilers.h file in CMakeModules. Not all

--- a/CMakeModules/InternalUtils.cmake
+++ b/CMakeModules/InternalUtils.cmake
@@ -177,8 +177,8 @@ macro(arrayfire_set_cmake_default_variables)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${ArrayFire_BINARY_DIR}/bin)
   endif()
 
-  if(APPLE AND (NOT DEFINED CMAKE_INSTALL_RPATH))
-    set(CMAKE_INSTALL_RPATH "/opt/arrayfire/lib")
+  if(APPLE)
+    list(APPEND CMAKE_INSTALL_RPATH "/opt/arrayfire/lib")
   endif()
 
   # This code is used to generate the compilers.h file in CMakeModules. Not all

--- a/CMakeModules/InternalUtils.cmake
+++ b/CMakeModules/InternalUtils.cmake
@@ -177,7 +177,7 @@ macro(arrayfire_set_cmake_default_variables)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${ArrayFire_BINARY_DIR}/bin)
   endif()
 
-  if(APPLE)
+  if(APPLE AND (NOT DEFINED CMAKE_INSTALL_RPATH))
     set(CMAKE_INSTALL_RPATH "/opt/arrayfire/lib")
   endif()
 


### PR DESCRIPTION
Description
-----------

Currently, `InternalUtils.cmake` sets `CMAKE_INSTALL_RPATH` on macOS to
`/opt/arrayfire/lib`. This is not always the install location (e.g. if a
user sets `CMAKE_INSTALL_PREFIX`), nor does it always make sense to only
have a single `LC_RPATH` command inside the libraries on macOS.

In particular, if a user passes `CMAKE_INSTALL_RPATH` from the
command-line on macOS, it would be good to avoid overriding that, since
the user is more likely to supply the correct paths for their system
than keeping a fixed value of `/opt/arrayfire/lib`.

Changes to Users
----------------
There are no changes that users need to make, but this does allow them to
set `CMAKE_INSTALL_RPATH` on macOS if they need to.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented

The last three items are not really applicable, but I checked them as indicated by the PR template.
