### PR TITLE
Fix iir errors and some other warnings in oneAPI

### DIFF
--- a/src/backend/oneapi/jit.cpp
+++ b/src/backend/oneapi/jit.cpp
@@ -294,9 +294,7 @@ void evalNodes(vector<Param<T>>& outputs, const vector<Node*>& output_nodes) {
     }
     if (numOutElems == 0) { return; }
 
-    const af::dtype outputType{output_nodes[0]->getType()};
     for (Node* node : output_nodes) {
-        assert(node->getType() == outputType);
         const int id{node->getNodesMap(nodes, full_nodes, full_ids)};
         output_ids.push_back(id);
     }

--- a/src/backend/oneapi/kernel/iir.hpp
+++ b/src/backend/oneapi/kernel/iir.hpp
@@ -12,6 +12,7 @@
 #include <Param.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
+#include <math.hpp>
 
 #include <sycl/sycl.hpp>
 
@@ -112,10 +113,10 @@ class iirKernel {
 
 template<typename T, bool batch_a>
 void iir(Param<T> y, Param<T> c, Param<T> a) {
-    const int groups_y = y.info.dims[1];
-    const int groups_x = y.info.dims[2];
+    const size_t groups_y = y.info.dims[1];
+    const size_t groups_x = y.info.dims[2];
 
-    int threads = 256;
+    size_t threads = 256;
     while (threads > y.info.dims[0] && threads > 32) threads /= 2;
     sycl::range<2> local = sycl::range{threads, 1};
 

--- a/src/backend/oneapi/kernel/pad_array_borders.hpp
+++ b/src/backend/oneapi/kernel/pad_array_borders.hpp
@@ -12,6 +12,7 @@
 #include <Param.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
+#include <math.hpp>
 #include <af/defines.h>
 
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
Fix narrowing errors in iir and pad_arrays

Description
-----------
Fixed a couple of errors on Linux when building oneAPI backend

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
