### PR TITLE
Fixed compile error on MSVC 16.11.26

### DIFF
--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -342,7 +342,8 @@ kJITHeuristics passesJitHeuristics(span<Node *> root_nodes) {
         // Setting the maximum to 5120 bytes to keep the compile times
         // resonable. This still results in large kernels but its not excessive.
         size_t max_param_size =
-            min(5120UL, device.getInfo<CL_DEVICE_MAX_PARAMETER_SIZE>());
+            min(static_cast<cl::size_type>(5120),
+                device.getInfo<CL_DEVICE_MAX_PARAMETER_SIZE>());
         max_param_size -= base_param_size;
 
         struct tree_info {


### PR DESCRIPTION
MSVC 16.11.26 fails compiling backend/opencl/Array.cpp, because the parameters of the min function are different types.

Description
-----------

Changes to Users
----------------
No changes

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
