### PR TITLE
fft, memcopy, reshape port to oneapi

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -284,6 +284,7 @@ target_compile_options(afoneapi
     #-fsycl-targets=nvptx64-vidia-cuda
     #-fsycl-force-target=nvptx64-nvidia-cuda-sm_86
     #-Wno-unknown-cuda-version
+    -qopenmp -qmkl=parallel
     -sycl-std=2020
 )
 
@@ -309,6 +310,8 @@ target_link_libraries(afoneapi
     OpenCL::OpenCL
     OpenCL::cl2hpp
     #-Wno-unknown-cuda-version
+    -qopenmp
+    -qmkl=parallel
   )
 
 af_split_debug_info(afoneapi ${AF_INSTALL_LIB_DIR})

--- a/src/backend/oneapi/fft.cpp
+++ b/src/backend/oneapi/fft.cpp
@@ -1,11 +1,13 @@
 /*******************************************************
- * Copyright (c) 2022, ArrayFire
+ * Copyright (c) 2023, ArrayFire
  * All rights reserved.
  *
  * This file is distributed under 3-clause BSD license.
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+
+#include <common/dispatch.hpp>
 
 #include <fft.hpp>
 
@@ -15,78 +17,156 @@
 #include <memory.hpp>
 #include <af/dim4.hpp>
 
+#include <array>
+using std::array;
+
 using af::dim4;
+
+#include <oneapi/mkl/dfti.hpp>
 
 namespace arrayfire {
 namespace oneapi {
 
 void setFFTPlanCacheSize(size_t numPlans) {}
 
-/*
-template<typename T>
-struct Precision;
-template<>
-struct Precision<cfloat> {
-    enum { type = CLFFT_SINGLE };
-};
-template<>
-struct Precision<cdouble> {
-    enum { type = CLFFT_DOUBLE };
-};
-*/
-
-void computeDims(size_t rdims[AF_MAX_DIMS], const dim4 &idims) {
-    for (int i = 0; i < AF_MAX_DIMS; i++) {
-        rdims[i] = static_cast<size_t>(idims[i]);
-    }
-}
-
-//(currently) true is in clFFT if length is a power of 2,3,5
-inline bool isSupLen(dim_t length) {
-    while (length > 1) {
-        if (length % 2 == 0) {
-            length /= 2;
-        } else if (length % 3 == 0) {
-            length /= 3;
-        } else if (length % 5 == 0) {
-            length /= 5;
-        } else if (length % 7 == 0) {
-            length /= 7;
-        } else if (length % 11 == 0) {
-            length /= 11;
-        } else if (length % 13 == 0) {
-            length /= 13;
-        } else {
-            return false;
-        }
-    }
-    return true;
-}
-
-void verifySupported(const int rank, const dim4 &dims) {
-    for (int i = 0; i < rank; i++) { ARG_ASSERT(1, isSupLen(dims[i])); }
+inline array<int, AF_MAX_DIMS> computeDims(const int rank, const dim4 &idims) {
+    array<int, AF_MAX_DIMS> retVal = {};
+    for (int i = 0; i < rank; i++) { retVal[i] = idims[(rank - 1) - i]; }
+    return retVal;
 }
 
 template<typename T>
 void fft_inplace(Array<T> &in, const int rank, const bool direction) {
-    ONEAPI_NOT_SUPPORTED("");
+    const dim4 idims    = in.dims();
+    const dim4 istrides = in.strides();
+
+    constexpr bool is_single = std::is_same_v<T, cfloat>;
+    constexpr auto precision = (is_single)
+                                   ? ::oneapi::mkl::dft::precision::SINGLE
+                                   : ::oneapi::mkl::dft::precision::DOUBLE;
+    using desc_ty =
+        ::oneapi::mkl::dft::descriptor<precision,
+                                       ::oneapi::mkl::dft::domain::COMPLEX>;
+
+    auto desc = [rank, &idims]() {
+        if (rank == 1) return desc_ty(idims[0]);
+        if (rank == 2) return desc_ty({idims[0], idims[1]});
+        if (rank == 3) return desc_ty({idims[0], idims[1], idims[2]});
+        return desc_ty({idims[0], idims[1], idims[2], idims[3]});
+    }();
+
+    desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT, DFTI_INPLACE);
+
+    int batch = 1;
+    for (int i = rank; i < 4; i++) { batch *= idims[i]; }
+    desc.set_value(::oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS,
+                   (int64_t)batch);
+
+    desc.set_value(::oneapi::mkl::dft::config_param::BWD_DISTANCE,
+                   istrides[rank]);
+    desc.set_value(::oneapi::mkl::dft::config_param::FWD_DISTANCE,
+                   istrides[rank]);
+
+    desc.commit(getQueue());
+    if (direction)
+        ::oneapi::mkl::dft::compute_forward(desc, *(in.getData()));
+    else
+        ::oneapi::mkl::dft::compute_backward(desc, *(in.getData()));
 }
 
 template<typename Tc, typename Tr>
 Array<Tc> fft_r2c(const Array<Tr> &in, const int rank) {
-    ONEAPI_NOT_SUPPORTED("");
-    dim4 odims = in.dims();
+    const dim4 idims    = in.dims();
+    const dim4 istrides = in.strides();
+    Array<Tc> out       = createEmptyArray<Tc>(
+        dim4({idims[0] / 2 + 1, idims[1], idims[2], idims[3]}));
+    const dim4 ostrides = out.strides();
 
-    odims[0] = odims[0] / 2 + 1;
+    constexpr bool is_single = std::is_same_v<Tr, float>;
+    constexpr auto precision = (is_single)
+                                   ? ::oneapi::mkl::dft::precision::SINGLE
+                                   : ::oneapi::mkl::dft::precision::DOUBLE;
+    using desc_ty =
+        ::oneapi::mkl::dft::descriptor<precision,
+                                       ::oneapi::mkl::dft::domain::REAL>;
 
-    Array<Tc> out = createEmptyArray<Tc>(odims);
+    auto desc = [rank, &idims]() {
+        if (rank == 1) return desc_ty(idims[0]);
+        if (rank == 2) return desc_ty({idims[0], idims[1]});
+        if (rank == 3) return desc_ty({idims[0], idims[1], idims[2]});
+        return desc_ty({idims[0], idims[1], idims[2], idims[3]});
+    }();
+
+    desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT,
+                   DFTI_NOT_INPLACE);
+
+    int batch = 1;
+    for (int i = rank; i < 4; i++) { batch *= idims[i]; }
+    desc.set_value(::oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS,
+                   (int64_t)batch);
+
+    desc.set_value(::oneapi::mkl::dft::config_param::BWD_DISTANCE,
+                   ostrides[rank]);
+    desc.set_value(::oneapi::mkl::dft::config_param::FWD_DISTANCE,
+                   istrides[rank]);
+
+    const std::int64_t fft_output_strides[5] = {
+        0, ostrides[(rank == 2) ? 1 : 0], ostrides[(rank == 2) ? 0 : 1],
+        ostrides[2], ostrides[3]};
+    desc.set_value(::oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
+                   fft_output_strides, rank);
+
+    desc.commit(getQueue());
+    ::oneapi::mkl::dft::compute_forward(desc, *(in.getData()),
+                                        *(out.getData()));
+
     return out;
 }
 
 template<typename Tr, typename Tc>
 Array<Tr> fft_c2r(const Array<Tc> &in, const dim4 &odims, const int rank) {
-    ONEAPI_NOT_SUPPORTED("");
-    Array<Tr> out = createEmptyArray<Tr>(odims);
+    const dim4 idims    = in.dims();
+    const dim4 istrides = in.strides();
+    Array<Tr> out       = createEmptyArray<Tr>(odims);
+    const dim4 ostrides = out.strides();
+
+    constexpr bool is_single = std::is_same_v<Tr, float>;
+    constexpr auto precision = (is_single)
+                                   ? ::oneapi::mkl::dft::precision::SINGLE
+                                   : ::oneapi::mkl::dft::precision::DOUBLE;
+    using desc_ty =
+        ::oneapi::mkl::dft::descriptor<precision,
+                                       ::oneapi::mkl::dft::domain::REAL>;
+
+    auto desc = [rank, &odims]() {
+        if (rank == 1) return desc_ty(odims[0]);
+        if (rank == 2) return desc_ty({odims[0], odims[1]});
+        if (rank == 3) return desc_ty({odims[0], odims[1], odims[2]});
+        return desc_ty({odims[0], odims[1], odims[2], odims[3]});
+    }();
+
+    desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT,
+                   DFTI_NOT_INPLACE);
+
+    int batch = 1;
+    for (int i = rank; i < 4; i++) { batch *= idims[i]; }
+    desc.set_value(::oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS,
+                   (int64_t)batch);
+
+    desc.set_value(::oneapi::mkl::dft::config_param::BWD_DISTANCE,
+                   istrides[rank]);
+    desc.set_value(::oneapi::mkl::dft::config_param::FWD_DISTANCE,
+                   ostrides[rank]);
+
+    const std::int64_t fft_output_strides[5] = {
+        0, ostrides[(rank == 2) ? 1 : 0], ostrides[(rank == 2) ? 0 : 1],
+        ostrides[2], ostrides[3]};
+    desc.set_value(::oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
+                   fft_output_strides, rank);
+
+    desc.commit(getQueue());
+    ::oneapi::mkl::dft::compute_backward(desc, *(in.getData()),
+                                         *(out.getData()));
     return out;
 }
 

--- a/src/backend/oneapi/kernel/memcopy.hpp
+++ b/src/backend/oneapi/kernel/memcopy.hpp
@@ -1,5 +1,5 @@
 /*******************************************************
- * Copyright (c) 2022, ArrayFire
+ * Copyright (c) 2023, ArrayFire
  * All rights reserved.
  *
  * This file is distributed under 3-clause BSD license.
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <CL/sycl.hpp>
 #include <Param.hpp>
 #include <common/dispatch.hpp>
 #include <common/half.hpp>
@@ -131,54 +132,54 @@ cdouble scale<cdouble>(cdouble value, double factor) {
 }
 
 template<typename inType, typename outType>
-outType convertType(inType value) {
+static outType convertType(inType value) {
     return static_cast<outType>(value);
 }
 
 template<>
-char convertType<compute_t<arrayfire::common::half>, char>(
+static char convertType<compute_t<arrayfire::common::half>, char>(
     compute_t<arrayfire::common::half> value) {
     return (char)((short)value);
 }
 
 template<>
-compute_t<arrayfire::common::half>
-convertType<char, compute_t<arrayfire::common::half>>(char value) {
+compute_t<arrayfire::common::half> static convertType<
+    char, compute_t<arrayfire::common::half>>(char value) {
     return compute_t<arrayfire::common::half>(value);
 }
 
 template<>
-unsigned char convertType<compute_t<arrayfire::common::half>, unsigned char>(
+static unsigned char
+convertType<compute_t<arrayfire::common::half>, unsigned char>(
     compute_t<arrayfire::common::half> value) {
     return (unsigned char)((short)value);
 }
 
 template<>
-compute_t<arrayfire::common::half>
-convertType<unsigned char, compute_t<arrayfire::common::half>>(
-    unsigned char value) {
+compute_t<arrayfire::common::half> static convertType<
+    unsigned char, compute_t<arrayfire::common::half>>(unsigned char value) {
     return compute_t<arrayfire::common::half>(value);
 }
 
 template<>
-cdouble convertType<cfloat, cdouble>(cfloat value) {
+static cdouble convertType<cfloat, cdouble>(cfloat value) {
     return cdouble(value.real(), value.imag());
 }
 
 template<>
-cfloat convertType<cdouble, cfloat>(cdouble value) {
+static cfloat convertType<cdouble, cfloat>(cdouble value) {
     return cfloat(value.real(), value.imag());
 }
 
-#define OTHER_SPECIALIZATIONS(IN_T)                      \
-    template<>                                           \
-    cfloat convertType<IN_T, cfloat>(IN_T value) {       \
-        return cfloat(static_cast<float>(value), 0.0f);  \
-    }                                                    \
-                                                         \
-    template<>                                           \
-    cdouble convertType<IN_T, cdouble>(IN_T value) {     \
-        return cdouble(static_cast<double>(value), 0.0); \
+#define OTHER_SPECIALIZATIONS(IN_T)                         \
+    template<>                                              \
+    static cfloat convertType<IN_T, cfloat>(IN_T value) {   \
+        return cfloat(static_cast<float>(value), 0.0f);     \
+    }                                                       \
+                                                            \
+    template<>                                              \
+    static cdouble convertType<IN_T, cdouble>(IN_T value) { \
+        return cdouble(static_cast<double>(value), 0.0);    \
     }
 
 OTHER_SPECIALIZATIONS(float)

--- a/src/backend/oneapi/reshape.cpp
+++ b/src/backend/oneapi/reshape.cpp
@@ -1,6 +1,5 @@
-
 /*******************************************************
- * Copyright (c) 2020, ArrayFire
+ * Copyright (c) 2023, ArrayFire
  * All rights reserved.
  *
  * This file is distributed under 3-clause BSD license.
@@ -12,7 +11,7 @@
 #include <err_oneapi.hpp>
 
 #include <common/half.hpp>
-// #include <kernel/memcopy.hpp>
+#include <kernel/memcopy.hpp>
 
 using arrayfire::common::half;
 
@@ -22,11 +21,11 @@ namespace oneapi {
 template<typename inType, typename outType>
 Array<outType> reshape(const Array<inType> &in, const dim4 &outDims,
                        outType defaultValue, double scale) {
-    ONEAPI_NOT_SUPPORTED("reshape Not supported");
-
     Array<outType> out = createEmptyArray<outType>(outDims);
-    // kernel::copy<inType, outType>(out, in, in.ndims(), defaultValue, scale,
-    //                               in.dims() == outDims);
+    if (out.elements() > 0) {
+        kernel::copy<inType, outType>(out, in, in.ndims(), defaultValue, scale,
+                                      in.dims() == outDims);
+    }
     return out;
 }
 


### PR DESCRIPTION
Port of FFT to OneAPI (OneMKL FFT underneath). Also includes `reshape` and `memcopy` ports that support FFT.

Note that FFT tests pass up until the `Input2D/*` suite. Once there, ArrayFire begins failing in the `randu` routines. However, when the tests are run independently, they pass. I suspect a stateful problem with FFT or `randu`.

Checklist
---------
<!-- Check if done or not applicable -->
- [X] Rebased on latest master
- [X] Code compiles
- [X] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
