### PR TITLE
Add device-code-split flags to oneapi backend to avoid double failures

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -257,7 +257,9 @@ target_include_directories(afoneapi
   )
 
 target_compile_options(afoneapi
-  PRIVATE -fsycl)
+  PRIVATE
+    -fsycl
+    -fsycl-device-code-split=per_kernel)
 
 target_compile_definitions(afoneapi
   PRIVATE
@@ -270,6 +272,7 @@ target_link_libraries(afoneapi
     cpp_api_interface
     afcommon_interface
     -fsycl
+    -fsycl-device-code-split=per_kernel
   )
 
 af_split_debug_info(afoneapi ${AF_INSTALL_LIB_DIR})


### PR DESCRIPTION
Add `-fsycl-device-code-split=per_kernel` flags to avoid JITing double kernels on devices that don't support double

Description
-----------
By default the oneAPI JIT seems to perform kernel compilation on a per-file basis. This is fine
until you run on GPUs like the A770 which do not support doubles. The per-file JIT compilation
causes runtime failures when running operations that are not using doubles anywhere in the
code if there is an instantiation of that kernel using doubles in the same translation unit.

This PR adds the `-fsycl-device-code-split=per_kernel` flag so that only the instantiation that is
called is compiled.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
