### PR TITLE
adds iir, pad_array_borders kernels

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -217,6 +217,7 @@ target_sources(afoneapi
     kernel/diagonal.hpp
     kernel/diff.hpp
     kernel/histogram.hpp
+    kernel/iir.hpp
     kernel/identity.hpp
     kernel/interp.hpp
     kernel/iota.hpp
@@ -224,6 +225,7 @@ target_sources(afoneapi
     kernel/lu_split.hpp
     kernel/memcopy.hpp
     kernel/mean.hpp
+    kernel/pad_array_borders.hpp
     kernel/random_engine.hpp
     kernel/random_engine_write.hpp
     kernel/random_engine_mersenne.hpp

--- a/src/backend/oneapi/copy.hpp
+++ b/src/backend/oneapi/copy.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <Array.hpp>
-// #include <kernel/pad_array_borders.hpp>
+#include <kernel/pad_array_borders.hpp>
 
 namespace arrayfire {
 namespace oneapi {
@@ -55,7 +55,7 @@ Array<T> padArrayBorders(Array<T> const &in, dim4 const &lowerBoundPadding,
 
     auto ret = createEmptyArray<T>(oDims);
 
-    // kernel::padBorders<T>(ret, in, lowerBoundPadding, btype);
+    kernel::padBorders<T>(ret, in, lowerBoundPadding, btype);
 
     return ret;
 }

--- a/src/backend/oneapi/iir.cpp
+++ b/src/backend/oneapi/iir.cpp
@@ -12,7 +12,7 @@
 #include <convolve.hpp>
 #include <err_oneapi.hpp>
 #include <iir.hpp>
-// #include <kernel/iir.hpp>
+#include <kernel/iir.hpp>
 #include <math.hpp>
 #include <af/dim4.hpp>
 
@@ -22,8 +22,29 @@ namespace arrayfire {
 namespace oneapi {
 template<typename T>
 Array<T> iir(const Array<T> &b, const Array<T> &a, const Array<T> &x) {
-    ONEAPI_NOT_SUPPORTED("");
-    Array<T> y = createEmptyArray<T>(dim4(1));
+    AF_BATCH_KIND type = x.ndims() == 1 ? AF_BATCH_NONE : AF_BATCH_SAME;
+    if (x.ndims() != b.ndims()) {
+        type = (x.ndims() < b.ndims()) ? AF_BATCH_RHS : AF_BATCH_LHS;
+    }
+
+    // Extract the first N elements
+    Array<T> c = convolve<T, T>(x, b, type, 1, true);
+    dim4 cdims = c.dims();
+    cdims[0]   = x.dims()[0];
+    c.resetDims(cdims);
+
+    int num_a = a.dims()[0];
+
+    if (num_a == 1) { return c; }
+
+    dim4 ydims = c.dims();
+    Array<T> y = createEmptyArray<T>(ydims);
+
+    if (a.ndims() > 1) {
+        kernel::iir<T, true>(y, c, a);
+    } else {
+        kernel::iir<T, false>(y, c, a);
+    }
     return y;
 }
 

--- a/src/backend/oneapi/kernel/iir.hpp
+++ b/src/backend/oneapi/kernel/iir.hpp
@@ -1,0 +1,150 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+
+#include <sycl/sycl.hpp>
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+template<typename T>
+using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
+template<typename T>
+using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
+
+constexpr int MAX_A_SIZE = 1024;
+
+template<typename T, bool batch_a>
+class iirKernel {
+   public:
+    iirKernel(write_accessor<T> y, KParam yInfo, read_accessor<T> c,
+              KParam cInfo, read_accessor<T> a, KParam aInfo,
+              sycl::local_accessor<T> s_z, sycl::local_accessor<T> s_a,
+              sycl::local_accessor<T> s_y, int groups_y)
+        : y_(y)
+        , yInfo_(yInfo)
+        , c_(c)
+        , cInfo_(cInfo)
+        , a_(a)
+        , aInfo_(aInfo)
+        , s_z_(s_z)
+        , s_a_(s_a)
+        , s_y_(s_y)
+        , groups_y_(groups_y) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+
+        const int idz = g.get_group_id(0);
+        const int idw = g.get_group_id(1) / groups_y_;
+        const int idy = g.get_group_id(1) - idw * groups_y_;
+
+        const int tx    = it.get_local_id(0);
+        const int num_a = aInfo_.dims[0];
+
+        int y_off = idw * yInfo_.strides[3] + idz * yInfo_.strides[2] +
+                    idy * yInfo_.strides[1];
+        int c_off = idw * cInfo_.strides[3] + idz * cInfo_.strides[2] +
+                    idy * cInfo_.strides[1];
+        int a_off = 0;
+
+        if (batch_a)
+            a_off = idw * aInfo_.strides[3] + idz * aInfo_.strides[2] +
+                    idy * aInfo_.strides[1];
+
+        T *d_y       = y_.get_pointer() + y_off;
+        const T *d_c = c_.get_pointer() + c_off;
+        const T *d_a = a_.get_pointer() + a_off;
+        const int repeat =
+            (num_a + g.get_local_range(0) - 1) / g.get_local_range(0);
+
+        for (int ii = 0; ii < MAX_A_SIZE / g.get_local_range(0); ii++) {
+            int id   = ii * g.get_local_range(0) + tx;
+            s_z_[id] = scalar<T>(0);
+            s_a_[id] = (id < num_a) ? d_a[id] : scalar<T>(0);
+        }
+        group_barrier(g);
+
+        for (int i = 0; i < yInfo_.dims[0]; i++) {
+            if (tx == 0) {
+                s_y_[0] = (d_c[i] + s_z_[0]) / s_a_[0];
+                d_y[i]  = s_y_[0];
+            }
+            group_barrier(g);
+
+#pragma unroll
+            for (int ii = 0; ii < repeat; ii++) {
+                int id = ii * g.get_local_range(0) + tx + 1;
+
+                T z = s_z_[id] - s_a_[id] * s_y_[0];
+                group_barrier(g);
+
+                s_z_[id - 1] = z;
+                group_barrier(g);
+            }
+        }
+    }
+
+   protected:
+    write_accessor<T> y_;
+    KParam yInfo_;
+    read_accessor<T> c_;
+    KParam cInfo_;
+    read_accessor<T> a_;
+    KParam aInfo_;
+    sycl::local_accessor<T> s_z_;
+    sycl::local_accessor<T> s_a_;
+    sycl::local_accessor<T> s_y_;
+    int groups_y_;
+};
+
+template<typename T, bool batch_a>
+void iir(Param<T> y, Param<T> c, Param<T> a) {
+    const int groups_y = y.info.dims[1];
+    const int groups_x = y.info.dims[2];
+
+    int threads = 256;
+    while (threads > y.info.dims[0] && threads > 32) threads /= 2;
+    sycl::range<2> local = sycl::range{threads, 1};
+
+    sycl::range<2> global =
+        sycl::range<2>{groups_x * local[0], groups_y * y.info.dims[3]};
+
+    getQueue().submit([&](sycl::handler &h) {
+        write_accessor<T> yAcc{*y.data, h};
+        read_accessor<T> cAcc{*c.data, h};
+        read_accessor<T> aAcc{*a.data, h};
+
+        auto s_z = sycl::local_accessor<T>(MAX_A_SIZE, h);
+        auto s_a = sycl::local_accessor<T>(MAX_A_SIZE, h);
+        auto s_y = sycl::local_accessor<T>(1, h);
+
+        if (batch_a) {
+            h.parallel_for(sycl::nd_range{global, local},
+                           iirKernel<T, true>(yAcc, y.info, cAcc, c.info, aAcc,
+                                              a.info, s_z, s_a, s_y, groups_y));
+        } else {
+            h.parallel_for(
+                sycl::nd_range{global, local},
+                iirKernel<T, false>(yAcc, y.info, cAcc, c.info, aAcc, a.info,
+                                    s_z, s_a, s_y, groups_y));
+        }
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/oneapi/kernel/pad_array_borders.hpp
+++ b/src/backend/oneapi/kernel/pad_array_borders.hpp
@@ -1,0 +1,216 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+#include <af/defines.h>
+
+#include <sycl/sycl.hpp>
+
+#include <array>
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+template<typename T>
+using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
+template<typename T>
+using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
+
+template<typename T, int BType>
+class padBordersKernel {
+   public:
+    padBordersKernel(write_accessor<T> out, KParam oInfo, read_accessor<T> in,
+                     KParam iInfo, const dim_t l0, const dim_t l1,
+                     const dim_t l2, const dim_t l3, const int groups_x,
+                     const int groups_y)
+        : out_(out)
+        , oInfo_(oInfo)
+        , in_(in)
+        , iInfo_(iInfo)
+        , l0_(l0)
+        , l1_(l1)
+        , l2_(l2)
+        , l3_(l3)
+        , groups_x_(groups_x)
+        , groups_y_(groups_y) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+        const int lx  = it.get_local_id(0);
+        const int ly  = it.get_local_id(1);
+        const int k   = g.get_group_id(0) / groups_x_;
+        const int l   = g.get_group_id(1) / groups_y_;
+
+        const int blockIdx_x = g.get_group_id(0) - (groups_x_)*k;
+        const int blockIdx_y = g.get_group_id(1) - (groups_y_)*l;
+        const int i          = blockIdx_x * g.get_local_range(0) + lx;
+        const int j          = blockIdx_y * g.get_local_range(1) + ly;
+
+        const size_t d0 = iInfo_.dims[0];
+        const size_t d1 = iInfo_.dims[1];
+        const size_t d2 = iInfo_.dims[2];
+        const size_t d3 = iInfo_.dims[3];
+        const size_t s0 = iInfo_.strides[0];
+        const size_t s1 = iInfo_.strides[1];
+        const size_t s2 = iInfo_.strides[2];
+        const size_t s3 = iInfo_.strides[3];
+
+        const T* src = in_.get_pointer() + iInfo_.offset;
+        T* dst       = out_.get_pointer();
+
+        bool isNotPadding =
+            (l >= l3_ && l < (d3 + l3_)) && (k >= l2_ && k < (d2 + l2_)) &&
+            (j >= l1_ && j < (d1 + l1_)) && (i >= l0_ && i < (d0 + l0_));
+
+        T value = scalar<T>(0);
+        if (isNotPadding) {
+            unsigned iLOff = (l - l3_) * s3;
+            unsigned iKOff = (k - l2_) * s2;
+            unsigned iJOff = (j - l1_) * s1;
+            unsigned iIOff = (i - l0_) * s0;
+
+            value = src[iLOff + iKOff + iJOff + iIOff];
+        } else if (BType != AF_PAD_ZERO) {
+            unsigned iLOff =
+                padBordersKernel<T, BType>::idxByndEdge(l, l3_, d3) * s3;
+            unsigned iKOff =
+                padBordersKernel<T, BType>::idxByndEdge(k, l2_, d2) * s2;
+            unsigned iJOff =
+                padBordersKernel<T, BType>::idxByndEdge(j, l1_, d1) * s1;
+            unsigned iIOff =
+                padBordersKernel<T, BType>::idxByndEdge(i, l0_, d0) * s0;
+
+            value = src[iLOff + iKOff + iJOff + iIOff];
+        }
+
+        size_t xlim = oInfo_.dims[0];
+        size_t ylim = oInfo_.dims[1];
+        size_t zlim = oInfo_.dims[2];
+        size_t wlim = oInfo_.dims[3];
+
+        size_t woStrides = oInfo_.strides[3];
+        size_t zoStrides = oInfo_.strides[2];
+        size_t yoStrides = oInfo_.strides[1];
+        size_t xoStrides = oInfo_.strides[0];
+
+        if (i < xlim && j < ylim && k < zlim && l < wlim) {
+            unsigned off =
+                (l * woStrides + k * zoStrides + j * yoStrides + i * xoStrides);
+            dst[off] = value;
+        }
+    }
+
+    static int trimIndex(int idx, const int len) {
+        int ret_val = idx;
+        if (ret_val < 0) {
+            int offset = (abs(ret_val) - 1) % len;
+            ret_val    = offset;
+        } else if (ret_val >= len) {
+            int offset = abs(ret_val) % len;
+            ret_val    = len - offset - 1;
+        }
+        return ret_val;
+    }
+
+    static int idxByndEdge(const int i, const int lb, const int len) {
+        uint retVal;
+        switch (BType) {
+            case AF_PAD_SYM:
+                retVal = padBordersKernel<T, BType>::trimIndex(i - lb, len);
+                break;
+            case AF_PAD_CLAMP_TO_EDGE:
+                retVal = sycl::clamp(i - lb, 0, len - 1);
+                break;
+            case AF_PAD_PERIODIC: {
+                int rem   = (i - lb) % len;
+                bool cond = rem < 0;
+                retVal    = cond * (rem + len) + (1 - cond) * rem;
+            } break;
+            default: retVal = 0; break;  // AF_PAD_ZERO
+        }
+        return retVal;
+    }
+
+   protected:
+    write_accessor<T> out_;
+    KParam oInfo_;
+    read_accessor<T> in_;
+    KParam iInfo_;
+    const dim_t l0_;
+    const dim_t l1_;
+    const dim_t l2_;
+    const dim_t l3_;
+    const int groups_x_;
+    const int groups_y_;
+};
+
+static const int PADB_THREADS_X = 32;
+static const int PADB_THREADS_Y = 8;
+
+template<typename T>
+void padBorders(Param<T> out, Param<T> in, dim4 const lBoundPadding,
+                const af::borderType btype) {
+    sycl::range<2> local(PADB_THREADS_X, PADB_THREADS_Y);
+
+    int groups_x = divup(out.info.dims[0], PADB_THREADS_X);
+    int groups_y = divup(out.info.dims[1], PADB_THREADS_Y);
+
+    sycl::range<2> global(groups_x * out.info.dims[2] * local[0],
+                          groups_y * out.info.dims[3] * local[1]);
+
+    getQueue().submit([&](sycl::handler& h) {
+        read_accessor<T> iData{*in.data, h};
+        write_accessor<T> oData{*out.data, h};
+
+        switch (btype) {
+            case AF_PAD_ZERO:
+                h.parallel_for(
+                    sycl::nd_range{global, local},
+                    padBordersKernel<T, AF_PAD_ZERO>(
+                        oData, out.info, iData, in.info, lBoundPadding[0],
+                        lBoundPadding[1], lBoundPadding[2], lBoundPadding[3],
+                        groups_x, groups_y));
+                break;
+            case AF_PAD_SYM:
+                h.parallel_for(
+                    sycl::nd_range{global, local},
+                    padBordersKernel<T, AF_PAD_SYM>(
+                        oData, out.info, iData, in.info, lBoundPadding[0],
+                        lBoundPadding[1], lBoundPadding[2], lBoundPadding[3],
+                        groups_x, groups_y));
+                break;
+            case AF_PAD_CLAMP_TO_EDGE:
+                h.parallel_for(
+                    sycl::nd_range{global, local},
+                    padBordersKernel<T, AF_PAD_CLAMP_TO_EDGE>(
+                        oData, out.info, iData, in.info, lBoundPadding[0],
+                        lBoundPadding[1], lBoundPadding[2], lBoundPadding[3],
+                        groups_x, groups_y));
+                break;
+            case AF_PAD_PERIODIC:
+                h.parallel_for(
+                    sycl::nd_range{global, local},
+                    padBordersKernel<T, AF_PAD_PERIODIC>(
+                        oData, out.info, iData, in.info, lBoundPadding[0],
+                        lBoundPadding[1], lBoundPadding[2], lBoundPadding[3],
+                        groups_x, groups_y));
+                break;
+        }
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire


### PR DESCRIPTION
Adds iir, pad_array_borders kernels to the oneapi backend.

Description
-----------
This PR adds enables the pad_array_borders, af_iir, af_fir functions.
The pad_array_borders kernel is required for several outstanding downstream functions, including fftconvolve.
It also enables the iir function since all prequisites are met (convolve).
Pad_array_borders tests are passing.
IIR tests are passing except for the fir tests which rely on indexing.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass