### PR TITLE
README: include links to codespace and colab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 
-<p align="center"><a href="http://arrayfire.com/"><img src="http://arrayfire.com/logos/arrayfire_logo_whitebkgnd.png" width="800"></a></p>
+<p align="left"><a href="http://arrayfire.com/"><img src="http://arrayfire.com/logos/arrayfire_logo_whitebkgnd.png" width="800"></a></p>
+
+[![Open in GitHub Codespaces](https://repo.arrayfire.com/pub/open-arrayfire-in-codespace.svg)](https://codespaces.new/pv-pterab-s/pv-pterab-s-temporary
+) [![Open in Colab](https://repo.arrayfire.com/pub/open-arrayfire-in-colab.svg)](https://colab.research.google.com/drive/1bOQY_XRn7JWWGRU6tDb5p2KMSRsYrzUE?usp=sharing)
 
 ArrayFire is a general-purpose tensor library that simplifies the process of
 software development for the parallel architectures found in CPUs, GPUs, and


### PR DESCRIPTION
codespace link in a temporary repository. let us move this to arrayfire official codespace repo once we agree on things. colab is same link from www.arrayfire.com homepage