### PR TITLE
set CXX_COMPILER_NAME based on the current compiler to detect sycl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ if(AF_WITH_EXTERNAL_PACKAGES_ONLY)
   set(AF_REQUIRED REQUIRED)
 endif()
 
+get_filename_component(CXX_COMPILER_NAME ${CMAKE_CXX_COMPILER} NAME)
 if(CXX_COMPILER_NAME STREQUAL "dpcpp" OR CXX_COMPILER_NAME STREQUAL "dpcpp.exe"
    OR CXX_COMPILER_NAME STREQUAL "icpx" OR CXX_COMPILER_NAME STREQUAL "icx.exe")
   set(MKL_THREAD_LAYER "TBB" CACHE STRING "The thread layer to choose for MKL")
@@ -130,7 +131,9 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
   # VCPKG overrides the find_package command and the PATH parameter is currently
   # broken with the current version of VCPKG so we are setting the MKL_ROOT
   # directory to the MKLROOT environment variable.
-  set(MKL_ROOT "$ENV{MKLROOT}")
+  if(DEFINED ENV{MKLROOT} AND NOT DEFINED MKL_ROOT)
+    set(MKL_ROOT "$ENV{MKLROOT}")
+  endif()
   find_package(MKL)
 endif()
 


### PR DESCRIPTION
This PR sets the CXX_COMPILER_NAME variable which was missing in the previous commit. This variable is used to detect if we are using the intel compiler to target oneAPI.

Description
-----------
* The CXX_COMPILER_NAME variable is used to detect the compiler so that we can set the type of MKL libraries to link against. When targeting sycl we need to target the ilp64 interface and the tbb threading layer.
* Also address an issue where the builds were failing when the MKLROOT environment variable is not defined.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
