### PR TITLE
Add CMake targets and exports for afoneapi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,7 +470,7 @@ install(DIRECTORY "${ArrayFire_SOURCE_DIR}/LICENSES/"
     DESTINATION LICENSES
     COMPONENT licenses)
 
-foreach(backend CPU CUDA OpenCL Unified)
+foreach(backend CPU CUDA OpenCL oneAPI Unified)
   string(TOUPPER ${backend} upper_backend)
   string(TOLOWER ${backend} lower_backend)
   if(AF_BUILD_${upper_backend})

--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -265,6 +265,19 @@ target_link_libraries(afoneapi
     -fsycl
   )
 
+af_split_debug_info(afoneapi ${AF_INSTALL_LIB_DIR})
+
+install(TARGETS afoneapi
+  EXPORT ArrayFireoneAPITargets
+  COMPONENT oneapi
+  PUBLIC_HEADER DESTINATION af
+  RUNTIME DESTINATION ${AF_INSTALL_BIN_DIR}
+  LIBRARY DESTINATION ${AF_INSTALL_LIB_DIR}
+  ARCHIVE DESTINATION ${AF_INSTALL_LIB_DIR}
+  FRAMEWORK DESTINATION framework
+  INCLUDES DESTINATION ${AF_INSTALL_INC_DIR}
+)
+
 source_group(include REGULAR_EXPRESSION ${ArrayFire_SOURCE_DIR}/include/*)
 source_group(api\\cpp REGULAR_EXPRESSION ${ArrayFire_SOURCE_DIR}/src/api/cpp/*)
 source_group(api\\c   REGULAR_EXPRESSION ${ArrayFire_SOURCE_DIR}/src/api/c/*)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -478,6 +478,8 @@ elseif(AF_BUILD_CUDA)
   target_link_libraries(print_info ArrayFire::afcuda)
 elseif(AF_BUILD_CPU)
   target_link_libraries(print_info ArrayFire::afcpu)
+elseif(AF_BUILD_ONEAPI)
+  target_link_libraries(print_info ArrayFire::afoneapi)
 endif()
 
 make_test(SRC jit_test_api.cpp)


### PR DESCRIPTION
The oneAPI target was not creating CMake configuration files. This caused a problem with
the print_info target when no other backends were built because CMake didn't include the ArrayFire
include directories and libraries.

Description
-----------
Fixes: #3308 

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
