### PR TITLE
diagonal port to oneapi. its tests pass except *LargeDim* and *GFOR*

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -206,6 +206,7 @@ target_sources(afoneapi
   PRIVATE
     kernel/KParam.hpp
     kernel/assign.hpp
+    kernel/diagonal.hpp
     kernel/iota.hpp
     kernel/memcopy.hpp
     kernel/random_engine.hpp

--- a/src/backend/oneapi/diagonal.cpp
+++ b/src/backend/oneapi/diagonal.cpp
@@ -11,7 +11,7 @@
 #include <common/half.hpp>
 #include <diagonal.hpp>
 #include <err_oneapi.hpp>
-//#include <kernel/diagonal.hpp>
+#include <kernel/diagonal.hpp>
 #include <math.hpp>
 #include <af/dim4.hpp>
 
@@ -20,19 +20,22 @@ using common::half;
 namespace oneapi {
 template<typename T>
 Array<T> diagCreate(const Array<T> &in, const int num) {
-    ONEAPI_NOT_SUPPORTED("");
     int size     = in.dims()[0] + std::abs(num);
     int batch    = in.dims()[1];
     Array<T> out = createEmptyArray<T>(dim4(size, size, batch));
+
+    kernel::diagCreate<T>(out, in, num);
+
     return out;
 }
 
 template<typename T>
 Array<T> diagExtract(const Array<T> &in, const int num) {
-    ONEAPI_NOT_SUPPORTED("");
     const dim_t *idims = in.dims().get();
     dim_t size         = std::min(idims[0], idims[1]) - std::abs(num);
     Array<T> out       = createEmptyArray<T>(dim4(size, 1, idims[2], idims[3]));
+
+    kernel::diagExtract<T>(out, in, num);
 
     return out;
 }

--- a/src/backend/oneapi/kernel/diagonal.hpp
+++ b/src/backend/oneapi/kernel/diagonal.hpp
@@ -1,0 +1,163 @@
+/*******************************************************
+ * Copyright (c) 2022 ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+#include <err_oneapi.hpp>
+#include <traits.hpp>
+
+#include <string>
+#include <vector>
+
+namespace oneapi {
+namespace kernel {
+
+template<typename T, int dimensions>
+using local_accessor =
+    sycl::accessor<T, dimensions, sycl::access::mode::read_write,
+                   sycl::access::target::local>;
+
+template<typename T>
+class diagCreateKernel {
+   public:
+    diagCreateKernel(sycl::accessor<T> oData, KParam oInfo,
+                     sycl::accessor<T> iData, KParam iInfo, int num,
+                     int groups_x)
+        : oData_(oData)
+        , oInfo_(oInfo)
+        , iData_(iData)
+        , iInfo_(iInfo)
+        , num_(num)
+        , groups_x_(groups_x) {}
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g      = it.get_group();
+        unsigned idz       = g.get_group_id(0) / groups_x_;
+        unsigned groupId_x = g.get_group_id(0) - idz * groups_x_;
+
+        unsigned idx = it.get_local_id(0) + groupId_x * g.get_local_range(0);
+        unsigned idy = it.get_global_id(1);
+
+        if (idx >= oInfo_.dims[0] || idy >= oInfo_.dims[1] ||
+            idz >= oInfo_.dims[2])
+            return;
+
+        T *optr = oData_.get_pointer();
+        optr += idz * oInfo_.strides[2] + idy * oInfo_.strides[1] + idx;
+
+        const T *iptr = iData_.get_pointer();
+        iptr +=
+            idz * iInfo_.strides[1] + ((num_ > 0) ? idx : idy) + iInfo_.offset;
+
+        T val = (idx == (idy - num_)) ? *iptr : (T)(0);
+        *optr = val;
+    }
+
+   private:
+    sycl::accessor<T> oData_;
+    KParam oInfo_;
+    sycl::accessor<T> iData_;
+    KParam iInfo_;
+    int num_;
+    int groups_x_;
+};
+
+template<typename T>
+static void diagCreate(Param<T> out, Param<T> in, int num) {
+    auto local   = sycl::range{32, 8};
+    int groups_x = divup(out.info.dims[0], local[0]);
+    int groups_y = divup(out.info.dims[1], local[1]);
+    auto global  = sycl::range{groups_x * local[0] * out.info.dims[2],
+                              groups_y * local[1]};
+
+    getQueue().submit([&](sycl::handler &h) {
+        auto oData = out.data->get_access(h);
+        auto iData = in.data->get_access(h);
+        sycl::stream debugStream(128, 128, h);
+
+        h.parallel_for(sycl::nd_range{global, local},
+                       diagCreateKernel<T>(oData, out.info, iData, in.info, num,
+                                           groups_x));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename T>
+class diagExtractKernel {
+   public:
+    diagExtractKernel(sycl::accessor<T> oData, KParam oInfo,
+                      sycl::accessor<T> iData, KParam iInfo, int num,
+                      int groups_z)
+        : oData_(oData)
+        , oInfo_(oInfo)
+        , iData_(iData)
+        , iInfo_(iInfo)
+        , num_(num)
+        , groups_z_(groups_z) {}
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+        unsigned idw  = g.get_group_id(1) / groups_z_;
+        unsigned idz  = g.get_group_id(1) - idw * groups_z_;
+
+        unsigned idx = it.get_global_id(0);
+
+        if (idx >= oInfo_.dims[0] || idz >= oInfo_.dims[2] ||
+            idw >= oInfo_.dims[3])
+            return;
+
+        T *optr = oData_.get_pointer();
+        optr += idz * oInfo_.strides[2] + idw * oInfo_.strides[3] + idx;
+
+        if (idx >= iInfo_.dims[0] || idx >= iInfo_.dims[1]) {
+            *optr = (T)(0);
+            return;
+        }
+
+        int i_off = (num_ > 0) ? (num_ * iInfo_.strides[1] + idx)
+                               : (idx - num_) + iInfo_.offset;
+
+        const T *iptr = iData_.get_pointer();
+        iptr += idz * iInfo_.strides[2] + idw * iInfo_.strides[3] + i_off;
+
+        *optr = iptr[idx * iInfo_.strides[1]];
+    }
+
+   private:
+    sycl::accessor<T> oData_;
+    KParam oInfo_;
+    sycl::accessor<T> iData_;
+    KParam iInfo_;
+    int num_;
+    int groups_z_;
+};
+
+template<typename T>
+static void diagExtract(Param<T> out, Param<T> in, int num) {
+    auto local   = sycl::range{256, 1};
+    int groups_x = divup(out.info.dims[0], local[0]);
+    int groups_z = out.info.dims[2];
+    auto global  = sycl::range{groups_x * local[0],
+                              groups_z * local[1] * out.info.dims[3]};
+
+    getQueue().submit([&](sycl::handler &h) {
+        auto oData = out.data->get_access(h);
+        auto iData = in.data->get_access(h);
+        sycl::stream debugStream(128, 128, h);
+
+        h.parallel_for(sycl::nd_range{global, local},
+                       diagExtractKernel<T>(oData, out.info, iData, in.info,
+                                            num, groups_z));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+}  // namespace kernel
+}  // namespace oneapi


### PR DESCRIPTION
Description
-----------
These changes constitute a partially-functioning port of the "diagonal" function to OneAPI. Its tests pass except for those fitting the patterns "*LargeDim*" or "*GFOR*". The former fails due to missing "getMaxMemorySize()" on the OneAPI backend and "GFOR" is not expected to function.

Checklist
---------
- [X] Rebased on latest master
- [X] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
