### PR TITLE
Avoid installing system forge when AF_INSTALL_STANDALONE not set

### DIFF
--- a/CMakeModules/AFconfigure_forge_dep.cmake
+++ b/CMakeModules/AFconfigure_forge_dep.cmake
@@ -75,7 +75,8 @@ else(AF_BUILD_FORGE)
 
     if(TARGET Forge::forge)
         get_target_property(fg_lib_type Forge::forge TYPE)
-        if(NOT ${fg_lib_type} STREQUAL "STATIC_LIBRARY")
+        if(NOT ${fg_lib_type} STREQUAL "STATIC_LIBRARY" AND
+           AF_INSTALL_STANDALONE)
             install(FILES
                     $<TARGET_FILE:Forge::forge>
                     $<$<PLATFORM_ID:Linux>:$<TARGET_SONAME_FILE:Forge::forge>>


### PR DESCRIPTION
Avoid installing system forge when AF_INSTALL_STANDALONE is OFF

Description
-----------

The install target was copying the forge library installed on the system. This is not expected because the install command only copies the artifacts generated by the project and not libraries installed on the system. We do want system libraries to be installed when AF_INSTALL_STANDALONE is enabled. This commit addresses both of these issues.

Fixes: #3295 

Changes to Users
----------------
System for libraries will not be installed when the install target is executed

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
