### PR TITLE
Fix oneAPI find_package command to look at the MKLROOT env var

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,8 +45,8 @@ if(AF_WITH_EXTERNAL_PACKAGES_ONLY)
   set(AF_REQUIRED REQUIRED)
 endif()
 
-#Set Intel OpenMP as default MKL thread layer
-if(CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM" OR CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+if(CXX_COMPILER_NAME STREQUAL "dpcpp" OR CXX_COMPILER_NAME STREQUAL "dpcpp.exe"
+   OR CXX_COMPILER_NAME STREQUAL "icpx" OR CXX_COMPILER_NAME STREQUAL "icx.exe")
   set(MKL_THREAD_LAYER "TBB" CACHE STRING "The thread layer to choose for MKL")
   set(MKL_INTERFACE "ilp64")
   set(MKL_INTERFACE_INTEGER_SIZE 8)
@@ -125,7 +125,14 @@ elseif(MKL_THREAD_LAYER STREQUAL "TBB")
   set(MKL_THREADING "tbb_thread")
 else()
 endif()
-find_package(MKL)
+
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+  # VCPKG overrides the find_package command and the PATH parameter is currently
+  # broken with the current version of VCPKG so we are setting the MKL_ROOT
+  # directory to the MKLROOT environment variable.
+  set(MKL_ROOT "$ENV{MKLROOT}")
+  find_package(MKL)
+endif()
 
 af_multiple_option(NAME        AF_COMPUTE_LIBRARY
                    DEFAULT     ${default_compute_library}
@@ -218,7 +225,7 @@ if(${AF_BUILD_CPU} OR ${AF_BUILD_OPENCL})
   if("${AF_COMPUTE_LIBRARY}" STREQUAL "Intel-MKL"
       OR "${AF_COMPUTE_LIBRARY}" STREQUAL "MKL")
     af_mkl_batch_check()
-    dependency_check(MKL_FOUND "Please ensure Intel-MKL / oneAPI-oneMKL is installed")
+    dependency_check(MKL_Shared_FOUND "Please ensure Intel-MKL / oneAPI-oneMKL is installed")
     set(BUILD_WITH_MKL ON)
   elseif("${AF_COMPUTE_LIBRARY}" STREQUAL "FFTW/LAPACK/BLAS")
     dependency_check(FFTW_FOUND "FFTW not found")

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -334,11 +334,15 @@ kJITHeuristics passesJitHeuristics(span<Node *> root_nodes) {
             (3 * sizeof(uint));
 
         const cl::Device &device = getDevice();
-        size_t max_param_size = device.getInfo<CL_DEVICE_MAX_PARAMETER_SIZE>();
         // typical values:
         //   NVIDIA     = 4096
         //   AMD        = 3520  (AMD A10 iGPU = 1024)
         //   Intel iGPU = 1024
+        //
+        // Setting the maximum to 5120 bytes to keep the compile times
+        // resonable. This still results in large kernels but its not excessive.
+        size_t max_param_size =
+            min(5120UL, device.getInfo<CL_DEVICE_MAX_PARAMETER_SIZE>());
         max_param_size -= base_param_size;
 
         struct tree_info {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,7 +76,9 @@ function(af_add_test target backend is_serial)
     if(${is_serial})
       set_tests_properties(${target}
         PROPERTIES
-        RUN_SERIAL ON)
+          ENVIRONMENT AF_PRINT_ERRORS=1
+          TIMEOUT 900
+          RUN_SERIAL ON)
     endif(${is_serial})
   endif()
 endfunction()


### PR DESCRIPTION
Improves the find_package(MKL) command to look at the MKLROOT environment variable. This environment variable was not being referenced when finding the config file by default in CMake.

Description
-----------
* find_package(MKL) now uses MKLROOT to find the MKLConfig.cmake file
* Update the compiler recognition code so that older CMake versions can find DPCPP compilers

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
