### PR TITLE
Add device-code-split flags to oneapi backend

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -281,9 +281,6 @@ target_include_directories(afoneapi
 target_compile_options(afoneapi
   PRIVATE
     -fsycl
-    #-fsycl-targets=nvptx64-vidia-cuda
-    #-fsycl-force-target=nvptx64-nvidia-cuda-sm_86
-    #-Wno-unknown-cuda-version
     -sycl-std=2020
 )
 
@@ -301,14 +298,14 @@ target_link_libraries(afoneapi
     -fsycl
     -fno-lto
     -fvisibility-inlines-hidden
-    #-fsycl-targets=nvptx64-nvidia-cuda-sm_86
-    #-fsycl-force-target=nvptx64-nvidia-cuda-sm_86
     c_api_interface
     cpp_api_interface
     afcommon_interface
     OpenCL::OpenCL
     OpenCL::cl2hpp
-    #-Wno-unknown-cuda-version
+    -fsycl
+    -fsycl-device-code-split=per_kernel
+    -fsycl-link-huge-device-code
   )
 
 af_split_debug_info(afoneapi ${AF_INSTALL_LIB_DIR})


### PR DESCRIPTION
The device-code-split flag is necessary to build oneAPI with oneMKL and to build on devices that do not support double.

Description
-----------
* This flag separate each kernel in its own object file in the fat binary.
* Add the sycl-link-huge-device-code flag to get round debug linking errors

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
