### PR TITLE
Remove getData usage in the oneAPI backend and make it private

### DIFF
--- a/src/api/c/memory.cpp
+++ b/src/api/c/memory.cpp
@@ -144,10 +144,7 @@ af_err af_get_device_ptr(void **data, const af_array arr) {
 
 template<typename T>
 inline void lockArray(const af_array arr) {
-    // Ideally we need to use .get(false), i.e. get ptr without offset
-    // This is however not supported in opencl
-    // Use getData().get() as alternative
-    memLock(getArray<T>(arr).getData().get());
+    memLock(getArray<T>(arr).get());
 }
 
 af_err af_lock_device_ptr(const af_array arr) { return af_lock_array(arr); }
@@ -180,10 +177,8 @@ af_err af_lock_array(const af_array arr) {
 
 template<typename T>
 inline bool checkUserLock(const af_array arr) {
-    // Ideally we need to use .get(false), i.e. get ptr without offset
-    // This is however not supported in opencl
-    // Use getData().get() as alternative
-    return isLocked(static_cast<void *>(getArray<T>(arr).getData().get()));
+    detail::Array<T> &out = const_cast<detail::Array<T> &>(getArray<T>(arr));
+    return isLocked(static_cast<void *>(out.get()));
 }
 
 af_err af_is_locked_array(bool *res, const af_array arr) {
@@ -214,10 +209,7 @@ af_err af_is_locked_array(bool *res, const af_array arr) {
 
 template<typename T>
 inline void unlockArray(const af_array arr) {
-    // Ideally we need to use .get(false), i.e. get ptr without offset
-    // This is however not supported in opencl
-    // Use getData().get() as alternative
-    memUnlock(getArray<T>(arr).getData().get());
+    memUnlock(getArray<T>(arr).get());
 }
 
 af_err af_unlock_device_ptr(const af_array arr) { return af_unlock_array(arr); }

--- a/src/backend/cuda/Array.hpp
+++ b/src/backend/cuda/Array.hpp
@@ -156,6 +156,8 @@ class Array {
     Array(Param<T> &tmp, bool owner);
     Array(const af::dim4 &dims, common::Node_ptr n);
 
+    std::shared_ptr<T> getData() const { return data; }
+
    public:
     Array(const Array<T> &other) = default;
 
@@ -227,7 +229,6 @@ class Array {
     void eval() const;
 
     dim_t getOffset() const { return info.getOffset(); }
-    std::shared_ptr<T> getData() const { return data; }
 
     dim4 getDataDims() const { return data_dims; }
 

--- a/src/backend/oneapi/Array.hpp
+++ b/src/backend/oneapi/Array.hpp
@@ -177,6 +177,8 @@ class Array {
     explicit Array(const af::dim4 &dims, sycl::buffer<T> *const mem,
                    size_t offset, bool copy);
 
+    std::shared_ptr<sycl::buffer<T>> getData() const { return data; }
+
    public:
     Array(const Array<T> &other) = default;
 
@@ -250,14 +252,7 @@ class Array {
         return const_cast<Array<T> *>(this)->device();
     }
 
-    // FIXME: This should do a copy if it is not owner. You do not want to
-    // overwrite parents data
-    sycl::buffer<T> *get() {
-        if (!isReady()) eval();
-        return data.get();
-    }
-
-    const sycl::buffer<T> *get() const {
+    sycl::buffer<T> *get() const {
         if (!isReady()) eval();
         return data.get();
     }
@@ -265,8 +260,6 @@ class Array {
     int useCount() const { return data.use_count(); }
 
     dim_t getOffset() const { return info.getOffset(); }
-
-    std::shared_ptr<sycl::buffer<T>> getData() const { return data; }
 
     dim4 getDataDims() const { return data_dims; }
 

--- a/src/backend/oneapi/Kernel.hpp
+++ b/src/backend/oneapi/Kernel.hpp
@@ -12,7 +12,6 @@
 #include <common/KernelInterface.hpp>
 #include <common/Logger.hpp>
 
-#include <CL/sycl.hpp>
 #include <backend.hpp>
 #include <string>
 

--- a/src/backend/oneapi/Module.hpp
+++ b/src/backend/oneapi/Module.hpp
@@ -9,8 +9,9 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
 #include <common/ModuleInterface.hpp>
+
+#include <sycl/kernel_bundle.hpp>
 
 namespace arrayfire {
 namespace oneapi {

--- a/src/backend/oneapi/compile_module.cpp
+++ b/src/backend/oneapi/compile_module.cpp
@@ -10,7 +10,6 @@
 #include <common/compile_module.hpp>  //compileModule & loadModuleFromDisk
 #include <common/kernel_cache.hpp>    //getKernel(Module&, ...)
 
-#include <CL/sycl.hpp>
 #include <common/Logger.hpp>
 #include <common/defines.hpp>
 #include <common/util.hpp>

--- a/src/backend/oneapi/copy.cpp
+++ b/src/backend/oneapi/copy.cpp
@@ -219,10 +219,12 @@ T getScalar(const Array<T> &in) {
 
     getQueue()
         .submit([&](sycl::handler &h) {
-            auto acc_in = in.getData()->get_access(
-                h, sycl::range{1},
-                sycl::id{static_cast<uintl>(in.getOffset())});
-            auto acc_out = retBuffer.get_access();
+            auto acc_in =
+                in.get()->template get_access<sycl::access::mode::read>(
+                    h, sycl::range{1},
+                    sycl::id{static_cast<uintl>(in.getOffset())});
+            auto acc_out =
+                retBuffer.template get_access<sycl::access::mode::write>(h);
             h.copy(acc_in, acc_out);
         })
         .wait();

--- a/src/backend/oneapi/fft.cpp
+++ b/src/backend/oneapi/fft.cpp
@@ -69,9 +69,9 @@ void fft_inplace(Array<T> &in, const int rank, const bool direction) {
 
     desc.commit(getQueue());
     if (direction)
-        ::oneapi::mkl::dft::compute_forward(desc, *(in.getData()));
+        ::oneapi::mkl::dft::compute_forward(desc, *in.get());
     else
-        ::oneapi::mkl::dft::compute_backward(desc, *(in.getData()));
+        ::oneapi::mkl::dft::compute_backward(desc, *in.get());
 }
 
 template<typename Tc, typename Tr>
@@ -117,8 +117,7 @@ Array<Tc> fft_r2c(const Array<Tr> &in, const int rank) {
                    fft_output_strides, rank);
 
     desc.commit(getQueue());
-    ::oneapi::mkl::dft::compute_forward(desc, *(in.getData()),
-                                        *(out.getData()));
+    ::oneapi::mkl::dft::compute_forward(desc, *in.get(), *out.get());
 
     return out;
 }
@@ -165,8 +164,7 @@ Array<Tr> fft_c2r(const Array<Tc> &in, const dim4 &odims, const int rank) {
                    fft_output_strides, rank);
 
     desc.commit(getQueue());
-    ::oneapi::mkl::dft::compute_backward(desc, *(in.getData()),
-                                         *(out.getData()));
+    ::oneapi::mkl::dft::compute_backward(desc, *in.get(), *out.get());
     return out;
 }
 

--- a/src/backend/oneapi/kernel/bilateral.hpp
+++ b/src/backend/oneapi/kernel/bilateral.hpp
@@ -148,8 +148,8 @@ class bilateralKernel {
     void load2LocalMem(local_accessor<outType, 1> shrd, const inType* in,
                        int lx, int ly, int shrdStride, int dim0, int dim1,
                        int gx, int gy, int inStride1, int inStride0) const {
-        int gx_ = std::clamp(gx, 0, dim0 - 1);
-        int gy_ = std::clamp(gy, 0, dim1 - 1);
+        int gx_ = sycl::clamp(gx, 0, dim0 - 1);
+        int gy_ = sycl::clamp(gy, 0, dim1 - 1);
         shrd[lIdx(lx, ly, shrdStride, 1)] =
             (outType)in[lIdx(gx_, gy_, inStride1, inStride0)];
     }

--- a/src/backend/oneapi/kernel/convolve2.hpp
+++ b/src/backend/oneapi/kernel/convolve2.hpp
@@ -121,9 +121,6 @@ template<typename T, typename aT>
 void conv2Helper(const conv_kparam_t<aT> &param, Param<T> out,
                  const Param<T> signal, const Param<aT> filter,
                  const bool expand) {
-    constexpr bool IsComplex =
-        std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value;
-
     const int f0 = filter.info.dims[0];
     const int f1 = filter.info.dims[1];
     const size_t LOC_SIZE =

--- a/src/backend/oneapi/kernel/convolve3.hpp
+++ b/src/backend/oneapi/kernel/convolve3.hpp
@@ -55,18 +55,12 @@ class conv3HelperCreateKernel {
              sstep3_ *
                  sInfo_.strides[3]); /* activated with batched input filter */
 
-        int lx  = it.get_local_id(0);
-        int ly  = it.get_local_id(1);
-        int lz  = it.get_local_id(2);
-        int gx  = g.get_local_range(0) * (g.get_group_id(0) - b2 * nBBS0_) + lx;
-        int gy  = g.get_local_range(1) * g.get_group_id(1) + ly;
-        int gz  = g.get_local_range(2) * g.get_group_id(2) + lz;
-        int lx2 = lx + g.get_local_range(0);
-        int ly2 = ly + g.get_local_range(1);
-        int lz2 = lz + g.get_local_range(2);
-        int gx2 = gx + g.get_local_range(0);
-        int gy2 = gy + g.get_local_range(1);
-        int gz2 = gz + g.get_local_range(2);
+        int lx = it.get_local_id(0);
+        int ly = it.get_local_id(1);
+        int lz = it.get_local_id(2);
+        int gx = g.get_local_range(0) * (g.get_group_id(0) - b2 * nBBS0_) + lx;
+        int gy = g.get_local_range(1) * g.get_group_id(1) + ly;
+        int gz = g.get_local_range(2) * g.get_group_id(2) + lz;
 
         int s0 = sInfo_.strides[0];
         int s1 = sInfo_.strides[1];

--- a/src/backend/oneapi/kernel/mean.hpp
+++ b/src/backend/oneapi/kernel/mean.hpp
@@ -629,13 +629,12 @@ T mean_all_weighted(Param<T> in, Param<Tw> iwt) {
 
         auto e1 = getQueue().submit([&](sycl::handler &h) {
             auto acc_in =
-                tmpOut.getData()->get_access(h, sycl::range{tmp_elements});
+                tmpOut.get()->get_access(h, sycl::range{tmp_elements});
             auto acc_out = hBuffer.get_access();
             h.copy(acc_in, acc_out);
         });
         auto e2 = getQueue().submit([&](sycl::handler &h) {
-            auto acc_in =
-                tmpWt.getData()->get_access(h, sycl::range{tmp_elements});
+            auto acc_in = tmpWt.get()->get_access(h, sycl::range{tmp_elements});
             auto acc_out = hwBuffer.get_access();
             h.copy(acc_in, acc_out);
         });
@@ -733,13 +732,12 @@ To mean_all(Param<Ti> in) {
 
         auto e1 = getQueue().submit([&](sycl::handler &h) {
             auto acc_in =
-                tmpOut.getData()->get_access(h, sycl::range{tmp_elements});
+                tmpOut.get()->get_access(h, sycl::range{tmp_elements});
             auto acc_out = hBuffer.get_access();
             h.copy(acc_in, acc_out);
         });
         auto e2 = getQueue().submit([&](sycl::handler &h) {
-            auto acc_in =
-                tmpCt.getData()->get_access(h, sycl::range{tmp_elements});
+            auto acc_in = tmpCt.get()->get_access(h, sycl::range{tmp_elements});
             auto acc_out = hcBuffer.get_access();
             h.copy(acc_in, acc_out);
         });

--- a/src/backend/oneapi/kernel/memcopy.hpp
+++ b/src/backend/oneapi/kernel/memcopy.hpp
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
 #include <Param.hpp>
 #include <common/dispatch.hpp>
 #include <common/half.hpp>
@@ -116,69 +115,60 @@ void memcopy(sycl::buffer<T> *out, const dim_t *ostrides,
 }
 
 template<typename T>
-static T scale(T value, double factor) {
+inline T scale(T value, double factor) {
     return (T)(double(value) * factor);
 }
 
 template<>
-cfloat scale<cfloat>(cfloat value, double factor) {
+inline cfloat scale<cfloat>(cfloat value, double factor) {
     return cfloat{static_cast<float>(value.real() * factor),
                   static_cast<float>(value.imag() * factor)};
 }
 
 template<>
-cdouble scale<cdouble>(cdouble value, double factor) {
+inline cdouble scale<cdouble>(cdouble value, double factor) {
     return cdouble{value.real() * factor, value.imag() * factor};
 }
 
 template<typename inType, typename outType>
-static outType convertType(inType value) {
+inline outType convertType(inType value) {
     return static_cast<outType>(value);
 }
 
 template<>
-static char convertType<compute_t<arrayfire::common::half>, char>(
+inline char convertType<compute_t<arrayfire::common::half>, char>(
     compute_t<arrayfire::common::half> value) {
     return (char)((short)value);
 }
 
 template<>
-compute_t<arrayfire::common::half> static convertType<
-    char, compute_t<arrayfire::common::half>>(char value) {
+inline compute_t<arrayfire::common::half>
+convertType<char, compute_t<arrayfire::common::half>>(char value) {
     return compute_t<arrayfire::common::half>(value);
 }
 
 template<>
-static unsigned char
-convertType<compute_t<arrayfire::common::half>, unsigned char>(
+unsigned char inline convertType<compute_t<arrayfire::common::half>,
+                                 unsigned char>(
     compute_t<arrayfire::common::half> value) {
     return (unsigned char)((short)value);
 }
 
 template<>
-compute_t<arrayfire::common::half> static convertType<
-    unsigned char, compute_t<arrayfire::common::half>>(unsigned char value) {
+inline compute_t<arrayfire::common::half>
+convertType<unsigned char, compute_t<arrayfire::common::half>>(
+    unsigned char value) {
     return compute_t<arrayfire::common::half>(value);
-}
-
-template<>
-static cdouble convertType<cfloat, cdouble>(cfloat value) {
-    return cdouble(value.real(), value.imag());
-}
-
-template<>
-static cfloat convertType<cdouble, cfloat>(cdouble value) {
-    return cfloat(value.real(), value.imag());
 }
 
 #define OTHER_SPECIALIZATIONS(IN_T)                         \
     template<>                                              \
-    static cfloat convertType<IN_T, cfloat>(IN_T value) {   \
+    inline cfloat convertType<IN_T, cfloat>(IN_T value) {   \
         return cfloat(static_cast<float>(value), 0.0f);     \
     }                                                       \
                                                             \
     template<>                                              \
-    static cdouble convertType<IN_T, cdouble>(IN_T value) { \
+    inline cdouble convertType<IN_T, cdouble>(IN_T value) { \
         return cdouble(static_cast<double>(value), 0.0);    \
     }
 

--- a/src/backend/oneapi/kernel/random_engine.hpp
+++ b/src/backend/oneapi/kernel/random_engine.hpp
@@ -58,11 +58,9 @@ void uniformDistributionCBRNG(Param<T> out, const size_t elements,
             getQueue().submit([=](sycl::handler &h) {
                 auto out_acc = out.data->get_access(h);
 
-                sycl::stream debug_stream(2048, 128, h);
-                h.parallel_for(
-                    ndrange,
-                    uniformPhilox<T>(out_acc, hi, lo, hic, loc,
-                                     elementsPerBlock, elements, debug_stream));
+                h.parallel_for(ndrange,
+                               uniformPhilox<T>(out_acc, hi, lo, hic, loc,
+                                                elementsPerBlock, elements));
             });
             ONEAPI_DEBUG_FINISH(getQueue());
             break;
@@ -70,11 +68,9 @@ void uniformDistributionCBRNG(Param<T> out, const size_t elements,
             getQueue().submit([=](sycl::handler &h) {
                 auto out_acc = out.data->get_access(h);
 
-                sycl::stream debug_stream(2048, 128, h);
                 h.parallel_for(ndrange,
                                uniformThreefry<T>(out_acc, hi, lo, hic, loc,
-                                                  elementsPerBlock, elements,
-                                                  debug_stream));
+                                                  elementsPerBlock, elements));
             });
             ONEAPI_DEBUG_FINISH(getQueue());
             break;
@@ -102,22 +98,18 @@ void normalDistributionCBRNG(Param<T> out, const size_t elements,
             getQueue().submit([=](sycl::handler &h) {
                 auto out_acc = out.data->get_access(h);
 
-                sycl::stream debug_stream(2048, 128, h);
-                h.parallel_for(
-                    ndrange,
-                    normalPhilox<T>(out_acc, hi, lo, hic, loc, elementsPerBlock,
-                                    elements, debug_stream));
+                h.parallel_for(ndrange,
+                               normalPhilox<T>(out_acc, hi, lo, hic, loc,
+                                               elementsPerBlock, elements));
             });
             break;
         case AF_RANDOM_ENGINE_THREEFRY_2X32_16:
             getQueue().submit([=](sycl::handler &h) {
                 auto out_acc = out.data->get_access(h);
 
-                sycl::stream debug_stream(2048, 128, h);
                 h.parallel_for(ndrange,
                                normalThreefry<T>(out_acc, hi, lo, hic, loc,
-                                                 elementsPerBlock, elements,
-                                                 debug_stream));
+                                                 elementsPerBlock, elements));
             });
             break;
         default:
@@ -154,12 +146,11 @@ void uniformDistributionMT(Param<T> out, const size_t elements,
         auto lrecursion_acc = local_accessor<uint, 1>(TABLE_SIZE, h);
         auto ltemper_acc    = local_accessor<uint, 1>(TABLE_SIZE, h);
 
-        sycl::stream debug_stream(2048, 128, h);
-        h.parallel_for(ndrange, uniformMersenne<T>(
-                                    out_acc, state_acc, pos_acc, sh1_acc,
-                                    sh2_acc, mask, recursion_acc, temper_acc,
-                                    lstate_acc, lrecursion_acc, ltemper_acc,
-                                    elementsPerBlock, elements, debug_stream));
+        h.parallel_for(
+            ndrange, uniformMersenne<T>(
+                         out_acc, state_acc, pos_acc, sh1_acc, sh2_acc, mask,
+                         recursion_acc, temper_acc, lstate_acc, lrecursion_acc,
+                         ltemper_acc, elementsPerBlock, elements));
     });
     ONEAPI_DEBUG_FINISH(getQueue());
 }
@@ -191,12 +182,11 @@ void normalDistributionMT(Param<T> out, const size_t elements,
         auto lrecursion_acc = local_accessor<uint, 1>(TABLE_SIZE, h);
         auto ltemper_acc    = local_accessor<uint, 1>(TABLE_SIZE, h);
 
-        sycl::stream debug_stream(2048, 128, h);
-        h.parallel_for(ndrange, normalMersenne<T>(
-                                    out_acc, state_acc, pos_acc, sh1_acc,
-                                    sh2_acc, mask, recursion_acc, temper_acc,
-                                    lstate_acc, lrecursion_acc, ltemper_acc,
-                                    elementsPerBlock, elements, debug_stream));
+        h.parallel_for(
+            ndrange, normalMersenne<T>(out_acc, state_acc, pos_acc, sh1_acc,
+                                       sh2_acc, mask, recursion_acc, temper_acc,
+                                       lstate_acc, lrecursion_acc, ltemper_acc,
+                                       elementsPerBlock, elements));
     });
     ONEAPI_DEBUG_FINISH(getQueue());
 }

--- a/src/backend/oneapi/kernel/random_engine_philox.hpp
+++ b/src/backend/oneapi/kernel/random_engine_philox.hpp
@@ -107,22 +107,18 @@ template<typename T>
 class uniformPhilox {
    public:
     uniformPhilox(sycl::accessor<T> out, uint hi, uint lo, uint hic, uint loc,
-                  uint elementsPerBlock, uint elements,
-                  sycl::stream debug_stream)
+                  uint elementsPerBlock, uint elements)
         : out_(out)
         , hi_(hi)
         , lo_(lo)
         , hic_(hic)
         , loc_(loc)
         , elementsPerBlock_(elementsPerBlock)
-        , elements_(elements)
-        , debug_(debug_stream) {}
+        , elements_(elements) {}
 
     void operator()(sycl::nd_item<1> it) const {
         sycl::group g = it.get_group();
 
-        // debug_ << "<" << g.get_group_id(0)  << ":" << it.get_local_id(0) <<
-        // "/" << g.get_group_range(0) << sycl::stream_manipulator::endl;
         uint index = g.get_group_id(0) * elementsPerBlock_ + it.get_local_id(0);
         uint key[2] = {lo_, hi_};
         uint ctr[4] = {loc_, hic_, 0, 0};
@@ -145,28 +141,23 @@ class uniformPhilox {
     sycl::accessor<T> out_;
     uint hi_, lo_, hic_, loc_;
     uint elementsPerBlock_, elements_;
-    sycl::stream debug_;
 };
 
 template<typename T>
 class normalPhilox {
    public:
     normalPhilox(sycl::accessor<T> out, uint hi, uint lo, uint hic, uint loc,
-                 uint elementsPerBlock, uint elements,
-                 sycl::stream debug_stream)
+                 uint elementsPerBlock, uint elements)
         : out_(out)
         , hi_(hi)
         , lo_(lo)
         , hic_(hic)
         , loc_(loc)
         , elementsPerBlock_(elementsPerBlock)
-        , elements_(elements)
-        , debug_(debug_stream) {}
+        , elements_(elements) {}
 
     void operator()(sycl::nd_item<1> it) const {
         sycl::group g = it.get_group();
-        // debug_ << "<" << g.get_group_id(0)  << ":" << it.get_local_id(0) <<
-        // "/" << g.get_group_range(0) << sycl::stream_manipulator::endl;
 
         uint index = g.get_group_id(0) * elementsPerBlock_ + it.get_local_id(0);
         uint key[2] = {lo_, hi_};
@@ -192,7 +183,6 @@ class normalPhilox {
     sycl::accessor<T> out_;
     uint hi_, lo_, hic_, loc_;
     uint elementsPerBlock_, elements_;
-    sycl::stream debug_;
 };
 
 }  // namespace kernel

--- a/src/backend/oneapi/kernel/random_engine_threefry.hpp
+++ b/src/backend/oneapi/kernel/random_engine_threefry.hpp
@@ -162,16 +162,14 @@ template<typename T>
 class uniformThreefry {
    public:
     uniformThreefry(sycl::accessor<T> out, uint hi, uint lo, uint hic, uint loc,
-                    uint elementsPerBlock, uint elements,
-                    sycl::stream debug_stream)
+                    uint elementsPerBlock, uint elements)
         : out_(out)
         , hi_(hi)
         , lo_(lo)
         , hic_(hic)
         , loc_(loc)
         , elementsPerBlock_(elementsPerBlock)
-        , elements_(elements)
-        , debug_(debug_stream) {}
+        , elements_(elements) {}
 
     void operator()(sycl::nd_item<1> it) const {
         sycl::group g = it.get_group();
@@ -203,23 +201,20 @@ class uniformThreefry {
     sycl::accessor<T> out_;
     uint hi_, lo_, hic_, loc_;
     uint elementsPerBlock_, elements_;
-    sycl::stream debug_;
 };
 
 template<typename T>
 class normalThreefry {
    public:
     normalThreefry(sycl::accessor<T> out, uint hi, uint lo, uint hic, uint loc,
-                   uint elementsPerBlock, uint elements,
-                   sycl::stream debug_stream)
+                   uint elementsPerBlock, uint elements)
         : out_(out)
         , hi_(hi)
         , lo_(lo)
         , hic_(hic)
         , loc_(loc)
         , elementsPerBlock_(elementsPerBlock)
-        , elements_(elements)
-        , debug_(debug_stream) {}
+        , elements_(elements) {}
 
     void operator()(sycl::nd_item<1> it) const {
         sycl::group g = it.get_group();
@@ -251,7 +246,6 @@ class normalThreefry {
     sycl::accessor<T> out_;
     uint hi_, lo_, hic_, loc_;
     uint elementsPerBlock_, elements_;
-    sycl::stream debug_;
 };
 
 }  // namespace kernel

--- a/src/backend/oneapi/kernel/random_engine_write.hpp
+++ b/src/backend/oneapi/kernel/random_engine_write.hpp
@@ -7,7 +7,8 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 #pragma once
-#include <CL/sycl.hpp>
+
+#include <sycl/builtins.hpp>
 
 namespace arrayfire {
 namespace oneapi {

--- a/src/backend/oneapi/kernel/reduce_all.hpp
+++ b/src/backend/oneapi/kernel/reduce_all.hpp
@@ -264,10 +264,10 @@ void reduce_all_launcher_default(Param<To> out, Param<Ti> in,
     Array<To> tmp = createEmptyArray<To>(tmp_elements);
 
     Array<unsigned> retirementCount = createValueArray<unsigned>(1, 0);
-    getQueue().submit([=](sycl::handler &h) {
+    getQueue().submit([&](sycl::handler &h) {
         write_accessor<To> out_acc{*out.data, h};
-        auto retCount_acc = retirementCount.getData()->get_access(h);
-        auto tmp_acc      = tmp.getData()->get_access(h);
+        auto retCount_acc = retirementCount.get()->get_access(h);
+        auto tmp_acc      = tmp.get()->get_access(h);
         read_accessor<Ti> in_acc{*in.data, h};
 
         auto shrdMem =

--- a/src/backend/oneapi/kernel/rotate.hpp
+++ b/src/backend/oneapi/kernel/rotate.hpp
@@ -136,9 +136,6 @@ void rotate(Param<T> out, const Param<T> in, const float theta,
 
     // Used for batching images
     constexpr int TI = 4;
-    constexpr bool isComplex =
-        static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
-        static_cast<af_dtype>(dtype_traits<T>::af_type) == c64;
 
     const float c = cos(-theta), s = sin(-theta);
     float tx, ty;

--- a/src/backend/oneapi/kernel/transform.hpp
+++ b/src/backend/oneapi/kernel/transform.hpp
@@ -126,7 +126,6 @@ class transformCreateKernel {
 
         // Index of transform
         const int eTfs2 = sycl::max((nTfs2_ / nImg2_), 1);
-        const int eTfs3 = sycl::max((nTfs3_ / nImg3_), 1);
 
         int t_idx3        = -1;  // init
         int t_idx2        = -1;  // init
@@ -243,8 +242,6 @@ template<typename T>
 void transform(Param<T> out, const Param<T> in, const Param<float> tf,
                bool isInverse, bool isPerspective, af_interp_type method,
                int order) {
-    static int counter = 0;
-
     using std::string;
 
     using BT = typename dtype_traits<T>::base_type;
@@ -253,9 +250,6 @@ void transform(Param<T> out, const Param<T> in, const Param<float> tf,
     constexpr int TY = 16;
     // Used for batching images
     constexpr int TI = 4;
-    constexpr bool isComplex =
-        static_cast<af_dtype>(dtype_traits<T>::af_type) == c32 ||
-        static_cast<af_dtype>(dtype_traits<T>::af_type) == c64;
 
     const int nImg2 = in.info.dims[2];
     const int nImg3 = in.info.dims[3];

--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -161,6 +161,8 @@ class Array {
     explicit Array(const af::dim4 &dims, const T *const in_data);
     explicit Array(const af::dim4 &dims, cl_mem mem, size_t offset, bool copy);
 
+    std::shared_ptr<cl::Buffer> getData() const { return data; }
+
    public:
     Array(const Array<T> &other) = default;
 
@@ -249,8 +251,6 @@ class Array {
     int useCount() const { return data.use_count(); }
 
     dim_t getOffset() const { return info.getOffset(); }
-
-    std::shared_ptr<cl::Buffer> getData() const { return data; }
 
     dim4 getDataDims() const { return data_dims; }
 


### PR DESCRIPTION
Remove getData usage in the oneAPI backend and make it private

Description
-----------
The getData function should not be used to get the buffer pointer. The get function should be called instead because the Array could be a node array and in that case it would be a null pointer. The get function will evaluate the buffer and then return the resulting array. This was causing crashes after the JIT changes

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
