### PR TITLE
Initial implementation of OpenCL based JIT for the oneAPI backend

### DIFF
--- a/src/backend/oneapi/Array.hpp
+++ b/src/backend/oneapi/Array.hpp
@@ -283,6 +283,11 @@ class Array {
         return out;
     }
 
+    operator AParam<T>() {
+        AParam<T> out(*getData(), dims().get(), strides().get(), getOffset());
+        return out;
+    }
+
     operator KParam() const {
         KParam kinfo = {
             {dims()[0], dims()[1], dims()[2], dims()[3]},

--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 include(InternalUtils)
 include(build_cl2hpp)
+include(FileToString)
 
 add_library(afoneapi
   Array.cpp
@@ -93,6 +94,8 @@ add_library(afoneapi
   ireduce.cpp
   ireduce.hpp
   jit.cpp
+  jit/BufferNode.hpp
+  jit/kernel_generators.hpp
   join.cpp
   join.hpp
   logic.hpp
@@ -239,6 +242,24 @@ target_sources(afoneapi
     kernel/wrap_dilated.hpp
 )
 
+set(kernel_src
+  ${CMAKE_CURRENT_SOURCE_DIR}/../opencl/kernel/KParam.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/../opencl/kernel/jit.cl
+)
+
+set( kernel_headers_dir "kernel_headers")
+
+file_to_string(
+  SOURCES ${kernel_src}
+  VARNAME kernel_files
+  EXTENSION "hpp"
+  OUTPUT_DIR ${kernel_headers_dir}
+  TARGETS cl_kernel_targets
+  NAMESPACE "arrayfire oneapi opencl"
+)
+
+add_dependencies(afoneapi ${cl_kernel_targets})
+
 add_library(ArrayFire::afoneapi ALIAS afoneapi)
 
 arrayfire_set_default_cxx_flags(afoneapi)
@@ -254,23 +275,40 @@ target_include_directories(afoneapi
     $<INSTALL_INTERFACE:${AF_INSTALL_INC_DIR}>
   PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
-
+    ${CMAKE_CURRENT_BINARY_DIR}
   )
 
 target_compile_options(afoneapi
-  PRIVATE -fsycl)
+  PRIVATE
+    -fsycl
+    #-fsycl-targets=nvptx64-vidia-cuda
+    #-fsycl-force-target=nvptx64-nvidia-cuda-sm_86
+    #-Wno-unknown-cuda-version
+    -sycl-std=2020
+)
 
 target_compile_definitions(afoneapi
   PRIVATE
     AF_ONEAPI
+    CL_TARGET_OPENCL_VERSION=300
+    CL_HPP_TARGET_OPENCL_VERSION=300
+    CL_HPP_MINIMUM_OPENCL_VERSION=110
+    CL_HPP_ENABLE_EXCEPTIONS
   )
 
 target_link_libraries(afoneapi
   PRIVATE
+    -fsycl
+    -fno-lto
+    -fvisibility-inlines-hidden
+    #-fsycl-targets=nvptx64-nvidia-cuda-sm_86
+    #-fsycl-force-target=nvptx64-nvidia-cuda-sm_86
     c_api_interface
     cpp_api_interface
     afcommon_interface
-    -fsycl
+    OpenCL::OpenCL
+    OpenCL::cl2hpp
+    #-Wno-unknown-cuda-version
   )
 
 af_split_debug_info(afoneapi ${AF_INSTALL_LIB_DIR})

--- a/src/backend/oneapi/Kernel.hpp
+++ b/src/backend/oneapi/Kernel.hpp
@@ -26,69 +26,40 @@ inline auto getLogger() -> spdlog::logger* {
 }  // namespace kernel_logger
 
 /*
+ */
 struct Enqueuer {
     template<typename... Args>
-    void operator()(std::string name, sycl::kernel ker,
-                    const cl::EnqueueArgs& qArgs, Args&&... args) {
-        auto launchOp = cl::KernelFunctor<Args...>(ker);
+    void operator()(std::string name, sycl::kernel ker, const Enqueuer& qArgs,
+                    Args&&... args) {
+        // auto launchOp = cl::KernelFunctor<Args...>(ker);
         using namespace kernel_logger;
         AF_TRACE("Launching {}", name);
-        launchOp(qArgs, std::forward<Args>(args)...);
+        // launchOp(qArgs, std::forward<Args>(args)...);
     }
 };
 
-class Kernel
-    : public common::KernelInterface<const cl::Program*, cl::Kernel, Enqueuer,
-                                     cl::Buffer*> {
-   public:
-    using ModuleType = const sycl::program*;
-    using KernelType = sycl::kernel;
-    using DevPtrType<T> = sycl::buffer<T>*;
-    using BaseClass =
-        common::KernelInterface<ModuleType, KernelType, Enqueuer,
-DevPtrType<T>>;
-
-    Kernel() : BaseClass("", nullptr, cl::Kernel{nullptr, false}) {}
-    Kernel(std::string name, ModuleType mod, KernelType ker)
-        : BaseClass(name, mod, ker) {}
-
-    // clang-format off
-    [[deprecated("OpenCL backend doesn't need Kernel::getDevPtr method")]]
-    DevPtrType<T> getDevPtr(const char* name) final;
-    // clang-format on
-
-    void copyToReadOnly(DevPtrType<T> dst, DevPtrType<T> src, size_t bytes)
-final;
-
-    void setFlag(DevPtrType<T> dst, int* scalarValPtr,
-                 const bool syncCopy = false) final;
-
-    int getFlag(DevPtrType<T> src) final;
-};
-*/
-
 class Kernel {
-   public:
-    using ModuleType =
-        const sycl::kernel_bundle<sycl::bundle_state::executable>*;
-    using KernelType = sycl::kernel;
-    template<typename T>
-    using DevPtrType = sycl::buffer<T>*;
-    // using BaseClass =
-    // common::KernelInterface<ModuleType, KernelType, Enqueuer, DevPtrType<T>>;
-
-    Kernel() {}
-    Kernel(std::string name, ModuleType mod, KernelType ker) {}
-
-    template<typename T>
-    void copyToReadOnly(DevPtrType<T> dst, DevPtrType<T> src, size_t bytes);
-
-    template<typename T>
-    void setFlag(DevPtrType<T> dst, int* scalarValPtr,
-                 const bool syncCopy = false);
-
-    template<typename T>
-    int getFlag(DevPtrType<T> src);
+    //   public:
+    //    using BaseClass =
+    //      common::KernelInterface<ModuleType, KernelType, Enqueuer,
+    //      sycl::buffer<float>*>;
+    //
+    //  Kernel() : {}
+    //    Kernel(std::string name, ModuleType mod, KernelType ker)
+    //        : BaseClass(name, mod, ker) {}
+    //
+    //    // clang-format off
+    //    [[deprecated("OpenCL backend doesn't need Kernel::getDevPtr method")]]
+    //    DevPtrType getDevPtr(const char* name) final;
+    //    // clang-format on
+    //
+    //    void copyToReadOnly(DevPtrType dst, DevPtrType src, size_t bytes)
+    // final;
+    //
+    //    void setFlag(DevPtrType dst, int* scalarValPtr,
+    //                 const bool syncCopy = false) final;
+    //
+    //    int getFlag(DevPtrType src) final;
 };
 
 }  // namespace oneapi

--- a/src/backend/oneapi/arith.hpp
+++ b/src/backend/oneapi/arith.hpp
@@ -11,7 +11,6 @@
 
 #include <Array.hpp>
 #include <common/jit/BinaryNode.hpp>
-#include <err_oneapi.hpp>
 #include <optypes.hpp>
 #include <af/dim4.hpp>
 
@@ -21,14 +20,12 @@ namespace oneapi {
 template<typename T, af_op_t op>
 Array<T> arithOp(const Array<T> &&lhs, const Array<T> &&rhs,
                  const af::dim4 &odims) {
-    ONEAPI_NOT_SUPPORTED(__FUNCTION__);
     return common::createBinaryNode<T, T, op>(lhs, rhs, odims);
 }
 
 template<typename T, af_op_t op>
 Array<T> arithOp(const Array<T> &lhs, const Array<T> &rhs,
                  const af::dim4 &odims) {
-    ONEAPI_NOT_SUPPORTED(__FUNCTION__);
     return common::createBinaryNode<T, T, op>(lhs, rhs, odims);
 }
 }  // namespace oneapi

--- a/src/backend/oneapi/err_oneapi.hpp
+++ b/src/backend/oneapi/err_oneapi.hpp
@@ -16,3 +16,31 @@
         throw SupportError(__AF_FUNC__, __AF_FILENAME__, __LINE__, message, \
                            boost::stacktrace::stacktrace());                \
     } while (0)
+
+#define CL_CHECK(call)                                                      \
+    do {                                                                    \
+        if (cl_int err = (call)) {                                          \
+            char cl_err_msg[2048];                                          \
+            const char* cl_err_call = #call;                                \
+            snprintf(cl_err_msg, sizeof(cl_err_msg),                        \
+                     "CL Error %s(%d): %d = %s\n", __FILE__, __LINE__, err, \
+                     cl_err_call);                                          \
+            AF_ERROR(cl_err_msg, AF_ERR_INTERNAL);                          \
+        }                                                                   \
+    } while (0)
+
+#define CL_CHECK_BUILD(call)                                                  \
+    do {                                                                      \
+        if (cl_int err = (call)) {                                            \
+            char log[8192];                                                   \
+            char cl_err_msg[8192];                                            \
+            const char* cl_err_call = #call;                                  \
+            size_t log_ret;                                                   \
+            clGetProgramBuildInfo(prog, dev, CL_PROGRAM_BUILD_LOG, 8192, log, \
+                                  &log_ret);                                  \
+            snprintf(cl_err_msg, sizeof(cl_err_msg),                          \
+                     "OpenCL Error building %s(%d): %d = %s\nLog:\n%s",       \
+                     __FILE__, __LINE__, err, cl_err_call, log);              \
+            AF_ERROR(cl_err_msg, AF_ERR_INTERNAL);                            \
+        }                                                                     \
+    } while (0)

--- a/src/backend/oneapi/histogram.cpp
+++ b/src/backend/oneapi/histogram.cpp
@@ -26,9 +26,7 @@ Array<uint> histogram(const Array<T> &in, const unsigned &nbins,
                       const bool isLinear) {
     const dim4 &dims = in.dims();
     dim4 outDims     = dim4(nbins, 1, dims[2], dims[3]);
-    // Array<uint> out  = createValueArray<uint>(outDims, uint(0));
-    // \TODO revert createEmptyArray to createValueArray once JIT functions
-    Array<uint> out = createEmptyArray<uint>(outDims);
+    Array<uint> out  = createValueArray<uint>(outDims, uint(0));
     kernel::histogram<T>(out, in, nbins, minval, maxval, isLinear);
     return out;
 }

--- a/src/backend/oneapi/index.cpp
+++ b/src/backend/oneapi/index.cpp
@@ -22,7 +22,7 @@ namespace oneapi {
 
 template<typename T>
 Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
-    ONEAPI_NOT_SUPPORTED("");
+    ONEAPI_NOT_SUPPORTED("Indexing not supported");
     Array<T> out = createEmptyArray<T>(af::dim4(1));
     return out;
 }

--- a/src/backend/oneapi/jit.cpp
+++ b/src/backend/oneapi/jit.cpp
@@ -7,21 +7,32 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#include <CL/cl.h>
+#include <jit/kernel_generators.hpp>
+
+#include <kernel_headers/KParam.hpp>
+#include <kernel_headers/jit.hpp>
+
 #include <Array.hpp>
-#include <common/compile_module.hpp>
+#include <common/debug.hpp>
 #include <common/dispatch.hpp>
+#include <common/half.hpp>
 #include <common/jit/ModdimNode.hpp>
 #include <common/jit/Node.hpp>
 #include <common/jit/NodeIterator.hpp>
-#include <common/kernel_cache.hpp>
 #include <common/util.hpp>
 #include <copy.hpp>
 #include <device_manager.hpp>
 #include <err_oneapi.hpp>
+#include <jit/BufferNode.hpp>
+#include <platform.hpp>
+#include <type_util.hpp>
 #include <af/dim4.hpp>
 
-//#include <jit/BufferNode.hpp>
+#include <sycl/backend.hpp>
+#include <sycl/interop_handle.hpp>
 
+#include <array>
 #include <cstdio>
 #include <functional>
 #include <sstream>
@@ -30,44 +41,553 @@
 #include <vector>
 
 using arrayfire::common::getFuncName;
+using arrayfire::common::half;
+using arrayfire::common::ModdimNode;
 using arrayfire::common::Node;
 using arrayfire::common::Node_ids;
 using arrayfire::common::Node_map_t;
+using arrayfire::common::Node_ptr;
+using arrayfire::common::NodeIterator;
+using arrayfire::oneapi::getActiveDeviceBaseBuildFlags;
+using arrayfire::oneapi::jit::BufferNode;
 
+using std::array;
+using std::find_if;
 using std::string;
 using std::stringstream;
 using std::to_string;
 using std::vector;
 
+using sycl::backend;
+
 namespace arrayfire {
+
+namespace opencl {
+string getKernelString(const string& funcName, const vector<Node*>& full_nodes,
+                       const vector<Node_ids>& full_ids,
+                       const vector<int>& output_ids, const bool is_linear,
+                       const bool loop0, const bool loop1, const bool loop3) {
+    // Common OpenCL code
+    // This part of the code does not change with the kernel.
+
+    static const char* kernelVoid = R"JIT(
+__kernel void )JIT";
+    static const char* dimParams  = "KParam oInfo";
+    static const char* blockStart = "{";
+    static const char* blockEnd   = "\n}\n";
+
+    static const char* linearInit = R"JIT(
+   int idx = get_global_id(0);
+   const int idxEnd = oInfo.dims[0];
+   if (idx < idxEnd) {
+)JIT";
+    static const char* linearEnd  = R"JIT(
+   })JIT";
+
+    static const char* linearLoop0Start = R"JIT(
+        const int idxID0Inc = get_global_size(0);
+        do {)JIT";
+    static const char* linearLoop0End   = R"JIT(
+            idx += idxID0Inc;
+            if (idx >= idxEnd) break;
+        } while (true);)JIT";
+
+    // ///////////////////////////////////////////////
+    // oInfo = output optimized information (dims, strides, offset).
+    //         oInfo has removed dimensions, to optimized block scheduling
+    // iInfo = input internal information (dims, strides, offset)
+    //         iInfo has the original dimensions, auto generated code
+    //
+    // Loop3 is fastest and becomes inside loop, since
+    //      - #of loops is known upfront
+    // Loop1 is used for extra dynamic looping (writing into cache)
+    // All loops are conditional and idependent
+    // Format Loop1 & Loop3
+    // ////////////////////////////
+    //  *stridedLoopNInit               // Always
+    //  *stridedLoop1Init               // Conditional
+    //  *stridedLoop2Init               // Conditional
+    //  *stridedLoop3Init               // Conditional
+    //  *stridedLoop1Start              // Conditional
+    //      *stridedLoop3Start          // Conditional
+    //          auto generated code     // Always
+    //      *stridedLoop3End            // Conditional
+    //  *stridedLoop1End                // Conditional
+    //  *StridedEnd                     // Always
+    //
+    // format loop0 (Vector only)
+    // //////////////////////////
+    // *stridedLoop0Init                // Always
+    // *stridedLoop0Start               // Always
+    //      auto generated code         // Always
+    // *stridedLoop0End                 // Always
+    // *stridedEnd                      // Always
+
+    static const char* stridedLoop0Init  = R"JIT(
+    int id0 = get_global_id(0);
+    const int id0End = oInfo.dims[0];
+    if (id0 < id0End) {
+#define id1 0
+#define id2 0
+#define id3 0
+        const int ostrides0 = oInfo.strides[0];
+        int idx = ostrides0*id0;)JIT";
+    static const char* stridedLoop0Start = R"JIT(
+        const int id0Inc = get_global_size(0);
+        const int idxID0Inc = ostrides0*id0Inc;
+        do {)JIT";
+    static const char* stridedLoop0End   = R"JIT(
+            id0 += id0Inc;
+            if (id0 >= id0End) break;
+            idx += idxID0Inc;
+        } while (true);)JIT";
+
+    // -------------
+    static const char* stridedLoopNInit = R"JIT(
+    int id0 = get_global_id(0);
+    int id1 = get_global_id(1);
+    const int id0End = oInfo.dims[0];
+    const int id1End = oInfo.dims[1];
+    //printf("id0: %d  id1: %d id0End: %d, id1End: %d\n")
+    if ((id0 < id0End) & (id1 < id1End)) {
+        const int id2 = get_global_id(2);
+#define id3 0
+        const int ostrides1 = oInfo.strides[1];
+        int idx = (int)oInfo.strides[0]*id0 + ostrides1*id1 + (int)oInfo.strides[2]*id2;)JIT";
+    static const char* stridedEnd       = R"JIT(
+    })JIT";
+
+    static const char* stridedLoop3Init  = R"JIT(
+#undef id3
+        int id3 = 0;
+        const int id3End = oInfo.dims[3];
+        const int idxID3Inc = oInfo.strides[3];)JIT";
+    static const char* stridedLoop3Start = R"JIT(
+                const int idxBaseID3 = idx;
+                do {)JIT";
+    static const char* stridedLoop3End   = R"JIT(
+                    ++id3;
+                    if (id3 == id3End) break;
+                    idx += idxID3Inc;
+                } while (true);
+                id3 = 0;
+                idx = idxBaseID3;)JIT";
+
+    static const char* stridedLoop1Init  = R"JIT(
+        const int id1Inc = get_global_size(1);
+        const int idxID1Inc = id1Inc * ostrides1;)JIT";
+    static const char* stridedLoop1Start = R"JIT(
+        do {)JIT";
+    static const char* stridedLoop1End   = R"JIT(
+            id1 += id1Inc;
+            if (id1 >= id1End) break;
+            idx += idxID1Inc;
+        } while (true);)JIT";
+
+    // Reuse stringstreams, because they are very costly during initilization
+    thread_local stringstream inParamStream;
+    thread_local stringstream outParamStream;
+    thread_local stringstream outOffsetStream;
+    thread_local stringstream inOffsetsStream;
+    thread_local stringstream opsStream;
+
+    int oid{0};
+    for (size_t i{0}; i < full_nodes.size(); i++) {
+        const auto& node{full_nodes[i]};
+        const auto& ids_curr{full_ids[i]};
+        // Generate input parameters, only needs current id
+        node->genParams(inParamStream, ids_curr.id, is_linear);
+        // Generate input offsets, only needs current id
+        node->genOffsets(inOffsetsStream, ids_curr.id, is_linear);
+        // Generate the core function body, needs children ids as well
+        node->genFuncs(opsStream, ids_curr);
+        for (auto outIt{begin(output_ids)}, endIt{end(output_ids)};
+             (outIt = find(outIt, endIt, ids_curr.id)) != endIt; ++outIt) {
+            // Generate also output parameters
+            outParamStream << "__global "
+                           << full_nodes[ids_curr.id]->getTypeStr() << " *out"
+                           << oid << ", int offset" << oid << ",\n";
+            // Apply output offset
+            outOffsetStream << "\nout" << oid << " += offset" << oid << ';';
+            // Generate code to write the output
+            opsStream << "out" << oid << "[idx] = val" << ids_curr.id << ";\n";
+            ++oid;
+        }
+    }
+
+    thread_local stringstream kerStream;
+    kerStream << kernelVoid << funcName << "(\n"
+              << inParamStream.str() << outParamStream.str() << dimParams << ")"
+              << blockStart;
+    if (is_linear) {
+        kerStream << linearInit << inOffsetsStream.str()
+                  << outOffsetStream.str() << '\n';
+        if (loop0) kerStream << linearLoop0Start;
+        kerStream << "\n\n" << opsStream.str();
+        if (loop0) kerStream << linearLoop0End;
+        kerStream << linearEnd;
+    } else {
+        if (loop0) {
+            kerStream << stridedLoop0Init << outOffsetStream.str() << '\n'
+                      << stridedLoop0Start;
+        } else {
+            kerStream << stridedLoopNInit << outOffsetStream.str() << '\n';
+            if (loop3) kerStream << stridedLoop3Init;
+            if (loop1) kerStream << stridedLoop1Init << stridedLoop1Start;
+            if (loop3) kerStream << stridedLoop3Start;
+        }
+        kerStream << "\n\n" << inOffsetsStream.str() << opsStream.str();
+        if (loop3) kerStream << stridedLoop3End;
+        if (loop1) kerStream << stridedLoop1End;
+        if (loop0) kerStream << stridedLoop0End;
+        kerStream << stridedEnd;
+    }
+    kerStream << blockEnd;
+    const string ret{kerStream.str()};
+
+    // Prepare for next round, limit memory
+    inParamStream.str("");
+    outParamStream.str("");
+    inOffsetsStream.str("");
+    outOffsetStream.str("");
+    opsStream.str("");
+    kerStream.str("");
+
+    return ret;
+}
+
+// cl::Kernel getKernel(const vector<Node*>& output_nodes,
+//                      const vector<int>& output_ids,
+//                      const vector<Node*>& full_nodes,
+//                      const vector<Node_ids>& full_ids, const bool is_linear)
+//                      {
+//     ONEAPI_NOT_SUPPORTED("");
+//     return common::getKernel("", "", true).get();
+// }
+
+}  // namespace opencl
+
 namespace oneapi {
 
-string getKernelString(const string &funcName, const vector<Node *> &full_nodes,
-                       const vector<Node_ids> &full_ids,
-                       const vector<int> &output_ids, bool is_linear) {
-    ONEAPI_NOT_SUPPORTED("");
-    return "";
+template<typename T>
+void evalNodes(vector<Param<T>>& outputs, const vector<Node*>& output_nodes) {
+    if (outputs.empty()) return;
+    Node_map_t nodes;
+    vector<Node*> full_nodes;
+    vector<Node_ids> full_ids;
+    vector<int> output_ids;
+    vector<Node_ptr> node_clones;
+
+    bool is_linear{true};
+    dim_t numOutElems{1};
+    KParam& out_info{outputs[0].info};
+    dim_t* outDims{out_info.dims};
+    dim_t* outStrides{out_info.strides};
+
+    dim_t ndims{outDims[3] > 1   ? 4
+                : outDims[2] > 1 ? 3
+                : outDims[1] > 1 ? 2
+                : outDims[0] > 0 ? 1
+                                 : 0};
+    for (dim_t dim{0}; dim < ndims; ++dim) {
+        is_linear &= (numOutElems == outStrides[dim]);
+        numOutElems *= outDims[dim];
+    }
+    if (numOutElems == 0) { return; }
+
+    const af::dtype outputType{output_nodes[0]->getType()};
+    for (Node* node : output_nodes) {
+        assert(node->getType() == outputType);
+        const int id{node->getNodesMap(nodes, full_nodes, full_ids)};
+        output_ids.push_back(id);
+    }
+
+    bool moddimsFound{false};
+    for (const Node* node : full_nodes) {
+        is_linear &= node->isLinear(outDims);
+        moddimsFound |= (node->getOp() == af_moddims_t);
+    }
+
+    bool emptyColumnsFound{false};
+    if (is_linear) {
+        outDims[0]    = numOutElems;
+        outDims[1]    = 1;
+        outDims[2]    = 1;
+        outDims[3]    = 1;
+        outStrides[0] = 1;
+        outStrides[1] = numOutElems;
+        outStrides[2] = numOutElems;
+        outStrides[3] = numOutElems;
+        ndims         = 1;
+    } else {
+        emptyColumnsFound = ndims > (outDims[0] == 1   ? 1
+                                     : outDims[1] == 1 ? 2
+                                     : outDims[2] == 1 ? 3
+                                                       : 4);
+    }
+
+    // for (auto* node : full_nodes) SHOW(*node);
+    //  Keep in global scope, so that the nodes remain active for later
+    //  referral in case moddims operations or column elimination have to
+    //  take place
+    //  Avoid all cloning/copying when no moddims node is present (high
+    //  chance)
+    if (moddimsFound || emptyColumnsFound) {
+        node_clones.clear();
+        node_clones.reserve(full_nodes.size());
+        for (Node* node : full_nodes) {
+            node_clones.emplace_back(node->clone());
+        }
+
+        for (const Node_ids& ids : full_ids) {
+            auto& children{node_clones[ids.id]->m_children};
+            for (int i{0}; i < Node::kMaxChildren && children[i] != nullptr;
+                 i++) {
+                children[i] = node_clones[ids.child_ids[i]];
+            }
+        }
+
+        if (moddimsFound) {
+            const auto isModdim{[](const Node_ptr& ptr) {
+                return ptr->getOp() == af_moddims_t;
+            }};
+            for (auto nodeIt{begin(node_clones)}, endIt{end(node_clones)};
+                 (nodeIt = find_if(nodeIt, endIt, isModdim)) != endIt;
+                 ++nodeIt) {
+                const ModdimNode* mn{static_cast<ModdimNode*>(nodeIt->get())};
+
+                const auto new_strides{calcStrides(mn->m_new_shape)};
+                const auto isBuffer{
+                    [](const Node& node) { return node.isBuffer(); }};
+                for (NodeIterator<> it{nodeIt->get()}, end{NodeIterator<>()};
+                     (it = find_if(it, end, isBuffer)) != end; ++it) {
+                    jit::BufferNode<T>* buf{
+                        static_cast<jit::BufferNode<T>*>(&(*it))};
+                    buf->m_param.dims[0]    = mn->m_new_shape[0];
+                    buf->m_param.dims[1]    = mn->m_new_shape[1];
+                    buf->m_param.dims[2]    = mn->m_new_shape[2];
+                    buf->m_param.dims[3]    = mn->m_new_shape[3];
+                    buf->m_param.strides[0] = new_strides[0];
+                    buf->m_param.strides[1] = new_strides[1];
+                    buf->m_param.strides[2] = new_strides[2];
+                    buf->m_param.strides[3] = new_strides[3];
+                }
+            }
+        }
+        if (emptyColumnsFound) {
+            const auto isBuffer{
+                [](const Node_ptr& ptr) { return ptr->isBuffer(); }};
+            for (auto nodeIt{begin(node_clones)}, endIt{end(node_clones)};
+                 (nodeIt = find_if(nodeIt, endIt, isBuffer)) != endIt;
+                 ++nodeIt) {
+                BufferNode<T>* buf{static_cast<BufferNode<T>*>(nodeIt->get())};
+                removeEmptyColumns(outDims, ndims, buf->m_param.dims.get(),
+                                   buf->m_param.strides.get());
+            }
+            for_each(++begin(outputs), end(outputs),
+                     [outDims, ndims](Param<T>& output) {
+                         removeEmptyColumns(outDims, ndims, output.info.dims,
+                                            output.info.strides);
+                     });
+            ndims = removeEmptyColumns(outDims, ndims, outDims, outStrides);
+        }
+
+        full_nodes.clear();
+        for (Node_ptr& node : node_clones) { full_nodes.push_back(node.get()); }
+    }
+
+    const string funcName{getFuncName(output_nodes, full_nodes, full_ids,
+                                      is_linear, false, false, false,
+                                      outputs[0].info.dims[2] > 1)};
+
+    getQueue()
+        .submit([&](sycl::handler& h) {
+            for (Node* node : full_nodes) {
+                if (node->isBuffer()) {
+                    BufferNode<T>* n = static_cast<BufferNode<T>*>(node);
+                    n->m_param.require(h);
+                }
+            }
+            vector<AParam<T>> ap;
+            transform(begin(outputs), end(outputs), back_inserter(ap),
+                      [&](const Param<T>& p) {
+                          return AParam<T>(h, *p.data, p.info.dims,
+                                           p.info.strides, p.info.offset);
+                      });
+
+            h.host_task([ap, full_nodes, output_ids, full_ids, is_linear,
+                         funcName](sycl::interop_handle hh) {
+                switch (hh.get_backend()) {
+                    case backend::opencl: {
+                        string jitstr = arrayfire::opencl::getKernelString(
+                            funcName, full_nodes, full_ids, output_ids,
+                            is_linear, false, false, ap[0].dims[2] > 1);
+
+                        cl_command_queue q =
+                            hh.get_native_queue<backend::opencl>();
+                        cl_context ctx =
+                            hh.get_native_context<backend::opencl>();
+                        cl_device_id dev =
+                            hh.get_native_device<backend::opencl>();
+
+                        cl_int err;
+                        vector<const char*> jitsources = {
+                            {arrayfire::oneapi::opencl::KParam_hpp,
+                             arrayfire::oneapi::opencl::jit_cl,
+                             jitstr.c_str()}};
+                        vector<size_t> jitsizes = {
+                            arrayfire::oneapi::opencl::KParam_hpp_len,
+                            arrayfire::oneapi::opencl::jit_cl_len,
+                            jitstr.size()};
+
+                        cl_program prog = clCreateProgramWithSource(
+                            ctx, jitsources.size(), jitsources.data(),
+                            jitsizes.data(), &err);
+
+                        std::string options = getActiveDeviceBaseBuildFlags();
+
+                        CL_CHECK_BUILD(clBuildProgram(
+                            prog, 1, &dev, options.c_str(), nullptr, nullptr));
+
+                        vector<cl_kernel> kernels(10);
+                        cl_uint ret_kernels = 0;
+                        CL_CHECK(clCreateKernelsInProgram(
+                            prog, 1, kernels.data(), &ret_kernels));
+                        int nargs{0};
+                        for (Node* node : full_nodes) {
+                            if (node->isBuffer()) {
+                                nargs = node->setArgs(
+                                    nargs, is_linear,
+                                    [&kernels, &hh, &is_linear](
+                                        int id, const void* ptr,
+                                        size_t arg_size) {
+                                        AParam<T>* info =
+                                            static_cast<AParam<T>*>(
+                                                const_cast<void*>(ptr));
+                                        vector<cl_mem> mem =
+                                            hh.get_native_mem<backend::opencl>(
+                                                info->ph.value());
+                                        if (is_linear) {
+                                            CL_CHECK(clSetKernelArg(
+                                                kernels[0], id++,
+                                                sizeof(cl_mem), &mem[0]));
+                                            CL_CHECK(clSetKernelArg(
+                                                kernels[0], id++, sizeof(dim_t),
+                                                &info->offset));
+                                        } else {
+                                            CL_CHECK(clSetKernelArg(
+                                                kernels[0], id++,
+                                                sizeof(cl_mem), &mem[0]));
+                                            KParam ooo = *info;
+                                            CL_CHECK(clSetKernelArg(
+                                                kernels[0], id++,
+                                                sizeof(KParam), &ooo));
+                                        }
+                                    });
+                            } else {
+                                nargs = node->setArgs(
+                                    nargs, is_linear,
+                                    [&kernels](int id, const void* ptr,
+                                               size_t arg_size) {
+                                        CL_CHECK(clSetKernelArg(kernels[0], id,
+                                                                arg_size, ptr));
+                                    });
+                            }
+                        }
+
+                        // Set output parameters
+                        vector<cl_mem> mem;
+                        for (const auto& output : ap) {
+                            mem = hh.get_native_mem<backend::opencl>(
+                                output.data.value());
+                            cl_mem mmm = mem[0];
+                            CL_CHECK(clSetKernelArg(kernels[0], nargs++,
+                                                    sizeof(cl_mem), &mmm));
+                            int off = output.offset;
+                            CL_CHECK(clSetKernelArg(kernels[0], nargs++,
+                                                    sizeof(int), &off));
+                        }
+                        const KParam ooo = ap[0];
+                        CL_CHECK(clSetKernelArg(kernels[0], nargs++,
+                                                sizeof(KParam), &ooo));
+                        array<size_t, 3> offset{0, 0, 0};
+                        array<size_t, 3> global;
+                        int ndims = 0;
+                        if (is_linear) {
+                            global = {(size_t)ap[0].dims.elements(), 0, 0};
+                            ndims  = 1;
+                        } else {
+                            global = {(size_t)ap[0].dims[0],
+                                      (size_t)ap[0].dims[1],
+                                      (size_t)ap[0].dims[2]};
+                            ndims  = 3;
+                        }
+                        // SHOW(global);
+                        CL_CHECK(clEnqueueNDRangeKernel(
+                            q, kernels[0], ndims, offset.data(), global.data(),
+                            nullptr, 0, nullptr, nullptr));
+
+                        CL_CHECK(clReleaseKernel(kernels[0]));
+                        CL_CHECK(clReleaseProgram(prog));
+                        CL_CHECK(clReleaseDevice(dev));
+                        CL_CHECK(clReleaseContext(ctx));
+                        CL_CHECK(clReleaseCommandQueue(q));
+
+                    } break;
+                    default: ONEAPI_NOT_SUPPORTED("Backend not supported");
+                }
+            });
+        })
+        .wait();
 }
 
-/*
-cl::Kernel getKernel(const vector<Node *> &output_nodes,
-                     const vector<int> &output_ids,
-                     const vector<Node *> &full_nodes,
-                     const vector<Node_ids> &full_ids, const bool is_linear) {
-    ONEAPI_NOT_SUPPORTED("");
-    return common::getKernel("", "", true).get();
-}
-*/
-
-/*
-void evalNodes(vector<Param> &outputs, const vector<Node *> &output_nodes) {
-    ONEAPI_NOT_SUPPORTED("");
+template<typename T>
+void evalNodes(Param<T>& out, Node* node) {
+    vector<Param<T>> outputs{out};
+    vector<Node*> nodes{node};
+    oneapi::evalNodes(outputs, nodes);
 }
 
-void evalNodes(Param &out, Node *node) {
-    ONEAPI_NOT_SUPPORTED("");
-}
-*/
+template void evalNodes<float>(Param<float>& out, Node* node);
+template void evalNodes<double>(Param<double>& out, Node* node);
+template void evalNodes<cfloat>(Param<cfloat>& out, Node* node);
+template void evalNodes<cdouble>(Param<cdouble>& out, Node* node);
+template void evalNodes<int>(Param<int>& out, Node* node);
+template void evalNodes<uint>(Param<uint>& out, Node* node);
+template void evalNodes<char>(Param<char>& out, Node* node);
+template void evalNodes<uchar>(Param<uchar>& out, Node* node);
+template void evalNodes<intl>(Param<intl>& out, Node* node);
+template void evalNodes<uintl>(Param<uintl>& out, Node* node);
+template void evalNodes<short>(Param<short>& out, Node* node);
+template void evalNodes<ushort>(Param<ushort>& out, Node* node);
+template void evalNodes<half>(Param<half>& out, Node* node);
+
+template void evalNodes<float>(vector<Param<float>>& out,
+                               const vector<Node*>& node);
+template void evalNodes<double>(vector<Param<double>>& out,
+                                const vector<Node*>& node);
+template void evalNodes<cfloat>(vector<Param<cfloat>>& out,
+                                const vector<Node*>& node);
+template void evalNodes<cdouble>(vector<Param<cdouble>>& out,
+                                 const vector<Node*>& node);
+template void evalNodes<int>(vector<Param<int>>& out,
+                             const vector<Node*>& node);
+template void evalNodes<uint>(vector<Param<uint>>& out,
+                              const vector<Node*>& node);
+template void evalNodes<char>(vector<Param<char>>& out,
+                              const vector<Node*>& node);
+template void evalNodes<uchar>(vector<Param<uchar>>& out,
+                               const vector<Node*>& node);
+template void evalNodes<intl>(vector<Param<intl>>& out,
+                              const vector<Node*>& node);
+template void evalNodes<uintl>(vector<Param<uintl>>& out,
+                               const vector<Node*>& node);
+template void evalNodes<short>(vector<Param<short>>& out,
+                               const vector<Node*>& node);
+template void evalNodes<ushort>(vector<Param<ushort>>& out,
+                                const vector<Node*>& node);
+template void evalNodes<half>(vector<Param<half>>& out,
+                              const vector<Node*>& node);
 
 }  // namespace oneapi
 }  // namespace arrayfire

--- a/src/backend/oneapi/jit/BufferNode.hpp
+++ b/src/backend/oneapi/jit/BufferNode.hpp
@@ -8,7 +8,9 @@
  ********************************************************/
 
 #pragma once
+#include <Param.hpp>
 #include <common/jit/BufferNodeBase.hpp>
+#include <jit/kernel_generators.hpp>
 
 #include <memory>
 
@@ -17,7 +19,7 @@ namespace oneapi {
 namespace jit {
 template<typename T>
 using BufferNode =
-    common::BufferNodeBase<std::shared_ptr<sycl::buffer<T>>, KParam>;
+    common::BufferNodeBase<std::shared_ptr<sycl::buffer<T>>, AParam<T>>;
 }
 }  // namespace oneapi
 

--- a/src/backend/oneapi/jit/kernel_generators.hpp
+++ b/src/backend/oneapi/jit/kernel_generators.hpp
@@ -8,10 +8,15 @@
  ********************************************************/
 
 #pragma once
+#include <Param.hpp>
+#include <err_oneapi.hpp>
+
+#include <sycl/buffer.hpp>
+
+#include <functional>
+#include <memory>
 #include <sstream>
 #include <string>
-
-#include <err_oneapi.hpp>
 
 namespace arrayfire {
 namespace oneapi {
@@ -27,7 +32,7 @@ inline void generateParamDeclaration(std::stringstream& kerStream, int id,
                   << ", dim_t iInfo" << id << "_offset, \n";
     } else {
         kerStream << "__global " << m_type_str << " *in" << id
-                  << ", Param iInfo" << id << ", \n";
+                  << ", KParam iInfo" << id << ", \n";
     }
 }
 
@@ -36,18 +41,8 @@ template<typename T>
 inline int setKernelArguments(
     int start_id, bool is_linear,
     std::function<void(int id, const void* ptr, size_t arg_size)>& setArg,
-    const std::shared_ptr<sycl::buffer<T>>& ptr, const KParam& info) {
-    // TODO(oneapi)
-    ONEAPI_NOT_SUPPORTED("ERROR");
-    // setArg(start_id + 0, static_cast<const void*>(&ptr.get()->operator()()),
-    // sizeof(cl_mem));
-    if (is_linear) {
-        // setArg(start_id + 1, static_cast<const void*>(&info.offset),
-        // sizeof(dim_t));
-    } else {
-        // setArg(start_id + 1, static_cast<const void*>(&info),
-        // sizeof(KParam));
-    }
+    const std::shared_ptr<sycl::buffer<T>>& ptr, const AParam<T>& info) {
+    setArg(start_id + 0, static_cast<const void*>(&info), sizeof(Param<T>));
     return start_id + 2;
 }
 

--- a/src/backend/oneapi/kernel/KParam.hpp
+++ b/src/backend/oneapi/kernel/KParam.hpp
@@ -10,11 +10,11 @@
 #ifndef __KPARAM_H
 #define __KPARAM_H
 
-//#ifndef __OPENCL_VERSION__
-// Only define dim_t in host code. dim_t is defined when setting the program
-// options in program.cpp
+// #ifndef __OPENCL_VERSION__
+//  Only define dim_t in host code. dim_t is defined when setting the program
+//  options in program.cpp
 #include <af/defines.h>
-//#endif
+// #endif
 
 // Defines the size and shape of the data in the OpenCL buffer
 typedef struct {

--- a/src/backend/oneapi/kernel/histogram.hpp
+++ b/src/backend/oneapi/kernel/histogram.hpp
@@ -142,15 +142,6 @@ void histogram(Param<uint> out, const Param<T> in, int nbins, float minval,
     const size_t global1 = in.info.dims[3];
     auto global          = sycl::range{global0, global1};
 
-    // \TODO drop this first memset once createEmptyArray is reverted back to
-    //       createValueArray in ../histogram.cpp
-    getQueue()
-        .submit([&](sycl::handler &h) {
-            auto outAcc = out.data->get_access(h);
-            h.parallel_for(sycl::range<1>{(size_t)nbins},
-                           [=](sycl::id<1> idx) { outAcc[idx[0]] = 0; });
-        })
-        .wait();
     getQueue().submit([&](sycl::handler &h) {
         auto inAcc  = in.data->get_access(h);
         auto outAcc = out.data->get_access(h);

--- a/src/backend/oneapi/kernel/reduce_all.hpp
+++ b/src/backend/oneapi/kernel/reduce_all.hpp
@@ -262,14 +262,8 @@ void reduce_all_launcher_default(Param<To> out, Param<Ti> in,
             AF_ERR_RUNTIME);
     }
     Array<To> tmp = createEmptyArray<To>(tmp_elements);
-    // TODO: JIT dependency
-    // Array<unsigned> retirementCount = createValueArray<unsigned>(1, 0);
-    Array<unsigned> retirementCount = createEmptyArray<unsigned>(1);
-    getQueue().submit([=](sycl::handler &h) {
-        auto acc = retirementCount.getData()->get_access(h);
-        h.single_task([=] { acc[0] = 0; });
-    });
 
+    Array<unsigned> retirementCount = createValueArray<unsigned>(1, 0);
     getQueue().submit([=](sycl::handler &h) {
         write_accessor<To> out_acc{*out.data, h};
         auto retCount_acc = retirementCount.getData()->get_access(h);

--- a/src/backend/oneapi/memory.cpp
+++ b/src/backend/oneapi/memory.cpp
@@ -205,18 +205,10 @@ void Allocator::shutdown() {
     // }
 }
 
-int Allocator::getActiveDeviceId() {
-    ONEAPI_NOT_SUPPORTED("Allocator::getActiveDeviceId Not supported");
-
-    return 0;
-    // return opencl::getActiveDeviceId();
-}
+int Allocator::getActiveDeviceId() { return oneapi::getActiveDeviceId(); }
 
 size_t Allocator::getMaxMemorySize(int id) {
-    ONEAPI_NOT_SUPPORTED("Allocator::getMaxMemorySize Not supported");
-
-    return 0;
-    // return opencl::getDeviceMemorySize(id);
+    return oneapi::getDeviceMemorySize(id);
 }
 
 void *Allocator::nativeAlloc(const size_t bytes) {

--- a/test/binary.cpp
+++ b/test/binary.cpp
@@ -44,60 +44,54 @@ af::array randgen(const int num, dtype ty) {
 
 #define MY_ASSERT_NEAR(aa, bb, cc) ASSERT_NEAR(abs(aa), abs(bb), (cc))
 
-#define BINARY_TESTS(Ta, Tb, Tc, func)                                \
-    TEST(BinaryTests, Test_##func##_##Ta##_##Tb) {                    \
-        SUPPORTED_TYPE_CHECK(Ta);                                     \
-        SUPPORTED_TYPE_CHECK(Tb);                                     \
-        SUPPORTED_TYPE_CHECK(Tc);                                     \
-                                                                      \
-        af_dtype ta = (af_dtype)dtype_traits<Ta>::af_type;            \
-        af_dtype tb = (af_dtype)dtype_traits<Tb>::af_type;            \
-        af::array a = randgen(num, ta);                               \
-        af::array b = randgen(num, tb);                               \
-        af::array c = func(a, b);                                     \
-        Ta *h_a     = a.host<Ta>();                                   \
-        Tb *h_b     = b.host<Tb>();                                   \
-        Tc *h_c     = c.host<Tc>();                                   \
-        for (int i = 0; i < num; i++)                                 \
-            ASSERT_EQ(h_c[i], func(h_a[i], h_b[i]))                   \
-                << "for values: " << h_a[i] << "," << h_b[i] << endl; \
-        af_free_host(h_a);                                            \
-        af_free_host(h_b);                                            \
-        af_free_host(h_c);                                            \
-    }                                                                 \
-                                                                      \
-    TEST(BinaryTests, Test_##func##_##Ta##_##Tb##_left) {             \
-        SUPPORTED_TYPE_CHECK(Ta);                                     \
-        SUPPORTED_TYPE_CHECK(Tb);                                     \
-                                                                      \
-        af_dtype ta = (af_dtype)dtype_traits<Ta>::af_type;            \
-        af::array a = randgen(num, ta);                               \
-        Tb h_b      = 3.0;                                            \
-        af::array c = func(a, h_b);                                   \
-        Ta *h_a     = a.host<Ta>();                                   \
-        Ta *h_c     = c.host<Ta>();                                   \
-        for (int i = 0; i < num; i++)                                 \
-            ASSERT_EQ(h_c[i], func(h_a[i], h_b))                      \
-                << "for values: " << h_a[i] << "," << h_b << endl;    \
-        af_free_host(h_a);                                            \
-        af_free_host(h_c);                                            \
-    }                                                                 \
-                                                                      \
-    TEST(BinaryTests, Test_##func##_##Ta##_##Tb##_right) {            \
-        SUPPORTED_TYPE_CHECK(Ta);                                     \
-        SUPPORTED_TYPE_CHECK(Tb);                                     \
-                                                                      \
-        af_dtype tb = (af_dtype)dtype_traits<Tb>::af_type;            \
-        Ta h_a      = 5.0;                                            \
-        af::array b = randgen(num, tb);                               \
-        af::array c = func(h_a, b);                                   \
-        Tb *h_b     = b.host<Tb>();                                   \
-        Tb *h_c     = c.host<Tb>();                                   \
-        for (int i = 0; i < num; i++)                                 \
-            ASSERT_EQ(h_c[i], func(h_a, h_b[i]))                      \
-                << "for values: " << h_a << "," << h_b[i] << endl;    \
-        af_free_host(h_b);                                            \
-        af_free_host(h_c);                                            \
+#define BINARY_TESTS(Ta, Tb, Tc, func)                                    \
+    TEST(BinaryTests, Test_##func##_##Ta##_##Tb) {                        \
+        SUPPORTED_TYPE_CHECK(Ta);                                         \
+        SUPPORTED_TYPE_CHECK(Tb);                                         \
+        SUPPORTED_TYPE_CHECK(Tc);                                         \
+                                                                          \
+        af_dtype ta = (af_dtype)dtype_traits<Ta>::af_type;                \
+        af_dtype tb = (af_dtype)dtype_traits<Tb>::af_type;                \
+        af::array a = randgen(num, ta);                                   \
+        af::array b = randgen(num, tb);                                   \
+        af::array c = func(a, b);                                         \
+        Ta *h_a     = a.host<Ta>();                                       \
+        Tb *h_b     = b.host<Tb>();                                       \
+        vector<Tc> gold(num);                                             \
+        for (int i = 0; i < num; i++) { gold[i] = func(h_a[i], h_b[i]); } \
+        ASSERT_VEC_ARRAY_EQ(gold, dim4(num), c);                          \
+        af_free_host(h_a);                                                \
+        af_free_host(h_b);                                                \
+    }                                                                     \
+                                                                          \
+    TEST(BinaryTests, Test_##func##_##Ta##_##Tb##_left) {                 \
+        SUPPORTED_TYPE_CHECK(Ta);                                         \
+        SUPPORTED_TYPE_CHECK(Tb);                                         \
+                                                                          \
+        af_dtype ta = (af_dtype)dtype_traits<Ta>::af_type;                \
+        af::array a = randgen(num, ta);                                   \
+        Tb h_b      = 3.0;                                                \
+        af::array c = func(a, h_b);                                       \
+        Ta *h_a     = a.host<Ta>();                                       \
+        vector<Tc> gold(num);                                             \
+        for (int i = 0; i < num; i++) { gold[i] = func(h_a[i], h_b); }    \
+        ASSERT_VEC_ARRAY_EQ(gold, dim4(num), c);                          \
+        af_free_host(h_a);                                                \
+    }                                                                     \
+                                                                          \
+    TEST(BinaryTests, Test_##func##_##Ta##_##Tb##_right) {                \
+        SUPPORTED_TYPE_CHECK(Ta);                                         \
+        SUPPORTED_TYPE_CHECK(Tb);                                         \
+                                                                          \
+        af_dtype tb = (af_dtype)dtype_traits<Tb>::af_type;                \
+        Ta h_a      = 5.0;                                                \
+        af::array b = randgen(num, tb);                                   \
+        af::array c = func(h_a, b);                                       \
+        Tb *h_b     = b.host<Tb>();                                       \
+        vector<Tc> gold(num);                                             \
+        for (int i = 0; i < num; i++) { gold[i] = func(h_a, h_b[i]); }    \
+        ASSERT_VEC_ARRAY_EQ(gold, dim4(num), c);                          \
+        af_free_host(h_b);                                                \
     }
 
 #define BINARY_TESTS_NEAR_GENERAL(Ta, Tb, Tc, Td, Te, func, err)      \


### PR DESCRIPTION
This is an initial implementation of JIT on the oneAPI backend.

Description
-----------
This is an initial implementation of the oneAPI JIT based on OpenCL kernel. It is currently limited to 3D shapes and breaks for 4D tensors. Additionally I had to skip checks that limit the size of the JIT kernels based on memory pressure because the memory manager is not implemented.

Changes to Users
----------------
Most JIT operations should be supported for the oneAPI backend now.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
