### PR TITLE
Fix the backend id encoding for the oneAPI backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,6 +322,7 @@ else()
   set_target_properties(bin2cpp
     PROPERTIES
       CXX_STANDARD 17)
+  target_link_libraries(bin2cpp PRIVATE nonstd::span-lite)
 
   # NOSPDLOG is used to remove the spdlog dependency from bin2cpp
   target_compile_definitions(bin2cpp PRIVATE NOSPDLOG)

--- a/src/api/unified/symbol_manager.hpp
+++ b/src/api/unified/symbol_manager.hpp
@@ -23,7 +23,7 @@
 
 namespace unified {
 
-const int NUM_BACKENDS = 3;
+const int NUM_BACKENDS = 4;
 
 #define UNIFIED_ERROR_LOAD_LIB()                                       \
     AF_RETURN_ERROR(                                                   \
@@ -37,6 +37,7 @@ static inline int backend_index(af::Backend be) {
         case AF_BACKEND_CPU: return 0;
         case AF_BACKEND_CUDA: return 1;
         case AF_BACKEND_OPENCL: return 2;
+        case AF_BACKEND_ONEAPI: return 3;
         default: return -1;
     }
 }

--- a/src/backend/common/ArrayInfo.cpp
+++ b/src/backend/common/ArrayInfo.cpp
@@ -38,26 +38,18 @@ unsigned ArrayInfo::getDevId() const {
 }
 
 void ArrayInfo::setId(int id) const {
-    // 1 << (backendId + 8) sets the 9th, 10th or 11th bit of devId to 1
-    // for CPU, CUDA and OpenCL respectively
-    // See ArrayInfo.hpp for more
-    unsigned backendId =
-        detail::getBackend() >> 1U;  // Convert enums 1, 2, 4 to ints 0, 1, 2
-    const_cast<ArrayInfo *>(this)->setId(id | 1 << (backendId + 8U));
+    const_cast<ArrayInfo *>(this)->setId(id);
 }
 
 void ArrayInfo::setId(int id) {
-    // 1 << (backendId + 8) sets the 9th, 10th or 11th bit of devId to 1
-    // for CPU, CUDA and OpenCL respectively
-    // See ArrayInfo.hpp for more
-    unsigned backendId =
-        detail::getBackend() >> 1U;  // Convert enums 1, 2, 4 to ints 0, 1, 2
-    devId = id | 1U << (backendId + 8U);
+    /// Shift the backend flag to the end of the devId integer
+    unsigned backendId = detail::getBackend();
+    devId              = id | backendId << 8U;
 }
 
 af_backend ArrayInfo::getBackendId() const {
     // devId >> 8 converts the backend info to 1, 2, 4 which are enums
-    // for CPU, CUDA and OpenCL respectively
+    // for CPU, CUDA, OpenCL, and oneAPI respectively
     // See ArrayInfo.hpp for more
     unsigned backendId = devId >> 8U;
     return static_cast<af_backend>(backendId);

--- a/src/backend/common/ArrayInfo.hpp
+++ b/src/backend/common/ArrayInfo.hpp
@@ -28,7 +28,8 @@ class ArrayInfo {
     // The devId variable stores information about the deviceId as well as the
     // backend. The 8 LSBs (0-7) are used to store the device ID. The 09th LSB
     // is set to 1 if backend is CPU The 10th LSB is set to 1 if backend is CUDA
-    // The 11th LSB is set to 1 if backend is OpenCL
+    // The 11th LSB is set to 1 if backend is OpenCL The 12th LSB is set to 1
+    // for oneAPI
     // This information can be retrieved directly from an af_array by doing
     //     int* devId = reinterpret_cast<int*>(a); // a is an af_array
     //     af_backend backendID = *devId >> 8;   // Returns 1, 2, 4 for CPU,

--- a/src/backend/common/TemplateArg.cpp
+++ b/src/backend/common/TemplateArg.cpp
@@ -34,6 +34,11 @@ template string toString<double>(double);
 template string toString<long double>(long double);
 
 template<>
+string toString(TemplateArg arg) {
+    return arg._tparam;
+}
+
+template<>
 string toString(bool val) {
     return string(val ? "true" : "false");
 }

--- a/src/backend/common/TemplateArg.hpp
+++ b/src/backend/common/TemplateArg.hpp
@@ -9,10 +9,15 @@
 
 #pragma once
 
+#include <array>
 #include <string>
 #include <utility>
 
 #include <optypes.hpp>
+#include <traits.hpp>
+
+template<typename T>
+class TemplateTypename;
 
 template<typename T>
 std::string toString(T value);
@@ -25,8 +30,17 @@ struct TemplateArg {
     TemplateArg(std::string str) : _tparam(std::move(str)) {}
 
     template<typename T>
+    constexpr TemplateArg(TemplateTypename<T> arg) noexcept : _tparam(arg) {}
+
+    template<typename T>
     constexpr TemplateArg(T value) noexcept : _tparam(toString(value)) {}
 };
+
+template<typename... Targs>
+std::array<TemplateArg, sizeof...(Targs)> TemplateArgs(Targs &&...args) {
+    return std::array<TemplateArg, sizeof...(Targs)>{
+        std::forward<Targs>(args)...};
+}
 
 #define DefineKey(arg) " -D " #arg
 #define DefineValue(arg) " -D " #arg "=" + toString(arg)

--- a/src/backend/common/TemplateTypename.hpp
+++ b/src/backend/common/TemplateTypename.hpp
@@ -19,14 +19,18 @@ struct TemplateTypename {
     operator TemplateArg() const noexcept {
         return {std::string(dtype_traits<T>::getName())};
     }
+    operator std::string() const noexcept {
+        return {std::string(dtype_traits<T>::getName())};
+    }
 };
 
-#define SPECIALIZE(TYPE, NAME)                      \
-    template<>                                      \
-    struct TemplateTypename<TYPE> {                 \
-        operator TemplateArg() const noexcept {     \
-            return TemplateArg(std::string(#NAME)); \
-        }                                           \
+#define SPECIALIZE(TYPE, NAME)                                  \
+    template<>                                                  \
+    struct TemplateTypename<TYPE> {                             \
+        operator TemplateArg() const noexcept {                 \
+            return TemplateArg(std::string(#NAME));             \
+        }                                                       \
+        operator std::string() const noexcept { return #NAME; } \
     }
 
 SPECIALIZE(unsigned char, detail::uchar);

--- a/src/backend/common/compile_module.hpp
+++ b/src/backend/common/compile_module.hpp
@@ -14,6 +14,7 @@
 #include <Module.hpp>
 #include <backend.hpp>
 
+#include <nonstd/span.hpp>
 #include <string>
 #include <vector>
 
@@ -43,9 +44,9 @@ namespace common {
 ///
 /// \returns Backend specific binary module that contains associated kernel
 detail::Module compileModule(const std::string& moduleKey,
-                             const std::vector<std::string>& sources,
-                             const std::vector<std::string>& options,
-                             const std::vector<std::string>& kInstances,
+                             nonstd::span<const std::string> sources,
+                             nonstd::span<const std::string> options,
+                             nonstd::span<const std::string> kInstances,
                              const bool isJIT);
 
 /// \brief Load module binary from disk cache

--- a/src/backend/common/kernel_cache.hpp
+++ b/src/backend/common/kernel_cache.hpp
@@ -17,6 +17,7 @@
 #include <common/TemplateTypename.hpp>
 #include <common/util.hpp>
 
+#include <nonstd/span.hpp>
 #include <string>
 #include <vector>
 
@@ -46,7 +47,7 @@ namespace common {
 /// Example Usage: transpose
 ///
 /// \code
-/// auto transpose = getKernel("cuda::transpose", {transpase_cuh_src},
+/// auto transpose = getKernel("cuda::transpose", std::array{transpase_cuh_src},
 ///         {
 ///           TemplateTypename<T>(),
 ///           TemplateArg(conjugate),
@@ -70,9 +71,9 @@ namespace common {
 ///            the kernel compilation.
 ///
 detail::Kernel getKernel(const std::string& kernelName,
-                         const std::vector<common::Source>& sources,
-                         const std::vector<TemplateArg>& templateArgs,
-                         const std::vector<std::string>& options = {},
+                         nonstd::span<const common::Source> sources,
+                         nonstd::span<const TemplateArg> templateArgs,
+                         nonstd::span<const std::string> options = {},
                          const bool sourceIsJIT                  = false);
 
 /// \brief Lookup a Module that matches the given key

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -23,6 +23,7 @@
 #include <common/util.hpp>
 #include <af/defines.h>
 
+#include <nonstd/span.hpp>
 #include <sys/stat.h>
 #include <algorithm>
 #include <cstdio>
@@ -34,6 +35,7 @@
 #include <thread>
 #include <vector>
 
+using nonstd::span;
 using std::accumulate;
 using std::hash;
 using std::ofstream;
@@ -248,13 +250,13 @@ size_t deterministicHash(const string& data, const size_t prevHash) {
     return deterministicHash(data.data(), data.size(), prevHash);
 }
 
-size_t deterministicHash(const vector<string>& list, const size_t prevHash) {
+size_t deterministicHash(span<const string> list, const size_t prevHash) {
     size_t hash = prevHash;
     for (auto s : list) { hash = deterministicHash(s.data(), s.size(), hash); }
     return hash;
 }
 
-size_t deterministicHash(const vector<common::Source>& list) {
+size_t deterministicHash(span<const common::Source> list) {
     // Combine the different source codes, via their hashes
     size_t hash = FNV1A_BASE_OFFSET;
     for (auto s : list) {

--- a/src/backend/common/util.hpp
+++ b/src/backend/common/util.hpp
@@ -12,6 +12,7 @@
 
 #include <af/defines.h>
 
+#include <nonstd/span.hpp>
 #include <iosfwd>
 #include <string>
 #include <vector>
@@ -78,8 +79,8 @@ std::size_t deterministicHash(const std::string& data,
                               const std::size_t prevHash = FNV1A_BASE_OFFSET);
 
 // This concatenates strings in the vector and computes hash
-std::size_t deterministicHash(const std::vector<std::string>& list,
+std::size_t deterministicHash(nonstd::span<const std::string> list,
                               const std::size_t prevHash = FNV1A_BASE_OFFSET);
 
 // This concatenates hashes of multiple sources
-std::size_t deterministicHash(const std::vector<common::Source>& list);
+std::size_t deterministicHash(nonstd::span<const common::Source> list);

--- a/src/backend/cuda/compile_module.cpp
+++ b/src/backend/cuda/compile_module.cpp
@@ -64,6 +64,7 @@
 using namespace cuda;
 
 using detail::Module;
+using nonstd::span;
 using std::accumulate;
 using std::array;
 using std::back_insert_iterator;
@@ -140,9 +141,9 @@ string getKernelCacheFilename(const int device, const string &key) {
 
 namespace common {
 
-Module compileModule(const string &moduleKey, const vector<string> &sources,
-                     const vector<string> &opts,
-                     const vector<string> &kInstances, const bool sourceIsJIT) {
+Module compileModule(const string &moduleKey, span<const string> sources,
+                     span<const string> opts, span<const string> kInstances,
+                     const bool sourceIsJIT) {
     nvrtcProgram prog;
     if (sourceIsJIT) {
         constexpr const char *header_names[] = {

--- a/src/backend/cuda/jit.cpp
+++ b/src/backend/cuda/jit.cpp
@@ -318,7 +318,8 @@ static CUfunction getKernel(const vector<Node*>& output_nodes,
         const common::Source jit_src{jitKer.c_str(), jitKer.size(),
                                      deterministicHash(jitKer)};
 
-        return common::getKernel(funcName, {jit_src}, {}, {}, true).get();
+        return common::getKernel(funcName, std::array{jit_src}, {}, {}, true)
+            .get();
     }
     return common::getKernel(entry, funcName, true).get();
 }

--- a/src/backend/cuda/kernel/anisotropic_diffusion.hpp
+++ b/src/backend/cuda/kernel/anisotropic_diffusion.hpp
@@ -27,10 +27,11 @@ template<typename T>
 void anisotropicDiffusion(Param<T> inout, const float dt, const float mct,
                           const af::fluxFunction fftype, bool isMCDE) {
     auto diffUpdate = common::getKernel(
-        "cuda::diffUpdate", {anisotropic_diffusion_cuh_src},
-        {TemplateTypename<T>(), TemplateArg(fftype), TemplateArg(isMCDE)},
-        {DefineValue(THREADS_X), DefineValue(THREADS_Y),
-         DefineValue(YDIM_LOAD)});
+        "cuda::diffUpdate", std::array{anisotropic_diffusion_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(fftype),
+                     TemplateArg(isMCDE)),
+        std::array{DefineValue(THREADS_X), DefineValue(THREADS_Y),
+                   DefineValue(YDIM_LOAD)});
 
     dim3 threads(THREADS_X, THREADS_Y, 1);
 

--- a/src/backend/cuda/kernel/approx.hpp
+++ b/src/backend/cuda/kernel/approx.hpp
@@ -27,10 +27,10 @@ template<typename Ty, typename Tp>
 void approx1(Param<Ty> yo, CParam<Ty> yi, CParam<Tp> xo, const int xdim,
              const Tp &xi_beg, const Tp &xi_step, const float offGrid,
              const af::interpType method, const int order) {
-    auto approx1 =
-        common::getKernel("cuda::approx1", {approx1_cuh_src},
-                          {TemplateTypename<Ty>(), TemplateTypename<Tp>(),
-                           TemplateArg(xdim), TemplateArg(order)});
+    auto approx1 = common::getKernel(
+        "cuda::approx1", std::array{approx1_cuh_src},
+        TemplateArgs(TemplateTypename<Ty>(), TemplateTypename<Tp>(),
+                     TemplateArg(xdim), TemplateArg(order)));
 
     dim3 threads(THREADS, 1, 1);
     int blocksPerMat = divup(yo.dims[0], threads.x);
@@ -57,9 +57,9 @@ void approx2(Param<Ty> zo, CParam<Ty> zi, CParam<Tp> xo, const int xdim,
              const Tp &yi_beg, const Tp &yi_step, const float offGrid,
              const af::interpType method, const int order) {
     auto approx2 = common::getKernel(
-        "cuda::approx2", {approx2_cuh_src},
-        {TemplateTypename<Ty>(), TemplateTypename<Tp>(), TemplateArg(xdim),
-         TemplateArg(ydim), TemplateArg(order)});
+        "cuda::approx2", std::array{approx2_cuh_src},
+        TemplateArgs(TemplateTypename<Ty>(), TemplateTypename<Tp>(),
+                     TemplateArg(xdim), TemplateArg(ydim), TemplateArg(order)));
 
     dim3 threads(TX, TY, 1);
     int blocksPerMatX = divup(zo.dims[0], threads.x);

--- a/src/backend/cuda/kernel/assign.hpp
+++ b/src/backend/cuda/kernel/assign.hpp
@@ -22,8 +22,9 @@ void assign(Param<T> out, CParam<T> in, const AssignKernelParam& p) {
     constexpr int THREADS_X = 32;
     constexpr int THREADS_Y = 8;
 
-    auto assignKer = common::getKernel("cuda::assign", {assign_cuh_src},
-                                       {TemplateTypename<T>()});
+    auto assignKer =
+        common::getKernel("cuda::assign", std::array{assign_cuh_src},
+                          TemplateArgs(TemplateTypename<T>()));
 
     const dim3 threads(THREADS_X, THREADS_Y);
 

--- a/src/backend/cuda/kernel/bilateral.hpp
+++ b/src/backend/cuda/kernel/bilateral.hpp
@@ -23,9 +23,9 @@ template<typename inType, typename outType>
 void bilateral(Param<outType> out, CParam<inType> in, float s_sigma,
                float c_sigma) {
     auto bilateral = common::getKernel(
-        "cuda::bilateral", {bilateral_cuh_src},
-        {TemplateTypename<inType>(), TemplateTypename<outType>()},
-        {DefineValue(THREADS_X), DefineValue(THREADS_Y)});
+        "cuda::bilateral", std::array{bilateral_cuh_src},
+        TemplateArgs(TemplateTypename<inType>(), TemplateTypename<outType>()),
+        std::array{DefineValue(THREADS_X), DefineValue(THREADS_Y)});
 
     dim3 threads(kernel::THREADS_X, kernel::THREADS_Y);
 

--- a/src/backend/cuda/kernel/canny.hpp
+++ b/src/backend/cuda/kernel/canny.hpp
@@ -27,9 +27,10 @@ template<typename T>
 void nonMaxSuppression(Param<T> output, CParam<T> magnitude, CParam<T> dx,
                        CParam<T> dy) {
     auto nonMaxSuppress = common::getKernel(
-        "cuda::nonMaxSuppression", {canny_cuh_src}, {TemplateTypename<T>()},
-        {DefineValue(STRONG), DefineValue(WEAK), DefineValue(NOEDGE),
-         DefineValue(THREADS_X), DefineValue(THREADS_Y)});
+        "cuda::nonMaxSuppression", std::array{canny_cuh_src},
+        TemplateArgs(TemplateTypename<T>()),
+        std::array{DefineValue(STRONG), DefineValue(WEAK), DefineValue(NOEDGE),
+                   DefineValue(THREADS_X), DefineValue(THREADS_Y)});
 
     dim3 threads(kernel::THREADS_X, kernel::THREADS_Y);
 
@@ -48,17 +49,20 @@ void nonMaxSuppression(Param<T> output, CParam<T> magnitude, CParam<T> dx,
 template<typename T>
 void edgeTrackingHysteresis(Param<T> output, CParam<T> strong, CParam<T> weak) {
     auto initEdgeOut = common::getKernel(
-        "cuda::initEdgeOut", {canny_cuh_src}, {TemplateTypename<T>()},
-        {DefineValue(STRONG), DefineValue(WEAK), DefineValue(NOEDGE),
-         DefineValue(THREADS_X), DefineValue(THREADS_Y)});
+        "cuda::initEdgeOut", std::array{canny_cuh_src},
+        TemplateArgs(TemplateTypename<T>()),
+        std::array{DefineValue(STRONG), DefineValue(WEAK), DefineValue(NOEDGE),
+                   DefineValue(THREADS_X), DefineValue(THREADS_Y)});
     auto edgeTrack = common::getKernel(
-        "cuda::edgeTrack", {canny_cuh_src}, {TemplateTypename<T>()},
-        {DefineValue(STRONG), DefineValue(WEAK), DefineValue(NOEDGE),
-         DefineValue(THREADS_X), DefineValue(THREADS_Y)});
+        "cuda::edgeTrack", std::array{canny_cuh_src},
+        TemplateArgs(TemplateTypename<T>()),
+        std::array{DefineValue(STRONG), DefineValue(WEAK), DefineValue(NOEDGE),
+                   DefineValue(THREADS_X), DefineValue(THREADS_Y)});
     auto suppressLeftOver = common::getKernel(
-        "cuda::suppressLeftOver", {canny_cuh_src}, {TemplateTypename<T>()},
-        {DefineValue(STRONG), DefineValue(WEAK), DefineValue(NOEDGE),
-         DefineValue(THREADS_X), DefineValue(THREADS_Y)});
+        "cuda::suppressLeftOver", std::array{canny_cuh_src},
+        TemplateArgs(TemplateTypename<T>()),
+        std::array{DefineValue(STRONG), DefineValue(WEAK), DefineValue(NOEDGE),
+                   DefineValue(THREADS_X), DefineValue(THREADS_Y)});
 
     dim3 threads(kernel::THREADS_X, kernel::THREADS_Y);
 

--- a/src/backend/cuda/kernel/convolve.hpp
+++ b/src/backend/cuda/kernel/convolve.hpp
@@ -101,9 +101,11 @@ template<typename T, typename aT>
 void convolve_1d(conv_kparam_t& p, Param<T> out, CParam<T> sig, CParam<aT> filt,
                  const bool expand) {
     auto convolve1 = common::getKernel(
-        "cuda::convolve1", {convolve1_cuh_src},
-        {TemplateTypename<T>(), TemplateTypename<aT>(), TemplateArg(expand)},
-        {DefineValue(MAX_CONV1_FILTER_LEN), DefineValue(CONV_THREADS)});
+        "cuda::convolve1", std::array{convolve1_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateTypename<aT>(),
+                     TemplateArg(expand)),
+        std::array{DefineValue(MAX_CONV1_FILTER_LEN),
+                   DefineValue(CONV_THREADS)});
 
     prepareKernelArgs<T>(p, out.dims, filt.dims, 1);
 
@@ -156,11 +158,11 @@ void conv2Helper(const conv_kparam_t& p, Param<T> out, CParam<T> sig,
     }
 
     auto convolve2 = common::getKernel(
-        "cuda::convolve2", {convolve2_cuh_src},
-        {TemplateTypename<T>(), TemplateTypename<aT>(), TemplateArg(expand),
-         TemplateArg(f0), TemplateArg(f1)},
-        {DefineValue(MAX_CONV1_FILTER_LEN), DefineValue(CONV_THREADS),
-         DefineValue(CONV2_THREADS_X), DefineValue(CONV2_THREADS_Y)});
+        "cuda::convolve2", std::array{convolve2_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateTypename<aT>(),
+                     TemplateArg(expand), TemplateArg(f0), TemplateArg(f1)),
+        std::array{DefineValue(MAX_CONV1_FILTER_LEN), DefineValue(CONV_THREADS),
+                   DefineValue(CONV2_THREADS_X), DefineValue(CONV2_THREADS_Y)});
 
     // FIXME: case where filter array is strided
     auto constMemPtr = convolve2.getDevPtr(conv_c_name);
@@ -201,11 +203,12 @@ template<typename T, typename aT>
 void convolve_3d(conv_kparam_t& p, Param<T> out, CParam<T> sig, CParam<aT> filt,
                  const bool expand) {
     auto convolve3 = common::getKernel(
-        "cuda::convolve3", {convolve3_cuh_src},
-        {TemplateTypename<T>(), TemplateTypename<aT>(), TemplateArg(expand)},
-        {DefineValue(MAX_CONV1_FILTER_LEN), DefineValue(CONV_THREADS),
-         DefineValue(CONV3_CUBE_X), DefineValue(CONV3_CUBE_Y),
-         DefineValue(CONV3_CUBE_Z)});
+        "cuda::convolve3", std::array{convolve3_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateTypename<aT>(),
+                     TemplateArg(expand)),
+        std::array{DefineValue(MAX_CONV1_FILTER_LEN), DefineValue(CONV_THREADS),
+                   DefineValue(CONV3_CUBE_X), DefineValue(CONV3_CUBE_Y),
+                   DefineValue(CONV3_CUBE_Z)});
 
     prepareKernelArgs<T>(p, out.dims, filt.dims, 3);
 
@@ -305,11 +308,12 @@ void convolve2(Param<T> out, CParam<T> signal, CParam<aT> filter, int conv_dim,
     }
 
     auto convolve2_separable = common::getKernel(
-        "cuda::convolve2_separable", {convolve_separable_cuh_src},
-        {TemplateTypename<T>(), TemplateTypename<aT>(), TemplateArg(conv_dim),
-         TemplateArg(expand), TemplateArg(fLen)},
-        {DefineValue(MAX_SCONV_FILTER_LEN), DefineValue(SCONV_THREADS_X),
-         DefineValue(SCONV_THREADS_Y)});
+        "cuda::convolve2_separable", std::array{convolve_separable_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateTypename<aT>(),
+                     TemplateArg(conv_dim), TemplateArg(expand),
+                     TemplateArg(fLen)),
+        std::array{DefineValue(MAX_SCONV_FILTER_LEN),
+                   DefineValue(SCONV_THREADS_X), DefineValue(SCONV_THREADS_Y)});
 
     dim3 threads(SCONV_THREADS_X, SCONV_THREADS_Y);
 

--- a/src/backend/cuda/kernel/diagonal.hpp
+++ b/src/backend/cuda/kernel/diagonal.hpp
@@ -20,8 +20,9 @@ namespace kernel {
 
 template<typename T>
 void diagCreate(Param<T> out, CParam<T> in, int num) {
-    auto genDiagMat = common::getKernel(
-        "cuda::createDiagonalMat", {diagonal_cuh_src}, {TemplateTypename<T>()});
+    auto genDiagMat = common::getKernel("cuda::createDiagonalMat",
+                                        std::array{diagonal_cuh_src},
+                                        TemplateArgs(TemplateTypename<T>()));
 
     dim3 threads(32, 8);
     int blocks_x = divup(out.dims[0], threads.x);
@@ -45,8 +46,9 @@ void diagCreate(Param<T> out, CParam<T> in, int num) {
 
 template<typename T>
 void diagExtract(Param<T> out, CParam<T> in, int num) {
-    auto extractDiag = common::getKernel(
-        "cuda::extractDiagonal", {diagonal_cuh_src}, {TemplateTypename<T>()});
+    auto extractDiag =
+        common::getKernel("cuda::extractDiagonal", std::array{diagonal_cuh_src},
+                          TemplateArgs(TemplateTypename<T>()));
 
     dim3 threads(256, 1);
     int blocks_x = divup(out.dims[0], threads.x);

--- a/src/backend/cuda/kernel/diff.hpp
+++ b/src/backend/cuda/kernel/diff.hpp
@@ -24,9 +24,10 @@ void diff(Param<T> out, CParam<T> in, const int indims, const unsigned dim,
     constexpr unsigned TX = 16;
     constexpr unsigned TY = 16;
 
-    auto diff = common::getKernel(
-        "cuda::diff", {diff_cuh_src},
-        {TemplateTypename<T>(), TemplateArg(dim), TemplateArg(isDiff2)});
+    auto diff =
+        common::getKernel("cuda::diff", std::array{diff_cuh_src},
+                          TemplateArgs(TemplateTypename<T>(), TemplateArg(dim),
+                                       TemplateArg(isDiff2)));
 
     dim3 threads(TX, TY, 1);
 

--- a/src/backend/cuda/kernel/exampleFunction.hpp
+++ b/src/backend/cuda/kernel/exampleFunction.hpp
@@ -27,11 +27,9 @@ static const unsigned TY = 16;  // Kernel Launch Config Values
 
 template<typename T>  // CUDA kernel wrapper function
 void exampleFunc(Param<T> c, CParam<T> a, CParam<T> b, const af_someenum_t p) {
-    auto exampleFunc =
-        common::getKernel("cuda::exampleFunc", {exampleFunction_cuh_src},
-                          {
-                              TemplateTypename<T>(),
-                          });
+    auto exampleFunc = common::getKernel("cuda::exampleFunc",
+                                         std::array{exampleFunction_cuh_src},
+                                         TemplateArgs(TemplateTypename<T>()));
 
     dim3 threads(TX, TY, 1);  // set your cuda launch config for blocks
 

--- a/src/backend/cuda/kernel/fftconvolve.hpp
+++ b/src/backend/cuda/kernel/fftconvolve.hpp
@@ -23,12 +23,12 @@ static const int THREADS = 256;
 template<typename convT, typename T>
 void packDataHelper(Param<convT> sig_packed, Param<convT> filter_packed,
                     CParam<T> sig, CParam<T> filter) {
-    auto packData =
-        common::getKernel("cuda::packData", {fftconvolve_cuh_src},
-                          {TemplateTypename<convT>(), TemplateTypename<T>()});
-    auto padArray =
-        common::getKernel("cuda::padArray", {fftconvolve_cuh_src},
-                          {TemplateTypename<convT>(), TemplateTypename<T>()});
+    auto packData = common::getKernel(
+        "cuda::packData", std::array{fftconvolve_cuh_src},
+        TemplateArgs(TemplateTypename<convT>(), TemplateTypename<T>()));
+    auto padArray = common::getKernel(
+        "cuda::padArray", std::array{fftconvolve_cuh_src},
+        TemplateArgs(TemplateTypename<convT>(), TemplateTypename<T>()));
 
     dim_t *sd = sig.dims;
 
@@ -67,9 +67,9 @@ void packDataHelper(Param<convT> sig_packed, Param<convT> filter_packed,
 template<typename T, typename convT>
 void complexMultiplyHelper(Param<convT> sig_packed, Param<convT> filter_packed,
                            AF_BATCH_KIND kind) {
-    auto cplxMul =
-        common::getKernel("cuda::complexMultiply", {fftconvolve_cuh_src},
-                          {TemplateTypename<convT>(), TemplateArg(kind)});
+    auto cplxMul = common::getKernel(
+        "cuda::complexMultiply", std::array{fftconvolve_cuh_src},
+        TemplateArgs(TemplateTypename<convT>(), TemplateArg(kind)));
 
     int sig_packed_elem    = 1;
     int filter_packed_elem = 1;
@@ -100,10 +100,10 @@ void reorderOutputHelper(Param<T> out, Param<convT> packed, CParam<T> sig,
                          CParam<T> filter, bool expand, int rank) {
     constexpr bool RoundResult = std::is_integral<T>::value;
 
-    auto reorderOut =
-        common::getKernel("cuda::reorderOutput", {fftconvolve_cuh_src},
-                          {TemplateTypename<T>(), TemplateTypename<convT>(),
-                           TemplateArg(expand), TemplateArg(RoundResult)});
+    auto reorderOut = common::getKernel(
+        "cuda::reorderOutput", std::array{fftconvolve_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateTypename<convT>(),
+                     TemplateArg(expand), TemplateArg(RoundResult)));
 
     dim_t *sd    = sig.dims;
     int fftScale = 1;

--- a/src/backend/cuda/kernel/flood_fill.hpp
+++ b/src/backend/cuda/kernel/flood_fill.hpp
@@ -45,13 +45,16 @@ void floodFill(Param<T> out, CParam<T> image, CParam<uint> seedsx,
         CUDA_NOT_SUPPORTED(errMessage);
     }
 
-    auto initSeeds = common::getKernel("cuda::initSeeds", {flood_fill_cuh_src},
-                                       {TemplateTypename<T>()});
+    auto initSeeds =
+        common::getKernel("cuda::initSeeds", std::array{flood_fill_cuh_src},
+                          TemplateArgs(TemplateTypename<T>()));
     auto floodStep = common::getKernel(
-        "cuda::floodStep", {flood_fill_cuh_src}, {TemplateTypename<T>()},
-        {DefineValue(THREADS_X), DefineValue(THREADS_Y)});
+        "cuda::floodStep", std::array{flood_fill_cuh_src},
+        TemplateArgs(TemplateTypename<T>()),
+        std::array{DefineValue(THREADS_X), DefineValue(THREADS_Y)});
     auto finalizeOutput = common::getKernel(
-        "cuda::finalizeOutput", {flood_fill_cuh_src}, {TemplateTypename<T>()});
+        "cuda::finalizeOutput", std::array{flood_fill_cuh_src},
+        TemplateArgs(TemplateTypename<T>()));
 
     EnqueueArgs qArgs(dim3(divup(seedsx.elements(), THREADS)), dim3(THREADS),
                       getActiveStream());

--- a/src/backend/cuda/kernel/gradient.hpp
+++ b/src/backend/cuda/kernel/gradient.hpp
@@ -15,6 +15,8 @@
 #include <debug_cuda.hpp>
 #include <nvrtc_kernel_headers/gradient_cuh.hpp>
 
+#include <array>
+
 namespace cuda {
 namespace kernel {
 
@@ -23,9 +25,10 @@ void gradient(Param<T> grad0, Param<T> grad1, CParam<T> in) {
     constexpr unsigned TX = 32;
     constexpr unsigned TY = 8;
 
-    auto gradient = common::getKernel("cuda::gradient", {gradient_cuh_src},
-                                      {TemplateTypename<T>()},
-                                      {DefineValue(TX), DefineValue(TY)});
+    auto gradient =
+        common::getKernel("cuda::gradient", std::array{gradient_cuh_src},
+                          TemplateArgs(TemplateTypename<T>()),
+                          std::array{DefineValue(TX), DefineValue(TY)});
 
     dim3 threads(TX, TY, 1);
 

--- a/src/backend/cuda/kernel/histogram.hpp
+++ b/src/backend/cuda/kernel/histogram.hpp
@@ -23,10 +23,10 @@ constexpr int THRD_LOAD = 16;
 template<typename T>
 void histogram(Param<uint> out, CParam<T> in, int nbins, float minval,
                float maxval, bool isLinear) {
-    auto histogram =
-        common::getKernel("cuda::histogram", {histogram_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(isLinear)},
-                          {DefineValue(MAX_BINS), DefineValue(THRD_LOAD)});
+    auto histogram = common::getKernel(
+        "cuda::histogram", std::array{histogram_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(isLinear)),
+        std::array{DefineValue(MAX_BINS), DefineValue(THRD_LOAD)});
 
     dim3 threads(kernel::THREADS_X, 1);
 

--- a/src/backend/cuda/kernel/hsv_rgb.hpp
+++ b/src/backend/cuda/kernel/hsv_rgb.hpp
@@ -21,9 +21,9 @@ static const int THREADS_Y = 16;
 
 template<typename T>
 void hsv2rgb_convert(Param<T> out, CParam<T> in, bool isHSV2RGB) {
-    auto hsvrgbConverter =
-        common::getKernel("cuda::hsvrgbConverter", {hsv_rgb_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(isHSV2RGB)});
+    auto hsvrgbConverter = common::getKernel(
+        "cuda::hsvrgbConverter", std::array{hsv_rgb_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(isHSV2RGB)));
 
     const dim3 threads(THREADS_X, THREADS_Y);
 

--- a/src/backend/cuda/kernel/identity.hpp
+++ b/src/backend/cuda/kernel/identity.hpp
@@ -20,8 +20,9 @@ namespace kernel {
 
 template<typename T>
 void identity(Param<T> out) {
-    auto identity = common::getKernel("cuda::identity", {identity_cuh_src},
-                                      {TemplateTypename<T>()});
+    auto identity =
+        common::getKernel("cuda::identity", std::array{identity_cuh_src},
+                          TemplateArgs(TemplateTypename<T>()));
 
     dim3 threads(32, 8);
     int blocks_x = divup(out.dims[0], threads.x);

--- a/src/backend/cuda/kernel/iir.hpp
+++ b/src/backend/cuda/kernel/iir.hpp
@@ -22,9 +22,10 @@ template<typename T, bool batch_a>
 void iir(Param<T> y, CParam<T> c, CParam<T> a) {
     constexpr int MAX_A_SIZE = 1024;
 
-    auto iir = common::getKernel("cuda::iir", {iir_cuh_src},
-                                 {TemplateTypename<T>(), TemplateArg(batch_a)},
-                                 {DefineValue(MAX_A_SIZE)});
+    auto iir = common::getKernel(
+        "cuda::iir", std::array{iir_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(batch_a)),
+        std::array{DefineValue(MAX_A_SIZE)});
 
     const int blocks_y = y.dims[1];
     const int blocks_x = y.dims[2];

--- a/src/backend/cuda/kernel/index.hpp
+++ b/src/backend/cuda/kernel/index.hpp
@@ -21,8 +21,8 @@ namespace kernel {
 
 template<typename T>
 void index(Param<T> out, CParam<T> in, const IndexKernelParam& p) {
-    auto index = common::getKernel("cuda::index", {index_cuh_src},
-                                   {TemplateTypename<T>()});
+    auto index = common::getKernel("cuda::index", std::array{index_cuh_src},
+                                   TemplateArgs(TemplateTypename<T>()));
     dim3 threads;
     switch (out.dims[1]) {
         case 1: threads.y = 1; break;

--- a/src/backend/cuda/kernel/iota.hpp
+++ b/src/backend/cuda/kernel/iota.hpp
@@ -26,8 +26,8 @@ void iota(Param<T> out, const af::dim4 &sdims) {
     constexpr unsigned TILEX   = 512;
     constexpr unsigned TILEY   = 32;
 
-    auto iota = common::getKernel("cuda::iota", {iota_cuh_src},
-                                  {TemplateTypename<T>()});
+    auto iota = common::getKernel("cuda::iota", std::array{iota_cuh_src},
+                                  TemplateArgs(TemplateTypename<T>()));
 
     dim3 threads(IOTA_TX, IOTA_TY, 1);
 

--- a/src/backend/cuda/kernel/ireduce.hpp
+++ b/src/backend/cuda/kernel/ireduce.hpp
@@ -37,10 +37,10 @@ void ireduce_dim_launcher(Param<T> out, uint *olptr, CParam<T> in,
     blocks.y = divup(blocks.y, blocks.z);
 
     auto ireduceDim = common::getKernel(
-        "cuda::ireduceDim", {ireduce_cuh_src},
-        {TemplateTypename<T>(), TemplateArg(op), TemplateArg(dim),
-         TemplateArg(is_first), TemplateArg(threads_y)},
-        {DefineValue(THREADS_X)});
+        "cuda::ireduceDim", std::array{ireduce_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(op), TemplateArg(dim),
+                     TemplateArg(is_first), TemplateArg(threads_y)),
+        std::array{DefineValue(THREADS_X)});
 
     EnqueueArgs qArgs(blocks, threads, getActiveStream());
 
@@ -104,11 +104,11 @@ void ireduce_first_launcher(Param<T> out, uint *olptr, CParam<T> in,
     uint repeat = divup(in.dims[0], (blocks_x * threads_x));
 
     // threads_x can take values 32, 64, 128, 256
-    auto ireduceFirst =
-        common::getKernel("cuda::ireduceFirst", {ireduce_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(op),
-                           TemplateArg(is_first), TemplateArg(threads_x)},
-                          {DefineValue(THREADS_PER_BLOCK)});
+    auto ireduceFirst = common::getKernel(
+        "cuda::ireduceFirst", std::array{ireduce_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(op),
+                     TemplateArg(is_first), TemplateArg(threads_x)),
+        std::array{DefineValue(THREADS_PER_BLOCK)});
 
     EnqueueArgs qArgs(blocks, threads, getActiveStream());
 

--- a/src/backend/cuda/kernel/lookup.hpp
+++ b/src/backend/cuda/kernel/lookup.hpp
@@ -43,9 +43,9 @@ void lookup(Param<in_t> out, CParam<in_t> in, CParam<idx_t> indices, int nDims,
         dim3 blocks(blks, 1);
 
         auto lookup1d = common::getKernel(
-            "cuda::lookup1D", {lookup_cuh_src},
-            {TemplateTypename<in_t>(), TemplateTypename<idx_t>()},
-            {DefineValue(THREADS), DefineValue(THRD_LOAD)});
+            "cuda::lookup1D", std::array{lookup_cuh_src},
+            TemplateArgs(TemplateTypename<in_t>(), TemplateTypename<idx_t>()),
+            std::array{DefineValue(THREADS), DefineValue(THRD_LOAD)});
 
         EnqueueArgs qArgs(blocks, threads, getActiveStream());
 
@@ -63,10 +63,10 @@ void lookup(Param<in_t> out, CParam<in_t> in, CParam<idx_t> indices, int nDims,
         blocks.z = divup(blocks.y, maxBlocksY);
         blocks.y = divup(blocks.y, blocks.z);
 
-        auto lookupnd =
-            common::getKernel("cuda::lookupND", {lookup_cuh_src},
-                              {TemplateTypename<in_t>(),
-                               TemplateTypename<idx_t>(), TemplateArg(dim)});
+        auto lookupnd = common::getKernel(
+            "cuda::lookupND", std::array{lookup_cuh_src},
+            TemplateArgs(TemplateTypename<in_t>(), TemplateTypename<idx_t>(),
+                         TemplateArg(dim)));
         EnqueueArgs qArgs(blocks, threads, getActiveStream());
 
         lookupnd(qArgs, out, in, indices, blks_x, blks_y);

--- a/src/backend/cuda/kernel/lu_split.hpp
+++ b/src/backend/cuda/kernel/lu_split.hpp
@@ -15,6 +15,8 @@
 #include <debug_cuda.hpp>
 #include <nvrtc_kernel_headers/lu_split_cuh.hpp>
 
+#include <array>
+
 namespace cuda {
 namespace kernel {
 
@@ -28,9 +30,9 @@ void lu_split(Param<T> lower, Param<T> upper, Param<T> in) {
     const bool sameDims =
         lower.dims[0] == in.dims[0] && lower.dims[1] == in.dims[1];
 
-    auto luSplit =
-        common::getKernel("cuda::luSplit", {lu_split_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(sameDims)});
+    auto luSplit = common::getKernel(
+        "cuda::luSplit", std::array{lu_split_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(sameDims)));
 
     dim3 threads(TX, TY, 1);
 

--- a/src/backend/cuda/kernel/match_template.hpp
+++ b/src/backend/cuda/kernel/match_template.hpp
@@ -25,9 +25,9 @@ void matchTemplate(Param<outType> out, CParam<inType> srch,
                    CParam<inType> tmplt, const af::matchType mType,
                    bool needMean) {
     auto matchTemplate = common::getKernel(
-        "cuda::matchTemplate", {match_template_cuh_src},
-        {TemplateTypename<inType>(), TemplateTypename<outType>(),
-         TemplateArg(mType), TemplateArg(needMean)});
+        "cuda::matchTemplate", std::array{match_template_cuh_src},
+        TemplateArgs(TemplateTypename<inType>(), TemplateTypename<outType>(),
+                     TemplateArg(mType), TemplateArg(needMean)));
 
     const dim3 threads(THREADS_X, THREADS_Y);
 

--- a/src/backend/cuda/kernel/meanshift.hpp
+++ b/src/backend/cuda/kernel/meanshift.hpp
@@ -13,6 +13,7 @@
 #include <debug_cuda.hpp>
 #include <nvrtc_kernel_headers/meanshift_cuh.hpp>
 
+#include <array>
 #include <type_traits>
 
 namespace cuda {
@@ -27,11 +28,10 @@ void meanshift(Param<T> out, CParam<T> in, const float spatialSigma,
     typedef typename std::conditional<std::is_same<T, double>::value, double,
                                       float>::type AccType;
     auto meanshift = common::getKernel(
-        "cuda::meanshift", {meanshift_cuh_src},
-        {
-            TemplateTypename<AccType>(), TemplateTypename<T>(),
-            TemplateArg((IsColor ? 3 : 1))  // channels
-        });
+        "cuda::meanshift", std::array{meanshift_cuh_src},
+        TemplateArgs(TemplateTypename<AccType>(), TemplateTypename<T>(),
+                     TemplateArg((IsColor ? 3 : 1))  // channels
+                     ));
 
     static dim3 threads(kernel::THREADS_X, kernel::THREADS_Y);
 

--- a/src/backend/cuda/kernel/medfilt.hpp
+++ b/src/backend/cuda/kernel/medfilt.hpp
@@ -26,11 +26,11 @@ template<typename T>
 void medfilt2(Param<T> out, CParam<T> in, const af::borderType pad, int w_len,
               int w_wid) {
     UNUSED(w_wid);
-    auto medfilt2 =
-        common::getKernel("cuda::medfilt2", {medfilt_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(pad),
-                           TemplateArg(w_len), TemplateArg(w_wid)},
-                          {DefineValue(THREADS_X), DefineValue(THREADS_Y)});
+    auto medfilt2 = common::getKernel(
+        "cuda::medfilt2", std::array{medfilt_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(pad),
+                     TemplateArg(w_len), TemplateArg(w_wid)),
+        std::array{DefineValue(THREADS_X), DefineValue(THREADS_Y)});
 
     const dim3 threads(THREADS_X, THREADS_Y);
 
@@ -46,9 +46,10 @@ void medfilt2(Param<T> out, CParam<T> in, const af::borderType pad, int w_len,
 
 template<typename T>
 void medfilt1(Param<T> out, CParam<T> in, const af::borderType pad, int w_wid) {
-    auto medfilt1 = common::getKernel(
-        "cuda::medfilt1", {medfilt_cuh_src},
-        {TemplateTypename<T>(), TemplateArg(pad), TemplateArg(w_wid)});
+    auto medfilt1 =
+        common::getKernel("cuda::medfilt1", std::array{medfilt_cuh_src},
+                          TemplateArgs(TemplateTypename<T>(), TemplateArg(pad),
+                                       TemplateArg(w_wid)));
 
     const dim3 threads(THREADS_X);
 

--- a/src/backend/cuda/kernel/memcopy.hpp
+++ b/src/backend/cuda/kernel/memcopy.hpp
@@ -126,35 +126,40 @@ void memcopy(Param<T> out, CParam<T> in, dim_t indims) {
     // Conversion to cuda base vector types.
     switch (sizeofNewT) {
         case 1: {
-            auto memCopy{
-                common::getKernel(kernelName, {memcopy_cuh_src}, {"char"})};
+            auto memCopy{common::getKernel(kernelName,
+                                           std::array{memcopy_cuh_src},
+                                           TemplateArgs(TemplateArg("char")))};
             memCopy(qArgs, Param<char>((char *)out.ptr, out.dims, out.strides),
                     CParam<char>((const char *)in.ptr, in.dims, in.strides));
         } break;
         case 2: {
-            auto memCopy{
-                common::getKernel(kernelName, {memcopy_cuh_src}, {"short"})};
+            auto memCopy{common::getKernel(kernelName,
+                                           std::array{memcopy_cuh_src},
+                                           TemplateArgs(TemplateArg("short")))};
             memCopy(qArgs,
                     Param<short>((short *)out.ptr, out.dims, out.strides),
                     CParam<short>((const short *)in.ptr, in.dims, in.strides));
         } break;
         case 4: {
-            auto memCopy{
-                common::getKernel(kernelName, {memcopy_cuh_src}, {"float"})};
+            auto memCopy{common::getKernel(kernelName,
+                                           std::array{memcopy_cuh_src},
+                                           TemplateArgs(TemplateArg("float")))};
             memCopy(qArgs,
                     Param<float>((float *)out.ptr, out.dims, out.strides),
                     CParam<float>((const float *)in.ptr, in.dims, in.strides));
         } break;
         case 8: {
             auto memCopy{
-                common::getKernel(kernelName, {memcopy_cuh_src}, {"float2"})};
+                common::getKernel(kernelName, std::array{memcopy_cuh_src},
+                                  TemplateArgs(TemplateArg("float2")))};
             memCopy(
                 qArgs, Param<float2>((float2 *)out.ptr, out.dims, out.strides),
                 CParam<float2>((const float2 *)in.ptr, in.dims, in.strides));
         } break;
         case 16: {
             auto memCopy{
-                common::getKernel(kernelName, {memcopy_cuh_src}, {"float4"})};
+                common::getKernel(kernelName, std::array{memcopy_cuh_src},
+                                  TemplateArgs(TemplateArg("float4")))};
             memCopy(
                 qArgs, Param<float4>((float4 *)out.ptr, out.dims, out.strides),
                 CParam<float4>((const float4 *)in.ptr, in.dims, in.strides));
@@ -188,18 +193,14 @@ void copy(Param<outType> dst, CParam<inType> src, dim_t ondims,
 
     EnqueueArgs qArgs(blocks, threads, getActiveStream());
 
-    auto copy{common::getKernel(th.loop0 ? "cuda::scaledCopyLoop0"
-                                : th.loop2 | th.loop3
-                                    ? "cuda::scaledCopyLoop123"
-                                : th.loop1 ? "cuda::scaledCopyLoop1"
-                                           : "cuda::scaledCopy",
-                                {copy_cuh_src},
-                                {
-                                    TemplateTypename<inType>(),
-                                    TemplateTypename<outType>(),
-                                    TemplateArg(same_dims),
-                                    TemplateArg(factor != 1.0),
-                                })};
+    auto copy{common::getKernel(
+        th.loop0              ? "cuda::scaledCopyLoop0"
+        : th.loop2 | th.loop3 ? "cuda::scaledCopyLoop123"
+        : th.loop1            ? "cuda::scaledCopyLoop1"
+                              : "cuda::scaledCopy",
+        std::array{copy_cuh_src},
+        TemplateArgs(TemplateTypename<inType>(), TemplateTypename<outType>(),
+                     TemplateArg(same_dims), TemplateArg(factor != 1.0)))};
 
     copy(qArgs, dst, src, default_value, factor);
 

--- a/src/backend/cuda/kernel/moments.hpp
+++ b/src/backend/cuda/kernel/moments.hpp
@@ -21,8 +21,9 @@ static const int THREADS = 128;
 
 template<typename T>
 void moments(Param<float> out, CParam<T> in, const af::momentType moment) {
-    auto moments = common::getKernel("cuda::moments", {moments_cuh_src},
-                                     {TemplateTypename<T>()});
+    auto moments =
+        common::getKernel("cuda::moments", std::array{moments_cuh_src},
+                          TemplateArgs(TemplateTypename<T>()));
 
     dim3 threads(THREADS, 1, 1);
     dim3 blocks(in.dims[1], in.dims[2] * in.dims[3]);

--- a/src/backend/cuda/kernel/morph.hpp
+++ b/src/backend/cuda/kernel/morph.hpp
@@ -31,11 +31,10 @@ void morph(Param<T> out, CParam<T> in, CParam<T> mask, bool isDilation) {
     const int SeLength = (windLen <= 10 ? windLen : 0);
 
     auto morph = common::getKernel(
-        "cuda::morph", {morph_cuh_src},
-        {TemplateTypename<T>(), TemplateArg(isDilation), TemplateArg(SeLength)},
-        {
-            DefineValue(MAX_MORPH_FILTER_LEN),
-        });
+        "cuda::morph", std::array{morph_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(isDilation),
+                     TemplateArg(SeLength)),
+        std::array{DefineValue(MAX_MORPH_FILTER_LEN)});
 
     morph.copyToReadOnly(morph.getDevPtr("cFilter"),
                          reinterpret_cast<CUdeviceptr>(mask.ptr),
@@ -68,11 +67,10 @@ void morph3d(Param<T> out, CParam<T> in, CParam<T> mask, bool isDilation) {
     }
 
     auto morph3D = common::getKernel(
-        "cuda::morph3D", {morph_cuh_src},
-        {TemplateTypename<T>(), TemplateArg(isDilation), TemplateArg(windLen)},
-        {
-            DefineValue(MAX_MORPH_FILTER_LEN),
-        });
+        "cuda::morph3D", std::array{morph_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(isDilation),
+                     TemplateArg(windLen)),
+        std::array{DefineValue(MAX_MORPH_FILTER_LEN)});
 
     morph3D.copyToReadOnly(
         morph3D.getDevPtr("cFilter"), reinterpret_cast<CUdeviceptr>(mask.ptr),

--- a/src/backend/cuda/kernel/pad_array_borders.hpp
+++ b/src/backend/cuda/kernel/pad_array_borders.hpp
@@ -16,6 +16,8 @@
 #include <nvrtc_kernel_headers/pad_array_borders_cuh.hpp>
 #include <af/defines.h>
 
+#include <array>
+
 namespace cuda {
 namespace kernel {
 
@@ -25,9 +27,9 @@ static const int PADB_THREADS_Y = 8;
 template<typename T>
 void padBorders(Param<T> out, CParam<T> in, dim4 const lBoundPadding,
                 const af::borderType btype) {
-    auto padBorders =
-        common::getKernel("cuda::padBorders", {pad_array_borders_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(btype)});
+    auto padBorders = common::getKernel(
+        "cuda::padBorders", std::array{pad_array_borders_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(btype)));
 
     dim3 threads(kernel::PADB_THREADS_X, kernel::PADB_THREADS_Y);
 

--- a/src/backend/cuda/kernel/range.hpp
+++ b/src/backend/cuda/kernel/range.hpp
@@ -25,8 +25,8 @@ void range(Param<T> out, const int dim) {
     constexpr unsigned RANGE_TILEX = 512;
     constexpr unsigned RANGE_TILEY = 32;
 
-    auto range = common::getKernel("cuda::range", {range_cuh_src},
-                                   {TemplateTypename<T>()});
+    auto range = common::getKernel("cuda::range", std::array{range_cuh_src},
+                                   TemplateArgs(TemplateTypename<T>()));
 
     dim3 threads(RANGE_TX, RANGE_TY, 1);
 

--- a/src/backend/cuda/kernel/reorder.hpp
+++ b/src/backend/cuda/kernel/reorder.hpp
@@ -25,8 +25,9 @@ void reorder(Param<T> out, CParam<T> in, const dim_t *rdims) {
     constexpr unsigned TILEX = 512;
     constexpr unsigned TILEY = 32;
 
-    auto reorder = common::getKernel("cuda::reorder", {reorder_cuh_src},
-                                     {TemplateTypename<T>()});
+    auto reorder =
+        common::getKernel("cuda::reorder", std::array{reorder_cuh_src},
+                          TemplateArgs(TemplateTypename<T>()));
 
     dim3 threads(TX, TY, 1);
 

--- a/src/backend/cuda/kernel/resize.hpp
+++ b/src/backend/cuda/kernel/resize.hpp
@@ -23,9 +23,9 @@ static const unsigned TY = 16;
 
 template<typename T>
 void resize(Param<T> out, CParam<T> in, af_interp_type method) {
-    auto resize =
-        common::getKernel("cuda::resize", {resize_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(method)});
+    auto resize = common::getKernel(
+        "cuda::resize", std::array{resize_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(method)));
 
     dim3 threads(TX, TY, 1);
     dim3 blocks(divup(out.dims[0], threads.x), divup(out.dims[1], threads.y));

--- a/src/backend/cuda/kernel/rotate.hpp
+++ b/src/backend/cuda/kernel/rotate.hpp
@@ -32,9 +32,9 @@ typedef struct {
 template<typename T>
 void rotate(Param<T> out, CParam<T> in, const float theta,
             const af::interpType method, const int order) {
-    auto rotate =
-        common::getKernel("cuda::rotate", {rotate_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(order)});
+    auto rotate = common::getKernel(
+        "cuda::rotate", std::array{rotate_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(order)));
 
     const float c = cos(-theta), s = sin(-theta);
     float tx, ty;

--- a/src/backend/cuda/kernel/scan_dim.hpp
+++ b/src/backend/cuda/kernel/scan_dim.hpp
@@ -25,11 +25,12 @@ static void scan_dim_launcher(Param<To> out, Param<To> tmp, CParam<Ti> in,
                               const uint threads_y, const dim_t blocks_all[4],
                               int dim, bool isFinalPass, bool inclusive_scan) {
     auto scan_dim = common::getKernel(
-        "cuda::scan_dim", {scan_dim_cuh_src},
-        {TemplateTypename<Ti>(), TemplateTypename<To>(), TemplateArg(op),
-         TemplateArg(dim), TemplateArg(isFinalPass), TemplateArg(threads_y),
-         TemplateArg(inclusive_scan)},
-        {DefineValue(THREADS_X)});
+        "cuda::scan_dim", std::array{scan_dim_cuh_src},
+        TemplateArgs(TemplateTypename<Ti>(), TemplateTypename<To>(),
+                     TemplateArg(op), TemplateArg(dim),
+                     TemplateArg(isFinalPass), TemplateArg(threads_y),
+                     TemplateArg(inclusive_scan)),
+        std::array{DefineValue(THREADS_X)});
 
     dim3 threads(THREADS_X, threads_y);
 
@@ -52,9 +53,10 @@ template<typename To, af_op_t op>
 static void bcast_dim_launcher(Param<To> out, CParam<To> tmp,
                                const uint threads_y, const dim_t blocks_all[4],
                                int dim, bool inclusive_scan) {
-    auto scan_dim_bcast = common::getKernel(
-        "cuda::scan_dim_bcast", {scan_dim_cuh_src},
-        {TemplateTypename<To>(), TemplateArg(op), TemplateArg(dim)});
+    auto scan_dim_bcast =
+        common::getKernel("cuda::scan_dim_bcast", std::array{scan_dim_cuh_src},
+                          TemplateArgs(TemplateTypename<To>(), TemplateArg(op),
+                                       TemplateArg(dim)));
 
     dim3 threads(THREADS_X, threads_y);
 

--- a/src/backend/cuda/kernel/scan_dim_by_key_impl.hpp
+++ b/src/backend/cuda/kernel/scan_dim_by_key_impl.hpp
@@ -32,10 +32,10 @@ static void scan_dim_nonfinal_launcher(Param<To> out, Param<To> tmp,
                                        const dim_t blocks_all[4],
                                        bool inclusive_scan) {
     auto scanbykey_dim_nonfinal = common::getKernel(
-        "cuda::scanbykey_dim_nonfinal", {scan_dim_by_key_cuh_src},
-        {TemplateTypename<Ti>(), TemplateTypename<Tk>(), TemplateTypename<To>(),
-         TemplateArg(op)},
-        {DefineValue(THREADS_X), DefineKeyValue(DIMY, threads_y)});
+        "cuda::scanbykey_dim_nonfinal", std::array{scan_dim_by_key_cuh_src},
+        TemplateArgs(TemplateTypename<Ti>(), TemplateTypename<Tk>(),
+                     TemplateTypename<To>(), TemplateArg(op)),
+        std::array{DefineValue(THREADS_X), DefineKeyValue(DIMY, threads_y)});
 
     dim3 threads(THREADS_X, threads_y);
 
@@ -56,10 +56,10 @@ static void scan_dim_final_launcher(Param<To> out, CParam<Ti> in,
                                     const dim_t blocks_all[4],
                                     bool calculateFlags, bool inclusive_scan) {
     auto scanbykey_dim_final = common::getKernel(
-        "cuda::scanbykey_dim_final", {scan_dim_by_key_cuh_src},
-        {TemplateTypename<Ti>(), TemplateTypename<Tk>(), TemplateTypename<To>(),
-         TemplateArg(op)},
-        {DefineValue(THREADS_X), DefineKeyValue(DIMY, threads_y)});
+        "cuda::scanbykey_dim_final", std::array{scan_dim_by_key_cuh_src},
+        TemplateArgs(TemplateTypename<Ti>(), TemplateTypename<Tk>(),
+                     TemplateTypename<To>(), TemplateArg(op)),
+        std::array{DefineValue(THREADS_X), DefineKeyValue(DIMY, threads_y)});
 
     dim3 threads(THREADS_X, threads_y);
 
@@ -78,8 +78,8 @@ static void bcast_dim_launcher(Param<To> out, CParam<To> tmp, Param<int> tlid,
                                const int dim, const uint threads_y,
                                const dim_t blocks_all[4]) {
     auto scanbykey_dim_bcast = common::getKernel(
-        "cuda::scanbykey_dim_bcast", {scan_dim_by_key_cuh_src},
-        {TemplateTypename<To>(), TemplateArg(op)});
+        "cuda::scanbykey_dim_bcast", std::array{scan_dim_by_key_cuh_src},
+        TemplateArgs(TemplateTypename<To>(), TemplateArg(op)));
     dim3 threads(THREADS_X, threads_y);
     dim3 blocks(blocks_all[0] * blocks_all[2], blocks_all[1] * blocks_all[3]);
 

--- a/src/backend/cuda/kernel/scan_first.hpp
+++ b/src/backend/cuda/kernel/scan_first.hpp
@@ -25,12 +25,12 @@ static void scan_first_launcher(Param<To> out, Param<To> tmp, CParam<Ti> in,
                                 const uint blocks_x, const uint blocks_y,
                                 const uint threads_x, bool isFinalPass,
                                 bool inclusive_scan) {
-    auto scan_first =
-        common::getKernel("cuda::scan_first", {scan_first_cuh_src},
-                          {TemplateTypename<Ti>(), TemplateTypename<To>(),
-                           TemplateArg(op), TemplateArg(isFinalPass),
-                           TemplateArg(threads_x), TemplateArg(inclusive_scan)},
-                          {DefineValue(THREADS_PER_BLOCK)});
+    auto scan_first = common::getKernel(
+        "cuda::scan_first", std::array{scan_first_cuh_src},
+        TemplateArgs(TemplateTypename<Ti>(), TemplateTypename<To>(),
+                     TemplateArg(op), TemplateArg(isFinalPass),
+                     TemplateArg(threads_x), TemplateArg(inclusive_scan)),
+        std::array{DefineValue(THREADS_PER_BLOCK)});
 
     dim3 threads(threads_x, THREADS_PER_BLOCK / threads_x);
     dim3 blocks(blocks_x * out.dims[2], blocks_y * out.dims[3]);
@@ -51,9 +51,9 @@ template<typename To, af_op_t op>
 static void bcast_first_launcher(Param<To> out, CParam<To> tmp,
                                  const uint blocks_x, const uint blocks_y,
                                  const uint threads_x, bool inclusive_scan) {
-    auto scan_first_bcast =
-        common::getKernel("cuda::scan_first_bcast", {scan_first_cuh_src},
-                          {TemplateTypename<To>(), TemplateArg(op)});
+    auto scan_first_bcast = common::getKernel(
+        "cuda::scan_first_bcast", std::array{scan_first_cuh_src},
+        TemplateArgs(TemplateTypename<To>(), TemplateArg(op)));
 
     dim3 threads(threads_x, THREADS_PER_BLOCK / threads_x);
     dim3 blocks(blocks_x * out.dims[2], blocks_y * out.dims[3]);

--- a/src/backend/cuda/kernel/scan_first_by_key_impl.hpp
+++ b/src/backend/cuda/kernel/scan_first_by_key_impl.hpp
@@ -30,10 +30,11 @@ static void scan_nonfinal_launcher(Param<To> out, Param<To> tmp,
                                    const uint blocks_x, const uint blocks_y,
                                    const uint threads_x, bool inclusive_scan) {
     auto scanbykey_first_nonfinal = common::getKernel(
-        "cuda::scanbykey_first_nonfinal", {scan_first_by_key_cuh_src},
-        {TemplateTypename<Ti>(), TemplateTypename<Tk>(), TemplateTypename<To>(),
-         TemplateArg(op)},
-        {DefineValue(THREADS_PER_BLOCK), DefineKeyValue(DIMX, threads_x)});
+        "cuda::scanbykey_first_nonfinal", std::array{scan_first_by_key_cuh_src},
+        TemplateArgs(TemplateTypename<Ti>(), TemplateTypename<Tk>(),
+                     TemplateTypename<To>(), TemplateArg(op)),
+        std::array{DefineValue(THREADS_PER_BLOCK),
+                   DefineKeyValue(DIMX, threads_x)});
     dim3 threads(threads_x, THREADS_PER_BLOCK / threads_x);
     dim3 blocks(blocks_x * out.dims[2], blocks_y * out.dims[3]);
 
@@ -51,10 +52,11 @@ static void scan_final_launcher(Param<To> out, CParam<Ti> in, CParam<Tk> key,
                                 const uint threads_x, bool calculateFlags,
                                 bool inclusive_scan) {
     auto scanbykey_first_final = common::getKernel(
-        "cuda::scanbykey_first_final", {scan_first_by_key_cuh_src},
-        {TemplateTypename<Ti>(), TemplateTypename<Tk>(), TemplateTypename<To>(),
-         TemplateArg(op)},
-        {DefineValue(THREADS_PER_BLOCK), DefineKeyValue(DIMX, threads_x)});
+        "cuda::scanbykey_first_final", std::array{scan_first_by_key_cuh_src},
+        TemplateArgs(TemplateTypename<Ti>(), TemplateTypename<Tk>(),
+                     TemplateTypename<To>(), TemplateArg(op)),
+        std::array{DefineValue(THREADS_PER_BLOCK),
+                   DefineKeyValue(DIMX, threads_x)});
     dim3 threads(threads_x, THREADS_PER_BLOCK / threads_x);
     dim3 blocks(blocks_x * out.dims[2], blocks_y * out.dims[3]);
 
@@ -71,8 +73,8 @@ static void bcast_first_launcher(Param<To> out, Param<To> tmp, Param<int> tlid,
                                  const dim_t blocks_x, const dim_t blocks_y,
                                  const uint threads_x) {
     auto scanbykey_first_bcast = common::getKernel(
-        "cuda::scanbykey_first_bcast", {scan_first_by_key_cuh_src},
-        {TemplateTypename<To>(), TemplateArg(op)});
+        "cuda::scanbykey_first_bcast", std::array{scan_first_by_key_cuh_src},
+        TemplateArgs(TemplateTypename<To>(), TemplateArg(op)));
     dim3 threads(threads_x, THREADS_PER_BLOCK / threads_x);
     dim3 blocks(blocks_x * out.dims[2], blocks_y * out.dims[3]);
     uint lim = divup(out.dims[0], (threads_x * blocks_x));

--- a/src/backend/cuda/kernel/select.hpp
+++ b/src/backend/cuda/kernel/select.hpp
@@ -29,9 +29,9 @@ void select(Param<T> out, CParam<char> cond, CParam<T> a, CParam<T> b,
     bool is_same = true;
     for (int i = 0; i < 4; i++) { is_same &= (a.dims[i] == b.dims[i]); }
 
-    auto select =
-        common::getKernel("cuda::select", {select_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(is_same)});
+    auto select = common::getKernel(
+        "cuda::select", std::array{select_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(is_same)));
 
     dim3 threads(DIMX, DIMY);
 
@@ -59,9 +59,9 @@ void select(Param<T> out, CParam<char> cond, CParam<T> a, CParam<T> b,
 template<typename T>
 void select_scalar(Param<T> out, CParam<char> cond, CParam<T> a, const T b,
                    int ndims, bool flip) {
-    auto selectScalar =
-        common::getKernel("cuda::selectScalar", {select_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(flip)});
+    auto selectScalar = common::getKernel(
+        "cuda::selectScalar", std::array{select_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(flip)));
 
     dim3 threads(DIMX, DIMY);
 

--- a/src/backend/cuda/kernel/sobel.hpp
+++ b/src/backend/cuda/kernel/sobel.hpp
@@ -26,13 +26,10 @@ void sobel(Param<To> dx, Param<To> dy, CParam<Ti> in,
            const unsigned& ker_size) {
     UNUSED(ker_size);
 
-    auto sobel3x3 =
-        common::getKernel("cuda::sobel3x3", {sobel_cuh_src},
-                          {
-                              TemplateTypename<Ti>(),
-                              TemplateTypename<To>(),
-                          },
-                          {DefineValue(THREADS_X), DefineValue(THREADS_Y)});
+    auto sobel3x3 = common::getKernel(
+        "cuda::sobel3x3", std::array{sobel_cuh_src},
+        TemplateArgs(TemplateTypename<Ti>(), TemplateTypename<To>()),
+        std::array{DefineValue(THREADS_X), DefineValue(THREADS_Y)});
 
     const dim3 threads(THREADS_X, THREADS_Y);
 

--- a/src/backend/cuda/kernel/sparse.hpp
+++ b/src/backend/cuda/kernel/sparse.hpp
@@ -23,9 +23,9 @@ void coo2dense(Param<T> output, CParam<T> values, CParam<int> rowIdx,
                CParam<int> colIdx) {
     constexpr int reps = 4;
 
-    auto coo2Dense =
-        common::getKernel("cuda::coo2Dense", {sparse_cuh_src},
-                          {TemplateTypename<T>()}, {DefineValue(reps)});
+    auto coo2Dense = common::getKernel(
+        "cuda::coo2Dense", std::array{sparse_cuh_src},
+        TemplateArgs(TemplateTypename<T>()), std::array{DefineValue(reps)});
 
     dim3 threads(256, 1, 1);
 

--- a/src/backend/cuda/kernel/sparse_arith.hpp
+++ b/src/backend/cuda/kernel/sparse_arith.hpp
@@ -27,9 +27,9 @@ template<typename T, af_op_t op>
 void sparseArithOpCSR(Param<T> out, CParam<T> values, CParam<int> rowIdx,
                       CParam<int> colIdx, CParam<T> rhs, const bool reverse) {
     auto csrArithDSD =
-        common::getKernel("cuda::csrArithDSD", {sparse_arith_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(op)},
-                          {DefineValue(TX), DefineValue(TY)});
+        common::getKernel("cuda::csrArithDSD", std::array{sparse_arith_cuh_src},
+                          TemplateArgs(TemplateTypename<T>(), TemplateArg(op)),
+                          std::array{DefineValue(TX), DefineValue(TY)});
 
     // Each Y for threads does one row
     dim3 threads(TX, TY, 1);
@@ -46,9 +46,10 @@ void sparseArithOpCSR(Param<T> out, CParam<T> values, CParam<int> rowIdx,
 template<typename T, af_op_t op>
 void sparseArithOpCOO(Param<T> out, CParam<T> values, CParam<int> rowIdx,
                       CParam<int> colIdx, CParam<T> rhs, const bool reverse) {
-    auto cooArithDSD = common::getKernel(
-        "cuda::cooArithDSD", {sparse_arith_cuh_src},
-        {TemplateTypename<T>(), TemplateArg(op)}, {DefineValue(THREADS)});
+    auto cooArithDSD =
+        common::getKernel("cuda::cooArithDSD", std::array{sparse_arith_cuh_src},
+                          TemplateArgs(TemplateTypename<T>(), TemplateArg(op)),
+                          std::array{DefineValue(THREADS)});
 
     // Linear indexing with one elements per thread
     dim3 threads(THREADS, 1, 1);
@@ -66,9 +67,9 @@ template<typename T, af_op_t op>
 void sparseArithOpCSR(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
                       CParam<T> rhs, const bool reverse) {
     auto csrArithSSD =
-        common::getKernel("cuda::csrArithSSD", {sparse_arith_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(op)},
-                          {DefineValue(TX), DefineValue(TY)});
+        common::getKernel("cuda::csrArithSSD", std::array{sparse_arith_cuh_src},
+                          TemplateArgs(TemplateTypename<T>(), TemplateArg(op)),
+                          std::array{DefineValue(TX), DefineValue(TY)});
 
     // Each Y for threads does one row
     dim3 threads(TX, TY, 1);
@@ -85,9 +86,10 @@ void sparseArithOpCSR(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
 template<typename T, af_op_t op>
 void sparseArithOpCOO(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
                       CParam<T> rhs, const bool reverse) {
-    auto cooArithSSD = common::getKernel(
-        "cuda::cooArithSSD", {sparse_arith_cuh_src},
-        {TemplateTypename<T>(), TemplateArg(op)}, {DefineValue(THREADS)});
+    auto cooArithSSD =
+        common::getKernel("cuda::cooArithSSD", std::array{sparse_arith_cuh_src},
+                          TemplateArgs(TemplateTypename<T>(), TemplateArg(op)),
+                          std::array{DefineValue(THREADS)});
 
     // Linear indexing with one elements per thread
     dim3 threads(THREADS, 1, 1);

--- a/src/backend/cuda/kernel/susan.hpp
+++ b/src/backend/cuda/kernel/susan.hpp
@@ -26,8 +26,9 @@ void susan_responses(T* out, const T* in, const unsigned idim0,
                      const unsigned idim1, const int radius, const float t,
                      const float g, const unsigned edge) {
     auto susan = common::getKernel(
-        "cuda::susan", {susan_cuh_src}, {TemplateTypename<T>()},
-        {DefineValue(BLOCK_X), DefineValue(BLOCK_Y)});
+        "cuda::susan", std::array{susan_cuh_src},
+        TemplateArgs(TemplateTypename<T>()),
+        std::array{DefineValue(BLOCK_X), DefineValue(BLOCK_Y)});
 
     dim3 threads(BLOCK_X, BLOCK_Y);
     dim3 blocks(divup(idim0 - edge * 2, BLOCK_X),
@@ -45,8 +46,8 @@ template<typename T>
 void nonMaximal(float* x_out, float* y_out, float* resp_out, unsigned* count,
                 const unsigned idim0, const unsigned idim1, const T* resp_in,
                 const unsigned edge, const unsigned max_corners) {
-    auto nonMax = common::getKernel("cuda::nonMax", {susan_cuh_src},
-                                    {TemplateTypename<T>()});
+    auto nonMax = common::getKernel("cuda::nonMax", std::array{susan_cuh_src},
+                                    TemplateArgs(TemplateTypename<T>()));
 
     dim3 threads(BLOCK_X, BLOCK_Y);
     dim3 blocks(divup(idim0 - edge * 2, BLOCK_X),

--- a/src/backend/cuda/kernel/tile.hpp
+++ b/src/backend/cuda/kernel/tile.hpp
@@ -25,8 +25,8 @@ void tile(Param<T> out, CParam<T> in) {
     constexpr unsigned TILEX = 512;
     constexpr unsigned TILEY = 32;
 
-    auto tile = common::getKernel("cuda::tile", {tile_cuh_src},
-                                  {TemplateTypename<T>()});
+    auto tile = common::getKernel("cuda::tile", std::array{tile_cuh_src},
+                                  TemplateArgs(TemplateTypename<T>()));
 
     dim3 threads(TX, TY, 1);
 

--- a/src/backend/cuda/kernel/transform.hpp
+++ b/src/backend/cuda/kernel/transform.hpp
@@ -31,8 +31,9 @@ template<typename T>
 void transform(Param<T> out, CParam<T> in, CParam<float> tf, const bool inverse,
                const bool perspective, const af::interpType method, int order) {
     auto transform = common::getKernel(
-        "cuda::transform", {transform_cuh_src},
-        {TemplateTypename<T>(), TemplateArg(inverse), TemplateArg(order)});
+        "cuda::transform", std::array{transform_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(inverse),
+                     TemplateArg(order)));
 
     const unsigned int nImg2  = in.dims[2];
     const unsigned int nImg3  = in.dims[3];

--- a/src/backend/cuda/kernel/transpose.hpp
+++ b/src/backend/cuda/kernel/transpose.hpp
@@ -25,11 +25,11 @@ static const int THREADS_Y = 256 / TILE_DIM;
 template<typename T>
 void transpose(Param<T> out, CParam<T> in, const bool conjugate,
                const bool is32multiple) {
-    auto transpose =
-        common::getKernel("cuda::transpose", {transpose_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(conjugate),
-                           TemplateArg(is32multiple)},
-                          {DefineValue(TILE_DIM), DefineValue(THREADS_Y)});
+    auto transpose = common::getKernel(
+        "cuda::transpose", std::array{transpose_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(conjugate),
+                     TemplateArg(is32multiple)),
+        std::array{DefineValue(TILE_DIM), DefineValue(THREADS_Y)});
 
     dim3 threads(kernel::THREADS_X, kernel::THREADS_Y);
 

--- a/src/backend/cuda/kernel/transpose_inplace.hpp
+++ b/src/backend/cuda/kernel/transpose_inplace.hpp
@@ -25,11 +25,11 @@ static const int THREADS_Y = 256 / TILE_DIM;
 template<typename T>
 void transpose_inplace(Param<T> in, const bool conjugate,
                        const bool is32multiple) {
-    auto transposeIP =
-        common::getKernel("cuda::transposeIP", {transpose_inplace_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(conjugate),
-                           TemplateArg(is32multiple)},
-                          {DefineValue(TILE_DIM), DefineValue(THREADS_Y)});
+    auto transposeIP = common::getKernel(
+        "cuda::transposeIP", std::array{transpose_inplace_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(conjugate),
+                     TemplateArg(is32multiple)),
+        std::array{DefineValue(TILE_DIM), DefineValue(THREADS_Y)});
 
     // dimensions passed to this function should be input dimensions
     // any necessary transformations and dimension related calculations are

--- a/src/backend/cuda/kernel/triangle.hpp
+++ b/src/backend/cuda/kernel/triangle.hpp
@@ -25,10 +25,10 @@ void triangle(Param<T> r, CParam<T> in, bool is_upper, bool is_unit_diag) {
     constexpr unsigned TILEX = 128;
     constexpr unsigned TILEY = 32;
 
-    auto triangle =
-        common::getKernel("cuda::triangle", {triangle_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(is_upper),
-                           TemplateArg(is_unit_diag)});
+    auto triangle = common::getKernel(
+        "cuda::triangle", std::array{triangle_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(is_upper),
+                     TemplateArg(is_unit_diag)));
 
     dim3 threads(TX, TY, 1);
 

--- a/src/backend/cuda/kernel/unwrap.hpp
+++ b/src/backend/cuda/kernel/unwrap.hpp
@@ -23,9 +23,9 @@ template<typename T>
 void unwrap(Param<T> out, CParam<T> in, const int wx, const int wy,
             const int sx, const int sy, const int px, const int py,
             const int dx, const int dy, const int nx, const bool is_column) {
-    auto unwrap =
-        common::getKernel("cuda::unwrap", {unwrap_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(is_column)});
+    auto unwrap = common::getKernel(
+        "cuda::unwrap", std::array{unwrap_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(is_column)));
 
     dim3 threads, blocks;
     int reps;

--- a/src/backend/cuda/kernel/where.hpp
+++ b/src/backend/cuda/kernel/where.hpp
@@ -23,8 +23,8 @@ namespace kernel {
 
 template<typename T>
 static void where(Param<uint> &out, CParam<T> in) {
-    auto where = common::getKernel("cuda::where", {where_cuh_src},
-                                   {TemplateTypename<T>()});
+    auto where = common::getKernel("cuda::where", std::array{where_cuh_src},
+                                   TemplateArgs(TemplateTypename<T>()));
 
     uint threads_x = nextpow2(std::max(32u, (uint)in.dims[0]));
     threads_x      = std::min(threads_x, THREADS_PER_BLOCK);

--- a/src/backend/cuda/kernel/wrap.hpp
+++ b/src/backend/cuda/kernel/wrap.hpp
@@ -22,9 +22,9 @@ namespace kernel {
 template<typename T>
 void wrap(Param<T> out, CParam<T> in, const int wx, const int wy, const int sx,
           const int sy, const int px, const int py, const bool is_column) {
-    auto wrap =
-        common::getKernel("cuda::wrap", {wrap_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(is_column)});
+    auto wrap = common::getKernel(
+        "cuda::wrap", std::array{wrap_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(is_column)));
 
     int nx = (out.dims[0] + 2 * px - wx) / sx + 1;
     int ny = (out.dims[1] + 2 * py - wy) / sy + 1;
@@ -51,9 +51,9 @@ void wrap_dilated(Param<T> out, CParam<T> in, const dim_t wx, const dim_t wy,
                   const dim_t sx, const dim_t sy, const dim_t px,
                   const dim_t py, const dim_t dx, const dim_t dy,
                   const bool is_column) {
-    auto wrap =
-        common::getKernel("cuda::wrap_dilated", {wrap_cuh_src},
-                          {TemplateTypename<T>(), TemplateArg(is_column)});
+    auto wrap = common::getKernel(
+        "cuda::wrap_dilated", std::array{wrap_cuh_src},
+        TemplateArgs(TemplateTypename<T>(), TemplateArg(is_column)));
 
     int nx = 1 + (out.dims[0] + 2 * px - (((wx - 1) * dx) + 1)) / sx;
     int ny = 1 + (out.dims[1] + 2 * py - (((wy - 1) * dy) + 1)) / sy;

--- a/src/backend/oneapi/kernel/memcopy.hpp
+++ b/src/backend/oneapi/kernel/memcopy.hpp
@@ -57,9 +57,6 @@ class memCopy {
         const int id0        = group_id_0 * gg.get_local_range(0) + lid0;
         const int id1        = group_id_1 * gg.get_local_range(1) + lid1;
 
-        debug_ << "[" << id0 << "," << id1 << "," << id2 << "," << id3 << "]"
-               << sycl::stream_manipulator::endl;
-
         T *iptr = in_.get_pointer();
         iptr += offset_;
         // FIXME: Do more work per work group

--- a/src/backend/opencl/compile_module.cpp
+++ b/src/backend/opencl/compile_module.cpp
@@ -17,6 +17,7 @@
 #include <debug_opencl.hpp>
 #include <err_opencl.hpp>
 #include <kernel_headers/KParam.hpp>
+#include <nonstd/span.hpp>
 #include <platform.hpp>
 #include <traits.hpp>
 
@@ -32,6 +33,7 @@ using cl::Error;
 using cl::Program;
 using common::loggerFactory;
 using fmt::format;
+using nonstd::span;
 using opencl::getActiveDeviceId;
 using opencl::getDevice;
 using opencl::Kernel;
@@ -99,8 +101,8 @@ const static string DEFAULT_MACROS_STR(
                                            #endif\n                     \
                                            ");
 
-Program buildProgram(const vector<string> &kernelSources,
-                     const vector<string> &compileOpts) {
+Program buildProgram(span<const string> kernelSources,
+                     span<const string> compileOpts) {
     Program retVal;
     try {
         static const string defaults =
@@ -151,9 +153,9 @@ string getKernelCacheFilename(const int device, const string &key) {
 
 namespace common {
 
-Module compileModule(const string &moduleKey, const vector<string> &sources,
-                     const vector<string> &options,
-                     const vector<string> &kInstances, const bool isJIT) {
+Module compileModule(const string &moduleKey, span<const string> sources,
+                     span<const string> options, span<const string> kInstances,
+                     const bool isJIT) {
     UNUSED(kInstances);
     UNUSED(isJIT);
 

--- a/src/backend/opencl/jit.cpp
+++ b/src/backend/opencl/jit.cpp
@@ -278,7 +278,8 @@ cl::Kernel getKernel(const vector<Node*>& output_nodes,
         if (isHalfSupported(device)) {
             options.emplace_back(DefineKey(USE_HALF));
         }
-        return common::getKernel(funcName, {jit_cl_src, jitKer_cl_src}, {},
+        return common::getKernel(funcName,
+                                 std::array{jit_cl_src, jitKer_cl_src}, {},
                                  options, true)
             .get();
     }

--- a/src/backend/opencl/kernel/anisotropic_diffusion.hpp
+++ b/src/backend/opencl/kernel/anisotropic_diffusion.hpp
@@ -49,9 +49,9 @@ void anisotropicDiffusion(Param inout, const float dt, const float mct,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto diffUpdate =
-        common::getKernel("aisoDiffUpdate", {anisotropic_diffusion_cl_src},
-                          tmpltArgs, compileOpts);
+    auto diffUpdate = common::getKernel(
+        "aisoDiffUpdate", std::array{anisotropic_diffusion_cl_src}, tmpltArgs,
+        compileOpts);
 
     NDRange local(THREADS_X, THREADS_Y, 1);
 

--- a/src/backend/opencl/kernel/approx.hpp
+++ b/src/backend/opencl/kernel/approx.hpp
@@ -72,8 +72,9 @@ void approx1(Param yo, const Param yi, const Param xo, const int xdim,
     };
     auto compileOpts = genCompileOptions<Ty, Tp>(order, xdim);
 
-    auto approx1 = common::getKernel("approx1", {interp_cl_src, approx1_cl_src},
-                                     tmpltArgs, compileOpts);
+    auto approx1 =
+        common::getKernel("approx1", std::array{interp_cl_src, approx1_cl_src},
+                          tmpltArgs, compileOpts);
 
     NDRange local(THREADS, 1, 1);
     dim_t blocksPerMat = divup(yo.info.dims[0], local[0]);
@@ -110,8 +111,9 @@ void approx2(Param zo, const Param zi, const Param xo, const int xdim,
     };
     auto compileOpts = genCompileOptions<Ty, Tp>(order, xdim, ydim);
 
-    auto approx2 = common::getKernel("approx2", {interp_cl_src, approx2_cl_src},
-                                     tmpltArgs, compileOpts);
+    auto approx2 =
+        common::getKernel("approx2", std::array{interp_cl_src, approx2_cl_src},
+                          tmpltArgs, compileOpts);
 
     NDRange local(TX, TY, 1);
     dim_t blocksPerMatX = divup(zo.info.dims[0], local[0]);

--- a/src/backend/opencl/kernel/assign.hpp
+++ b/src/backend/opencl/kernel/assign.hpp
@@ -34,16 +34,15 @@ void assign(Param out, const Param in, const AssignKernelParam_t& p,
     constexpr int THREADS_X = 32;
     constexpr int THREADS_Y = 8;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 1> targs = {
         TemplateTypename<T>(),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 2> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto assign =
-        common::getKernel("assignKernel", {assign_cl_src}, targs, options);
+    auto assign = common::getKernel("assignKernel", std::array{assign_cl_src},
+                                    targs, options);
 
     cl::NDRange local(THREADS_X, THREADS_Y);
 

--- a/src/backend/opencl/kernel/bilateral.hpp
+++ b/src/backend/opencl/kernel/bilateral.hpp
@@ -32,7 +32,7 @@ void bilateral(Param out, const Param in, const float s_sigma,
     constexpr bool UseNativeExp = !std::is_same<inType, double>::value ||
                                   std::is_same<inType, cdouble>::value;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<inType>(),
         TemplateTypename<outType>(),
     };
@@ -43,8 +43,8 @@ void bilateral(Param out, const Param in, const float s_sigma,
     if (UseNativeExp) { options.emplace_back(DefineKey(USE_NATIVE_EXP)); }
     options.emplace_back(getTypeBuildDefinition<inType>());
 
-    auto bilateralOp =
-        common::getKernel("bilateral", {bilateral_cl_src}, targs, options);
+    auto bilateralOp = common::getKernel(
+        "bilateral", std::array{bilateral_cl_src}, targs, options);
 
     cl::NDRange local(THREADS_X, THREADS_Y);
 

--- a/src/backend/opencl/kernel/canny.hpp
+++ b/src/backend/opencl/kernel/canny.hpp
@@ -41,9 +41,9 @@ void nonMaxSuppression(Param output, const Param magnitude, const Param dx,
     };
     options.emplace_back(getTypeBuildDefinition<T>());
 
-    auto nonMaxOp = common::getKernel("nonMaxSuppressionKernel",
-                                      {nonmax_suppression_cl_src},
-                                      {TemplateTypename<T>()}, options);
+    auto nonMaxOp = common::getKernel(
+        "nonMaxSuppressionKernel", std::array{nonmax_suppression_cl_src},
+        TemplateArgs(TemplateTypename<T>()), options);
 
     NDRange threads(kernel::THREADS_X, kernel::THREADS_Y, 1);
 
@@ -74,8 +74,9 @@ void initEdgeOut(Param output, const Param strong, const Param weak) {
     };
     options.emplace_back(getTypeBuildDefinition<T>());
 
-    auto initOp = common::getKernel("initEdgeOutKernel", {trace_edge_cl_src},
-                                    {TemplateTypename<T>()}, options);
+    auto initOp =
+        common::getKernel("initEdgeOutKernel", std::array{trace_edge_cl_src},
+                          TemplateArgs(TemplateTypename<T>()), options);
 
     NDRange threads(kernel::THREADS_X, kernel::THREADS_Y, 1);
 
@@ -106,9 +107,9 @@ void suppressLeftOver(Param output) {
     };
     options.emplace_back(getTypeBuildDefinition<T>());
 
-    auto finalOp =
-        common::getKernel("suppressLeftOverKernel", {trace_edge_cl_src},
-                          {TemplateTypename<T>()}, options);
+    auto finalOp = common::getKernel(
+        "suppressLeftOverKernel", std::array{trace_edge_cl_src},
+        TemplateArgs(TemplateTypename<T>()), options);
 
     NDRange threads(kernel::THREADS_X, kernel::THREADS_Y, 1);
 
@@ -142,8 +143,9 @@ void edgeTrackingHysteresis(Param output, const Param strong,
     };
     options.emplace_back(getTypeBuildDefinition<T>());
 
-    auto edgeTraceOp = common::getKernel("edgeTrackKernel", {trace_edge_cl_src},
-                                         {TemplateTypename<T>()}, options);
+    auto edgeTraceOp =
+        common::getKernel("edgeTrackKernel", std::array{trace_edge_cl_src},
+                          TemplateArgs(TemplateTypename<T>()), options);
 
     NDRange threads(kernel::THREADS_X, kernel::THREADS_Y);
 

--- a/src/backend/opencl/kernel/convolve/conv2_impl.hpp
+++ b/src/backend/opencl/kernel/convolve/conv2_impl.hpp
@@ -50,8 +50,9 @@ void conv2Helper(const conv_kparam_t& param, Param out, const Param signal,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto convolve = common::getKernel("convolve", {ops_cl_src, convolve_cl_src},
-                                      tmpltArgs, compileOpts);
+    auto convolve =
+        common::getKernel("convolve", std::array{ops_cl_src, convolve_cl_src},
+                          tmpltArgs, compileOpts);
 
     convolve(EnqueueArgs(getQueue(), param.global, param.local), *out.data,
              out.info, *signal.data, signal.info, *param.impulse, filter.info,

--- a/src/backend/opencl/kernel/convolve/conv_common.hpp
+++ b/src/backend/opencl/kernel/convolve/conv_common.hpp
@@ -113,8 +113,9 @@ void convNHelper(const conv_kparam_t& param, Param& out, const Param& signal,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto convolve = common::getKernel("convolve", {ops_cl_src, convolve_cl_src},
-                                      tmpltArgs, compileOpts);
+    auto convolve =
+        common::getKernel("convolve", std::array{ops_cl_src, convolve_cl_src},
+                          tmpltArgs, compileOpts);
 
     convolve(EnqueueArgs(getQueue(), param.global, param.local), *out.data,
              out.info, *signal.data, signal.info, cl::Local(param.loc_size),

--- a/src/backend/opencl/kernel/convolve_separable.cpp
+++ b/src/backend/opencl/kernel/convolve_separable.cpp
@@ -44,12 +44,12 @@ void convSep(Param out, const Param signal, const Param filter,
     const size_t C1_SIZE = (THREADS_Y + 2 * (fLen - 1)) * THREADS_X;
     size_t locSize       = (conv_dim == 0 ? C0_SIZE : C1_SIZE);
 
-    std::vector<TemplateArg> tmpltArgs = {
+    std::array<TemplateArg, 5> tmpltArgs = {
         TemplateTypename<T>(), TemplateTypename<accType>(),
         TemplateArg(conv_dim), TemplateArg(expand),
         TemplateArg(fLen),
     };
-    std::vector<std::string> compileOpts = {
+    std::array<std::string, 11> compileOpts = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(Ti, dtype_traits<T>::getName()),
         DefineKeyValue(To, dtype_traits<accType>::getName()),
@@ -60,12 +60,11 @@ void convSep(Param out, const Param signal, const Param filter,
         DefineKeyFromStr(binOpName<af_mul_t>()),
         DefineKeyValue(IS_CPLX, (IsComplex ? 1 : 0)),
         DefineKeyValue(LOCAL_MEM_SIZE, locSize),
-    };
-    compileOpts.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto conv =
-        common::getKernel("convolve", {ops_cl_src, convolve_separable_cl_src},
-                          tmpltArgs, compileOpts);
+    auto conv = common::getKernel(
+        "convolve", std::array{ops_cl_src, convolve_separable_cl_src},
+        tmpltArgs, compileOpts);
 
     cl::NDRange local(THREADS_X, THREADS_Y);
 

--- a/src/backend/opencl/kernel/cscmm.hpp
+++ b/src/backend/opencl/kernel/cscmm.hpp
@@ -38,13 +38,13 @@ void cscmm_nn(Param out, const Param &values, const Param &colIdx,
     const bool use_alpha = (alpha != scalar<T>(1.0));
     const bool use_beta  = (beta != scalar<T>(0.0));
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 7> targs = {
         TemplateTypename<T>(),       TemplateArg(use_alpha),
         TemplateArg(use_beta),       TemplateArg(is_conj),
         TemplateArg(rows_per_group), TemplateArg(cols_per_group),
         TemplateArg(threads),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 9> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(USE_ALPHA, use_alpha),
         DefineKeyValue(USE_BETA, use_beta),
@@ -53,11 +53,10 @@ void cscmm_nn(Param out, const Param &values, const Param &colIdx,
         DefineKeyValue(ROWS_PER_GROUP, rows_per_group),
         DefineKeyValue(COLS_PER_GROUP, cols_per_group),
         DefineKeyValue(IS_CPLX, (af::iscplx<T>() ? 1 : 0)),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
     auto cscmmNN =
-        common::getKernel("cscmm_nn", {cscmm_cl_src}, targs, options);
+        common::getKernel("cscmm_nn", std::array{cscmm_cl_src}, targs, options);
 
     cl::NDRange local(threads, 1);
     int M = out.info.dims[0];

--- a/src/backend/opencl/kernel/cscmv.hpp
+++ b/src/backend/opencl/kernel/cscmv.hpp
@@ -38,12 +38,12 @@ void cscmv(Param out, const Param &values, const Param &colIdx,
 
     cl::NDRange local(THREADS_PER_GROUP);
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 6> targs = {
         TemplateTypename<T>(),       TemplateArg(use_alpha),
         TemplateArg(use_beta),       TemplateArg(is_conj),
         TemplateArg(rows_per_group), TemplateArg(local[0]),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 8> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(USE_ALPHA, use_alpha),
         DefineKeyValue(USE_BETA, use_beta),
@@ -51,11 +51,10 @@ void cscmv(Param out, const Param &values, const Param &colIdx,
         DefineKeyValue(THREADS, local[0]),
         DefineKeyValue(ROWS_PER_GROUP, rows_per_group),
         DefineKeyValue(IS_CPLX, (af::iscplx<T>() ? 1 : 0)),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto cscmvBlock =
-        common::getKernel("cscmv_block", {cscmv_cl_src}, targs, options);
+    auto cscmvBlock = common::getKernel("cscmv_block", std::array{cscmv_cl_src},
+                                        targs, options);
 
     int K        = colIdx.info.dims[0] - 1;
     int M        = out.info.dims[0];

--- a/src/backend/opencl/kernel/csrmm.hpp
+++ b/src/backend/opencl/kernel/csrmm.hpp
@@ -38,25 +38,24 @@ void csrmm_nt(Param out, const Param &values, const Param &rowIdx,
     const bool use_alpha = (alpha != scalar<T>(1.0));
     const bool use_beta  = (beta != scalar<T>(0.0));
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 4> targs = {
         TemplateTypename<T>(),
         TemplateArg(use_alpha),
         TemplateArg(use_beta),
         TemplateArg(use_greedy),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 7> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(USE_ALPHA, use_alpha),
         DefineKeyValue(USE_BETA, use_beta),
         DefineKeyValue(USE_GREEDY, use_greedy),
         DefineValue(THREADS_PER_GROUP),
         DefineKeyValue(IS_CPLX, (af::iscplx<T>() ? 1 : 0)),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
     // FIXME: Switch to perf (thread vs block) baesd kernel
     auto csrmm_nt_func =
-        common::getKernel("csrmm_nt", {csrmm_cl_src}, targs, options);
+        common::getKernel("csrmm_nt", std::array{csrmm_cl_src}, targs, options);
 
     cl::NDRange local(THREADS_PER_GROUP, 1);
     int M = rowIdx.info.dims[0] - 1;

--- a/src/backend/opencl/kernel/csrmv.hpp
+++ b/src/backend/opencl/kernel/csrmv.hpp
@@ -43,24 +43,24 @@ void csrmv(Param out, const Param &values, const Param &rowIdx,
 
     cl::NDRange local(THREADS_PER_GROUP);
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 5> targs = {
         TemplateTypename<T>(),   TemplateArg(use_alpha), TemplateArg(use_beta),
         TemplateArg(use_greedy), TemplateArg(local[0]),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 7> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(USE_ALPHA, use_alpha),
         DefineKeyValue(USE_BETA, use_beta),
         DefineKeyValue(USE_GREEDY, use_greedy),
         DefineKeyValue(THREADS, local[0]),
         DefineKeyValue(IS_CPLX, (af::iscplx<T>() ? 1 : 0)),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
     auto csrmv =
         (is_csrmv_block
-             ? common::getKernel("csrmv_thread", {csrmv_cl_src}, targs, options)
-             : common::getKernel("csrmv_block", {csrmv_cl_src}, targs,
+             ? common::getKernel("csrmv_thread", std::array{csrmv_cl_src},
+                                 targs, options)
+             : common::getKernel("csrmv_block", std::array{csrmv_cl_src}, targs,
                                  options));
 
     int M = rowIdx.info.dims[0] - 1;

--- a/src/backend/opencl/kernel/diagonal.hpp
+++ b/src/backend/opencl/kernel/diagonal.hpp
@@ -27,17 +27,16 @@ namespace kernel {
 
 template<typename T>
 static void diagCreate(Param out, Param in, int num) {
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 1> targs = {
         TemplateTypename<T>(),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 3> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(ZERO, af::scalar_to_option(scalar<T>(0))),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto diagCreate = common::getKernel("diagCreateKernel",
-                                        {diag_create_cl_src}, targs, options);
+    auto diagCreate = common::getKernel(
+        "diagCreateKernel", std::array{diag_create_cl_src}, targs, options);
 
     cl::NDRange local(32, 8);
     int groups_x = divup(out.info.dims[0], local[0]);
@@ -52,17 +51,16 @@ static void diagCreate(Param out, Param in, int num) {
 
 template<typename T>
 static void diagExtract(Param out, Param in, int num) {
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 1> targs = {
         TemplateTypename<T>(),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 3> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(ZERO, af::scalar_to_option(scalar<T>(0))),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto diagExtract = common::getKernel("diagExtractKernel",
-                                         {diag_extract_cl_src}, targs, options);
+    auto diagExtract = common::getKernel(
+        "diagExtractKernel", std::array{diag_extract_cl_src}, targs, options);
 
     cl::NDRange local(256, 1);
     int groups_x = divup(out.info.dims[0], local[0]);

--- a/src/backend/opencl/kernel/diff.hpp
+++ b/src/backend/opencl/kernel/diff.hpp
@@ -28,20 +28,18 @@ void diff(Param out, const Param in, const unsigned indims, const unsigned dim,
     constexpr int TX = 16;
     constexpr int TY = 16;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 3> targs = {
         TemplateTypename<T>(),
         TemplateArg(dim),
         TemplateArg(isDiff2),
     };
-    std::vector<std::string> options = {
-        DefineKeyValue(T, dtype_traits<T>::getName()),
-        DefineKeyValue(DIM, dim),
+    std::array<std::string, 4> options = {
+        DefineKeyValue(T, dtype_traits<T>::getName()), DefineKeyValue(DIM, dim),
         DefineKeyValue(isDiff2, (isDiff2 ? 1 : 0)),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto diffOp =
-        common::getKernel("diff_kernel", {diff_cl_src}, targs, options);
+    auto diffOp = common::getKernel("diff_kernel", std::array{diff_cl_src},
+                                    targs, options);
 
     cl::NDRange local(TX, TY, 1);
     if (dim == 0 && indims == 1) { local = cl::NDRange(TX * TY, 1, 1); }

--- a/src/backend/opencl/kernel/exampleFunction.hpp
+++ b/src/backend/opencl/kernel/exampleFunction.hpp
@@ -43,25 +43,25 @@ template<typename T>
 void exampleFunc(Param c, const Param a, const Param b, const af_someenum_t p) {
     // Compilation options for compiling OpenCL kernel.
     // Go to common/kernel_cache.hpp to find details on this.
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 1> targs = {
         TemplateTypename<T>(),
     };
 
     // Compilation options for compiling OpenCL kernel.
     // Go to common/kernel_cache.hpp to find details on this.
-    std::vector<std::string> options = {
+    std::array<std::string, 2> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
-    };
 
-    // The following templated function can take variable
-    // number of template parameters and if one of them is double
-    // precision, it will enable necessary constants, flags, ops
-    // in opencl kernel compilation stage
-    options.emplace_back(getTypeBuildDefinition<T>());
+        // The following templated function can take variable
+        // number of template parameters and if one of them is double
+        // precision, it will enable necessary constants, flags, ops
+        // in opencl kernel compilation stage
+        getTypeBuildDefinition<T>()};
 
     // Fetch the Kernel functor, go to common/kernel_cache.hpp
     // to find details of this function
-    auto exOp = common::getKernel("example", {example_cl_src}, targs, options);
+    auto exOp = common::getKernel("example", std::array{example_cl_src}, targs,
+                                  options);
 
     // configure work group parameters
     cl::NDRange local(THREADS_X, THREADS_Y);

--- a/src/backend/opencl/kernel/fast.hpp
+++ b/src/backend/opencl/kernel/fast.hpp
@@ -33,24 +33,23 @@ void fast(const unsigned arc_length, unsigned *out_feat, Param &x_out,
     constexpr int FAST_THREADS_NONMAX_X = 32;
     constexpr int FAST_THREADS_NONMAX_Y = 8;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 3> targs = {
         TemplateTypename<T>(),
         TemplateArg(arc_length),
         TemplateArg(nonmax),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 4> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(ARC_LENGTH, arc_length),
         DefineKeyValue(NONMAX, static_cast<unsigned>(nonmax)),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto locate =
-        common::getKernel("locate_features", {fast_cl_src}, targs, options);
-    auto nonMax =
-        common::getKernel("non_max_counts", {fast_cl_src}, targs, options);
-    auto getFeat =
-        common::getKernel("get_features", {fast_cl_src}, targs, options);
+    auto locate  = common::getKernel("locate_features", std::array{fast_cl_src},
+                                     targs, options);
+    auto nonMax  = common::getKernel("non_max_counts", std::array{fast_cl_src},
+                                     targs, options);
+    auto getFeat = common::getKernel("get_features", std::array{fast_cl_src},
+                                     targs, options);
 
     const unsigned max_feat =
         ceil(in.info.dims[0] * in.info.dims[1] * feature_ratio);

--- a/src/backend/opencl/kernel/fftconvolve.hpp
+++ b/src/backend/opencl/kernel/fftconvolve.hpp
@@ -70,25 +70,24 @@ void packDataHelper(Param packed, Param sig, Param filter, const int rank,
     constexpr auto ctDType =
         static_cast<af_dtype>(dtype_traits<convT>::af_type);
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 3> targs = {
         TemplateTypename<T>(),
         TemplateTypename<convT>(),
         TemplateArg(IsTypeDouble),
     };
     std::vector<std::string> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
-    };
+        getTypeBuildDefinition<T, convT>()};
     if (ctDType == c32) {
         options.emplace_back(DefineKeyValue(CONVT, "float"));
     } else if (ctDType == c64 && IsTypeDouble) {
         options.emplace_back(DefineKeyValue(CONVT, "double"));
     }
-    options.emplace_back(getTypeBuildDefinition<T, convT>());
 
-    auto packData = common::getKernel("pack_data", {fftconvolve_pack_cl_src},
-                                      targs, options);
-    auto padArray = common::getKernel("pad_array", {fftconvolve_pack_cl_src},
-                                      targs, options);
+    auto packData = common::getKernel(
+        "pack_data", std::array{fftconvolve_pack_cl_src}, targs, options);
+    auto padArray = common::getKernel(
+        "pad_array", std::array{fftconvolve_pack_cl_src}, targs, options);
 
     Param sig_tmp, filter_tmp;
     calcParamSizes(sig_tmp, filter_tmp, packed, sig, filter, rank, kind);
@@ -129,7 +128,7 @@ void complexMultiplyHelper(Param packed, Param sig, Param filter,
     constexpr auto ctDType =
         static_cast<af_dtype>(dtype_traits<convT>::af_type);
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 3> targs = {
         TemplateTypename<T>(),
         TemplateTypename<convT>(),
         TemplateArg(IsTypeDouble),
@@ -140,16 +139,16 @@ void complexMultiplyHelper(Param packed, Param sig, Param filter,
         DefineKeyValue(AF_BATCH_LHS, static_cast<int>(AF_BATCH_LHS)),
         DefineKeyValue(AF_BATCH_RHS, static_cast<int>(AF_BATCH_RHS)),
         DefineKeyValue(AF_BATCH_SAME, static_cast<int>(AF_BATCH_SAME)),
-    };
+        getTypeBuildDefinition<T, convT>()};
     if (ctDType == c32) {
         options.emplace_back(DefineKeyValue(CONVT, "float"));
     } else if (ctDType == c64 && IsTypeDouble) {
         options.emplace_back(DefineKeyValue(CONVT, "double"));
     }
-    options.emplace_back(getTypeBuildDefinition<T, convT>());
 
-    auto cplxMul = common::getKernel(
-        "complex_multiply", {fftconvolve_multiply_cl_src}, targs, options);
+    auto cplxMul = common::getKernel("complex_multiply",
+                                     std::array{fftconvolve_multiply_cl_src},
+                                     targs, options);
 
     Param sig_tmp, filter_tmp;
     calcParamSizes(sig_tmp, filter_tmp, packed, sig, filter, rank, kind);
@@ -179,7 +178,7 @@ void reorderOutputHelper(Param out, Param packed, Param sig, Param filter,
         static_cast<af_dtype>(dtype_traits<convT>::af_type);
     constexpr bool RoundResult = std::is_integral<T>::value;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 5> targs = {
         TemplateTypename<T>(),     TemplateTypename<convT>(),
         TemplateArg(IsTypeDouble), TemplateArg(RoundResult),
         TemplateArg(expand),
@@ -188,16 +187,16 @@ void reorderOutputHelper(Param out, Param packed, Param sig, Param filter,
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(ROUND_OUT, static_cast<int>(RoundResult)),
         DefineKeyValue(EXPAND, static_cast<int>(expand)),
-    };
+        getTypeBuildDefinition<T, convT>()};
     if (ctDType == c32) {
         options.emplace_back(DefineKeyValue(CONVT, "float"));
     } else if (ctDType == c64 && IsTypeDouble) {
         options.emplace_back(DefineKeyValue(CONVT, "double"));
     }
-    options.emplace_back(getTypeBuildDefinition<T, convT>());
 
-    auto reorder = common::getKernel(
-        "reorder_output", {fftconvolve_reorder_cl_src}, targs, options);
+    auto reorder = common::getKernel("reorder_output",
+                                     std::array{fftconvolve_reorder_cl_src},
+                                     targs, options);
 
     int fftScale = 1;
 

--- a/src/backend/opencl/kernel/flood_fill.hpp
+++ b/src/backend/opencl/kernel/flood_fill.hpp
@@ -33,15 +33,13 @@ constexpr int ZERO      = 0;
 
 template<typename T>
 void initSeeds(Param out, const Param seedsx, const Param seedsy) {
-    std::vector<std::string> options = {
-        DefineKeyValue(T, dtype_traits<T>::getName()),
-        DefineValue(VALID),
-        DefineKey(INIT_SEEDS),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+    std::array<std::string, 4> options = {
+        DefineKeyValue(T, dtype_traits<T>::getName()), DefineValue(VALID),
+        DefineKey(INIT_SEEDS), getTypeBuildDefinition<T>()};
 
-    auto initSeeds = common::getKernel("init_seeds", {flood_fill_cl_src},
-                                       {TemplateTypename<T>()}, options);
+    auto initSeeds =
+        common::getKernel("init_seeds", std::array{flood_fill_cl_src},
+                          TemplateArgs(TemplateTypename<T>()), options);
     cl::NDRange local(kernel::THREADS, 1, 1);
     cl::NDRange global(divup(seedsx.info.dims[0], local[0]) * local[0], 1, 1);
 
@@ -52,16 +50,14 @@ void initSeeds(Param out, const Param seedsx, const Param seedsy) {
 
 template<typename T>
 void finalizeOutput(Param out, const T newValue) {
-    std::vector<std::string> options = {
-        DefineKeyValue(T, dtype_traits<T>::getName()),
-        DefineValue(VALID),
-        DefineValue(ZERO),
-        DefineKey(FINALIZE_OUTPUT),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+    std::array<std::string, 5> options = {
+        DefineKeyValue(T, dtype_traits<T>::getName()), DefineValue(VALID),
+        DefineValue(ZERO), DefineKey(FINALIZE_OUTPUT),
+        getTypeBuildDefinition<T>()};
 
-    auto finalizeOut = common::getKernel("finalize_output", {flood_fill_cl_src},
-                                         {TemplateTypename<T>()}, options);
+    auto finalizeOut =
+        common::getKernel("finalize_output", std::array{flood_fill_cl_src},
+                          TemplateArgs(TemplateTypename<T>()), options);
     cl::NDRange local(kernel::THREADS_X, kernel::THREADS_Y, 1);
     cl::NDRange global(divup(out.info.dims[0], local[0]) * local[0],
                        divup(out.info.dims[1], local[1]) * local[1], 1);
@@ -77,7 +73,7 @@ void floodFill(Param out, const Param image, const Param seedsx,
     constexpr int RADIUS = 1;
 
     UNUSED(nlookup);
-    std::vector<std::string> options = {
+    std::array<std::string, 11> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineValue(RADIUS),
         DefineValue(VALID),
@@ -89,11 +85,11 @@ void floodFill(Param out, const Param image, const Param seedsx,
         DefineKeyValue(GROUP_SIZE, (THREADS_Y * THREADS_X)),
         DefineKeyValue(AF_IS_PLATFORM_NVIDIA,
                        (int)(AFCL_PLATFORM_NVIDIA == getActivePlatform())),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto floodStep = common::getKernel("flood_step", {flood_fill_cl_src},
-                                       {TemplateTypename<T>()}, options);
+    auto floodStep =
+        common::getKernel("flood_step", std::array{flood_fill_cl_src},
+                          TemplateArgs(TemplateTypename<T>()), options);
     cl::NDRange local(kernel::THREADS_X, kernel::THREADS_Y, 1);
     cl::NDRange global(divup(out.info.dims[0], local[0]) * local[0],
                        divup(out.info.dims[1], local[1]) * local[1], 1);

--- a/src/backend/opencl/kernel/gradient.hpp
+++ b/src/backend/opencl/kernel/gradient.hpp
@@ -29,20 +29,19 @@ void gradient(Param grad0, Param grad1, const Param in) {
     constexpr int TX = 32;
     constexpr int TY = 8;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 1> targs = {
         TemplateTypename<T>(),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 6> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineValue(TX),
         DefineValue(TY),
         DefineKeyValue(ZERO, af::scalar_to_option(scalar<T>(0))),
         DefineKeyValue(CPLX, static_cast<int>(af::iscplx<T>())),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto gradOp =
-        common::getKernel("gradient", {gradient_cl_src}, targs, options);
+    auto gradOp = common::getKernel("gradient", std::array{gradient_cl_src},
+                                    targs, options);
 
     cl::NDRange local(TX, TY, 1);
 

--- a/src/backend/opencl/kernel/harris.hpp
+++ b/src/backend/opencl/kernel/harris.hpp
@@ -62,20 +62,22 @@ void conv_helper(Array<T> &ixx, Array<T> &ixy, Array<T> &iyy,
 
 template<typename T>
 std::array<Kernel, 4> getHarrisKernels() {
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 1> targs = {
         TemplateTypename<T>(),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 2> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
     return {
-        common::getKernel("second_order_deriv", {harris_cl_src}, targs,
+        common::getKernel("second_order_deriv", std::array{harris_cl_src},
+                          targs, options),
+        common::getKernel("keep_corners", std::array{harris_cl_src}, targs,
                           options),
-        common::getKernel("keep_corners", {harris_cl_src}, targs, options),
-        common::getKernel("harris_responses", {harris_cl_src}, targs, options),
-        common::getKernel("non_maximal", {harris_cl_src}, targs, options),
+        common::getKernel("harris_responses", std::array{harris_cl_src}, targs,
+                          options),
+        common::getKernel("non_maximal", std::array{harris_cl_src}, targs,
+                          options),
     };
 }
 

--- a/src/backend/opencl/kernel/histogram.hpp
+++ b/src/backend/opencl/kernel/histogram.hpp
@@ -29,7 +29,7 @@ void histogram(Param out, const Param in, int nbins, float minval, float maxval,
     constexpr int THREADS_X = 256;
     constexpr int THRD_LOAD = 16;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(),
         TemplateArg(isLinear),
     };
@@ -41,8 +41,8 @@ void histogram(Param out, const Param in, int nbins, float minval, float maxval,
     options.emplace_back(getTypeBuildDefinition<T>());
     if (isLinear) { options.emplace_back(DefineKey(IS_LINEAR)); }
 
-    auto histogram =
-        common::getKernel("histogram", {histogram_cl_src}, targs, options);
+    auto histogram = common::getKernel(
+        "histogram", std::array{histogram_cl_src}, targs, options);
 
     int nElems  = in.info.dims[0] * in.info.dims[1];
     int blk_x   = divup(nElems, THRD_LOAD * THREADS_X);

--- a/src/backend/opencl/kernel/homography.hpp
+++ b/src/backend/opencl/kernel/homography.hpp
@@ -31,16 +31,14 @@ constexpr int HG_THREADS   = 256;
 
 template<typename T>
 std::array<Kernel, 5> getHomographyKernels(const af_homography_type htype) {
-    std::vector<TemplateArg> targs   = {TemplateTypename<T>(),
+    std::array<TemplateArg, 2> targs = {TemplateTypename<T>(),
                                         TemplateArg(htype)};
     std::vector<std::string> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
-    options.emplace_back(
+        getTypeBuildDefinition<T>(),
         DefineKeyValue(EPS, (std::is_same<T, double>::value
                                  ? std::numeric_limits<double>::epsilon()
-                                 : std::numeric_limits<float>::epsilon())));
+                                 : std::numeric_limits<float>::epsilon()))};
     if (htype == AF_HOMOGRAPHY_RANSAC) {
         options.emplace_back(DefineKey(RANSAC));
     }
@@ -51,16 +49,16 @@ std::array<Kernel, 5> getHomographyKernels(const af_homography_type htype) {
         options.emplace_back(DefineKey(IS_CPU));
     }
     return {
-        common::getKernel("compute_homography", {homography_cl_src}, targs,
-                          options),
-        common::getKernel("eval_homography", {homography_cl_src}, targs,
-                          options),
-        common::getKernel("compute_median", {homography_cl_src}, targs,
-                          options),
-        common::getKernel("find_min_median", {homography_cl_src}, targs,
-                          options),
-        common::getKernel("compute_lmeds_inliers", {homography_cl_src}, targs,
-                          options),
+        common::getKernel("compute_homography", std::array{homography_cl_src},
+                          targs, options),
+        common::getKernel("eval_homography", std::array{homography_cl_src},
+                          targs, options),
+        common::getKernel("compute_median", std::array{homography_cl_src},
+                          targs, options),
+        common::getKernel("find_min_median", std::array{homography_cl_src},
+                          targs, options),
+        common::getKernel("compute_lmeds_inliers",
+                          std::array{homography_cl_src}, targs, options),
     };
 }
 

--- a/src/backend/opencl/kernel/hsv_rgb.hpp
+++ b/src/backend/opencl/kernel/hsv_rgb.hpp
@@ -27,18 +27,17 @@ void hsv2rgb_convert(Param out, const Param in, bool isHSV2RGB) {
     constexpr int THREADS_X = 16;
     constexpr int THREADS_Y = 16;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(),
         TemplateArg(isHSV2RGB),
     };
     std::vector<std::string> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
     if (isHSV2RGB) { options.emplace_back(DefineKey(isHSV2RGB)); }
 
-    auto convert =
-        common::getKernel("hsvrgbConvert", {hsv_rgb_cl_src}, targs, options);
+    auto convert = common::getKernel(
+        "hsvrgbConvert", std::array{hsv_rgb_cl_src}, targs, options);
 
     cl::NDRange local(THREADS_X, THREADS_Y);
 

--- a/src/backend/opencl/kernel/identity.hpp
+++ b/src/backend/opencl/kernel/identity.hpp
@@ -27,18 +27,17 @@ namespace kernel {
 
 template<typename T>
 static void identity(Param out) {
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 1> targs = {
         TemplateTypename<T>(),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 4> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(ONE, af::scalar_to_option(scalar<T>(1))),
         DefineKeyValue(ZERO, af::scalar_to_option(scalar<T>(0))),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto identityOp =
-        common::getKernel("identity_kernel", {identity_cl_src}, targs, options);
+    auto identityOp = common::getKernel(
+        "identity_kernel", std::array{identity_cl_src}, targs, options);
 
     cl::NDRange local(32, 8);
     int groups_x = divup(out.info.dims[0], local[0]);

--- a/src/backend/opencl/kernel/iir.hpp
+++ b/src/backend/opencl/kernel/iir.hpp
@@ -29,19 +29,18 @@ void iir(Param y, Param c, Param a) {
     // allocted outside
     constexpr int MAX_A_SIZE = (1024 * sizeof(double)) / sizeof(T);
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(),
         TemplateArg(batch_a),
     };
-    std::vector<std::string> options = {
-        DefineKeyValue(T, dtype_traits<T>::getName()),
-        DefineValue(MAX_A_SIZE),
+    std::array<std::string, 5> options = {
+        DefineKeyValue(T, dtype_traits<T>::getName()), DefineValue(MAX_A_SIZE),
         DefineKeyValue(BATCH_A, batch_a),
         DefineKeyValue(ZERO, af::scalar_to_option(scalar<T>(0))),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto iir = common::getKernel("iir_kernel", {iir_cl_src}, targs, options);
+    auto iir =
+        common::getKernel("iir_kernel", std::array{iir_cl_src}, targs, options);
 
     const int groups_y = y.info.dims[1];
     const int groups_x = y.info.dims[2];

--- a/src/backend/opencl/kernel/index.hpp
+++ b/src/backend/opencl/kernel/index.hpp
@@ -31,13 +31,13 @@ typedef struct {
 template<typename T>
 void index(Param out, const Param in, const IndexKernelParam_t& p,
            cl::Buffer* bPtr[4]) {
-    std::vector<std::string> options = {
+    std::array<std::string, 2> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto index    = common::getKernel("indexKernel", {index_cl_src},
-                                      {TemplateTypename<T>()}, options);
+    auto index =
+        common::getKernel("indexKernel", std::array{index_cl_src},
+                          TemplateArgs(TemplateTypename<T>()), options);
     int threads_x = 256;
     int threads_y = 1;
     cl::NDRange local(threads_x, threads_y);

--- a/src/backend/opencl/kernel/iota.hpp
+++ b/src/backend/opencl/kernel/iota.hpp
@@ -31,13 +31,12 @@ void iota(Param out, const af::dim4& sdims) {
     constexpr int TILEX   = 512;
     constexpr int TILEY   = 32;
 
-    std::vector<std::string> options = {
+    std::array<std::string, 2> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto iota = common::getKernel("iota_kernel", {iota_cl_src},
-                                  {TemplateTypename<T>()}, options);
+    auto iota = common::getKernel("iota_kernel", std::array{iota_cl_src},
+                                  TemplateArgs(TemplateTypename<T>()), options);
     cl::NDRange local(IOTA_TX, IOTA_TY, 1);
 
     int blocksPerMatX = divup(out.info.dims[0], TILEX);

--- a/src/backend/opencl/kernel/ireduce.hpp
+++ b/src/backend/opencl/kernel/ireduce.hpp
@@ -33,11 +33,11 @@ void ireduceDimLauncher(Param out, cl::Buffer *oidx, Param in, cl::Buffer *iidx,
                         const int dim, const int threads_y, const bool is_first,
                         const uint groups_all[4], Param rlen) {
     ToNumStr<T> toNumStr;
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 5> targs = {
         TemplateTypename<T>(), TemplateArg(dim),       TemplateArg(op),
         TemplateArg(is_first), TemplateArg(threads_y),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 9> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(kDim, dim),
         DefineKeyValue(DIMY, threads_y),
@@ -46,12 +46,11 @@ void ireduceDimLauncher(Param out, cl::Buffer *oidx, Param in, cl::Buffer *iidx,
         DefineKeyFromStr(binOpName<op>()),
         DefineKeyValue(CPLX, af::iscplx<T>()),
         DefineKeyValue(IS_FIRST, is_first),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto ireduceDim =
-        common::getKernel("ireduce_dim_kernel",
-                          {iops_cl_src, ireduce_dim_cl_src}, targs, options);
+    auto ireduceDim = common::getKernel(
+        "ireduce_dim_kernel", std::array{iops_cl_src, ireduce_dim_cl_src},
+        targs, options);
 
     cl::NDRange local(THREADS_X, threads_y);
     cl::NDRange global(groups_all[0] * groups_all[2] * local[0],
@@ -109,13 +108,13 @@ void ireduceFirstLauncher(Param out, cl::Buffer *oidx, Param in,
                           const bool is_first, const uint groups_x,
                           const uint groups_y, Param rlen) {
     ToNumStr<T> toNumStr;
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 4> targs = {
         TemplateTypename<T>(),
         TemplateArg(op),
         TemplateArg(is_first),
         TemplateArg(threads_x),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 8> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(DIMX, threads_x),
         DefineValue(THREADS_PER_GROUP),
@@ -123,12 +122,11 @@ void ireduceFirstLauncher(Param out, cl::Buffer *oidx, Param in,
         DefineKeyFromStr(binOpName<op>()),
         DefineKeyValue(CPLX, af::iscplx<T>()),
         DefineKeyValue(IS_FIRST, is_first),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto ireduceFirst =
-        common::getKernel("ireduce_first_kernel",
-                          {iops_cl_src, ireduce_first_cl_src}, targs, options);
+    auto ireduceFirst = common::getKernel(
+        "ireduce_first_kernel", std::array{iops_cl_src, ireduce_first_cl_src},
+        targs, options);
 
     cl::NDRange local(threads_x, THREADS_PER_GROUP / threads_x);
     cl::NDRange global(groups_x * in.info.dims[2] * local[0],

--- a/src/backend/opencl/kernel/laset.hpp
+++ b/src/backend/opencl/kernel/laset.hpp
@@ -46,20 +46,18 @@ void laset(int m, int n, T offdiag, T diag, cl_mem dA, size_t dA_offset,
     constexpr int BLK_X = 64;
     constexpr int BLK_Y = 32;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(),
         TemplateArg(uplo),
     };
-    std::vector<std::string> options = {
-        DefineKeyValue(T, dtype_traits<T>::getName()),
-        DefineValue(BLK_X),
+    std::array<std::string, 5> options = {
+        DefineKeyValue(T, dtype_traits<T>::getName()), DefineValue(BLK_X),
         DefineValue(BLK_Y),
         DefineKeyValue(IS_CPLX, static_cast<int>(af::iscplx<T>())),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto lasetOp =
-        common::getKernel(laset_name<uplo>(), {laset_cl_src}, targs, options);
+    auto lasetOp = common::getKernel(laset_name<uplo>(),
+                                     std::array{laset_cl_src}, targs, options);
 
     int groups_x = (m - 1) / BLK_X + 1;
     int groups_y = (n - 1) / BLK_Y + 1;

--- a/src/backend/opencl/kernel/laset_band.hpp
+++ b/src/backend/opencl/kernel/laset_band.hpp
@@ -36,15 +36,15 @@ void laset_band(int m, int  n, int k,
 {
     static const std::string src(laset_band_cl, laset_band_cl_len);
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(), TemplateArg(uplo),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 4> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineValue(NB),
         DefineKeyValue(IS_CPLX, static_cast<int>(af::iscplx<T>())),
+        getTypeBuildDefinition<T>()
     };
-    options.emplace_back(getTypeBuildDefinition<T>());
 
     auto lasetBandOp = common::getKernel(laset_band_name<uplo>(), {src}, targs, options);
 

--- a/src/backend/opencl/kernel/laswp.hpp
+++ b/src/backend/opencl/kernel/laswp.hpp
@@ -34,16 +34,15 @@ void laswp(int n, cl_mem in, size_t offset, int ldda, int k1, int k2,
            const int *ipiv, int inci, cl::CommandQueue &queue) {
     constexpr int NTHREADS = 256;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 1> targs = {
         TemplateTypename<T>(),
     };
-    std::vector<std::string> options = {
-        DefineKeyValue(T, dtype_traits<T>::getName()),
-        DefineValue(MAX_PIVOTS),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+    std::array<std::string, 3> options = {
+        DefineKeyValue(T, dtype_traits<T>::getName()), DefineValue(MAX_PIVOTS),
+        getTypeBuildDefinition<T>()};
 
-    auto laswpOp = common::getKernel("laswp", {laswp_cl_src}, targs, options);
+    auto laswpOp =
+        common::getKernel("laswp", std::array{laswp_cl_src}, targs, options);
 
     int groups = divup(n, NTHREADS);
     cl::NDRange local(NTHREADS);

--- a/src/backend/opencl/kernel/lookup.hpp
+++ b/src/backend/opencl/kernel/lookup.hpp
@@ -29,17 +29,15 @@ void lookup(Param out, const Param in, const Param indices,
     constexpr int THREADS_X = 32;
     constexpr int THREADS_Y = 8;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 3> targs = {
         TemplateTypename<in_t>(),
         TemplateTypename<idx_t>(),
         TemplateArg(dim),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 4> options = {
         DefineKeyValue(in_t, dtype_traits<in_t>::getName()),
         DefineKeyValue(idx_t, dtype_traits<idx_t>::getName()),
-        DefineKeyValue(DIM, dim),
-    };
-    options.emplace_back(getTypeBuildDefinition<in_t, idx_t>());
+        DefineKeyValue(DIM, dim), getTypeBuildDefinition<in_t, idx_t>()};
 
     cl::NDRange local(THREADS_X, THREADS_Y);
 
@@ -49,8 +47,8 @@ void lookup(Param out, const Param in, const Param indices,
     cl::NDRange global(blk_x * out.info.dims[2] * THREADS_X,
                        blk_y * out.info.dims[3] * THREADS_Y);
 
-    auto arrIdxOp =
-        common::getKernel("lookupND", {lookup_cl_src}, targs, options);
+    auto arrIdxOp = common::getKernel("lookupND", std::array{lookup_cl_src},
+                                      targs, options);
 
     arrIdxOp(cl::EnqueueArgs(getQueue(), global, local), *out.data, out.info,
              *in.data, in.info, *indices.data, indices.info, blk_x, blk_y);

--- a/src/backend/opencl/kernel/lu_split.hpp
+++ b/src/backend/opencl/kernel/lu_split.hpp
@@ -30,20 +30,18 @@ void luSplitLauncher(Param lower, Param upper, const Param in, bool same_dims) {
     constexpr unsigned TILEX = 128;
     constexpr unsigned TILEY = 32;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(),
         TemplateArg(same_dims),
     };
-    std::vector<std::string> options = {
-        DefineKeyValue(T, dtype_traits<T>::getName()),
-        DefineValue(same_dims),
+    std::array<std::string, 5> options = {
+        DefineKeyValue(T, dtype_traits<T>::getName()), DefineValue(same_dims),
         DefineKeyValue(ZERO, af::scalar_to_option(scalar<T>(0))),
         DefineKeyValue(ONE, af::scalar_to_option(scalar<T>(1))),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto luSplit =
-        common::getKernel("luSplit", {lu_split_cl_src}, targs, options);
+    auto luSplit = common::getKernel("luSplit", std::array{lu_split_cl_src},
+                                     targs, options);
 
     cl::NDRange local(TX, TY);
 

--- a/src/backend/opencl/kernel/match_template.hpp
+++ b/src/backend/opencl/kernel/match_template.hpp
@@ -28,13 +28,13 @@ void matchTemplate(Param out, const Param srch, const Param tmplt,
     constexpr int THREADS_X = 16;
     constexpr int THREADS_Y = 16;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 4> targs = {
         TemplateTypename<inType>(),
         TemplateTypename<outType>(),
         TemplateArg(mType),
         TemplateArg(needMean),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 14> options = {
         DefineKeyValue(inType, dtype_traits<inType>::getName()),
         DefineKeyValue(outType, dtype_traits<outType>::getName()),
         DefineKeyValue(MATCH_T, static_cast<int>(mType)),
@@ -48,11 +48,10 @@ void matchTemplate(Param out, const Param srch, const Param tmplt,
         DefineKeyValue(AF_NCC, static_cast<int>(AF_NCC)),
         DefineKeyValue(AF_ZNCC, static_cast<int>(AF_ZNCC)),
         DefineKeyValue(AF_SHD, static_cast<int>(AF_SHD)),
-    };
-    options.emplace_back(getTypeBuildDefinition<outType>());
+        getTypeBuildDefinition<outType>()};
 
-    auto matchImgOp = common::getKernel("matchTemplate", {matchTemplate_cl_src},
-                                        targs, options);
+    auto matchImgOp = common::getKernel(
+        "matchTemplate", std::array{matchTemplate_cl_src}, targs, options);
 
     cl::NDRange local(THREADS_X, THREADS_Y);
 

--- a/src/backend/opencl/kernel/mean.hpp
+++ b/src/backend/opencl/kernel/mean.hpp
@@ -108,7 +108,7 @@ void meanDimLauncher(Param out, Param owt, Param in, Param inWeight,
     ToNumStr<Tw> twNumStr;
     common::Transform<uint, Tw, af_add_t> transform_weight;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 7> targs = {
         TemplateTypename<Ti>(),     TemplateTypename<To>(),
         TemplateTypename<Tw>(),     TemplateArg(dim),
         TemplateArg(threads_y),     TemplateArg(input_weight),
@@ -124,13 +124,13 @@ void meanDimLauncher(Param out, Param owt, Param in, Param inWeight,
         DefineKeyValue(init_To, toNumStr(common::Binary<To, af_add_t>::init())),
         DefineKeyValue(init_Tw, twNumStr(transform_weight(0))),
         DefineKeyValue(one_Tw, twNumStr(transform_weight(1))),
-    };
-    options.emplace_back(getTypeBuildDefinition<Ti, To>());
+        getTypeBuildDefinition<Ti, To>()};
     if (input_weight) { options.emplace_back(DefineKey(INPUT_WEIGHT)); }
     if (output_weight) { options.emplace_back(DefineKey(OUTPUT_WEIGHT)); }
 
     auto meanOp = common::getKernel(
-        "meanDim", {mean_ops_cl_src, mean_dim_cl_src}, targs, options);
+        "meanDim", std::array{mean_ops_cl_src, mean_dim_cl_src}, targs,
+        options);
 
     NDRange local(THREADS_X, threads_y);
     NDRange global(groups_all[0] * groups_all[2] * local[0],
@@ -202,7 +202,7 @@ void meanFirstLauncher(Param out, Param owt, Param in, Param inWeight,
     ToNumStr<Tw> twNumStr;
     common::Transform<uint, Tw, af_add_t> transform_weight;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 6> targs = {
         TemplateTypename<Ti>(),    TemplateTypename<To>(),
         TemplateTypename<Tw>(),    TemplateArg(threads_x),
         TemplateArg(input_weight), TemplateArg(output_weight),
@@ -222,7 +222,8 @@ void meanFirstLauncher(Param out, Param owt, Param in, Param inWeight,
     if (output_weight) { options.emplace_back(DefineKey(OUTPUT_WEIGHT)); }
 
     auto meanOp = common::getKernel(
-        "meanFirst", {mean_ops_cl_src, mean_first_cl_src}, targs, options);
+        "meanFirst", std::array{mean_ops_cl_src, mean_first_cl_src}, targs,
+        options);
 
     NDRange local(threads_x, THREADS_PER_GROUP / threads_x);
     NDRange global(groups_x * in.info.dims[2] * local[0],

--- a/src/backend/opencl/kernel/meanshift.hpp
+++ b/src/backend/opencl/kernel/meanshift.hpp
@@ -32,19 +32,18 @@ void meanshift(Param out, const Param in, const float spatialSigma,
     constexpr int THREADS_X = 16;
     constexpr int THREADS_Y = 16;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(),
         TemplateArg(is_color),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 4> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(AccType, dtype_traits<AccType>::getName()),
         DefineKeyValue(MAX_CHANNELS, (is_color ? 3 : 1)),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto meanshiftOp =
-        common::getKernel("meanshift", {meanshift_cl_src}, targs, options);
+    auto meanshiftOp = common::getKernel(
+        "meanshift", std::array{meanshift_cl_src}, targs, options);
 
     cl::NDRange local(THREADS_X, THREADS_Y);
 

--- a/src/backend/opencl/kernel/medfilt.hpp
+++ b/src/backend/opencl/kernel/medfilt.hpp
@@ -35,22 +35,21 @@ void medfilt1(Param out, const Param in, const unsigned w_wid,
     const int ARR_SIZE = (w_wid - w_wid / 2) + 1;
     size_t loc_size    = (THREADS_X + w_wid - 1) * sizeof(T);
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(),
         TemplateArg(pad),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 7> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(pad, static_cast<int>(pad)),
         DefineKeyValue(AF_PAD_ZERO, static_cast<int>(AF_PAD_ZERO)),
         DefineKeyValue(AF_PAD_SYM, static_cast<int>(AF_PAD_SYM)),
         DefineValue(ARR_SIZE),
         DefineValue(w_wid),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto medfiltOp =
-        common::getKernel("medfilt1", {medfilt1_cl_src}, targs, options);
+    auto medfiltOp = common::getKernel("medfilt1", std::array{medfilt1_cl_src},
+                                       targs, options);
 
     cl::NDRange local(THREADS_X, 1, 1);
 
@@ -71,13 +70,13 @@ void medfilt2(Param out, const Param in, const af_border_type pad,
     const size_t loc_size =
         (THREADS_X + w_len - 1) * (THREADS_Y + w_wid - 1) * sizeof(T);
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 4> targs = {
         TemplateTypename<T>(),
         TemplateArg(pad),
         TemplateArg(w_len),
         TemplateArg(w_wid),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 8> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(pad, static_cast<int>(pad)),
         DefineKeyValue(AF_PAD_ZERO, static_cast<int>(AF_PAD_ZERO)),
@@ -85,11 +84,10 @@ void medfilt2(Param out, const Param in, const af_border_type pad,
         DefineValue(ARR_SIZE),
         DefineValue(w_wid),
         DefineValue(w_len),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto medfiltOp =
-        common::getKernel("medfilt2", {medfilt2_cl_src}, targs, options);
+    auto medfiltOp = common::getKernel("medfilt2", std::array{medfilt2_cl_src},
+                                       targs, options);
 
     cl::NDRange local(THREADS_X, THREADS_Y);
 

--- a/src/backend/opencl/kernel/moments.hpp
+++ b/src/backend/opencl/kernel/moments.hpp
@@ -28,18 +28,17 @@ template<typename T>
 void moments(Param out, const Param in, af_moment_type moment) {
     constexpr int THREADS = 128;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(),
         TemplateArg(out.info.dims[0]),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 3> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(MOMENTS_SZ, out.info.dims[0]),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto momentsOp =
-        common::getKernel("moments", {moments_cl_src}, targs, options);
+    auto momentsOp = common::getKernel("moments", std::array{moments_cl_src},
+                                       targs, options);
 
     cl::NDRange local(THREADS, 1, 1);
     cl::NDRange global(in.info.dims[1] * local[0],

--- a/src/backend/opencl/kernel/morph.hpp
+++ b/src/backend/opencl/kernel/morph.hpp
@@ -55,7 +55,8 @@ void morph(Param out, const Param in, const Param mask, bool isDilation) {
     };
     options.emplace_back(getTypeBuildDefinition<T>());
 
-    auto morphOp = common::getKernel("morph", {morph_cl_src}, targs, options);
+    auto morphOp =
+        common::getKernel("morph", std::array{morph_cl_src}, targs, options);
 
     NDRange local(THREADS_X, THREADS_Y);
 
@@ -114,7 +115,8 @@ void morph3d(Param out, const Param in, const Param mask, bool isDilation) {
     };
     options.emplace_back(getTypeBuildDefinition<T>());
 
-    auto morphOp = common::getKernel("morph3d", {morph_cl_src}, targs, options);
+    auto morphOp =
+        common::getKernel("morph3d", std::array{morph_cl_src}, targs, options);
 
     NDRange local(CUBE_X, CUBE_Y, CUBE_Z);
 

--- a/src/backend/opencl/kernel/nearest_neighbour.hpp
+++ b/src/backend/opencl/kernel/nearest_neighbour.hpp
@@ -45,7 +45,7 @@ void allDistances(Param dist, Param query, Param train, const dim_t dist_dim,
     unsigned unroll_len = nextpow2(feat_len);
     if (unroll_len != feat_len) unroll_len = 0;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 4> targs = {
         TemplateTypename<T>(),
         TemplateArg(dist_type),
         TemplateArg(use_lmem),
@@ -70,8 +70,9 @@ void allDistances(Param dist, Param query, Param train, const dim_t dist_dim,
         options.emplace_back(DefineKeyValue(DISTOP, "_shd_"));
         options.emplace_back(DefineKey(__SHD__));
     }
-    auto hmOp = common::getKernel("knnAllDistances", {nearest_neighbour_cl_src},
-                                  targs, options);
+    auto hmOp =
+        common::getKernel("knnAllDistances",
+                          std::array{nearest_neighbour_cl_src}, targs, options);
 
     const dim_t sample_dim = (dist_dim == 0) ? 1 : 0;
 

--- a/src/backend/opencl/kernel/orb.hpp
+++ b/src/backend/opencl/kernel/orb.hpp
@@ -87,10 +87,14 @@ std::array<Kernel, 4> getOrbKernels() {
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
     return {
-        common::getKernel("harris_response", {orb_cl_src}, targs, compileOpts),
-        common::getKernel("keep_features", {orb_cl_src}, targs, compileOpts),
-        common::getKernel("centroid_angle", {orb_cl_src}, targs, compileOpts),
-        common::getKernel("extract_orb", {orb_cl_src}, targs, compileOpts),
+        common::getKernel("harris_response", std::array{orb_cl_src}, targs,
+                          compileOpts),
+        common::getKernel("keep_features", std::array{orb_cl_src}, targs,
+                          compileOpts),
+        common::getKernel("centroid_angle", std::array{orb_cl_src}, targs,
+                          compileOpts),
+        common::getKernel("extract_orb", std::array{orb_cl_src}, targs,
+                          compileOpts),
     };
 }
 

--- a/src/backend/opencl/kernel/pad_array_borders.hpp
+++ b/src/backend/opencl/kernel/pad_array_borders.hpp
@@ -45,8 +45,9 @@ void padBorders(Param out, const Param in, dim4 const& lBPadding,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto pad = common::getKernel("padBorders", {pad_array_borders_cl_src},
-                                 tmpltArgs, compileOpts);
+    auto pad =
+        common::getKernel("padBorders", std::array{pad_array_borders_cl_src},
+                          tmpltArgs, compileOpts);
 
     NDRange local(PADB_THREADS_X, PADB_THREADS_Y);
 

--- a/src/backend/opencl/kernel/random_engine.hpp
+++ b/src/backend/opencl/kernel/random_engine.hpp
@@ -56,7 +56,7 @@ static Kernel getRandomEngineKernel(const af_random_engine_type type,
         default:
             AF_ERROR("Random Engine Type Not Supported", AF_ERR_NOT_SUPPORTED);
     }
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(),
         TemplateArg(kerIdx),
     };
@@ -162,8 +162,9 @@ void initMersenneState(cl::Buffer state, cl::Buffer table, const uintl &seed) {
     cl::NDRange local(THREADS_PER_GROUP, 1);
     cl::NDRange global(local[0] * MAX_BLOCKS, 1);
 
-    auto initOp = common::getKernel("mersenneInitState",
-                                    {random_engine_mersenne_init_cl_src}, {});
+    auto initOp =
+        common::getKernel("mersenneInitState",
+                          std::array{random_engine_mersenne_init_cl_src}, {});
     initOp(cl::EnqueueArgs(getQueue(), global, local), state, table, seed);
     CL_DEBUG_FINISH(getQueue());
 }

--- a/src/backend/opencl/kernel/range.hpp
+++ b/src/backend/opencl/kernel/range.hpp
@@ -30,14 +30,13 @@ void range(Param out, const int dim) {
     constexpr int RANGE_TILEX = 512;
     constexpr int RANGE_TILEY = 32;
 
-    std::vector<TemplateArg> targs   = {TemplateTypename<T>()};
-    std::vector<std::string> options = {
+    std::array<TemplateArg, 1> targs   = {TemplateTypename<T>()};
+    std::array<std::string, 2> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto rangeOp =
-        common::getKernel("range_kernel", {range_cl_src}, targs, options);
+    auto rangeOp = common::getKernel("range_kernel", std::array{range_cl_src},
+                                     targs, options);
 
     cl::NDRange local(RANGE_TX, RANGE_TY, 1);
 

--- a/src/backend/opencl/kernel/reduce.hpp
+++ b/src/backend/opencl/kernel/reduce.hpp
@@ -38,11 +38,11 @@ void reduceDimLauncher(Param out, Param in, const int dim, const uint threads_y,
                        const uint groups_all[4], int change_nan,
                        double nanval) {
     ToNumStr<To> toNumStr;
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 5> targs = {
         TemplateTypename<Ti>(), TemplateTypename<To>(), TemplateArg(dim),
         TemplateArg(op),        TemplateArg(threads_y),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 10> options = {
         DefineKeyValue(Ti, dtype_traits<Ti>::getName()),
         DefineKeyValue(To, dtype_traits<To>::getName()),
         DefineKeyValue(T, "To"),
@@ -52,11 +52,11 @@ void reduceDimLauncher(Param out, Param in, const int dim, const uint threads_y,
         DefineKeyValue(init, toNumStr(common::Binary<To, op>::init())),
         DefineKeyFromStr(binOpName<op>()),
         DefineKeyValue(CPLX, af::iscplx<Ti>()),
-    };
-    options.emplace_back(getTypeBuildDefinition<Ti, To>());
+        getTypeBuildDefinition<Ti, To>()};
 
     auto reduceDim = common::getKernel(
-        "reduce_dim_kernel", {ops_cl_src, reduce_dim_cl_src}, targs, options);
+        "reduce_dim_kernel", std::array{ops_cl_src, reduce_dim_cl_src}, targs,
+        options);
 
     cl::NDRange local(THREADS_X, threads_y);
     cl::NDRange global(groups_all[0] * groups_all[2] * local[0],
@@ -115,13 +115,13 @@ void reduceAllLauncher(Param out, Param in, const uint groups_x,
                        const uint groups_y, const uint threads_x,
                        int change_nan, double nanval) {
     ToNumStr<To> toNumStr;
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 4> targs = {
         TemplateTypename<Ti>(),
         TemplateTypename<To>(),
         TemplateArg(op),
         TemplateArg(threads_x),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 9> options = {
         DefineKeyValue(Ti, dtype_traits<Ti>::getName()),
         DefineKeyValue(To, dtype_traits<To>::getName()),
         DefineKeyValue(T, "To"),
@@ -130,11 +130,11 @@ void reduceAllLauncher(Param out, Param in, const uint groups_x,
         DefineKeyValue(init, toNumStr(common::Binary<To, op>::init())),
         DefineKeyFromStr(binOpName<op>()),
         DefineKeyValue(CPLX, af::iscplx<Ti>()),
-    };
-    options.emplace_back(getTypeBuildDefinition<Ti, To>());
+        getTypeBuildDefinition<Ti, To>()};
 
     auto reduceAll = common::getKernel(
-        "reduce_all_kernel", {ops_cl_src, reduce_all_cl_src}, targs, options);
+        "reduce_all_kernel", std::array{ops_cl_src, reduce_all_cl_src}, targs,
+        options);
 
     cl::NDRange local(threads_x, THREADS_PER_GROUP / threads_x);
     cl::NDRange global(groups_x * in.info.dims[2] * local[0],
@@ -163,13 +163,13 @@ void reduceFirstLauncher(Param out, Param in, const uint groups_x,
                          const uint groups_y, const uint threads_x,
                          int change_nan, double nanval) {
     ToNumStr<To> toNumStr;
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 4> targs = {
         TemplateTypename<Ti>(),
         TemplateTypename<To>(),
         TemplateArg(op),
         TemplateArg(threads_x),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 9> options = {
         DefineKeyValue(Ti, dtype_traits<Ti>::getName()),
         DefineKeyValue(To, dtype_traits<To>::getName()),
         DefineKeyValue(T, "To"),
@@ -178,12 +178,11 @@ void reduceFirstLauncher(Param out, Param in, const uint groups_x,
         DefineKeyValue(init, toNumStr(common::Binary<To, op>::init())),
         DefineKeyFromStr(binOpName<op>()),
         DefineKeyValue(CPLX, af::iscplx<Ti>()),
-    };
-    options.emplace_back(getTypeBuildDefinition<Ti, To>());
+        getTypeBuildDefinition<Ti, To>()};
 
-    auto reduceFirst =
-        common::getKernel("reduce_first_kernel",
-                          {ops_cl_src, reduce_first_cl_src}, targs, options);
+    auto reduceFirst = common::getKernel(
+        "reduce_first_kernel", std::array{ops_cl_src, reduce_first_cl_src},
+        targs, options);
 
     cl::NDRange local(threads_x, THREADS_PER_GROUP / threads_x);
     cl::NDRange global(groups_x * in.info.dims[2] * local[0],

--- a/src/backend/opencl/kernel/reduce_by_key.hpp
+++ b/src/backend/opencl/kernel/reduce_by_key.hpp
@@ -65,7 +65,8 @@ void reduceBlocksByKeyDim(cl::Buffer *reduced_block_sizes, Param keys_out,
 
     auto reduceBlocksByKeyDim = common::getKernel(
         "reduce_blocks_by_key_dim",
-        {ops_cl_src, reduce_blocks_by_key_dim_cl_src}, tmpltArgs, compileOpts);
+        std::array{ops_cl_src, reduce_blocks_by_key_dim_cl_src}, tmpltArgs,
+        compileOpts);
     int numBlocks = divup(n, threads_x);
 
     cl::NDRange local(threads_x);
@@ -105,10 +106,10 @@ void reduceBlocksByKey(cl::Buffer *reduced_block_sizes, Param keys_out,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<Ti>());
 
-    auto reduceBlocksByKeyFirst =
-        common::getKernel("reduce_blocks_by_key_first",
-                          {ops_cl_src, reduce_blocks_by_key_first_cl_src},
-                          tmpltArgs, compileOpts);
+    auto reduceBlocksByKeyFirst = common::getKernel(
+        "reduce_blocks_by_key_first",
+        std::array{ops_cl_src, reduce_blocks_by_key_first_cl_src}, tmpltArgs,
+        compileOpts);
     int numBlocks = divup(n, threads_x);
 
     cl::NDRange local(threads_x);
@@ -146,9 +147,10 @@ void finalBoundaryReduce(cl::Buffer *reduced_block_sizes, Param keys_out,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<To>());
 
-    auto finalBoundaryReduce = common::getKernel(
-        "final_boundary_reduce", {ops_cl_src, reduce_by_key_boundary_cl_src},
-        tmpltArgs, compileOpts);
+    auto finalBoundaryReduce =
+        common::getKernel("final_boundary_reduce",
+                          std::array{ops_cl_src, reduce_by_key_boundary_cl_src},
+                          tmpltArgs, compileOpts);
 
     cl::NDRange local(threads_x);
     cl::NDRange global(threads_x * numBlocks);
@@ -184,10 +186,10 @@ void finalBoundaryReduceDim(cl::Buffer *reduced_block_sizes, Param keys_out,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<To>());
 
-    auto finalBoundaryReduceDim =
-        common::getKernel("final_boundary_reduce_dim",
-                          {ops_cl_src, reduce_by_key_boundary_dim_cl_src},
-                          tmpltArgs, compileOpts);
+    auto finalBoundaryReduceDim = common::getKernel(
+        "final_boundary_reduce_dim",
+        std::array{ops_cl_src, reduce_by_key_boundary_dim_cl_src}, tmpltArgs,
+        compileOpts);
 
     cl::NDRange local(threads_x);
     cl::NDRange global(threads_x * numBlocks,
@@ -220,9 +222,9 @@ void compact(cl::Buffer *reduced_block_sizes, Param keys_out, Param vals_out,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<To>());
 
-    auto compact =
-        common::getKernel("compact", {ops_cl_src, reduce_by_key_compact_cl_src},
-                          tmpltArgs, compileOpts);
+    auto compact = common::getKernel(
+        "compact", std::array{ops_cl_src, reduce_by_key_compact_cl_src},
+        tmpltArgs, compileOpts);
 
     cl::NDRange local(threads_x);
     cl::NDRange global(threads_x * numBlocks, vals_out.info.dims[1],
@@ -256,7 +258,7 @@ void compactDim(cl::Buffer *reduced_block_sizes, Param keys_out, Param vals_out,
     compileOpts.emplace_back(getTypeBuildDefinition<To>());
 
     auto compactDim = common::getKernel(
-        "compact_dim", {ops_cl_src, reduce_by_key_compact_dim_cl_src},
+        "compact_dim", std::array{ops_cl_src, reduce_by_key_compact_dim_cl_src},
         tmpltArgs, compileOpts);
 
     cl::NDRange local(threads_x);
@@ -285,10 +287,10 @@ void testNeedsReduction(cl::Buffer needs_reduction, cl::Buffer needs_boundary,
         DefineKeyValue(DIMX, threads_x),
     };
 
-    auto testIfNeedsReduction =
-        common::getKernel("test_needs_reduction",
-                          {ops_cl_src, reduce_by_key_needs_reduction_cl_src},
-                          tmpltArgs, compileOpts);
+    auto testIfNeedsReduction = common::getKernel(
+        "test_needs_reduction",
+        std::array{ops_cl_src, reduce_by_key_needs_reduction_cl_src}, tmpltArgs,
+        compileOpts);
 
     cl::NDRange local(threads_x);
     cl::NDRange global(threads_x * numBlocks);

--- a/src/backend/opencl/kernel/regions.hpp
+++ b/src/backend/opencl/kernel/regions.hpp
@@ -66,9 +66,12 @@ std::array<Kernel, 3> getRegionsKernels(const bool full_conn,
     options.emplace_back(getTypeBuildDefinition<T>());
 
     return {
-        common::getKernel("initial_label", {regions_cl_src}, targs, options),
-        common::getKernel("final_relabel", {regions_cl_src}, targs, options),
-        common::getKernel("update_equiv", {regions_cl_src}, targs, options),
+        common::getKernel("initial_label", std::array{regions_cl_src}, targs,
+                          options),
+        common::getKernel("final_relabel", std::array{regions_cl_src}, targs,
+                          options),
+        common::getKernel("update_equiv", std::array{regions_cl_src}, targs,
+                          options),
     };
 }
 

--- a/src/backend/opencl/kernel/reorder.hpp
+++ b/src/backend/opencl/kernel/reorder.hpp
@@ -28,16 +28,15 @@ void reorder(Param out, const Param in, const dim_t* rdims) {
     constexpr int TILEX = 512;
     constexpr int TILEY = 32;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 1> targs = {
         TemplateTypename<T>(),
     };
-    std::vector<std::string> options = {
+    std::array<std::string, 2> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+        getTypeBuildDefinition<T>()};
 
-    auto reorderOp =
-        common::getKernel("reorder_kernel", {reorder_cl_src}, targs, options);
+    auto reorderOp = common::getKernel(
+        "reorder_kernel", std::array{reorder_cl_src}, targs, options);
 
     cl::NDRange local(TX, TY, 1);
 

--- a/src/backend/opencl/kernel/resize.hpp
+++ b/src/backend/opencl/kernel/resize.hpp
@@ -40,7 +40,7 @@ void resize(Param out, const Param in, const af_interp_type method) {
     constexpr bool IsComplex =
         std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value;
 
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(),
         TemplateArg(method),
     };
@@ -48,12 +48,10 @@ void resize(Param out, const Param in, const af_interp_type method) {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(VT, dtype_traits<vtype_t<T>>::getName()),
         DefineKeyValue(WT, dtype_traits<wtype_t<BT>>::getName()),
-        DefineKeyValue(CPLX, (IsComplex ? 1 : 0)),
-    };
+        DefineKeyValue(CPLX, (IsComplex ? 1 : 0)), getTypeBuildDefinition<T>()};
     if (IsComplex) {
         options.emplace_back(DefineKeyValue(TB, dtype_traits<BT>::getName()));
     }
-    options.emplace_back(getTypeBuildDefinition<T>());
 
     switch (method) {
         case AF_INTERP_NEAREST:
@@ -68,8 +66,8 @@ void resize(Param out, const Param in, const af_interp_type method) {
         default: break;
     }
 
-    auto resizeOp =
-        common::getKernel("resize_kernel", {resize_cl_src}, targs, options);
+    auto resizeOp = common::getKernel(
+        "resize_kernel", std::array{resize_cl_src}, targs, options);
 
     cl::NDRange local(RESIZE_TX, RESIZE_TY, 1);
 

--- a/src/backend/opencl/kernel/rotate.hpp
+++ b/src/backend/opencl/kernel/rotate.hpp
@@ -79,8 +79,9 @@ void rotate(Param out, const Param in, const float theta, af_interp_type method,
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
     addInterpEnumOptions(compileOpts);
 
-    auto rotate = common::getKernel(
-        "rotateKernel", {interp_cl_src, rotate_cl_src}, tmpltArgs, compileOpts);
+    auto rotate = common::getKernel("rotateKernel",
+                                    std::array{interp_cl_src, rotate_cl_src},
+                                    tmpltArgs, compileOpts);
 
     const float c = cos(-theta), s = sin(-theta);
     float tx, ty;

--- a/src/backend/opencl/kernel/scan_by_key/CMakeLists.txt
+++ b/src/backend/opencl/kernel/scan_by_key/CMakeLists.txt
@@ -40,6 +40,7 @@ foreach(SBK_BINARY_OP ${SBK_BINARY_OPS})
         $<TARGET_PROPERTY:OpenCL::OpenCL,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:OpenCL::cl2hpp,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:Boost::boost,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:nonstd::span-lite,INTERFACE_INCLUDE_DIRECTORIES>
         ${ArrayFire_BINARY_DIR}/include
       )
     if(TARGET Forge::forge)
@@ -80,6 +81,7 @@ foreach(SBK_BINARY_OP ${SBK_BINARY_OPS})
         ${opencl_compile_definitions}
         $<TARGET_PROPERTY:Boost::boost,INTERFACE_COMPILE_DEFINITIONS>
         $<TARGET_PROPERTY:af_spdlog,INTERFACE_COMPILE_DEFINITIONS>
+        $<TARGET_PROPERTY:nonstd::span-lite,INTERFACE_COMPILE_DEFINITIONS>
         TYPE=${SBK_BINARY_OP} AFDLL)
     target_sources(opencl_scan_by_key
       INTERFACE $<TARGET_OBJECTS:opencl_scan_by_key_${SBK_BINARY_OP}>)

--- a/src/backend/opencl/kernel/scan_dim.hpp
+++ b/src/backend/opencl/kernel/scan_dim.hpp
@@ -57,8 +57,8 @@ static opencl::Kernel getScanDimKernel(const std::string key, int dim,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<Ti>());
 
-    return common::getKernel(key, {ops_cl_src, scan_dim_cl_src}, tmpltArgs,
-                             compileOpts);
+    return common::getKernel(key, std::array{ops_cl_src, scan_dim_cl_src},
+                             tmpltArgs, compileOpts);
 }
 
 template<typename Ti, typename To, af_op_t op>

--- a/src/backend/opencl/kernel/scan_dim_by_key_impl.hpp
+++ b/src/backend/opencl/kernel/scan_dim_by_key_impl.hpp
@@ -57,7 +57,8 @@ static opencl::Kernel getScanDimKernel(const std::string key, int dim,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<Ti>());
 
-    return common::getKernel(key, {ops_cl_src, scan_dim_by_key_cl_src},
+    return common::getKernel(key,
+                             std::array{ops_cl_src, scan_dim_by_key_cl_src},
                              tmpltArgs, compileOpts);
 }
 

--- a/src/backend/opencl/kernel/scan_first.hpp
+++ b/src/backend/opencl/kernel/scan_first.hpp
@@ -58,8 +58,8 @@ static opencl::Kernel getScanFirstKernel(const std::string key,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<Ti>());
 
-    return common::getKernel(key, {ops_cl_src, scan_first_cl_src}, tmpltArgs,
-                             compileOpts);
+    return common::getKernel(key, std::array{ops_cl_src, scan_first_cl_src},
+                             tmpltArgs, compileOpts);
 }
 
 template<typename Ti, typename To, af_op_t op>

--- a/src/backend/opencl/kernel/scan_first_by_key_impl.hpp
+++ b/src/backend/opencl/kernel/scan_first_by_key_impl.hpp
@@ -61,7 +61,8 @@ static opencl::Kernel getScanFirstKernel(const std::string key,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<Ti>());
 
-    return common::getKernel(key, {ops_cl_src, scan_first_by_key_cl_src},
+    return common::getKernel(key,
+                             std::array{ops_cl_src, scan_first_by_key_cl_src},
                              tmpltArgs, compileOpts);
 }
 

--- a/src/backend/opencl/kernel/select.hpp
+++ b/src/backend/opencl/kernel/select.hpp
@@ -29,18 +29,16 @@ constexpr int REPEAT = 64;
 template<typename T>
 void selectLauncher(Param out, Param cond, Param a, Param b, const int ndims,
                     const bool is_same) {
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(),
         TemplateArg(is_same),
     };
-    std::vector<std::string> options = {
-        DefineKeyValue(T, dtype_traits<T>::getName()),
-        DefineValue(is_same),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+    std::array<std::string, 3> options = {
+        DefineKeyValue(T, dtype_traits<T>::getName()), DefineValue(is_same),
+        getTypeBuildDefinition<T>()};
 
-    auto selectOp =
-        common::getKernel("select_kernel", {select_cl_src}, targs, options);
+    auto selectOp = common::getKernel(
+        "select_kernel", std::array{select_cl_src}, targs, options);
 
     int threads[] = {DIMX, DIMY};
 
@@ -74,18 +72,16 @@ void select(Param out, Param cond, Param a, Param b, int ndims) {
 template<typename T>
 void select_scalar(Param out, Param cond, Param a, const T b, const int ndims,
                    const bool flip) {
-    std::vector<TemplateArg> targs = {
+    std::array<TemplateArg, 2> targs = {
         TemplateTypename<T>(),
         TemplateArg(flip),
     };
-    std::vector<std::string> options = {
-        DefineKeyValue(T, dtype_traits<T>::getName()),
-        DefineValue(flip),
-    };
-    options.emplace_back(getTypeBuildDefinition<T>());
+    std::array<std::string, 3> options = {
+        DefineKeyValue(T, dtype_traits<T>::getName()), DefineValue(flip),
+        getTypeBuildDefinition<T>()};
 
-    auto selectOp = common::getKernel("select_scalar_kernel", {select_cl_src},
-                                      targs, options);
+    auto selectOp = common::getKernel(
+        "select_scalar_kernel", std::array{select_cl_src}, targs, options);
 
     int threads[] = {DIMX, DIMY};
 

--- a/src/backend/opencl/kernel/sift.hpp
+++ b/src/backend/opencl/kernel/sift.hpp
@@ -355,19 +355,20 @@ std::array<Kernel, 7> getSiftKernels() {
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
     return {
-        common::getKernel("sub", {sift_nonfree_cl_src}, targs, compileOpts),
-        common::getKernel("detectExtrema", {sift_nonfree_cl_src}, targs,
+        common::getKernel("sub", std::array{sift_nonfree_cl_src}, targs,
                           compileOpts),
-        common::getKernel("interpolateExtrema", {sift_nonfree_cl_src}, targs,
-                          compileOpts),
-        common::getKernel("calcOrientation", {sift_nonfree_cl_src}, targs,
-                          compileOpts),
-        common::getKernel("removeDuplicates", {sift_nonfree_cl_src}, targs,
-                          compileOpts),
-        common::getKernel("computeDescriptor", {sift_nonfree_cl_src}, targs,
-                          compileOpts),
-        common::getKernel("computeGLOHDescriptor", {sift_nonfree_cl_src}, targs,
-                          compileOpts),
+        common::getKernel("detectExtrema", std::array{sift_nonfree_cl_src},
+                          targs, compileOpts),
+        common::getKernel("interpolateExtrema", std::array{sift_nonfree_cl_src},
+                          targs, compileOpts),
+        common::getKernel("calcOrientation", std::array{sift_nonfree_cl_src},
+                          targs, compileOpts),
+        common::getKernel("removeDuplicates", std::array{sift_nonfree_cl_src},
+                          targs, compileOpts),
+        common::getKernel("computeDescriptor", std::array{sift_nonfree_cl_src},
+                          targs, compileOpts),
+        common::getKernel("computeGLOHDescriptor",
+                          std::array{sift_nonfree_cl_src}, targs, compileOpts),
     };
 }
 

--- a/src/backend/opencl/kernel/sobel.hpp
+++ b/src/backend/opencl/kernel/sobel.hpp
@@ -38,8 +38,8 @@ void sobel(Param dx, Param dy, const Param in) {
     };
     compileOpts.emplace_back(getTypeBuildDefinition<Ti>());
 
-    auto sobel =
-        common::getKernel("sobel3x3", {sobel_cl_src}, targs, compileOpts);
+    auto sobel = common::getKernel("sobel3x3", std::array{sobel_cl_src}, targs,
+                                   compileOpts);
 
     cl::NDRange local(THREADS_X, THREADS_Y);
 

--- a/src/backend/opencl/kernel/sparse.hpp
+++ b/src/backend/opencl/kernel/sparse.hpp
@@ -42,8 +42,8 @@ void coo2dense(Param out, const Param values, const Param rowIdx,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto coo2dense = common::getKernel("coo2Dense", {coo2dense_cl_src},
-                                       tmpltArgs, compileOpts);
+    auto coo2dense = common::getKernel(
+        "coo2Dense", std::array{coo2dense_cl_src}, tmpltArgs, compileOpts);
 
     cl::NDRange local(THREADS_PER_GROUP, 1, 1);
 
@@ -75,8 +75,8 @@ void csr2dense(Param output, const Param values, const Param rowIdx,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto csr2dense = common::getKernel("csr2Dense", {csr2dense_cl_src},
-                                       tmpltArgs, compileOpts);
+    auto csr2dense = common::getKernel(
+        "csr2Dense", std::array{csr2dense_cl_src}, tmpltArgs, compileOpts);
 
     cl::NDRange local(threads, 1);
     int groups_x = std::min((int)(divup(M, local[0])), MAX_GROUPS);
@@ -101,8 +101,8 @@ void dense2csr(Param values, Param rowIdx, Param colIdx, const Param dense) {
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto dense2Csr = common::getKernel("dense2Csr", {dense2csr_cl_src},
-                                       tmpltArgs, compileOpts);
+    auto dense2Csr = common::getKernel(
+        "dense2Csr", std::array{dense2csr_cl_src}, tmpltArgs, compileOpts);
 
     int num_rows = dense.info.dims[0];
     int num_cols = dense.info.dims[1];
@@ -146,8 +146,8 @@ void swapIndex(Param ovalues, Param oindex, const Param ivalues,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto swapIndex = common::getKernel("swapIndex", {csr2coo_cl_src}, tmpltArgs,
-                                       compileOpts);
+    auto swapIndex = common::getKernel("swapIndex", std::array{csr2coo_cl_src},
+                                       tmpltArgs, compileOpts);
 
     cl::NDRange global(ovalues.info.dims[0], 1, 1);
 
@@ -168,8 +168,8 @@ void csr2coo(Param ovalues, Param orowIdx, Param ocolIdx, const Param ivalues,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto csr2coo =
-        common::getKernel("csr2Coo", {csr2coo_cl_src}, tmpltArgs, compileOpts);
+    auto csr2coo = common::getKernel("csr2Coo", std::array{csr2coo_cl_src},
+                                     tmpltArgs, compileOpts);
 
     const int MAX_GROUPS = 4096;
     int M                = irowIdx.info.dims[0] - 1;
@@ -208,8 +208,8 @@ void coo2csr(Param ovalues, Param orowIdx, Param ocolIdx, const Param ivalues,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto csrReduce = common::getKernel("csrReduce", {csr2coo_cl_src}, tmpltArgs,
-                                       compileOpts);
+    auto csrReduce = common::getKernel("csrReduce", std::array{csr2coo_cl_src},
+                                       tmpltArgs, compileOpts);
 
     // Now we need to sort this into column major
     kernel::sort0ByKeyIterative<int, int>(rowCopy, index, true);

--- a/src/backend/opencl/kernel/sparse_arith.hpp
+++ b/src/backend/opencl/kernel/sparse_arith.hpp
@@ -50,7 +50,7 @@ auto fetchKernel(const std::string key, const common::Source &additionalSrc,
     constexpr bool IsComplex =
         std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value;
 
-    std::vector<TemplateArg> tmpltArgs = {
+    std::array<TemplateArg, 2> tmpltArgs = {
         TemplateTypename<T>(),
         TemplateArg(op),
     };
@@ -62,8 +62,9 @@ auto fetchKernel(const std::string key, const common::Source &additionalSrc,
     options.emplace_back(getTypeBuildDefinition<T>());
     options.insert(std::end(options), std::begin(additionalOptions),
                    std::end(additionalOptions));
-    return common::getKernel(key, {sparse_arith_common_cl_src, additionalSrc},
-                             tmpltArgs, options);
+    return common::getKernel(
+        key, std::array{sparse_arith_common_cl_src, additionalSrc}, tmpltArgs,
+        options);
 }
 
 template<typename T, af_op_t op>
@@ -142,8 +143,9 @@ static void csrCalcOutNNZ(Param outRowIdx, unsigned &nnzC, const uint M,
         TemplateTypename<uint>(),
     };
 
-    auto calcNNZ = common::getKernel(
-        "csr_calc_out_nnz", {ssarith_calc_out_nnz_cl_src}, tmpltArgs, {});
+    auto calcNNZ = common::getKernel("csr_calc_out_nnz",
+                                     std::array{ssarith_calc_out_nnz_cl_src},
+                                     tmpltArgs, {});
 
     cl::NDRange local(256, 1);
     cl::NDRange global(divup(M, local[0]) * local[0], 1, 1);

--- a/src/backend/opencl/kernel/susan.hpp
+++ b/src/backend/opencl/kernel/susan.hpp
@@ -48,8 +48,8 @@ void susan(cl::Buffer* out, const cl::Buffer* in, const unsigned in_off,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto susan = common::getKernel("susan_responses", {susan_cl_src}, targs,
-                                   compileOpts);
+    auto susan = common::getKernel("susan_responses", std::array{susan_cl_src},
+                                   targs, compileOpts);
 
     cl::NDRange local(SUSAN_THREADS_X, SUSAN_THREADS_Y);
     cl::NDRange global(divup(idim0 - 2 * edge, local[0]) * local[0],
@@ -74,8 +74,8 @@ unsigned nonMaximal(cl::Buffer* x_out, cl::Buffer* y_out, cl::Buffer* resp_out,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto nonMax =
-        common::getKernel("non_maximal", {susan_cl_src}, targs, compileOpts);
+    auto nonMax = common::getKernel("non_maximal", std::array{susan_cl_src},
+                                    targs, compileOpts);
 
     unsigned corners_found = 0;
     auto d_corners_found   = memAlloc<unsigned>(1);

--- a/src/backend/opencl/kernel/swapdblk.hpp
+++ b/src/backend/opencl/kernel/swapdblk.hpp
@@ -41,8 +41,8 @@ void swapdblk(int n, int nb, cl_mem dA, size_t dA_offset, int ldda, int inca,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto swapdblk =
-        common::getKernel("swapdblk", {swapdblk_cl_src}, targs, compileOpts);
+    auto swapdblk = common::getKernel("swapdblk", std::array{swapdblk_cl_src},
+                                      targs, compileOpts);
 
     int nblocks = n / nb;
 

--- a/src/backend/opencl/kernel/tile.hpp
+++ b/src/backend/opencl/kernel/tile.hpp
@@ -41,7 +41,8 @@ void tile(Param out, const Param in) {
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto tile = common::getKernel("tile", {tile_cl_src}, targs, compileOpts);
+    auto tile =
+        common::getKernel("tile", std::array{tile_cl_src}, targs, compileOpts);
 
     NDRange local(TX, TY, 1);
 

--- a/src/backend/opencl/kernel/transform.hpp
+++ b/src/backend/opencl/kernel/transform.hpp
@@ -79,9 +79,9 @@ void transform(Param out, const Param in, const Param tf, bool isInverse,
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
     addInterpEnumOptions(compileOpts);
 
-    auto transform =
-        common::getKernel("transformKernel", {interp_cl_src, transform_cl_src},
-                          tmpltArgs, compileOpts);
+    auto transform = common::getKernel(
+        "transformKernel", std::array{interp_cl_src, transform_cl_src},
+        tmpltArgs, compileOpts);
 
     const int nImg2 = in.info.dims[2];
     const int nImg3 = in.info.dims[3];

--- a/src/backend/opencl/kernel/transpose.hpp
+++ b/src/backend/opencl/kernel/transpose.hpp
@@ -48,8 +48,8 @@ void transpose(Param out, const Param in, cl::CommandQueue queue,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto transpose = common::getKernel("transpose", {transpose_cl_src},
-                                       tmpltArgs, compileOpts);
+    auto transpose = common::getKernel(
+        "transpose", std::array{transpose_cl_src}, tmpltArgs, compileOpts);
 
     NDRange local(THREADS_X, THREADS_Y);
 

--- a/src/backend/opencl/kernel/transpose_inplace.hpp
+++ b/src/backend/opencl/kernel/transpose_inplace.hpp
@@ -48,9 +48,9 @@ void transpose_inplace(Param in, cl::CommandQueue& queue, const bool conjugate,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto transpose =
-        common::getKernel("transpose_inplace", {transpose_inplace_cl_src},
-                          tmpltArgs, compileOpts);
+    auto transpose = common::getKernel("transpose_inplace",
+                                       std::array{transpose_inplace_cl_src},
+                                       tmpltArgs, compileOpts);
 
     NDRange local(THREADS_X, THREADS_Y);
 

--- a/src/backend/opencl/kernel/triangle.hpp
+++ b/src/backend/opencl/kernel/triangle.hpp
@@ -51,8 +51,8 @@ void triangle(Param out, const Param in, bool is_upper, bool is_unit_diag) {
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto triangle = common::getKernel("triangle", {triangle_cl_src}, tmpltArgs,
-                                      compileOpts);
+    auto triangle = common::getKernel("triangle", std::array{triangle_cl_src},
+                                      tmpltArgs, compileOpts);
 
     NDRange local(TX, TY);
 

--- a/src/backend/opencl/kernel/unwrap.hpp
+++ b/src/backend/opencl/kernel/unwrap.hpp
@@ -46,8 +46,8 @@ void unwrap(Param out, const Param in, const dim_t wx, const dim_t wy,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto unwrap =
-        common::getKernel("unwrap", {unwrap_cl_src}, tmpltArgs, compileOpts);
+    auto unwrap = common::getKernel("unwrap", std::array{unwrap_cl_src},
+                                    tmpltArgs, compileOpts);
 
     dim_t TX = 1, TY = 1;
     dim_t BX       = 1;

--- a/src/backend/opencl/kernel/where.hpp
+++ b/src/backend/opencl/kernel/where.hpp
@@ -45,8 +45,8 @@ static void get_out_idx(cl::Buffer *out_data, Param &otmp, Param &rtmp,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto getIdx = common::getKernel("get_out_idx", {where_cl_src}, tmpltArgs,
-                                    compileOpts);
+    auto getIdx = common::getKernel("get_out_idx", std::array{where_cl_src},
+                                    tmpltArgs, compileOpts);
 
     NDRange local(threads_x, THREADS_PER_GROUP / threads_x);
     NDRange global(local[0] * groups_x * in.info.dims[2],

--- a/src/backend/opencl/kernel/wrap.hpp
+++ b/src/backend/opencl/kernel/wrap.hpp
@@ -46,8 +46,8 @@ void wrap(Param out, const Param in, const dim_t wx, const dim_t wy,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto wrap =
-        common::getKernel("wrap", {wrap_cl_src}, tmpltArgs, compileOpts);
+    auto wrap = common::getKernel("wrap", std::array{wrap_cl_src}, tmpltArgs,
+                                  compileOpts);
 
     dim_t nx = (out.info.dims[0] + 2 * px - wx) / sx + 1;
     dim_t ny = (out.info.dims[1] + 2 * py - wy) / sy + 1;
@@ -91,8 +91,9 @@ void wrap_dilated(Param out, const Param in, const dim_t wx, const dim_t wy,
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 
-    auto dilatedWrap = common::getKernel("wrap_dilated", {wrap_dilated_cl_src},
-                                         tmpltArgs, compileOpts);
+    auto dilatedWrap =
+        common::getKernel("wrap_dilated", std::array{wrap_dilated_cl_src},
+                          tmpltArgs, compileOpts);
 
     dim_t nx = 1 + (out.info.dims[0] + 2 * px - (((wx - 1) * dx) + 1)) / sx;
     dim_t ny = 1 + (out.info.dims[1] + 2 * py - (((wy - 1) * dy) + 1)) / sy;


### PR DESCRIPTION
The way we were formatting the backend ID was incorrect and failed when we had
more than 3 backends. With the new oneAPI backend, this mechanism was failing
and causing errors.

Description
-----------
* Fix the way we encode the beckend ID in ArrayInfo
* Remove the use of vectors in the getKernel API and use span instead. This allows the use of std::array which are allocated on the stack instead of the heap.
* Remove an extraneous print in the oneAPI memcpy kernel

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
