### PR TITLE
Fix synchronize issues related to OpenCL oneAPI JIT

### DIFF
--- a/src/backend/oneapi/Array.cpp
+++ b/src/backend/oneapi/Array.cpp
@@ -279,7 +279,7 @@ template<typename T>
 Node_ptr Array<T>::getNode() {
     if (node) { return node; }
 
-    AParam<T> info = *this;
+    AParam<T, sycl::access_mode::read> info = *this;
     unsigned bytes = this->dims().elements() * sizeof(T);
     auto nn        = bufferNodePtr<T>();
     nn->setData(info, data, bytes, isLinear());

--- a/src/backend/oneapi/Array.hpp
+++ b/src/backend/oneapi/Array.hpp
@@ -41,7 +41,7 @@ namespace oneapi {
 
 template<typename T>
 struct Param;
-template<typename T>
+template<typename T, sycl::access_mode AM>
 struct AParam;
 
 template<typename T>
@@ -254,7 +254,7 @@ class Array {
     }
 
     sycl::buffer<T> *get() const {
-        if (!isReady()) eval();
+        if (!isReady()) { eval(); }
         return data.get();
     }
 
@@ -277,8 +277,15 @@ class Array {
         return out;
     }
 
-    operator AParam<T>() {
-        AParam<T> out(*getData(), dims().get(), strides().get(), getOffset());
+    operator AParam<T, sycl::access_mode::write>() {
+        AParam<T, sycl::access_mode::write> out(*getData(), dims().get(),
+                                                strides().get(), getOffset());
+        return out;
+    }
+
+    operator AParam<T, sycl::access_mode::read>() const {
+        AParam<T, sycl::access_mode::read> out(*getData(), dims().get(),
+                                               strides().get(), getOffset());
         return out;
     }
 

--- a/src/backend/oneapi/Param.hpp
+++ b/src/backend/oneapi/Param.hpp
@@ -8,12 +8,11 @@
  ********************************************************/
 
 #pragma once
+#include <sycl/sycl.hpp>
 
 #include <kernel/KParam.hpp>
 #include <types.hpp>
 #include <af/dim4.hpp>
-
-#include <sycl/sycl.hpp>
 
 #include <optional>
 
@@ -43,9 +42,9 @@ struct Param {
     ~Param() = default;
 };
 
-template<typename T>
+template<typename T, sycl::access_mode AM>
 struct AParam {
-    sycl::accessor<T, 1, sycl::access_mode::read_write, sycl::target::device,
+    sycl::accessor<T, 1, AM, sycl::target::device,
                    sycl::access::placeholder::true_t>
         data;
     af::dim4 dims;
@@ -60,17 +59,11 @@ struct AParam {
 
     AParam(sycl::buffer<T, 1>& data_, const dim_t dims_[4],
            const dim_t strides_[4], dim_t offset_)
-        : data(data_.get_access())
-        , dims(4, dims_)
-        , strides(4, strides_)
-        , offset(offset_) {}
+        : data(data_), dims(4, dims_), strides(4, strides_), offset(offset_) {}
     // AF_DEPRECATED("Use Array<T>")
     AParam(sycl::handler& h, sycl::buffer<T, 1>& data_, const dim_t dims_[4],
            const dim_t strides_[4], dim_t offset_)
-        : data(data_.get_access())
-        , dims(4, dims_)
-        , strides(4, strides_)
-        , offset(offset_) {
+        : data(data_), dims(4, dims_), strides(4, strides_), offset(offset_) {
         require(h);
     }
 

--- a/src/backend/oneapi/jit/BufferNode.hpp
+++ b/src/backend/oneapi/jit/BufferNode.hpp
@@ -18,8 +18,8 @@ namespace arrayfire {
 namespace oneapi {
 namespace jit {
 template<typename T>
-using BufferNode =
-    common::BufferNodeBase<std::shared_ptr<sycl::buffer<T>>, AParam<T>>;
+using BufferNode = common::BufferNodeBase<std::shared_ptr<sycl::buffer<T>>,
+                                          AParam<T, sycl::access_mode::read>>;
 }  // namespace jit
 }  // namespace oneapi
 

--- a/src/backend/oneapi/jit/kernel_generators.hpp
+++ b/src/backend/oneapi/jit/kernel_generators.hpp
@@ -41,7 +41,8 @@ template<typename T>
 inline int setKernelArguments(
     int start_id, bool is_linear,
     std::function<void(int id, const void* ptr, size_t arg_size)>& setArg,
-    const std::shared_ptr<sycl::buffer<T>>& ptr, const AParam<T>& info) {
+    const std::shared_ptr<sycl::buffer<T>>& ptr,
+    const AParam<T, sycl::access_mode::read>& info) {
     setArg(start_id + 0, static_cast<const void*>(&info), sizeof(Param<T>));
     return start_id + 2;
 }


### PR DESCRIPTION
Fix synchronization issues related to oneAPI JIT on the OpenCL backend

Description
-----------
The out of order queues on the oneAPI backend requires us to insert Barriers into the queue after a native kernel is enqueued. Previously we were adding a marker which does not perform the same level of synchronization. All JIT tests now pass after this PR. 

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
