### PR TITLE
Fix clamp documentation

### DIFF
--- a/docs/details/arith.dox
+++ b/docs/details/arith.dox
@@ -190,13 +190,18 @@ Bitwise xor operation of two inputs
 Minimum of two inputs.
 
 
-
 \defgroup arith_func_max max
 
 \ingroup numeric_mat
 
 Maximum of two inputs.
 
+
+\defgroup arith_func_clamp clamp
+
+\ingroup numeric_mat
+
+Limits the range of the in array to the values between lo and hi
 
 
 \defgroup arith_func_rem rem

--- a/include/af/arith.h
+++ b/include/af/arith.h
@@ -888,16 +888,16 @@ extern "C" {
 
 #if AF_API_VERSION >= 34
     /**
-       C Interface for max of two arrays
+       C Interface for clamp
 
-       \param[out] out will contain the values from \p clamped between \p lo and \p hi
+       \param[out] out will contain the values from \p in clamped between \p lo and \p hi
        \param[in] in Input array
        \param[in] lo Value for lower limit
        \param[in] hi Value for upper limit
        \param[in] batch specifies if operations need to be performed in batch mode
        \return \ref AF_SUCCESS if the execution completes properly
 
-       \ingroup arith_func_max
+       \ingroup arith_func_clamp
     */
     AFAPI af_err af_clamp(af_array *out, const af_array in,
                           const af_array lo, const af_array hi, const bool batch);

--- a/test/clamp.cpp
+++ b/test/clamp.cpp
@@ -144,7 +144,7 @@ TEST_P(ClampFloatingPoint, Basic) {
     ASSERT_ARRAYS_NEAR(gold_, out, 1e-5);
 }
 
-TEST(ClampTests, FloatArrayArray) {
+TEST(Clamp, FloatArrayArray) {
     array in = randu(num, f32);
     array lo = randu(num, f32) / 10;        // Ensure lo <= 0.1
     array hi = 1.0 - randu(num, f32) / 10;  // Ensure hi >= 0.9
@@ -165,7 +165,7 @@ TEST(ClampTests, FloatArrayArray) {
     }
 }
 
-TEST(ClampTests, FloatArrayScalar) {
+TEST(Clamp, FloatArrayScalar) {
     array in = randu(num, f32);
     array lo = randu(num, f32) / 10;  // Ensure lo <= 0.1
     float hi = 0.9;
@@ -185,7 +185,7 @@ TEST(ClampTests, FloatArrayScalar) {
     }
 }
 
-TEST(ClampTests, FloatScalarArray) {
+TEST(Clamp, FloatScalarArray) {
     array in = randu(num, f32);
     float lo = 0.1;
     array hi = 1.0 - randu(num, f32) / 10;  // Ensure hi >= 0.9
@@ -205,7 +205,7 @@ TEST(ClampTests, FloatScalarArray) {
     }
 }
 
-TEST(ClampTests, FloatScalarScalar) {
+TEST(Clamp, FloatScalarScalar) {
     array in = randu(num, f32);
     float lo = 0.1;
     float hi = 0.9;


### PR DESCRIPTION
Clamp was showing up under the maxof function. This PR fixes this issue so that it correctly shows up in the function list.

Description
-----------
N/A

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- [x] Functions documented
