### PR TITLE
[BUG] Corrects exceptions thrown in opencl tests qr, rank & solve

### DIFF
--- a/.github/workflows/unix_cpu_build.yml
+++ b/.github/workflows/unix_cpu_build.yml
@@ -17,11 +17,11 @@ jobs:
               uses: actions/checkout@master
 
             - name: Check Sources
-              uses: DoozyX/clang-format-lint-action@v0.14
+              uses: DoozyX/clang-format-lint-action@v0.15
               with:
                 source: './src ./test ./examples'
                 extensions: 'h,cpp,hpp'
-                clangFormatVersion: 14
+                clangFormatVersion: 15
 
     documentation:
         name: Documentation

--- a/src/api/unified/symbol_manager.hpp
+++ b/src/api/unified/symbol_manager.hpp
@@ -156,7 +156,7 @@ bool checkArrays(af_backend activeBackend, T a, Args... arg) {
         if (index_ != arrayfire::unified::getActiveBackend()) {                  \
             index_ = arrayfire::unified::getActiveBackend();                     \
             func   = (af_func)arrayfire::common::getFunctionPointer(             \
-                  arrayfire::unified::getActiveHandle(), __func__);              \
+                arrayfire::unified::getActiveHandle(), __func__);              \
         }                                                                        \
         return func(__VA_ARGS__);                                                \
     } else {                                                                     \

--- a/src/backend/common/graphics_common.cpp
+++ b/src/backend/common/graphics_common.cpp
@@ -260,7 +260,7 @@ fg_window ForgeManager::getMainWindow() {
             }
             fg_window w = nullptr;
             forgeError  = this->mPlugin->fg_create_window(
-                 &w, WIDTH, HEIGHT, "ArrayFire", NULL, true);
+                &w, WIDTH, HEIGHT, "ArrayFire", NULL, true);
             if (forgeError != FG_ERR_NONE) { return; }
             this->setWindowChartGrid(w, 1, 1);
             this->mPlugin->fg_make_window_current(w);

--- a/src/backend/cpu/convolve.cpp
+++ b/src/backend/cpu/convolve.cpp
@@ -193,7 +193,7 @@ Array<T> conv2DataGradient(const Array<T> &incoming_gradient,
     Array<T> collapsed_gradient = incoming_gradient;
     collapsed_gradient          = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
     collapsed_gradient          = modDims(
-                 collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
+        collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
 
     Array<T> res =
         matmul(collapsed_gradient, collapsed_filter, AF_MAT_NONE, AF_MAT_TRANS);
@@ -232,7 +232,7 @@ Array<T> conv2FilterGradient(const Array<T> &incoming_gradient,
     Array<T> collapsed_gradient = incoming_gradient;
     collapsed_gradient          = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
     collapsed_gradient          = modDims(
-                 collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
+        collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
 
     Array<T> res =
         matmul(unwrapped, collapsed_gradient, AF_MAT_NONE, AF_MAT_NONE);

--- a/src/backend/cuda/convolveNN.cpp
+++ b/src/backend/cuda/convolveNN.cpp
@@ -260,7 +260,7 @@ Array<T> data_gradient_base(const Array<T> &incoming_gradient,
     Array<T> collapsed_gradient = incoming_gradient;
     collapsed_gradient          = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
     collapsed_gradient          = modDims(
-                 collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
+        collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
 
     T alpha        = scalar<T>(1.0);
     T beta         = scalar<T>(0.0);
@@ -390,7 +390,7 @@ Array<T> filter_gradient_base(const Array<T> &incoming_gradient,
     Array<T> collapsed_gradient = incoming_gradient;
     collapsed_gradient          = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
     collapsed_gradient          = modDims(
-                 collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
+        collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
 
     T alpha        = scalar<T>(1.0);
     T beta         = scalar<T>(0.0);

--- a/src/backend/cuda/kernel/random_engine.hpp
+++ b/src/backend/cuda/kernel/random_engine.hpp
@@ -60,9 +60,9 @@ static const int THREADS = 256;
 #define HALF_HALF_FACTOR __ushort_as_half(0x80)
 
 // Conversion to half adapted from Random123
-//#define SIGNED_HALF_FACTOR                                \
+// #define SIGNED_HALF_FACTOR                                \
     //((1.0f) / (std::numeric_limits<short>::max() + (1.0f)))
-//#define SIGNED_HALF_HALF_FACTOR ((0.5f) * SIGNED_HALF_FACTOR)
+// #define SIGNED_HALF_HALF_FACTOR ((0.5f) * SIGNED_HALF_FACTOR)
 //
 // NOTE: The following constants for half were calculated using the formulas
 // above. This is done so that we can avoid unnecessary computations because the

--- a/src/backend/oneapi/compile_module.cpp
+++ b/src/backend/oneapi/compile_module.cpp
@@ -71,23 +71,6 @@ string getProgramBuildLog(const kernel_bundle<bundle_state::executable> &prog) {
 namespace arrayfire {
 namespace oneapi {
 
-// const static string DEFAULT_MACROS_STR(
-// "\n\
-                                           //#ifdef USE_DOUBLE\n\
-                                           //#pragma OPENCL EXTENSION cl_khr_fp64 : enable\n\
-                                           //#endif\n                     \
-                                           //#ifdef USE_HALF\n\
-                                           //#pragma OPENCL EXTENSION cl_khr_fp16 : enable\n\
-                                           //#else\n                     \
-                                           //#define half short\n          \
-                                           //#endif\n                      \
-                                           //#ifndef M_PI\n               \
-                                           //#define
-// M_PI 3.1415926535897932384626433832795028841971693993751058209749445923078164\n
-// \
-                                           //#endif\n                     \
-                                           //");
-
 /*
 get_kernel_bundle<>() needs sycl::context
 kernel_bundle<bundle_state::executable> buildProgram(const vector<string>

--- a/src/backend/oneapi/exampleFunction.cpp
+++ b/src/backend/oneapi/exampleFunction.cpp
@@ -16,11 +16,11 @@
 #include <err_oneapi.hpp>  // error check functions and Macros
                            // specific to oneapi backend
 
-//#include <kernel/exampleFunction.hpp>  // this header under the folder
-// src/oneapi/kernel
-// defines the OneAPI kernel wrapper
-// function to which the main computation of your
-// algorithm should be relayed to
+// #include <kernel/exampleFunction.hpp>  // this header under the folder
+//  src/oneapi/kernel
+//  defines the OneAPI kernel wrapper
+//  function to which the main computation of your
+//  algorithm should be relayed to
 
 using af::dim4;
 

--- a/src/backend/oneapi/jit.cpp
+++ b/src/backend/oneapi/jit.cpp
@@ -231,7 +231,7 @@ __kernel void )JIT";
     }
 
     thread_local stringstream kerStream;
-    kerStream << kernelVoid << funcName << "(\n"
+    kerStream << DEFAULT_MACROS_STR << kernelVoid << funcName << "(\n"
               << inParamStream.str() << outParamStream.str() << dimParams << ")"
               << blockStart;
     if (is_linear) {

--- a/src/backend/oneapi/jit.cpp
+++ b/src/backend/oneapi/jit.cpp
@@ -62,6 +62,22 @@ using sycl::backend;
 namespace arrayfire {
 
 namespace opencl {
+
+const static string DEFAULT_MACROS_STR(R"JIT(
+#ifdef USE_DOUBLE
+#pragma OPENCL EXTENSION cl_khr_fp64 : enable
+#endif
+#ifdef USE_HALF
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+#else
+#define half short
+#endif
+#ifndef M_PI
+#define
+ M_PI 3.1415926535897932384626433832795028841971693993751058209749445923078164
+#endif
+)JIT");
+
 string getKernelString(const string& funcName, const vector<Node*>& full_nodes,
                        const vector<Node_ids>& full_ids,
                        const vector<int>& output_ids, const bool is_linear,

--- a/src/backend/opencl/convolve.cpp
+++ b/src/backend/opencl/convolve.cpp
@@ -185,7 +185,7 @@ Array<T> conv2DataGradient(const Array<T> &incoming_gradient,
     Array<T> collapsed_gradient = incoming_gradient;
     collapsed_gradient          = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
     collapsed_gradient          = modDims(
-                 collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
+        collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
 
     Array<T> res =
         matmul(collapsed_gradient, collapsed_filter, AF_MAT_NONE, AF_MAT_TRANS);
@@ -224,7 +224,7 @@ Array<T> conv2FilterGradient(const Array<T> &incoming_gradient,
     Array<T> collapsed_gradient = incoming_gradient;
     collapsed_gradient          = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
     collapsed_gradient          = modDims(
-                 collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
+        collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
 
     Array<T> res =
         matmul(unwrapped, collapsed_gradient, AF_MAT_NONE, AF_MAT_NONE);

--- a/src/backend/opencl/kernel/laset.hpp
+++ b/src/backend/opencl/kernel/laset.hpp
@@ -69,7 +69,7 @@ void laset(int m, int n, T offdiag, T diag, cl_mem dA, size_t dA_offset,
     // retain the cl_mem object during cl::Buffer creation
     cl::Buffer dAObj(dA, true);
 
-    cl::CommandQueue q(queue);
+    cl::CommandQueue q(queue, true);
     lasetOp(cl::EnqueueArgs(q, global, local), m, n, offdiag, diag, dAObj,
             dA_offset, ldda);
 }

--- a/src/backend/opencl/kernel/swapdblk.hpp
+++ b/src/backend/opencl/kernel/swapdblk.hpp
@@ -34,6 +34,9 @@ void swapdblk(int n, int nb, cl_mem dA, size_t dA_offset, int ldda, int inca,
     using std::string;
     using std::vector;
 
+    int nblocks = n / nb;
+    if (nblocks == 0) return;
+
     vector<TemplateArg> targs = {
         TemplateTypename<T>(),
     };
@@ -44,10 +47,6 @@ void swapdblk(int n, int nb, cl_mem dA, size_t dA_offset, int ldda, int inca,
 
     auto swapdblk =
         common::getKernel("swapdblk", {{swapdblk_cl_src}}, targs, compileOpts);
-
-    int nblocks = n / nb;
-
-    if (nblocks == 0) return;
 
     int info = 0;
     if (n < 0) {
@@ -75,7 +74,7 @@ void swapdblk(int n, int nb, cl_mem dA, size_t dA_offset, int ldda, int inca,
     Buffer dAObj(dA, true);
     Buffer dBObj(dB, true);
 
-    CommandQueue q(queue);
+    CommandQueue q(queue, true);
     swapdblk(EnqueueArgs(q, global, local), nb, dAObj, dA_offset, ldda, inca,
              dBObj, dB_offset, lddb, incb);
     CL_DEBUG_FINISH(getQueue());

--- a/src/backend/opencl/magma/magma_data.h
+++ b/src/backend/opencl/magma/magma_data.h
@@ -79,7 +79,7 @@ static magma_int_t magma_malloc(magma_ptr* ptrPtr, int num) {
 
 // --------------------
 // Free GPU memory allocated by magma_malloc.
-static inline magma_int_t magma_free(cl_mem ptr) {
+static inline magma_int_t magma_free(magma_ptr ptr) {
     cl_int err = clReleaseMemObject(ptr);
     if (err != CL_SUCCESS) { return MAGMA_ERR_INVALID_PTR; }
     return MAGMA_SUCCESS;
@@ -321,9 +321,9 @@ static void magma_setmatrix_async(magma_int_t m, magma_int_t n, T const* hA_src,
     size_t host_orig[3]     = {0, 0, 0};
     size_t region[3]        = {m * sizeof(T), (size_t)n, 1};
     cl_int err              = clEnqueueWriteBufferRect(
-                     queue, dB_dst, CL_FALSE,  // non-blocking
-                     buffer_origin, host_orig, region, lddb * sizeof(T), 0, ldha * sizeof(T),
-                     0, hA_src, 0, NULL, event);
+        queue, dB_dst, CL_FALSE,  // non-blocking
+        buffer_origin, host_orig, region, lddb * sizeof(T), 0, ldha * sizeof(T),
+        0, hA_src, 0, NULL, event);
     clFlush(queue);
     check_error(err);
 }
@@ -357,9 +357,9 @@ static void magma_getmatrix_async(magma_int_t m, magma_int_t n, cl_mem dA_src,
     size_t host_orig[3]     = {0, 0, 0};
     size_t region[3]        = {m * sizeof(T), (size_t)n, 1};
     cl_int err              = clEnqueueReadBufferRect(
-                     queue, dA_src, CL_FALSE,  // non-blocking
-                     buffer_origin, host_orig, region, ldda * sizeof(T), 0, ldhb * sizeof(T),
-                     0, hB_dst, 0, NULL, event);
+        queue, dA_src, CL_FALSE,  // non-blocking
+        buffer_origin, host_orig, region, ldda * sizeof(T), 0, ldhb * sizeof(T),
+        0, hB_dst, 0, NULL, event);
     clFlush(queue);
     check_error(err);
 }

--- a/src/backend/opencl/magma/ungqr.cpp
+++ b/src/backend/opencl/magma/ungqr.cpp
@@ -129,7 +129,12 @@ magma_int_t magma_ungqr_gpu(magma_int_t m, magma_int_t n, magma_int_t k,
     // ((n+31)/32*32)*nb for dW larfb workspace.
     lddwork = std::min(m, n);
     cl_mem dW;
-    magma_malloc<Ty>(&dW, (((n + 31) / 32) * 32) * nb);
+    if (MAGMA_SUCCESS != magma_malloc<Ty>(&dW, (((n + 31) / 32) * 32) * nb)) {
+        magma_free_cpu(work);
+        magma_free(dV);
+        *info = MAGMA_ERR_DEVICE_ALLOC;
+        return *info;
+    }
 
     cpu_lapack_ungqr_work_func<Ty> cpu_lapack_ungqr;
 

--- a/src/backend/opencl/memory.cpp
+++ b/src/backend/opencl/memory.cpp
@@ -204,8 +204,8 @@ size_t Allocator::getMaxMemorySize(int id) {
 void *Allocator::nativeAlloc(const size_t bytes) {
     cl_int err = CL_SUCCESS;
     auto ptr   = static_cast<void *>(clCreateBuffer(
-          getContext()(), CL_MEM_READ_WRITE,  // NOLINT(hicpp-signed-bitwise)
-          bytes, nullptr, &err));
+        getContext()(), CL_MEM_READ_WRITE,  // NOLINT(hicpp-signed-bitwise)
+        bytes, nullptr, &err));
 
     if (err != CL_SUCCESS) {
         auto str = fmt::format("Failed to allocate device memory of size {}",

--- a/src/backend/opencl/svd.cpp
+++ b/src/backend/opencl/svd.cpp
@@ -137,8 +137,8 @@ void svd(Array<T> &arrU, Array<Tr> &arrS, Array<T> &arrVT, Array<T> &arrA,
 
     if (want_vectors) {
         mappedU  = static_cast<T *>(getQueue().enqueueMapBuffer(
-             *arrU.get(), CL_FALSE, CL_MAP_WRITE, sizeof(T) * arrU.getOffset(),
-             sizeof(T) * arrU.elements()));
+            *arrU.get(), CL_FALSE, CL_MAP_WRITE, sizeof(T) * arrU.getOffset(),
+            sizeof(T) * arrU.elements()));
         mappedVT = static_cast<T *>(getQueue().enqueueMapBuffer(
             *arrVT.get(), CL_TRUE, CL_MAP_WRITE, sizeof(T) * arrVT.getOffset(),
             sizeof(T) * arrVT.elements()));

--- a/src/backend/opencl/topk.cpp
+++ b/src/backend/opencl/topk.cpp
@@ -76,13 +76,13 @@ void topk(Array<T>& vals, Array<unsigned>& idxs, const Array<T>& in,
         cl::Event ev_in, ev_val, ev_ind;
 
         T* ptr     = static_cast<T*>(getQueue().enqueueMapBuffer(
-                *in_buf, CL_FALSE, CL_MAP_READ, 0, in.elements() * sizeof(T),
-                nullptr, &ev_in));
+            *in_buf, CL_FALSE, CL_MAP_READ, 0, in.elements() * sizeof(T),
+            nullptr, &ev_in));
         uint* iptr = static_cast<uint*>(getQueue().enqueueMapBuffer(
             *ibuf, CL_FALSE, CL_MAP_READ | CL_MAP_WRITE, 0, k * sizeof(uint),
             nullptr, &ev_ind));
         T* vptr    = static_cast<T*>(getQueue().enqueueMapBuffer(
-               *vbuf, CL_FALSE, CL_MAP_WRITE, 0, k * sizeof(T), nullptr, &ev_val));
+            *vbuf, CL_FALSE, CL_MAP_WRITE, 0, k * sizeof(T), nullptr, &ev_val));
 
         vector<uint> idx(in.elements());
 


### PR DESCRIPTION
Exception 0x5 was thrown in the tests qr_dense_opencl, rank_dense_opencl & solve_dense_opencl.

<!--
Inside  some MAGMA functions, the queue is converted from C to C++ while taking over ownership.  At the end of the function, the C++ queue was destroyed resulting in the elimination of the global queue in C.

When the original queue is overwritten, this resulted in arbitrary throwing an exception.
-->

Description
-----------
Bug fixing.
Exceptions are thrown on AMD iGPU A10-7870K  (GTX-750 Ti did run without showing errors).
Backporting to 3.8 is possible, since MAGMA code remained untouched as well as the interfaces.

Changes to Users
----------------
Improved stability.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] More Tests passing
- [ ] Functions added to unified API
- [ ] Functions documented
