### PR TITLE
adds shared memory based reduction to oneapi backend [WIP]

### DIFF
--- a/src/api/c/optypes.hpp
+++ b/src/api/c/optypes.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 
-typedef enum af_op_t : int {
+enum af_op_t : int {
     af_none_t = -1,
     af_add_t  = 0,
     af_sub_t,

--- a/src/api/c/optypes.hpp
+++ b/src/api/c/optypes.hpp
@@ -9,7 +9,7 @@
 
 #pragma once
 
-typedef enum {
+typedef enum af_op_t : int {
     af_none_t = -1,
     af_add_t  = 0,
     af_sub_t,
@@ -100,4 +100,4 @@ typedef enum {
     af_rsqrt_t,
 
     af_moddims_t
-} af_op_t;
+};

--- a/src/backend/common/Binary.hpp
+++ b/src/backend/common/Binary.hpp
@@ -78,15 +78,17 @@ template<>
 struct Binary<char, af_min_t> {
     static __DH__ char init() { return 1; }
 
-    __DH__ char operator()(char lhs, char rhs) { return min(lhs > 0, rhs > 0); }
+    __DH__ char operator()(char lhs, char rhs) {
+        return detail::min(lhs > 0, rhs > 0);
+    }
 };
 
-#define SPECIALIZE_COMPLEX_MIN(T, Tr)                               \
-    template<>                                                      \
-    struct Binary<T, af_min_t> {                                    \
-        static __DH__ T init() { return scalar<T>(maxval<Tr>()); }  \
-                                                                    \
-        __DH__ T operator()(T lhs, T rhs) { return min(lhs, rhs); } \
+#define SPECIALIZE_COMPLEX_MIN(T, Tr)                                       \
+    template<>                                                              \
+    struct Binary<T, af_min_t> {                                            \
+        static __DH__ T init() { return scalar<T>(maxval<Tr>()); }          \
+                                                                            \
+        __DH__ T operator()(T lhs, T rhs) { return detail::min(lhs, rhs); } \
     };
 
 SPECIALIZE_COMPLEX_MIN(cfloat, float)

--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -222,9 +222,11 @@ target_sources(afoneapi
     kernel/reduce_all.hpp
     kernel/reduce_first.hpp
     kernel/reduce_dim.hpp
+    kernel/scan_first.hpp
     kernel/transpose.hpp
     kernel/transpose_inplace.hpp
     kernel/triangle.hpp
+    kernel/where.hpp
 )
 
 add_library(ArrayFire::afoneapi ALIAS afoneapi)

--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -223,6 +223,7 @@ target_sources(afoneapi
     kernel/reduce_first.hpp
     kernel/reduce_dim.hpp
     kernel/scan_first.hpp
+    kernel/scan_dim.hpp
     kernel/transpose.hpp
     kernel/transpose_inplace.hpp
     kernel/triangle.hpp

--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -217,6 +217,10 @@ target_sources(afoneapi
     kernel/random_engine_philox.hpp
     kernel/random_engine_threefry.hpp
     kernel/range.hpp
+    kernel/reduce.hpp
+    kernel/reduce_all.hpp
+    kernel/reduce_first.hpp
+    kernel/reduce_dim.hpp
     kernel/transpose.hpp
     kernel/transpose_inplace.hpp
     kernel/triangle.hpp

--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -211,6 +211,7 @@ target_sources(afoneapi
     kernel/iota.hpp
     kernel/histogram.hpp
     kernel/memcopy.hpp
+    kernel/mean.hpp
     kernel/random_engine.hpp
     kernel/random_engine_write.hpp
     kernel/random_engine_mersenne.hpp

--- a/src/backend/oneapi/copy.cpp
+++ b/src/backend/oneapi/copy.cpp
@@ -218,8 +218,9 @@ T getScalar(const Array<T> &in) {
 
     getQueue()
         .submit([&](sycl::handler &h) {
-            auto acc_in  = in.getData()->get_access(h, sycl::range{1},
-                                                    sycl::id{in.getOffset()});
+            auto acc_in = in.getData()->get_access(
+                h, sycl::range{1},
+                sycl::id{static_cast<uintl>(in.getOffset())});
             auto acc_out = retBuffer.get_access();
             h.copy(acc_in, acc_out);
         })

--- a/src/backend/oneapi/copy.cpp
+++ b/src/backend/oneapi/copy.cpp
@@ -213,13 +213,15 @@ template<typename T>
 T getScalar(const Array<T> &in) {
     T retVal{};
 
+    sycl::buffer retBuffer(&retVal, {1},
+                           {sycl::property::buffer::use_host_ptr()});
+
     getQueue()
-        .submit([=](sycl::handler &h) {
-            sycl::range rr(1);
-            sycl::id offset_id(in.getOffset());
-            auto acc_in = const_cast<sycl::buffer<T> *>(in.get())->get_access(
-                h, rr, offset_id);
-            h.copy(acc_in, (void *)&retVal);
+        .submit([&](sycl::handler &h) {
+            auto acc_in  = in.getData()->get_access(h, sycl::range{1},
+                                                    sycl::id{in.getOffset()});
+            auto acc_out = retBuffer.get_access();
+            h.copy(acc_in, acc_out);
         })
         .wait();
 

--- a/src/backend/oneapi/kernel/default_config.hpp
+++ b/src/backend/oneapi/kernel/default_config.hpp
@@ -12,14 +12,10 @@
 namespace oneapi {
 namespace kernel {
 
-namespace creduce {
-// TODO: are different values more appropriate for reduce on oneapi?
 static const uint THREADS_PER_BLOCK = 256;
 static const uint THREADS_X         = 32;
 static const uint THREADS_Y         = THREADS_PER_BLOCK / THREADS_X;
 static const uint REPEAT            = 32;
-
-}  // namespace creduce
 
 }  // namespace kernel
 }  // namespace oneapi

--- a/src/backend/oneapi/kernel/mean.hpp
+++ b/src/backend/oneapi/kernel/mean.hpp
@@ -1,0 +1,789 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Param.hpp>
+#include <backend.hpp>
+#include <common/Binary.hpp>
+#include <common/Transform.hpp>
+#include <common/dispatch.hpp>
+#include <common/half.hpp>
+//#include <copy.hpp>?
+#include <debug_oneapi.hpp>
+#include <err_oneapi.hpp>
+#include <kernel/reduce_config.hpp>
+#include <math.hpp>
+#include <memory.hpp>
+
+#include <iostream>
+#include <memory>
+#include <vector>
+
+namespace oneapi {
+
+/*
+TODO: port half
+__device__ auto operator*(float lhs, __half rhs) -> __half {
+    return __float2half(lhs * __half2float(rhs));
+}
+
+__device__ auto operator/(__half lhs, float rhs) -> __half {
+    return __float2half(__half2float(lhs) / rhs);
+}
+*/
+
+namespace kernel {
+
+template<typename T, int dimensions>
+using local_accessor =
+    sycl::accessor<T, dimensions, sycl::access::mode::read_write,
+                   sycl::access::target::local>;
+
+template<typename To, typename Tw>
+void stable_mean(To *lhs, Tw *l_wt, To rhs, Tw r_wt) {
+    if (((*l_wt) != (Tw)0) || (r_wt != (Tw)0)) {
+        Tw l_scale = (*l_wt);
+        (*l_wt) += r_wt;
+        l_scale = l_scale / (*l_wt);
+
+        Tw r_scale = r_wt / (*l_wt);
+        (*lhs)     = (l_scale * *lhs) + (r_scale * rhs);
+    }
+}
+
+template<typename Ti, typename Tw, typename To, uint dim, uint DIMY>
+class meanDimKernelSMEM {
+   public:
+    meanDimKernelSMEM(sycl::accessor<To> out, KParam oInfo,
+                      sycl::accessor<Tw> owt, KParam owInfo,
+                      sycl::accessor<Ti> in, KParam iInfo,
+                      sycl::accessor<Tw> iwt, KParam iwInfo, uint groups_x,
+                      uint groups_y, uint offset_dim,
+                      local_accessor<compute_t<To>, 1> s_val,
+                      local_accessor<compute_t<Tw>, 1> s_idx,
+                      sycl::stream debug, bool input_weight, bool output_weight)
+        : out_(out)
+        , oInfo_(oInfo)
+        , owt_(owt)
+        , owInfo_(owInfo)
+        , in_(in)
+        , iInfo_(iInfo)
+        , iwt_(iwt)
+        , iwInfo_(iwInfo)
+        , groups_x_(groups_x)
+        , groups_y_(groups_y)
+        , offset_dim_(offset_dim)
+        , s_val_(s_val)
+        , s_idx_(s_idx)
+        , debug_(debug)
+        , input_weight_(input_weight)
+        , output_weight_(output_weight) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g   = it.get_group();
+        const uint lidx = it.get_local_id(0);
+        const uint lidy = it.get_local_id(1);
+        const uint lid  = lidy * g.get_local_range(0) + lidx;
+
+        const uint zid        = g.get_group_id(0) / groups_x_;
+        const uint wid        = g.get_group_id(1) / groups_y_;
+        const uint groupIdx_x = g.get_group_id(0) - (groups_x_)*zid;
+        const uint groupIdx_y = g.get_group_id(1) - (groups_y_)*wid;
+        const uint xid        = groupIdx_x * g.get_local_range(0) + lidx;
+        const uint yid =
+            groupIdx_y;  // yid  of output. updated for input later.
+
+        uint ids[4] = {xid, yid, zid, wid};
+
+        const Ti *iptr = in_.get_pointer();
+        To *optr       = out_.get_pointer();
+
+        uint ooffset = ids[3] * oInfo_.strides[3] + ids[2] * oInfo_.strides[2] +
+                       ids[1] * oInfo_.strides[1] + ids[0];
+        // There is only one element per block for out
+        // There are blockDim.y elements per block for in
+        // Hence increment ids[dim] just after offseting out and before
+        // offsetting in
+        optr += ooffset;
+
+        const uint blockIdx_dim = ids[dim];
+        ids[dim]                = ids[dim] * g.get_local_range(1) + lidy;
+
+        uint ioffset = ids[3] * iInfo_.strides[3] + ids[2] * iInfo_.strides[2] +
+                       ids[1] * iInfo_.strides[1] + ids[0];
+        iptr += ioffset;
+
+        const Tw *iwptr;
+        Tw *owptr;
+
+        if (output_weight_) owptr = owt_.get_pointer() + ooffset;
+        if (input_weight_) iwptr = iwt_.get_pointer() + ioffset;
+
+        const uint id_dim_in   = ids[dim];
+        const uint istride_dim = iInfo_.strides[dim];
+
+        bool is_valid = (ids[0] < iInfo_.dims[0]) &&
+                        (ids[1] < iInfo_.dims[1]) &&
+                        (ids[2] < iInfo_.dims[2]) && (ids[3] < iInfo_.dims[3]);
+
+        common::Transform<Ti, compute_t<To>, af_add_t> transform;
+
+        compute_t<To> val    = common::Binary<compute_t<To>, af_add_t>::init();
+        compute_t<Tw> weight = common::Binary<compute_t<Tw>, af_add_t>::init();
+
+        if (is_valid && id_dim_in < iInfo_.dims[dim]) {
+            val = transform(*iptr);
+            if (iwptr != NULL) {
+                weight = *iwptr;
+            } else {
+                weight = (Tw)1;
+            }
+        }
+
+        const uint id_dim_in_start =
+            id_dim_in + offset_dim_ * g.get_local_range(0);
+
+        for (int id = id_dim_in_start; is_valid && (id < iInfo_.dims[dim]);
+             id += offset_dim_ * g.get_local_range(0)) {
+            iptr = iptr + offset_dim_ * g.get_local_range(0) * istride_dim;
+            if (input_weight_) {
+                iwptr =
+                    iwptr + offset_dim_ * g.get_local_range(0) * istride_dim;
+                stable_mean(&val, &weight, transform(*iptr),
+                            compute_t<Tw>(*iwptr));
+            } else {
+                // Faster version of stable_mean when iwptr is NULL
+                val    = val + (transform(*iptr) - val) / (weight + (Tw)1);
+                weight = weight + (Tw)1;
+            }
+        }
+
+        s_val_[lid] = val;
+        s_idx_[lid] = weight;
+
+        compute_t<To> *s_vptr = s_val_.get_pointer() + lid;
+        compute_t<Tw> *s_iptr = s_idx_.get_pointer() + lid;
+        group_barrier(g);
+
+        if (DIMY == 8) {
+            if (lidy < 4) {
+                stable_mean(s_vptr, s_iptr, s_vptr[THREADS_X * 4],
+                            s_iptr[THREADS_X * 4]);
+            }
+            group_barrier(g);
+        }
+
+        if (DIMY >= 4) {
+            if (lidy < 2) {
+                stable_mean(s_vptr, s_iptr, s_vptr[THREADS_X * 2],
+                            s_iptr[THREADS_X * 2]);
+            }
+            group_barrier(g);
+        }
+
+        if (DIMY >= 2) {
+            if (lidy < 1) {
+                stable_mean(s_vptr, s_iptr, s_vptr[THREADS_X * 1],
+                            s_iptr[THREADS_X * 1]);
+            }
+            group_barrier(g);
+        }
+
+        if (lidy == 0 && is_valid && (blockIdx_dim < oInfo_.dims[dim])) {
+            *optr = *s_vptr;
+            if (output_weight_) *owptr = *s_iptr;
+        }
+    }
+
+   protected:
+    sycl::accessor<To> out_;
+    sycl::accessor<Tw> owt_;
+    sycl::accessor<Ti> in_;
+    sycl::accessor<Tw> iwt_;
+    KParam oInfo_, owInfo_, iInfo_, iwInfo_;
+    const uint groups_x_, groups_y_, offset_dim_;
+    local_accessor<compute_t<To>, 1> s_val_;
+    local_accessor<compute_t<Tw>, 1> s_idx_;
+    bool input_weight_, output_weight_;
+    sycl::stream debug_;
+};
+
+template<typename Ti, typename Tw, typename To, int dim>
+void mean_dim_launcher(Param<To> out, Param<Tw> owt, Param<Ti> in,
+                       Param<Tw> iwt, const uint threads_y,
+                       const dim_t blocks_dim[4]) {
+    sycl::range<2> local(THREADS_X, threads_y);
+    sycl::range<2> global(blocks_dim[0] * blocks_dim[2] * local[0],
+                          blocks_dim[1] * blocks_dim[3] * local[1]);
+
+    sycl::buffer<Tw, 1> empty(sycl::range<1>{1});
+    getQueue().submit([&](sycl::handler &h) {
+        auto out_acc = out.data->get_access(h);
+        auto in_acc  = in.data->get_access(h);
+
+        sycl::stream debug_stream(2048 * 2048, 2048, h);
+
+        auto s_val = local_accessor<compute_t<To>, 1>(THREADS_PER_BLOCK, h);
+        auto s_idx = local_accessor<compute_t<Tw>, 1>(THREADS_PER_BLOCK, h);
+
+        bool input_weight = ((iwt.info.dims[0] * iwt.info.dims[1] *
+                              iwt.info.dims[2] * iwt.info.dims[3]) != 0);
+
+        bool output_weight = ((owt.info.dims[0] * owt.info.dims[1] *
+                               owt.info.dims[2] * owt.info.dims[3]) != 0);
+
+        auto owt_acc =
+            (output_weight) ? owt.data->get_access(h) : empty.get_access(h);
+        auto iwt_acc =
+            (input_weight) ? iwt.data->get_access(h) : empty.get_access(h);
+
+        switch (threads_y) {
+            case 8:
+                h.parallel_for(sycl::nd_range<2>(global, local),
+                               meanDimKernelSMEM<Ti, Tw, To, dim, 8>(
+                                   out_acc, out.info, owt_acc, owt.info, in_acc,
+                                   in.info, iwt_acc, iwt.info, blocks_dim[0],
+                                   blocks_dim[1], blocks_dim[dim], s_val, s_idx,
+                                   debug_stream, input_weight, output_weight));
+                break;
+            case 4:
+                h.parallel_for(sycl::nd_range<2>(global, local),
+                               meanDimKernelSMEM<Ti, Tw, To, dim, 8>(
+                                   out_acc, out.info, owt_acc, owt.info, in_acc,
+                                   in.info, iwt_acc, iwt.info, blocks_dim[0],
+                                   blocks_dim[1], blocks_dim[dim], s_val, s_idx,
+                                   debug_stream, input_weight, output_weight));
+                break;
+            case 2:
+                h.parallel_for(sycl::nd_range<2>(global, local),
+                               meanDimKernelSMEM<Ti, Tw, To, dim, 8>(
+                                   out_acc, out.info, owt_acc, owt.info, in_acc,
+                                   in.info, iwt_acc, iwt.info, blocks_dim[0],
+                                   blocks_dim[1], blocks_dim[dim], s_val, s_idx,
+                                   debug_stream, input_weight, output_weight));
+                break;
+            case 1:
+                h.parallel_for(sycl::nd_range<2>(global, local),
+                               meanDimKernelSMEM<Ti, Tw, To, dim, 8>(
+                                   out_acc, out.info, owt_acc, owt.info, in_acc,
+                                   in.info, iwt_acc, iwt.info, blocks_dim[0],
+                                   blocks_dim[1], blocks_dim[dim], s_val, s_idx,
+                                   debug_stream, input_weight, output_weight));
+                break;
+        }
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename Ti, typename Tw, typename To, int dim>
+void mean_dim(Param<To> out, Param<Ti> in, Param<Tw> iwt) {
+    uint threads_y = std::min(THREADS_Y, nextpow2(in.info.dims[dim]));
+    uint threads_x = THREADS_X;
+
+    dim_t blocks_dim[] = {divup(in.info.dims[0], threads_x), in.info.dims[1],
+                          in.info.dims[2], in.info.dims[3]};
+
+    blocks_dim[dim] = divup(in.info.dims[dim], threads_y * REPEAT);
+
+    Array<To> tmpOut = createEmptyArray<To>(dim4());
+    Array<Tw> tmpWt  = createEmptyArray<Tw>(dim4());
+
+    if (blocks_dim[dim] > 1) {
+        dim4 dims(4, out.info.dims);
+        dims[dim] = blocks_dim[dim];
+        tmpOut    = createEmptyArray<To>(dims);
+        tmpWt     = createEmptyArray<Tw>(dims);
+    } else {
+        tmpOut = createParamArray(out, false);
+    }
+
+    mean_dim_launcher<Ti, Tw, To, dim>(tmpOut, tmpWt, in, iwt, threads_y,
+                                       blocks_dim);
+
+    if (blocks_dim[dim] > 1) {
+        blocks_dim[dim] = 1;
+
+        Array<Tw> owt = createEmptyArray<Tw>(dim4());
+        mean_dim_launcher<To, Tw, To, dim>(out, owt, tmpOut, tmpWt, threads_y,
+                                           blocks_dim);
+    }
+}
+
+// Calculate mean along the first dimension. If wt is an empty Param, use
+// weight as 1 and treat it as count. If owt is empty Param, do not write
+// temporary reduced counts/weights to it.
+template<typename Ti, typename Tw, typename To>
+class meanFirstKernelSMEM {
+   public:
+    meanFirstKernelSMEM(sycl::accessor<To> out, KParam oInfo,
+                        sycl::accessor<Tw> owt, KParam owInfo,
+                        sycl::accessor<Ti> in, KParam iInfo,
+                        sycl::accessor<Tw> iwt, KParam iwInfo, const uint DIMX,
+                        const uint groups_x, const uint groups_y,
+                        const uint repeat,
+                        local_accessor<compute_t<To>, 1> s_val,
+                        local_accessor<compute_t<Tw>, 1> s_idx,
+                        sycl::stream debug, bool input_weight,
+                        bool output_weight)
+        : out_(out)
+        , oInfo_(oInfo)
+        , owt_(owt)
+        , owInfo_(owInfo)
+        , in_(in)
+        , iInfo_(iInfo)
+        , iwt_(iwt)
+        , iwInfo_(iwInfo)
+        , DIMX_(DIMX)
+        , groups_x_(groups_x)
+        , groups_y_(groups_y)
+        , repeat_(repeat)
+        , s_val_(s_val)
+        , s_idx_(s_idx)
+        , debug_(debug)
+        , input_weight_(input_weight)
+        , output_weight_(output_weight) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g   = it.get_group();
+        const uint lidx = it.get_local_id(0);
+        const uint lidy = it.get_local_id(1);
+        const uint lid  = lidy * DIMX_ + lidx;
+
+        const uint zid        = g.get_group_id(0) / groups_x_;
+        const uint wid        = g.get_group_id(1) / groups_y_;
+        const uint groupIdx_x = g.get_group_id(0) - (groups_x_)*zid;
+        const uint groupIdx_y = g.get_group_id(1) - (groups_y_)*wid;
+        const uint xid = groupIdx_x * g.get_local_range(0) * repeat_ + lidx;
+        const uint yid = groupIdx_y * g.get_local_range(1) + lidy;
+
+        const Ti *iptr = in_.get_pointer();
+        To *optr       = out_.get_pointer();
+
+        iptr += wid * iInfo_.strides[3] + zid * iInfo_.strides[2] +
+                yid * iInfo_.strides[1];
+        optr += wid * oInfo_.strides[3] + zid * oInfo_.strides[2] +
+                yid * oInfo_.strides[1];
+
+        const Tw *iwptr;
+        Tw *owptr;
+        if (input_weight_)
+            iwptr = iwt_.get_pointer() + wid * iwInfo_.strides[3] +
+                    zid * iwInfo_.strides[2] + yid * iwInfo_.strides[1];
+
+        if (output_weight_)
+            owptr = owt_.get_pointer() + wid * oInfo_.strides[3] +
+                    zid * oInfo_.strides[2] + yid * oInfo_.strides[1];
+
+        bool cond = (yid < iInfo_.dims[1] && zid < iInfo_.dims[2] &&
+                     wid < iInfo_.dims[3]);
+
+        int lim = sycl::min((dim_t)(xid + repeat_ * DIMX_), iInfo_.dims[0]);
+
+        common::Transform<Ti, compute_t<To>, af_add_t> transform;
+
+        compute_t<To> val    = common::Binary<compute_t<To>, af_add_t>::init();
+        compute_t<Tw> weight = common::Binary<compute_t<Tw>, af_add_t>::init();
+
+        if (cond && xid < lim) {
+            val = transform(iptr[xid]);
+            if (input_weight_) {
+                weight = iwptr[xid];
+            } else {
+                weight = (Tw)1;
+            }
+        }
+
+        if (input_weight_) {
+            for (int id = xid + DIMX_; cond && id < lim; id += DIMX_) {
+                stable_mean(&val, &weight, transform(iptr[id]),
+                            compute_t<Tw>(iwptr[id]));
+            }
+        } else {
+            for (int id = xid + DIMX_; cond && id < lim; id += DIMX_) {
+                // Faster version of stable_mean when iwptr is NULL
+                val    = val + (transform(iptr[id]) - val) / (weight + (Tw)1);
+                weight = weight + (Tw)1;
+            }
+        }
+
+        s_val_[lid] = val;
+        s_idx_[lid] = weight;
+        group_barrier(g);
+
+        compute_t<To> *s_vptr = s_val_.get_pointer() + lidy * DIMX_;
+        compute_t<Tw> *s_iptr = s_idx_.get_pointer() + lidy * DIMX_;
+
+        if (DIMX_ == 256) {
+            if (lidx < 128) {
+                stable_mean(s_vptr + lidx, s_iptr + lidx, s_vptr[lidx + 128],
+                            s_iptr[lidx + 128]);
+            }
+            group_barrier(g);
+        }
+
+        if (DIMX_ >= 128) {
+            if (lidx < 64) {
+                stable_mean(s_vptr + lidx, s_iptr + lidx, s_vptr[lidx + 64],
+                            s_iptr[lidx + 64]);
+            }
+            group_barrier(g);
+        }
+
+        if (DIMX_ >= 64) {
+            if (lidx < 32) {
+                stable_mean(s_vptr + lidx, s_iptr + lidx, s_vptr[lidx + 32],
+                            s_iptr[lidx + 32]);
+            }
+            group_barrier(g);
+        }
+
+        if (lidx < 16) {
+            stable_mean(s_vptr + lidx, s_iptr + lidx, s_vptr[lidx + 16],
+                        s_iptr[lidx + 16]);
+        }
+        group_barrier(g);
+
+        if (lidx < 8) {
+            stable_mean(s_vptr + lidx, s_iptr + lidx, s_vptr[lidx + 8],
+                        s_iptr[lidx + 8]);
+        }
+        group_barrier(g);
+
+        if (lidx < 4) {
+            stable_mean(s_vptr + lidx, s_iptr + lidx, s_vptr[lidx + 4],
+                        s_iptr[lidx + 4]);
+        }
+        group_barrier(g);
+
+        if (lidx < 2) {
+            stable_mean(s_vptr + lidx, s_iptr + lidx, s_vptr[lidx + 2],
+                        s_iptr[lidx + 2]);
+        }
+        group_barrier(g);
+
+        if (lidx < 1) {
+            stable_mean(s_vptr + lidx, s_iptr + lidx, s_vptr[lidx + 1],
+                        s_iptr[lidx + 1]);
+        }
+        group_barrier(g);
+
+        if (cond && lidx == 0) {
+            optr[groupIdx_x] = s_vptr[0];
+            if (output_weight_) owptr[groupIdx_x] = s_iptr[0];
+        }
+    }
+
+   protected:
+    sycl::accessor<To> out_;
+    sycl::accessor<Tw> owt_;
+    sycl::accessor<Ti> in_;
+    sycl::accessor<Tw> iwt_;
+    KParam oInfo_, owInfo_, iInfo_, iwInfo_;
+    const uint DIMX_, groups_x_, groups_y_, repeat_;
+    local_accessor<compute_t<To>, 1> s_val_;
+    local_accessor<compute_t<Tw>, 1> s_idx_;
+    bool input_weight_, output_weight_;
+    sycl::stream debug_;
+};
+
+template<typename Ti, typename Tw, typename To>
+void mean_first_launcher(Param<To> out, Param<Tw> owt, Param<Ti> in,
+                         Param<Tw> iwt, const uint groups_x,
+                         const uint groups_y, const uint threads_x) {
+    sycl::range<2> local(threads_x, THREADS_PER_BLOCK / threads_x);
+    sycl::range<2> global(groups_x * in.info.dims[2] * local[0],
+                          groups_y * in.info.dims[3] * local[1]);
+
+    uint repeat = divup(in.info.dims[0], (groups_x * threads_x));
+
+    sycl::buffer<Tw, 1> empty(sycl::range<1>{1});
+    getQueue().submit([&](sycl::handler &h) {
+        auto out_acc = out.data->get_access(h);
+        auto in_acc  = in.data->get_access(h);
+
+        sycl::stream debug_stream(2048 * 2048, 2048, h);
+
+        auto s_val = local_accessor<compute_t<To>, 1>(THREADS_PER_BLOCK, h);
+        auto s_idx = local_accessor<compute_t<Tw>, 1>(THREADS_PER_BLOCK, h);
+
+        bool input_weight = ((iwt.info.dims[0] * iwt.info.dims[1] *
+                              iwt.info.dims[2] * iwt.info.dims[3]) != 0);
+
+        bool output_weight = ((owt.info.dims[0] * owt.info.dims[1] *
+                               owt.info.dims[2] * owt.info.dims[3]) != 0);
+
+        auto owt_acc =
+            (output_weight) ? owt.data->get_access(h) : empty.get_access(h);
+        auto iwt_acc =
+            (input_weight) ? iwt.data->get_access(h) : empty.get_access(h);
+
+        h.parallel_for(
+            sycl::nd_range<2>(global, local),
+            meanFirstKernelSMEM<Ti, Tw, To>(
+                out_acc, out.info, owt_acc, owt.info, in_acc, in.info, iwt_acc,
+                iwt.info, threads_x, groups_x, groups_y, repeat, s_val, s_idx,
+                debug_stream, input_weight, output_weight));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename Ti, typename Tw, typename To>
+void mean_first(Param<To> out, Param<Ti> in, Param<Tw> iwt) {
+    uint threads_x = nextpow2(std::max(32u, (uint)in.info.dims[0]));
+    threads_x      = std::min(threads_x, THREADS_PER_BLOCK);
+    uint threads_y = THREADS_PER_BLOCK / threads_x;
+
+    uint blocks_x = divup(in.info.dims[0], threads_x * REPEAT);
+    uint blocks_y = divup(in.info.dims[1], threads_y);
+
+    Array<To> tmpOut = createEmptyArray<To>(dim4());
+    Array<Tw> tmpWt  = createEmptyArray<Tw>(dim4());
+    if (blocks_x > 1) {
+        tmpOut = createEmptyArray<To>(
+            {blocks_x, in.info.dims[1], in.info.dims[2], in.info.dims[3]});
+        tmpWt = createEmptyArray<Tw>(
+            {blocks_x, in.info.dims[1], in.info.dims[2], in.info.dims[3]});
+    } else {
+        tmpOut = createParamArray(out, false);
+    }
+
+    mean_first_launcher<Ti, Tw, To>(tmpOut, tmpWt, in, iwt, blocks_x, blocks_y,
+                                    threads_x);
+
+    if (blocks_x > 1) {
+        Param<Tw> owt;
+        owt.data = nullptr;
+        mean_first_launcher<To, Tw, To>(out, owt, tmpOut, tmpWt, 1, blocks_y,
+                                        threads_x);
+    }
+}
+
+template<typename Ti, typename Tw, typename To>
+void mean_weighted(Param<To> out, Param<Ti> in, Param<Tw> iwt, int dim) {
+    switch (dim) {
+        case 0: return mean_first<Ti, Tw, To>(out, in, iwt);
+        case 1: return mean_dim<Ti, Tw, To, 1>(out, in, iwt);
+        case 2: return mean_dim<Ti, Tw, To, 2>(out, in, iwt);
+        case 3: return mean_dim<Ti, Tw, To, 3>(out, in, iwt);
+    }
+}
+
+template<typename Ti, typename Tw, typename To>
+void mean(Param<To> out, Param<Ti> in, int dim) {
+    Param<Tw> dummy_weight;
+    mean_weighted<Ti, Tw, To>(out, in, dummy_weight, dim);
+}
+
+template<typename T, typename Tw>
+T mean_all_weighted(Param<T> in, Param<Tw> iwt) {
+    int in_elements =
+        in.info.dims[0] * in.info.dims[1] * in.info.dims[2] * in.info.dims[3];
+    // FIXME: Use better heuristics to get to the optimum number
+    if (in_elements > 4096) {
+        bool in_is_linear = (in.info.strides[0] == 1);
+        bool wt_is_linear = (iwt.info.strides[0] == 1);
+        for (int k = 1; k < 4; k++) {
+            in_is_linear &= (in.info.strides[k] ==
+                             (in.info.strides[k - 1] * in.info.dims[k - 1]));
+            wt_is_linear &= (iwt.info.strides[k] ==
+                             (iwt.info.strides[k - 1] * iwt.info.dims[k - 1]));
+        }
+
+        if (in_is_linear && wt_is_linear) {
+            in.info.dims[0] = in_elements;
+            for (int k = 1; k < 4; k++) {
+                in.info.dims[k]    = 1;
+                in.info.strides[k] = in_elements;
+            }
+
+            for (int k = 0; k < 4; k++) {
+                iwt.info.dims[k]    = in.info.dims[k];
+                iwt.info.strides[k] = in.info.strides[k];
+            }
+        }
+
+        uint threads_x = nextpow2(std::max(32u, (uint)in.info.dims[0]));
+        threads_x      = std::min(threads_x, THREADS_PER_BLOCK);
+        uint threads_y = THREADS_PER_BLOCK / threads_x;
+
+        uint blocks_x = divup(in.info.dims[0], threads_x * REPEAT);
+        uint blocks_y = divup(in.info.dims[1], threads_y);
+
+        Array<T> tmpOut = createEmptyArray<T>(
+            {blocks_x, in.info.dims[1], in.info.dims[2], in.info.dims[3]});
+        Array<Tw> tmpWt = createEmptyArray<Tw>(
+            {blocks_x, in.info.dims[1], in.info.dims[2], in.info.dims[3]});
+
+        int tmp_elements = tmpOut.elements();
+
+        mean_first_launcher<T, Tw, T>(tmpOut, tmpWt, in, iwt, blocks_x,
+                                      blocks_y, threads_x);
+
+        std::vector<T> h_ptr(tmp_elements);
+        std::vector<Tw> h_wptr(tmp_elements);
+        sycl::buffer hBuffer(h_ptr.data(), {tmp_elements},
+                             {sycl::property::buffer::use_host_ptr()});
+        sycl::buffer hwBuffer(h_wptr.data(), {tmp_elements},
+                              {sycl::property::buffer::use_host_ptr()});
+
+        auto e1 = getQueue().submit([&](sycl::handler &h) {
+            auto acc_in =
+                tmpOut.getData()->get_access(h, sycl::range{tmp_elements});
+            auto acc_out = hBuffer.get_access();
+            h.copy(acc_in, acc_out);
+        });
+        auto e2 = getQueue().submit([&](sycl::handler &h) {
+            auto acc_in =
+                tmpWt.getData()->get_access(h, sycl::range{tmp_elements});
+            auto acc_out = hwBuffer.get_access();
+            h.copy(acc_in, acc_out);
+        });
+        e1.wait();
+        e2.wait();
+
+        compute_t<T> val     = static_cast<compute_t<T>>(h_ptr[0]);
+        compute_t<Tw> weight = static_cast<compute_t<Tw>>(h_wptr[0]);
+
+        for (int i = 1; i < tmp_elements; i++) {
+            stable_mean(&val, &weight, compute_t<T>(h_ptr[i]),
+                        compute_t<Tw>(h_wptr[i]));
+        }
+
+        return static_cast<T>(val);
+    } else {
+        std::vector<T> h_ptr(in_elements);
+        std::vector<Tw> h_wptr(in_elements);
+
+        sycl::buffer hBuffer(h_ptr.data(), {in_elements},
+                             {sycl::property::buffer::use_host_ptr()});
+        sycl::buffer hwBuffer(h_wptr.data(), {in_elements},
+                              {sycl::property::buffer::use_host_ptr()});
+
+        auto e1 = getQueue().submit([&](sycl::handler &h) {
+            auto acc_in  = in.data->get_access(h, sycl::range{in_elements});
+            auto acc_out = hBuffer.get_access();
+            h.copy(acc_in, acc_out);
+        });
+        auto e2 = getQueue().submit([&](sycl::handler &h) {
+            auto acc_in  = iwt.data->get_access(h, sycl::range{in_elements});
+            auto acc_out = hwBuffer.get_access();
+            h.copy(acc_in, acc_out);
+        });
+        e1.wait();
+        e2.wait();
+
+        compute_t<T> val     = static_cast<compute_t<T>>(h_ptr[0]);
+        compute_t<Tw> weight = static_cast<compute_t<Tw>>(h_wptr[0]);
+        for (int i = 1; i < in_elements; i++) {
+            stable_mean(&val, &weight, compute_t<T>(h_ptr[i]),
+                        compute_t<Tw>(h_wptr[i]));
+        }
+
+        return static_cast<T>(val);
+    }
+}
+
+template<typename Ti, typename Tw, typename To>
+To mean_all(Param<Ti> in) {
+    using std::unique_ptr;
+    int in_elements =
+        in.info.dims[0] * in.info.dims[1] * in.info.dims[2] * in.info.dims[3];
+    bool is_linear = (in.info.strides[0] == 1);
+    for (int k = 1; k < 4; k++) {
+        is_linear &= (in.info.strides[k] ==
+                      (in.info.strides[k - 1] * in.info.dims[k - 1]));
+    }
+
+    // FIXME: Use better heuristics to get to the optimum number
+    if (in_elements > 4096 || !is_linear) {
+        if (is_linear) {
+            in.info.dims[0] = in_elements;
+            for (int k = 1; k < 4; k++) {
+                in.info.dims[k]    = 1;
+                in.info.strides[k] = in_elements;
+            }
+        }
+
+        uint threads_x = nextpow2(std::max(32u, (uint)in.info.dims[0]));
+        threads_x      = std::min(threads_x, THREADS_PER_BLOCK);
+        uint threads_y = THREADS_PER_BLOCK / threads_x;
+
+        uint blocks_x = divup(in.info.dims[0], threads_x * REPEAT);
+        uint blocks_y = divup(in.info.dims[1], threads_y);
+
+        dim4 outDims(blocks_x, in.info.dims[1], in.info.dims[2],
+                     in.info.dims[3]);
+
+        Array<To> tmpOut = createEmptyArray<To>(outDims);
+        Array<Tw> tmpCt  = createEmptyArray<Tw>(outDims);
+
+        Param<Tw> iwt;
+        mean_first_launcher<Ti, Tw, To>(tmpOut, tmpCt, in, iwt, blocks_x,
+                                        blocks_y, threads_x);
+
+        int tmp_elements = tmpOut.elements();
+        std::vector<To> h_ptr(tmp_elements);
+        std::vector<Tw> h_cptr(tmp_elements);
+
+        sycl::buffer hBuffer(h_ptr.data(), {tmp_elements},
+                             {sycl::property::buffer::use_host_ptr()});
+        sycl::buffer hcBuffer(h_cptr.data(), {tmp_elements},
+                              {sycl::property::buffer::use_host_ptr()});
+
+        auto e1 = getQueue().submit([&](sycl::handler &h) {
+            auto acc_in =
+                tmpOut.getData()->get_access(h, sycl::range{tmp_elements});
+            auto acc_out = hBuffer.get_access();
+            h.copy(acc_in, acc_out);
+        });
+        auto e2 = getQueue().submit([&](sycl::handler &h) {
+            auto acc_in =
+                tmpCt.getData()->get_access(h, sycl::range{tmp_elements});
+            auto acc_out = hcBuffer.get_access();
+            h.copy(acc_in, acc_out);
+        });
+        e1.wait();
+        e2.wait();
+
+        compute_t<To> val    = static_cast<compute_t<To>>(h_ptr[0]);
+        compute_t<Tw> weight = static_cast<compute_t<Tw>>(h_cptr[0]);
+
+        for (int i = 1; i < tmp_elements; i++) {
+            stable_mean(&val, &weight, compute_t<To>(h_ptr[i]),
+                        compute_t<Tw>(h_cptr[i]));
+        }
+
+        return static_cast<To>(val);
+    } else {
+        std::vector<Ti> h_ptr(in_elements);
+        sycl::buffer outBuffer(h_ptr.data(), {in_elements},
+                               {sycl::property::buffer::use_host_ptr()});
+
+        getQueue()
+            .submit([&](sycl::handler &h) {
+                auto acc_in  = in.data->get_access(h);
+                auto acc_out = outBuffer.get_access();
+                h.copy(acc_in, acc_out);
+            })
+            .wait();
+
+        common::Transform<Ti, compute_t<To>, af_add_t> transform;
+        compute_t<Tw> count = static_cast<compute_t<Tw>>(1);
+
+        compute_t<To> val    = transform(h_ptr[0]);
+        compute_t<Tw> weight = count;
+        for (int i = 1; i < in_elements; i++) {
+            stable_mean(&val, &weight, transform(h_ptr[i]), count);
+        }
+
+        return static_cast<To>(val);
+    }
+}
+
+}  // namespace kernel
+}  // namespace oneapi

--- a/src/backend/oneapi/kernel/mean.hpp
+++ b/src/backend/oneapi/kernel/mean.hpp
@@ -16,6 +16,7 @@
 //#include <copy.hpp>?
 #include <debug_oneapi.hpp>
 #include <err_oneapi.hpp>
+#include <kernel/default_config.hpp>
 #include <kernel/reduce_config.hpp>
 #include <math.hpp>
 #include <memory.hpp>
@@ -253,7 +254,7 @@ void mean_dim_launcher(Param<To> out, Param<Tw> owt, Param<Ti> in,
                 break;
             case 4:
                 h.parallel_for(sycl::nd_range<2>(global, local),
-                               meanDimKernelSMEM<Ti, Tw, To, dim, 8>(
+                               meanDimKernelSMEM<Ti, Tw, To, dim, 4>(
                                    out_acc, out.info, owt_acc, owt.info, in_acc,
                                    in.info, iwt_acc, iwt.info, blocks_dim[0],
                                    blocks_dim[1], blocks_dim[dim], s_val, s_idx,
@@ -261,7 +262,7 @@ void mean_dim_launcher(Param<To> out, Param<Tw> owt, Param<Ti> in,
                 break;
             case 2:
                 h.parallel_for(sycl::nd_range<2>(global, local),
-                               meanDimKernelSMEM<Ti, Tw, To, dim, 8>(
+                               meanDimKernelSMEM<Ti, Tw, To, dim, 2>(
                                    out_acc, out.info, owt_acc, owt.info, in_acc,
                                    in.info, iwt_acc, iwt.info, blocks_dim[0],
                                    blocks_dim[1], blocks_dim[dim], s_val, s_idx,
@@ -269,7 +270,7 @@ void mean_dim_launcher(Param<To> out, Param<Tw> owt, Param<Ti> in,
                 break;
             case 1:
                 h.parallel_for(sycl::nd_range<2>(global, local),
-                               meanDimKernelSMEM<Ti, Tw, To, dim, 8>(
+                               meanDimKernelSMEM<Ti, Tw, To, dim, 1>(
                                    out_acc, out.info, owt_acc, owt.info, in_acc,
                                    in.info, iwt_acc, iwt.info, blocks_dim[0],
                                    blocks_dim[1], blocks_dim[dim], s_val, s_idx,

--- a/src/backend/oneapi/kernel/mean.hpp
+++ b/src/backend/oneapi/kernel/mean.hpp
@@ -583,7 +583,7 @@ void mean(Param<To> out, Param<Ti> in, int dim) {
 
 template<typename T, typename Tw>
 T mean_all_weighted(Param<T> in, Param<Tw> iwt) {
-    int in_elements =
+    uintl in_elements =
         in.info.dims[0] * in.info.dims[1] * in.info.dims[2] * in.info.dims[3];
     // FIXME: Use better heuristics to get to the optimum number
     if (in_elements > 4096) {
@@ -621,7 +621,7 @@ T mean_all_weighted(Param<T> in, Param<Tw> iwt) {
         Array<Tw> tmpWt = createEmptyArray<Tw>(
             {blocks_x, in.info.dims[1], in.info.dims[2], in.info.dims[3]});
 
-        int tmp_elements = tmpOut.elements();
+        uintl tmp_elements = tmpOut.elements();
 
         mean_first_launcher<T, Tw, T>(tmpOut, tmpWt, in, iwt, blocks_x,
                                       blocks_y, threads_x);
@@ -693,7 +693,7 @@ T mean_all_weighted(Param<T> in, Param<Tw> iwt) {
 template<typename Ti, typename Tw, typename To>
 To mean_all(Param<Ti> in) {
     using std::unique_ptr;
-    int in_elements =
+    uintl in_elements =
         in.info.dims[0] * in.info.dims[1] * in.info.dims[2] * in.info.dims[3];
     bool is_linear = (in.info.strides[0] == 1);
     for (int k = 1; k < 4; k++) {
@@ -728,7 +728,7 @@ To mean_all(Param<Ti> in) {
         mean_first_launcher<Ti, Tw, To>(tmpOut, tmpCt, in, iwt, blocks_x,
                                         blocks_y, threads_x);
 
-        int tmp_elements = tmpOut.elements();
+        uintl tmp_elements = tmpOut.elements();
         std::vector<To> h_ptr(tmp_elements);
         std::vector<Tw> h_cptr(tmp_elements);
 

--- a/src/backend/oneapi/kernel/reduce.hpp
+++ b/src/backend/oneapi/kernel/reduce.hpp
@@ -1,0 +1,112 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+#include <Param.hpp>
+#include <backend.hpp>
+#include <common/Binary.hpp>
+#include <common/Transform.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+#include <err_oneapi.hpp>
+#include <kernel/reduce_all.hpp>
+#include <kernel/reduce_config.hpp>
+#include <kernel/reduce_dim.hpp>
+#include <kernel/reduce_first.hpp>
+#include <math.hpp>
+#include <memory.hpp>
+
+#include <algorithm>
+#include <climits>
+#include <complex>
+#include <iostream>
+#include <vector>
+
+namespace oneapi {
+namespace kernel {
+
+template<typename Ti, typename To, af_op_t op>
+void reduce_cpu_dispatch(Param<To> out, Param<Ti> in, int dim, bool change_nan,
+                         double nanval) {
+    // TODO: use kernels optimized for SIMD-based subgroup sizes
+    reduce_default_dispatch<Ti, To, op>(out, in, dim, change_nan, nanval);
+}
+
+template<typename Ti, typename To, af_op_t op>
+void reduce_gpu_dispatch(Param<To> out, Param<Ti> in, int dim, bool change_nan,
+                         double nanval) {
+    // TODO: use kernels optimized for gpu subgroup sizes
+    reduce_default_dispatch<Ti, To, op>(out, in, dim, change_nan, nanval);
+}
+
+template<typename Ti, typename To, af_op_t op>
+void reduce_default_dispatch(Param<To> out, Param<Ti> in, int dim,
+                             bool change_nan, double nanval) {
+    switch (dim) {
+        case 0:
+            return reduce_first_default<Ti, To, op>(out, in, change_nan,
+                                                    nanval);
+        case 1:
+            return reduce_dim_default<Ti, To, op, 1>(out, in, change_nan,
+                                                     nanval);
+        case 2:
+            return reduce_dim_default<Ti, To, op, 2>(out, in, change_nan,
+                                                     nanval);
+        case 3:
+            return reduce_dim_default<Ti, To, op, 3>(out, in, change_nan,
+                                                     nanval);
+    }
+}
+
+template<typename Ti, typename To, af_op_t op>
+void reduce(Param<To> out, Param<Ti> in, int dim, bool change_nan,
+            double nanval) {
+    // TODO: logic to dispatch to different kernels depending on device type
+    if (getQueue().get_device().is_cpu()) {
+        reduce_cpu_dispatch<Ti, To, op>(out, in, dim, change_nan, nanval);
+    } else if (getQueue().get_device().is_gpu()) {
+        reduce_gpu_dispatch<Ti, To, op>(out, in, dim, change_nan, nanval);
+    } else {
+        reduce_default_dispatch<Ti, To, op>(out, in, dim, change_nan, nanval);
+    }
+}
+
+template<typename Ti, typename To, af_op_t op>
+void reduce_all(Param<To> out, Param<Ti> in, bool change_nan, double nanval) {
+    int in_elements =
+        in.info.dims[0] * in.info.dims[1] * in.info.dims[2] * in.info.dims[3];
+    bool is_linear = (in.info.strides[0] == 1);
+    for (int k = 1; k < 4; k++) {
+        is_linear &= (in.info.strides[k] ==
+                      (in.info.strides[k - 1] * in.info.dims[k - 1]));
+    }
+
+    if (is_linear) {
+        in.info.dims[0] = in_elements;
+        for (int k = 1; k < 4; k++) {
+            in.info.dims[k]    = 1;
+            in.info.strides[k] = in_elements;
+        }
+    }
+
+    uint threads_x = nextpow2(std::max(32u, (uint)in.info.dims[0]));
+    threads_x      = std::min(threads_x, THREADS_PER_BLOCK);
+    uint threads_y = THREADS_PER_BLOCK / threads_x;
+
+    // TODO: perf REPEAT, consider removing or runtime eval
+    // max problem size < SM resident threads, don't use REPEAT
+    uint blocks_x = divup(in.info.dims[0], threads_x * REPEAT);
+    uint blocks_y = divup(in.info.dims[1], threads_y);
+
+    reduce_all_launcher_default<Ti, To, op>(out, in, blocks_x, blocks_y,
+                                            threads_x, change_nan, nanval);
+}
+
+}  // namespace kernel
+}  // namespace oneapi

--- a/src/backend/oneapi/kernel/reduce.hpp
+++ b/src/backend/oneapi/kernel/reduce.hpp
@@ -96,12 +96,12 @@ void reduce_all(Param<To> out, Param<Ti> in, bool change_nan, double nanval) {
     }
 
     uint threads_x = nextpow2(std::max(32u, (uint)in.info.dims[0]));
-    threads_x      = std::min(threads_x, THREADS_PER_BLOCK);
-    uint threads_y = THREADS_PER_BLOCK / threads_x;
+    threads_x      = std::min(threads_x, creduce::THREADS_PER_BLOCK);
+    uint threads_y = creduce::THREADS_PER_BLOCK / threads_x;
 
     // TODO: perf REPEAT, consider removing or runtime eval
     // max problem size < SM resident threads, don't use REPEAT
-    uint blocks_x = divup(in.info.dims[0], threads_x * REPEAT);
+    uint blocks_x = divup(in.info.dims[0], threads_x * creduce::REPEAT);
     uint blocks_y = divup(in.info.dims[1], threads_y);
 
     reduce_all_launcher_default<Ti, To, op>(out, in, blocks_x, blocks_y,

--- a/src/backend/oneapi/kernel/reduce.hpp
+++ b/src/backend/oneapi/kernel/reduce.hpp
@@ -32,20 +32,6 @@ namespace oneapi {
 namespace kernel {
 
 template<typename Ti, typename To, af_op_t op>
-void reduce_cpu_dispatch(Param<To> out, Param<Ti> in, int dim, bool change_nan,
-                         double nanval) {
-    // TODO: use kernels optimized for SIMD-based subgroup sizes
-    reduce_default_dispatch<Ti, To, op>(out, in, dim, change_nan, nanval);
-}
-
-template<typename Ti, typename To, af_op_t op>
-void reduce_gpu_dispatch(Param<To> out, Param<Ti> in, int dim, bool change_nan,
-                         double nanval) {
-    // TODO: use kernels optimized for gpu subgroup sizes
-    reduce_default_dispatch<Ti, To, op>(out, in, dim, change_nan, nanval);
-}
-
-template<typename Ti, typename To, af_op_t op>
 void reduce_default_dispatch(Param<To> out, Param<Ti> in, int dim,
                              bool change_nan, double nanval) {
     switch (dim) {
@@ -62,6 +48,20 @@ void reduce_default_dispatch(Param<To> out, Param<Ti> in, int dim,
             return reduce_dim_default<Ti, To, op, 3>(out, in, change_nan,
                                                      nanval);
     }
+}
+
+template<typename Ti, typename To, af_op_t op>
+void reduce_cpu_dispatch(Param<To> out, Param<Ti> in, int dim, bool change_nan,
+                         double nanval) {
+    // TODO: use kernels optimized for SIMD-based subgroup sizes
+    reduce_default_dispatch<Ti, To, op>(out, in, dim, change_nan, nanval);
+}
+
+template<typename Ti, typename To, af_op_t op>
+void reduce_gpu_dispatch(Param<To> out, Param<Ti> in, int dim, bool change_nan,
+                         double nanval) {
+    // TODO: use kernels optimized for gpu subgroup sizes
+    reduce_default_dispatch<Ti, To, op>(out, in, dim, change_nan, nanval);
 }
 
 template<typename Ti, typename To, af_op_t op>

--- a/src/backend/oneapi/kernel/reduce_all.hpp
+++ b/src/backend/oneapi/kernel/reduce_all.hpp
@@ -1,0 +1,288 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+#include <Param.hpp>
+#include <backend.hpp>
+#include <common/Binary.hpp>
+#include <common/Transform.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+#include <err_oneapi.hpp>
+#include <kernel/reduce_config.hpp>
+#include <math.hpp>
+#include <memory.hpp>
+
+#include <algorithm>
+#include <climits>
+#include <complex>
+#include <iostream>
+#include <vector>
+
+namespace oneapi {
+namespace kernel {
+
+template<typename T, int dimensions>
+using local_accessor =
+    sycl::accessor<T, dimensions, sycl::access::mode::read_write,
+                   sycl::access::target::local>;
+
+template<typename T>
+using global_atomic_ref =
+    sycl::atomic_ref<T, sycl::memory_order::relaxed, sycl::memory_scope::system,
+                     sycl::access::address_space::global_space>;
+
+template<typename Ti, typename To, af_op_t op>
+class reduceAllKernelSMEM {
+   public:
+    reduceAllKernelSMEM(sycl::accessor<To> out, KParam oInfo,
+                        sycl::accessor<unsigned> retCount,
+                        sycl::accessor<To> tmp, KParam tmpInfo,
+                        sycl::accessor<Ti> in, KParam iInfo, uint DIMX,
+                        uint groups_x, uint groups_y, uint repeat,
+                        bool change_nan, To nanval,
+                        local_accessor<compute_t<To>, 1> s_ptr,
+                        local_accessor<bool, 1> amLast, sycl::stream debug)
+        : out_(out)
+        , oInfo_(oInfo)
+        , retCount_(retCount)
+        , tmp_(tmp)
+        , tmpInfo_(tmpInfo)
+        , in_(in)
+        , iInfo_(iInfo)
+        , DIMX_(DIMX)
+        , groups_x_(groups_x)
+        , groups_y_(groups_y)
+        , repeat_(repeat)
+        , change_nan_(change_nan)
+        , nanval_(nanval)
+        , s_ptr_(s_ptr)
+        , amLast_(amLast)
+        , debug_(debug) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g   = it.get_group();
+        const uint lidx = it.get_local_id(0);
+        const uint lidy = it.get_local_id(1);
+        const uint lid  = lidy * DIMX_ + lidx;
+
+        const uint zid       = g.get_group_id(0) / groups_x_;
+        const uint wid       = g.get_group_id(1) / groups_y_;
+        const uint groupId_x = g.get_group_id(0) - (groups_x_)*zid;
+        const uint groupId_y = g.get_group_id(1) - (groups_y_)*wid;
+        const uint xid = groupId_x * g.get_local_range(0) * repeat_ + lidx;
+        const uint yid = groupId_y * g.get_local_range(1) + lidy;
+
+        common::Binary<compute_t<To>, op> reduce;
+        common::Transform<Ti, compute_t<To>, op> transform;
+
+        const data_t<Ti> *const iptr =
+            in_.get_pointer() + wid * iInfo_.strides[3] +
+            zid * iInfo_.strides[2] + yid * iInfo_.strides[1] + iInfo_.offset;
+
+        bool cond = (yid < iInfo_.dims[1]) && (zid < iInfo_.dims[2]) &&
+                    (wid < iInfo_.dims[3]);
+
+        dim_t last = (xid + repeat_ * DIMX_);
+        int lim    = sycl::min(last, iInfo_.dims[0]);
+
+        compute_t<To> out_val = common::Binary<compute_t<To>, op>::init();
+        for (int id = xid; cond && id < lim; id += DIMX_) {
+            compute_t<To> in_val = transform(iptr[id]);
+            if (change_nan_)
+                in_val = !IS_NAN(in_val) ? in_val
+                                         : static_cast<compute_t<To>>(nanval_);
+            out_val = reduce(in_val, out_val);
+        }
+
+        s_ptr_[lid] = out_val;
+
+        group_barrier(g);
+
+        if (THREADS_PER_BLOCK == 256) {
+            if (lid < 128) s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 128]);
+            group_barrier(g);
+        }
+
+        if (THREADS_PER_BLOCK >= 128) {
+            if (lid < 64) s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 64]);
+            group_barrier(g);
+        }
+
+        if (THREADS_PER_BLOCK >= 64) {
+            if (lid < 32) s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 32]);
+            group_barrier(g);
+        }
+
+        // TODO: replace with subgroup operations in optimized kernels
+        if (lid < 16) s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 16]);
+        group_barrier(g);
+
+        if (lid < 8) s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 8]);
+        group_barrier(g);
+
+        if (lid < 4) s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 4]);
+        group_barrier(g);
+
+        if (lid < 2) s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 2]);
+        group_barrier(g);
+
+        if (lid < 1) s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 1]);
+        group_barrier(g);
+
+        const unsigned total_blocks =
+            (g.get_group_range(0) * g.get_group_range(1));
+        const int uubidx =
+            (g.get_group_range(0) * g.get_group_id(1)) + g.get_group_id(0);
+        if (cond && lid == 0) {
+            if (total_blocks != 1) {
+                tmp_[uubidx] = s_ptr_[0];
+            } else {
+                out_[0] = s_ptr_[0];
+            }
+        }
+
+        // Last block to perform final reduction
+        if (total_blocks > 1) {
+            sycl::atomic_fence(sycl::memory_order::seq_cst,
+                               sycl::memory_scope::device);
+
+            // thread 0 takes a ticket
+            if (lid == 0) {
+                unsigned int ticket = global_atomic_ref<uint>(retCount_[0])++;
+                // If the ticket ID == number of blocks, we are the last block
+                amLast_[0] = (ticket == (total_blocks - 1));
+            }
+            group_barrier(g);
+
+            if (amLast_[0]) {
+                int i   = lid;
+                out_val = common::Binary<compute_t<To>, op>::init();
+
+                while (i < total_blocks) {
+                    compute_t<To> in_val = compute_t<To>(tmp_[i]);
+                    out_val              = reduce(in_val, out_val);
+                    i += THREADS_PER_BLOCK;
+                }
+
+                s_ptr_[lid] = out_val;
+                group_barrier(g);
+
+                // reduce final block
+                if (THREADS_PER_BLOCK == 256) {
+                    if (lid < 128)
+                        s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 128]);
+                    group_barrier(g);
+                }
+
+                if (THREADS_PER_BLOCK >= 128) {
+                    if (lid < 64)
+                        s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 64]);
+                    group_barrier(g);
+                }
+
+                if (THREADS_PER_BLOCK >= 64) {
+                    if (lid < 32)
+                        s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 32]);
+                    group_barrier(g);
+                }
+
+                if (lid < 16)
+                    s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 16]);
+                group_barrier(g);
+
+                if (lid < 8) s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 8]);
+                group_barrier(g);
+
+                if (lid < 4) s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 4]);
+                group_barrier(g);
+
+                if (lid < 2) s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 2]);
+                group_barrier(g);
+
+                if (lid < 1) s_ptr_[lid] = reduce(s_ptr_[lid], s_ptr_[lid + 1]);
+                group_barrier(g);
+
+                if (lid == 0) {
+                    out_[0] = s_ptr_[0];
+
+                    // reset retirement count so that next run succeeds
+                    retCount_[0] = 0;
+                }
+            }
+        }
+    }
+
+   protected:
+    sycl::accessor<To> out_;
+    sycl::accessor<unsigned> retCount_;
+    sycl::accessor<To> tmp_;
+    KParam oInfo_, tmpInfo_, iInfo_;
+    sycl::accessor<Ti> in_;
+    uint DIMX_, repeat_;
+    uint groups_x_, groups_y_;
+    bool change_nan_;
+    To nanval_;
+    local_accessor<compute_t<To>, 1> s_ptr_;
+    local_accessor<bool, 1> amLast_;
+    sycl::stream debug_;
+};
+
+template<typename Ti, typename To, af_op_t op>
+void reduce_all_launcher_default(Param<To> out, Param<Ti> in,
+                                 const uint groups_x, const uint groups_y,
+                                 const uint threads_x, bool change_nan,
+                                 double nanval) {
+    sycl::range<2> local(threads_x, THREADS_PER_BLOCK / threads_x);
+    sycl::range<2> global(groups_x * in.info.dims[2] * local[0],
+                          groups_y * in.info.dims[3] * local[1]);
+
+    uint repeat = divup(in.info.dims[0], (groups_x * threads_x));
+
+    long tmp_elements = groups_x * in.info.dims[2] * groups_y * in.info.dims[3];
+    if (tmp_elements > UINT_MAX) {
+        AF_ERROR(
+            "Too many blocks requested (typeof(retirementCount) == unsigned)",
+            AF_ERR_RUNTIME);
+    }
+    Array<To> tmp = createEmptyArray<To>(tmp_elements);
+    // TODO: JIT dependency
+    // Array<unsigned> retirementCount = createValueArray<unsigned>(1, 0);
+    Array<unsigned> retirementCount = createEmptyArray<unsigned>(1);
+    getQueue().submit([=](sycl::handler &h) {
+        auto acc = retirementCount.getData()->get_access(h);
+        h.single_task([=] { acc[0] = 0; });
+    });
+
+    getQueue()
+        .submit([=](sycl::handler &h) {
+            auto out_acc      = out.data->get_access(h);
+            auto retCount_acc = retirementCount.getData()->get_access(h);
+            auto tmp_acc      = tmp.getData()->get_access(h);
+            auto in_acc       = in.data->get_access(h);
+
+            sycl::stream debug_stream(2048 * 256, 128, h);
+
+            auto shrdMem =
+                local_accessor<compute_t<To>, 1>(THREADS_PER_BLOCK, h);
+            auto amLast = local_accessor<bool, 1>(1, h);
+            h.parallel_for(
+                sycl::nd_range<2>(global, local),
+                reduceAllKernelSMEM<Ti, To, op>(
+                    out_acc, out.info, retCount_acc, tmp_acc, (KParam)tmp,
+                    in_acc, in.info, threads_x, groups_x, groups_y, repeat,
+                    change_nan, scalar<To>(nanval), shrdMem, amLast,
+                    debug_stream));
+        })
+        .wait_and_throw();
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+}  // namespace kernel
+}  // namespace oneapi

--- a/src/backend/oneapi/kernel/reduce_config.hpp
+++ b/src/backend/oneapi/kernel/reduce_config.hpp
@@ -1,0 +1,22 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+namespace oneapi {
+namespace kernel {
+
+// TODO: are different values more appropriate for reduce on oneapi?
+static const uint THREADS_PER_BLOCK = 256;
+static const uint THREADS_X         = 32;
+static const uint THREADS_Y         = THREADS_PER_BLOCK / THREADS_X;
+static const uint REPEAT            = 32;
+
+}  // namespace kernel
+}  // namespace oneapi

--- a/src/backend/oneapi/kernel/reduce_dim.hpp
+++ b/src/backend/oneapi/kernel/reduce_dim.hpp
@@ -33,11 +33,17 @@ using local_accessor =
     sycl::accessor<T, dimensions, sycl::access::mode::read_write,
                    sycl::access::target::local>;
 
+template<typename T>
+using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
+
+template<typename T>
+using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
+
 template<typename Ti, typename To, af_op_t op, uint dim, uint DIMY>
 class reduceDimKernelSMEM {
    public:
-    reduceDimKernelSMEM(sycl::accessor<To> out, KParam oInfo,
-                        sycl::accessor<Ti> in, KParam iInfo, uint groups_x,
+    reduceDimKernelSMEM(write_accessor<To> out, KParam oInfo,
+                        read_accessor<Ti> in, KParam iInfo, uint groups_x,
                         uint groups_y, uint offset_dim, bool change_nan,
                         To nanval, local_accessor<compute_t<To>, 1> s_val,
                         sycl::stream debug)
@@ -128,9 +134,9 @@ class reduceDimKernelSMEM {
     }
 
    protected:
-    sycl::accessor<To> out_;
+    write_accessor<To> out_;
     KParam oInfo_, iInfo_;
-    sycl::accessor<Ti> in_;
+    read_accessor<Ti> in_;
     uint groups_x_, groups_y_, offset_dim_;
     bool change_nan_;
     To nanval_;
@@ -148,8 +154,8 @@ void reduce_dim_launcher_default(Param<To> out, Param<Ti> in,
                           blocks_dim[1] * blocks_dim[3] * local[1]);
 
     getQueue().submit([=](sycl::handler &h) {
-        auto out_acc = out.data->get_access(h);
-        auto in_acc  = in.data->get_access(h);
+        write_accessor<To> out_acc{*out.data, h};
+        read_accessor<Ti> in_acc{*in.data, h};
 
         sycl::stream debug_stream(2048 * 256, 128, h);
 

--- a/src/backend/oneapi/kernel/reduce_dim.hpp
+++ b/src/backend/oneapi/kernel/reduce_dim.hpp
@@ -1,0 +1,236 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+#include <Param.hpp>
+#include <backend.hpp>
+#include <common/Binary.hpp>
+#include <common/Transform.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+#include <err_oneapi.hpp>
+#include <kernel/reduce_config.hpp>
+#include <math.hpp>
+#include <memory.hpp>
+
+#include <algorithm>
+#include <climits>
+#include <complex>
+#include <iostream>
+#include <vector>
+
+namespace oneapi {
+namespace kernel {
+
+template<typename T, int dimensions>
+using local_accessor =
+    sycl::accessor<T, dimensions, sycl::access::mode::read_write,
+                   sycl::access::target::local>;
+
+template<typename Ti, typename To, af_op_t op, uint dim, uint DIMY>
+class reduceDimKernelSMEM {
+   public:
+    reduceDimKernelSMEM(sycl::accessor<To> out, KParam oInfo,
+                        sycl::accessor<Ti> in, KParam iInfo, uint groups_x,
+                        uint groups_y, uint offset_dim, bool change_nan,
+                        To nanval, local_accessor<compute_t<To>, 1> s_val,
+                        sycl::stream debug)
+        : out_(out)
+        , oInfo_(oInfo)
+        , in_(in)
+        , iInfo_(iInfo)
+        , groups_x_(groups_x)
+        , groups_y_(groups_y)
+        , offset_dim_(offset_dim)
+        , change_nan_(change_nan)
+        , nanval_(nanval)
+        , s_val_(s_val)
+        , debug_(debug) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g   = it.get_group();
+        const uint lidx = it.get_local_id(0);
+        const uint lidy = it.get_local_id(1);
+        const uint lid  = lidy * g.get_local_range(0) + lidx;
+
+        const uint zid       = g.get_group_id(0) / groups_x_;
+        const uint wid       = g.get_group_id(1) / groups_y_;
+        const uint groupId_x = g.get_group_id(0) - (groups_x_)*zid;
+        const uint groupId_y = g.get_group_id(1) - (groups_y_)*wid;
+        const uint xid       = groupId_x * g.get_local_range(0) + lidx;
+        const uint yid       = groupId_y;
+
+        uint ids[4] = {xid, yid, zid, wid};
+
+        data_t<To> *const optr =
+            out_.get_pointer() + ids[3] * oInfo_.strides[3] +
+            ids[2] * oInfo_.strides[2] + ids[1] * oInfo_.strides[1] + ids[0];
+
+        const uint groupIdx_dim = ids[dim];
+        ids[dim]                = ids[dim] * g.get_local_range(1) + lidy;
+
+        const data_t<Ti> *iptr =
+            in_.get_pointer() + ids[3] * iInfo_.strides[3] +
+            ids[2] * iInfo_.strides[2] + ids[1] * iInfo_.strides[1] + ids[0];
+
+        const uint id_dim_in   = ids[dim];
+        const uint istride_dim = iInfo_.strides[dim];
+        bool is_valid          = (ids[0] < iInfo_.dims[0]) &&
+                        (ids[1] < iInfo_.dims[1]) &&
+                        (ids[2] < iInfo_.dims[2]) && (ids[3] < iInfo_.dims[3]);
+
+        common::Binary<compute_t<To>, op> reduce;
+        common::Transform<Ti, compute_t<To>, op> transform;
+
+        compute_t<To> out_val = common::Binary<compute_t<To>, op>::init();
+        for (int id = id_dim_in; is_valid && (id < iInfo_.dims[dim]);
+             id += offset_dim_ * g.get_local_range(1)) {
+            compute_t<To> in_val = transform(*iptr);
+            if (change_nan_)
+                in_val = !IS_NAN(in_val) ? in_val
+                                         : static_cast<compute_t<To>>(nanval_);
+            out_val = reduce(in_val, out_val);
+            iptr += offset_dim_ * g.get_local_range(1) * istride_dim;
+        }
+
+        s_val_[lid] = out_val;
+
+        it.barrier();
+        compute_t<To> *s_ptr = s_val_.get_pointer() + lid;
+
+        if (DIMY == 8) {
+            if (lidy < 4) *s_ptr = reduce(*s_ptr, s_ptr[THREADS_X * 4]);
+            it.barrier();
+        }
+
+        if (DIMY >= 4) {
+            if (lidy < 2) *s_ptr = reduce(*s_ptr, s_ptr[THREADS_X * 2]);
+            it.barrier();
+        }
+
+        if (DIMY >= 2) {
+            if (lidy < 1) *s_ptr = reduce(*s_ptr, s_ptr[THREADS_X * 1]);
+            it.barrier();
+        }
+
+        if (lidy == 0 && is_valid && (groupIdx_dim < oInfo_.dims[dim])) {
+            *optr = data_t<To>(*s_ptr);
+        }
+    }
+
+   protected:
+    sycl::accessor<To> out_;
+    KParam oInfo_, iInfo_;
+    sycl::accessor<Ti> in_;
+    uint groups_x_, groups_y_, offset_dim_;
+    bool change_nan_;
+    To nanval_;
+    local_accessor<compute_t<To>, 1> s_val_;
+    sycl::stream debug_;
+};
+
+template<typename Ti, typename To, af_op_t op, uint dim>
+void reduce_dim_launcher_default(Param<To> out, Param<Ti> in,
+                                 const uint threads_y,
+                                 const dim_t blocks_dim[4], bool change_nan,
+                                 double nanval) {
+    sycl::range<2> local(THREADS_X, threads_y);
+    sycl::range<2> global(blocks_dim[0] * blocks_dim[2] * local[0],
+                          blocks_dim[1] * blocks_dim[3] * local[1]);
+
+    getQueue().submit([=](sycl::handler &h) {
+        auto out_acc = out.data->get_access(h);
+        auto in_acc  = in.data->get_access(h);
+
+        sycl::stream debug_stream(2048 * 256, 128, h);
+
+        auto shrdMem =
+            local_accessor<compute_t<To>, 1>(THREADS_X * threads_y, h);
+
+        switch (threads_y) {
+            case 8:
+                h.parallel_for(
+                    sycl::nd_range<2>(global, local),
+                    reduceDimKernelSMEM<Ti, To, op, dim, 8>(
+                        out_acc, out.info, in_acc, in.info, blocks_dim[0],
+                        blocks_dim[1], blocks_dim[dim], change_nan,
+                        scalar<To>(nanval), shrdMem, debug_stream));
+                break;
+            case 4:
+                h.parallel_for(
+                    sycl::nd_range<2>(global, local),
+                    reduceDimKernelSMEM<Ti, To, op, dim, 4>(
+                        out_acc, out.info, in_acc, in.info, blocks_dim[0],
+                        blocks_dim[1], blocks_dim[dim], change_nan,
+                        scalar<To>(nanval), shrdMem, debug_stream));
+                break;
+            case 2:
+                h.parallel_for(
+                    sycl::nd_range<2>(global, local),
+                    reduceDimKernelSMEM<Ti, To, op, dim, 2>(
+                        out_acc, out.info, in_acc, in.info, blocks_dim[0],
+                        blocks_dim[1], blocks_dim[dim], change_nan,
+                        scalar<To>(nanval), shrdMem, debug_stream));
+                break;
+            case 1:
+                h.parallel_for(
+                    sycl::nd_range<2>(global, local),
+                    reduceDimKernelSMEM<Ti, To, op, dim, 1>(
+                        out_acc, out.info, in_acc, in.info, blocks_dim[0],
+                        blocks_dim[1], blocks_dim[dim], change_nan,
+                        scalar<To>(nanval), shrdMem, debug_stream));
+                break;
+        }
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename Ti, typename To, af_op_t op, int dim>
+void reduce_dim_default(Param<To> out, Param<Ti> in, bool change_nan,
+                        double nanval) {
+    uint threads_y = std::min(THREADS_Y, nextpow2(in.info.dims[dim]));
+    uint threads_x = THREADS_X;
+
+    dim_t blocks_dim[] = {divup(in.info.dims[0], threads_x), in.info.dims[1],
+                          in.info.dims[2], in.info.dims[3]};
+    blocks_dim[dim]    = divup(in.info.dims[dim], threads_y * REPEAT);
+
+    Param<To> tmp = out;
+    bufptr<To> tmp_alloc;
+    if (blocks_dim[dim] > 1) {
+        tmp.info.dims[dim] = blocks_dim[dim];
+        int tmp_elements   = tmp.info.dims[0] * tmp.info.dims[1] *
+                           tmp.info.dims[2] * tmp.info.dims[3];
+
+        tmp_alloc = memAlloc<To>(tmp_elements);
+        tmp.data  = tmp_alloc.get();
+
+        tmp.info.dims[dim] = blocks_dim[dim];
+        for (int k = dim + 1; k < 4; k++)
+            tmp.info.strides[k] *= blocks_dim[dim];
+    }
+
+    reduce_dim_launcher_default<Ti, To, op, dim>(tmp, in, threads_y, blocks_dim,
+                                                 change_nan, nanval);
+
+    if (blocks_dim[dim] > 1) {
+        blocks_dim[dim] = 1;
+
+        if (op == af_notzero_t) {
+            reduce_dim_launcher_default<To, To, af_add_t, dim>(
+                out, tmp, threads_y, blocks_dim, change_nan, nanval);
+        } else {
+            reduce_dim_launcher_default<To, To, op, dim>(
+                out, tmp, threads_y, blocks_dim, change_nan, nanval);
+        }
+    }
+}
+
+}  // namespace kernel
+}  // namespace oneapi

--- a/src/backend/oneapi/kernel/reduce_first.hpp
+++ b/src/backend/oneapi/kernel/reduce_first.hpp
@@ -1,0 +1,236 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+#include <Param.hpp>
+#include <backend.hpp>
+#include <common/Binary.hpp>
+#include <common/Transform.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+#include <err_oneapi.hpp>
+#include <kernel/reduce_config.hpp>
+#include <math.hpp>
+#include <memory.hpp>
+
+#include <algorithm>
+#include <climits>
+#include <complex>
+#include <iostream>
+#include <vector>
+
+namespace oneapi {
+namespace kernel {
+
+template<typename T, int dimensions>
+using local_accessor =
+    sycl::accessor<T, dimensions, sycl::access::mode::read_write,
+                   sycl::access::target::local>;
+
+template<typename Ti, typename To, af_op_t op, uint DIMX>
+class reduceFirstKernelSMEM {
+   public:
+    reduceFirstKernelSMEM(sycl::accessor<To> out, KParam oInfo,
+                          sycl::accessor<Ti> in, KParam iInfo, uint groups_x,
+                          uint groups_y, uint repeat, bool change_nan,
+                          To nanval, local_accessor<compute_t<To>, 1> s_val,
+                          sycl::stream debug)
+        : out_(out)
+        , oInfo_(oInfo)
+        , in_(in)
+        , iInfo_(iInfo)
+        , groups_x_(groups_x)
+        , groups_y_(groups_y)
+        , repeat_(repeat)
+        , change_nan_(change_nan)
+        , nanval_(nanval)
+        , s_val_(s_val)
+        , debug_(debug) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g   = it.get_group();
+        const uint lidx = it.get_local_id(0);
+        const uint lidy = it.get_local_id(1);
+        const uint lid  = lidy * g.get_local_range(0) + lidx;
+
+        const uint zid       = g.get_group_id(0) / groups_x_;
+        const uint wid       = g.get_group_id(1) / groups_y_;
+        const uint groupId_x = g.get_group_id(0) - (groups_x_)*zid;
+        const uint groupId_y = g.get_group_id(1) - (groups_y_)*wid;
+        const uint xid = groupId_x * g.get_local_range(0) * repeat_ + lidx;
+        const uint yid = groupId_y * g.get_local_range(1) + lidy;
+
+        common::Binary<compute_t<To>, op> reduce;
+        common::Transform<Ti, compute_t<To>, op> transform;
+
+        const data_t<Ti> *const iptr =
+            in_.get_pointer() + wid * iInfo_.strides[3] +
+            zid * iInfo_.strides[2] + yid * iInfo_.strides[1] + iInfo_.offset;
+
+        data_t<To> *const optr = out_.get_pointer() + wid * oInfo_.strides[3] +
+                                 zid * oInfo_.strides[2] +
+                                 yid * oInfo_.strides[1];
+
+        bool cond = (yid < iInfo_.dims[1]) && (zid < iInfo_.dims[2]) &&
+                    (wid < iInfo_.dims[3]);
+
+        dim_t last = (xid + repeat_ * DIMX);
+        int lim    = sycl::min(last, iInfo_.dims[0]);
+
+        compute_t<To> out_val = common::Binary<compute_t<To>, op>::init();
+        for (int id = xid; cond && id < lim; id += DIMX) {
+            compute_t<To> in_val = transform(iptr[id]);
+            if (change_nan_)
+                in_val = !IS_NAN(in_val) ? in_val
+                                         : static_cast<compute_t<To>>(nanval_);
+            out_val = reduce(in_val, out_val);
+        }
+
+        s_val_[lid] = out_val;
+
+        it.barrier();
+        compute_t<To> *s_ptr = s_val_.get_pointer() + lidy * DIMX;
+
+        if (DIMX == 256) {
+            if (lidx < 128)
+                s_ptr[lidx] = reduce(s_ptr[lidx], s_ptr[lidx + 128]);
+            it.barrier();
+        }
+
+        if (DIMX >= 128) {
+            if (lidx < 64) s_ptr[lidx] = reduce(s_ptr[lidx], s_ptr[lidx + 64]);
+            it.barrier();
+        }
+
+        if (DIMX >= 64) {
+            if (lidx < 32) s_ptr[lidx] = reduce(s_ptr[lidx], s_ptr[lidx + 32]);
+            it.barrier();
+        }
+
+        // TODO: replace with subgroup operations in optimized kernels
+        if (lidx < 16) s_ptr[lidx] = reduce(s_ptr[lidx], s_ptr[lidx + 16]);
+        it.barrier();
+
+        if (lidx < 8) s_ptr[lidx] = reduce(s_ptr[lidx], s_ptr[lidx + 8]);
+        it.barrier();
+
+        if (lidx < 4) s_ptr[lidx] = reduce(s_ptr[lidx], s_ptr[lidx + 4]);
+        it.barrier();
+
+        if (lidx < 2) s_ptr[lidx] = reduce(s_ptr[lidx], s_ptr[lidx + 2]);
+        it.barrier();
+
+        if (lidx < 1) s_ptr[lidx] = reduce(s_ptr[lidx], s_ptr[lidx + 1]);
+        it.barrier();
+
+        if (cond && lidx == 0) optr[groupId_x] = data_t<To>(s_ptr[lidx]);
+    }
+
+   protected:
+    sycl::accessor<To> out_;
+    KParam oInfo_, iInfo_;
+    sycl::accessor<Ti> in_;
+    uint groups_x_, groups_y_, repeat_;
+    bool change_nan_;
+    To nanval_;
+    local_accessor<compute_t<To>, 1> s_val_;
+    sycl::stream debug_;
+};
+
+template<typename Ti, typename To, af_op_t op>
+void reduce_first_launcher_default(Param<To> out, Param<Ti> in,
+                                   const uint groups_x, const uint groups_y,
+                                   const uint threads_x, bool change_nan,
+                                   double nanval) {
+    sycl::range<2> local(threads_x, THREADS_PER_BLOCK / threads_x);
+    sycl::range<2> global(groups_x * in.info.dims[2] * local[0],
+                          groups_y * in.info.dims[3] * local[1]);
+
+    uint repeat = divup(in.info.dims[0], (groups_x * threads_x));
+
+    getQueue().submit([=](sycl::handler &h) {
+        auto out_acc = out.data->get_access(h);
+        auto in_acc  = in.data->get_access(h);
+
+        sycl::stream debug_stream(2048 * 256, 128, h);
+
+        auto shrdMem = local_accessor<compute_t<To>, 1>(THREADS_PER_BLOCK, h);
+
+        switch (threads_x) {
+            case 32:
+                h.parallel_for(sycl::nd_range<2>(global, local),
+                               reduceFirstKernelSMEM<Ti, To, op, 32>(
+                                   out_acc, out.info, in_acc, in.info, groups_x,
+                                   groups_y, repeat, change_nan,
+                                   scalar<To>(nanval), shrdMem, debug_stream));
+                break;
+            case 64:
+                h.parallel_for(sycl::nd_range<2>(global, local),
+                               reduceFirstKernelSMEM<Ti, To, op, 64>(
+                                   out_acc, out.info, in_acc, in.info, groups_x,
+                                   groups_y, repeat, change_nan,
+                                   scalar<To>(nanval), shrdMem, debug_stream));
+                break;
+            case 128:
+                h.parallel_for(sycl::nd_range<2>(global, local),
+                               reduceFirstKernelSMEM<Ti, To, op, 128>(
+                                   out_acc, out.info, in_acc, in.info, groups_x,
+                                   groups_y, repeat, change_nan,
+                                   scalar<To>(nanval), shrdMem, debug_stream));
+                break;
+            case 256:
+                h.parallel_for(sycl::nd_range<2>(global, local),
+                               reduceFirstKernelSMEM<Ti, To, op, 256>(
+                                   out_acc, out.info, in_acc, in.info, groups_x,
+                                   groups_y, repeat, change_nan,
+                                   scalar<To>(nanval), shrdMem, debug_stream));
+                break;
+        }
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename Ti, typename To, af_op_t op>
+void reduce_first_default(Param<To> out, Param<Ti> in, bool change_nan,
+                          double nanval) {
+    uint threads_x = nextpow2(std::max(32u, (uint)in.info.dims[0]));
+    threads_x      = std::min(threads_x, THREADS_PER_BLOCK);
+    uint threads_y = THREADS_PER_BLOCK / threads_x;
+
+    uint blocks_x = divup(in.info.dims[0], threads_x * REPEAT);
+    uint blocks_y = divup(in.info.dims[1], threads_y);
+
+    Param<To> tmp = out;
+    bufptr<To> tmp_alloc;
+    if (blocks_x > 1) {
+        tmp_alloc = memAlloc<To>(blocks_x * in.info.dims[1] * in.info.dims[2] *
+                                 in.info.dims[3]);
+        tmp.data  = tmp_alloc.get();
+
+        tmp.info.dims[0] = blocks_x;
+        for (int k = 1; k < 4; k++) tmp.info.strides[k] *= blocks_x;
+    }
+
+    reduce_first_launcher_default<Ti, To, op>(tmp, in, blocks_x, blocks_y,
+                                              threads_x, change_nan, nanval);
+
+    if (blocks_x > 1) {
+        // FIXME: Is there an alternative to the if condition?
+        if (op == af_notzero_t) {
+            reduce_first_launcher_default<To, To, af_add_t>(
+                out, tmp, 1, blocks_y, threads_x, change_nan, nanval);
+        } else {
+            reduce_first_launcher_default<To, To, op>(
+                out, tmp, 1, blocks_y, threads_x, change_nan, nanval);
+        }
+    }
+}
+
+}  // namespace kernel
+}  // namespace oneapi

--- a/src/backend/oneapi/kernel/reduce_first.hpp
+++ b/src/backend/oneapi/kernel/reduce_first.hpp
@@ -148,7 +148,7 @@ void reduce_first_launcher_default(Param<To> out, Param<Ti> in,
                                    const uint groups_x, const uint groups_y,
                                    const uint threads_x, bool change_nan,
                                    double nanval) {
-    sycl::range<2> local(threads_x, THREADS_PER_BLOCK / threads_x);
+    sycl::range<2> local(threads_x, creduce::THREADS_PER_BLOCK / threads_x);
     sycl::range<2> global(groups_x * in.info.dims[2] * local[0],
                           groups_y * in.info.dims[3] * local[1]);
 
@@ -160,7 +160,8 @@ void reduce_first_launcher_default(Param<To> out, Param<Ti> in,
 
         sycl::stream debug_stream(2048 * 256, 128, h);
 
-        auto shrdMem = local_accessor<compute_t<To>, 1>(THREADS_PER_BLOCK, h);
+        auto shrdMem =
+            local_accessor<compute_t<To>, 1>(creduce::THREADS_PER_BLOCK, h);
 
         switch (threads_x) {
             case 32:
@@ -200,10 +201,10 @@ template<typename Ti, typename To, af_op_t op>
 void reduce_first_default(Param<To> out, Param<Ti> in, bool change_nan,
                           double nanval) {
     uint threads_x = nextpow2(std::max(32u, (uint)in.info.dims[0]));
-    threads_x      = std::min(threads_x, THREADS_PER_BLOCK);
-    uint threads_y = THREADS_PER_BLOCK / threads_x;
+    threads_x      = std::min(threads_x, creduce::THREADS_PER_BLOCK);
+    uint threads_y = creduce::THREADS_PER_BLOCK / threads_x;
 
-    uint blocks_x = divup(in.info.dims[0], threads_x * REPEAT);
+    uint blocks_x = divup(in.info.dims[0], threads_x * creduce::REPEAT);
     uint blocks_y = divup(in.info.dims[1], threads_y);
 
     Param<To> tmp = out;

--- a/src/backend/oneapi/kernel/scan_dim.hpp
+++ b/src/backend/oneapi/kernel/scan_dim.hpp
@@ -1,0 +1,349 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Param.hpp>
+#include <backend.hpp>
+#include <common/Binary.hpp>
+#include <common/Transform.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+#include <err_oneapi.hpp>
+#include <kernel/default_config.hpp>
+#include <memory.hpp>
+
+namespace oneapi {
+namespace kernel {
+
+template<typename T, int dimensions>
+using local_accessor =
+    sycl::accessor<T, dimensions, sycl::access::mode::read_write,
+                   sycl::access::target::local>;
+
+template<typename Ti, typename To, af_op_t op, int dim>
+class scanDimKernel {
+   public:
+    scanDimKernel(sycl::accessor<To> out_acc, KParam oInfo,
+                  sycl::accessor<To> tmp_acc, KParam tInfo,
+                  sycl::accessor<Ti> in_acc, KParam iInfo, const uint groups_x,
+                  const uint groups_y, const uint blocks_dim, const uint lim,
+                  const bool isFinalPass, const uint DIMY,
+                  const bool inclusive_scan, local_accessor<To, 1> s_val,
+                  local_accessor<To, 1> s_tmp, sycl::stream debug)
+        : out_acc_(out_acc)
+        , oInfo_(oInfo)
+        , tmp_acc_(tmp_acc)
+        , tInfo_(tInfo)
+        , in_acc_(in_acc)
+        , iInfo_(iInfo)
+        , groups_x_(groups_x)
+        , groups_y_(groups_y)
+        , blocks_dim_(blocks_dim)
+        , lim_(lim)
+        , isFinalPass_(isFinalPass)
+        , DIMY_(DIMY)
+        , inclusive_scan_(inclusive_scan)
+        , s_val_(s_val)
+        , s_tmp_(s_tmp)
+        , debug_(debug) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g   = it.get_group();
+        const uint lidx = it.get_local_id(0);
+        const uint lidy = it.get_local_id(1);
+        const uint lid  = lidy * g.get_local_range(0) + lidx;
+
+        const uint zid       = g.get_group_id(0) / groups_x_;
+        const uint wid       = g.get_group_id(1) / groups_y_;
+        const uint groupId_x = g.get_group_id(0) - (groups_x_)*zid;
+        const uint groupId_y = g.get_group_id(1) - (groups_y_)*wid;
+        const uint xid       = groupId_x * g.get_local_range(0) + lidx;
+        const uint yid       = groupId_y;
+
+        int ids[4] = {xid, yid, zid, wid};
+
+        const Ti *iptr = in_acc_.get_pointer();
+        To *optr       = out_acc_.get_pointer();
+        To *tptr       = tmp_acc_.get_pointer();
+
+        // There is only one element per block for out
+        // There are blockDim.y elements per block for in
+        // Hence increment ids[dim] just after offseting out and before
+        // offsetting in
+        tptr += ids[3] * tInfo_.strides[3] + ids[2] * tInfo_.strides[2] +
+                ids[1] * tInfo_.strides[1] + ids[0];
+
+        const int groupIdx_dim = ids[dim];
+        ids[dim]               = ids[dim] * g.get_local_range(1) * lim_ + lidy;
+
+        optr += ids[3] * oInfo_.strides[3] + ids[2] * oInfo_.strides[2] +
+                ids[1] * oInfo_.strides[1] + ids[0];
+        iptr += ids[3] * iInfo_.strides[3] + ids[2] * iInfo_.strides[2] +
+                ids[1] * iInfo_.strides[1] + ids[0];
+        int id_dim        = ids[dim];
+        const int out_dim = oInfo_.dims[dim];
+
+        bool is_valid = (ids[0] < oInfo_.dims[0]) &&
+                        (ids[1] < oInfo_.dims[1]) &&
+                        (ids[2] < oInfo_.dims[2]) && (ids[3] < oInfo_.dims[3]);
+
+        const int ostride_dim = oInfo_.strides[dim];
+        const int istride_dim = iInfo_.strides[dim];
+
+        To *sptr = s_val_.get_pointer() + lid;
+
+        common::Transform<Ti, To, op> transform;
+        common::Binary<To, op> binop;
+
+        const To init = common::Binary<To, op>::init();
+        To val        = init;
+
+        const bool isLast = (lidy == (DIMY_ - 1));
+
+        for (int k = 0; k < lim_; k++) {
+            if (isLast) s_tmp_[lidx] = val;
+
+            bool cond = (is_valid) && (id_dim < out_dim);
+            val       = cond ? transform(*iptr) : init;
+            *sptr     = val;
+            group_barrier(g);
+
+            int start = 0;
+#pragma unroll
+            for (int off = 1; off < DIMY_; off *= 2) {
+                if (lidy >= off)
+                    val = binop(val, sptr[(start - off) * (int)THREADS_X]);
+                start                   = DIMY_ - start;
+                sptr[start * THREADS_X] = val;
+
+                group_barrier(g);
+            }
+
+            val = binop(val, s_tmp_[lidx]);
+            if (inclusive_scan_) {
+                if (cond) { *optr = val; }
+            } else if (is_valid) {
+                if (id_dim == (out_dim - 1)) {
+                    *(optr - (id_dim * ostride_dim)) = init;
+                } else if (id_dim < (out_dim - 1)) {
+                    *(optr + ostride_dim) = val;
+                }
+            }
+            id_dim += g.get_local_range(1);
+            iptr += g.get_local_range(1) * istride_dim;
+            optr += g.get_local_range(1) * ostride_dim;
+            group_barrier(g);
+        }
+
+        if (!isFinalPass_ && is_valid && (groupIdx_dim < tInfo_.dims[dim]) &&
+            isLast) {
+            *tptr = val;
+        }
+    }
+
+   protected:
+    sycl::accessor<To> out_acc_;
+    sycl::accessor<To> tmp_acc_;
+    sycl::accessor<Ti> in_acc_;
+    KParam oInfo_, tInfo_, iInfo_;
+    const uint groups_x_, groups_y_, blocks_dim_, lim_, DIMY_;
+    const bool isFinalPass_, inclusive_scan_;
+    local_accessor<To, 1> s_val_;
+    local_accessor<To, 1> s_tmp_;
+    sycl::stream debug_;
+};
+
+template<typename To, af_op_t op, int dim>
+class scanDimBcastKernel {
+   public:
+    scanDimBcastKernel(sycl::accessor<To> out_acc, KParam oInfo,
+                       sycl::accessor<To> tmp_acc, KParam tInfo,
+                       const uint groups_x, const uint groups_y,
+                       const uint groups_dim, const uint lim,
+                       const bool inclusive_scan, sycl::stream debug)
+        : out_acc_(out_acc)
+        , oInfo_(oInfo)
+        , tmp_acc_(tmp_acc)
+        , tInfo_(tInfo)
+        , groups_x_(groups_x)
+        , groups_y_(groups_y)
+        , groups_dim_(groups_dim)
+        , lim_(lim)
+        , inclusive_scan_(inclusive_scan)
+        , debug_(debug) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g   = it.get_group();
+        const uint lidx = it.get_local_id(0);
+        const uint lidy = it.get_local_id(1);
+
+        const uint zid       = g.get_group_id(0) / groups_x_;
+        const uint wid       = g.get_group_id(1) / groups_y_;
+        const uint groupId_x = g.get_group_id(0) - (groups_x_)*zid;
+        const uint groupId_y = g.get_group_id(1) - (groups_y_)*wid;
+        const uint xid       = groupId_x * g.get_local_range(0) + lidx;
+        const uint yid       = groupId_y;
+
+        int ids[4] = {xid, yid, zid, wid};
+
+        const To *tptr = tmp_acc_.get_pointer();
+        To *optr       = out_acc_.get_pointer();
+
+        // There is only one element per block for out
+        // There are blockDim.y elements per block for in
+        // Hence increment ids[dim] just after offseting out and before
+        // offsetting in
+        tptr += ids[3] * tInfo_.strides[3] + ids[2] * tInfo_.strides[2] +
+                ids[1] * tInfo_.strides[1] + ids[0];
+
+        const int groupIdx_dim = ids[dim];
+        ids[dim]               = ids[dim] * g.get_local_range(1) * lim_ + lidy;
+
+        optr += ids[3] * oInfo_.strides[3] + ids[2] * oInfo_.strides[2] +
+                ids[1] * oInfo_.strides[1] + ids[0];
+        const int id_dim  = ids[dim];
+        const int out_dim = oInfo_.dims[dim];
+
+        // Shift broadcast one step to the right for exclusive scan (#2366)
+        int offset = inclusive_scan_ ? 0 : oInfo_.strides[dim];
+        optr += offset;
+
+        bool is_valid = (ids[0] < oInfo_.dims[0]) &&
+                        (ids[1] < oInfo_.dims[1]) &&
+                        (ids[2] < oInfo_.dims[2]) && (ids[3] < oInfo_.dims[3]);
+
+        if (!is_valid) return;
+        if (groupIdx_dim == 0) return;
+
+        To accum = *(tptr - tInfo_.strides[dim]);
+
+        common::Binary<To, op> binop;
+        const int ostride_dim = oInfo_.strides[dim];
+
+        for (int k = 0, id = id_dim; is_valid && k < lim_ && (id < out_dim);
+             k++, id += g.get_local_range(1)) {
+            *optr = binop(*optr, accum);
+            optr += g.get_local_range(1) * ostride_dim;
+        }
+    }
+
+   protected:
+    sycl::accessor<To> out_acc_;
+    sycl::accessor<To> tmp_acc_;
+    KParam oInfo_, tInfo_;
+    const uint groups_x_, groups_y_, groups_dim_, lim_;
+    const bool inclusive_scan_;
+    sycl::stream debug_;
+};
+
+template<typename Ti, typename To, af_op_t op, int dim>
+static void scan_dim_launcher(Param<To> out, Param<To> tmp, Param<Ti> in,
+                              const uint threads_y, const dim_t blocks_all[4],
+                              bool isFinalPass, bool inclusive_scan) {
+    sycl::range<2> local(THREADS_X, threads_y);
+    sycl::range<2> global(blocks_all[0] * blocks_all[2] * local[0],
+                          blocks_all[1] * blocks_all[3] * local[1]);
+
+    uint lim = divup(out.info.dims[dim], (threads_y * blocks_all[dim]));
+
+    getQueue().submit([&](sycl::handler &h) {
+        // TODO: specify access modes in all kernels
+        auto out_acc = out.data->get_access(h);
+        auto tmp_acc = tmp.data->get_access(h);
+        auto in_acc  = in.data->get_access(h);
+
+        sycl::stream debug_stream(2048 * 256, 128, h);
+
+        auto s_val =
+            local_accessor<compute_t<To>, 1>(THREADS_X * threads_y * 2, h);
+        auto s_tmp = local_accessor<compute_t<To>, 1>(THREADS_X, h);
+
+        h.parallel_for(
+            sycl::nd_range<2>(global, local),
+            scanDimKernel<Ti, To, op, dim>(
+                out_acc, out.info, tmp_acc, tmp.info, in_acc, in.info,
+                blocks_all[0], blocks_all[1], blocks_all[dim], lim, isFinalPass,
+                threads_y, inclusive_scan, s_val, s_tmp, debug_stream));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename To, af_op_t op, int dim>
+static void bcast_dim_launcher(Param<To> out, Param<To> tmp,
+                               const uint threads_y, const dim_t blocks_all[4],
+                               bool inclusive_scan) {
+    sycl::range<2> local(THREADS_X, threads_y);
+    sycl::range<2> global(blocks_all[0] * blocks_all[2] * local[0],
+                          blocks_all[1] * blocks_all[3] * local[1]);
+
+    uint lim = divup(out.info.dims[dim], (threads_y * blocks_all[dim]));
+
+    getQueue().submit([&](sycl::handler &h) {
+        auto out_acc = out.data->get_access(h);
+        auto tmp_acc = tmp.data->get_access(h);
+
+        sycl::stream debug_stream(2048 * 256, 128, h);
+
+        h.parallel_for(sycl::nd_range<2>(global, local),
+                       scanDimBcastKernel<To, op, dim>(
+                           out_acc, out.info, tmp_acc, tmp.info, blocks_all[0],
+                           blocks_all[1], blocks_all[dim], lim, inclusive_scan,
+                           debug_stream));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename Ti, typename To, af_op_t op, int dim>
+static void scan_dim(Param<To> out, Param<Ti> in, bool inclusive_scan) {
+    uint threads_y = std::min(THREADS_Y, nextpow2(out.info.dims[dim]));
+    uint threads_x = THREADS_X;
+
+    dim_t blocks_all[] = {divup(out.info.dims[0], threads_x), out.info.dims[1],
+                          out.info.dims[2], out.info.dims[3]};
+
+    blocks_all[dim] = divup(out.info.dims[dim], threads_y * REPEAT);
+
+    if (blocks_all[dim] == 1) {
+        scan_dim_launcher<Ti, To, op, dim>(out, out, in, threads_y, blocks_all,
+                                           true, inclusive_scan);
+    } else {
+        Param<To> tmp = out;
+
+        tmp.info.dims[dim]  = blocks_all[dim];
+        tmp.info.strides[0] = 1;
+        for (int k = 1; k < 4; k++)
+            tmp.info.strides[k] =
+                tmp.info.strides[k - 1] * tmp.info.dims[k - 1];
+
+        int tmp_elements = tmp.info.strides[3] * tmp.info.dims[3];
+        auto tmp_alloc   = memAlloc<To>(tmp_elements);
+        tmp.data         = tmp_alloc.get();
+
+        scan_dim_launcher<Ti, To, op, dim>(out, tmp, in, threads_y, blocks_all,
+                                           false, inclusive_scan);
+
+        int bdim        = blocks_all[dim];
+        blocks_all[dim] = 1;
+
+        // FIXME: Is there an alternative to the if condition ?
+        if (op == af_notzero_t) {
+            scan_dim_launcher<To, To, af_add_t, dim>(tmp, tmp, tmp, threads_y,
+                                                     blocks_all, true, true);
+        } else {
+            scan_dim_launcher<To, To, op, dim>(tmp, tmp, tmp, threads_y,
+                                               blocks_all, true, true);
+        }
+
+        blocks_all[dim] = bdim;
+        bcast_dim_launcher<To, op, dim>(out, tmp, threads_y, blocks_all,
+                                        inclusive_scan);
+    }
+}
+
+}  // namespace kernel
+}  // namespace oneapi

--- a/src/backend/oneapi/kernel/scan_dim.hpp
+++ b/src/backend/oneapi/kernel/scan_dim.hpp
@@ -42,17 +42,17 @@ class scanDimKernel {
                   const bool inclusive_scan, local_accessor<To, 1> s_val,
                   local_accessor<To, 1> s_tmp, sycl::stream debug)
         : out_acc_(out_acc)
-        , oInfo_(oInfo)
         , tmp_acc_(tmp_acc)
-        , tInfo_(tInfo)
         , in_acc_(in_acc)
+        , oInfo_(oInfo)
+        , tInfo_(tInfo)
         , iInfo_(iInfo)
         , groups_x_(groups_x)
         , groups_y_(groups_y)
         , blocks_dim_(blocks_dim)
         , lim_(lim)
-        , isFinalPass_(isFinalPass)
         , DIMY_(DIMY)
+        , isFinalPass_(isFinalPass)
         , inclusive_scan_(inclusive_scan)
         , s_val_(s_val)
         , s_tmp_(s_tmp)
@@ -71,7 +71,7 @@ class scanDimKernel {
         const uint xid       = groupId_x * g.get_local_range(0) + lidx;
         const uint yid       = groupId_y;
 
-        int ids[4] = {xid, yid, zid, wid};
+        uint ids[4] = {xid, yid, zid, wid};
 
         const Ti *iptr = in_acc_.get_pointer();
         To *optr       = out_acc_.get_pointer();
@@ -173,8 +173,8 @@ class scanDimBcastKernel {
                        const uint groups_dim, const uint lim,
                        const bool inclusive_scan, sycl::stream debug)
         : out_acc_(out_acc)
-        , oInfo_(oInfo)
         , tmp_acc_(tmp_acc)
+        , oInfo_(oInfo)
         , tInfo_(tInfo)
         , groups_x_(groups_x)
         , groups_y_(groups_y)
@@ -195,7 +195,7 @@ class scanDimBcastKernel {
         const uint xid       = groupId_x * g.get_local_range(0) + lidx;
         const uint yid       = groupId_y;
 
-        int ids[4] = {xid, yid, zid, wid};
+        uint ids[4] = {xid, yid, zid, wid};
 
         const To *tptr = tmp_acc_.get_pointer();
         To *optr       = out_acc_.get_pointer();

--- a/src/backend/oneapi/kernel/scan_first.hpp
+++ b/src/backend/oneapi/kernel/scan_first.hpp
@@ -1,0 +1,303 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Param.hpp>
+#include <backend.hpp>
+#include <common/Binary.hpp>
+#include <common/Transform.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+#include <err_oneapi.hpp>
+#include <kernel/reduce_config.hpp>
+#include <memory.hpp>
+
+namespace oneapi {
+namespace kernel {
+
+template<typename T, int dimensions>
+using local_accessor =
+    sycl::accessor<T, dimensions, sycl::access::mode::read_write,
+                   sycl::access::target::local>;
+
+template<typename Ti, typename To, af_op_t op>
+class scanFirstKernel {
+public:
+    scanFirstKernel(sycl::accessor<To> out_acc, KParam oInfo,
+                    sycl::accessor<To> tmp_acc, KParam tInfo,
+                    sycl::accessor<Ti> in_acc, KParam iInfo,
+                    const uint groups_x, const uint groups_y, const uint lim,
+                    const bool isFinalPass, const uint DIMX, const bool inclusive_scan,
+                    local_accessor<To, 1> s_val, local_accessor<To, 1> s_tmp,
+                    sycl::stream debug_stream) :
+        out_acc_(out_acc), oInfo_(oInfo),
+        tmp_acc_(tmp_acc), tInfo_(tInfo),
+        in_acc_(in_acc),   iInfo_(iInfo),
+        groups_x_(groups_x), groups_y_(groups_y), lim_(lim),
+        isFinalPass_(isFinalPass), DIMX_(DIMX), inclusive_scan_(inclusive_scan),
+        s_val_(s_val), s_tmp_(s_tmp), debug_stream_(debug_stream) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+        const uint lidx = it.get_local_id(0);
+        const uint lidy = it.get_local_id(1);
+        const uint lid  = lidy * g.get_local_range(0) + lidx;
+
+        const uint zid       = g.get_group_id(0) / groups_x_;
+        const uint wid       = g.get_group_id(1) / groups_y_;
+        const uint groupId_x = g.get_group_id(0) - (groups_x_)*zid;
+        const uint groupId_y = g.get_group_id(1) - (groups_y_)*wid;
+        const uint xid       = groupId_x * g.get_local_range(0) * lim_ + lidx;
+        const uint yid       = groupId_y * g.get_local_range(1) + lidy;
+
+        bool cond_yzw =
+            (yid < oInfo_.dims[1]) && (zid < oInfo_.dims[2]) && (wid < oInfo_.dims[3]);
+
+        //if (!cond_yzw) return;  // retire warps early TODO: move
+
+        const Ti *iptr = in_acc_.get_pointer();
+        To *optr       = out_acc_.get_pointer();
+        To *tptr       = tmp_acc_.get_pointer();
+
+        iptr += wid * iInfo_.strides[3] + zid * iInfo_.strides[2] + yid * iInfo_.strides[1];
+        optr += wid * oInfo_.strides[3] + zid * oInfo_.strides[2] + yid * oInfo_.strides[1];
+        tptr += wid * tInfo_.strides[3] + zid * tInfo_.strides[2] + yid * tInfo_.strides[1];
+
+        To *sptr = s_val_.get_pointer() + lidy * (2 * DIMX_ + 1);
+
+        common::Transform<Ti, To, op> transform;
+        common::Binary<To, op> binop;
+
+        const To init = common::Binary<To, op>::init();
+        int id        = xid;
+        To val        = init;
+
+        const bool isLast = (lidx == (DIMX_ - 1));
+        for (int k = 0; k < lim_; k++) {
+            if (isLast) s_tmp_[lidy] = val;
+
+            bool cond  = (id < oInfo_.dims[0]) && cond_yzw;
+            val        = cond ? transform(iptr[id]) : init;
+            /*
+            if constexpr(std::is_fundamental<To>::value) {
+                debug_stream_ << id<<":"<<val <<", "<< sycl::stream_manipulator::endl;
+            }
+            */
+            sptr[lidx] = val;
+            group_barrier(g);
+
+            int start = 0;
+            #pragma unroll
+            for (int off = 1; off < DIMX_; off *= 2) {
+                if (lidx >= off) val = binop(val, sptr[(start - off) + lidx]);
+                start              = DIMX_ - start;
+                sptr[start + lidx] = val;
+
+                group_barrier(g);
+            }
+
+            val = binop(val, s_tmp_[lidy]);
+
+            if (inclusive_scan_) {
+                if (cond && cond_yzw) {
+                    //debug_stream_ << "oi0 ";
+                     optr[id] = val; }
+            } else {
+                if (cond_yzw && id == (oInfo_.dims[0] - 1)) {
+                    optr[0] = init;
+                } else if (cond_yzw && id < (oInfo_.dims[0] - 1)) {
+                    //debug_stream_ << "oe0 ";
+                    optr[id + 1] = val;
+                }
+            }
+            id += g.get_local_range(0);
+            group_barrier(g);
+        }
+
+        if (!isFinalPass_ && isLast && cond_yzw) {
+            //debug_stream_ << "ot ";
+             tptr[groupId_x] = val; }
+    }
+
+protected:
+    sycl::accessor<To> out_acc_;
+    sycl::accessor<To> tmp_acc_;
+    sycl::accessor<Ti> in_acc_; 
+    KParam oInfo_, tInfo_, iInfo_;
+    const uint groups_x_, groups_y_, lim_, DIMX_;
+    const bool isFinalPass_, inclusive_scan_;
+    local_accessor<To, 1> s_val_;
+    local_accessor<To, 1> s_tmp_;
+    sycl::stream debug_stream_;
+};
+
+template<typename To, af_op_t op>
+class scanFirstBcastKernel {
+public: 
+    scanFirstBcastKernel(sycl::accessor<To> out_acc, KParam oInfo,
+                         sycl::accessor<To> tmp_acc, KParam tInfo,
+                         const uint groups_x, const uint groups_y, const uint lim,
+                         const bool inclusive_scan, sycl::stream debug_stream) :
+        out_acc_(out_acc), oInfo_(oInfo),
+        tmp_acc_(tmp_acc), tInfo_(tInfo),
+        groups_x_(groups_x), groups_y_(groups_y), lim_(lim),
+        inclusive_scan_(inclusive_scan), debug_stream_(debug_stream) {}
+    
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+        const uint lidx = it.get_local_id(0);
+        const uint lidy = it.get_local_id(1);
+        const uint lid  = lidy * g.get_local_range(0) + lidx;
+
+        const uint zid       = g.get_group_id(0) / groups_x_;
+        const uint wid       = g.get_group_id(1) / groups_y_;
+        const uint groupId_x = g.get_group_id(0) - (groups_x_)*zid;
+        const uint groupId_y = g.get_group_id(1) - (groups_y_)*wid;
+        const uint xid       = groupId_x * g.get_local_range(0) * lim_ + lidx;
+        const uint yid       = groupId_y * g.get_local_range(1) + lidy;
+
+        if (groupId_x == 0) return;
+
+        bool cond =
+            (yid < oInfo_.dims[1]) && (zid < oInfo_.dims[2]) && (wid < oInfo_.dims[3]);
+        if (!cond) return;
+
+        To *optr       = out_acc_.get_pointer();
+        const To *tptr = tmp_acc_.get_pointer();
+
+        optr += wid * oInfo_.strides[3] + zid * oInfo_.strides[2] + yid * oInfo_.strides[1];
+        tptr += wid * tInfo_.strides[3] + zid * tInfo_.strides[2] + yid * tInfo_.strides[1];
+
+        common::Binary<To, op> binop;
+        To accum = tptr[groupId_x - 1];
+
+        // Shift broadcast one step to the right for exclusive scan (#2366)
+        int offset = !inclusive_scan_;
+        for (int k = 0, id = xid + offset; k < lim_ && id < oInfo_.dims[0];
+            k++, id += g.get_group_range(0)) {
+            optr[id] = binop(accum, optr[id]);
+        }
+    }
+protected:
+    sycl::accessor<To> out_acc_; 
+    sycl::accessor<To> tmp_acc_;
+    KParam oInfo_, tInfo_;
+    const uint groups_x_, groups_y_, lim_;
+    const bool inclusive_scan_;
+    sycl::stream debug_stream_;
+};
+
+
+template<typename Ti, typename To, af_op_t op>
+static void scan_first_launcher(Param<To> out, Param<To> tmp, Param<Ti> in,
+                                const uint groups_x, const uint groups_y,
+                                const uint threads_x, bool isFinalPass,
+                                bool inclusive_scan) {
+    sycl::range<2> local(threads_x, THREADS_PER_BLOCK / threads_x);
+    sycl::range<2> global(groups_x * out.info.dims[2] * local[0], 
+                          groups_y * out.info.dims[3] * local[1]);
+    uint lim = divup(out.info.dims[0], (threads_x * groups_x));
+
+    getQueue().submit([&] (sycl::handler &h) {
+        auto out_acc = out.data->get_access(h);
+        auto tmp_acc = tmp.data->get_access(h);
+        auto in_acc  = in.data->get_access(h);
+
+        sycl::stream debug_stream(2048 * 256, 128, h);
+
+        const int DIMY            = THREADS_PER_BLOCK / threads_x;
+        const int SHARED_MEM_SIZE = (2 * threads_x + 1) * (DIMY);
+        auto s_val = local_accessor<compute_t<To>, 1>(SHARED_MEM_SIZE, h);
+        auto s_tmp = local_accessor<compute_t<To>, 1>(DIMY, h);
+
+        //TODO threads_x as template arg for #pragma unroll?
+        h.parallel_for(sycl::nd_range<2>(global, local), 
+            scanFirstKernel<Ti, To, op>(
+                    out_acc, out.info,
+                    tmp_acc, tmp.info,
+                    in_acc, in.info,
+                    groups_x, groups_y, lim,
+                    isFinalPass, threads_x, inclusive_scan,
+                    s_val, s_tmp, debug_stream));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename To, af_op_t op>
+static void bcast_first_launcher(Param<To> out, Param<To> tmp,
+                                 const uint groups_x, const uint groups_y,
+                                 const uint threads_x, bool inclusive_scan) {
+    sycl::range<2> local(threads_x, THREADS_PER_BLOCK / threads_x);
+    sycl::range<2> global(groups_x * out.info.dims[2] * local[0], 
+                          groups_y * out.info.dims[3] * local[1]);
+    uint lim = divup(out.info.dims[0], (threads_x * groups_x));
+
+    getQueue().submit([&] (sycl::handler &h) {
+        auto out_acc = out.data->get_access(h);
+        auto tmp_acc = tmp.data->get_access(h);
+
+        sycl::stream debug_stream(2048 * 256, 128, h);
+
+        const int DIMY            = THREADS_PER_BLOCK / threads_x;
+        const int SHARED_MEM_SIZE = (2 * threads_x + 1) * (DIMY);
+        auto s_val = local_accessor<compute_t<To>, 1>(SHARED_MEM_SIZE, h);
+        auto s_tmp = local_accessor<compute_t<To>, 1>(DIMY, h);
+
+        h.parallel_for(sycl::nd_range<2>(global, local), 
+            scanFirstBcastKernel<To, op>(
+                    out_acc, out.info,
+                    tmp_acc, tmp.info,
+                    groups_x, groups_y, lim,
+                    inclusive_scan, debug_stream));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename Ti, typename To, af_op_t op>
+static void scan_first(Param<To> out, Param<Ti> in, bool inclusive_scan) {
+    uint threads_x = nextpow2(std::max(32u, (uint)out.info.dims[0]));
+    threads_x      = std::min(threads_x, THREADS_PER_BLOCK);
+    uint threads_y = THREADS_PER_BLOCK / threads_x;
+
+    uint groups_x = divup(out.info.dims[0], threads_x * REPEAT);
+    uint groups_y = divup(out.info.dims[1], threads_y);
+
+    if (groups_x == 1) {
+        scan_first_launcher<Ti, To, op>(out, out, in, groups_x, groups_y,
+                                        threads_x, true, inclusive_scan);
+    } else {
+        Param<To> tmp = out;
+
+        tmp.info.dims[0]    = groups_x;
+        tmp.info.strides[0] = 1;
+        for (int k = 1; k < 4; k++)
+            tmp.info.strides[k] = tmp.info.strides[k - 1] * tmp.info.dims[k - 1];
+
+        int tmp_elements = tmp.info.strides[3] * tmp.info.dims[3];
+        auto tmp_alloc   = memAlloc<To>(tmp_elements);
+        tmp.data          = tmp_alloc.get();
+
+        scan_first_launcher<Ti, To, op>(out, tmp, in, groups_x, groups_y,
+                                        threads_x, false, inclusive_scan);
+
+        // FIXME: Is there an alternative to the if condition ?
+        if (op == af_notzero_t) {
+            scan_first_launcher<To, To, af_add_t>(tmp, tmp, tmp, 1, groups_y,
+                                                  threads_x, true, true);
+        } else {
+            scan_first_launcher<To, To, op>(tmp, tmp, tmp, 1, groups_y,
+                                            threads_x, true, true);
+        }
+
+        bcast_first_launcher<To, op>(out, tmp, groups_x, groups_y, threads_x,
+                                     inclusive_scan);
+    }
+}
+
+}  // namespace kernel
+}  // namespace oneapi

--- a/src/backend/oneapi/kernel/scan_first.hpp
+++ b/src/backend/oneapi/kernel/scan_first.hpp
@@ -42,16 +42,16 @@ class scanFirstKernel {
                     local_accessor<To, 1> s_val, local_accessor<To, 1> s_tmp,
                     sycl::stream debug_stream)
         : out_acc_(out_acc)
-        , oInfo_(oInfo)
         , tmp_acc_(tmp_acc)
-        , tInfo_(tInfo)
         , in_acc_(in_acc)
+        , oInfo_(oInfo)
+        , tInfo_(tInfo)
         , iInfo_(iInfo)
         , groups_x_(groups_x)
         , groups_y_(groups_y)
         , lim_(lim)
-        , isFinalPass_(isFinalPass)
         , DIMX_(DIMX)
+        , isFinalPass_(isFinalPass)
         , inclusive_scan_(inclusive_scan)
         , s_val_(s_val)
         , s_tmp_(s_tmp)
@@ -61,7 +61,6 @@ class scanFirstKernel {
         sycl::group g   = it.get_group();
         const uint lidx = it.get_local_id(0);
         const uint lidy = it.get_local_id(1);
-        const uint lid  = lidy * g.get_local_range(0) + lidx;
 
         const uint zid       = g.get_group_id(0) / groups_x_;
         const uint wid       = g.get_group_id(1) / groups_y_;
@@ -157,8 +156,8 @@ class scanFirstBcastKernel {
                          const uint lim, const bool inclusive_scan,
                          sycl::stream debug_stream)
         : out_acc_(out_acc)
-        , oInfo_(oInfo)
         , tmp_acc_(tmp_acc)
+        , oInfo_(oInfo)
         , tInfo_(tInfo)
         , groups_x_(groups_x)
         , groups_y_(groups_y)
@@ -170,7 +169,6 @@ class scanFirstBcastKernel {
         sycl::group g   = it.get_group();
         const uint lidx = it.get_local_id(0);
         const uint lidy = it.get_local_id(1);
-        const uint lid  = lidy * g.get_local_range(0) + lidx;
 
         const uint zid       = g.get_group_id(0) / groups_x_;
         const uint wid       = g.get_group_id(1) / groups_y_;

--- a/src/backend/oneapi/kernel/where.hpp
+++ b/src/backend/oneapi/kernel/where.hpp
@@ -12,9 +12,9 @@
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
 #include <err_oneapi.hpp>
-#include <memory.hpp>
-#include <kernel/reduce_config.hpp>
+#include <kernel/default_config.hpp>
 #include <kernel/scan_first.hpp>
+#include <memory.hpp>
 
 #include <Param.hpp>
 #include <backend.hpp>
@@ -25,18 +25,27 @@ namespace kernel {
 
 template<typename T>
 class whereKernel {
-public:
-    whereKernel(sycl::accessor<uint> out_acc,  KParam oInfo,
+   public:
+    whereKernel(sycl::accessor<uint> out_acc, KParam oInfo,
                 sycl::accessor<uint> otmp_acc, KParam otInfo,
                 sycl::accessor<uint> rtmp_acc, KParam rtInfo,
-                sycl::accessor<T> in_acc,      KParam iInfo,
-                uint groups_x, uint groups_y, uint lim, sycl::stream debug) : 
-        out_acc_(out_acc), oInfo_(oInfo), otmp_acc_(otmp_acc), otInfo_(otInfo),
-        rtmp_acc_(rtmp_acc), rtInfo_(rtInfo), in_acc_(in_acc), iInfo_(iInfo),
-        groups_x_(groups_x), groups_y_(groups_y), lim_(lim), debug_(debug) {}
+                sycl::accessor<T> in_acc, KParam iInfo, uint groups_x,
+                uint groups_y, uint lim, sycl::stream debug)
+        : out_acc_(out_acc)
+        , oInfo_(oInfo)
+        , otmp_acc_(otmp_acc)
+        , otInfo_(otInfo)
+        , rtmp_acc_(rtmp_acc)
+        , rtInfo_(rtInfo)
+        , in_acc_(in_acc)
+        , iInfo_(iInfo)
+        , groups_x_(groups_x)
+        , groups_y_(groups_y)
+        , lim_(lim)
+        , debug_(debug) {}
 
     void operator()(sycl::nd_item<2> it) const {
-        sycl::group g = it.get_group();
+        sycl::group g   = it.get_group();
         const uint lidx = it.get_local_id(0);
         const uint lidy = it.get_local_id(1);
         const uint lid  = lidy * g.get_local_range(0) + lidx;
@@ -52,17 +61,18 @@ public:
         const uint *rtptr = rtmp_acc_.get_pointer();
         const T *iptr     = in_acc_.get_pointer();
 
-        const uint off =
-            wid * otInfo_.strides[3] + zid * otInfo_.strides[2] + yid * otInfo_.strides[1];
+        const uint off = wid * otInfo_.strides[3] + zid * otInfo_.strides[2] +
+                         yid * otInfo_.strides[1];
         const uint bid = wid * rtInfo_.strides[3] + zid * rtInfo_.strides[2] +
-                        yid * rtInfo_.strides[1] + groupId_x;
+                         yid * rtInfo_.strides[1] + groupId_x;
 
-        otptr +=
-            wid * otInfo_.strides[3] + zid * otInfo_.strides[2] + yid * otInfo_.strides[1];
-        iptr += wid * iInfo_.strides[3] + zid * iInfo_.strides[2] + yid * iInfo_.strides[1];
+        otptr += wid * otInfo_.strides[3] + zid * otInfo_.strides[2] +
+                 yid * otInfo_.strides[1];
+        iptr += wid * iInfo_.strides[3] + zid * iInfo_.strides[2] +
+                yid * iInfo_.strides[1];
 
-        bool cond =
-            (yid < otInfo_.dims[1]) && (zid < otInfo_.dims[2]) && (wid < otInfo_.dims[3]);
+        bool cond = (yid < otInfo_.dims[1]) && (zid < otInfo_.dims[2]) &&
+                    (wid < otInfo_.dims[3]);
         T zero = scalar<T>(0);
 
         if (!cond) return;
@@ -70,12 +80,13 @@ public:
         uint accum = (bid == 0) ? 0 : rtptr[bid - 1];
 
         for (uint k = 0, id = xid; k < lim_ && id < otInfo_.dims[0];
-            k++, id += g.get_local_range(0)) {
+             k++, id += g.get_local_range(0)) {
             uint idx = otptr[id] + accum;
             if (iptr[id] != zero) out_acc_[idx - 1] = (off + id);
         }
     }
-protected:
+
+   protected:
     sycl::accessor<uint> out_acc_;
     sycl::accessor<uint> otmp_acc_;
     sycl::accessor<uint> rtmp_acc_;
@@ -113,15 +124,15 @@ static void where(Param<uint> &out, Param<T> in) {
     int otmp_elements = otmp.info.strides[3] * otmp.info.dims[3];
     auto rtmp_alloc   = memAlloc<uint>(rtmp_elements);
     auto otmp_alloc   = memAlloc<uint>(otmp_elements);
-    rtmp.data          = rtmp_alloc.get();
-    otmp.data          = otmp_alloc.get();
+    rtmp.data         = rtmp_alloc.get();
+    otmp.data         = otmp_alloc.get();
 
     scan_first_launcher<T, uint, af_notzero_t>(
         otmp, rtmp, in, groups_x, groups_y, threads_x, false, true);
 
     // Linearize the dimensions and perform scan
-    Param<uint> ltmp = rtmp;
-    ltmp.info.dims[0]     = rtmp_elements;
+    Param<uint> ltmp  = rtmp;
+    ltmp.info.dims[0] = rtmp_elements;
     for (int k = 1; k < 4; k++) {
         ltmp.info.dims[k]    = 1;
         ltmp.info.strides[k] = rtmp_elements;
@@ -132,17 +143,19 @@ static void where(Param<uint> &out, Param<T> in) {
     // Get output size and allocate output
     uint total;
     sycl::buffer retBuffer(&total, {1},
-        {sycl::property::buffer::use_host_ptr()});
+                           {sycl::property::buffer::use_host_ptr()});
 
     getQueue()
         .submit([&](sycl::handler &h) {
-            auto acc_in = rtmp.data->get_access(h, sycl::range{1}, sycl::id{rtmp_elements - 1});
+            auto acc_in  = rtmp.data->get_access(h, sycl::range{1},
+                                                 sycl::id{rtmp_elements - 1});
             auto acc_out = retBuffer.get_access();
             h.copy(acc_in, acc_out);
-    }).wait();
+        })
+        .wait();
 
     auto out_alloc = memAlloc<uint>(total);
-    out.data        = out_alloc.get();
+    out.data       = out_alloc.get();
 
     out.info.dims[0]    = total;
     out.info.strides[0] = 1;
@@ -152,25 +165,21 @@ static void where(Param<uint> &out, Param<T> in) {
     }
 
     sycl::range<2> local(threads_x, THREADS_PER_BLOCK / threads_x);
-    sycl::range<2> global(groups_x * in.info.dims[2] * local[0], 
+    sycl::range<2> global(groups_x * in.info.dims[2] * local[0],
                           groups_y * in.info.dims[3] * local[1]);
     uint lim = divup(otmp.info.dims[0], (threads_x * groups_x));
 
-    getQueue().submit([&] (sycl::handler &h) {
-        auto out_acc = out.data->get_access(h);
+    getQueue().submit([&](sycl::handler &h) {
+        auto out_acc  = out.data->get_access(h);
         auto otmp_acc = otmp.data->get_access(h);
         auto rtmp_acc = rtmp.data->get_access(h);
-        auto in_acc  = in.data->get_access(h);
+        auto in_acc   = in.data->get_access(h);
 
         sycl::stream debug_stream(2048 * 256, 128, h);
-        h.parallel_for(sycl::nd_range<2>(global, local), 
-            whereKernel<T>(
-                    out_acc, out.info,
-                    otmp_acc, otmp.info,
-                    rtmp_acc, rtmp.info,
-                    in_acc, in.info,
-                    groups_x, groups_y, lim,
-                    debug_stream));
+        h.parallel_for(sycl::nd_range<2>(global, local),
+                       whereKernel<T>(out_acc, out.info, otmp_acc, otmp.info,
+                                      rtmp_acc, rtmp.info, in_acc, in.info,
+                                      groups_x, groups_y, lim, debug_stream));
     });
     ONEAPI_DEBUG_FINISH(getQueue());
     out_alloc.release();

--- a/src/backend/oneapi/kernel/where.hpp
+++ b/src/backend/oneapi/kernel/where.hpp
@@ -1,0 +1,180 @@
+/*******************************************************
+ * Copyright (c) 2022, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Param.hpp>
+#include <backend.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+#include <err_oneapi.hpp>
+#include <memory.hpp>
+#include <kernel/reduce_config.hpp>
+#include <kernel/scan_first.hpp>
+
+#include <Param.hpp>
+#include <backend.hpp>
+#include <math.hpp>
+
+namespace oneapi {
+namespace kernel {
+
+template<typename T>
+class whereKernel {
+public:
+    whereKernel(sycl::accessor<uint> out_acc,  KParam oInfo,
+                sycl::accessor<uint> otmp_acc, KParam otInfo,
+                sycl::accessor<uint> rtmp_acc, KParam rtInfo,
+                sycl::accessor<T> in_acc,      KParam iInfo,
+                uint groups_x, uint groups_y, uint lim, sycl::stream debug) : 
+        out_acc_(out_acc), oInfo_(oInfo), otmp_acc_(otmp_acc), otInfo_(otInfo),
+        rtmp_acc_(rtmp_acc), rtInfo_(rtInfo), in_acc_(in_acc), iInfo_(iInfo),
+        groups_x_(groups_x), groups_y_(groups_y), lim_(lim), debug_(debug) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+        const uint lidx = it.get_local_id(0);
+        const uint lidy = it.get_local_id(1);
+        const uint lid  = lidy * g.get_local_range(0) + lidx;
+
+        const uint zid       = g.get_group_id(0) / groups_x_;
+        const uint wid       = g.get_group_id(1) / groups_y_;
+        const uint groupId_x = g.get_group_id(0) - (groups_x_)*zid;
+        const uint groupId_y = g.get_group_id(1) - (groups_y_)*wid;
+        const uint xid       = groupId_x * g.get_local_range(0) * lim_ + lidx;
+        const uint yid       = groupId_y * g.get_local_range(1) + lidy;
+
+        const uint *otptr = otmp_acc_.get_pointer();
+        const uint *rtptr = rtmp_acc_.get_pointer();
+        const T *iptr     = in_acc_.get_pointer();
+
+        const uint off =
+            wid * otInfo_.strides[3] + zid * otInfo_.strides[2] + yid * otInfo_.strides[1];
+        const uint bid = wid * rtInfo_.strides[3] + zid * rtInfo_.strides[2] +
+                        yid * rtInfo_.strides[1] + groupId_x;
+
+        otptr +=
+            wid * otInfo_.strides[3] + zid * otInfo_.strides[2] + yid * otInfo_.strides[1];
+        iptr += wid * iInfo_.strides[3] + zid * iInfo_.strides[2] + yid * iInfo_.strides[1];
+
+        bool cond =
+            (yid < otInfo_.dims[1]) && (zid < otInfo_.dims[2]) && (wid < otInfo_.dims[3]);
+        T zero = scalar<T>(0);
+
+        if (!cond) return;
+
+        uint accum = (bid == 0) ? 0 : rtptr[bid - 1];
+
+        for (uint k = 0, id = xid; k < lim_ && id < otInfo_.dims[0];
+            k++, id += g.get_local_range(0)) {
+            uint idx = otptr[id] + accum;
+            if (iptr[id] != zero) out_acc_[idx - 1] = (off + id);
+        }
+    }
+protected:
+    sycl::accessor<uint> out_acc_;
+    sycl::accessor<uint> otmp_acc_;
+    sycl::accessor<uint> rtmp_acc_;
+    sycl::accessor<T> in_acc_;
+    KParam oInfo_, otInfo_, rtInfo_, iInfo_;
+    uint groups_x_, groups_y_, lim_;
+    sycl::stream debug_;
+};
+
+template<typename T>
+static void where(Param<uint> &out, Param<T> in) {
+    uint threads_x = nextpow2(std::max(32u, (uint)in.info.dims[0]));
+    threads_x      = std::min(threads_x, THREADS_PER_BLOCK);
+    uint threads_y = THREADS_PER_BLOCK / threads_x;
+
+    uint groups_x = divup((uint)in.info.dims[0], (uint)(threads_x * REPEAT));
+    uint groups_y = divup(in.info.dims[1], threads_y);
+
+    Param<uint> rtmp;
+    Param<uint> otmp;
+    rtmp.info.dims[0]    = groups_x;
+    otmp.info.dims[0]    = in.info.dims[0];
+    rtmp.info.strides[0] = 1;
+    otmp.info.strides[0] = 1;
+
+    for (int k = 1; k < 4; k++) {
+        rtmp.info.dims[k]    = in.info.dims[k];
+        rtmp.info.strides[k] = rtmp.info.strides[k - 1] * rtmp.info.dims[k - 1];
+
+        otmp.info.dims[k]    = in.info.dims[k];
+        otmp.info.strides[k] = otmp.info.strides[k - 1] * otmp.info.dims[k - 1];
+    }
+
+    int rtmp_elements = rtmp.info.strides[3] * rtmp.info.dims[3];
+    int otmp_elements = otmp.info.strides[3] * otmp.info.dims[3];
+    auto rtmp_alloc   = memAlloc<uint>(rtmp_elements);
+    auto otmp_alloc   = memAlloc<uint>(otmp_elements);
+    rtmp.data          = rtmp_alloc.get();
+    otmp.data          = otmp_alloc.get();
+
+    scan_first_launcher<T, uint, af_notzero_t>(
+        otmp, rtmp, in, groups_x, groups_y, threads_x, false, true);
+
+    // Linearize the dimensions and perform scan
+    Param<uint> ltmp = rtmp;
+    ltmp.info.dims[0]     = rtmp_elements;
+    for (int k = 1; k < 4; k++) {
+        ltmp.info.dims[k]    = 1;
+        ltmp.info.strides[k] = rtmp_elements;
+    }
+
+    scan_first<uint, uint, af_add_t>(ltmp, ltmp, true);
+
+    // Get output size and allocate output
+    uint total;
+    sycl::buffer retBuffer(&total, {1},
+        {sycl::property::buffer::use_host_ptr()});
+
+    getQueue()
+        .submit([&](sycl::handler &h) {
+            auto acc_in = rtmp.data->get_access(h, sycl::range{1}, sycl::id{rtmp_elements - 1});
+            auto acc_out = retBuffer.get_access();
+            h.copy(acc_in, acc_out);
+    }).wait();
+
+    auto out_alloc = memAlloc<uint>(total);
+    out.data        = out_alloc.get();
+
+    out.info.dims[0]    = total;
+    out.info.strides[0] = 1;
+    for (int k = 1; k < 4; k++) {
+        out.info.dims[k]    = 1;
+        out.info.strides[k] = total;
+    }
+
+    sycl::range<2> local(threads_x, THREADS_PER_BLOCK / threads_x);
+    sycl::range<2> global(groups_x * in.info.dims[2] * local[0], 
+                          groups_y * in.info.dims[3] * local[1]);
+    uint lim = divup(otmp.info.dims[0], (threads_x * groups_x));
+
+    getQueue().submit([&] (sycl::handler &h) {
+        auto out_acc = out.data->get_access(h);
+        auto otmp_acc = otmp.data->get_access(h);
+        auto rtmp_acc = rtmp.data->get_access(h);
+        auto in_acc  = in.data->get_access(h);
+
+        sycl::stream debug_stream(2048 * 256, 128, h);
+        h.parallel_for(sycl::nd_range<2>(global, local), 
+            whereKernel<T>(
+                    out_acc, out.info,
+                    otmp_acc, otmp.info,
+                    rtmp_acc, rtmp.info,
+                    in_acc, in.info,
+                    groups_x, groups_y, lim,
+                    debug_stream));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+    out_alloc.release();
+}
+
+}  // namespace kernel
+}  // namespace oneapi

--- a/src/backend/oneapi/kernel/where.hpp
+++ b/src/backend/oneapi/kernel/where.hpp
@@ -54,7 +54,6 @@ class whereKernel {
         sycl::group g   = it.get_group();
         const uint lidx = it.get_local_id(0);
         const uint lidy = it.get_local_id(1);
-        const uint lid  = lidy * g.get_local_range(0) + lidx;
 
         const uint zid       = g.get_group_id(0) / groups_x_;
         const uint wid       = g.get_group_id(1) / groups_y_;
@@ -126,12 +125,12 @@ static void where(Param<uint> &out, Param<T> in) {
         otmp.info.strides[k] = otmp.info.strides[k - 1] * otmp.info.dims[k - 1];
     }
 
-    int rtmp_elements = rtmp.info.strides[3] * rtmp.info.dims[3];
-    int otmp_elements = otmp.info.strides[3] * otmp.info.dims[3];
-    auto rtmp_alloc   = memAlloc<uint>(rtmp_elements);
-    auto otmp_alloc   = memAlloc<uint>(otmp_elements);
-    rtmp.data         = rtmp_alloc.get();
-    otmp.data         = otmp_alloc.get();
+    uintl rtmp_elements = rtmp.info.strides[3] * rtmp.info.dims[3];
+    uintl otmp_elements = otmp.info.strides[3] * otmp.info.dims[3];
+    auto rtmp_alloc     = memAlloc<uint>(rtmp_elements);
+    auto otmp_alloc     = memAlloc<uint>(otmp_elements);
+    rtmp.data           = rtmp_alloc.get();
+    otmp.data           = otmp_alloc.get();
 
     scan_first_launcher<T, uint, af_notzero_t>(
         otmp, rtmp, in, groups_x, groups_y, threads_x, false, true);

--- a/src/backend/oneapi/mean.cpp
+++ b/src/backend/oneapi/mean.cpp
@@ -11,7 +11,7 @@
 #include <mean.hpp>
 
 #include <common/half.hpp>
-// #include <kernel/mean.hpp>
+#include <kernel/mean.hpp>
 #include <af/dim4.hpp>
 
 using af::dim4;
@@ -21,39 +21,29 @@ using std::swap;
 namespace oneapi {
 template<typename Ti, typename Tw, typename To>
 To mean(const Array<Ti>& in) {
-    ONEAPI_NOT_SUPPORTED("mean Not supported");
-
-    return To(0);
-    // return kernel::meanAll<Ti, Tw, To>(in);
+    return kernel::mean_all<Ti, Tw, To>(in);
 }
 
 template<typename T, typename Tw>
 T mean(const Array<T>& in, const Array<Tw>& wts) {
-    ONEAPI_NOT_SUPPORTED("mean Not supported");
-
-    return T(0);
-    // return kernel::meanAllWeighted<T, Tw>(in, wts);
+    return kernel::mean_all_weighted<T, Tw>(in, wts);
 }
 
 template<typename Ti, typename Tw, typename To>
 Array<To> mean(const Array<Ti>& in, const int dim) {
-    ONEAPI_NOT_SUPPORTED("mean Not supported");
-
     dim4 odims    = in.dims();
     odims[dim]    = 1;
     Array<To> out = createEmptyArray<To>(odims);
-    // kernel::mean<Ti, Tw, To>(out, in, dim);
+    kernel::mean<Ti, Tw, To>(out, in, dim);
     return out;
 }
 
 template<typename T, typename Tw>
 Array<T> mean(const Array<T>& in, const Array<Tw>& wts, const int dim) {
-    ONEAPI_NOT_SUPPORTED("mean Not supported");
-
     dim4 odims   = in.dims();
     odims[dim]   = 1;
     Array<T> out = createEmptyArray<T>(odims);
-    // kernel::meanWeighted<T, Tw, T>(out, in, wts, dim);
+    kernel::mean_weighted<T, Tw, T>(out, in, wts, dim);
     return out;
 }
 

--- a/src/backend/oneapi/platform.cpp
+++ b/src/backend/oneapi/platform.cpp
@@ -355,13 +355,11 @@ bool isGLSharingSupported() {
 
 bool isDoubleSupported(unsigned device) {
     DeviceManager& devMngr = DeviceManager::getInstance();
-
-    sycl::device dev;
     {
         common::lock_guard_t lock(devMngr.deviceMutex);
-        dev = *devMngr.mDevices[device];
+        sycl::device& dev = *devMngr.mDevices[device];
+        return dev.has(sycl::aspect::fp64);
     }
-    return dev.has(sycl::aspect::fp64);
 }
 
 bool isHalfSupported(unsigned device) {

--- a/src/backend/oneapi/reduce_impl.hpp
+++ b/src/backend/oneapi/reduce_impl.hpp
@@ -9,7 +9,7 @@
 
 #include <Array.hpp>
 #include <err_oneapi.hpp>
-//#include <kernel/reduce.hpp>
+#include <kernel/reduce.hpp>
 //#include <kernel/reduce_by_key.hpp>
 #include <reduce.hpp>
 #include <af/dim4.hpp>
@@ -17,12 +17,16 @@
 
 using af::dim4;
 using std::swap;
+
 namespace oneapi {
+
 template<af_op_t op, typename Ti, typename To>
 Array<To> reduce(const Array<Ti> &in, const int dim, bool change_nan,
                  double nanval) {
-    ONEAPI_NOT_SUPPORTED("");
-    Array<To> out = createEmptyArray<To>(1);
+    dim4 odims    = in.dims();
+    odims[dim]    = 1;
+    Array<To> out = createEmptyArray<To>(odims);
+    kernel::reduce<Ti, To, op>(out, in, dim, change_nan, nanval);
     return out;
 }
 
@@ -35,8 +39,8 @@ void reduce_by_key(Array<Tk> &keys_out, Array<To> &vals_out,
 
 template<af_op_t op, typename Ti, typename To>
 Array<To> reduce_all(const Array<Ti> &in, bool change_nan, double nanval) {
-    ONEAPI_NOT_SUPPORTED("");
     Array<To> out = createEmptyArray<To>(1);
+    kernel::reduce_all<Ti, To, op>(out, in, change_nan, nanval);
     return out;
 }
 

--- a/src/backend/oneapi/scan.cpp
+++ b/src/backend/oneapi/scan.cpp
@@ -11,23 +11,21 @@
 #include <scan.hpp>
 
 // #include <kernel/scan_dim.hpp>
-// #include <kernel/scan_first.hpp>
+#include <kernel/scan_first.hpp>
 
 namespace oneapi {
 template<af_op_t op, typename Ti, typename To>
 Array<To> scan(const Array<Ti>& in, const int dim, bool inclusiveScan) {
-    ONEAPI_NOT_SUPPORTED("scan Not supported");
-
     Array<To> out = createEmptyArray<To>(in.dims());
 
-    // Param Out = out;
-    // Param In  = in;
+    Param<To> Out = out;
+    Param<Ti> In  = in;
 
-    // if (dim == 0) {
-    //     kernel::scanFirst<Ti, To, op>(Out, In, inclusiveScan);
-    // } else {
+    if (dim == 0) {
+        kernel::scan_first<Ti, To, op>(Out, In, inclusiveScan);
+    } else {
     //     kernel::scanDim<Ti, To, op>(Out, In, dim, inclusiveScan);
-    // }
+    }
 
     return out;
 }

--- a/src/backend/oneapi/scan.cpp
+++ b/src/backend/oneapi/scan.cpp
@@ -10,7 +10,7 @@
 #include <err_oneapi.hpp>
 #include <scan.hpp>
 
-// #include <kernel/scan_dim.hpp>
+#include <kernel/scan_dim.hpp>
 #include <kernel/scan_first.hpp>
 
 namespace oneapi {
@@ -21,10 +21,11 @@ Array<To> scan(const Array<Ti>& in, const int dim, bool inclusiveScan) {
     Param<To> Out = out;
     Param<Ti> In  = in;
 
-    if (dim == 0) {
-        kernel::scan_first<Ti, To, op>(Out, In, inclusiveScan);
-    } else {
-    //     kernel::scanDim<Ti, To, op>(Out, In, dim, inclusiveScan);
+    switch (dim) {
+        case 0: kernel::scan_first<Ti, To, op>(Out, In, inclusiveScan); break;
+        case 1: kernel::scan_dim<Ti, To, op, 1>(Out, In, inclusiveScan); break;
+        case 2: kernel::scan_dim<Ti, To, op, 2>(Out, In, inclusiveScan); break;
+        case 3: kernel::scan_dim<Ti, To, op, 3>(Out, In, inclusiveScan); break;
     }
 
     return out;

--- a/src/backend/oneapi/where.cpp
+++ b/src/backend/oneapi/where.cpp
@@ -9,7 +9,7 @@
 
 #include <Array.hpp>
 #include <err_oneapi.hpp>
-// #include <kernel/where.hpp>
+#include <kernel/where.hpp>
 #include <where.hpp>
 #include <af/dim4.hpp>
 #include <complex>
@@ -18,12 +18,10 @@ namespace oneapi {
 
 template<typename T>
 Array<uint> where(const Array<T> &in) {
-    // Param<uint> Out;
-    // Param<T> In = in;
-    ONEAPI_NOT_SUPPORTED("where Not supported");
-    // kernel::where<T>(Out, In);
-    // return createParamArray<uint>(Out, true);
-    return createEmptyArray<uint>(af::dim4(1));
+    Param<uint> Out;
+    Param<T> In = in;
+    kernel::where<T>(Out, In);
+    return createParamArray<uint>(Out, true);
 }
 
 #define INSTANTIATE(T) template Array<uint> where<T>(const Array<T> &in);


### PR DESCRIPTION
Adds reduce_first, reduce_dim, reduce_all functions to oneapi backend.
This method of reduction is not optimized for all types of devices yet. Future revisions will need to add more kernel types for each targeted accelerator. For now, shared memory based reductions are implemented. Related reduction functions also included in this PR. (mean, scan)
Failing tests are missing functions or JIT related.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
