### PR TITLE
adds per-kernel online compilation

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -258,7 +258,7 @@ target_include_directories(afoneapi
   )
 
 target_compile_options(afoneapi
-  PRIVATE -fsycl)
+  PRIVATE -fsycl -fsycl-device-code-split=per_kernel)
 
 target_compile_definitions(afoneapi
   PRIVATE
@@ -271,6 +271,7 @@ target_link_libraries(afoneapi
     cpp_api_interface
     afcommon_interface
     -fsycl
+	-fsycl-device-code-split=per_kernel
   )
 
 af_split_debug_info(afoneapi ${AF_INSTALL_LIB_DIR})

--- a/src/backend/oneapi/kernel/convolve3.hpp
+++ b/src/backend/oneapi/kernel/convolve3.hpp
@@ -142,11 +142,17 @@ void conv3Helper(const conv_kparam_t<aT> &param, Param<T> &out,
                  const Param<T> &signal, const Param<aT> &impulse,
                  const int rank, const bool EXPAND) {
     auto Q = getQueue();
+
+    static auto conv3ExeBundle =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+    getContext(), {sycl::get_kernel_id<conv3HelperCreateKernel<T, aT>>()} );
+
     Q.submit([&](auto &h) {
         local_accessor<aT> localMem(param.loc_size, h);
         write_accessor<T> outAcc{*out.data, h};
         read_accessor<T> signalAcc{*signal.data, h};
         read_accessor<aT> impulseAcc{*param.impulse, h};
+        h.use_kernel_bundle(conv3ExeBundle);
         h.parallel_for(
             sycl::nd_range{param.global, param.local},
             conv3HelperCreateKernel<T, aT>(

--- a/src/backend/oneapi/kernel/diagonal.hpp
+++ b/src/backend/oneapi/kernel/diagonal.hpp
@@ -79,11 +79,16 @@ static void diagCreate(Param<T> out, Param<T> in, int num) {
     auto global  = sycl::range{groups_x * local[0] * out.info.dims[2],
                               groups_y * local[1]};
 
+    static auto diagCreateExeBundle =
+    sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+        getContext(), {sycl::get_kernel_id<diagCreateKernel<T>>()} );
+
     getQueue().submit([&](sycl::handler &h) {
         auto oData = out.data->get_access(h);
         auto iData = in.data->get_access(h);
         sycl::stream debugStream(128, 128, h);
 
+        h.use_kernel_bundle(diagCreateExeBundle);
         h.parallel_for(sycl::nd_range{global, local},
                        diagCreateKernel<T>(oData, out.info, iData, in.info, num,
                                            groups_x));
@@ -148,11 +153,16 @@ static void diagExtract(Param<T> out, Param<T> in, int num) {
     auto global  = sycl::range{groups_x * local[0],
                               groups_z * local[1] * out.info.dims[3]};
 
+    static auto diagExtractExeBundle =
+    sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+        getContext(), {sycl::get_kernel_id<diagExtractKernel<T>>()} );
+
     getQueue().submit([&](sycl::handler &h) {
         auto oData = out.data->get_access(h);
         auto iData = in.data->get_access(h);
         sycl::stream debugStream(128, 128, h);
 
+        h.use_kernel_bundle(diagExtractExeBundle);
         h.parallel_for(sycl::nd_range{global, local},
                        diagExtractKernel<T>(oData, out.info, iData, in.info,
                                             num, groups_z));

--- a/src/backend/oneapi/kernel/iota.hpp
+++ b/src/backend/oneapi/kernel/iota.hpp
@@ -28,7 +28,7 @@ class iotaKernel {
    public:
     iotaKernel(sycl::accessor<T> out, KParam oinfo, const int s0, const int s1,
                const int s2, const int s3, const int blocksPerMatX,
-               const int blocksPerMatY, sycl::stream debug)
+               const int blocksPerMatY)
         : out_(out)
         , oinfo_(oinfo)
         , s0_(s0)
@@ -36,8 +36,7 @@ class iotaKernel {
         , s2_(s2)
         , s3_(s3)
         , blocksPerMatX_(blocksPerMatX)
-        , blocksPerMatY_(blocksPerMatY)
-        , debug_(debug) {}
+        , blocksPerMatY_(blocksPerMatY) {}
 
     void operator()(sycl::nd_item<2> it) const {
         sycl::group gg = it.get_group();
@@ -77,7 +76,6 @@ class iotaKernel {
     KParam oinfo_;
     int s0_, s1_, s2_, s3_;
     int blocksPerMatX_, blocksPerMatY_;
-    sycl::stream debug_;
 };
 
 template<typename T>
@@ -96,19 +94,21 @@ void iota(Param<T> out, const af::dim4& sdims) {
     sycl::nd_range<2> ndrange(global, local);
 
     try {
+        static auto iotaExeBundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            getContext(), {sycl::get_kernel_id<iotaKernel<T>>()} );
+
         getQueue()
             .submit([=](sycl::handler& h) {
                 auto out_acc = out.data->get_access(h);
 
-                sycl::stream debug_stream(2048, 128, h);
-
+                h.use_kernel_bundle(iotaExeBundle);
                 h.parallel_for(
                     ndrange,
                     iotaKernel<T>(out_acc, out.info, static_cast<int>(sdims[0]),
                                   static_cast<int>(sdims[1]),
                                   static_cast<int>(sdims[2]),
                                   static_cast<int>(sdims[3]), blocksPerMatX,
-                                  blocksPerMatY, debug_stream));
+                                  blocksPerMatY));
             })
             .wait();
         ONEAPI_DEBUG_FINISH(getQueue());

--- a/src/backend/oneapi/kernel/random_engine_philox.hpp
+++ b/src/backend/oneapi/kernel/random_engine_philox.hpp
@@ -107,22 +107,18 @@ template<typename T>
 class uniformPhilox {
    public:
     uniformPhilox(sycl::accessor<T> out, uint hi, uint lo, uint hic, uint loc,
-                  uint elementsPerBlock, uint elements,
-                  sycl::stream debug_stream)
+                  uint elementsPerBlock, uint elements)
         : out_(out)
         , hi_(hi)
         , lo_(lo)
         , hic_(hic)
         , loc_(loc)
         , elementsPerBlock_(elementsPerBlock)
-        , elements_(elements)
-        , debug_(debug_stream) {}
+        , elements_(elements) {}
 
     void operator()(sycl::nd_item<1> it) const {
         sycl::group g = it.get_group();
 
-        // debug_ << "<" << g.get_group_id(0)  << ":" << it.get_local_id(0) <<
-        // "/" << g.get_group_range(0) << sycl::stream_manipulator::endl;
         uint index = g.get_group_id(0) * elementsPerBlock_ + it.get_local_id(0);
         uint key[2] = {lo_, hi_};
         uint ctr[4] = {loc_, hic_, 0, 0};
@@ -145,28 +141,23 @@ class uniformPhilox {
     sycl::accessor<T> out_;
     uint hi_, lo_, hic_, loc_;
     uint elementsPerBlock_, elements_;
-    sycl::stream debug_;
 };
 
 template<typename T>
 class normalPhilox {
    public:
     normalPhilox(sycl::accessor<T> out, uint hi, uint lo, uint hic, uint loc,
-                 uint elementsPerBlock, uint elements,
-                 sycl::stream debug_stream)
+                 uint elementsPerBlock, uint elements)
         : out_(out)
         , hi_(hi)
         , lo_(lo)
         , hic_(hic)
         , loc_(loc)
         , elementsPerBlock_(elementsPerBlock)
-        , elements_(elements)
-        , debug_(debug_stream) {}
+        , elements_(elements) {}
 
     void operator()(sycl::nd_item<1> it) const {
         sycl::group g = it.get_group();
-        // debug_ << "<" << g.get_group_id(0)  << ":" << it.get_local_id(0) <<
-        // "/" << g.get_group_range(0) << sycl::stream_manipulator::endl;
 
         uint index = g.get_group_id(0) * elementsPerBlock_ + it.get_local_id(0);
         uint key[2] = {lo_, hi_};
@@ -192,7 +183,6 @@ class normalPhilox {
     sycl::accessor<T> out_;
     uint hi_, lo_, hic_, loc_;
     uint elementsPerBlock_, elements_;
-    sycl::stream debug_;
 };
 
 }  // namespace kernel

--- a/src/backend/oneapi/kernel/random_engine_threefry.hpp
+++ b/src/backend/oneapi/kernel/random_engine_threefry.hpp
@@ -162,16 +162,14 @@ template<typename T>
 class uniformThreefry {
    public:
     uniformThreefry(sycl::accessor<T> out, uint hi, uint lo, uint hic, uint loc,
-                    uint elementsPerBlock, uint elements,
-                    sycl::stream debug_stream)
+                    uint elementsPerBlock, uint elements)
         : out_(out)
         , hi_(hi)
         , lo_(lo)
         , hic_(hic)
         , loc_(loc)
         , elementsPerBlock_(elementsPerBlock)
-        , elements_(elements)
-        , debug_(debug_stream) {}
+        , elements_(elements) {}
 
     void operator()(sycl::nd_item<1> it) const {
         sycl::group g = it.get_group();
@@ -203,23 +201,20 @@ class uniformThreefry {
     sycl::accessor<T> out_;
     uint hi_, lo_, hic_, loc_;
     uint elementsPerBlock_, elements_;
-    sycl::stream debug_;
 };
 
 template<typename T>
 class normalThreefry {
    public:
     normalThreefry(sycl::accessor<T> out, uint hi, uint lo, uint hic, uint loc,
-                   uint elementsPerBlock, uint elements,
-                   sycl::stream debug_stream)
+                   uint elementsPerBlock, uint elements)
         : out_(out)
         , hi_(hi)
         , lo_(lo)
         , hic_(hic)
         , loc_(loc)
         , elementsPerBlock_(elementsPerBlock)
-        , elements_(elements)
-        , debug_(debug_stream) {}
+        , elements_(elements) {}
 
     void operator()(sycl::nd_item<1> it) const {
         sycl::group g = it.get_group();
@@ -251,7 +246,6 @@ class normalThreefry {
     sycl::accessor<T> out_;
     uint hi_, lo_, hic_, loc_;
     uint elementsPerBlock_, elements_;
-    sycl::stream debug_;
 };
 
 }  // namespace kernel

--- a/src/backend/oneapi/kernel/random_engine_write.hpp
+++ b/src/backend/oneapi/kernel/random_engine_write.hpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 #pragma once
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 
 namespace arrayfire {
 namespace oneapi {

--- a/src/backend/oneapi/kernel/range.hpp
+++ b/src/backend/oneapi/kernel/range.hpp
@@ -29,20 +29,14 @@ template<typename T>
 class rangeOp {
    public:
     rangeOp(sycl::accessor<T> out, KParam oinfo, const int dim,
-            const int blocksPerMatX, const int blocksPerMatY,
-            sycl::stream debug)
+            const int blocksPerMatX, const int blocksPerMatY)
         : out_(out)
         , oinfo_(oinfo)
         , dim_(dim)
         , blocksPerMatX_(blocksPerMatX)
-        , blocksPerMatY_(blocksPerMatY)
-        , debug_(debug) {}
+        , blocksPerMatY_(blocksPerMatY) {}
 
     void operator()(sycl::nd_item<2> it) const {
-        // printf("[%d,%d]\n", it.get_global_id(0), it.get_global_id(1));
-        // debug_ << "[" << it.get_global_id(0) << "," << it.get_global_id(1) <<
-        // "]" << sycl::stream_manipulator::endl;
-
         const int mul0 = (dim_ == 0);
         const int mul1 = (dim_ == 1);
         const int mul2 = (dim_ == 2);
@@ -87,7 +81,6 @@ class rangeOp {
     KParam oinfo_;
     int dim_;
     int blocksPerMatX_, blocksPerMatY_;
-    sycl::stream debug_;
 };
 
 template<typename T>
@@ -105,14 +98,17 @@ void range(Param<T> out, const int dim) {
                           local[1] * blocksPerMatY * out.info.dims[3]);
     sycl::nd_range<2> ndrange(global, local);
 
+    static auto rangeExeBundle =
+    sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+        getContext(), {sycl::get_kernel_id<rangeOp<T>>()} );
+
     getQueue().submit([=](sycl::handler& h) {
         auto out_acc = out.data->get_access(h);
 
-        sycl::stream debug_stream(2048, 128, h);
-
+        h.use_kernel_bundle(rangeExeBundle);
         h.parallel_for(ndrange,
                        rangeOp<T>(out_acc, out.info, dim, blocksPerMatX,
-                                  blocksPerMatY, debug_stream));
+                                  blocksPerMatY));
     });
     ONEAPI_DEBUG_FINISH(getQueue());
 }

--- a/src/backend/oneapi/kernel/reduce_first.hpp
+++ b/src/backend/oneapi/kernel/reduce_first.hpp
@@ -40,14 +40,15 @@ using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
 template<typename T>
 using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
-template<typename Ti, typename To, af_op_t op, uint DIMX>
+template<typename Ti, typename To, af_op_t op>
 class reduceFirstKernelSMEM {
    public:
+    static constexpr sycl::specialization_id<uint> dimx;
+
     reduceFirstKernelSMEM(write_accessor<To> out, KParam oInfo,
                           read_accessor<Ti> in, KParam iInfo, uint groups_x,
                           uint groups_y, uint repeat, bool change_nan,
-                          To nanval, local_accessor<compute_t<To>, 1> s_val,
-                          sycl::stream debug)
+                          To nanval, local_accessor<compute_t<To>, 1> s_val)
         : out_(out)
         , oInfo_(oInfo)
         , iInfo_(iInfo)
@@ -57,10 +58,11 @@ class reduceFirstKernelSMEM {
         , repeat_(repeat)
         , change_nan_(change_nan)
         , nanval_(nanval)
-        , s_val_(s_val)
-        , debug_(debug) {}
+        , s_val_(s_val) {}
 
-    void operator()(sycl::nd_item<2> it) const {
+    void operator()(sycl::nd_item<2> it, sycl::kernel_handler kh) const {
+        uint DIMX = kh.get_specialization_constant<reduceFirstKernelSMEM::dimx>();
+
         sycl::group g   = it.get_group();
         const uint lidx = it.get_local_id(0);
         const uint lidy = it.get_local_id(1);
@@ -68,8 +70,8 @@ class reduceFirstKernelSMEM {
 
         const uint zid       = g.get_group_id(0) / groups_x_;
         const uint wid       = g.get_group_id(1) / groups_y_;
-        const uint groupId_x = g.get_group_id(0) - (groups_x_)*zid;
-        const uint groupId_y = g.get_group_id(1) - (groups_y_)*wid;
+        const uint groupId_x = g.get_group_id(0) - (groups_x_) * zid;
+        const uint groupId_y = g.get_group_id(1) - (groups_y_) * wid;
         const uint xid = groupId_x * g.get_local_range(0) * repeat_ + lidx;
         const uint yid = groupId_y * g.get_local_range(1) + lidy;
 
@@ -147,7 +149,6 @@ class reduceFirstKernelSMEM {
     bool change_nan_;
     To nanval_;
     local_accessor<compute_t<To>, 1> s_val_;
-    sycl::stream debug_;
 };
 
 template<typename Ti, typename To, af_op_t op>
@@ -161,45 +162,26 @@ void reduce_first_launcher_default(Param<To> out, Param<Ti> in,
 
     uint repeat = divup(in.info.dims[0], (groups_x * threads_x));
 
+    static auto reduceInputBundle =
+    sycl::get_kernel_bundle<sycl::bundle_state::input>(
+        getContext(),
+        {sycl::get_kernel_id<reduceFirstKernelSMEM<Ti, To, op>>()});
+    reduceInputBundle.template set_specialization_constant<reduceFirstKernelSMEM<Ti, To, op>::dimx>(threads_x);
+    static auto reduceExeBundle = sycl::build(reduceInputBundle);
+
     getQueue().submit([=](sycl::handler &h) {
         write_accessor<To> out_acc{*out.data, h};
         read_accessor<Ti> in_acc{*in.data, h};
 
-        sycl::stream debug_stream(2048 * 256, 128, h);
-
         auto shrdMem =
             local_accessor<compute_t<To>, 1>(creduce::THREADS_PER_BLOCK, h);
 
-        switch (threads_x) {
-            case 32:
-                h.parallel_for(sycl::nd_range<2>(global, local),
-                               reduceFirstKernelSMEM<Ti, To, op, 32>(
-                                   out_acc, out.info, in_acc, in.info, groups_x,
-                                   groups_y, repeat, change_nan,
-                                   scalar<To>(nanval), shrdMem, debug_stream));
-                break;
-            case 64:
-                h.parallel_for(sycl::nd_range<2>(global, local),
-                               reduceFirstKernelSMEM<Ti, To, op, 64>(
-                                   out_acc, out.info, in_acc, in.info, groups_x,
-                                   groups_y, repeat, change_nan,
-                                   scalar<To>(nanval), shrdMem, debug_stream));
-                break;
-            case 128:
-                h.parallel_for(sycl::nd_range<2>(global, local),
-                               reduceFirstKernelSMEM<Ti, To, op, 128>(
-                                   out_acc, out.info, in_acc, in.info, groups_x,
-                                   groups_y, repeat, change_nan,
-                                   scalar<To>(nanval), shrdMem, debug_stream));
-                break;
-            case 256:
-                h.parallel_for(sycl::nd_range<2>(global, local),
-                               reduceFirstKernelSMEM<Ti, To, op, 256>(
-                                   out_acc, out.info, in_acc, in.info, groups_x,
-                                   groups_y, repeat, change_nan,
-                                   scalar<To>(nanval), shrdMem, debug_stream));
-                break;
-        }
+        h.use_kernel_bundle(reduceExeBundle);
+        h.parallel_for(sycl::nd_range<2>(global, local),
+                        reduceFirstKernelSMEM<Ti, To, op>(
+                            out_acc, out.info, in_acc, in.info, groups_x,
+                            groups_y, repeat, change_nan,
+                            scalar<To>(nanval), shrdMem));
     });
     ONEAPI_DEBUG_FINISH(getQueue());
 }

--- a/src/backend/oneapi/kernel/select.hpp
+++ b/src/backend/oneapi/kernel/select.hpp
@@ -140,11 +140,17 @@ void selectLauncher(Param<T> out, Param<char> cond, Param<T> a, Param<T> b,
     auto global = sycl::range(groups_0 * out.info.dims[2] * local[0],
                               groups_1 * out.info.dims[3] * local[1]);
 
+    static auto selectExeBundle =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            getContext(),
+            {sycl::get_kernel_id<selectKernelCreateKernel<T>>()});
+
     getQueue().submit([&](auto &h) {
         write_accessor<T> d_out{*out.data, h};
         read_accessor<char> d_cond{*cond.data, h};
         read_accessor<T> d_a{*a.data, h};
         read_accessor<T> d_b{*b.data, h};
+        h.use_kernel_bundle(selectExeBundle);
         h.parallel_for(sycl::nd_range{global, local},
                        selectKernelCreateKernel<T>(
                            d_out, out.info, d_cond, cond.info, d_a, a.info, d_b,
@@ -243,10 +249,16 @@ void select_scalar(Param<T> out, Param<char> cond, Param<T> a, const T b,
     auto global = sycl::range(groups_0 * out.info.dims[2] * local[0],
                               groups_1 * out.info.dims[3] * local[1]);
 
+    static auto selectExeBundle =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            getContext(),
+            {sycl::get_kernel_id<selectScalarCreateKernel<T>>()});
+
     getQueue().submit([&](auto &h) {
         write_accessor<T> d_out{*out.data, h};
         read_accessor<char> d_cond{*cond.data, h};
         read_accessor<T> d_a{*a.data, h};
+        h.use_kernel_bundle(selectExeBundle);
         h.parallel_for(
             sycl::nd_range{global, local},
             selectScalarCreateKernel<T>(d_out, out.info, d_cond, cond.info, d_a,

--- a/src/backend/oneapi/kernel/transpose.hpp
+++ b/src/backend/oneapi/kernel/transpose.hpp
@@ -54,7 +54,7 @@ class transposeKernel {
                     const sycl::accessor<T> iData, const KParam in,
                     const int blocksPerMatX, const int blocksPerMatY,
                     const bool conjugate, const bool IS32MULTIPLE,
-                    local_accessor<T, 1> shrdMem, sycl::stream debugStream)
+                    local_accessor<T, 1> shrdMem)
         : oData_(oData)
         , out_(out)
         , iData_(iData)
@@ -63,8 +63,8 @@ class transposeKernel {
         , blocksPerMatY_(blocksPerMatY)
         , conjugate_(conjugate)
         , IS32MULTIPLE_(IS32MULTIPLE)
-        , shrdMem_(shrdMem)
-        , debugStream_(debugStream) {}
+        , shrdMem_(shrdMem) {}
+
     void operator()(sycl::nd_item<2> it) const {
         const int shrdStride = TILE_DIM + 1;
 
@@ -134,7 +134,6 @@ class transposeKernel {
     bool conjugate_;
     bool IS32MULTIPLE_;
     local_accessor<T, 1> shrdMem_;
-    sycl::stream debugStream_;
 };
 
 template<typename T>
@@ -148,17 +147,22 @@ void transpose(Param<T> out, const Param<T> in, const bool conjugate,
     auto global = sycl::range{blk_x * local[0] * in.info.dims[2],
                               blk_y * local[1] * in.info.dims[3]};
 
+    static auto transposeExeBundle =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            getContext(),
+            {sycl::get_kernel_id<transposeKernel<T>>()});
+
     getQueue().submit([&](sycl::handler &h) {
         auto r = in.data->get_access(h);
         auto q = out.data->get_access(h);
-        sycl::stream debugStream(128, 128, h);
 
         auto shrdMem = local_accessor<T, 1>(TILE_DIM * (TILE_DIM + 1), h);
 
+        h.use_kernel_bundle(transposeExeBundle);
         h.parallel_for(
             sycl::nd_range{global, local},
             transposeKernel<T>(q, out.info, r, in.info, blk_x, blk_y, conjugate,
-                               IS32MULTIPLE, shrdMem, debugStream));
+                               IS32MULTIPLE, shrdMem));
     });
     ONEAPI_DEBUG_FINISH(getQueue());
 }

--- a/src/backend/oneapi/kernel/where.hpp
+++ b/src/backend/oneapi/kernel/where.hpp
@@ -37,7 +37,7 @@ class whereKernel {
                 read_accessor<uint> otmp_acc, KParam otInfo,
                 read_accessor<uint> rtmp_acc, KParam rtInfo,
                 read_accessor<T> in_acc, KParam iInfo, uint groups_x,
-                uint groups_y, uint lim, sycl::stream debug)
+                uint groups_y, uint lim)
         : out_acc_(out_acc)
         , otmp_acc_(otmp_acc)
         , rtmp_acc_(rtmp_acc)
@@ -48,8 +48,7 @@ class whereKernel {
         , iInfo_(iInfo)
         , groups_x_(groups_x)
         , groups_y_(groups_y)
-        , lim_(lim)
-        , debug_(debug) {}
+        , lim_(lim) {}
 
     void operator()(sycl::nd_item<2> it) const {
         sycl::group g   = it.get_group();
@@ -99,7 +98,6 @@ class whereKernel {
     read_accessor<T> in_acc_;
     KParam oInfo_, otInfo_, rtInfo_, iInfo_;
     uint groups_x_, groups_y_, lim_;
-    sycl::stream debug_;
 };
 
 template<typename T>
@@ -175,17 +173,22 @@ static void where(Param<uint> &out, Param<T> in) {
                           groups_y * in.info.dims[3] * local[1]);
     uint lim = divup(otmp.info.dims[0], (threads_x * groups_x));
 
+    static auto whereExeBundle =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            getContext(),
+            {sycl::get_kernel_id<whereKernel<T>>()});
+
     getQueue().submit([&](sycl::handler &h) {
         write_accessor<uint> out_acc{*out.data, h};
         read_accessor<uint> otmp_acc{*otmp.data, h};
         read_accessor<uint> rtmp_acc{*rtmp.data, h};
         read_accessor<T> in_acc{*in.data, h};
 
-        sycl::stream debug_stream(2048 * 256, 128, h);
+        h.use_kernel_bundle(whereExeBundle);
         h.parallel_for(sycl::nd_range<2>(global, local),
                        whereKernel<T>(out_acc, out.info, otmp_acc, otmp.info,
                                       rtmp_acc, rtmp.info, in_acc, in.info,
-                                      groups_x, groups_y, lim, debug_stream));
+                                      groups_x, groups_y, lim));
     });
     ONEAPI_DEBUG_FINISH(getQueue());
     out_alloc.release();


### PR DESCRIPTION
Allows for subset of kernels to be built right before they are used. 

Description
-----------
Allows for subset of kernels to be built right before they are used. This needs to be done programmatically
since the -fsycl-device-code-split=per_kernel is currently broken. Thoeretically, this should result in faster initial runtimes since only the kernels that are used will be compiled. Although this PR is written to request a single kernel at a time, the current sycl implementation does not return just one kernel and many kernels actually end up being built. There will still be a runtime speedup, just not as efficient as possible for now(perhaps the implementation will evolve).

A few of the changed kernels were also updated to use sycl::specialization_id constants instead of template parameters. Less template parameters should reduce compile times eventually once the specialization constants are optimized in the compiler. Specialization constants will permit avoiding the generation of all template parameters and only generate a subset of the parameters required during runtime.

