### PR TITLE
Set minimum required oneAPI version to 2023.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
   if(DEFINED ENV{MKLROOT} AND NOT DEFINED MKL_ROOT)
     set(MKL_ROOT "$ENV{MKLROOT}")
   endif()
-  find_package(MKL)
+  find_package(MKL 2023.1)
 endif()
 
 af_multiple_option(NAME        AF_COMPUTE_LIBRARY

--- a/CMakeModules/FindAF_MKL.cmake
+++ b/CMakeModules/FindAF_MKL.cmake
@@ -73,7 +73,6 @@
 
 include(CheckTypeSize)
 include(FindPackageHandleStandardArgs)
-find_package(OpenMP QUIET)
 
 check_type_size("int" INT_SIZE
   BUILTIN_TYPES_ONLY LANGUAGE C)

--- a/src/backend/common/debug.hpp
+++ b/src/backend/common/debug.hpp
@@ -43,15 +43,18 @@ void print(const char *F, const first &FF, ARGS... args) {
 #define SHOW5(val1, val2, val3, val4, val5)                              \
     debugging::print(#val1, val1, #val2, val2, #val3, val3, #val4, val4, \
                      #val5, val5)
+#define SHOW6(val1, val2, val3, val4, val5, val6)                        \
+    debugging::print(#val1, val1, #val2, val2, #val3, val3, #val4, val4, \
+                     #val5, val5, #val6, val6)
 
-#define GET_MACRO(_1, _2, _3, _4, _5, NAME, ...) NAME
+#define GET_MACRO(_1, _2, _3, _4, _5, _6, NAME, ...) NAME
 
-#define SHOW(...)                                                 \
-    do {                                                          \
-        fmt::print(std::cout, "{}:({}): ", __FILE__, __LINE__);   \
-        GET_MACRO(__VA_ARGS__, SHOW5, SHOW4, SHOW3, SHOW2, SHOW1) \
-        (__VA_ARGS__);                                            \
-        fmt::print(std::cout, "\n");                              \
+#define SHOW(...)                                                        \
+    do {                                                                 \
+        fmt::print(std::cout, "{}:({}): ", __FILE__, __LINE__);          \
+        GET_MACRO(__VA_ARGS__, SHOW6, SHOW5, SHOW4, SHOW3, SHOW2, SHOW1) \
+        (__VA_ARGS__);                                                   \
+        fmt::print(std::cout, "\n");                                     \
     } while (0)
 
 #define PRINTVEC(val)                                                        \

--- a/src/backend/common/half.hpp
+++ b/src/backend/common/half.hpp
@@ -33,7 +33,7 @@
 #endif
 
 #ifdef AF_ONEAPI
-#include <sycl/half_type.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 #include <backend.hpp>

--- a/src/backend/oneapi/Array.hpp
+++ b/src/backend/oneapi/Array.hpp
@@ -17,7 +17,7 @@
 #include <types.hpp>
 #include <af/dim4.hpp>
 
-#include <sycl/buffer.hpp>
+#include <sycl/sycl.hpp>
 
 #include <nonstd/span.hpp>
 #include <algorithm>

--- a/src/backend/oneapi/Event.hpp
+++ b/src/backend/oneapi/Event.hpp
@@ -9,11 +9,9 @@
 #pragma once
 
 #include <common/EventBase.hpp>
-
 #include <af/event.h>
 
-#include <sycl/event.hpp>
-#include <sycl/queue.hpp>
+#include <sycl/sycl.hpp>
 
 namespace arrayfire {
 namespace oneapi {

--- a/src/backend/oneapi/Module.hpp
+++ b/src/backend/oneapi/Module.hpp
@@ -10,9 +10,8 @@
 #pragma once
 
 #include <common/ModuleInterface.hpp>
-#include <sycl/sycl.hpp>
 
-#include <sycl/kernel_bundle.hpp>
+#include <sycl/sycl.hpp>
 
 namespace arrayfire {
 namespace oneapi {

--- a/src/backend/oneapi/Param.hpp
+++ b/src/backend/oneapi/Param.hpp
@@ -11,17 +11,9 @@
 
 #include <kernel/KParam.hpp>
 #include <types.hpp>
-
 #include <af/dim4.hpp>
 
-/// The get_pointer function in the accessor class throws a few warnings in the
-/// 2023.0 release of the library. Review this warning in the future
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wsycl-strict"
-#include <sycl/accessor.hpp>
-#pragma clang diagnostic pop
-#include <sycl/buffer.hpp>
-#include <sycl/handler.hpp>
+#include <sycl/sycl.hpp>
 
 #include <optional>
 

--- a/src/backend/oneapi/blas.cpp
+++ b/src/backend/oneapi/blas.cpp
@@ -24,7 +24,8 @@
 #include <types.hpp>
 
 #include <sycl/sycl.hpp>
-#include "oneapi/mkl/blas.hpp"
+
+#include <oneapi/mkl/blas.hpp>
 
 #include <complex>
 #include <vector>

--- a/src/backend/oneapi/compile_module.cpp
+++ b/src/backend/oneapi/compile_module.cpp
@@ -14,10 +14,10 @@
 #include <common/defines.hpp>
 #include <common/util.hpp>
 #include <err_oneapi.hpp>
-#include <sycl/sycl.hpp>
-// #include <kernel_headers/KParam.hpp>
 #include <platform.hpp>
 #include <traits.hpp>
+
+#include <sycl/sycl.hpp>
 
 #include <algorithm>
 #include <cctype>

--- a/src/backend/oneapi/device_manager.cpp
+++ b/src/backend/oneapi/device_manager.cpp
@@ -23,12 +23,7 @@
 #include <af/oneapi.h>
 #include <af/version.h>
 
-#include <sycl/context.hpp>
-#include <sycl/device.hpp>
-#include <sycl/exception.hpp>
-#include <sycl/exception_list.hpp>
-#include <sycl/platform.hpp>
-#include <sycl/queue.hpp>
+#include <sycl/sycl.hpp>
 
 #include <algorithm>
 #include <iterator>

--- a/src/backend/oneapi/device_manager.hpp
+++ b/src/backend/oneapi/device_manager.hpp
@@ -9,9 +9,7 @@
 
 #pragma once
 
-#include <sycl/context.hpp>
-#include <sycl/device.hpp>
-#include <sycl/queue.hpp>
+#include <sycl/sycl.hpp>
 
 #include <memory>
 #include <mutex>

--- a/src/backend/oneapi/iota.cpp
+++ b/src/backend/oneapi/iota.cpp
@@ -29,15 +29,6 @@ Array<T> iota(const dim4 &dims, const dim4 &tile_dims) {
     return out;
 }
 
-template<>
-Array<half> iota(const dim4 &dims, const dim4 &tile_dims) {
-    ONEAPI_NOT_SUPPORTED("");
-    // dim4 outdims = dims * tile_dims;
-
-    // Array<half> out = createEmptyArray<half>(outdims);
-    // return out;
-}
-
 #define INSTANTIATE(T) \
     template Array<T> iota<T>(const af::dim4 &dims, const af::dim4 &tile_dims);
 
@@ -50,5 +41,6 @@ INSTANTIATE(uintl)
 INSTANTIATE(uchar)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
+INSTANTIATE(half)
 }  // namespace oneapi
 }  // namespace arrayfire

--- a/src/backend/oneapi/jit.cpp
+++ b/src/backend/oneapi/jit.cpp
@@ -29,7 +29,7 @@
 #include <af/dim4.hpp>
 
 #include <sycl/backend.hpp>
-#include <sycl/interop_handle.hpp>
+#include <sycl/sycl.hpp>
 
 #include <array>
 #include <cstdio>

--- a/src/backend/oneapi/jit.cpp
+++ b/src/backend/oneapi/jit.cpp
@@ -465,7 +465,7 @@ void evalNodes(vector<Param<T>>& outputs, const vector<Node*>& output_nodes) {
                                                 const_cast<void*>(ptr));
                                         vector<cl_mem> mem =
                                             hh.get_native_mem<backend::opencl>(
-                                                info->ph.value());
+                                                info->data);
                                         if (is_linear) {
                                             CL_CHECK(clSetKernelArg(
                                                 kernels[0], id++,
@@ -497,8 +497,8 @@ void evalNodes(vector<Param<T>>& outputs, const vector<Node*>& output_nodes) {
                         // Set output parameters
                         vector<cl_mem> mem;
                         for (const auto& output : ap) {
-                            mem = hh.get_native_mem<backend::opencl>(
-                                output.data.value());
+                            mem =
+                                hh.get_native_mem<backend::opencl>(output.data);
                             cl_mem mmm = mem[0];
                             CL_CHECK(clSetKernelArg(kernels[0], nargs++,
                                                     sizeof(cl_mem), &mmm));

--- a/src/backend/oneapi/jit/kernel_generators.hpp
+++ b/src/backend/oneapi/jit/kernel_generators.hpp
@@ -11,7 +11,7 @@
 #include <Param.hpp>
 #include <err_oneapi.hpp>
 
-#include <sycl/buffer.hpp>
+#include <sycl/sycl.hpp>
 
 #include <functional>
 #include <memory>

--- a/src/backend/oneapi/kernel/approx1.hpp
+++ b/src/backend/oneapi/kernel/approx1.hpp
@@ -14,9 +14,10 @@
 #include <debug_oneapi.hpp>
 #include <err_oneapi.hpp>
 #include <kernel/interp.hpp>
-#include <af/constants.h>
-// #include <kernel/default_config.hpp>
 #include <traits.hpp>
+#include <af/constants.h>
+
+#include <sycl/sycl.hpp>
 
 #include <string>
 #include <vector>

--- a/src/backend/oneapi/kernel/approx2.hpp
+++ b/src/backend/oneapi/kernel/approx2.hpp
@@ -14,9 +14,10 @@
 #include <debug_oneapi.hpp>
 #include <err_oneapi.hpp>
 #include <kernel/interp.hpp>
-#include <af/constants.h>
-// #include <kernel/default_config.hpp>
 #include <traits.hpp>
+#include <af/constants.h>
+
+#include <sycl/sycl.hpp>
 
 #include <string>
 #include <vector>

--- a/src/backend/oneapi/kernel/assign.hpp
+++ b/src/backend/oneapi/kernel/assign.hpp
@@ -14,6 +14,8 @@
 #include <debug_oneapi.hpp>
 #include <traits.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/kernel/bilateral.hpp
+++ b/src/backend/oneapi/kernel/bilateral.hpp
@@ -15,7 +15,7 @@
 #include <err_oneapi.hpp>
 #include <traits.hpp>
 
-#include <sycl/builtins.hpp>
+#include <sycl/sycl.hpp>
 
 #include <string>
 #include <vector>

--- a/src/backend/oneapi/kernel/convolve.hpp
+++ b/src/backend/oneapi/kernel/convolve.hpp
@@ -1,5 +1,5 @@
 /*******************************************************
- * Copyright (c) 2014, ArrayFire
+ * Copyright (c) 2023, ArrayFire
  * All rights reserved.
  *
  * This file is distributed under 3-clause BSD license.
@@ -9,10 +9,13 @@
 
 #pragma once
 #include <Param.hpp>
+#include <accessor.hpp>
 #include <common/dispatch.hpp>
 #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
 #include <af/defines.h>
+
+#include <sycl/sycl.hpp>
 
 #include <string>
 #include <vector>

--- a/src/backend/oneapi/kernel/convolve1.hpp
+++ b/src/backend/oneapi/kernel/convolve1.hpp
@@ -1,3 +1,13 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+#pragma once
+
 template<typename T, typename aT>
 class conv1HelperCreateKernel {
    public:

--- a/src/backend/oneapi/kernel/diagonal.hpp
+++ b/src/backend/oneapi/kernel/diagonal.hpp
@@ -15,6 +15,8 @@
 #include <err_oneapi.hpp>
 #include <traits.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/kernel/diff.hpp
+++ b/src/backend/oneapi/kernel/diff.hpp
@@ -15,6 +15,8 @@
 #include <err_oneapi.hpp>
 #include <traits.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/kernel/gradient.hpp
+++ b/src/backend/oneapi/kernel/gradient.hpp
@@ -15,6 +15,8 @@
 #include <debug_oneapi.hpp>
 #include <kernel/default_config.hpp>
 
+#include <sycl/sycl.hpp>
+
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {

--- a/src/backend/oneapi/kernel/histogram.hpp
+++ b/src/backend/oneapi/kernel/histogram.hpp
@@ -15,7 +15,7 @@
 #include <err_oneapi.hpp>
 #include <traits.hpp>
 
-#include <sycl/atomic_ref.hpp>
+#include <sycl/sycl.hpp>
 
 #include <string>
 #include <vector>

--- a/src/backend/oneapi/kernel/interp.hpp
+++ b/src/backend/oneapi/kernel/interp.hpp
@@ -12,7 +12,7 @@
 #include <types.hpp>
 #include <af/constants.h>
 
-#include <sycl/builtins.hpp>
+#include <sycl/sycl.hpp>
 
 #include <algorithm>
 

--- a/src/backend/oneapi/kernel/iota.hpp
+++ b/src/backend/oneapi/kernel/iota.hpp
@@ -16,6 +16,8 @@
 #include <traits.hpp>
 #include <af/dim4.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/kernel/iota.hpp
+++ b/src/backend/oneapi/kernel/iota.hpp
@@ -51,24 +51,27 @@ class iotaKernel {
         const int xx = it.get_local_id(0) + blockIdx_x * gg.get_local_range(0);
         const int yy = it.get_local_id(1) + blockIdx_y * gg.get_local_range(1);
 
-        if (xx >= oinfo_.dims[0] || yy >= oinfo_.dims[1] ||
-            oz >= oinfo_.dims[2] || ow >= oinfo_.dims[3])
-            return;
+        size_t odims0 = oinfo_.dims[0];
+        size_t odims1 = oinfo_.dims[1];
+        size_t odims2 = oinfo_.dims[2];
+        size_t odims3 = oinfo_.dims[3];
 
-        const int ozw = ow * oinfo_.strides[3] + oz * oinfo_.strides[2];
+        if (xx < odims0 && yy < odims1 && oz < odims2 && ow < odims3) {
+            const int ozw = ow * oinfo_.strides[3] + oz * oinfo_.strides[2];
 
-        T val = static_cast<T>((ow % s3_) * s2_ * s1_ * s0_);
-        val += static_cast<T>((oz % s2_) * s1_ * s0_);
+            T val = static_cast<T>((ow % s3_) * s2_ * s1_ * s0_);
+            val += static_cast<T>((oz % s2_) * s1_ * s0_);
 
-        const int incy = blocksPerMatY_ * gg.get_local_range(1);
-        const int incx = blocksPerMatX_ * gg.get_local_range(0);
+            const int incy = blocksPerMatY_ * gg.get_local_range(1);
+            const int incx = blocksPerMatX_ * gg.get_local_range(0);
 
-        for (int oy = yy; oy < oinfo_.dims[1]; oy += incy) {
-            T valY   = val + (oy % s1_) * s0_;
-            int oyzw = ozw + oy * oinfo_.strides[1];
-            for (int ox = xx; ox < oinfo_.dims[0]; ox += incx) {
-                int oidx   = oyzw + ox;
-                out_[oidx] = valY + (ox % s0_);
+            for (int oy = yy; oy < odims1; oy += incy) {
+                T valY   = val + (oy % s1_) * s0_;
+                int oyzw = ozw + oy * oinfo_.strides[1];
+                for (int ox = xx; ox < odims0; ox += incx) {
+                    int oidx   = oyzw + ox;
+                    out_[oidx] = valY + (ox % s0_);
+                }
             }
         }
     }

--- a/src/backend/oneapi/kernel/iota.hpp
+++ b/src/backend/oneapi/kernel/iota.hpp
@@ -14,6 +14,7 @@
 #include <common/half.hpp>
 #include <debug_oneapi.hpp>
 #include <traits.hpp>
+#include <types.hpp>
 #include <af/dim4.hpp>
 
 #include <sycl/sycl.hpp>
@@ -59,15 +60,16 @@ class iotaKernel {
         if (xx < odims0 && yy < odims1 && oz < odims2 && ow < odims3) {
             const int ozw = ow * oinfo_.strides[3] + oz * oinfo_.strides[2];
 
-            T val = static_cast<T>((ow % s3_) * s2_ * s1_ * s0_);
-            val += static_cast<T>((oz % s2_) * s1_ * s0_);
+            compute_t<T> val =
+                static_cast<compute_t<T>>((ow % s3_) * s2_ * s1_ * s0_);
+            val += static_cast<compute_t<T>>((oz % s2_) * s1_ * s0_);
 
             const int incy = blocksPerMatY_ * gg.get_local_range(1);
             const int incx = blocksPerMatX_ * gg.get_local_range(0);
 
             for (int oy = yy; oy < odims1; oy += incy) {
-                T valY   = val + (oy % s1_) * s0_;
-                int oyzw = ozw + oy * oinfo_.strides[1];
+                compute_t<T> valY = val + (oy % s1_) * s0_;
+                int oyzw          = ozw + oy * oinfo_.strides[1];
                 for (int ox = xx; ox < odims0; ox += incx) {
                     int oidx   = oyzw + ox;
                     out_[oidx] = valY + (ox % s0_);

--- a/src/backend/oneapi/kernel/ireduce.hpp
+++ b/src/backend/oneapi/kernel/ireduce.hpp
@@ -19,7 +19,7 @@
 #include <memory.hpp>
 #include <minmax_op.hpp>
 
-#include <sycl/sycl.hpp>  //TODO: exact headers
+#include <sycl/sycl.hpp>
 
 #include <algorithm>
 #include <climits>

--- a/src/backend/oneapi/kernel/lookup.hpp
+++ b/src/backend/oneapi/kernel/lookup.hpp
@@ -14,6 +14,8 @@
 #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/kernel/mean.hpp
+++ b/src/backend/oneapi/kernel/mean.hpp
@@ -20,8 +20,7 @@
 #include <math.hpp>
 #include <memory.hpp>
 
-#include <sycl/builtins.hpp>
-#include <sycl/group_algorithm.hpp>
+#include <sycl/sycl.hpp>
 
 #include <memory>
 #include <vector>

--- a/src/backend/oneapi/kernel/meanshift.hpp
+++ b/src/backend/oneapi/kernel/meanshift.hpp
@@ -14,6 +14,8 @@
 #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <algorithm>
 #include <string>
 #include <vector>

--- a/src/backend/oneapi/kernel/memcopy.hpp
+++ b/src/backend/oneapi/kernel/memcopy.hpp
@@ -69,14 +69,19 @@ class memCopy {
                 id1 * istrides_.dim[1];
 
         int istride0 = istrides_.dim[0];
-        if (id0 < idims_.dim[0] && id1 < idims_.dim[1] && id2 < idims_.dim[2] &&
-            id3 < idims_.dim[3]) {
+        size_t idd0  = idims_.dim[0];
+        size_t idd1  = idims_.dim[1];
+        size_t idd2  = idims_.dim[2];
+        size_t idd3  = idims_.dim[3];
+
+        if (id0 < idd0 && id1 < idd1 && id2 < idd2 && id3 < idd3) {
             optr[id0] = iptr[id0 * istride0];
         }
     }
 
    protected:
-    sycl::accessor<T> out_, in_;
+    sycl::accessor<T> out_;
+    sycl::accessor<T> in_;
     dims_t ostrides_, idims_, istrides_;
     int offset_, groups_0_, groups_1_;
 };
@@ -228,13 +233,22 @@ class reshapeCopy {
         uint istride0 = iInfo_.strides[0];
         uint ostride0 = oInfo_.strides[0];
 
-        if (gy < oInfo_.dims[1] && gz < oInfo_.dims[2] && gw < oInfo_.dims[3]) {
+        size_t odims0 = oInfo_.dims[0];
+        size_t odims1 = oInfo_.dims[1];
+        size_t odims2 = oInfo_.dims[2];
+        size_t odims3 = oInfo_.dims[3];
+
+        size_t tdims0 = trgt_.dim[0];
+        size_t tdims1 = trgt_.dim[1];
+        size_t tdims2 = trgt_.dim[2];
+        size_t tdims3 = trgt_.dim[3];
+
+        if (gy < odims1 && gz < odims2 && gw < odims3) {
             int loop_offset = gg.get_local_range(0) * blk_x_;
-            bool cond =
-                gy < trgt_.dim[1] && gz < trgt_.dim[2] && gw < trgt_.dim[3];
-            for (int rep = gx; rep < oInfo_.dims[0]; rep += loop_offset) {
+            bool cond       = gy < tdims1 && gz < tdims2 && gw < tdims3;
+            for (int rep = gx; rep < odims0; rep += loop_offset) {
                 outType temp = default_value_;
-                if (SAMEDIMS || (rep < trgt_.dim[0] && cond)) {
+                if (SAMEDIMS || (rep < tdims0 && cond)) {
                     temp = convertType<inType, outType>(
                         scale<inType>(in[rep * istride0], factor_));
                 }

--- a/src/backend/oneapi/kernel/memcopy.hpp
+++ b/src/backend/oneapi/kernel/memcopy.hpp
@@ -17,6 +17,8 @@
 #include <sycl/sycl.hpp>
 #include <traits.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <algorithm>
 #include <string>
 #include <vector>

--- a/src/backend/oneapi/kernel/random_engine_mersenne.hpp
+++ b/src/backend/oneapi/kernel/random_engine_mersenne.hpp
@@ -44,6 +44,8 @@
 #pragma once
 #include <kernel/random_engine_write.hpp>
 
+#include <sycl/sycl.hpp>
+
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {

--- a/src/backend/oneapi/kernel/range.hpp
+++ b/src/backend/oneapi/kernel/range.hpp
@@ -18,6 +18,8 @@
 #include <traits.hpp>
 #include <af/dim4.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/kernel/reduce_all.hpp
+++ b/src/backend/oneapi/kernel/reduce_all.hpp
@@ -19,10 +19,7 @@
 #include <math.hpp>
 #include <memory.hpp>
 
-#include <sycl/atomic_fence.hpp>
-#include <sycl/atomic_ref.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/group_algorithm.hpp>
+#include <sycl/sycl.hpp>
 
 #include <algorithm>
 #include <climits>

--- a/src/backend/oneapi/kernel/reduce_first.hpp
+++ b/src/backend/oneapi/kernel/reduce_first.hpp
@@ -19,6 +19,8 @@
 #include <math.hpp>
 #include <memory.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <algorithm>
 #include <climits>
 #include <complex>

--- a/src/backend/oneapi/kernel/reorder.hpp
+++ b/src/backend/oneapi/kernel/reorder.hpp
@@ -14,6 +14,8 @@
 #include <debug_oneapi.hpp>
 #include <traits.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/kernel/resize.hpp
+++ b/src/backend/oneapi/kernel/resize.hpp
@@ -15,7 +15,7 @@
 #include <debug_oneapi.hpp>
 #include <traits.hpp>
 
-#include <sycl/builtins.hpp>
+#include <sycl/sycl.hpp>
 
 #include <string>
 #include <vector>

--- a/src/backend/oneapi/kernel/rotate.hpp
+++ b/src/backend/oneapi/kernel/rotate.hpp
@@ -16,6 +16,8 @@
 #include <math.hpp>
 #include <traits.hpp>
 
+#include <sycl/sycl.hpp>
+
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {

--- a/src/backend/oneapi/kernel/scan_dim.hpp
+++ b/src/backend/oneapi/kernel/scan_dim.hpp
@@ -17,8 +17,7 @@
 #include <kernel/default_config.hpp>
 #include <memory.hpp>
 
-#include <sycl/builtins.hpp>
-#include <sycl/group_algorithm.hpp>
+#include <sycl/sycl.hpp>
 
 namespace arrayfire {
 namespace oneapi {

--- a/src/backend/oneapi/kernel/scan_first.hpp
+++ b/src/backend/oneapi/kernel/scan_first.hpp
@@ -17,8 +17,7 @@
 #include <kernel/default_config.hpp>
 #include <memory.hpp>
 
-#include <sycl/builtins.hpp>
-#include <sycl/group_algorithm.hpp>
+#include <sycl/sycl.hpp>
 
 namespace arrayfire {
 namespace oneapi {

--- a/src/backend/oneapi/kernel/select.hpp
+++ b/src/backend/oneapi/kernel/select.hpp
@@ -14,6 +14,8 @@
 #include <common/kernel_cache.hpp>
 #include <math.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/kernel/tile.hpp
+++ b/src/backend/oneapi/kernel/tile.hpp
@@ -14,6 +14,8 @@
 #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/kernel/transform.hpp
+++ b/src/backend/oneapi/kernel/transform.hpp
@@ -12,12 +12,12 @@
 #include <Param.hpp>
 #include <common/complex.hpp>
 #include <common/dispatch.hpp>
-// #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
-// #include <kernel/config.hpp>
 #include <kernel/interp.hpp>
 #include <math.hpp>
 #include <traits.hpp>
+
+#include <sycl/sycl.hpp>
 
 #include <string>
 #include <vector>

--- a/src/backend/oneapi/kernel/transpose.hpp
+++ b/src/backend/oneapi/kernel/transpose.hpp
@@ -15,6 +15,8 @@
 #include <err_oneapi.hpp>
 #include <traits.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/kernel/transpose_inplace.hpp
+++ b/src/backend/oneapi/kernel/transpose_inplace.hpp
@@ -16,6 +16,8 @@
 #include <err_oneapi.hpp>
 #include <traits.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/kernel/triangle.hpp
+++ b/src/backend/oneapi/kernel/triangle.hpp
@@ -15,6 +15,8 @@
 #include <err_oneapi.hpp>
 #include <traits.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/kernel/unwrap.hpp
+++ b/src/backend/oneapi/kernel/unwrap.hpp
@@ -15,6 +15,8 @@
 #include <debug_oneapi.hpp>
 #include <kernel/default_config.hpp>
 
+#include <sycl/sycl.hpp>
+
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {

--- a/src/backend/oneapi/kernel/where.hpp
+++ b/src/backend/oneapi/kernel/where.hpp
@@ -16,6 +16,8 @@
 #include <kernel/scan_first.hpp>
 #include <memory.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <Param.hpp>
 #include <backend.hpp>
 #include <math.hpp>

--- a/src/backend/oneapi/kernel/wrap.hpp
+++ b/src/backend/oneapi/kernel/wrap.hpp
@@ -16,6 +16,8 @@
 #include <kernel/default_config.hpp>
 #include <math.hpp>
 
+#include <sycl/sycl.hpp>
+
 #include <string>
 #include <vector>
 

--- a/src/backend/oneapi/memory.cpp
+++ b/src/backend/oneapi/memory.cpp
@@ -18,8 +18,7 @@
 #include <types.hpp>
 #include <af/dim4.hpp>
 
-#include <sycl/builtins.hpp>
-#include <sycl/usm.hpp>
+#include <sycl/sycl.hpp>
 
 #include <utility>
 

--- a/src/backend/oneapi/memory.hpp
+++ b/src/backend/oneapi/memory.hpp
@@ -10,7 +10,7 @@
 
 #include <common/AllocatorInterface.hpp>
 
-#include <sycl/buffer.hpp>
+#include <sycl/sycl.hpp>
 
 #include <cstdlib>
 #include <functional>

--- a/src/backend/oneapi/platform.cpp
+++ b/src/backend/oneapi/platform.cpp
@@ -28,7 +28,7 @@
 #include <OpenGL/CGLCurrent.h>
 #endif
 
-#include <sycl/platform.hpp>
+#include <sycl/sycl.hpp>
 
 #include <cctype>
 #include <cstdlib>

--- a/src/backend/oneapi/platform.hpp
+++ b/src/backend/oneapi/platform.hpp
@@ -11,9 +11,7 @@
 
 #include <af/oneapi.h>
 
-#include <sycl/context.hpp>
-#include <sycl/device.hpp>
-#include <sycl/queue.hpp>
+#include <sycl/sycl.hpp>
 
 #include <memory>
 #include <string>

--- a/src/backend/oneapi/types.hpp
+++ b/src/backend/oneapi/types.hpp
@@ -14,7 +14,7 @@
 #include <af/compilers.h>
 #include <af/traits.hpp>
 
-#include <sycl/aliases.hpp>
+#include <sycl/sycl.hpp>
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
This PR updates the version of the required oneAPI version to 2023.1.

Description
-----------
2023.1 adds the ability to create a accessor using a default constructor which is part of the 2020 SYCL standard. This is required to create several internal objects. This PR also updates the AParam object which can take advantage of the default constructor of the sycl::accessor object.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [ ] Rebased on latest master
- [ ] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
