### PR TITLE
corrects missing oneapi accessor semantics

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -210,6 +210,7 @@ add_library(afoneapi
 target_sources(afoneapi
   PRIVATE
     kernel/KParam.hpp
+    kernel/accessors.hpp
     kernel/approx1.hpp
     kernel/approx2.hpp
     kernel/assign.hpp

--- a/src/backend/oneapi/kernel/accessors.hpp
+++ b/src/backend/oneapi/kernel/accessors.hpp
@@ -1,0 +1,17 @@
+/*******************************************************
+ * Copyright (c) 2022 ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+#include <sycl/sycl.hpp>
+
+template<typename T>
+using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
+
+template<typename T>
+using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;

--- a/src/backend/oneapi/kernel/approx1.hpp
+++ b/src/backend/oneapi/kernel/approx1.hpp
@@ -13,6 +13,7 @@
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
 #include <err_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <kernel/interp.hpp>
 #include <traits.hpp>
 #include <af/constants.h>
@@ -29,17 +30,6 @@ namespace kernel {
 constexpr int TILE_DIM  = 32;
 constexpr int THREADS_X = TILE_DIM;
 constexpr int THREADS_Y = 256 / TILE_DIM;
-
-template<typename T, int dimensions>
-using local_accessor =
-    sycl::accessor<T, dimensions, sycl::access::mode::read_write,
-                   sycl::access::target::local>;
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename Ty, typename Tp, int order>
 class approx1Kernel {

--- a/src/backend/oneapi/kernel/approx2.hpp
+++ b/src/backend/oneapi/kernel/approx2.hpp
@@ -13,6 +13,7 @@
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
 #include <err_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <kernel/interp.hpp>
 #include <traits.hpp>
 #include <af/constants.h>
@@ -29,17 +30,6 @@ namespace kernel {
 constexpr int TILE_DIM  = 32;
 constexpr int THREADS_X = TILE_DIM;
 constexpr int THREADS_Y = 256 / TILE_DIM;
-
-template<typename T, int dimensions>
-using local_accessor =
-    sycl::accessor<T, dimensions, sycl::access::mode::read_write,
-                   sycl::access::target::local>;
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename Ty, typename Tp, int order>
 class approx2Kernel {

--- a/src/backend/oneapi/kernel/assign_kernel_param.hpp
+++ b/src/backend/oneapi/kernel/assign_kernel_param.hpp
@@ -1,9 +1,17 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
 
 #include <sycl/sycl.hpp>
 
 #include <array>
-
-#pragma once
 
 namespace arrayfire {
 namespace oneapi {

--- a/src/backend/oneapi/kernel/convolve.hpp
+++ b/src/backend/oneapi/kernel/convolve.hpp
@@ -9,10 +9,10 @@
 
 #pragma once
 #include <Param.hpp>
-#include <accessor.hpp>
 #include <common/dispatch.hpp>
 #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <af/defines.h>
 
 #include <sycl/sycl.hpp>
@@ -108,11 +108,6 @@ void memcpyBuffer(sycl::buffer<T, 1> &dest, sycl::buffer<T, 1> &src,
         h.copy(srcAcc, destAcc);
     });
 }
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 #include "convolve1.hpp"
 #include "convolve2.hpp"

--- a/src/backend/oneapi/kernel/identity.hpp
+++ b/src/backend/oneapi/kernel/identity.hpp
@@ -12,15 +12,13 @@
 #include <Param.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <math.hpp>
 #include <types.hpp>
 
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename T>
 class identityKernel {

--- a/src/backend/oneapi/kernel/iir.hpp
+++ b/src/backend/oneapi/kernel/iir.hpp
@@ -1,5 +1,5 @@
 /*******************************************************
- * Copyright (c) 2014, ArrayFire
+ * Copyright (c) 2023, ArrayFire
  * All rights reserved.
  *
  * This file is distributed under 3-clause BSD license.
@@ -12,6 +12,7 @@
 #include <Param.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <math.hpp>
 
 #include <sycl/sycl.hpp>
@@ -19,11 +20,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 constexpr int MAX_A_SIZE = 1024;
 

--- a/src/backend/oneapi/kernel/index.hpp
+++ b/src/backend/oneapi/kernel/index.hpp
@@ -12,6 +12,7 @@
 #include <Param.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <kernel/assign_kernel_param.hpp>
 
 namespace arrayfire {
@@ -20,19 +21,18 @@ namespace kernel {
 
 template<typename T>
 class indexKernel {
-    sycl::accessor<T, 1, sycl::access::mode::write> out;
+    write_accessor<T> out;
     KParam outp;
-    sycl::accessor<T, 1, sycl::access::mode::read> in;
+    read_accessor<T> in;
     KParam inp;
     IndexKernelParam p;
     int nBBS0;
     int nBBS1;
 
    public:
-    indexKernel(sycl::accessor<T, 1, sycl::access::mode::write> out_,
-                KParam outp_,
-                sycl::accessor<T, 1, sycl::access::mode::read> in_, KParam inp_,
-                const IndexKernelParam p_, const int nBBS0_, const int nBBS1_)
+    indexKernel(write_accessor<T> out_, KParam outp_, read_accessor<T> in_,
+                KParam inp_, const IndexKernelParam p_, const int nBBS0_,
+                const int nBBS1_)
         : out(out_)
         , outp(outp_)
         , in(in_)

--- a/src/backend/oneapi/kernel/interp.hpp
+++ b/src/backend/oneapi/kernel/interp.hpp
@@ -7,7 +7,10 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#pragma once
+
 #include <Param.hpp>
+#include <kernel/accessors.hpp>
 #include <math.hpp>
 #include <types.hpp>
 #include <af/constants.h>
@@ -18,12 +21,6 @@
 
 namespace arrayfire {
 namespace oneapi {
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename T>
 struct itype_t {

--- a/src/backend/oneapi/kernel/iota.hpp
+++ b/src/backend/oneapi/kernel/iota.hpp
@@ -13,6 +13,7 @@
 #include <common/dispatch.hpp>
 #include <common/half.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <traits.hpp>
 #include <types.hpp>
 #include <af/dim4.hpp>
@@ -29,7 +30,7 @@ namespace kernel {
 template<typename T>
 class iotaKernel {
    public:
-    iotaKernel(sycl::accessor<T> out, KParam oinfo, const int s0, const int s1,
+    iotaKernel(write_accessor<T> out, KParam oinfo, const int s0, const int s1,
                const int s2, const int s3, const int blocksPerMatX,
                const int blocksPerMatY)
         : out_(out)
@@ -79,7 +80,7 @@ class iotaKernel {
     }
 
    protected:
-    sycl::accessor<T> out_;
+    write_accessor<T> out_;
     KParam oinfo_;
     int s0_, s1_, s2_, s3_;
     int blocksPerMatX_, blocksPerMatY_;
@@ -100,24 +101,17 @@ void iota(Param<T> out, const af::dim4& sdims) {
                           local[1] * blocksPerMatY * out.info.dims[3]);
     sycl::nd_range<2> ndrange(global, local);
 
-    try {
-        getQueue()
-            .submit([=](sycl::handler& h) {
-                auto out_acc = out.data->get_access(h);
+    getQueue().submit([=](sycl::handler& h) {
+        write_accessor<T> out_acc{*out.data, h};
 
-                h.parallel_for(
-                    ndrange,
-                    iotaKernel<T>(out_acc, out.info, static_cast<int>(sdims[0]),
-                                  static_cast<int>(sdims[1]),
-                                  static_cast<int>(sdims[2]),
-                                  static_cast<int>(sdims[3]), blocksPerMatX,
-                                  blocksPerMatY));
-            })
-            .wait();
-        ONEAPI_DEBUG_FINISH(getQueue());
-    } catch (sycl::exception& e) {
-        std::cout << e.what() << std::endl;
-    } catch (std::exception& e) { std::cout << e.what() << std::endl; }
+        h.parallel_for(ndrange, iotaKernel<T>(out_acc, out.info,
+                                              static_cast<int>(sdims[0]),
+                                              static_cast<int>(sdims[1]),
+                                              static_cast<int>(sdims[2]),
+                                              static_cast<int>(sdims[3]),
+                                              blocksPerMatX, blocksPerMatY));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
 }
 
 }  // namespace kernel

--- a/src/backend/oneapi/kernel/lookup.hpp
+++ b/src/backend/oneapi/kernel/lookup.hpp
@@ -13,6 +13,7 @@
 #include <common/dispatch.hpp>
 #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 
 #include <sycl/sycl.hpp>
 
@@ -22,11 +23,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 int trimIndex(int idx, const int len) {
     int ret_val = idx;

--- a/src/backend/oneapi/kernel/lu_split.hpp
+++ b/src/backend/oneapi/kernel/lu_split.hpp
@@ -12,6 +12,7 @@
 #include <Param.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 
 #include <math.hpp>
 #include <array>
@@ -19,11 +20,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename T, bool same_dims>
 class luSplitKernel {

--- a/src/backend/oneapi/kernel/meanshift.hpp
+++ b/src/backend/oneapi/kernel/meanshift.hpp
@@ -13,6 +13,7 @@
 #include <common/dispatch.hpp>
 #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 
 #include <sycl/sycl.hpp>
 
@@ -23,11 +24,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 inline int convert_int_rtz(float number) { return ((int)(number)); }
 

--- a/src/backend/oneapi/kernel/pad_array_borders.hpp
+++ b/src/backend/oneapi/kernel/pad_array_borders.hpp
@@ -12,6 +12,7 @@
 #include <Param.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <math.hpp>
 #include <af/defines.h>
 
@@ -22,11 +23,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename T, int BType>
 class padBordersKernel {

--- a/src/backend/oneapi/kernel/random_engine.hpp
+++ b/src/backend/oneapi/kernel/random_engine.hpp
@@ -12,6 +12,7 @@
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
 #include <err_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <kernel/random_engine_mersenne.hpp>
 #include <kernel/random_engine_philox.hpp>
 #include <kernel/random_engine_threefry.hpp>
@@ -56,7 +57,7 @@ void uniformDistributionCBRNG(Param<T> out, const size_t elements,
     switch (type) {
         case AF_RANDOM_ENGINE_PHILOX_4X32_10:
             getQueue().submit([=](sycl::handler &h) {
-                auto out_acc = out.data->get_access(h);
+                write_accessor<T> out_acc{*out.data, h};
 
                 h.parallel_for(ndrange,
                                uniformPhilox<T>(out_acc, hi, lo, hic, loc,
@@ -66,7 +67,7 @@ void uniformDistributionCBRNG(Param<T> out, const size_t elements,
             break;
         case AF_RANDOM_ENGINE_THREEFRY_2X32_16:
             getQueue().submit([=](sycl::handler &h) {
-                auto out_acc = out.data->get_access(h);
+                write_accessor<T> out_acc{*out.data, h};
 
                 h.parallel_for(ndrange,
                                uniformThreefry<T>(out_acc, hi, lo, hic, loc,
@@ -96,7 +97,7 @@ void normalDistributionCBRNG(Param<T> out, const size_t elements,
     switch (type) {
         case AF_RANDOM_ENGINE_PHILOX_4X32_10:
             getQueue().submit([=](sycl::handler &h) {
-                auto out_acc = out.data->get_access(h);
+                write_accessor<T> out_acc{*out.data, h};
 
                 h.parallel_for(ndrange,
                                normalPhilox<T>(out_acc, hi, lo, hic, loc,
@@ -105,7 +106,7 @@ void normalDistributionCBRNG(Param<T> out, const size_t elements,
             break;
         case AF_RANDOM_ENGINE_THREEFRY_2X32_16:
             getQueue().submit([=](sycl::handler &h) {
-                auto out_acc = out.data->get_access(h);
+                write_accessor<T> out_acc{*out.data, h};
 
                 h.parallel_for(ndrange,
                                normalThreefry<T>(out_acc, hi, lo, hic, loc,
@@ -134,7 +135,7 @@ void uniformDistributionMT(Param<T> out, const size_t elements,
     sycl::nd_range<1> ndrange(sycl::range<1>(blocks * threads),
                               sycl::range<1>(threads));
     getQueue().submit([=](sycl::handler &h) {
-        auto out_acc       = out.data->get_access(h);
+        write_accessor<T> out_acc{*out.data, h};
         auto state_acc     = state.data->get_access(h);
         auto pos_acc       = pos.data->get_access(h);
         auto sh1_acc       = sh1.data->get_access(h);
@@ -142,9 +143,9 @@ void uniformDistributionMT(Param<T> out, const size_t elements,
         auto recursion_acc = sh2.data->get_access(h);
         auto temper_acc    = sh2.data->get_access(h);
 
-        auto lstate_acc     = local_accessor<uint, 1>(STATE_SIZE, h);
-        auto lrecursion_acc = local_accessor<uint, 1>(TABLE_SIZE, h);
-        auto ltemper_acc    = local_accessor<uint, 1>(TABLE_SIZE, h);
+        auto lstate_acc     = sycl::local_accessor<uint, 1>(STATE_SIZE, h);
+        auto lrecursion_acc = sycl::local_accessor<uint, 1>(TABLE_SIZE, h);
+        auto ltemper_acc    = sycl::local_accessor<uint, 1>(TABLE_SIZE, h);
 
         h.parallel_for(
             ndrange, uniformMersenne<T>(
@@ -170,7 +171,7 @@ void normalDistributionMT(Param<T> out, const size_t elements,
     sycl::nd_range<1> ndrange(sycl::range<1>(blocks * threads),
                               sycl::range<1>(threads));
     getQueue().submit([=](sycl::handler &h) {
-        auto out_acc       = out.data->get_access(h);
+        write_accessor<T> out_acc{*out.data, h};
         auto state_acc     = state.data->get_access(h);
         auto pos_acc       = pos.data->get_access(h);
         auto sh1_acc       = sh1.data->get_access(h);
@@ -178,9 +179,9 @@ void normalDistributionMT(Param<T> out, const size_t elements,
         auto recursion_acc = sh2.data->get_access(h);
         auto temper_acc    = sh2.data->get_access(h);
 
-        auto lstate_acc     = local_accessor<uint, 1>(STATE_SIZE, h);
-        auto lrecursion_acc = local_accessor<uint, 1>(TABLE_SIZE, h);
-        auto ltemper_acc    = local_accessor<uint, 1>(TABLE_SIZE, h);
+        auto lstate_acc     = sycl::local_accessor<uint, 1>(STATE_SIZE, h);
+        auto lrecursion_acc = sycl::local_accessor<uint, 1>(TABLE_SIZE, h);
+        auto ltemper_acc    = sycl::local_accessor<uint, 1>(TABLE_SIZE, h);
 
         h.parallel_for(
             ndrange, normalMersenne<T>(out_acc, state_acc, pos_acc, sh1_acc,

--- a/src/backend/oneapi/kernel/random_engine_philox.hpp
+++ b/src/backend/oneapi/kernel/random_engine_philox.hpp
@@ -45,6 +45,7 @@
  *********************************************************/
 
 #pragma once
+#include <kernel/accessors.hpp>
 #include <kernel/random_engine_write.hpp>
 
 namespace arrayfire {
@@ -106,7 +107,7 @@ static inline void philox(uint key[2], uint ctr[4]) {
 template<typename T>
 class uniformPhilox {
    public:
-    uniformPhilox(sycl::accessor<T> out, uint hi, uint lo, uint hic, uint loc,
+    uniformPhilox(write_accessor<T> out, uint hi, uint lo, uint hic, uint loc,
                   uint elementsPerBlock, uint elements)
         : out_(out)
         , hi_(hi)
@@ -138,7 +139,7 @@ class uniformPhilox {
     }
 
    protected:
-    sycl::accessor<T> out_;
+    write_accessor<T> out_;
     uint hi_, lo_, hic_, loc_;
     uint elementsPerBlock_, elements_;
 };
@@ -146,7 +147,7 @@ class uniformPhilox {
 template<typename T>
 class normalPhilox {
    public:
-    normalPhilox(sycl::accessor<T> out, uint hi, uint lo, uint hic, uint loc,
+    normalPhilox(write_accessor<T> out, uint hi, uint lo, uint hic, uint loc,
                  uint elementsPerBlock, uint elements)
         : out_(out)
         , hi_(hi)
@@ -180,7 +181,7 @@ class normalPhilox {
     }
 
    protected:
-    sycl::accessor<T> out_;
+    write_accessor<T> out_;
     uint hi_, lo_, hic_, loc_;
     uint elementsPerBlock_, elements_;
 };

--- a/src/backend/oneapi/kernel/random_engine_threefry.hpp
+++ b/src/backend/oneapi/kernel/random_engine_threefry.hpp
@@ -45,6 +45,7 @@
  *********************************************************/
 
 #pragma once
+#include <kernel/accessors.hpp>
 #include <kernel/random_engine_write.hpp>
 
 namespace arrayfire {
@@ -161,7 +162,7 @@ void threefry(uint k[2], uint c[2], uint X[2]) {
 template<typename T>
 class uniformThreefry {
    public:
-    uniformThreefry(sycl::accessor<T> out, uint hi, uint lo, uint hic, uint loc,
+    uniformThreefry(write_accessor<T> out, uint hi, uint lo, uint hic, uint loc,
                     uint elementsPerBlock, uint elements)
         : out_(out)
         , hi_(hi)
@@ -198,7 +199,7 @@ class uniformThreefry {
     }
 
    protected:
-    sycl::accessor<T> out_;
+    write_accessor<T> out_;
     uint hi_, lo_, hic_, loc_;
     uint elementsPerBlock_, elements_;
 };
@@ -206,7 +207,7 @@ class uniformThreefry {
 template<typename T>
 class normalThreefry {
    public:
-    normalThreefry(sycl::accessor<T> out, uint hi, uint lo, uint hic, uint loc,
+    normalThreefry(write_accessor<T> out, uint hi, uint lo, uint hic, uint loc,
                    uint elementsPerBlock, uint elements)
         : out_(out)
         , hi_(hi)
@@ -243,7 +244,7 @@ class normalThreefry {
     }
 
    protected:
-    sycl::accessor<T> out_;
+    write_accessor<T> out_;
     uint hi_, lo_, hic_, loc_;
     uint elementsPerBlock_, elements_;
 };

--- a/src/backend/oneapi/kernel/range.hpp
+++ b/src/backend/oneapi/kernel/range.hpp
@@ -15,6 +15,7 @@
 #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
 #include <err_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <traits.hpp>
 #include <af/dim4.hpp>
 
@@ -30,7 +31,7 @@ namespace kernel {
 template<typename T>
 class rangeOp {
    public:
-    rangeOp(sycl::accessor<T> out, KParam oinfo, const int dim,
+    rangeOp(write_accessor<T> out, KParam oinfo, const int dim,
             const int blocksPerMatX, const int blocksPerMatY)
         : out_(out)
         , oinfo_(oinfo)
@@ -82,7 +83,7 @@ class rangeOp {
     }
 
    protected:
-    sycl::accessor<T> out_;
+    write_accessor<T> out_;
     KParam oinfo_;
     int dim_;
     int blocksPerMatX_, blocksPerMatY_;
@@ -104,7 +105,7 @@ void range(Param<T> out, const int dim) {
     sycl::nd_range<2> ndrange(global, local);
 
     getQueue().submit([=](sycl::handler& h) {
-        auto out_acc = out.data->get_access(h);
+        write_accessor<T> out_acc{*out.data, h};
 
         h.parallel_for(ndrange, rangeOp<T>(out_acc, out.info, dim,
                                            blocksPerMatX, blocksPerMatY));

--- a/src/backend/oneapi/kernel/reduce.hpp
+++ b/src/backend/oneapi/kernel/reduce.hpp
@@ -8,6 +8,7 @@
  ********************************************************/
 
 #pragma once
+
 #include <Param.hpp>
 #include <backend.hpp>
 #include <common/Binary.hpp>

--- a/src/backend/oneapi/kernel/reduce_dim.hpp
+++ b/src/backend/oneapi/kernel/reduce_dim.hpp
@@ -8,6 +8,7 @@
  ********************************************************/
 
 #pragma once
+
 #include <Param.hpp>
 #include <backend.hpp>
 #include <common/Binary.hpp>
@@ -15,6 +16,7 @@
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
 #include <err_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <kernel/reduce_config.hpp>
 #include <math.hpp>
 #include <memory.hpp>
@@ -29,23 +31,12 @@ namespace arrayfire {
 namespace oneapi {
 namespace kernel {
 
-template<typename T, int dimensions>
-using local_accessor =
-    sycl::accessor<T, dimensions, sycl::access::mode::read_write,
-                   sycl::access::target::local>;
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
-
 template<typename Ti, typename To, af_op_t op, uint dim, uint DIMY>
 class reduceDimKernelSMEM {
    public:
     reduceDimKernelSMEM(Param<To> out, Param<Ti> in, uint groups_x,
                         uint groups_y, uint offset_dim, bool change_nan,
-                        To nanval, local_accessor<compute_t<To>, 1> s_val,
+                        To nanval, sycl::local_accessor<compute_t<To>, 1> s_val,
                         sycl::handler &h)
         : out_(out.template get_accessor<sycl::access::mode::write>(h))
         , in_(in.template get_accessor<sycl::access::mode::read>(h))
@@ -141,7 +132,7 @@ class reduceDimKernelSMEM {
     uint groups_x_, groups_y_, offset_dim_;
     bool change_nan_;
     To nanval_;
-    local_accessor<compute_t<To>, 1> s_val_;
+    sycl::local_accessor<compute_t<To>, 1> s_val_;
 };
 
 template<typename Ti, typename To, af_op_t op, uint dim>
@@ -154,8 +145,8 @@ void reduce_dim_launcher_default(Param<To> out, Param<Ti> in,
                           blocks_dim[1] * blocks_dim[3] * local[1]);
 
     getQueue().submit([=](sycl::handler &h) {
-        auto shrdMem =
-            local_accessor<compute_t<To>, 1>(creduce::THREADS_X * threads_y, h);
+        auto shrdMem = sycl::local_accessor<compute_t<To>, 1>(
+            creduce::THREADS_X * threads_y, h);
 
         switch (threads_y) {
             case 8:

--- a/src/backend/oneapi/kernel/reorder.hpp
+++ b/src/backend/oneapi/kernel/reorder.hpp
@@ -12,6 +12,7 @@
 #include <Param.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <traits.hpp>
 
 #include <sycl/sycl.hpp>
@@ -22,11 +23,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename T>
 class reorderCreateKernel {

--- a/src/backend/oneapi/kernel/resize.hpp
+++ b/src/backend/oneapi/kernel/resize.hpp
@@ -13,6 +13,7 @@
 #include <common/complex.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <traits.hpp>
 
 #include <sycl/sycl.hpp>
@@ -32,11 +33,6 @@ template<typename AT>
 std::complex<double> mul(AT a, std::complex<double> b) {
     return std::complex<double>(a * b.real(), a * b.imag());
 }
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename T>
 using wtype_t = typename std::conditional<std::is_same<T, double>::value,

--- a/src/backend/oneapi/kernel/rotate.hpp
+++ b/src/backend/oneapi/kernel/rotate.hpp
@@ -12,6 +12,7 @@
 #include <common/complex.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <kernel/interp.hpp>
 #include <math.hpp>
 #include <traits.hpp>
@@ -21,11 +22,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 typedef struct {
     float tmat[6];

--- a/src/backend/oneapi/kernel/scan_first.hpp
+++ b/src/backend/oneapi/kernel/scan_first.hpp
@@ -14,6 +14,7 @@
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
 #include <err_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <kernel/default_config.hpp>
 #include <memory.hpp>
 
@@ -23,17 +24,6 @@ namespace arrayfire {
 namespace oneapi {
 namespace kernel {
 
-template<typename T, int dimensions>
-using local_accessor =
-    sycl::accessor<T, dimensions, sycl::access::mode::read_write,
-                   sycl::access::target::local>;
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
-
 template<typename Ti, typename To, af_op_t op>
 class scanFirstKernel {
    public:
@@ -42,7 +32,8 @@ class scanFirstKernel {
                     read_accessor<Ti> in_acc, KParam iInfo, const uint groups_x,
                     const uint groups_y, const uint lim, const bool isFinalPass,
                     const uint DIMX, const bool inclusive_scan,
-                    local_accessor<To, 1> s_val, local_accessor<To, 1> s_tmp)
+                    sycl::local_accessor<To, 1> s_val,
+                    sycl::local_accessor<To, 1> s_tmp)
         : out_acc_(out_acc)
         , tmp_acc_(tmp_acc)
         , in_acc_(in_acc)
@@ -138,8 +129,8 @@ class scanFirstKernel {
     KParam oInfo_, tInfo_, iInfo_;
     const uint groups_x_, groups_y_, lim_, DIMX_;
     const bool isFinalPass_, inclusive_scan_;
-    local_accessor<To, 1> s_val_;
-    local_accessor<To, 1> s_tmp_;
+    sycl::local_accessor<To, 1> s_val_;
+    sycl::local_accessor<To, 1> s_tmp_;
 };
 
 template<typename To, af_op_t op>
@@ -220,8 +211,8 @@ static void scan_first_launcher(Param<To> out, Param<To> tmp, Param<Ti> in,
 
         const int DIMY            = THREADS_PER_BLOCK / threads_x;
         const int SHARED_MEM_SIZE = (2 * threads_x + 1) * (DIMY);
-        auto s_val = local_accessor<compute_t<To>, 1>(SHARED_MEM_SIZE, h);
-        auto s_tmp = local_accessor<compute_t<To>, 1>(DIMY, h);
+        auto s_val = sycl::local_accessor<compute_t<To>, 1>(SHARED_MEM_SIZE, h);
+        auto s_tmp = sycl::local_accessor<compute_t<To>, 1>(DIMY, h);
 
         // TODO threads_x as template arg for #pragma unroll?
         h.parallel_for(sycl::nd_range<2>(global, local),

--- a/src/backend/oneapi/kernel/select.hpp
+++ b/src/backend/oneapi/kernel/select.hpp
@@ -12,6 +12,7 @@
 #include <Param.hpp>
 #include <common/dispatch.hpp>
 #include <common/kernel_cache.hpp>
+#include <kernel/accessors.hpp>
 #include <math.hpp>
 
 #include <sycl/sycl.hpp>
@@ -22,11 +23,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 constexpr uint DIMX  = 32;
 constexpr uint DIMY  = 8;

--- a/src/backend/oneapi/kernel/tile.hpp
+++ b/src/backend/oneapi/kernel/tile.hpp
@@ -13,6 +13,7 @@
 #include <common/dispatch.hpp>
 #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 
 #include <sycl/sycl.hpp>
 
@@ -22,11 +23,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename T>
 class tileCreateKernel {

--- a/src/backend/oneapi/kernel/transform.hpp
+++ b/src/backend/oneapi/kernel/transform.hpp
@@ -13,6 +13,7 @@
 #include <common/complex.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <kernel/interp.hpp>
 #include <math.hpp>
 #include <traits.hpp>
@@ -25,11 +26,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename T>
 using wtype_t = typename std::conditional<std::is_same<T, double>::value,

--- a/src/backend/oneapi/kernel/where.hpp
+++ b/src/backend/oneapi/kernel/where.hpp
@@ -7,11 +7,14 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#pragma once
+
 #include <Param.hpp>
 #include <backend.hpp>
 #include <common/dispatch.hpp>
 #include <debug_oneapi.hpp>
 #include <err_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <kernel/default_config.hpp>
 #include <kernel/scan_first.hpp>
 #include <memory.hpp>
@@ -25,12 +28,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename T>
 class whereKernel {

--- a/src/backend/oneapi/kernel/wrap.hpp
+++ b/src/backend/oneapi/kernel/wrap.hpp
@@ -13,9 +13,9 @@
 #include <common/dispatch.hpp>
 #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <kernel/default_config.hpp>
 #include <math.hpp>
-#include <sycl/sycl.hpp>
 
 #include <sycl/sycl.hpp>
 
@@ -25,14 +25,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using local_accessor = sycl::accessor<T, 1, sycl::access::mode::read_write,
-                                      sycl::access::target::local>;
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename T>
 class wrapCreateKernel {

--- a/src/backend/oneapi/kernel/wrap_dilated.hpp
+++ b/src/backend/oneapi/kernel/wrap_dilated.hpp
@@ -13,6 +13,7 @@
 #include <common/dispatch.hpp>
 #include <common/kernel_cache.hpp>
 #include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <kernel/default_config.hpp>
 #include <math.hpp>
 
@@ -23,14 +24,6 @@
 namespace arrayfire {
 namespace oneapi {
 namespace kernel {
-
-template<typename T>
-using local_accessor = sycl::accessor<T, 1, sycl::access::mode::read_write,
-                                      sycl::access::target::local>;
-template<typename T>
-using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-template<typename T>
-using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
 template<typename T>
 class wrapDilatedCreateKernel {


### PR DESCRIPTION
Corrects missing oneapi accessor semantics

Description
---------
This PR goes back to the oneapi kernels and audits them for correct read/write/local semantics. This will allow the sycl runtime to create an out of order task-graph for better parallelism between unrelated(through memory accesses) kernels. This PR also removes a few uneccessary .wait() statements, further reducing host-side blocking. A few kernels had read/write buffers that were left as default sycl::accessor<T>. The mean kernel is still outstanding as there are other issues that need to be addressed in that kernel.


Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass