### PR TITLE
Corrected availability check of work_group_collection_functions for O…

### DIFF
--- a/src/backend/opencl/kernel/reduce_blocks_by_key_dim.cl
+++ b/src/backend/opencl/kernel/reduce_blocks_by_key_dim.cl
@@ -9,7 +9,12 @@
 
 // Starting from OpenCL 2.0, core profile includes work group level
 // inclusive scan operations, hence skip defining custom one
-#if __OPENCL_VERSION__ < 200
+#if __OPENCL_C_VERSION__ == 200 || __OPENCL_C_VERSION__ == 210 || \
+    __OPENCL_C_VERSION__ == 220 || __opencl_c_work_group_collective_functions
+#define BUILTIN_WORK_GROUP_COLLECTIVE_FUNCTIONS
+#endif
+
+#ifndef BUILTIN_WORK_GROUP_COLLECTIVE_FUNCTIONS
 int work_group_scan_inclusive_add(local int *wg_temp, __local int *arr) {
     local int *active_buf;
 
@@ -29,15 +34,15 @@ int work_group_scan_inclusive_add(local int *wg_temp, __local int *arr) {
     int res = active_buf[lid];
     return res;
 }
-#endif  // __OPENCL_VERSION__ < 200
+#endif
 
 kernel void reduce_blocks_by_key_dim(global int *reduced_block_sizes,
-                                       global Tk *oKeys, KParam oKInfo,
-                                       global To *oVals, KParam oVInfo,
-                                       const global Tk *iKeys, KParam iKInfo,
-                                       const global Ti *iVals, KParam iVInfo,
-                                       int change_nan, To nanval, int n,
-                                       const int nBlocksZ) {
+                                     global Tk *oKeys, KParam oKInfo,
+                                     global To *oVals, KParam oVInfo,
+                                     const global Tk *iKeys, KParam iKInfo,
+                                     const global Ti *iVals, KParam iVInfo,
+                                     int change_nan, To nanval, int n,
+                                     const int nBlocksZ) {
     const uint lid  = get_local_id(0);
     const uint gidx = get_global_id(0);
 
@@ -50,7 +55,7 @@ kernel void reduce_blocks_by_key_dim(global int *reduced_block_sizes,
     local Tk reduced_keys[DIMX];
     local To reduced_vals[DIMX];
     local int unique_ids[DIMX];
-#if __OPENCL_VERSION__ < 200
+#ifndef BUILTIN_WORK_GROUP_COLLECTIVE_FUNCTIONS
     local int wg_temp[DIMX];
     local int unique_flags[DIMX];
 #endif
@@ -98,11 +103,11 @@ kernel void reduce_blocks_by_key_dim(global int *reduced_block_sizes,
     int eq_check    = (lid > 0) ? (k != reduced_keys[lid - 1]) : 0;
     int unique_flag = (eq_check || (lid == 0)) && (gidx < n);
 
-#if __OPENCL_VERSION__ < 200
+#ifdef BUILTIN_WORK_GROUP_COLLECTIVE_FUNCTIONS
+    int unique_id = work_group_scan_inclusive_add(unique_flag);
+#else
     unique_flags[lid] = unique_flag;
     int unique_id     = work_group_scan_inclusive_add(wg_temp, unique_flags);
-#else
-    int unique_id = work_group_scan_inclusive_add(unique_flag);
 #endif
     unique_ids[lid] = unique_id;
 


### PR DESCRIPTION
Corrected the availability check of builtin work_group_collection_functions for OpenCL C 2.x

Description
-----------
work_group_scan_inclusive_add is a builtin function when
  - OpenCL C 1.0, 1.1 & 1.2 (Not available)
  - OpenCL C 2.0, 2.1 & 2.2 (Mandatory, so no check available)
  - OpenCL C 3.0 (optional, check via __opencl_c_work_group_collective_functions)

As a result, all special cases have to be checked individually.  The OCL C 3.0 check will also return false for lower versions since it is not defined here.

Backport to 3.8.3 is possible.

Fixes: #3391

Changes to Users
----------------
Bug fix, no other changes.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass (OCL 2.0 & OCL 3.0)
- [ ] Functions added to unified API
- [ ] Functions documented
