### PR TITLE
Fix segfault in mean

### DIFF
--- a/src/backend/common/ArrayFireTypesIO.hpp
+++ b/src/backend/common/ArrayFireTypesIO.hpp
@@ -10,7 +10,9 @@
 #pragma once
 #include <common/Version.hpp>
 #include <spdlog/fmt/ostr.h>
+#include <af/dim4.hpp>
 #include <af/seq.h>
+#include <complex>
 
 template<>
 struct fmt::formatter<af_seq> {
@@ -32,6 +34,15 @@ struct fmt::formatter<af_seq> {
         return format_to(ctx.out(), "({} -({})-> {})", p.begin, p.step, p.end);
     }
 };
+
+#if FMT_VERSION >= 90000
+template<>
+struct fmt::formatter<af::dim4> : ostream_formatter {};
+template<>
+struct fmt::formatter<std::complex<float>> : ostream_formatter {};
+template<>
+struct fmt::formatter<std::complex<double>> : ostream_formatter {};
+#endif
 
 template<>
 struct fmt::formatter<arrayfire::common::Version> {

--- a/src/backend/oneapi/copy.cpp
+++ b/src/backend/oneapi/copy.cpp
@@ -61,7 +61,7 @@ Array<T> copyArray(const Array<T> &A) {
             sycl::buffer<T> *out_buf = out.get();
 
             size_t aelem = A.elements();
-            getQueue().submit([=](sycl::handler &h) {
+            getQueue().submit([&](sycl::handler &h) {
                 range rr(aelem);
                 id offset_id(offset);
                 accessor offset_acc_A =
@@ -114,7 +114,7 @@ struct copyWrapper<T, T> {
             sycl::buffer<T> *out_buf = out.get();
 
             getQueue()
-                .submit([=](sycl::handler &h) {
+                .submit([&](sycl::handler &h) {
                     sycl::range rr(in.elements());
                     sycl::id in_offset_id(in_offset);
                     sycl::id out_offset_id(out_offset);

--- a/src/backend/oneapi/join.cpp
+++ b/src/backend/oneapi/join.cpp
@@ -94,7 +94,7 @@ Array<T> join(const int jdim, const Array<T> &first, const Array<T> &second) {
     if (first.isReady()) {
         if (1LL + jdim >= first.ndims() && first.isLinear()) {
             // first & out are linear
-            getQueue().submit([=](sycl::handler &h) {
+            getQueue().submit([&](sycl::handler &h) {
                 sycl::range sz(first.elements());
                 sycl::id src_offset(first.getOffset());
                 sycl::accessor offset_acc_src =
@@ -125,7 +125,7 @@ Array<T> join(const int jdim, const Array<T> &first, const Array<T> &second) {
     if (second.isReady()) {
         if (1LL + jdim >= second.ndims() && second.isLinear()) {
             // second & out are linear
-            getQueue().submit([=](sycl::handler &h) {
+            getQueue().submit([&](sycl::handler &h) {
                 sycl::range sz(second.elements());
                 sycl::id src_offset(second.getOffset());
                 sycl::accessor offset_acc_src =
@@ -216,7 +216,7 @@ void join(Array<T> &out, const int jdim, const vector<Array<T>> &inputs) {
             for (const Array<T> *in : s.ins) {
                 if (in->isReady()) {
                     if (1LL + jdim >= in->ndims() && in->isLinear()) {
-                        getQueue().submit([=](sycl::handler &h) {
+                        getQueue().submit([&](sycl::handler &h) {
                             sycl::range sz(in->elements());
                             sycl::id src_offset(in->getOffset());
                             sycl::accessor offset_acc_src =

--- a/src/backend/oneapi/kernel/assign.hpp
+++ b/src/backend/oneapi/kernel/assign.hpp
@@ -125,7 +125,7 @@ void assign(Param<T> out, const Param<T> in, const AssignKernelParam& p,
     sycl::range<2> global(blk_x * in.info.dims[2] * THREADS_X,
                           blk_y * in.info.dims[3] * THREADS_Y);
 
-    getQueue().submit([=](sycl::handler& h) {
+    getQueue().submit([&](sycl::handler& h) {
         auto pp = p;
         write_accessor<T> out_acc{*out.data, h};
         read_accessor<T> in_acc{*in.data, h};

--- a/src/backend/oneapi/kernel/index.hpp
+++ b/src/backend/oneapi/kernel/index.hpp
@@ -133,7 +133,7 @@ void index(Param<T> out, Param<T> in, IndexKernelParam& p,
     blocks[0] *= threads[0];
 
     sycl::nd_range<3> marange(blocks, threads);
-    getQueue().submit([=](sycl::handler& h) {
+    getQueue().submit([&](sycl::handler& h) {
         auto pp = p;
         for (dim_t x = 0; x < 4; ++x) {
             pp.ptr[x] =

--- a/src/backend/oneapi/kernel/iota.hpp
+++ b/src/backend/oneapi/kernel/iota.hpp
@@ -101,7 +101,7 @@ void iota(Param<T> out, const af::dim4& sdims) {
                           local[1] * blocksPerMatY * out.info.dims[3]);
     sycl::nd_range<2> ndrange(global, local);
 
-    getQueue().submit([=](sycl::handler& h) {
+    getQueue().submit([&](sycl::handler& h) {
         write_accessor<T> out_acc{*out.data, h};
 
         h.parallel_for(ndrange, iotaKernel<T>(out_acc, out.info,

--- a/src/backend/oneapi/kernel/memcopy.hpp
+++ b/src/backend/oneapi/kernel/memcopy.hpp
@@ -115,7 +115,7 @@ void memcopy(sycl::buffer<T> *out, const dim_t *ostrides,
                           groups_1 * idims[3] * local_size[1]);
     sycl::nd_range<2> ndrange(global, local);
 
-    getQueue().submit([=](sycl::handler &h) {
+    getQueue().submit([&](sycl::handler &h) {
         write_accessor<T> out_acc{*out, h};
         read_accessor<T> in_acc{*const_cast<sycl::buffer<T> *>(in), h};
 
@@ -303,7 +303,7 @@ void copy(Param<outType> dst, const Param<inType> src, const int ndims,
         trgt_dims    = {{trgt_i, trgt_j, trgt_k, trgt_l}};
     }
 
-    getQueue().submit([=](sycl::handler &h) {
+    getQueue().submit([&](sycl::handler &h) {
         write_accessor<outType> dst_acc{*dst.data, h};
         read_accessor<inType> src_acc{
             *const_cast<sycl::buffer<inType> *>(src.data), h};

--- a/src/backend/oneapi/kernel/random_engine.hpp
+++ b/src/backend/oneapi/kernel/random_engine.hpp
@@ -56,7 +56,7 @@ void uniformDistributionCBRNG(Param<T> out, const size_t elements,
                               sycl::range<1>(threads));
     switch (type) {
         case AF_RANDOM_ENGINE_PHILOX_4X32_10:
-            getQueue().submit([=](sycl::handler &h) {
+            getQueue().submit([&](sycl::handler &h) {
                 write_accessor<T> out_acc{*out.data, h};
 
                 h.parallel_for(ndrange,
@@ -66,7 +66,7 @@ void uniformDistributionCBRNG(Param<T> out, const size_t elements,
             ONEAPI_DEBUG_FINISH(getQueue());
             break;
         case AF_RANDOM_ENGINE_THREEFRY_2X32_16:
-            getQueue().submit([=](sycl::handler &h) {
+            getQueue().submit([&](sycl::handler &h) {
                 write_accessor<T> out_acc{*out.data, h};
 
                 h.parallel_for(ndrange,
@@ -96,7 +96,7 @@ void normalDistributionCBRNG(Param<T> out, const size_t elements,
                               sycl::range<1>(threads));
     switch (type) {
         case AF_RANDOM_ENGINE_PHILOX_4X32_10:
-            getQueue().submit([=](sycl::handler &h) {
+            getQueue().submit([&](sycl::handler &h) {
                 write_accessor<T> out_acc{*out.data, h};
 
                 h.parallel_for(ndrange,
@@ -105,7 +105,7 @@ void normalDistributionCBRNG(Param<T> out, const size_t elements,
             });
             break;
         case AF_RANDOM_ENGINE_THREEFRY_2X32_16:
-            getQueue().submit([=](sycl::handler &h) {
+            getQueue().submit([&](sycl::handler &h) {
                 write_accessor<T> out_acc{*out.data, h};
 
                 h.parallel_for(ndrange,
@@ -134,7 +134,7 @@ void uniformDistributionMT(Param<T> out, const size_t elements,
 
     sycl::nd_range<1> ndrange(sycl::range<1>(blocks * threads),
                               sycl::range<1>(threads));
-    getQueue().submit([=](sycl::handler &h) {
+    getQueue().submit([&](sycl::handler &h) {
         write_accessor<T> out_acc{*out.data, h};
         auto state_acc     = state.data->get_access(h);
         auto pos_acc       = pos.data->get_access(h);
@@ -170,7 +170,7 @@ void normalDistributionMT(Param<T> out, const size_t elements,
 
     sycl::nd_range<1> ndrange(sycl::range<1>(blocks * threads),
                               sycl::range<1>(threads));
-    getQueue().submit([=](sycl::handler &h) {
+    getQueue().submit([&](sycl::handler &h) {
         write_accessor<T> out_acc{*out.data, h};
         auto state_acc     = state.data->get_access(h);
         auto pos_acc       = pos.data->get_access(h);

--- a/src/backend/oneapi/kernel/random_engine_mersenne.hpp
+++ b/src/backend/oneapi/kernel/random_engine_mersenne.hpp
@@ -145,7 +145,7 @@ class initMersenneKernel {
 
 void initMersenneState(Param<uint> state, const Param<uint> tbl, uintl seed) {
     sycl::nd_range<1> ndrange({BLOCKS * N}, {N});
-    getQueue().submit([=](sycl::handler &h) {
+    getQueue().submit([&](sycl::handler &h) {
         write_accessor<uint> state_acc{*state.data, h};
         read_accessor<uint> tbl_acc{*tbl.data, h};
         auto lstate_acc = sycl::local_accessor<uint, 1>(N, h);

--- a/src/backend/oneapi/kernel/range.hpp
+++ b/src/backend/oneapi/kernel/range.hpp
@@ -104,7 +104,7 @@ void range(Param<T> out, const int dim) {
                           local[1] * blocksPerMatY * out.info.dims[3]);
     sycl::nd_range<2> ndrange(global, local);
 
-    getQueue().submit([=](sycl::handler& h) {
+    getQueue().submit([&](sycl::handler& h) {
         write_accessor<T> out_acc{*out.data, h};
 
         h.parallel_for(ndrange, rangeOp<T>(out_acc, out.info, dim,

--- a/src/backend/oneapi/kernel/reduce_dim.hpp
+++ b/src/backend/oneapi/kernel/reduce_dim.hpp
@@ -144,7 +144,7 @@ void reduce_dim_launcher_default(Param<To> out, Param<Ti> in,
     sycl::range<2> global(blocks_dim[0] * blocks_dim[2] * local[0],
                           blocks_dim[1] * blocks_dim[3] * local[1]);
 
-    getQueue().submit([=](sycl::handler &h) {
+    getQueue().submit([&](sycl::handler &h) {
         auto shrdMem = sycl::local_accessor<compute_t<To>, 1>(
             creduce::THREADS_X * threads_y, h);
 

--- a/src/backend/oneapi/kernel/reduce_first.hpp
+++ b/src/backend/oneapi/kernel/reduce_first.hpp
@@ -151,7 +151,7 @@ void reduce_first_launcher_default(Param<To> out, Param<Ti> in,
 
     uint repeat = divup(in.info.dims[0], (groups_x * threads_x));
 
-    getQueue().submit([=](sycl::handler &h) {
+    getQueue().submit([&](sycl::handler &h) {
         write_accessor<To> out_acc{*out.data, h};
         read_accessor<Ti> in_acc{*in.data, h};
 

--- a/src/backend/oneapi/platform.cpp
+++ b/src/backend/oneapi/platform.cpp
@@ -384,12 +384,8 @@ bool isDoubleSupported(unsigned device) {
 bool isHalfSupported(unsigned device) {
     DeviceManager& devMngr = DeviceManager::getInstance();
 
-    sycl::device dev;
-    {
-        common::lock_guard_t lock(devMngr.deviceMutex);
-        dev = *devMngr.mDevices[device];
-    }
-    return dev.has(sycl::aspect::fp16);
+    common::lock_guard_t lock(devMngr.deviceMutex);
+    return devMngr.mDevices[device]->has(sycl::aspect::fp16);
 }
 
 void devprop(char* d_name, char* d_platform, char* d_toolkit, char* d_compute) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -480,7 +480,7 @@ foreach(backend ${enabled_backends})
       PRIVATE
       ArrayFire::af${backend})
   endif()
-  af_add_test(${target} ${backend} ON)
+  add_test(NAME ${target} COMMAND ${target})
 endforeach()
 
 if(AF_TEST_WITH_MTX_FILES)


### PR DESCRIPTION
This PR fixes a segfault in the mean function

Description
-----------
* Fixes a segfault in mean.
* Changes some of the submit calls from value to reference
* Add fmt formatters for dim4 and complex values
* Fix a segfault in test discovery of GTest tests in basic_c
* Fix a segfault in `isHalfSupported`
* 

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
