### PR TITLE
convolve2 and convolve_separable oneapi ports

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -214,6 +214,7 @@ target_sources(afoneapi
     kernel/approx2.hpp
     kernel/assign.hpp
     kernel/bilateral.hpp
+    kernel/convolve_separable.cpp
     kernel/diagonal.hpp
     kernel/diff.hpp
     kernel/histogram.hpp

--- a/src/backend/oneapi/convolve.cpp
+++ b/src/backend/oneapi/convolve.cpp
@@ -138,7 +138,7 @@ Array<T> convolve2_unwrap(const Array<T> &signal, const Array<T> &filter,
                               dim4(fDims[0] * fDims[1] * fDims[2], fDims[3]));
 
     Array<T> res =
-      matmul(unwrapped, collapsedFilter, AF_MAT_TRANS, AF_MAT_NONE);
+        matmul(unwrapped, collapsedFilter, AF_MAT_TRANS, AF_MAT_NONE);
     res = modDims(res, dim4(outputWidth, outputHeight, signal.dims()[3],
                             collapsedFilter.dims()[1]));
     Array<T> out = reorder(res, dim4(0, 1, 3, 2));
@@ -149,15 +149,14 @@ Array<T> convolve2_unwrap(const Array<T> &signal, const Array<T> &filter,
 template<typename T>
 Array<T> convolve2(Array<T> const &signal, Array<T> const &filter,
                    const dim4 stride, const dim4 padding, const dim4 dilation) {
-    if constexpr(!std::is_same<T, half>::value) {
-      Array<T> out =
-        convolve2_unwrap<T>(signal, filter, stride, padding, dilation);
-      return out;
-    }
-    else {
-      ONEAPI_NOT_SUPPORTED("");
-      Array<T> out = createEmptyArray<T>(dim4(1));
-      return out;
+    if constexpr (!std::is_same<T, half>::value) {
+        Array<T> out =
+            convolve2_unwrap<T>(signal, filter, stride, padding, dilation);
+        return out;
+    } else {
+        ONEAPI_NOT_SUPPORTED("");
+        Array<T> out = createEmptyArray<T>(dim4(1));
+        return out;
     }
 }
 
@@ -178,39 +177,38 @@ Array<T> conv2DataGradient(const Array<T> &incoming_gradient,
                            const Array<T> & /*convolved_output*/,
                            af::dim4 stride, af::dim4 padding,
                            af::dim4 dilation) {
-    if constexpr(!std::is_same<T, half>::value) {
-      const dim4 &cDims = incoming_gradient.dims();
-      const dim4 &sDims = original_signal.dims();
-      const dim4 &fDims = original_filter.dims();
+    if constexpr (!std::is_same<T, half>::value) {
+        const dim4 &cDims = incoming_gradient.dims();
+        const dim4 &sDims = original_signal.dims();
+        const dim4 &fDims = original_filter.dims();
 
-      Array<T> collapsed_filter = original_filter;
+        Array<T> collapsed_filter = original_filter;
 
-      collapsed_filter = flip(collapsed_filter, {1, 1, 0, 0});
-      collapsed_filter = modDims(collapsed_filter,
-                                 dim4(fDims[0] * fDims[1] * fDims[2], fDims[3]));
+        collapsed_filter = flip(collapsed_filter, {1, 1, 0, 0});
+        collapsed_filter = modDims(
+            collapsed_filter, dim4(fDims[0] * fDims[1] * fDims[2], fDims[3]));
 
-      Array<T> collapsed_gradient = incoming_gradient;
-      collapsed_gradient          = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
-      collapsed_gradient          = modDims(
-                                            collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
+        Array<T> collapsed_gradient = incoming_gradient;
+        collapsed_gradient = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
+        collapsed_gradient = modDims(
+            collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
 
-      Array<T> res =
-        matmul(collapsed_gradient, collapsed_filter, AF_MAT_NONE, AF_MAT_TRANS);
-      res = modDims(res, dim4(res.dims()[0] / sDims[3], sDims[3],
-                              fDims[0] * fDims[1], sDims[2]));
-      res = reorder(res, dim4(0, 2, 3, 1));
+        Array<T> res = matmul(collapsed_gradient, collapsed_filter, AF_MAT_NONE,
+                              AF_MAT_TRANS);
+        res          = modDims(res, dim4(res.dims()[0] / sDims[3], sDims[3],
+                                         fDims[0] * fDims[1], sDims[2]));
+        res          = reorder(res, dim4(0, 2, 3, 1));
 
-      const bool retCols = false;
-      res = wrap_dilated(res, sDims[0], sDims[1], fDims[0], fDims[1], stride[0],
-                         stride[1], padding[0], padding[1], dilation[0],
-                         dilation[1], retCols);
+        const bool retCols = false;
+        res = wrap_dilated(res, sDims[0], sDims[1], fDims[0], fDims[1],
+                           stride[0], stride[1], padding[0], padding[1],
+                           dilation[0], dilation[1], retCols);
 
-      return res;
-    }
-    else {
-      ONEAPI_NOT_SUPPORTED("");
-      Array<T> out = createEmptyArray<T>(dim4(1));
-      return out;
+        return res;
+    } else {
+        ONEAPI_NOT_SUPPORTED("");
+        Array<T> out = createEmptyArray<T>(dim4(1));
+        return out;
     }
 }
 
@@ -221,36 +219,35 @@ Array<T> conv2FilterGradient(const Array<T> &incoming_gradient,
                              const Array<T> & /*convolved_output*/,
                              af::dim4 stride, af::dim4 padding,
                              af::dim4 dilation) {
-    if constexpr(!std::is_same<T, half>::value) {
-      const dim4 &cDims = incoming_gradient.dims();
-      const dim4 &fDims = original_filter.dims();
+    if constexpr (!std::is_same<T, half>::value) {
+        const dim4 &cDims = incoming_gradient.dims();
+        const dim4 &fDims = original_filter.dims();
 
-      const bool retCols = false;
-      Array<T> unwrapped =
-        unwrap(original_signal, fDims[0], fDims[1], stride[0], stride[1],
-               padding[0], padding[1], dilation[0], dilation[1], retCols);
+        const bool retCols = false;
+        Array<T> unwrapped =
+            unwrap(original_signal, fDims[0], fDims[1], stride[0], stride[1],
+                   padding[0], padding[1], dilation[0], dilation[1], retCols);
 
-      unwrapped  = reorder(unwrapped, dim4(1, 2, 0, 3));
-      dim4 uDims = unwrapped.dims();
-      unwrapped =
-        modDims(unwrapped, dim4(uDims[0] * uDims[1], uDims[2] * uDims[3]));
+        unwrapped  = reorder(unwrapped, dim4(1, 2, 0, 3));
+        dim4 uDims = unwrapped.dims();
+        unwrapped =
+            modDims(unwrapped, dim4(uDims[0] * uDims[1], uDims[2] * uDims[3]));
 
-      Array<T> collapsed_gradient = incoming_gradient;
-      collapsed_gradient          = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
-      collapsed_gradient          = modDims(
-                                            collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
+        Array<T> collapsed_gradient = incoming_gradient;
+        collapsed_gradient = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
+        collapsed_gradient = modDims(
+            collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
 
-      Array<T> res =
-        matmul(unwrapped, collapsed_gradient, AF_MAT_NONE, AF_MAT_NONE);
-      res = modDims(res, dim4(fDims[0], fDims[1], fDims[2], fDims[3]));
+        Array<T> res =
+            matmul(unwrapped, collapsed_gradient, AF_MAT_NONE, AF_MAT_NONE);
+        res = modDims(res, dim4(fDims[0], fDims[1], fDims[2], fDims[3]));
 
-      auto out = flip(res, {1, 1, 0, 0});
-      return out;
-    }
-    else {
-      ONEAPI_NOT_SUPPORTED("");
-      Array<T> out = createEmptyArray<T>(dim4(1));
-      return out;
+        auto out = flip(res, {1, 1, 0, 0});
+        return out;
+    } else {
+        ONEAPI_NOT_SUPPORTED("");
+        Array<T> out = createEmptyArray<T>(dim4(1));
+        return out;
     }
 }
 

--- a/src/backend/oneapi/convolve_separable.cpp
+++ b/src/backend/oneapi/convolve_separable.cpp
@@ -1,5 +1,5 @@
 /*******************************************************
- * Copyright (c) 2022, ArrayFire
+ * Copyright (c) 2023, ArrayFire
  * All rights reserved.
  *
  * This file is distributed under 3-clause BSD license.
@@ -11,6 +11,7 @@
 
 #include <Array.hpp>
 #include <err_oneapi.hpp>
+#include <kernel/convolve_separable.hpp>
 #include <af/dim4.hpp>
 
 using af::dim4;
@@ -21,8 +22,36 @@ namespace oneapi {
 template<typename T, typename accT>
 Array<T> convolve2(Array<T> const& signal, Array<accT> const& c_filter,
                    Array<accT> const& r_filter, const bool expand) {
-    ONEAPI_NOT_SUPPORTED("");
-    Array<T> out = createEmptyArray<T>(dim4(1));
+    const auto cflen = c_filter.elements();
+    const auto rflen = r_filter.elements();
+
+    if ((cflen > kernel::MAX_SCONV_FILTER_LEN) ||
+        (rflen > kernel::MAX_SCONV_FILTER_LEN)) {
+        // TODO call upon fft
+        char errMessage[256];
+        snprintf(errMessage, sizeof(errMessage),
+                 "\noneAPI Separable convolution doesn't support %llu(coloumn) "
+                 "%llu(row) filters\n",
+                 cflen, rflen);
+        ONEAPI_NOT_SUPPORTED(errMessage);
+    }
+
+    const dim4& sDims = signal.dims();
+    dim4 tDims        = sDims;
+    dim4 oDims        = sDims;
+
+    if (expand) {
+        tDims[0] += cflen - 1;
+        oDims[0] += cflen - 1;
+        oDims[1] += rflen - 1;
+    }
+
+    Array<T> temp = createEmptyArray<T>(tDims);
+    Array<T> out  = createEmptyArray<T>(oDims);
+
+    kernel::convSep<T, accT>(temp, signal, c_filter, 0, expand);
+    kernel::convSep<T, accT>(out, temp, r_filter, 1, expand);
+
     return out;
 }
 

--- a/src/backend/oneapi/kernel/convolve2.hpp
+++ b/src/backend/oneapi/kernel/convolve2.hpp
@@ -1,3 +1,13 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+#pragma once
+
 template<typename T, typename aT>
 class conv2HelperCreateKernel {
    public:

--- a/src/backend/oneapi/kernel/convolve3.hpp
+++ b/src/backend/oneapi/kernel/convolve3.hpp
@@ -1,3 +1,13 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+#pragma once
+
 int index(int i, int j, int k, int jstride, int kstride) {
     return i + j * jstride + k * kstride;
 }

--- a/src/backend/oneapi/kernel/convolve_separable.cpp
+++ b/src/backend/oneapi/kernel/convolve_separable.cpp
@@ -1,0 +1,217 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <common/kernel_cache.hpp>
+#include <debug_oneapi.hpp>
+
+#include <string>
+#include <vector>
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+template<typename T>
+using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
+template<typename T>
+using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
+
+template<typename T, typename accType>
+class convolveSeparableCreateKernel {
+   public:
+    convolveSeparableCreateKernel(write_accessor<T> out, KParam oInfo,
+                                  read_accessor<T> signal, KParam sInfo,
+                                  read_accessor<accType> impulse, int nBBS0,
+                                  int nBBS1, const int FLEN, const int CONV_DIM,
+                                  const bool EXPAND,
+                                  sycl::local_accessor<T> localMem)
+        : out_(out)
+        , oInfo_(oInfo)
+        , signal_(signal)
+        , sInfo_(sInfo)
+        , impulse_(impulse)
+        , nBBS0_(nBBS0)
+        , nBBS1_(nBBS1)
+        , FLEN_(FLEN)
+        , CONV_DIM_(CONV_DIM)
+        , EXPAND_(EXPAND)
+        , localMem_(localMem) {}
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+
+        const int radius  = FLEN_ - 1;
+        const int padding = 2 * radius;
+        const int s0      = sInfo_.strides[0];
+        const int s1      = sInfo_.strides[1];
+        const int d0      = sInfo_.dims[0];
+        const int d1      = sInfo_.dims[1];
+        const int shrdLen =
+            g.get_local_range(0) + (CONV_DIM_ == 0 ? padding : 0);
+
+        unsigned b2 = g.get_group_id(0) / nBBS0_;
+        unsigned b3 = g.get_group_id(1) / nBBS1_;
+        T *dst      = out_.get_pointer() +
+                 (b2 * oInfo_.strides[2] + b3 * oInfo_.strides[3]);
+        const T *src = signal_.get_pointer() +
+                       (b2 * sInfo_.strides[2] + b3 * sInfo_.strides[3]) +
+                       sInfo_.offset;
+
+        int lx = it.get_local_id(0);
+        int ly = it.get_local_id(1);
+        int ox = g.get_local_range(0) * (g.get_group_id(0) - b2 * nBBS0_) + lx;
+        int oy = g.get_local_range(1) * (g.get_group_id(1) - b3 * nBBS1_) + ly;
+        int gx = ox;
+        int gy = oy;
+
+        // below if-else statement is based on MACRO value passed while kernel
+        // compilation
+        if (CONV_DIM_ == 0) {
+            gx += (EXPAND_ ? 0 : FLEN_ >> 1);
+            int endX = ((FLEN_ - 1) << 1) + g.get_local_range(0);
+#pragma unroll
+            for (int lx = it.get_local_id(0), glb_x = gx; lx < endX;
+                 lx += g.get_local_range(0), glb_x += g.get_local_range(0)) {
+                int i     = glb_x - radius;
+                int j     = gy;
+                bool is_i = i >= 0 && i < d0;
+                bool is_j = j >= 0 && j < d1;
+                localMem_[ly * shrdLen + lx] =
+                    (is_i && is_j ? src[i * s0 + j * s1] : (T)(0));
+            }
+
+        } else if (CONV_DIM_ == 1) {
+            gy += (EXPAND_ ? 0 : FLEN_ >> 1);
+            int endY = ((FLEN_ - 1) << 1) + g.get_local_range(1);
+#pragma unroll
+            for (int ly = it.get_local_id(1), glb_y = gy; ly < endY;
+                 ly += g.get_local_range(1), glb_y += g.get_local_range(1)) {
+                int i     = gx;
+                int j     = glb_y - radius;
+                bool is_i = i >= 0 && i < d0;
+                bool is_j = j >= 0 && j < d1;
+                localMem_[ly * shrdLen + lx] =
+                    (is_i && is_j ? src[i * s0 + j * s1] : (T)(0));
+            }
+        }
+        it.barrier();
+
+        if (ox < oInfo_.dims[0] && oy < oInfo_.dims[1]) {
+            // below conditional statement is based on MACRO value passed while
+            // kernel compilation
+            int i         = (CONV_DIM_ == 0 ? lx : ly) + radius;
+            accType accum = (accType)(0);
+#pragma unroll
+            for (int f = 0; f < FLEN_; ++f) {
+                accType f_val = impulse_[f];
+                // below conditional statement is based on MACRO value passed
+                // while kernel compilation
+                int s_idx = (CONV_DIM_ == 0 ? (ly * shrdLen + (i - f))
+                                            : ((i - f) * shrdLen + lx));
+                T s_val   = localMem_[s_idx];
+
+                // binOp omitted from OpenCL implementation (see
+                // convolve_separable.cl)
+                accum = accum + (accType)s_val * (accType)f_val;
+            }
+            dst[oy * oInfo_.strides[1] + ox] = (T)accum;
+        }
+    }
+
+   private:
+    write_accessor<T> out_;
+    KParam oInfo_;
+    read_accessor<T> signal_;
+    KParam sInfo_;
+    read_accessor<accType> impulse_;
+    int nBBS0_;
+    int nBBS1_;
+    const int FLEN_;
+    const int CONV_DIM_;
+    const bool EXPAND_;
+    sycl::local_accessor<T> localMem_;
+};
+
+template<typename T>
+void memcpyBuffer(sycl::buffer<T, 1> &dest, sycl::buffer<T, 1> &src,
+                  const size_t n, const size_t srcOffset) {
+    getQueue().submit([&](auto &h) {
+        sycl::accessor srcAcc{src, h, sycl::range{n}, sycl::id{srcOffset},
+                              sycl::read_only};
+        sycl::accessor destAcc{
+            dest,         h, sycl::range{n}, sycl::id{0}, sycl::write_only,
+            sycl::no_init};
+        h.copy(srcAcc, destAcc);
+    });
+}
+
+template<typename T, typename accType>
+void convSep(Param<T> out, const Param<T> signal, const Param<accType> filter,
+             const int conv_dim, const bool expand) {
+    if (!(conv_dim == 0 || conv_dim == 1)) {
+        AF_ERROR(
+            "Separable convolution accepts only 0 or 1 as convolution "
+            "dimension",
+            AF_ERR_NOT_SUPPORTED);
+    }
+    constexpr int THREADS_X = 16;
+    constexpr int THREADS_Y = 16;
+    constexpr bool IsComplex =
+        std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value;
+
+    const int fLen       = filter.info.dims[0] * filter.info.dims[1];
+    const size_t C0_SIZE = (THREADS_X + 2 * (fLen - 1)) * THREADS_Y;
+    const size_t C1_SIZE = (THREADS_Y + 2 * (fLen - 1)) * THREADS_X;
+    size_t locSize       = (conv_dim == 0 ? C0_SIZE : C1_SIZE);
+
+    auto local = sycl::range(THREADS_X, THREADS_Y);
+
+    int blk_x = divup(out.info.dims[0], THREADS_X);
+    int blk_y = divup(out.info.dims[1], THREADS_Y);
+
+    auto global = sycl::range(blk_x * signal.info.dims[2] * THREADS_X,
+                              blk_y * signal.info.dims[3] * THREADS_Y);
+
+    sycl::buffer<accType> mBuff = {sycl::range(fLen * sizeof(accType))};
+    memcpyBuffer(mBuff, *filter.data, fLen, 0);
+
+    getQueue().submit([&](auto &h) {
+        sycl::accessor d_signal{*signal.data, h, sycl::read_only};
+        sycl::accessor d_out{*out.data, h, sycl::write_only, sycl::no_init};
+        sycl::accessor d_mBuff{mBuff, h, sycl::read_only};
+        sycl::local_accessor<T> localMem(locSize, h);
+        h.parallel_for(sycl::nd_range{global, local},
+                       convolveSeparableCreateKernel<T, accType>(
+                           d_out, out.info, d_signal, signal.info, d_mBuff,
+                           blk_x, blk_y, fLen, conv_dim, expand, localMem));
+    });
+}
+
+#define INSTANTIATE(T, accT)                                          \
+    template void convSep<T, accT>(Param<T>, const Param<T>,          \
+                                   const Param<accT> filt, const int, \
+                                   const bool);
+
+INSTANTIATE(cdouble, cdouble)
+INSTANTIATE(cfloat, cfloat)
+INSTANTIATE(double, double)
+INSTANTIATE(float, float)
+INSTANTIATE(uint, float)
+INSTANTIATE(int, float)
+INSTANTIATE(uchar, float)
+INSTANTIATE(char, float)
+INSTANTIATE(ushort, float)
+INSTANTIATE(short, float)
+INSTANTIATE(uintl, float)
+INSTANTIATE(intl, float)
+
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/oneapi/kernel/convolve_separable.hpp
+++ b/src/backend/oneapi/kernel/convolve_separable.hpp
@@ -21,7 +21,8 @@ namespace kernel {
 constexpr int MAX_SCONV_FILTER_LEN = 31;
 
 template<typename T, typename accT>
-void convSep(Param<T> out, const Param<T> sig, const Param<accT> filt, const int cDim, const bool expand);
+void convSep(Param<T> out, const Param<T> sig, const Param<accT> filt,
+             const int cDim, const bool expand);
 
 }  // namespace kernel
 }  // namespace oneapi

--- a/src/backend/oneapi/kernel/convolve_separable.hpp
+++ b/src/backend/oneapi/kernel/convolve_separable.hpp
@@ -1,0 +1,28 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Param.hpp>
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+// below shared MAX_*_LEN's are calculated based on
+// a maximum shared memory configuration of 48KB per block
+// considering complex types as well
+constexpr int MAX_SCONV_FILTER_LEN = 31;
+
+template<typename T, typename accT>
+void convSep(Param<T> out, const Param<T> sig, const Param<accT> filt, const int cDim, const bool expand);
+
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire


### PR DESCRIPTION
oneapi port of convolve2 and convolve_separable. should close out necessary ports on the convolutions. this is missing support for the half data type. see comments on `src/backend/oneapi/convolve.cpp`.

Checklist
---------
- [X] Rebased on latest master
- [X] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
