### PR TITLE
Implement the memory manager in the oneAPI backend

### DIFF
--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -128,6 +128,9 @@ static af_err af_arith(af_array *out, const af_array lhs, const af_array rhs,
 
         if (batchMode || linfo.dims() == rinfo.dims()) {
             dim4 odims = getOutDims(linfo.dims(), rinfo.dims(), batchMode);
+            if (odims.ndims() == 0) {
+                return af_create_handle(out, 0, nullptr, otype);
+            }
 
             switch (otype) {
                 case f32: res = arithOp<float, op>(lhs, rhs, odims); break;
@@ -146,6 +149,9 @@ static af_err af_arith(af_array *out, const af_array lhs, const af_array rhs,
                 default: TYPE_ERROR(0, otype);
             }
         } else {
+            if (linfo.ndims() == 0 && rinfo.ndims() == 0) {
+                return af_create_handle(out, 0, nullptr, otype);
+            }
             switch (otype) {
                 case f32: res = arithOpBroadcast<float, op>(lhs, rhs); break;
                 case f64: res = arithOpBroadcast<double, op>(lhs, rhs); break;
@@ -178,8 +184,11 @@ static af_err af_arith_real(af_array *out, const af_array lhs,
         const ArrayInfo &rinfo = getInfo(rhs);
 
         dim4 odims = getOutDims(linfo.dims(), rinfo.dims(), batchMode);
-
         const af_dtype otype = implicit(linfo.getType(), rinfo.getType());
+        if (odims.ndims() == 0) {
+            return af_create_handle(out, 0, nullptr, otype);
+        }
+
         af_array res;
         switch (otype) {
             case f32: res = arithOp<float, op>(lhs, rhs, odims); break;
@@ -462,6 +471,9 @@ af_err af_atan2(af_array *out, const af_array lhs, const af_array rhs,
         const ArrayInfo &rinfo = getInfo(rhs);
 
         dim4 odims = getOutDims(linfo.dims(), rinfo.dims(), batchMode);
+        if (odims.ndims() == 0) {
+            return af_create_handle(out, 0, nullptr, type);
+        }
 
         af_array res;
         switch (type) {
@@ -490,6 +502,10 @@ af_err af_hypot(af_array *out, const af_array lhs, const af_array rhs,
         const ArrayInfo &rinfo = getInfo(rhs);
 
         dim4 odims = getOutDims(linfo.dims(), rinfo.dims(), batchMode);
+
+        if (odims.ndims() == 0) {
+            return af_create_handle(out, 0, nullptr, type);
+        }
 
         af_array res;
         switch (type) {
@@ -522,6 +538,10 @@ static af_err af_logic(af_array *out, const af_array lhs, const af_array rhs,
         const ArrayInfo &rinfo = getInfo(rhs);
 
         dim4 odims = getOutDims(linfo.dims(), rinfo.dims(), batchMode);
+
+        if (odims.ndims() == 0) {
+            return af_create_handle(out, 0, nullptr, type);
+        }
 
         af_array res;
         switch (type) {

--- a/src/api/c/complex.cpp
+++ b/src/api/c/complex.cpp
@@ -47,9 +47,11 @@ af_err af_cplx2(af_array *out, const af_array lhs, const af_array rhs,
         }
 
         if (type != f64) { type = f32; }
-
         dim4 odims =
             getOutDims(getInfo(lhs).dims(), getInfo(rhs).dims(), batchMode);
+        if (odims.ndims() == 0) {
+            return af_create_handle(out, 0, nullptr, type);
+        }
 
         af_array res;
         switch (type) {
@@ -72,6 +74,7 @@ af_err af_cplx(af_array *out, const af_array in) {
         if (type == c32 || type == c64) {
             AF_ERROR("Inputs to cplx2 can not be of complex type", AF_ERR_ARG);
         }
+        if (info.ndims() == 0) { return af_retain_array(out, in); }
 
         af_array tmp;
         AF_CHECK(af_constant(&tmp, 0, info.ndims(), info.dims().get(), type));
@@ -98,6 +101,7 @@ af_err af_real(af_array *out, const af_array in) {
         af_dtype type         = info.getType();
 
         if (type != c32 && type != c64) { return af_retain_array(out, in); }
+        if (info.ndims() == 0) { return af_retain_array(out, in); }
 
         af_array res;
         switch (type) {
@@ -125,6 +129,7 @@ af_err af_imag(af_array *out, const af_array in) {
         if (type != c32 && type != c64) {
             return af_constant(out, 0, info.ndims(), info.dims().get(), type);
         }
+        if (info.ndims() == 0) { return af_retain_array(out, in); }
 
         af_array res;
         switch (type) {
@@ -150,6 +155,7 @@ af_err af_conjg(af_array *out, const af_array in) {
         af_dtype type         = info.getType();
 
         if (type != c32 && type != c64) { return af_retain_array(out, in); }
+        if (info.ndims() == 0) { return af_retain_array(out, in); }
 
         af_array res;
         switch (type) {
@@ -178,6 +184,7 @@ af_err af_abs(af_array *out, const af_array in) {
         // Convert all inputs to floats / doubles
         af_dtype type = implicit(in_type, f32);
         if (in_type == f16) { type = f16; }
+        if (in_info.ndims() == 0) { return af_retain_array(out, in); }
 
         switch (type) {
             // clang-format off

--- a/src/api/c/unary.cpp
+++ b/src/api/c/unary.cpp
@@ -79,6 +79,7 @@ static af_err af_unary(af_array *out, const af_array in) {
         // Convert all inputs to floats / doubles
         af_dtype type = implicit(in_type, f32);
         if (in_type == f16) { type = f16; }
+        if (in_info.ndims() == 0) { return af_retain_array(out, in); }
 
         switch (type) {
             case f16: res = unaryOp<half, op>(in); break;
@@ -104,6 +105,7 @@ static af_err af_unary_complex(af_array *out, const af_array in) {
         // Convert all inputs to floats / doubles
         af_dtype type = implicit(in_type, f32);
         if (in_type == f16) { type = f16; }
+        if (in_info.ndims() == 0) { return af_retain_array(out, in); }
 
         switch (type) {
             case f32: res = unaryOp<float, op>(in); break;
@@ -562,6 +564,7 @@ af_err af_not(af_array *out, const af_array in) {
     try {
         af_array tmp;
         const ArrayInfo &in_info = getInfo(in);
+        if (in_info.ndims() == 0) { return af_retain_array(out, in); }
 
         AF_CHECK(af_constant(&tmp, 0, in_info.ndims(), in_info.dims().get(),
                              in_info.getType()));
@@ -613,6 +616,7 @@ af_err af_bitnot(af_array *out, const af_array in) {
 af_err af_arg(af_array *out, const af_array in) {
     try {
         const ArrayInfo &in_info = getInfo(in);
+        if (in_info.ndims() == 0) { return af_retain_array(out, in); }
 
         if (!in_info.isComplex()) {
             return af_constant(out, 0, in_info.ndims(), in_info.dims().get(),
@@ -639,6 +643,7 @@ af_err af_pow2(af_array *out, const af_array in) {
     try {
         af_array two;
         const ArrayInfo &in_info = getInfo(in);
+        if (in_info.ndims() == 0) { return af_retain_array(out, in); }
 
         AF_CHECK(af_constant(&two, 2, in_info.ndims(), in_info.dims().get(),
                              in_info.getType()));
@@ -656,6 +661,7 @@ af_err af_factorial(af_array *out, const af_array in) {
     try {
         af_array one;
         const ArrayInfo &in_info = getInfo(in);
+        if (in_info.ndims() == 0) { return af_retain_array(out, in); }
 
         AF_CHECK(af_constant(&one, 1, in_info.ndims(), in_info.dims().get(),
                              in_info.getType()));
@@ -722,6 +728,7 @@ static af_err af_check(af_array *out, const af_array in) {
         // Convert all inputs to floats / doubles / complex
         af_dtype type = implicit(in_type, f32);
         if (in_type == f16) { type = f16; }
+        if (in_info.ndims() == 0) { return af_retain_array(out, in); }
 
         switch (type) {
             case f32: res = checkOp<float, op>(in); break;

--- a/src/backend/oneapi/Array.cpp
+++ b/src/backend/oneapi/Array.cpp
@@ -91,7 +91,7 @@ template<typename T>
 Array<T>::Array(const dim4 &dims)
     : info(getActiveDeviceId(), dims, 0, calcStrides(dims),
            static_cast<af_dtype>(dtype_traits<T>::af_type))
-    , data(memAlloc<T>(info.elements()).release(), bufferFree<T>)
+    , data(memAlloc<T>(info.elements()).release(), memFree<T>)
     , data_dims(dims)
     , node()
     , owner(true) {}
@@ -112,7 +112,7 @@ template<typename T>
 Array<T>::Array(const dim4 &dims, const T *const in_data)
     : info(getActiveDeviceId(), dims, 0, calcStrides(dims),
            static_cast<af_dtype>(dtype_traits<T>::af_type))
-    , data(memAlloc<T>(info.elements()).release(), bufferFree<T>)
+    , data(memAlloc<T>(info.elements()).release(), memFree<T>)
     , data_dims(dims)
     , node()
     , owner(true) {
@@ -138,7 +138,7 @@ Array<T>::Array(const af::dim4 &dims, buffer<T> *const mem, size_t offset,
     : info(getActiveDeviceId(), dims, 0, calcStrides(dims),
            static_cast<af_dtype>(dtype_traits<T>::af_type))
     , data(copy ? memAlloc<T>(info.elements()).release() : new buffer<T>(*mem),
-           bufferFree<T>)
+           memFree<T>)
     , data_dims(dims)
     , node()
     , owner(true) {
@@ -171,7 +171,7 @@ Array<T>::Array(Param<T> &tmp, bool owner_)
                 tmp.info.strides[3]),
            static_cast<af_dtype>(dtype_traits<T>::af_type))
     , data(
-          tmp.data, owner_ ? bufferFree<T> : [](buffer<T> * /*unused*/) {})
+          tmp.data, owner_ ? memFree<T> : [](sycl::buffer<T> * /*unused*/) {})
     , data_dims(dim4(tmp.info.dims[0], tmp.info.dims[1], tmp.info.dims[2],
                      tmp.info.dims[3]))
     , node()
@@ -205,7 +205,7 @@ void Array<T>::eval() {
 
     this->setId(getActiveDeviceId());
     data = std::shared_ptr<sycl::buffer<T>>(
-        memAlloc<T>(info.elements()).release(), bufferFree<T>);
+        memAlloc<T>(info.elements()).release(), memFree<T>);
 
     // Do not replace this with cast operator
     KParam info = {{dims()[0], dims()[1], dims()[2], dims()[3]},
@@ -256,7 +256,7 @@ void evalMultiple(vector<Array<T> *> arrays) {
 
         array->setId(getActiveDeviceId());
         array->data = std::shared_ptr<buffer<T>>(
-            memAlloc<T>(info.elements()).release(), bufferFree<T>);
+            memAlloc<T>(info.elements()).release(), memFree<T>);
 
         // Do not replace this with cast operator
         KParam kInfo = {

--- a/src/backend/oneapi/kernel/scan_first.hpp
+++ b/src/backend/oneapi/kernel/scan_first.hpp
@@ -105,7 +105,6 @@ class scanFirstKernel {
             group_barrier(g);
 
             int start = 0;
-#pragma unroll
             for (int off = 1; off < DIMX_; off *= 2) {
                 if (lidx >= off) val = binop(val, sptr[(start - off) + lidx]);
                 start              = DIMX_ - start;

--- a/src/backend/oneapi/memory.hpp
+++ b/src/backend/oneapi/memory.hpp
@@ -20,11 +20,6 @@
 
 namespace arrayfire {
 namespace oneapi {
-template<typename T>
-sycl::buffer<T> *bufferAlloc(const size_t &bytes);
-
-template<typename T>
-void bufferFree(sycl::buffer<T> *buf);
 
 template<typename T>
 using bufptr =
@@ -37,7 +32,8 @@ void *memAllocUser(const size_t &bytes);
 // Need these as 2 separate function and not a default argument
 // This is because it is used as the deleter in shared pointer
 // which cannot support default arguments
-void memFree(void *ptr);
+template<typename T>
+void memFree(sycl::buffer<T> *ptr);
 void memFreeUser(void *ptr);
 
 template<typename T>


### PR DESCRIPTION
Implement the memory manager in the oneAPI backend

Description
-----------
Adds memory management to the oneAPI backend. This was done by storing sycl::buffers as byte buffer pointers. These buffers are then reinterpreted in the alloc funciton call before they are returned to the caller of memAlloc.

This PR also handles 0 element inputs in the arithmetic, logic and math functions. 

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
