### PR TITLE
Corrected field example (#3369)

### DIFF
--- a/examples/graphics/field.cpp
+++ b/examples/graphics/field.cpp
@@ -22,7 +22,7 @@ int main(int, char**) {
         af::info();
         af::Window myWindow(1024, 1024, "2D Vector Field example: ArrayFire");
 
-        myWindow.grid(1, 2);
+        myWindow.grid(2, 2);
 
         array dataRange = seq(MINIMUM, MAXIMUM, STEP);
 
@@ -38,12 +38,21 @@ int main(int, char**) {
             array saddle = join(1, flat(x), -1.0f * flat(y));
 
             array bvals = sin(scale * (x * x + y * y));
-            array hbowl = join(1, constant(1, x.elements()), flat(bvals));
+            array hbowl = join(1, constant(1., x.elements()), flat(bvals));
             hbowl.eval();
 
+            // 2D points
             myWindow(0, 0).vectorField(points, saddle, "Saddle point");
             myWindow(0, 1).vectorField(
                 points, hbowl, "hilly bowl (in a loop with varying amplitude)");
+
+            // 2D coordinates
+            myWindow(1, 0).vectorField(2.0 * flat(x), flat(y), flat(x),
+                                       -flat(y), "Saddle point");
+            myWindow(1, 1).vectorField(
+                2.0 * flat(x), flat(y), constant(1., x.elements()), flat(bvals),
+                "hilly bowl (in a loop with varying amplitude)");
+
             myWindow.show();
 
             scale -= 0.0010f;

--- a/src/api/c/vector_field.cpp
+++ b/src/api/c/vector_field.cpp
@@ -50,20 +50,21 @@ fg_chart setup_vector_field(fg_window window, const vector<af_array>& points,
     vector<Array<T>> pnts;
     vector<Array<T>> dirs;
 
-    for (unsigned i = 0; i < points.size(); ++i) {
-        pnts.push_back(getArray<T>(points[i]));
-        dirs.push_back(getArray<T>(directions[i]));
+    Array<T> pIn = getArray<T>(points[0]);
+    Array<T> dIn = getArray<T>(directions[0]);
+    if (points.size() > 1) {
+        for (unsigned i = 0; i < points.size(); ++i) {
+            pnts.push_back(getArray<T>(points[i]));
+            dirs.push_back(getArray<T>(directions[i]));
+        }
+
+        // Join for set up vector
+        const dim4 odims(pIn.dims()[0], points.size());
+        pIn = createEmptyArray<T>(odims);
+        dIn = createEmptyArray<T>(odims);
+        detail::join<T>(pIn, 1, pnts);
+        detail::join<T>(dIn, 1, dirs);
     }
-
-    // Join for set up vector
-    dim4 odims(3, points.size());
-    Array<T> out_pnts = createEmptyArray<T>(odims);
-    Array<T> out_dirs = createEmptyArray<T>(odims);
-    detail::join(out_pnts, 1, pnts);
-    detail::join(out_dirs, 1, dirs);
-    Array<T> pIn = out_pnts;
-    Array<T> dIn = out_dirs;
-
     // do transpose if required
     if (transpose_) {
         pIn = transpose<T>(pIn, false);


### PR DESCRIPTION
Uninitialized buffer used to collect partial join (2D -> 3D)
Join now accepts any buffer as out array, as long as it is large enough.

Description
-----------
* This is a BUG fix reported in issue 3369
* The array provided to join was insufficient dimensioned, resulting in buffer overflow and wrong results.
* This can be back-ported to 3.8.3 (where the issue is first reported)
* No new functions added, only corrected.

Fixes: #3369

Changes to Users
----------------
Non

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [-] Functions added to unified API
- [-] Functions documented
