### PR TITLE
Fix scalar in the oneAPI backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ option(AF_WITH_STATIC_CUDA_NUMERIC_LIBS "Link libafcuda with static numeric libr
 option(AF_WITH_SPDLOG_HEADER_ONLY "Build ArrayFire with header only version of spdlog" OFF)
 option(AF_WITH_FMT_HEADER_ONLY "Build ArrayFire with header only version of fmt" OFF)
 option(AF_WITH_FAST_MATH "Use lower precision but high performance numeric optimizations" OFF)
+option(AF_CTEST_SEPARATED "Run tests separately when called from ctest(increases test times)" OFF)
 
 if(AF_WITH_STATIC_CUDA_NUMERIC_LIBS)
   option(AF_WITH_PRUNE_STATIC_CUDA_NUMERIC_LIBS "Prune CUDA static libraries to reduce binary size.(WARNING: May break some libs on older CUDA toolkits for some compute arch)" OFF)

--- a/src/backend/oneapi/Array.cpp
+++ b/src/backend/oneapi/Array.cpp
@@ -397,10 +397,6 @@ kJITHeuristics passesJitHeuristics(span<Node *> root_nodes) {
 template<typename T>
 void *getDevicePtr(const Array<T> &arr) {
     const buffer<T> *buf = arr.device();
-    // if (!buf) { return NULL; }
-    // memLock(buf);
-    // cl_mem mem = (*buf)();
-    ONEAPI_NOT_SUPPORTED("pointer to sycl::buffer should be accessor");
     return (void *)buf;
 }
 

--- a/src/backend/oneapi/copy.cpp
+++ b/src/backend/oneapi/copy.cpp
@@ -214,18 +214,13 @@ template<typename T>
 T getScalar(const Array<T> &in) {
     T retVal{};
 
-    sycl::buffer retBuffer(&retVal, {1},
-                           {sycl::property::buffer::use_host_ptr()});
-
     getQueue()
         .submit([&](sycl::handler &h) {
             auto acc_in =
                 in.get()->template get_access<sycl::access::mode::read>(
                     h, sycl::range{1},
                     sycl::id{static_cast<uintl>(in.getOffset())});
-            auto acc_out =
-                retBuffer.template get_access<sycl::access::mode::write>(h);
-            h.copy(acc_in, acc_out);
+            h.copy(acc_in, &retVal);
         })
         .wait();
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,10 @@ set(AF_TEST_WITH_MTX_FILES
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 
+if(AF_CTEST_SEPARATED)
+  include(GoogleTest)
+endif()
+
 if(AF_TEST_WITH_MTX_FILES)
   include(download_sparse_datasets)
 endif()
@@ -54,6 +58,28 @@ endif()
 if(NOT TARGET mmio)
   add_subdirectory(mmio)
 endif()
+
+
+# Registers test with ctest
+#
+# Parameters
+#  target: The target associated with this test
+#  backend: The backend associated with this test
+#  is_serial: If true the test will be serialized
+function(af_add_test target backend is_serial)
+  if(AF_CTEST_SEPARATED)
+    gtest_discover_tests(${target}
+      TEST_PREFIX $<UPPER_CASE:${backend}>.
+      DISCOVERY_TIMEOUT 40)
+  else()
+    add_test(NAME ${target} COMMAND ${target})
+    if(${is_serial})
+      set_tests_properties(${target}
+        PROPERTIES
+        RUN_SERIAL ON)
+    endif(${is_serial})
+  endif()
+endfunction()
 
 # Reset the CXX flags for tests
 set(CMAKE_CXX_STANDARD 11)
@@ -238,12 +264,7 @@ function(make_test)
 
     # TODO(umar): Create this executable separately
     if(NOT ${backend} STREQUAL "unified" OR ${target} STREQUAL "backend_unified")
-      add_test(NAME ${target} COMMAND ${target})
-	    if(${mt_args_SERIAL})
-        set_tests_properties(${target}
-          PROPERTIES
-            RUN_SERIAL ON)
-	    endif(${mt_args_SERIAL})
+      af_add_test(${target} ${backend} ${mt_args_SERIAL})
     endif()
 
   endforeach()
@@ -387,7 +408,7 @@ if(CUDA_FOUND)
           OUTPUT_NAME "cuda_${backend}")
 
       if(NOT ${backend} STREQUAL "unified")
-        add_test(NAME ${target} COMMAND ${target})
+        af_add_test(${target} ${backend} ON)
       endif()
     endif()
   endforeach()
@@ -457,7 +478,7 @@ foreach(backend ${enabled_backends})
       PRIVATE
       ArrayFire::af${backend})
   endif()
-  add_test(NAME test_${target} COMMAND ${target})
+  af_add_test(${target} ${backend} ON)
 endforeach()
 
 if(AF_TEST_WITH_MTX_FILES)

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -502,12 +502,12 @@ TEST(DeviceId, Different) {
 
 TEST(Device, empty) {
     array a = array();
-    ASSERT_EQ(a.device<float>() == NULL, 1);
+    ASSERT_EQ(a.device<float>(), nullptr);
 }
 
 TEST(Device, JIT) {
     array a = constant(1, 5, 5);
-    ASSERT_EQ(a.device<float>() != NULL, 1);
+    ASSERT_NE(a.device<float>(), nullptr);
 }
 
 TYPED_TEST(Array, Scalar) {
@@ -520,7 +520,7 @@ TYPED_TEST(Array, Scalar) {
 
     a.host((void *)gold.data());
 
-    EXPECT_EQ(true, gold[0] == a.scalar<TypeParam>());
+    EXPECT_EQ(gold[0], a.scalar<TypeParam>());
 }
 
 TEST(Array, ScalarTypeMismatch) {


### PR DESCRIPTION
This PR fixes the scalar function in the oneAPI backend. It also adds the ability to run individual gtest tests in ctests allowing for better granularity but increased runtimes.

Description
-----------
* Fix the scalar function by fixing the copy operation to write directly to the host memory instead of creating a host backed buffer
* Sparate tests in ctest so that each test is executed in a separate invocation. this allows for finer granularity when using the cdash reports but increases runtime because of the loading of each processes
* The device pointer now returns a pointer to the buffer<T> object.
* Refactor some of the array test's asserts

Changes to Users
----------------
* Builders can now set AF_CTEST_SEPARATE to ON so that they can separate tests. The default value is off

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
