### PR TITLE
Implement generalized indexing in oneAPI

### DIFF
--- a/src/backend/common/err_common.cpp
+++ b/src/backend/common/err_common.cpp
@@ -24,6 +24,8 @@
 #ifdef AF_OPENCL
 #include <errorcodes.hpp>
 #include <platform.hpp>
+#elif defined(AF_ONEAPI)
+#include <sycl/sycl.hpp>
 #endif
 
 using boost::stacktrace::stacktrace;
@@ -161,6 +163,14 @@ af_err processException() {
         if (is_stacktrace_enabled()) { ss << ex.getStacktrace(); }
 
         err = set_global_error_string(ss.str(), ex.getError());
+#ifdef AF_ONEAPI
+    } catch (const sycl::exception &ex) {
+        char oneapi_err_msg[1024];
+        snprintf(oneapi_err_msg, sizeof(oneapi_err_msg),
+                 "oneAPI Error (%d): %s", ex.code().value(), ex.what());
+
+        err = set_global_error_string(oneapi_err_msg, AF_ERR_INTERNAL);
+#endif
 #ifdef AF_OPENCL
     } catch (const cl::Error &ex) {
         char opencl_err_msg[1024];

--- a/src/backend/oneapi/assign.cpp
+++ b/src/backend/oneapi/assign.cpp
@@ -25,7 +25,7 @@ namespace oneapi {
 
 template<typename T>
 void assign(Array<T>& out, const af_index_t idxrs[], const Array<T>& rhs) {
-    kernel::AssignKernelParam_t p;
+    AssignKernelParam p;
     std::vector<af_seq> seqs(4, af_span);
     // create seq vector to retrieve output
     // dimensions, offsets & offsets

--- a/src/backend/oneapi/index.cpp
+++ b/src/backend/oneapi/index.cpp
@@ -12,18 +12,53 @@
 #include <Array.hpp>
 #include <err_oneapi.hpp>
 #include <handle.hpp>
+#include <kernel/assign_kernel_param.hpp>
+#include <kernel/index.hpp>
 #include <memory.hpp>
 #include <af/dim4.hpp>
 
 using arrayfire::common::half;
+using arrayfire::oneapi::IndexKernelParam;
 
 namespace arrayfire {
 namespace oneapi {
 
 template<typename T>
 Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
-    ONEAPI_NOT_SUPPORTED("Indexing not supported");
-    Array<T> out = createEmptyArray<T>(af::dim4(1));
+    IndexKernelParam p;
+    std::vector<af_seq> seqs(4, af_span);
+    // create seq vector to retrieve output
+    // dimensions, offsets & offsets
+    for (dim_t x = 0; x < 4; ++x) {
+        if (idxrs[x].isSeq) { seqs[x] = idxrs[x].idx.seq; }
+    }
+
+    // retrieve dimensions, strides and offsets
+    const dim4& iDims = in.dims();
+    dim4 dDims        = in.getDataDims();
+    dim4 oDims        = toDims(seqs, iDims);
+    dim4 iOffs        = toOffset(seqs, dDims);
+    dim4 iStrds       = in.strides();
+
+    for (dim_t i = 0; i < 4; ++i) {
+        p.isSeq[i] = idxrs[i].isSeq;
+        p.offs[i]  = iOffs[i];
+        p.strds[i] = iStrds[i];
+    }
+
+    std::vector<Array<uint>> idxArrs(4, createEmptyArray<uint>(dim4(1)));
+    // look through indexs to read af_array indexs
+    for (dim_t x = 0; x < 4; ++x) {
+        if (!p.isSeq[x]) {
+            idxArrs[x] = castArray<uint>(idxrs[x].idx.arr);
+            oDims[x]   = idxArrs[x].elements();
+        }
+    }
+
+    Array<T> out = createEmptyArray<T>(oDims);
+    if (oDims.elements() == 0) { return out; }
+    kernel::index<T>(out, in, p, idxArrs);
+
     return out;
 }
 

--- a/src/backend/oneapi/kernel/assign.hpp
+++ b/src/backend/oneapi/kernel/assign.hpp
@@ -82,8 +82,7 @@ class assignKernel {
         size_t idims2 = iInfo_.dims[2];
         size_t idims3 = iInfo_.dims[3];
 
-        if (gx < idims0 && gy < idims1 && gz < idims2 &&
-            gw < idims3) {
+        if (gx < idims0 && gy < idims1 && gz < idims2 && gw < idims3) {
             // calculate pointer offsets for input
             int i = p_.strds[0] *
                     trimIndex(s0 ? gx + p_.offs[0] : ptr0_[gx], oInfo_.dims[0]);

--- a/src/backend/oneapi/kernel/assign.hpp
+++ b/src/backend/oneapi/kernel/assign.hpp
@@ -76,8 +76,14 @@ class assignKernel {
         const int gy =
             g.get_local_range(1) * (g.get_group_id(1) - gw * nBBS1_) +
             it.get_local_id(1);
-        if (gx < iInfo_.dims[0] && gy < iInfo_.dims[1] && gz < iInfo_.dims[2] &&
-            gw < iInfo_.dims[3]) {
+
+        size_t idims0 = iInfo_.dims[0];
+        size_t idims1 = iInfo_.dims[1];
+        size_t idims2 = iInfo_.dims[2];
+        size_t idims3 = iInfo_.dims[3];
+
+        if (gx < idims0 && gy < idims1 && gz < idims2 &&
+            gw < idims3) {
             // calculate pointer offsets for input
             int i = p_.strds[0] *
                     trimIndex(s0 ? gx + p_.offs[0] : ptr0_[gx], oInfo_.dims[0]);

--- a/src/backend/oneapi/kernel/assign.hpp
+++ b/src/backend/oneapi/kernel/assign.hpp
@@ -12,6 +12,7 @@
 #include <Param.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/assign_kernel_param.hpp>
 #include <traits.hpp>
 
 #include <sycl/sycl.hpp>
@@ -22,12 +23,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-typedef struct {
-    int offs[4];
-    int strds[4];
-    char isSeq[4];
-} AssignKernelParam_t;
 
 static int trimIndex(int idx, const int len) {
     int ret_val = idx;
@@ -45,18 +40,13 @@ template<typename T>
 class assignKernel {
    public:
     assignKernel(sycl::accessor<T> out, KParam oInfo, sycl::accessor<T> in,
-                 KParam iInfo, AssignKernelParam_t p, sycl::accessor<uint> ptr0,
-                 sycl::accessor<uint> ptr1, sycl::accessor<uint> ptr2,
-                 sycl::accessor<uint> ptr3, const int nBBS0, const int nBBS1)
+                 KParam iInfo, AssignKernelParam p, const int nBBS0,
+                 const int nBBS1)
         : out_(out)
         , in_(in)
         , oInfo_(oInfo)
         , iInfo_(iInfo)
         , p_(p)
-        , ptr0_(ptr0)
-        , ptr1_(ptr1)
-        , ptr2_(ptr2)
-        , ptr3_(ptr3)
         , nBBS0_(nBBS0)
         , nBBS1_(nBBS1) {}
 
@@ -84,14 +74,18 @@ class assignKernel {
 
         if (gx < idims0 && gy < idims1 && gz < idims2 && gw < idims3) {
             // calculate pointer offsets for input
-            int i = p_.strds[0] *
-                    trimIndex(s0 ? gx + p_.offs[0] : ptr0_[gx], oInfo_.dims[0]);
-            int j = p_.strds[1] *
-                    trimIndex(s1 ? gy + p_.offs[1] : ptr1_[gy], oInfo_.dims[1]);
-            int k = p_.strds[2] *
-                    trimIndex(s2 ? gz + p_.offs[2] : ptr2_[gz], oInfo_.dims[2]);
-            int l = p_.strds[3] *
-                    trimIndex(s3 ? gw + p_.offs[3] : ptr3_[gw], oInfo_.dims[3]);
+            int i =
+                p_.strds[0] *
+                trimIndex(s0 ? gx + p_.offs[0] : p_.ptr[0][gx], oInfo_.dims[0]);
+            int j =
+                p_.strds[1] *
+                trimIndex(s1 ? gy + p_.offs[1] : p_.ptr[1][gy], oInfo_.dims[1]);
+            int k =
+                p_.strds[2] *
+                trimIndex(s2 ? gz + p_.offs[2] : p_.ptr[2][gz], oInfo_.dims[2]);
+            int l =
+                p_.strds[3] *
+                trimIndex(s3 ? gw + p_.offs[3] : p_.ptr[3][gw], oInfo_.dims[3]);
 
             T* iptr = in_.get_pointer();
             // offset input and output pointers
@@ -110,16 +104,16 @@ class assignKernel {
    protected:
     sycl::accessor<T> out_, in_;
     KParam oInfo_, iInfo_;
-    AssignKernelParam_t p_;
-    sycl::accessor<uint> ptr0_, ptr1_, ptr2_, ptr3_;
+    AssignKernelParam p_;
     const int nBBS0_, nBBS1_;
 };
 
 template<typename T>
-void assign(Param<T> out, const Param<T> in, const AssignKernelParam_t& p,
+void assign(Param<T> out, const Param<T> in, const AssignKernelParam& p,
             sycl::buffer<uint>* bPtr[4]) {
     constexpr int THREADS_X = 32;
     constexpr int THREADS_Y = 8;
+    using sycl::access_mode;
 
     sycl::range<2> local(THREADS_X, THREADS_Y);
 
@@ -130,18 +124,18 @@ void assign(Param<T> out, const Param<T> in, const AssignKernelParam_t& p,
                           blk_y * in.info.dims[3] * THREADS_Y);
 
     getQueue().submit([=](sycl::handler& h) {
+        auto pp      = p;
         auto out_acc = out.data->get_access(h);
         auto in_acc  = in.data->get_access(h);
 
-        auto bptr0 = bPtr[0]->get_access(h);
-        auto bptr1 = bPtr[1]->get_access(h);
-        auto bptr2 = bPtr[2]->get_access(h);
-        auto bptr3 = bPtr[3]->get_access(h);
+        pp.ptr[0] = bPtr[0]->template get_access<access_mode::read>(h);
+        pp.ptr[1] = bPtr[1]->template get_access<access_mode::read>(h);
+        pp.ptr[2] = bPtr[2]->template get_access<access_mode::read>(h);
+        pp.ptr[3] = bPtr[3]->template get_access<access_mode::read>(h);
 
-        h.parallel_for(
-            sycl::nd_range<2>(global, local),
-            assignKernel<T>(out_acc, out.info, in_acc, in.info, p, bptr0, bptr1,
-                            bptr2, bptr3, blk_x, blk_y));
+        h.parallel_for(sycl::nd_range<2>(global, local),
+                       assignKernel<T>(out_acc, out.info, in_acc, in.info, pp,
+                                       blk_x, blk_y));
     });
     ONEAPI_DEBUG_FINISH(getQueue());
 }

--- a/src/backend/oneapi/kernel/assign_kernel_param.hpp
+++ b/src/backend/oneapi/kernel/assign_kernel_param.hpp
@@ -1,0 +1,25 @@
+
+#include <sycl/sycl.hpp>
+
+#include <array>
+
+#pragma once
+
+namespace arrayfire {
+namespace oneapi {
+
+typedef struct {
+    int offs[4];
+    int strds[4];
+    bool isSeq[4];
+    std::array<sycl::accessor<unsigned int, 1, sycl::access::mode::read,
+                              sycl::access::target::device>,
+               4>
+        ptr;
+
+} AssignKernelParam;
+
+using IndexKernelParam = AssignKernelParam;
+
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/oneapi/kernel/index.hpp
+++ b/src/backend/oneapi/kernel/index.hpp
@@ -1,0 +1,156 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+#include <kernel/assign_kernel_param.hpp>
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+template<typename T>
+class indexKernel {
+    sycl::accessor<T, 1, sycl::access::mode::write> out;
+    KParam outp;
+    sycl::accessor<T, 1, sycl::access::mode::read> in;
+    KParam inp;
+    IndexKernelParam p;
+    int nBBS0;
+    int nBBS1;
+
+   public:
+    indexKernel(sycl::accessor<T, 1, sycl::access::mode::write> out_,
+                KParam outp_,
+                sycl::accessor<T, 1, sycl::access::mode::read> in_, KParam inp_,
+                const IndexKernelParam p_, const int nBBS0_, const int nBBS1_)
+        : out(out_)
+        , outp(outp_)
+        , in(in_)
+        , inp(inp_)
+        , p(p_)
+        , nBBS0(nBBS0_)
+        , nBBS1(nBBS1_) {}
+
+    int trimIndex(int idx, const int len) const {
+        int ret_val = idx;
+        if (ret_val < 0) {
+            int offset = (abs(ret_val) - 1) % len;
+            ret_val    = offset;
+        } else if (ret_val >= len) {
+            int offset = abs(ret_val) % len;
+            ret_val    = len - offset - 1;
+        }
+        return ret_val;
+    }
+
+    void operator()(sycl::nd_item<3> it) const {
+        // retrieve index pointers
+        // these can be 0 where af_array index is not used
+        sycl::group g    = it.get_group();
+        const uint* ptr0 = p.ptr[0].get_pointer();
+        const uint* ptr1 = p.ptr[1].get_pointer();
+        const uint* ptr2 = p.ptr[2].get_pointer();
+        const uint* ptr3 = p.ptr[3].get_pointer();
+        // retrive booleans that tell us which index to use
+        const bool s0 = p.isSeq[0];
+        const bool s1 = p.isSeq[1];
+        const bool s2 = p.isSeq[2];
+        const bool s3 = p.isSeq[3];
+
+        const int gz = g.get_group_id(0) / nBBS0;
+        const int gx = g.get_local_range(0) * (g.get_group_id(0) - gz * nBBS0) +
+                       it.get_local_id(0);
+
+        const int gw =
+            (g.get_group_id(1) + g.get_group_id(2) * g.get_group_range(1)) /
+            nBBS1;
+        const int gy =
+            g.get_local_range(1) * ((g.get_group_id(1) +
+                                     g.get_group_id(2) * g.get_group_range(1)) -
+                                    gw * nBBS1) +
+            it.get_local_id(1);
+
+        size_t odims0 = outp.dims[0];
+        size_t odims1 = outp.dims[1];
+        size_t odims2 = outp.dims[2];
+        size_t odims3 = outp.dims[3];
+
+        if (gx < odims0 && gy < odims1 && gz < odims2 && gw < odims3) {
+            // calculate pointer offsets for input
+            int i = p.strds[0] *
+                    trimIndex(s0 ? gx + p.offs[0] : ptr0[gx], inp.dims[0]);
+            int j = p.strds[1] *
+                    trimIndex(s1 ? gy + p.offs[1] : ptr1[gy], inp.dims[1]);
+            int k = p.strds[2] *
+                    trimIndex(s2 ? gz + p.offs[2] : ptr2[gz], inp.dims[2]);
+            int l = p.strds[3] *
+                    trimIndex(s3 ? gw + p.offs[3] : ptr3[gw], inp.dims[3]);
+            // offset input and output pointers
+            const T* src = (const T*)in.get_pointer() + (i + j + k + l);
+            T* dst       = (T*)out.get_pointer() +
+                     (gx * outp.strides[0] + gy * outp.strides[1] +
+                      gz * outp.strides[2] + gw * outp.strides[3]);
+            // set the output
+            dst[0] = src[0];
+        }
+    }
+};
+
+template<typename T>
+void index(Param<T> out, Param<T> in, IndexKernelParam& p,
+           std::vector<Array<uint>>& idxArrs) {
+    sycl::range<3> threads(0, 0, 1);
+    switch (out.info.dims[1]) {
+        case 1: threads[1] = 1; break;
+        case 2: threads[1] = 2; break;
+        case 3:
+        case 4: threads[1] = 4; break;
+        default: threads[1] = 8; break;
+    }
+    threads[0] = static_cast<unsigned>(256.f / threads[1]);
+
+    int blks_x = divup(out.info.dims[0], threads[0]);
+    int blks_y = divup(out.info.dims[1], threads[1]);
+
+    sycl::range<3> blocks(blks_x * out.info.dims[2], blks_y * out.info.dims[3],
+                          1);
+
+    const size_t maxBlocksY =
+        getDevice().get_info<sycl::info::device::max_work_item_sizes<3>>()[2];
+    blocks[2] = divup(blocks[1], maxBlocksY);
+    blocks[1] = divup(blocks[1], blocks[2]) * threads[1];
+    blocks[1] = blocks[1] * threads[1];
+    blocks[0] *= threads[0];
+
+    sycl::nd_range<3> marange(blocks, threads);
+    getQueue().submit([=](sycl::handler& h) {
+        auto pp = p;
+        for (dim_t x = 0; x < 4; ++x) {
+            pp.ptr[x] =
+                idxArrs[x].get()->get_access<sycl::access::mode::read>(h);
+        }
+
+        h.parallel_for(
+            marange,
+            indexKernel<T>(
+                out.data->template get_access<sycl::access::mode::write>(h),
+                out.info,
+                in.data->template get_access<sycl::access::mode::read>(h),
+                in.info, pp, blks_x, blks_y));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/oneapi/kernel/where.hpp
+++ b/src/backend/oneapi/kernel/where.hpp
@@ -148,19 +148,16 @@ static void where(Param<uint> &out, Param<T> in) {
 
     // Get output size and allocate output
     uint total;
-    sycl::buffer retBuffer(&total, {1},
-                           {sycl::property::buffer::use_host_ptr()});
 
     getQueue()
         .submit([&](sycl::handler &h) {
             auto acc_in  = rtmp.data->get_access(h, sycl::range{1},
                                                  sycl::id{rtmp_elements - 1});
-            auto acc_out = retBuffer.get_access();
-            h.copy(acc_in, acc_out);
+            h.copy(acc_in, &total);
         })
         .wait();
 
-    auto out_alloc = memAlloc<uint>(total);
+    auto out_alloc = memAlloc<uint>(std::max(1U,total));
     out.data       = out_alloc.get();
 
     out.info.dims[0]    = total;

--- a/test/index.cpp
+++ b/test/index.cpp
@@ -586,12 +586,13 @@ TYPED_TEST(Indexing, 3D_to_1D) {
 }
 
 TEST(Index, Docs_Util_C_API) {
+    // clang-format off
+    ASSERT_EQ(0, ([]() -> int {
     //![ex_index_util_0]
     af_index_t *indexers = 0;
-    af_err err           = af_create_indexers(
-                  &indexers);  // Memory is allocated on heap by the callee
-    // by default all the indexers span all the elements along the given
-    // dimension
+    af_err err = af_create_indexers(&indexers); // Memory is allocated on heap by the callee
+                                                // by default all the indexers span all the elements along
+                                                // the given dimension
 
     // Create array
     af_array a;
@@ -613,12 +614,11 @@ TEST(Index, Docs_Util_C_API) {
 
     // index with indexers
     af_array out;
-    af_index_gen(&out, a, 2,
-                 indexers);  // number of indexers should be two since
-                             // we have set only second af_index_t
+    err = af_index_gen(&out, a, 2, indexers);  // number of indexers should be two since
+                                               // we have set only second af_index_t
     if (err != AF_SUCCESS) {
         printf("Failed in af_index_gen: %d\n", err);
-        throw;
+        return 1;
     }
     af_print_array(out);
     af_release_array(out);
@@ -630,7 +630,7 @@ TEST(Index, Docs_Util_C_API) {
     err = af_index_gen(&out, a, 2, indexers);
     if (err != AF_SUCCESS) {
         printf("Failed in af_index_gen: %d\n", err);
-        throw;
+        return 1;
     }
     af_print_array(out);
 
@@ -638,7 +638,10 @@ TEST(Index, Docs_Util_C_API) {
     af_release_array(a);
     af_release_array(idx);
     af_release_array(out);
+    return 0;
     //![ex_index_util_0]
+    }()));
+    // clang-format on
 }
 
 //////////////////////////////// CPP ////////////////////////////////


### PR DESCRIPTION
Generalized indexing in the oneAPI backend

Description
-----------
This PR adds the ability to index using non-linear sequences and arrays.
* workarounds for the long long bug in where, assign and copy
* Update the Docs_Util_C_API tests to avoid calling throw
* Catch sycl exceptions and display appropriate message in processException

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
