### PR TITLE
Workaround for range kernel bug for oneAPI

### DIFF
--- a/src/backend/oneapi/jit.cpp
+++ b/src/backend/oneapi/jit.cpp
@@ -401,7 +401,7 @@ void evalNodes(vector<Param<T>>& outputs, const vector<Node*>& output_nodes) {
                                       outputs[0].info.dims[2] > 1)};
 
     getQueue()
-        .submit([&](sycl::handler& h) {
+        .submit([=](sycl::handler& h) {
             for (Node* node : full_nodes) {
                 if (node->isBuffer()) {
                     BufferNode<T>* n = static_cast<BufferNode<T>*>(node);

--- a/src/backend/oneapi/jit/BufferNode.hpp
+++ b/src/backend/oneapi/jit/BufferNode.hpp
@@ -20,7 +20,7 @@ namespace jit {
 template<typename T>
 using BufferNode =
     common::BufferNodeBase<std::shared_ptr<sycl::buffer<T>>, AParam<T>>;
-}
+}  // namespace jit
 }  // namespace oneapi
 
 namespace common {

--- a/src/backend/oneapi/kernel/bilateral.hpp
+++ b/src/backend/oneapi/kernel/bilateral.hpp
@@ -121,9 +121,7 @@ class bilateralKernel {
             int joff = (ly - radius) * shrdLen + (lx - radius);
             int goff = 0;
 
-#pragma unroll
             for (int wj = 0; wj < window_size; ++wj) {
-#pragma unroll
                 for (int wi = 0; wi < window_size; ++wi) {
                     outType tmp_color = localMem_[joff + wi];
                     const outType c   = center_color - tmp_color;

--- a/src/backend/oneapi/platform.cpp
+++ b/src/backend/oneapi/platform.cpp
@@ -320,14 +320,10 @@ const std::string& getActiveDeviceBaseBuildFlags() {
 size_t getDeviceMemorySize(int device) {
     DeviceManager& devMngr = DeviceManager::getInstance();
 
-    sycl::device dev;
-    {
-        common::lock_guard_t lock(devMngr.deviceMutex);
-        // Assuming devices don't deallocate or are invalidated during execution
-        dev = *devMngr.mDevices[device];
-    }
-    size_t msize = dev.get_info<sycl::info::device::global_mem_size>();
-    return msize;
+    common::lock_guard_t lock(devMngr.deviceMutex);
+    // Assuming devices don't deallocate or are invalidated during execution
+    sycl::device& dev = *devMngr.mDevices[device];
+    return dev.get_info<sycl::info::device::global_mem_size>();
 }
 
 size_t getHostMemorySize() { return common::getHostMemorySize(); }

--- a/test/anisotropic_diffusion.cpp
+++ b/test/anisotropic_diffusion.cpp
@@ -50,7 +50,7 @@ void imageTest(string pTestFile, const float dt, const float K,
             OutType;
 
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     using af::dim4;
 

--- a/test/arrayfire_test.cpp
+++ b/test/arrayfire_test.cpp
@@ -822,18 +822,6 @@ void cleanSlate() {
     ASSERT_EQ(af::getMemStepSize(), step_bytes);
 }
 
-bool noImageIOTests() {
-    bool ret = !af::isImageIOAvailable();
-    if (ret) printf("Image IO Not Configured. Test will exit\n");
-    return ret;
-}
-
-bool noLAPACKTests() {
-    bool ret = !af::isLAPACKAvailable();
-    if (ret) printf("LAPACK Not Configured. Test will exit\n");
-    return ret;
-}
-
 template<typename inType, typename outType>
 void readTestsFromFile(const std::string &FileName,
                        std::vector<af::dim4> &inputDims,

--- a/test/bilateral.cpp
+++ b/test/bilateral.cpp
@@ -25,7 +25,7 @@ using std::vector;
 template<typename T, bool isColor>
 void bilateralTest(string pTestFile) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;

--- a/test/canny.cpp
+++ b/test/canny.cpp
@@ -93,7 +93,7 @@ TEST(Canny, DISABLED_Exact) {
 template<typename T>
 void cannyImageOtsuTest(string pTestFile, bool isColor) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     using af::dim4;
 
@@ -220,7 +220,7 @@ TEST(CannyEdgeDetector, Sobel5x5_Invalid) {
 template<typename T>
 void cannyImageOtsuBatchTest(string pTestFile, const dim_t targetBatchCount) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     using af::array;
     using af::canny;

--- a/test/cholesky_dense.cpp
+++ b/test/cholesky_dense.cpp
@@ -34,7 +34,7 @@ using std::vector;
 template<typename T>
 void choleskyTester(const int n, double eps, bool is_upper) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
     dtype ty = (dtype)dtype_traits<T>::af_type;
 

--- a/test/confidence_connected.cpp
+++ b/test/confidence_connected.cpp
@@ -58,7 +58,7 @@ void testImage(const std::string pTestFile, const size_t numSeeds,
                const int multiplier, const unsigned neighborhood_radius,
                const int iter) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<af::dim4> inDims;
     vector<string> inFiles;

--- a/test/fast.cpp
+++ b/test/fast.cpp
@@ -69,7 +69,7 @@ TYPED_TEST_SUITE(FixedFAST, FixedTestTypes);
 template<typename T>
 void fastTest(string pTestFile, bool nonmax) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;
@@ -180,7 +180,7 @@ using af::features;
 using af::loadImage;
 
 TEST(FloatFAST, CPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;

--- a/test/gloh.cpp
+++ b/test/gloh.cpp
@@ -137,7 +137,7 @@ TYPED_TEST_SUITE(GLOH, TestTypes);
 template<typename T>
 void glohTest(string pTestFile) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;
@@ -261,7 +261,7 @@ GLOH_INIT(man, man);
 ///////////////////////////////////// CPP ////////////////////////////////
 //
 TEST(GLOH, CPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;

--- a/test/harris.cpp
+++ b/test/harris.cpp
@@ -61,7 +61,7 @@ TYPED_TEST_SUITE(Harris, TestTypes);
 template<typename T>
 void harrisTest(string pTestFile, float sigma, unsigned block_size) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;
@@ -167,7 +167,7 @@ using af::harris;
 using af::loadImage;
 
 TEST(FloatHarris, CPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;

--- a/test/homography.cpp
+++ b/test/homography.cpp
@@ -49,7 +49,7 @@ void homographyTest(string pTestFile, const af_homography_type htype,
     using af::Pi;
 
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;
@@ -220,7 +220,7 @@ using af::features;
 using af::loadImage;
 
 TEST(Homography, CPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;

--- a/test/imageio.cpp
+++ b/test/imageio.cpp
@@ -36,7 +36,7 @@ typedef ::testing::Types<float> TestTypes;
 TYPED_TEST_SUITE(ImageIO, TestTypes);
 
 void loadImageTest(string pTestFile, string pImageFile, const bool isColor) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> numDims;
 
@@ -93,7 +93,7 @@ TYPED_TEST(ImageIO, ColorSeq) {
 }
 
 void loadimageArgsTest(string pImageFile, const bool isColor, af_err err) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     af_array imgArray = 0;
 
@@ -122,7 +122,7 @@ using af::saveImageMem;
 using af::span;
 
 TEST(ImageIO, CPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> numDims;
 
@@ -150,7 +150,7 @@ TEST(ImageIO, CPP) {
 }
 
 TEST(ImageIO, SavePNGCPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     array input(10, 10, 3, f32);
 
@@ -170,7 +170,7 @@ TEST(ImageIO, SavePNGCPP) {
 }
 
 TEST(ImageIO, SaveBMPCPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     array input(10, 10, 3, f32);
 
@@ -190,7 +190,7 @@ TEST(ImageIO, SaveBMPCPP) {
 }
 
 TEST(ImageMem, SaveMemPNG) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     array img =
         loadImage(string(TEST_DIR "/imageio/color_seq.png").c_str(), true);
@@ -205,7 +205,7 @@ TEST(ImageMem, SaveMemPNG) {
 }
 
 TEST(ImageMem, SaveMemJPG1) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     array img =
         loadImage(string(TEST_DIR "/imageio/color_seq.png").c_str(), false);
@@ -222,7 +222,7 @@ TEST(ImageMem, SaveMemJPG1) {
 }
 
 TEST(ImageMem, SaveMemJPG3) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     array img =
         loadImage(string(TEST_DIR "/imageio/color_seq.png").c_str(), true);
@@ -239,7 +239,7 @@ TEST(ImageMem, SaveMemJPG3) {
 }
 
 TEST(ImageMem, SaveMemBMP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     array img =
         loadImage(string(TEST_DIR "/imageio/color_rand.png").c_str(), true);
@@ -254,7 +254,7 @@ TEST(ImageMem, SaveMemBMP) {
 }
 
 TEST(ImageIO, LoadImage16CPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> numDims;
 
@@ -284,7 +284,7 @@ TEST(ImageIO, LoadImage16CPP) {
 }
 
 TEST(ImageIO, SaveImage16CPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     dim4 dims(16, 24, 3);
 
@@ -312,7 +312,7 @@ using af::saveImageNative;
 
 template<typename T>
 void loadImageNativeCPPTest(string pTestFile, string pImageFile) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> numDims;
 
@@ -362,7 +362,7 @@ TEST(ImageIONative, LoadImageNative16GrayCPP) {
 
 template<typename T>
 void saveLoadImageNativeCPPTest(dim4 dims) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     array input = randu(dims, (af_dtype)dtype_traits<T>::af_type);
 

--- a/test/inverse_deconv.cpp
+++ b/test/inverse_deconv.cpp
@@ -38,7 +38,7 @@ void invDeconvImageTest(string pTestFile, const float gamma,
             OutType;
 
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     using af::dim4;
 

--- a/test/inverse_dense.cpp
+++ b/test/inverse_dense.cpp
@@ -34,7 +34,7 @@ using std::abs;
 template<typename T>
 void inverseTester(const int m, const int n, double eps) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 #if 1
     array A = cpu_randu<T>(dim4(m, n));
 #else

--- a/test/iterative_deconv.cpp
+++ b/test/iterative_deconv.cpp
@@ -38,7 +38,7 @@ void iterDeconvImageTest(string pTestFile, const unsigned iters, const float rf,
             OutType;
 
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     using af::dim4;
 

--- a/test/lu_dense.cpp
+++ b/test/lu_dense.cpp
@@ -37,7 +37,7 @@ using std::string;
 using std::vector;
 
 TEST(LU, InPlaceSmall) {
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
     int resultIdx = 0;
 
@@ -75,7 +75,7 @@ TEST(LU, InPlaceSmall) {
 }
 
 TEST(LU, SplitSmall) {
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
     int resultIdx = 0;
 
@@ -128,7 +128,7 @@ TEST(LU, SplitSmall) {
 template<typename T>
 void luTester(const int m, const int n, double eps) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
 #if 1
     array a_orig = cpu_randu<T>(dim4(m, n));
@@ -237,7 +237,7 @@ TYPED_TEST(LU, RectangularMultipleOfTwoLarge1) {
 }
 
 TEST(LU, NullLowerOutput) {
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
     dim4 dims(3, 3);
     af_array in = 0;
     ASSERT_SUCCESS(af_randu(&in, dims.ndims(), dims.get(), f32));
@@ -248,7 +248,7 @@ TEST(LU, NullLowerOutput) {
 }
 
 TEST(LU, NullUpperOutput) {
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
     dim4 dims(3, 3);
     af_array in = 0;
     ASSERT_SUCCESS(af_randu(&in, dims.ndims(), dims.get(), f32));
@@ -259,7 +259,7 @@ TEST(LU, NullUpperOutput) {
 }
 
 TEST(LU, NullPivotOutput) {
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
     dim4 dims(3, 3);
     af_array in = 0;
     ASSERT_SUCCESS(af_randu(&in, dims.ndims(), dims.get(), f32));
@@ -270,7 +270,7 @@ TEST(LU, NullPivotOutput) {
 }
 
 TEST(LU, InPlaceNullOutput) {
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
     dim4 dims(3, 3);
     af_array in = 0;
     ASSERT_SUCCESS(af_randu(&in, dims.ndims(), dims.get(), f32));

--- a/test/meanshift.cpp
+++ b/test/meanshift.cpp
@@ -54,7 +54,7 @@ TYPED_TEST(Meanshift, InvalidArgs) {
 template<typename T, bool isColor>
 void meanshiftTest(string pTestFile, const float ss) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;
@@ -131,7 +131,7 @@ using af::seq;
 using af::span;
 
 TEST(Meanshift, Color_CPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;

--- a/test/medfilt.cpp
+++ b/test/medfilt.cpp
@@ -166,7 +166,7 @@ TYPED_TEST(MedianFilter1d, BATCH_SYMMETRIC_PAD_3) {
 template<typename T, bool isColor>
 void medfiltImageTest(string pTestFile, dim_t w_len, dim_t w_wid) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;

--- a/test/moments.cpp
+++ b/test/moments.cpp
@@ -98,7 +98,7 @@ void momentsTest(string pTestFile) {
 }
 
 void momentsOnImageTest(string pTestFile, string pImageFile, bool isColor) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
     vector<dim4> numDims;
 
     vector<vector<float>> in;

--- a/test/morph.cpp
+++ b/test/morph.cpp
@@ -136,7 +136,7 @@ TYPED_TEST(Morph, Erode4x4x4) {
 template<typename T, bool isDilation, bool isColor>
 void morphImageTest(string pTestFile, dim_t seLen) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;
@@ -390,7 +390,7 @@ using af::span;
 template<typename T, bool isDilation, bool isColor>
 void cppMorphImageTest(string pTestFile) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;

--- a/test/orb.cpp
+++ b/test/orb.cpp
@@ -129,7 +129,7 @@ TYPED_TEST_SUITE(ORB, TestTypes);
 template<typename T>
 void orbTest(string pTestFile) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;
@@ -246,7 +246,7 @@ TYPED_TEST(ORB, Lena) { orbTest<TypeParam>(string(TEST_DIR "/orb/lena.test")); }
 ///////////////////////////////////// CPP ////////////////////////////////
 //
 TEST(ORB, CPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;

--- a/test/qr_dense.cpp
+++ b/test/qr_dense.cpp
@@ -34,7 +34,7 @@ using std::vector;
 
 ///////////////////////////////// CPP ////////////////////////////////////
 TEST(QRFactorized, CPP) {
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
     int resultIdx = 0;
 
@@ -90,7 +90,7 @@ template<typename T>
 void qrTester(const int m, const int n, double eps) {
     try {
         SUPPORTED_TYPE_CHECK(T);
-        if (noLAPACKTests()) return;
+        LAPACK_ENABLED_CHECK();
 
 #if 1
         array in = cpu_randu<T>(dim4(m, n));
@@ -181,7 +181,7 @@ TYPED_TEST(QR, RectangularMultipleOfTwoLarge1) {
 }
 
 TEST(QR, InPlaceNullOutput) {
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
     dim4 dims(3, 3);
     af_array in = 0;
     ASSERT_SUCCESS(af_randu(&in, dims.ndims(), dims.get(), f32));

--- a/test/rank_dense.cpp
+++ b/test/rank_dense.cpp
@@ -46,7 +46,7 @@ TYPED_TEST_SUITE(Det, TestTypes);
 template<typename T>
 void rankSmall() {
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
     T ha[] = {1, 4, 7, 2, 5, 8, 3, 6, 20};
     array a(3, 3, ha);
@@ -57,7 +57,7 @@ void rankSmall() {
 template<typename T>
 void rankBig(const int num) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
     dtype dt = (dtype)dtype_traits<T>::af_type;
     array a  = randu(num, num, dt);
@@ -71,7 +71,7 @@ void rankBig(const int num) {
 template<typename T>
 void rankLow(const int num) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
     dtype dt = (dtype)dtype_traits<T>::af_type;
 
@@ -93,7 +93,7 @@ TYPED_TEST(Rank, low) { rankBig<TypeParam>(512); }
 template<typename T>
 void detTest() {
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
     dtype dt = (dtype)dtype_traits<T>::af_type;
 
@@ -114,7 +114,7 @@ void detTest() {
 TYPED_TEST(Det, Small) { detTest<TypeParam>(); }
 
 TEST(Rank, NullOutput) {
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
     dim4 dims(3, 3);
     af_array in = 0;
     af_randu(&in, dims.ndims(), dims.get(), f32);

--- a/test/sift.cpp
+++ b/test/sift.cpp
@@ -138,7 +138,7 @@ template<typename T>
 void siftTest(string pTestFile, unsigned nLayers, float contrastThr,
               float edgeThr, float initSigma, bool doubleInput) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;
@@ -272,7 +272,7 @@ SIFT_INIT(Man_NoDoubleInput, man_nodoubleinput, 3, 0.04f, 10.0f, 1.6f, false);
 ///////////////////////////////////// CPP ////////////////////////////////
 //
 TEST(SIFT, CPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;

--- a/test/solve_common.hpp
+++ b/test/solve_common.hpp
@@ -35,7 +35,7 @@ void solveTester(const int m, const int n, const int k, double eps,
     af::deviceGC();
 
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
 #if 1
     af::array A  = cpu_randu<T>(af::dim4(m, n));
@@ -65,7 +65,7 @@ void solveLUTester(const int n, const int k, double eps,
     af::deviceGC();
 
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
 #if 1
     af::array A  = cpu_randu<T>(af::dim4(n, n));
@@ -95,7 +95,7 @@ void solveTriangleTester(const int n, const int k, bool is_upper, double eps,
     af::deviceGC();
 
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
 #if 1
     af::array A  = cpu_randu<T>(af::dim4(n, n));

--- a/test/solve_dense.cpp
+++ b/test/solve_dense.cpp
@@ -51,7 +51,7 @@ void solveTester(const int m, const int n, const int k, const int b, double eps,
     deviceGC();
 
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
 #if 1
     array A  = cpu_randu<T>(dim4(m, n, b));
@@ -88,7 +88,7 @@ void solveLUTester(const int n, const int k, double eps,
     deviceGC();
 
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
 #if 1
     array A  = cpu_randu<T>(dim4(n, n));
@@ -125,7 +125,7 @@ void solveTriangleTester(const int n, const int k, bool is_upper, double eps,
     deviceGC();
 
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
 #if 1
     array A  = cpu_randu<T>(dim4(n, n));

--- a/test/susan.cpp
+++ b/test/susan.cpp
@@ -67,7 +67,7 @@ TYPED_TEST_SUITE(Susan, TestTypes);
 template<typename T>
 void susanTest(string pTestFile, float t, float g) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;

--- a/test/svd_dense.cpp
+++ b/test/svd_dense.cpp
@@ -58,7 +58,7 @@ double get_val<cdouble>(cdouble val) {
 template<typename T>
 void svdTest(const int M, const int N) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
     dtype ty = (dtype)dtype_traits<T>::af_type;
 
@@ -87,7 +87,7 @@ void svdTest(const int M, const int N) {
 template<typename T>
 void svdInPlaceTest(const int M, const int N) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
     dtype ty = (dtype)dtype_traits<T>::af_type;
 
@@ -115,7 +115,7 @@ void svdInPlaceTest(const int M, const int N) {
 template<typename T>
 void checkInPlaceSameResults(const int M, const int N) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noLAPACKTests()) return;
+    LAPACK_ENABLED_CHECK();
 
     dtype ty = (dtype)dtype_traits<T>::af_type;
 

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -227,7 +227,13 @@ bool noHalfTests(af::dtype ty);
     if (noDoubleTests((af_dtype)af::dtype_traits<type>::af_type)) \
         GTEST_SKIP() << "Device doesn't support Doubles";         \
     if (noHalfTests((af_dtype)af::dtype_traits<type>::af_type))   \
-        GTEST_SKIP() << "Device doesn't support Half";
+    GTEST_SKIP() << "Device doesn't support Half"
+
+#define LAPACK_ENABLED_CHECK() \
+    if (!af::isLAPACKAvailable()) GTEST_SKIP() << "LAPACK Not Configured."
+
+#define IMAGEIO_ENABLED_CHECK() \
+    if (!af::isImageIOAvailable()) GTEST_SKIP() << "Image IO Not Configured"
 
 #ifdef AF_WITH_FAST_MATH
 #define SKIP_IF_FAST_MATH_ENABLED() \
@@ -235,10 +241,6 @@ bool noHalfTests(af::dtype ty);
 #else
 #define SKIP_IF_FAST_MATH_ENABLED()
 #endif
-
-bool noImageIOTests();
-
-bool noLAPACKTests();
 
 template<typename TO, typename FROM>
 TO convert_to(FROM in) {

--- a/test/threading.cpp
+++ b/test/threading.cpp
@@ -141,7 +141,7 @@ void morphTest(const array input, const array mask, const bool isDilation,
 }
 
 TEST(Threading, SetPerThreadActiveDevice) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<bool> isDilationFlags;
     vector<bool> isColorFlags;

--- a/test/transform.cpp
+++ b/test/transform.cpp
@@ -97,7 +97,7 @@ template<typename T>
 void transformTest(string pTestFile, string pHomographyFile,
                    const af_interp_type method, const bool invert) {
     SUPPORTED_TYPE_CHECK(T);
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     af_array sceneArray = 0;
     af_array goldArray  = 0;
@@ -304,7 +304,7 @@ class TransformV2 : public Transform<T> {
     }
 
     void setTestData(string pTestFile, string pHomographyFile) {
-        if (noImageIOTests()) return;
+        IMAGEIO_ENABLED_CHECK();
         releaseArrays();
 
         genTestData<T>(&gold, &in, &transform, &odim0, &odim1, pTestFile,
@@ -390,7 +390,7 @@ class TransformV2 : public Transform<T> {
 
     void testSpclOutArray(TestOutputArrayType out_array_type) {
         SUPPORTED_TYPE_CHECK(T);
-        if (noImageIOTests()) return;
+        IMAGEIO_ENABLED_CHECK();
 
         af_array out = 0;
         TestOutputArrayInfo metadata(out_array_type);
@@ -481,7 +481,7 @@ TEST_F(TransformNullArgs, V2NullTransformArray) {
 ///////////////////////////////////// CPP ////////////////////////////////
 //
 TEST(Transform, CPP) {
-    if (noImageIOTests()) return;
+    IMAGEIO_ENABLED_CHECK();
 
     vector<dim4> inDims;
     vector<string> inFiles;


### PR DESCRIPTION
The range kernel was reading out of bounds because of a compiler bug. This PR adds a workaround for that failure

Description
-----------
* Fix range kernel because of compiler error
* Narrow access modes for the transpose kernel
* Pass values into lambda by value
* Use SKIP_TEST instead of silently returning if a test relies on a feature that wasn't compiled into the library.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
