### PR TITLE
convolve{1,2,3} oneapi port redo

### DIFF
--- a/src/backend/oneapi/kernel/convolve.hpp
+++ b/src/backend/oneapi/kernel/convolve.hpp
@@ -1,0 +1,147 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <common/kernel_cache.hpp>
+#include <debug_oneapi.hpp>
+// #include <memory.hpp>
+// #include <traits.hpp>
+// #include <types.hpp>
+#include <af/defines.h>
+
+#include <string>
+#include <vector>
+
+namespace oneapi {
+namespace kernel {
+
+// below shared MAX_*_LEN's are calculated based on
+// a maximum shared memory configuration of 48KB per block
+// considering complex types as well
+constexpr int MAX_CONV1_FILTER_LEN = 129;
+constexpr int MAX_CONV2_FILTER_LEN = 17;
+constexpr int MAX_CONV3_FILTER_LEN = 5;
+
+constexpr int MAX_SCONV_FILTER_LEN = 31;
+
+constexpr int THREADS   = 256;
+constexpr int THREADS_X = 16;
+constexpr int THREADS_Y = 16;
+constexpr int CUBE_X    = 8;
+constexpr int CUBE_Y    = 8;
+constexpr int CUBE_Z    = 4;
+
+template<typename aT>
+struct conv_kparam_t {
+    sycl::range<3> global{0, 0, 0};
+    sycl::range<3> local{0, 0, 0};
+    size_t loc_size;
+    int nBBS0;
+    int nBBS1;
+    bool outHasNoOffset;
+    bool inHasNoOffset;
+    bool launchMoreBlocks;
+    int o[3];
+    int s[3];
+    sycl::buffer<aT> *impulse;
+};
+
+template<typename T>
+T binOp(T lhs, T rhs) {
+    return lhs * rhs;
+}
+
+template<typename aT>
+void prepareKernelArgs(conv_kparam_t<aT> &param, dim_t *oDims,
+                       const dim_t *fDims, const int rank) {
+    using sycl::range;
+
+    int batchDims[4] = {1, 1, 1, 1};
+    for (int i = rank; i < 4; ++i) {
+        batchDims[i] = (param.launchMoreBlocks ? 1 : oDims[i]);
+    }
+
+    if (rank == 1) {
+        param.local    = range<3>{THREADS, 1, 1};
+        param.nBBS0    = divup(oDims[0], THREADS);
+        param.nBBS1    = batchDims[2];
+        param.global   = range<3>(param.nBBS0 * THREADS * batchDims[1],
+                                param.nBBS1 * batchDims[3], 1);
+        param.loc_size = (THREADS + 2 * (fDims[0] - 1));
+    } else if (rank == 2) {
+        param.local  = range<3>{THREADS_X, THREADS_Y, 1};
+        param.nBBS0  = divup(oDims[0], THREADS_X);
+        param.nBBS1  = divup(oDims[1], THREADS_Y);
+        param.global = range<3>(param.nBBS0 * THREADS_X * batchDims[2],
+                                param.nBBS1 * THREADS_Y * batchDims[3], 1);
+    } else if (rank == 3) {
+        param.local    = range<3>{CUBE_X, CUBE_Y, CUBE_Z};
+        param.nBBS0    = divup(oDims[0], CUBE_X);
+        param.nBBS1    = divup(oDims[1], CUBE_Y);
+        int blk_z      = divup(oDims[2], CUBE_Z);
+        param.global   = range<3>(param.nBBS0 * CUBE_X * batchDims[3],
+                                param.nBBS1 * CUBE_Y, blk_z * CUBE_Z);
+        param.loc_size = (CUBE_X + 2 * (fDims[0] - 1)) *
+                         (CUBE_Y + 2 * (fDims[1] - 1)) *
+                         (CUBE_Z + 2 * (fDims[2] - 1));
+    }
+}
+
+template<typename T>
+void memcpyBuffer(sycl::buffer<T, 1> &dest, sycl::buffer<T, 1> &src,
+                  const size_t n, const size_t srcOffset) {
+    getQueue().submit([&](auto &h) {
+        sycl::accessor srcAcc{src, h, sycl::range{n}, sycl::id{srcOffset},
+                              sycl::read_only};
+        sycl::accessor destAcc{
+            dest,         h, sycl::range{n}, sycl::id{0}, sycl::write_only,
+            sycl::no_init};
+        h.copy(srcAcc, destAcc);
+    });
+}
+
+template<typename T>
+using local_accessor = sycl::accessor<T, 1, sycl::access::mode::read_write, sycl::access::target::local>;
+template<typename T>
+using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
+template<typename T>
+using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
+
+#include "convolve1.hpp"
+#include "convolve2.hpp"
+#include "convolve3.hpp"
+
+template<typename T, typename aT>
+void convolve_nd(Param<T> out, const Param<T> signal, const Param<aT> filter,
+                 AF_BATCH_KIND kind, const int rank, const bool expand) {
+    conv_kparam_t<aT> param;
+
+    for (int i = 0; i < 3; ++i) {
+        param.o[i] = 0;
+        param.s[i] = 0;
+    }
+    param.launchMoreBlocks = kind == AF_BATCH_SAME || kind == AF_BATCH_RHS;
+    param.outHasNoOffset   = kind == AF_BATCH_LHS || kind == AF_BATCH_NONE;
+    param.inHasNoOffset    = kind != AF_BATCH_SAME;
+
+    prepareKernelArgs<aT>(param, out.info.dims, filter.info.dims, rank);
+
+    switch (rank) {
+        case 1: conv1<T, aT>(param, out, signal, filter, expand); break;
+        case 2: conv2<T, aT>(param, out, signal, filter, expand); break;
+        case 3: conv3<T, aT>(param, out, signal, filter, expand); break;
+    }
+
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+}  // namespace kernel
+}  // namespace oneapi

--- a/src/backend/oneapi/kernel/convolve.hpp
+++ b/src/backend/oneapi/kernel/convolve.hpp
@@ -106,7 +106,8 @@ void memcpyBuffer(sycl::buffer<T, 1> &dest, sycl::buffer<T, 1> &src,
 }
 
 template<typename T>
-using local_accessor = sycl::accessor<T, 1, sycl::access::mode::read_write, sycl::access::target::local>;
+using local_accessor = sycl::accessor<T, 1, sycl::access::mode::read_write,
+                                      sycl::access::target::local>;
 template<typename T>
 using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
 template<typename T>

--- a/src/backend/oneapi/kernel/convolve.hpp
+++ b/src/backend/oneapi/kernel/convolve.hpp
@@ -12,9 +12,6 @@
 #include <common/dispatch.hpp>
 #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
-// #include <memory.hpp>
-// #include <traits.hpp>
-// #include <types.hpp>
 #include <af/defines.h>
 
 #include <string>

--- a/src/backend/oneapi/kernel/convolve1.hpp
+++ b/src/backend/oneapi/kernel/convolve1.hpp
@@ -105,7 +105,8 @@ template<typename T, typename aT>
 void conv1Helper(const conv_kparam_t<aT> &param, Param<T> &out,
                  const Param<T> &signal, const Param<aT> &filter,
                  const int rank, const bool expand) {
-    getQueue().submit([&](auto &h) {
+    auto Q = getQueue();
+    Q.submit([&](auto &h) {
         sycl::accessor<aT, 1, sycl::access::mode::read_write,
                        sycl::access::target::local>
             localMem(param.loc_size, h);
@@ -119,6 +120,7 @@ void conv1Helper(const conv_kparam_t<aT> &param, Param<T> &out,
                 filter.info, param.nBBS0, param.nBBS1, param.o[0], param.o[1],
                 param.o[2], param.s[0], param.s[1], param.s[2], expand));
     });
+    ONEAPI_DEBUG_FINISH(Q);
 }
 
 template<typename T, typename aT>

--- a/src/backend/oneapi/kernel/convolve1.hpp
+++ b/src/backend/oneapi/kernel/convolve1.hpp
@@ -1,0 +1,145 @@
+template <typename T, typename aT>
+class conv1HelperCreateKernel {
+public:
+  conv1HelperCreateKernel(write_accessor<T> out, KParam oInfo,
+                          read_accessor<T> signal, KParam sInfo,
+                          local_accessor<aT> localMem,
+                          read_accessor<aT> impulse, KParam fInfo, int nBBS0,
+                          int nBBS1, int ostep1, int ostep2, int ostep3, int sstep1,
+                          int sstep2, int sstep3, const bool expand) : out_(out), oInfo_(oInfo), signal_(signal), sInfo_(sInfo), localMem_(localMem), impulse_(impulse), fInfo_(fInfo), nBBS0_(nBBS0), nBBS1_(nBBS1), ostep1_(ostep1), ostep2_(ostep2), ostep3_(ostep3), sstep1_(sstep1), sstep2_(sstep2), sstep3_(sstep3), expand_(expand) {}
+  void operator()(sycl::nd_item<3> it) const {
+      sycl::group g = it.get_group();
+
+      int fLen          = fInfo_.dims[0];
+      int padding       = fLen - 1;
+      int shrdLen       = g.get_local_range(0) + 2 * padding;
+      const unsigned b1 = g.get_group_id(0) / nBBS0_;
+      const unsigned b0 = g.get_group_id(0) - nBBS0_ * b1;
+      const unsigned b3 = g.get_group_id(1) / nBBS1_;
+      const unsigned b2 = g.get_group_id(1) - nBBS1_ * b3;
+
+      T *dst =
+        out_.get_pointer() +
+        (b1 * oInfo_.strides[1] +     /* activated with batched input signal_ */
+         ostep1_ * oInfo_.strides[1] + /* activated with batched input filter */
+         b2 * oInfo_.strides[2] +     /* activated with batched input signal_ */
+         ostep2_ * oInfo_.strides[2] + /* activated with batched input filter */
+         b3 * oInfo_.strides[3] +     /* activated with batched input signal_ */
+         ostep3_ * oInfo_.strides[3]); /* activated with batched input filter */
+
+      T const *src =
+        signal_.get_pointer() + sInfo_.offset +
+        (b1 * sInfo_.strides[1] +     /* activated with batched input signal_ */
+         sstep1_ * sInfo_.strides[1] + /* activated with batched input filter */
+         b2 * sInfo_.strides[2] +     /* activated with batched input signal_ */
+         sstep2_ * sInfo_.strides[2] + /* activated with batched input filter */
+         b3 * sInfo_.strides[3] +     /* activated with batched input signal_ */
+         sstep3_ * sInfo_.strides[3]); /* activated with batched input filter */
+
+      int gx = g.get_local_range(0) * b0;
+
+      for (int i = it.get_local_id(0); i < shrdLen; i += g.get_local_range(0)) {
+        int idx     = gx - padding + i;
+        localMem_[i] = (idx >= 0 && idx < sInfo_.dims[0])
+          ? src[idx * sInfo_.strides[0]]
+          : (T)(0);
+      }
+      it.barrier();
+      gx += it.get_local_id(0);
+
+      if (gx >= 0 && gx < oInfo_.dims[0]) {
+        int lx        = it.get_local_id(0) + padding + (expand_ ? 0 : fLen >> 1);
+        aT accum = (aT)(0);
+        for (int f = 0; f < fLen; ++f) {
+          // binOp will do MUL_OP for convolution operation
+          accum = accum + binOp((aT)localMem_[lx - f], (aT)impulse_[f]);
+        }
+        dst[gx] = (T)accum;
+      }
+  }
+
+private:
+  write_accessor<T> out_;
+  KParam oInfo_;
+  read_accessor<T> signal_;
+  KParam sInfo_;
+  local_accessor<aT> localMem_;
+  read_accessor<aT> impulse_;
+  KParam fInfo_;
+  int nBBS0_;
+  int nBBS1_;
+  int ostep1_;
+  int ostep2_;
+  int ostep3_;
+  int sstep1_;
+  int sstep2_;
+  int sstep3_;
+  const bool expand_;
+};
+
+template<typename T, typename aT>
+void conv1Helper(const conv_kparam_t<aT> &param, Param<T> &out,
+                 const Param<T> &signal, const Param<aT> &filter,
+                 const int rank, const bool expand) {
+    getQueue().submit([&](auto &h) {
+        sycl::accessor<aT, 1, sycl::access::mode::read_write,
+                       sycl::access::target::local>
+          localMem(param.loc_size, h);
+        sycl::accessor outAcc{*out.data, h, sycl::write_only, sycl::no_init};
+        sycl::accessor signalAcc{*signal.data, h, sycl::read_only};
+        sycl::accessor impulseAcc{*param.impulse, h, sycl::read_only};
+        h.parallel_for(sycl::nd_range{param.global, param.local},
+                       conv1HelperCreateKernel<T, aT>(outAcc, out.info, signalAcc, signal.info, localMem, impulseAcc, filter.info, param.nBBS0, param.nBBS1, param.o[0], param.o[1], param.o[2], param.s[0], param.s[1], param.s[2], expand));
+    });
+}
+
+
+template<typename T, typename aT>
+void conv1(conv_kparam_t<aT> &p, Param<T> &out, const Param<T> &sig,
+           const Param<aT> &filt, const bool expand) {
+    const size_t se_size = filt.info.dims[0];
+    sycl::buffer<aT> impulse{sycl::range(filt.info.dims[0])};
+    int f0Off = filt.info.offset;
+    for (int b3 = 0; b3 < filt.info.dims[3]; ++b3) {
+        int f3Off = b3 * filt.info.strides[3];
+
+        for (int b2 = 0; b2 < filt.info.dims[2]; ++b2) {
+            int f2Off = b2 * filt.info.strides[2];
+
+            for (int b1 = 0; b1 < filt.info.dims[1]; ++b1) {
+                int f1Off = b1 * filt.info.strides[1];
+
+                const size_t srcOffset = f0Off + f1Off + f2Off + f3Off;
+                memcpyBuffer(impulse, *filt.data, se_size, srcOffset);
+                p.impulse = &impulse;
+
+                p.o[0] = (p.outHasNoOffset ? 0 : b1);
+                p.o[1] = (p.outHasNoOffset ? 0 : b2);
+                p.o[2] = (p.outHasNoOffset ? 0 : b3);
+                p.s[0] = (p.inHasNoOffset ? 0 : b1);
+                p.s[1] = (p.inHasNoOffset ? 0 : b2);
+                p.s[2] = (p.inHasNoOffset ? 0 : b3);
+
+                conv1Helper<T, aT>(p, out, sig, filt, 1, expand);
+            }
+        }
+    }
+}
+
+#define INSTANTIATE_CONV1(T, aT)                                    \
+    template void conv1<T, aT>(conv_kparam_t<aT> &, Param<T> &,     \
+                               const Param<T> &, const Param<aT> &, \
+                               const bool);
+
+INSTANTIATE_CONV1(cdouble, cdouble)
+INSTANTIATE_CONV1(cfloat, cfloat)
+INSTANTIATE_CONV1(double, double)
+INSTANTIATE_CONV1(float, float)
+INSTANTIATE_CONV1(uint, float)
+INSTANTIATE_CONV1(int, float)
+INSTANTIATE_CONV1(uchar, float)
+INSTANTIATE_CONV1(char, float)
+INSTANTIATE_CONV1(ushort, float)
+INSTANTIATE_CONV1(short, float)
+INSTANTIATE_CONV1(uintl, float)
+INSTANTIATE_CONV1(intl, float)

--- a/src/backend/oneapi/kernel/convolve2.hpp
+++ b/src/backend/oneapi/kernel/convolve2.hpp
@@ -1,0 +1,166 @@
+template <typename T, typename aT>
+class conv2HelperCreateKernel {
+public:
+  conv2HelperCreateKernel(write_accessor<T> out, KParam oInfo,
+                          read_accessor<T> signal, KParam sInfo,
+                          read_accessor<aT> impulse, KParam fInfo, int nBBS0,
+                          int nBBS1, int ostep2, int ostep3, int sstep2,
+                          int sstep3, local_accessor<aT> localMem, const int f0,
+                          const int f1, const bool expand) : out_(out), oInfo_(oInfo), signal_(signal), sInfo_(sInfo), impulse_(impulse), fInfo_(fInfo), nBBS0_(nBBS0), nBBS1_(nBBS1), ostep2_(ostep2), ostep3_(ostep3), sstep2_(sstep2), sstep3_(sstep3), localMem_(localMem), f0_(f0), f1_(f1), expand_(expand) {}
+  void operator()(sycl::nd_item<3> it) const {
+      sycl::group g = it.get_group();
+
+      int radius0  = f0_ - 1;
+      int radius1  = f1_ - 1;
+      int padding0 = 2 * radius0;
+      int padding1 = 2 * radius1;
+      int shrdLen0 = g.get_local_range(0) + padding0;
+      int shrdLen1 = g.get_local_range(1) + padding1;
+
+      unsigned b0 = g.get_group_id(0) / nBBS0_;
+      unsigned b1 = g.get_group_id(1) / nBBS1_;
+
+      T *dst =
+        out_.get_pointer() +
+        (b0 * oInfo_.strides[2] +     /* activated with batched input signal_ */
+         ostep2_ * oInfo_.strides[2] + /* activated with batched input filter */
+         b1 * oInfo_.strides[3] +     /* activated with batched input signal_ */
+         ostep3_ * oInfo_.strides[3]); /* activated with batched input filter */
+
+      const T *src =
+        signal_.get_pointer() + sInfo_.offset +
+        (b0 * sInfo_.strides[2] +     /* activated with batched input signal_ */
+         sstep2_ * sInfo_.strides[2] + /* activated with batched input filter */
+         b1 * sInfo_.strides[3] +     /* activated with batched input signal_ */
+         sstep3_ * sInfo_.strides[3]); /* activated with batched input filter */
+
+      int lx = it.get_local_id(0);
+      int ly = it.get_local_id(1);
+      int gx = g.get_local_range(0) * (g.get_group_id(0) - b0 * nBBS0_) + lx;
+      int gy = g.get_local_range(1) * (g.get_group_id(1) - b1 * nBBS1_) + ly;
+
+      // below loops are traditional loops, they only run multiple
+      // times filter length is more than launch size
+      int s0 = sInfo_.strides[0];
+      int s1 = sInfo_.strides[1];
+      int d0 = sInfo_.dims[0];
+      int d1 = sInfo_.dims[1];
+      for (int b = ly, gy2 = gy; b < shrdLen1;
+           b += g.get_local_range(1), gy2 += g.get_local_range(1)) {
+        int j     = gy2 - radius1;
+        bool is_j = j >= 0 && j < d1;
+        // move row_set g.get_local_range(1) along coloumns
+        for (int a = lx, gx2 = gx; a < shrdLen0;
+             a += g.get_local_range(0), gx2 += g.get_local_range(0)) {
+          int i     = gx2 - radius0;
+          bool is_i = i >= 0 && i < d0;
+          localMem_[b * shrdLen0 + a] =
+            (is_i && is_j ? src[i * s0 + j * s1] : (T)(0));
+        }
+      }
+      it.barrier();
+
+      if (gx < oInfo_.dims[0] && gy < oInfo_.dims[1]) {
+        int ci = lx + radius0 + (expand_ ? 0 : f0_ >> 1);
+        int cj = ly + radius1 + (expand_ ? 0 : f1_ >> 1);
+
+        aT accum = (aT)(0);
+        for (int fj = 0; fj < f1_; ++fj) {
+          for (int fi = 0; fi < f0_; ++fi) {
+            aT f_val = impulse_[fj * f0_ + fi];
+            T s_val       = localMem_[(cj - fj) * shrdLen0 + (ci - fi)];
+
+            // binOp will do MUL_OP for convolution operation
+            accum = accum + binOp((aT)s_val, (aT)f_val);
+          }
+        }
+        dst[gy * oInfo_.strides[1] + gx] = (T)accum;
+      }
+  }
+private:
+  write_accessor<T> out_;
+  KParam oInfo_;
+  read_accessor<T> signal_;
+  KParam sInfo_;
+  read_accessor<aT> impulse_;
+  KParam fInfo_;
+  int nBBS0_;
+  int nBBS1_;
+  int ostep2_;
+  int ostep3_;
+  int sstep2_;
+  int sstep3_;
+  local_accessor<aT> localMem_;
+  const int f0_;
+  const int f1_;
+  const bool expand_;
+};
+
+template<typename T, typename aT>
+void conv2Helper(const conv_kparam_t<aT> &param, Param<T> out,
+                 const Param<T> signal, const Param<aT> filter,
+                 const bool expand) {
+    constexpr bool IsComplex =
+      std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value;
+
+    const int f0 = filter.info.dims[0];
+    const int f1 = filter.info.dims[1];
+    const size_t LOC_SIZE =
+      (THREADS_X + 2 * (f0 - 1)) * (THREADS_Y + 2 * (f1 - 1));
+
+    getQueue().submit([&](auto &h) {
+        sycl::accessor<aT, 1, sycl::access::mode::read_write,
+                       sycl::access::target::local>
+          localMem(LOC_SIZE, h);
+        sycl::accessor outAcc{*out.data, h, sycl::write_only, sycl::no_init};
+        sycl::accessor signalAcc{*signal.data, h, sycl::read_only};
+        sycl::accessor impulseAcc{*param.impulse, h, sycl::read_only};
+        h.parallel_for(sycl::nd_range{param.global, param.local},
+                       conv2HelperCreateKernel<T, aT>(outAcc, out.info, signalAcc, signal.info, impulseAcc, filter.info, param.nBBS0, param.nBBS1, param.o[1], param.o[2], param.s[1], param.s[2], localMem, f0, f1, expand));
+    });
+}
+
+template<typename T, typename aT>
+void conv2(conv_kparam_t<aT> &p, Param<T> &out, const Param<T> &sig,
+           const Param<aT> &filt, const bool expand) {
+    size_t se_size = filt.info.dims[0] * filt.info.dims[1];
+    sycl::buffer<aT> impulse{sycl::range(se_size)};
+    int f0Off = filt.info.offset;
+
+    for (int b3 = 0; b3 < filt.info.dims[3]; ++b3) {
+      int f3Off = b3 * filt.info.strides[3];
+
+      for (int b2 = 0; b2 < filt.info.dims[2]; ++b2) {
+        int f2Off = b2 * filt.info.strides[2];
+
+        const size_t srcOffset = f2Off + f3Off + f0Off;
+        memcpyBuffer(impulse, *filt.data, se_size, srcOffset);
+        p.impulse = &impulse;
+
+        p.o[1] = (p.outHasNoOffset ? 0 : b2);
+        p.o[2] = (p.outHasNoOffset ? 0 : b3);
+        p.s[1] = (p.inHasNoOffset ? 0 : b2);
+        p.s[2] = (p.inHasNoOffset ? 0 : b3);
+
+        conv2Helper<T, aT>(p, out, sig, filt, expand);
+      }
+    }
+}
+
+#define INSTANTIATE_CONV2(T, aT)                                        \
+  template void conv2<T, aT>(conv_kparam_t<aT> &, Param<T> &,           \
+                             const Param<T> &, const Param<aT> &,       \
+                             const bool);
+
+INSTANTIATE_CONV2(char, float)
+INSTANTIATE_CONV2(cfloat, cfloat)
+INSTANTIATE_CONV2(cdouble, cdouble)
+INSTANTIATE_CONV2(float, float)
+INSTANTIATE_CONV2(double, double)
+INSTANTIATE_CONV2(short, float)
+INSTANTIATE_CONV2(int, float)
+INSTANTIATE_CONV2(intl, float)
+INSTANTIATE_CONV2(ushort, float)
+INSTANTIATE_CONV2(uint, float)
+INSTANTIATE_CONV2(uintl, float)
+INSTANTIATE_CONV2(uchar, float)

--- a/src/backend/oneapi/kernel/convolve2.hpp
+++ b/src/backend/oneapi/kernel/convolve2.hpp
@@ -129,7 +129,8 @@ void conv2Helper(const conv_kparam_t<aT> &param, Param<T> out,
     const size_t LOC_SIZE =
         (THREADS_X + 2 * (f0 - 1)) * (THREADS_Y + 2 * (f1 - 1));
 
-    getQueue().submit([&](auto &h) {
+    auto Q = getQueue();
+    Q.submit([&](auto &h) {
         sycl::accessor<aT, 1, sycl::access::mode::read_write,
                        sycl::access::target::local>
             localMem(LOC_SIZE, h);
@@ -143,6 +144,7 @@ void conv2Helper(const conv_kparam_t<aT> &param, Param<T> out,
                 filter.info, param.nBBS0, param.nBBS1, param.o[1], param.o[2],
                 param.s[1], param.s[2], localMem, f0, f1, expand));
     });
+    ONEAPI_DEBUG_FINISH(Q);
 }
 
 template<typename T, typename aT>

--- a/src/backend/oneapi/kernel/convolve2.hpp
+++ b/src/backend/oneapi/kernel/convolve2.hpp
@@ -1,99 +1,120 @@
-template <typename T, typename aT>
+template<typename T, typename aT>
 class conv2HelperCreateKernel {
-public:
-  conv2HelperCreateKernel(write_accessor<T> out, KParam oInfo,
-                          read_accessor<T> signal, KParam sInfo,
-                          read_accessor<aT> impulse, KParam fInfo, int nBBS0,
-                          int nBBS1, int ostep2, int ostep3, int sstep2,
-                          int sstep3, local_accessor<aT> localMem, const int f0,
-                          const int f1, const bool expand) : out_(out), oInfo_(oInfo), signal_(signal), sInfo_(sInfo), impulse_(impulse), fInfo_(fInfo), nBBS0_(nBBS0), nBBS1_(nBBS1), ostep2_(ostep2), ostep3_(ostep3), sstep2_(sstep2), sstep3_(sstep3), localMem_(localMem), f0_(f0), f1_(f1), expand_(expand) {}
-  void operator()(sycl::nd_item<3> it) const {
-      sycl::group g = it.get_group();
+   public:
+    conv2HelperCreateKernel(write_accessor<T> out, KParam oInfo,
+                            read_accessor<T> signal, KParam sInfo,
+                            read_accessor<aT> impulse, KParam fInfo, int nBBS0,
+                            int nBBS1, int ostep2, int ostep3, int sstep2,
+                            int sstep3, local_accessor<aT> localMem,
+                            const int f0, const int f1, const bool expand)
+        : out_(out)
+        , oInfo_(oInfo)
+        , signal_(signal)
+        , sInfo_(sInfo)
+        , impulse_(impulse)
+        , fInfo_(fInfo)
+        , nBBS0_(nBBS0)
+        , nBBS1_(nBBS1)
+        , ostep2_(ostep2)
+        , ostep3_(ostep3)
+        , sstep2_(sstep2)
+        , sstep3_(sstep3)
+        , localMem_(localMem)
+        , f0_(f0)
+        , f1_(f1)
+        , expand_(expand) {}
+    void operator()(sycl::nd_item<3> it) const {
+        sycl::group g = it.get_group();
 
-      int radius0  = f0_ - 1;
-      int radius1  = f1_ - 1;
-      int padding0 = 2 * radius0;
-      int padding1 = 2 * radius1;
-      int shrdLen0 = g.get_local_range(0) + padding0;
-      int shrdLen1 = g.get_local_range(1) + padding1;
+        int radius0  = f0_ - 1;
+        int radius1  = f1_ - 1;
+        int padding0 = 2 * radius0;
+        int padding1 = 2 * radius1;
+        int shrdLen0 = g.get_local_range(0) + padding0;
+        int shrdLen1 = g.get_local_range(1) + padding1;
 
-      unsigned b0 = g.get_group_id(0) / nBBS0_;
-      unsigned b1 = g.get_group_id(1) / nBBS1_;
+        unsigned b0 = g.get_group_id(0) / nBBS0_;
+        unsigned b1 = g.get_group_id(1) / nBBS1_;
 
-      T *dst =
-        out_.get_pointer() +
-        (b0 * oInfo_.strides[2] +     /* activated with batched input signal_ */
-         ostep2_ * oInfo_.strides[2] + /* activated with batched input filter */
-         b1 * oInfo_.strides[3] +     /* activated with batched input signal_ */
-         ostep3_ * oInfo_.strides[3]); /* activated with batched input filter */
+        T *dst =
+            out_.get_pointer() +
+            (b0 * oInfo_.strides[2] + /* activated with batched input signal_ */
+             ostep2_ *
+                 oInfo_.strides[2] +  /* activated with batched input filter */
+             b1 * oInfo_.strides[3] + /* activated with batched input signal_ */
+             ostep3_ *
+                 oInfo_.strides[3]); /* activated with batched input filter */
 
-      const T *src =
-        signal_.get_pointer() + sInfo_.offset +
-        (b0 * sInfo_.strides[2] +     /* activated with batched input signal_ */
-         sstep2_ * sInfo_.strides[2] + /* activated with batched input filter */
-         b1 * sInfo_.strides[3] +     /* activated with batched input signal_ */
-         sstep3_ * sInfo_.strides[3]); /* activated with batched input filter */
+        const T *src =
+            signal_.get_pointer() + sInfo_.offset +
+            (b0 * sInfo_.strides[2] + /* activated with batched input signal_ */
+             sstep2_ *
+                 sInfo_.strides[2] +  /* activated with batched input filter */
+             b1 * sInfo_.strides[3] + /* activated with batched input signal_ */
+             sstep3_ *
+                 sInfo_.strides[3]); /* activated with batched input filter */
 
-      int lx = it.get_local_id(0);
-      int ly = it.get_local_id(1);
-      int gx = g.get_local_range(0) * (g.get_group_id(0) - b0 * nBBS0_) + lx;
-      int gy = g.get_local_range(1) * (g.get_group_id(1) - b1 * nBBS1_) + ly;
+        int lx = it.get_local_id(0);
+        int ly = it.get_local_id(1);
+        int gx = g.get_local_range(0) * (g.get_group_id(0) - b0 * nBBS0_) + lx;
+        int gy = g.get_local_range(1) * (g.get_group_id(1) - b1 * nBBS1_) + ly;
 
-      // below loops are traditional loops, they only run multiple
-      // times filter length is more than launch size
-      int s0 = sInfo_.strides[0];
-      int s1 = sInfo_.strides[1];
-      int d0 = sInfo_.dims[0];
-      int d1 = sInfo_.dims[1];
-      for (int b = ly, gy2 = gy; b < shrdLen1;
-           b += g.get_local_range(1), gy2 += g.get_local_range(1)) {
-        int j     = gy2 - radius1;
-        bool is_j = j >= 0 && j < d1;
-        // move row_set g.get_local_range(1) along coloumns
-        for (int a = lx, gx2 = gx; a < shrdLen0;
-             a += g.get_local_range(0), gx2 += g.get_local_range(0)) {
-          int i     = gx2 - radius0;
-          bool is_i = i >= 0 && i < d0;
-          localMem_[b * shrdLen0 + a] =
-            (is_i && is_j ? src[i * s0 + j * s1] : (T)(0));
+        // below loops are traditional loops, they only run multiple
+        // times filter length is more than launch size
+        int s0 = sInfo_.strides[0];
+        int s1 = sInfo_.strides[1];
+        int d0 = sInfo_.dims[0];
+        int d1 = sInfo_.dims[1];
+        for (int b = ly, gy2 = gy; b < shrdLen1;
+             b += g.get_local_range(1), gy2 += g.get_local_range(1)) {
+            int j     = gy2 - radius1;
+            bool is_j = j >= 0 && j < d1;
+            // move row_set g.get_local_range(1) along coloumns
+            for (int a = lx, gx2 = gx; a < shrdLen0;
+                 a += g.get_local_range(0), gx2 += g.get_local_range(0)) {
+                int i     = gx2 - radius0;
+                bool is_i = i >= 0 && i < d0;
+                localMem_[b * shrdLen0 + a] =
+                    (is_i && is_j ? src[i * s0 + j * s1] : (T)(0));
+            }
         }
-      }
-      it.barrier();
+        it.barrier();
 
-      if (gx < oInfo_.dims[0] && gy < oInfo_.dims[1]) {
-        int ci = lx + radius0 + (expand_ ? 0 : f0_ >> 1);
-        int cj = ly + radius1 + (expand_ ? 0 : f1_ >> 1);
+        if (gx < oInfo_.dims[0] && gy < oInfo_.dims[1]) {
+            int ci = lx + radius0 + (expand_ ? 0 : f0_ >> 1);
+            int cj = ly + radius1 + (expand_ ? 0 : f1_ >> 1);
 
-        aT accum = (aT)(0);
-        for (int fj = 0; fj < f1_; ++fj) {
-          for (int fi = 0; fi < f0_; ++fi) {
-            aT f_val = impulse_[fj * f0_ + fi];
-            T s_val       = localMem_[(cj - fj) * shrdLen0 + (ci - fi)];
+            aT accum = (aT)(0);
+            for (int fj = 0; fj < f1_; ++fj) {
+                for (int fi = 0; fi < f0_; ++fi) {
+                    aT f_val = impulse_[fj * f0_ + fi];
+                    T s_val  = localMem_[(cj - fj) * shrdLen0 + (ci - fi)];
 
-            // binOp will do MUL_OP for convolution operation
-            accum = accum + binOp((aT)s_val, (aT)f_val);
-          }
+                    // binOp will do MUL_OP for convolution operation
+                    accum = accum + binOp((aT)s_val, (aT)f_val);
+                }
+            }
+            dst[gy * oInfo_.strides[1] + gx] = (T)accum;
         }
-        dst[gy * oInfo_.strides[1] + gx] = (T)accum;
-      }
-  }
-private:
-  write_accessor<T> out_;
-  KParam oInfo_;
-  read_accessor<T> signal_;
-  KParam sInfo_;
-  read_accessor<aT> impulse_;
-  KParam fInfo_;
-  int nBBS0_;
-  int nBBS1_;
-  int ostep2_;
-  int ostep3_;
-  int sstep2_;
-  int sstep3_;
-  local_accessor<aT> localMem_;
-  const int f0_;
-  const int f1_;
-  const bool expand_;
+    }
+
+   private:
+    write_accessor<T> out_;
+    KParam oInfo_;
+    read_accessor<T> signal_;
+    KParam sInfo_;
+    read_accessor<aT> impulse_;
+    KParam fInfo_;
+    int nBBS0_;
+    int nBBS1_;
+    int ostep2_;
+    int ostep3_;
+    int sstep2_;
+    int sstep3_;
+    local_accessor<aT> localMem_;
+    const int f0_;
+    const int f1_;
+    const bool expand_;
 };
 
 template<typename T, typename aT>
@@ -101,22 +122,26 @@ void conv2Helper(const conv_kparam_t<aT> &param, Param<T> out,
                  const Param<T> signal, const Param<aT> filter,
                  const bool expand) {
     constexpr bool IsComplex =
-      std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value;
+        std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value;
 
     const int f0 = filter.info.dims[0];
     const int f1 = filter.info.dims[1];
     const size_t LOC_SIZE =
-      (THREADS_X + 2 * (f0 - 1)) * (THREADS_Y + 2 * (f1 - 1));
+        (THREADS_X + 2 * (f0 - 1)) * (THREADS_Y + 2 * (f1 - 1));
 
     getQueue().submit([&](auto &h) {
         sycl::accessor<aT, 1, sycl::access::mode::read_write,
                        sycl::access::target::local>
-          localMem(LOC_SIZE, h);
+            localMem(LOC_SIZE, h);
         sycl::accessor outAcc{*out.data, h, sycl::write_only, sycl::no_init};
         sycl::accessor signalAcc{*signal.data, h, sycl::read_only};
         sycl::accessor impulseAcc{*param.impulse, h, sycl::read_only};
-        h.parallel_for(sycl::nd_range{param.global, param.local},
-                       conv2HelperCreateKernel<T, aT>(outAcc, out.info, signalAcc, signal.info, impulseAcc, filter.info, param.nBBS0, param.nBBS1, param.o[1], param.o[2], param.s[1], param.s[2], localMem, f0, f1, expand));
+        h.parallel_for(
+            sycl::nd_range{param.global, param.local},
+            conv2HelperCreateKernel<T, aT>(
+                outAcc, out.info, signalAcc, signal.info, impulseAcc,
+                filter.info, param.nBBS0, param.nBBS1, param.o[1], param.o[2],
+                param.s[1], param.s[2], localMem, f0, f1, expand));
     });
 }
 
@@ -128,29 +153,29 @@ void conv2(conv_kparam_t<aT> &p, Param<T> &out, const Param<T> &sig,
     int f0Off = filt.info.offset;
 
     for (int b3 = 0; b3 < filt.info.dims[3]; ++b3) {
-      int f3Off = b3 * filt.info.strides[3];
+        int f3Off = b3 * filt.info.strides[3];
 
-      for (int b2 = 0; b2 < filt.info.dims[2]; ++b2) {
-        int f2Off = b2 * filt.info.strides[2];
+        for (int b2 = 0; b2 < filt.info.dims[2]; ++b2) {
+            int f2Off = b2 * filt.info.strides[2];
 
-        const size_t srcOffset = f2Off + f3Off + f0Off;
-        memcpyBuffer(impulse, *filt.data, se_size, srcOffset);
-        p.impulse = &impulse;
+            const size_t srcOffset = f2Off + f3Off + f0Off;
+            memcpyBuffer(impulse, *filt.data, se_size, srcOffset);
+            p.impulse = &impulse;
 
-        p.o[1] = (p.outHasNoOffset ? 0 : b2);
-        p.o[2] = (p.outHasNoOffset ? 0 : b3);
-        p.s[1] = (p.inHasNoOffset ? 0 : b2);
-        p.s[2] = (p.inHasNoOffset ? 0 : b3);
+            p.o[1] = (p.outHasNoOffset ? 0 : b2);
+            p.o[2] = (p.outHasNoOffset ? 0 : b3);
+            p.s[1] = (p.inHasNoOffset ? 0 : b2);
+            p.s[2] = (p.inHasNoOffset ? 0 : b3);
 
-        conv2Helper<T, aT>(p, out, sig, filt, expand);
-      }
+            conv2Helper<T, aT>(p, out, sig, filt, expand);
+        }
     }
 }
 
-#define INSTANTIATE_CONV2(T, aT)                                        \
-  template void conv2<T, aT>(conv_kparam_t<aT> &, Param<T> &,           \
-                             const Param<T> &, const Param<aT> &,       \
-                             const bool);
+#define INSTANTIATE_CONV2(T, aT)                                    \
+    template void conv2<T, aT>(conv_kparam_t<aT> &, Param<T> &,     \
+                               const Param<T> &, const Param<aT> &, \
+                               const bool);
 
 INSTANTIATE_CONV2(char, float)
 INSTANTIATE_CONV2(cfloat, cfloat)

--- a/src/backend/oneapi/kernel/convolve3.hpp
+++ b/src/backend/oneapi/kernel/convolve3.hpp
@@ -2,118 +2,139 @@ int index(int i, int j, int k, int jstride, int kstride) {
     return i + j * jstride + k * kstride;
 }
 
-template <typename T, typename aT>
+template<typename T, typename aT>
 class conv3HelperCreateKernel {
-public:
- conv3HelperCreateKernel(write_accessor<T> out, KParam oInfo,
-                         read_accessor<T> signal, KParam sInfo,
-                         local_accessor<aT> localMem, read_accessor<aT> impulse,
-                         KParam fInfo, int nBBS0, int nBBS1, int ostep1, int ostep2,
-                         int ostep3, int sstep1, int sstep2, int sstep3, const bool EXPAND) : out_(out), oInfo_(oInfo), signal_(signal), sInfo_(sInfo), localMem_(localMem), impulse_(impulse), fInfo_(fInfo), nBBS0_(nBBS0), nBBS1_(nBBS1), ostep1_(ostep1), ostep2_(ostep2), ostep3_(ostep3), sstep1_(sstep1), sstep2_(sstep2), sstep3_(sstep3), EXPAND_(EXPAND) {}
-  void operator()(sycl::nd_item<3> it) const {
-      sycl::group g = it.get_group();
-    int fLen0    = fInfo_.dims[0];
-    int fLen1    = fInfo_.dims[1];
-    int fLen2    = fInfo_.dims[2];
-    int radius0  = fLen0 - 1;
-    int radius1  = fLen1 - 1;
-    int radius2  = fLen2 - 1;
-    int shrdLen0 = g.get_local_range(0) + 2 * radius0;
-    int shrdLen1 = g.get_local_range(1) + 2 * radius1;
-    int shrdLen2 = g.get_local_range(2) + 2 * radius2;
-    int skStride = shrdLen0 * shrdLen1;
-    int fStride  = fLen0 * fLen1;
-    unsigned b2  = g.get_group_id(0) / nBBS0_;
+   public:
+    conv3HelperCreateKernel(write_accessor<T> out, KParam oInfo,
+                            read_accessor<T> signal, KParam sInfo,
+                            local_accessor<aT> localMem,
+                            read_accessor<aT> impulse, KParam fInfo, int nBBS0,
+                            int nBBS1, int ostep1, int ostep2, int ostep3,
+                            int sstep1, int sstep2, int sstep3,
+                            const bool EXPAND)
+        : out_(out)
+        , oInfo_(oInfo)
+        , signal_(signal)
+        , sInfo_(sInfo)
+        , localMem_(localMem)
+        , impulse_(impulse)
+        , fInfo_(fInfo)
+        , nBBS0_(nBBS0)
+        , nBBS1_(nBBS1)
+        , ostep1_(ostep1)
+        , ostep2_(ostep2)
+        , ostep3_(ostep3)
+        , sstep1_(sstep1)
+        , sstep2_(sstep2)
+        , sstep3_(sstep3)
+        , EXPAND_(EXPAND) {}
+    void operator()(sycl::nd_item<3> it) const {
+        sycl::group g = it.get_group();
+        int fLen0     = fInfo_.dims[0];
+        int fLen1     = fInfo_.dims[1];
+        int fLen2     = fInfo_.dims[2];
+        int radius0   = fLen0 - 1;
+        int radius1   = fLen1 - 1;
+        int radius2   = fLen2 - 1;
+        int shrdLen0  = g.get_local_range(0) + 2 * radius0;
+        int shrdLen1  = g.get_local_range(1) + 2 * radius1;
+        int shrdLen2  = g.get_local_range(2) + 2 * radius2;
+        int skStride  = shrdLen0 * shrdLen1;
+        int fStride   = fLen0 * fLen1;
+        unsigned b2   = g.get_group_id(0) / nBBS0_;
 
-    T *dst =
-      out_.get_pointer() +
-        (b2 * oInfo_.strides[3] +     /* activated with batched input signal_ */
-         ostep3_ * oInfo_.strides[3]); /* activated with batched input filter */
+        T *dst =
+            out_.get_pointer() +
+            (b2 * oInfo_.strides[3] + /* activated with batched input signal_ */
+             ostep3_ *
+                 oInfo_.strides[3]); /* activated with batched input filter */
 
-    const T *src =
-      signal_.get_pointer() + sInfo_.offset +
-        (b2 * sInfo_.strides[3] +     /* activated with batched input signal_ */
-         sstep3_ * sInfo_.strides[3]); /* activated with batched input filter */
+        const T *src =
+            signal_.get_pointer() + sInfo_.offset +
+            (b2 * sInfo_.strides[3] + /* activated with batched input signal_ */
+             sstep3_ *
+                 sInfo_.strides[3]); /* activated with batched input filter */
 
-    int lx  = it.get_local_id(0);
-    int ly  = it.get_local_id(1);
-    int lz  = it.get_local_id(2);
-    int gx  = g.get_local_range(0) * (g.get_group_id(0) - b2 * nBBS0_) + lx;
-    int gy  = g.get_local_range(1) * g.get_group_id(1) + ly;
-    int gz  = g.get_local_range(2) * g.get_group_id(2) + lz;
-    int lx2 = lx + g.get_local_range(0);
-    int ly2 = ly + g.get_local_range(1);
-    int lz2 = lz + g.get_local_range(2);
-    int gx2 = gx + g.get_local_range(0);
-    int gy2 = gy + g.get_local_range(1);
-    int gz2 = gz + g.get_local_range(2);
+        int lx  = it.get_local_id(0);
+        int ly  = it.get_local_id(1);
+        int lz  = it.get_local_id(2);
+        int gx  = g.get_local_range(0) * (g.get_group_id(0) - b2 * nBBS0_) + lx;
+        int gy  = g.get_local_range(1) * g.get_group_id(1) + ly;
+        int gz  = g.get_local_range(2) * g.get_group_id(2) + lz;
+        int lx2 = lx + g.get_local_range(0);
+        int ly2 = ly + g.get_local_range(1);
+        int lz2 = lz + g.get_local_range(2);
+        int gx2 = gx + g.get_local_range(0);
+        int gy2 = gy + g.get_local_range(1);
+        int gz2 = gz + g.get_local_range(2);
 
-    int s0 = sInfo_.strides[0];
-    int s1 = sInfo_.strides[1];
-    int s2 = sInfo_.strides[2];
-    int d0 = sInfo_.dims[0];
-    int d1 = sInfo_.dims[1];
-    int d2 = sInfo_.dims[2];
+        int s0 = sInfo_.strides[0];
+        int s1 = sInfo_.strides[1];
+        int s2 = sInfo_.strides[2];
+        int d0 = sInfo_.dims[0];
+        int d1 = sInfo_.dims[1];
+        int d2 = sInfo_.dims[2];
 
-    for (int c = lz, gz2 = gz; c < shrdLen2;
-         c += g.get_local_range(2), gz2 += g.get_local_range(2)) {
-        int k     = gz2 - radius2;
-        bool is_k = k >= 0 && k < d2;
-        for (int b = ly, gy2 = gy; b < shrdLen1;
-             b += g.get_local_range(1), gy2 += g.get_local_range(1)) {
-            int j     = gy2 - radius1;
-            bool is_j = j >= 0 && j < d1;
-            for (int a = lx, gx2 = gx; a < shrdLen0;
-                 a += g.get_local_range(0), gx2 += g.get_local_range(0)) {
-                int i     = gx2 - radius0;
-                bool is_i = i >= 0 && i < d0;
-                localMem_[c * skStride + b * shrdLen0 + a] =
-                    (is_i && is_j && is_k ?src[i * s0 + j * s1 + k * s2]
-                                          : (T)(0));
-            }
-        }
-    }
-    it.barrier();
-
-    if (gx < oInfo_.dims[0] && gy < oInfo_.dims[1] && gz < oInfo_.dims[2]) {
-        int ci = lx + radius0 + (EXPAND_ ? 0 : fLen0 >> 1);
-        int cj = ly + radius1 + (EXPAND_ ? 0 : fLen1 >> 1);
-        int ck = lz + radius2 + (EXPAND_ ? 0 : fLen2 >> 1);
-
-        aT accum = (aT)(0);
-        for (int fk = 0; fk < fLen2; ++fk) {
-            for (int fj = 0; fj < fLen1; ++fj) {
-                for (int fi = 0; fi < fLen0; ++fi) {
-                    aT f_val = impulse_[index(fi, fj, fk, fLen0, fStride)];
-                    T s_val       = localMem_[index(ci - fi, cj - fj, ck - fk,
-                                             shrdLen0, skStride)];
-
-                    // binOp will do MUL_OP for convolution operation
-                    accum = accum + binOp((aT)s_val, (aT)f_val);
+        for (int c = lz, gz2 = gz; c < shrdLen2;
+             c += g.get_local_range(2), gz2 += g.get_local_range(2)) {
+            int k     = gz2 - radius2;
+            bool is_k = k >= 0 && k < d2;
+            for (int b = ly, gy2 = gy; b < shrdLen1;
+                 b += g.get_local_range(1), gy2 += g.get_local_range(1)) {
+                int j     = gy2 - radius1;
+                bool is_j = j >= 0 && j < d1;
+                for (int a = lx, gx2 = gx; a < shrdLen0;
+                     a += g.get_local_range(0), gx2 += g.get_local_range(0)) {
+                    int i     = gx2 - radius0;
+                    bool is_i = i >= 0 && i < d0;
+                    localMem_[c * skStride + b * shrdLen0 + a] =
+                        (is_i && is_j && is_k ? src[i * s0 + j * s1 + k * s2]
+                                              : (T)(0));
                 }
             }
         }
-        dst[index(gx, gy, gz, oInfo_.strides[1], oInfo_.strides[2])] = (T)accum;
-    }
-  }
+        it.barrier();
 
-private:
-write_accessor<T> out_;
-KParam oInfo_;
-read_accessor<T> signal_;
-KParam sInfo_;
-local_accessor<aT> localMem_;
-read_accessor<aT> impulse_;
-KParam fInfo_;
-int nBBS0_;
-int nBBS1_;
-int ostep1_;
-int ostep2_;
-int ostep3_;
-int sstep1_;
-int sstep2_;
-int sstep3_;
-const bool EXPAND_;
+        if (gx < oInfo_.dims[0] && gy < oInfo_.dims[1] && gz < oInfo_.dims[2]) {
+            int ci = lx + radius0 + (EXPAND_ ? 0 : fLen0 >> 1);
+            int cj = ly + radius1 + (EXPAND_ ? 0 : fLen1 >> 1);
+            int ck = lz + radius2 + (EXPAND_ ? 0 : fLen2 >> 1);
+
+            aT accum = (aT)(0);
+            for (int fk = 0; fk < fLen2; ++fk) {
+                for (int fj = 0; fj < fLen1; ++fj) {
+                    for (int fi = 0; fi < fLen0; ++fi) {
+                        aT f_val = impulse_[index(fi, fj, fk, fLen0, fStride)];
+                        T s_val  = localMem_[index(ci - fi, cj - fj, ck - fk,
+                                                   shrdLen0, skStride)];
+
+                        // binOp will do MUL_OP for convolution operation
+                        accum = accum + binOp((aT)s_val, (aT)f_val);
+                    }
+                }
+            }
+            dst[index(gx, gy, gz, oInfo_.strides[1], oInfo_.strides[2])] =
+                (T)accum;
+        }
+    }
+
+   private:
+    write_accessor<T> out_;
+    KParam oInfo_;
+    read_accessor<T> signal_;
+    KParam sInfo_;
+    local_accessor<aT> localMem_;
+    read_accessor<aT> impulse_;
+    KParam fInfo_;
+    int nBBS0_;
+    int nBBS1_;
+    int ostep1_;
+    int ostep2_;
+    int ostep3_;
+    int sstep1_;
+    int sstep2_;
+    int sstep3_;
+    const bool EXPAND_;
 };
 
 template<typename T, typename aT>
@@ -129,7 +150,10 @@ void conv3Helper(const conv_kparam_t<aT> &param, Param<T> &out,
         sycl::accessor impulseAcc{*param.impulse, h, sycl::read_only};
         h.parallel_for(
             sycl::nd_range{param.global, param.local},
-            conv3HelperCreateKernel<T, aT>(outAcc, out.info, signalAcc, signal.info, localMem, impulseAcc, impulse.info, param.nBBS0, param.nBBS1, param.o[0], param.o[1], param.o[2], param.s[0], param.s[1], param.s[2], EXPAND));
+            conv3HelperCreateKernel<T, aT>(
+                outAcc, out.info, signalAcc, signal.info, localMem, impulseAcc,
+                impulse.info, param.nBBS0, param.nBBS1, param.o[0], param.o[1],
+                param.o[2], param.s[0], param.s[1], param.s[2], EXPAND));
     });
 }
 

--- a/src/backend/oneapi/kernel/convolve3.hpp
+++ b/src/backend/oneapi/kernel/convolve3.hpp
@@ -1,0 +1,173 @@
+int index(int i, int j, int k, int jstride, int kstride) {
+    return i + j * jstride + k * kstride;
+}
+
+template <typename T, typename aT>
+class conv3HelperCreateKernel {
+public:
+ conv3HelperCreateKernel(write_accessor<T> out, KParam oInfo,
+                         read_accessor<T> signal, KParam sInfo,
+                         local_accessor<aT> localMem, read_accessor<aT> impulse,
+                         KParam fInfo, int nBBS0, int nBBS1, int ostep1, int ostep2,
+                         int ostep3, int sstep1, int sstep2, int sstep3, const bool EXPAND) : out_(out), oInfo_(oInfo), signal_(signal), sInfo_(sInfo), localMem_(localMem), impulse_(impulse), fInfo_(fInfo), nBBS0_(nBBS0), nBBS1_(nBBS1), ostep1_(ostep1), ostep2_(ostep2), ostep3_(ostep3), sstep1_(sstep1), sstep2_(sstep2), sstep3_(sstep3), EXPAND_(EXPAND) {}
+  void operator()(sycl::nd_item<3> it) const {
+      sycl::group g = it.get_group();
+    int fLen0    = fInfo_.dims[0];
+    int fLen1    = fInfo_.dims[1];
+    int fLen2    = fInfo_.dims[2];
+    int radius0  = fLen0 - 1;
+    int radius1  = fLen1 - 1;
+    int radius2  = fLen2 - 1;
+    int shrdLen0 = g.get_local_range(0) + 2 * radius0;
+    int shrdLen1 = g.get_local_range(1) + 2 * radius1;
+    int shrdLen2 = g.get_local_range(2) + 2 * radius2;
+    int skStride = shrdLen0 * shrdLen1;
+    int fStride  = fLen0 * fLen1;
+    unsigned b2  = g.get_group_id(0) / nBBS0_;
+
+    T *dst =
+      out_.get_pointer() +
+        (b2 * oInfo_.strides[3] +     /* activated with batched input signal_ */
+         ostep3_ * oInfo_.strides[3]); /* activated with batched input filter */
+
+    const T *src =
+      signal_.get_pointer() + sInfo_.offset +
+        (b2 * sInfo_.strides[3] +     /* activated with batched input signal_ */
+         sstep3_ * sInfo_.strides[3]); /* activated with batched input filter */
+
+    int lx  = it.get_local_id(0);
+    int ly  = it.get_local_id(1);
+    int lz  = it.get_local_id(2);
+    int gx  = g.get_local_range(0) * (g.get_group_id(0) - b2 * nBBS0_) + lx;
+    int gy  = g.get_local_range(1) * g.get_group_id(1) + ly;
+    int gz  = g.get_local_range(2) * g.get_group_id(2) + lz;
+    int lx2 = lx + g.get_local_range(0);
+    int ly2 = ly + g.get_local_range(1);
+    int lz2 = lz + g.get_local_range(2);
+    int gx2 = gx + g.get_local_range(0);
+    int gy2 = gy + g.get_local_range(1);
+    int gz2 = gz + g.get_local_range(2);
+
+    int s0 = sInfo_.strides[0];
+    int s1 = sInfo_.strides[1];
+    int s2 = sInfo_.strides[2];
+    int d0 = sInfo_.dims[0];
+    int d1 = sInfo_.dims[1];
+    int d2 = sInfo_.dims[2];
+
+    for (int c = lz, gz2 = gz; c < shrdLen2;
+         c += g.get_local_range(2), gz2 += g.get_local_range(2)) {
+        int k     = gz2 - radius2;
+        bool is_k = k >= 0 && k < d2;
+        for (int b = ly, gy2 = gy; b < shrdLen1;
+             b += g.get_local_range(1), gy2 += g.get_local_range(1)) {
+            int j     = gy2 - radius1;
+            bool is_j = j >= 0 && j < d1;
+            for (int a = lx, gx2 = gx; a < shrdLen0;
+                 a += g.get_local_range(0), gx2 += g.get_local_range(0)) {
+                int i     = gx2 - radius0;
+                bool is_i = i >= 0 && i < d0;
+                localMem_[c * skStride + b * shrdLen0 + a] =
+                    (is_i && is_j && is_k ?src[i * s0 + j * s1 + k * s2]
+                                          : (T)(0));
+            }
+        }
+    }
+    it.barrier();
+
+    if (gx < oInfo_.dims[0] && gy < oInfo_.dims[1] && gz < oInfo_.dims[2]) {
+        int ci = lx + radius0 + (EXPAND_ ? 0 : fLen0 >> 1);
+        int cj = ly + radius1 + (EXPAND_ ? 0 : fLen1 >> 1);
+        int ck = lz + radius2 + (EXPAND_ ? 0 : fLen2 >> 1);
+
+        aT accum = (aT)(0);
+        for (int fk = 0; fk < fLen2; ++fk) {
+            for (int fj = 0; fj < fLen1; ++fj) {
+                for (int fi = 0; fi < fLen0; ++fi) {
+                    aT f_val = impulse_[index(fi, fj, fk, fLen0, fStride)];
+                    T s_val       = localMem_[index(ci - fi, cj - fj, ck - fk,
+                                             shrdLen0, skStride)];
+
+                    // binOp will do MUL_OP for convolution operation
+                    accum = accum + binOp((aT)s_val, (aT)f_val);
+                }
+            }
+        }
+        dst[index(gx, gy, gz, oInfo_.strides[1], oInfo_.strides[2])] = (T)accum;
+    }
+  }
+
+private:
+write_accessor<T> out_;
+KParam oInfo_;
+read_accessor<T> signal_;
+KParam sInfo_;
+local_accessor<aT> localMem_;
+read_accessor<aT> impulse_;
+KParam fInfo_;
+int nBBS0_;
+int nBBS1_;
+int ostep1_;
+int ostep2_;
+int ostep3_;
+int sstep1_;
+int sstep2_;
+int sstep3_;
+const bool EXPAND_;
+};
+
+template<typename T, typename aT>
+void conv3Helper(const conv_kparam_t<aT> &param, Param<T> &out,
+                 const Param<T> &signal, const Param<aT> &impulse,
+                 const int rank, const bool EXPAND) {
+    getQueue().submit([&](auto &h) {
+        sycl::accessor<aT, 1, sycl::access::mode::read_write,
+                       sycl::access::target::local>
+            localMem(param.loc_size, h);
+        sycl::accessor outAcc{*out.data, h, sycl::write_only, sycl::no_init};
+        sycl::accessor signalAcc{*signal.data, h, sycl::read_only};
+        sycl::accessor impulseAcc{*param.impulse, h, sycl::read_only};
+        h.parallel_for(
+            sycl::nd_range{param.global, param.local},
+            conv3HelperCreateKernel<T, aT>(outAcc, out.info, signalAcc, signal.info, localMem, impulseAcc, impulse.info, param.nBBS0, param.nBBS1, param.o[0], param.o[1], param.o[2], param.s[0], param.s[1], param.s[2], EXPAND));
+    });
+}
+
+template<typename T, typename aT>
+void conv3(conv_kparam_t<aT> &p, Param<T> &out, const Param<T> &sig,
+           const Param<aT> &filt, const bool expand) {
+    size_t se_size = filt.info.dims[0] * filt.info.dims[1] * filt.info.dims[2];
+    sycl::buffer<aT> impulse{sycl::range(se_size)};
+    int f0Off = filt.info.offset;
+
+    for (int b3 = 0; b3 < filt.info.dims[3]; ++b3) {
+        int f3Off = b3 * filt.info.strides[3];
+
+        const size_t srcOffset = f3Off + f0Off;
+        memcpyBuffer(impulse, *filt.data, se_size, srcOffset);
+        p.impulse = &impulse;
+
+        p.o[2] = (p.outHasNoOffset ? 0 : b3);
+        p.s[2] = (p.inHasNoOffset ? 0 : b3);
+
+        conv3Helper<T, aT>(p, out, sig, filt, 3, expand);
+    }
+}
+
+#define INSTANTIATE_CONV3(T, aT)                                    \
+    template void conv3<T, aT>(conv_kparam_t<aT> &, Param<T> &,     \
+                               const Param<T> &, const Param<aT> &, \
+                               const bool);
+
+INSTANTIATE_CONV3(cdouble, cdouble)
+INSTANTIATE_CONV3(cfloat, cfloat)
+INSTANTIATE_CONV3(double, double)
+INSTANTIATE_CONV3(float, float)
+INSTANTIATE_CONV3(uint, float)
+INSTANTIATE_CONV3(int, float)
+INSTANTIATE_CONV3(uchar, float)
+INSTANTIATE_CONV3(char, float)
+INSTANTIATE_CONV3(ushort, float)
+INSTANTIATE_CONV3(short, float)
+INSTANTIATE_CONV3(uintl, float)
+INSTANTIATE_CONV3(intl, float)

--- a/src/backend/oneapi/kernel/convolve3.hpp
+++ b/src/backend/oneapi/kernel/convolve3.hpp
@@ -141,7 +141,8 @@ template<typename T, typename aT>
 void conv3Helper(const conv_kparam_t<aT> &param, Param<T> &out,
                  const Param<T> &signal, const Param<aT> &impulse,
                  const int rank, const bool EXPAND) {
-    getQueue().submit([&](auto &h) {
+    auto Q = getQueue();
+    Q.submit([&](auto &h) {
         sycl::accessor<aT, 1, sycl::access::mode::read_write,
                        sycl::access::target::local>
             localMem(param.loc_size, h);
@@ -155,6 +156,7 @@ void conv3Helper(const conv_kparam_t<aT> &param, Param<T> &out,
                 impulse.info, param.nBBS0, param.nBBS1, param.o[0], param.o[1],
                 param.o[2], param.s[0], param.s[1], param.s[2], EXPAND));
     });
+    ONEAPI_DEBUG_FINISH(Q);
 }
 
 template<typename T, typename aT>


### PR DESCRIPTION
convolve{1,2,3} port to one api. fails separable, unwrap, double, jit. as expected. re-written in separate files 

Checklist
---------
<!-- Check if done or not applicable -->
- [X] Rebased on latest master
- [X] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
