### PR TITLE
Update ArrayFireConfig to include oneAPI binaries. Build examples.

### DIFF
--- a/CMakeModules/ArrayFireConfig.cmake.in
+++ b/CMakeModules/ArrayFireConfig.cmake.in
@@ -20,6 +20,8 @@
 #   Target for the ArrayFire CPU backend.
 # ``ArrayFire::afcuda``
 #   Target for the ArrayFire CUDA backend.
+# ``ArrayFire::afoneapi``
+#   Target for the ArrayFire oneAPI backend.
 # ``ArrayFire::afopencl``
 #   Target for the ArrayFire OpenCL backend.
 #
@@ -60,6 +62,11 @@
 # ``ArrayFire_CUDA_LIBRARIES``
 #   Location of ArrayFire's CUDA library, if found
 #
+# ``ArrayFire_oneAPI_FOUND``
+#   True of the ArrayFire oneAPI library has been found.
+# ``ArrayFire_oneAPI_LIBRARIES``
+#   Location of ArrayFire's oneAPI library, if found
+#
 # ``ArrayFire_OpenCL_FOUND``
 #   True of the ArrayFire OpenCL library has been found.
 # ``ArrayFire_OpenCL_LIBRARIES``
@@ -85,7 +92,7 @@
 
 set_and_check(ArrayFire_INCLUDE_DIRS @PACKAGE_INCLUDE_DIRS@)
 
-foreach(backend Unified CPU OpenCL CUDA)
+foreach(backend Unified CPU oneAPI OpenCL CUDA)
   if(backend STREQUAL "Unified")
     set(lowerbackend "")
   else()
@@ -140,4 +147,4 @@ foreach(_comp ${ArrayFire_FIND_COMPONENTS})
   endif()
 endforeach()
 
-check_required_components(CPU OpenCL CUDA Unified)
+check_required_components(CPU oneAPI OpenCL CUDA Unified)

--- a/examples/benchmarks/CMakeLists.txt
+++ b/examples/benchmarks/CMakeLists.txt
@@ -26,7 +26,6 @@ if(ArrayFire_CPU_FOUND)
   target_link_libraries(pi_cpu ArrayFire::afcpu)
 endif()
 
-
 if(ArrayFire_CUDA_FOUND)
   add_executable(blas_cuda blas.cpp)
   target_link_libraries(blas_cuda ArrayFire::afcuda)
@@ -41,7 +40,6 @@ if(ArrayFire_CUDA_FOUND)
   target_link_libraries(pi_cuda ArrayFire::afcuda)
 endif()
 
-
 if(ArrayFire_OpenCL_FOUND)
   add_executable(blas_opencl blas.cpp)
   target_link_libraries(blas_opencl ArrayFire::afopencl)
@@ -54,4 +52,18 @@ if(ArrayFire_OpenCL_FOUND)
 
   add_executable(pi_opencl pi.cpp)
   target_link_libraries(pi_opencl ArrayFire::afopencl)
+endif()
+
+if(ArrayFire_oneAPI_FOUND)
+  add_executable(blas_oneapi blas.cpp)
+  target_link_libraries(blas_oneapi ArrayFire::afoneapi)
+
+  add_executable(cg_oneapi cg.cpp)
+  target_link_libraries(cg_oneapi ArrayFire::afoneapi)
+
+  add_executable(fft_oneapi fft.cpp)
+  target_link_libraries(fft_oneapi ArrayFire::afoneapi)
+
+  add_executable(pi_oneapi pi.cpp)
+  target_link_libraries(pi_oneapi ArrayFire::afoneapi)
 endif()

--- a/examples/computer_vision/CMakeLists.txt
+++ b/examples/computer_vision/CMakeLists.txt
@@ -59,3 +59,17 @@ if (ArrayFire_OpenCL_FOUND)
   add_executable(susan_opencl susan.cpp)
   target_link_libraries(susan_opencl ArrayFire::afopencl)
 endif()
+
+if (ArrayFire_oneAPI_FOUND)
+  add_executable(fast_oneapi fast.cpp)
+  target_link_libraries(fast_oneapi ArrayFire::afoneapi)
+
+  add_executable(harris_oneapi harris.cpp)
+  target_link_libraries(harris_oneapi ArrayFire::afoneapi)
+
+  add_executable(matching_oneapi matching.cpp)
+  target_link_libraries(matching_oneapi ArrayFire::afoneapi)
+
+  add_executable(susan_oneapi susan.cpp)
+  target_link_libraries(susan_oneapi ArrayFire::afoneapi)
+endif()

--- a/examples/financial/CMakeLists.txt
+++ b/examples/financial/CMakeLists.txt
@@ -47,3 +47,14 @@ if(ArrayFire_OpenCL_FOUND)
   add_executable(heston_model_opencl heston_model.cpp)
   target_link_libraries(heston_model_opencl ArrayFire::afopencl)
 endif()
+
+if(ArrayFire_oneAPI_FOUND)
+  add_executable(monte_carlo_options_oneapi monte_carlo_options.cpp)
+  target_link_libraries(monte_carlo_options_oneapi ArrayFire::afoneapi)
+
+  add_executable(black_scholes_options_oneapi black_scholes_options.cpp input.h)
+  target_link_libraries(black_scholes_options_oneapi ArrayFire::afoneapi)
+
+  add_executable(heston_model_oneapi heston_model.cpp)
+  target_link_libraries(heston_model_oneapi ArrayFire::afoneapi)
+endif()

--- a/examples/getting_started/CMakeLists.txt
+++ b/examples/getting_started/CMakeLists.txt
@@ -57,3 +57,17 @@ if(ArrayFire_OpenCL_FOUND)
   add_executable(vectorize_opencl vectorize.cpp)
   target_link_libraries(vectorize_opencl ArrayFire::afopencl)
 endif()
+
+if(ArrayFire_oneAPI_FOUND)
+  add_executable(convolve_oneapi convolve.cpp)
+  target_link_libraries(convolve_oneapi ArrayFire::afoneapi)
+
+  add_executable(integer_oneapi integer.cpp)
+  target_link_libraries(integer_oneapi ArrayFire::afoneapi)
+
+  add_executable(rainfall_oneapi rainfall.cpp)
+  target_link_libraries(rainfall_oneapi ArrayFire::afoneapi)
+
+  add_executable(vectorize_oneapi vectorize.cpp)
+  target_link_libraries(vectorize_oneapi ArrayFire::afoneapi)
+endif()

--- a/examples/graphics/CMakeLists.txt
+++ b/examples/graphics/CMakeLists.txt
@@ -111,3 +111,33 @@ if(ArrayFire_OpenCL_FOUND)
   add_executable(surface_opencl surface.cpp)
   target_link_libraries(surface_opencl ArrayFire::afopencl)
 endif()
+
+if(ArrayFire_oneAPI_FOUND)
+  add_executable(conway_oneapi conway.cpp)
+  target_link_libraries(conway_oneapi ArrayFire::afoneapi)
+
+  add_executable(conway_pretty_oneapi conway_pretty.cpp)
+  target_link_libraries(conway_pretty_oneapi ArrayFire::afoneapi)
+
+  add_executable(field_oneapi field.cpp)
+  target_link_libraries(field_oneapi ArrayFire::afoneapi)
+
+  add_executable(fractal_oneapi fractal.cpp)
+  target_link_libraries(fractal_oneapi ArrayFire::afoneapi)
+
+  add_executable(gravity_sim_oneapi gravity_sim.cpp gravity_sim_init.h)
+  target_link_libraries(gravity_sim_oneapi ArrayFire::afoneapi)
+
+  add_executable(histogram_oneapi histogram.cpp)
+  target_compile_definitions(histogram_oneapi PRIVATE "ASSETS_DIR=\"${ASSETS_DIR}\"")
+  target_link_libraries(histogram_oneapi ArrayFire::afoneapi)
+
+  add_executable(plot2d_oneapi plot2d.cpp)
+  target_link_libraries(plot2d_oneapi ArrayFire::afoneapi)
+
+  add_executable(plot3_oneapi plot3.cpp)
+  target_link_libraries(plot3_oneapi ArrayFire::afoneapi)
+
+  add_executable(surface_oneapi surface.cpp)
+  target_link_libraries(surface_oneapi ArrayFire::afoneapi)
+endif()

--- a/examples/helloworld/CMakeLists.txt
+++ b/examples/helloworld/CMakeLists.txt
@@ -27,3 +27,8 @@ if(ArrayFire_OpenCL_FOUND)
   add_executable(helloworld_opencl helloworld.cpp)
   target_link_libraries(helloworld_opencl ArrayFire::afopencl)
 endif()
+
+if(ArrayFire_oneAPI_FOUND)
+  add_executable(helloworld_oneapi helloworld.cpp)
+  target_link_libraries(helloworld_oneapi ArrayFire::afoneapi)
+endif()

--- a/examples/image_processing/CMakeLists.txt
+++ b/examples/image_processing/CMakeLists.txt
@@ -156,3 +156,47 @@ if(ArrayFire_OpenCL_FOUND)
   add_executable(deconvolution_opencl deconvolution.cpp)
   target_link_libraries(deconvolution_opencl ArrayFire::afopencl)
 endif()
+
+if(ArrayFire_oneAPI_FOUND)
+  add_executable(adaptive_thresholding_oneapi adaptive_thresholding.cpp)
+  target_link_libraries(adaptive_thresholding_oneapi ArrayFire::afoneapi)
+
+  add_executable(binary_thresholding_oneapi binary_thresholding.cpp)
+  target_link_libraries(binary_thresholding_oneapi ArrayFire::afoneapi)
+
+  add_executable(brain_segmentation_oneapi brain_segmentation.cpp)
+  target_link_libraries(brain_segmentation_oneapi ArrayFire::afoneapi)
+
+  add_executable(confidence_connected_components_oneapi
+      confidence_connected_components.cpp)
+  target_link_libraries(confidence_connected_components_oneapi ArrayFire::afoneapi)
+
+  add_executable(edge_oneapi edge.cpp)
+  target_link_libraries(edge_oneapi ArrayFire::afoneapi)
+
+  add_executable(filters_oneapi filters.cpp)
+  target_link_libraries(filters_oneapi ArrayFire::afoneapi)
+
+  add_executable(image_demo_oneapi image_demo.cpp)
+  target_link_libraries(image_demo_oneapi ArrayFire::afoneapi)
+
+  add_executable(image_editing_oneapi image_editing.cpp)
+  target_link_libraries(image_editing_oneapi ArrayFire::afoneapi)
+
+  add_executable(morphing_oneapi morphing.cpp)
+  target_link_libraries(morphing_oneapi ArrayFire::afoneapi)
+
+  add_executable(optical_flow_oneapi optical_flow.cpp)
+  target_link_libraries(optical_flow_oneapi ArrayFire::afoneapi)
+
+  add_executable(pyramids_oneapi pyramids.cpp)
+  target_link_libraries(pyramids_oneapi ArrayFire::afoneapi)
+
+  # Gradient anisotropic diffusion example
+  add_executable(gradient_diffusion_oneapi gradient_diffusion.cpp)
+  target_link_libraries(gradient_diffusion_oneapi ArrayFire::afoneapi)
+
+  #Image Deconvolution Example
+  add_executable(deconvolution_oneapi deconvolution.cpp)
+  target_link_libraries(deconvolution_oneapi ArrayFire::afoneapi)
+endif()

--- a/examples/lin_algebra/CMakeLists.txt
+++ b/examples/lin_algebra/CMakeLists.txt
@@ -57,3 +57,17 @@ if(ArrayFire_OpenCL_FOUND)
   add_executable(svd_opencl svd.cpp)
   target_link_libraries(svd_opencl ArrayFire::afopencl)
 endif()
+
+if(ArrayFire_oneAPI_FOUND)
+  add_executable(cholesky_oneapi cholesky.cpp)
+  target_link_libraries(cholesky_oneapi ArrayFire::afoneapi)
+
+  add_executable(lu_oneapi lu.cpp)
+  target_link_libraries(lu_oneapi ArrayFire::afoneapi)
+
+  add_executable(qr_oneapi qr.cpp)
+  target_link_libraries(qr_oneapi ArrayFire::afoneapi)
+
+  add_executable(svd_oneapi svd.cpp)
+  target_link_libraries(svd_oneapi ArrayFire::afoneapi)
+endif()

--- a/examples/machine_learning/CMakeLists.txt
+++ b/examples/machine_learning/CMakeLists.txt
@@ -119,3 +119,35 @@ if(ArrayFire_OpenCL_FOUND)
   add_executable(softmax_regression_opencl softmax_regression.cpp)
   target_link_libraries(softmax_regression_opencl ArrayFire::afopencl)
 endif()
+
+if(ArrayFire_oneAPI_FOUND)
+  add_executable(bagging_oneapi bagging.cpp)
+  target_link_libraries(bagging_oneapi ArrayFire::afoneapi)
+
+  add_executable(deep_belief_net_oneapi deep_belief_net.cpp)
+  target_link_libraries(deep_belief_net_oneapi ArrayFire::afoneapi)
+
+  add_executable(geneticalgorithm_oneapi geneticalgorithm.cpp)
+  target_link_libraries(geneticalgorithm_oneapi ArrayFire::afoneapi)
+
+  add_executable(kmeans_oneapi kmeans.cpp)
+  target_link_libraries(kmeans_oneapi ArrayFire::afoneapi)
+
+  add_executable(logistic_regression_oneapi logistic_regression.cpp)
+  target_link_libraries(logistic_regression_oneapi ArrayFire::afoneapi)
+
+  add_executable(naive_bayes_oneapi naive_bayes.cpp)
+  target_link_libraries(naive_bayes_oneapi ArrayFire::afoneapi)
+
+  add_executable(neural_network_oneapi neural_network.cpp)
+  target_link_libraries(neural_network_oneapi ArrayFire::afoneapi)
+
+  add_executable(perceptron_oneapi perceptron.cpp)
+  target_link_libraries(perceptron_oneapi ArrayFire::afoneapi)
+
+  add_executable(rbm_oneapi rbm.cpp)
+  target_link_libraries(rbm_oneapi ArrayFire::afoneapi)
+
+  add_executable(softmax_regression_oneapi softmax_regression.cpp)
+  target_link_libraries(softmax_regression_oneapi ArrayFire::afoneapi)
+endif()

--- a/examples/pde/CMakeLists.txt
+++ b/examples/pde/CMakeLists.txt
@@ -27,3 +27,8 @@ if(ArrayFire_OpenCL_FOUND)
   add_executable(swe_opencl swe.cpp)
   target_link_libraries(swe_opencl ArrayFire::afopencl)
 endif()
+
+if(ArrayFire_oneAPI_FOUND)
+  add_executable(swe_oneapi swe.cpp)
+  target_link_libraries(swe_oneapi ArrayFire::afoneapi)
+endif()


### PR DESCRIPTION
Update the ArrayFireConfig file to export oneAPI targets and enable examples

Description
-----------
* Update the ArrayFireConfig file to include the ArrayFire::afoneapi target.
* Build oneAPI examples if oneAPI is enabled.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
