### PR TITLE
unified backend: fix missing tweaks necessary for new oneapi backend

### DIFF
--- a/src/api/unified/symbol_manager.hpp
+++ b/src/api/unified/symbol_manager.hpp
@@ -23,7 +23,7 @@
 
 namespace unified {
 
-const int NUM_BACKENDS = 3;
+const int NUM_BACKENDS = 4;
 
 #define UNIFIED_ERROR_LOAD_LIB()                                       \
     AF_RETURN_ERROR(                                                   \

--- a/src/backend/common/ArrayInfo.cpp
+++ b/src/backend/common/ArrayInfo.cpp
@@ -59,7 +59,7 @@ af_backend ArrayInfo::getBackendId() const {
     // devId >> 8 converts the backend info to 1, 2, 4 which are enums
     // for CPU, CUDA and OpenCL respectively
     // See ArrayInfo.hpp for more
-    unsigned backendId = devId >> 8U;
+    unsigned backendId = devId >> 9U;
     return static_cast<af_backend>(backendId);
 }
 


### PR DESCRIPTION
Description
-----------
The unified backend `./test/transpose_unified` now runs while failing expected tests due to dimension limits and missing JIT.

The unified backend failed to appropriately bit-shift the new `devId` associated with the new OneAPI backend. The code also incorrectly specified the wrong number of backends (3) while there are now 4.

Checklist
---------
<!-- Check if done or not applicable -->
- [X] Rebased on latest master
- [X] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
