### PR TITLE
diff port to oneapi. its tests pass except *LargeDim* and *GFOR*

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -206,6 +206,7 @@ target_sources(afoneapi
   PRIVATE
     kernel/KParam.hpp
     kernel/assign.hpp
+    kernel/diff.hpp
     kernel/iota.hpp
     kernel/memcopy.hpp
     kernel/random_engine.hpp

--- a/src/backend/oneapi/diff.cpp
+++ b/src/backend/oneapi/diff.cpp
@@ -9,8 +9,7 @@
 
 #include <Array.hpp>
 #include <diff.hpp>
-//#include <kernel/diff.hpp>
-#include <err_oneapi.hpp>
+#include <kernel/diff.hpp>
 #include <af/dim4.hpp>
 #include <stdexcept>
 
@@ -18,7 +17,6 @@ namespace oneapi {
 
 template<typename T>
 Array<T> diff(const Array<T> &in, const int dim, const bool isDiff2) {
-    ONEAPI_NOT_SUPPORTED("");
     const af::dim4 &iDims = in.dims();
     af::dim4 oDims        = iDims;
     oDims[dim] -= (isDiff2 + 1);
@@ -27,18 +25,17 @@ Array<T> diff(const Array<T> &in, const int dim, const bool isDiff2) {
         throw std::runtime_error("Elements are 0");
     }
     Array<T> out = createEmptyArray<T>(oDims);
+    kernel::diff<T>(out, in, in.ndims(), dim, isDiff2);
     return out;
 }
 
 template<typename T>
 Array<T> diff1(const Array<T> &in, const int dim) {
-    ONEAPI_NOT_SUPPORTED("");
     return diff<T>(in, dim, false);
 }
 
 template<typename T>
 Array<T> diff2(const Array<T> &in, const int dim) {
-    ONEAPI_NOT_SUPPORTED("");
     return diff<T>(in, dim, true);
 }
 

--- a/src/backend/oneapi/kernel/diff.hpp
+++ b/src/backend/oneapi/kernel/diff.hpp
@@ -1,0 +1,124 @@
+/*******************************************************
+ * Copyright (c) 2022 ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+#include <err_oneapi.hpp>
+#include <traits.hpp>
+
+#include <string>
+#include <vector>
+
+namespace oneapi {
+namespace kernel {
+
+template<typename T, int dimensions>
+using local_accessor =
+    sycl::accessor<T, dimensions, sycl::access::mode::read_write,
+                   sycl::access::target::local>;
+
+template<typename T>
+class diffKernel {
+   public:
+    diffKernel(sycl::accessor<T> outAcc, const sycl::accessor<T> inAcc,
+               const KParam op, const KParam ip, const int oElem,
+               const int blocksPerMatX, const int blocksPerMatY,
+               const bool isDiff2, const unsigned DIM)
+        : outAcc_(outAcc)
+        , inAcc_(inAcc)
+        , op_(op)
+        , ip_(ip)
+        , oElem_(oElem)
+        , blocksPerMatX_(blocksPerMatX)
+        , blocksPerMatY_(blocksPerMatY)
+        , isDiff2_(isDiff2)
+        , DIM_(DIM) {}
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+        const int idz = g.get_group_id(0) / blocksPerMatX_;
+        const int idw = g.get_group_id(1) / blocksPerMatY_;
+
+        const int blockIdx_x = g.get_group_id(0) - idz * blocksPerMatX_;
+        const int blockIdx_y = g.get_group_id(1) - idw * blocksPerMatY_;
+
+        const int idx = it.get_local_id(0) + blockIdx_x * g.get_local_range(0);
+        const int idy = it.get_local_id(1) + blockIdx_y * g.get_local_range(1);
+
+        if (idx >= op_.dims[0] || idy >= op_.dims[1] || idz >= op_.dims[2] ||
+            idw >= op_.dims[3])
+            return;
+
+        int iMem0 = idw * ip_.strides[3] + idz * ip_.strides[2] +
+                    idy * ip_.strides[1] + idx;
+        int iMem1 = iMem0 + ip_.strides[DIM_];
+        int iMem2 = iMem1 + ip_.strides[DIM_];
+
+        int oMem = idw * op_.strides[3] + idz * op_.strides[2] +
+                   idy * op_.strides[1] + idx;
+
+        iMem2 *= isDiff2_;
+
+        T *out      = outAcc_.get_pointer();
+        const T *in = inAcc_.get_pointer() + ip_.offset;
+        if (isDiff2_ == 0) {
+            out[oMem] = in[iMem1] - in[iMem0];
+        } else {
+            out[oMem] = in[iMem2] - in[iMem1] - in[iMem1] + in[iMem0];
+        }
+
+        // diff_this(out, in + ip.offset, oMem, iMem0, iMem1, iMem2);
+    }
+
+   private:
+    sycl::accessor<T> outAcc_;
+    const sycl::accessor<T> inAcc_;
+    const KParam op_;
+    const KParam ip_;
+    const int oElem_;
+    const int blocksPerMatX_;
+    const int blocksPerMatY_;
+    const bool isDiff2_;
+    const unsigned DIM_;
+};
+
+template<typename T>
+void diff(Param<T> out, const Param<T> in, const unsigned indims,
+          const unsigned dim, const bool isDiff2) {
+    constexpr int TX = 16;
+    constexpr int TY = 16;
+
+    auto local = sycl::range{TX, TY};
+    if (dim == 0 && indims == 1) { local = sycl::range{TX * TY, 1}; }
+
+    int blocksPerMatX = divup(out.info.dims[0], local[0]);
+    int blocksPerMatY = divup(out.info.dims[1], local[1]);
+    auto global       = sycl::range{local[0] * blocksPerMatX * out.info.dims[2],
+                              local[1] * blocksPerMatY * out.info.dims[3]};
+
+    const int oElem = out.info.dims[0] * out.info.dims[1] * out.info.dims[2] *
+                      out.info.dims[3];
+
+    getQueue().submit([&](sycl::handler &h) {
+        auto inAcc  = in.data->get_access(h);
+        auto outAcc = out.data->get_access(h);
+        sycl::stream debugStream(128, 128, h);
+
+        h.parallel_for(
+            sycl::nd_range{global, local},
+            diffKernel<T>(outAcc, inAcc, out.info, in.info, oElem,
+                          blocksPerMatX, blocksPerMatY, isDiff2, dim));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+}  // namespace kernel
+}  // namespace oneapi


### PR DESCRIPTION
Description
-----------
These changes constitute a partially-functioning port of the "diff" function to OneAPI. Its tests pass except for those fitting the patterns "*LargeDim*" or "*GFOR*". The former fails due to missing "getMaxMemorySize()" on the OneAPI backend and "GFOR" is not expected to function.

Checklist
---------
- [X] Rebased on latest master
- [X] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
