### PR TITLE
Fixed initialization error on gebrd

### DIFF
--- a/src/backend/opencl/magma/gebrd.cpp
+++ b/src/backend/opencl/magma/gebrd.cpp
@@ -239,11 +239,17 @@ magma_int_t magma_gebrd_hybrid(magma_int_t m, magma_int_t n, Ty *a,
         return *info;
     }
 
-    if (MAGMA_SUCCESS != magma_malloc<Ty>(&dwork, (m + n) * nb)) {
+    const size_t size = (m + n) * nb;
+    if (MAGMA_SUCCESS != magma_malloc<Ty>(&dwork, size)) {
         *info = MAGMA_ERR_DEVICE_ALLOC;
         return *info;
     }
     size_t dwork_offset = 0;
+    // initialize dwork to 0.0
+    const float dfill = 0.0;
+    cl_int err = clEnqueueFillBuffer(queue, dwork, &dfill, sizeof(dfill), 0,
+                                     size * sizeof(Ty), 0, nullptr, nullptr);
+    check_error(err);
 
     cl_event event = 0;
 


### PR DESCRIPTION
test_svd_opencl.exe is failing on Radeon R7, although passes on GTX 750 Ti.

Description
-----------
Output:
ArrayFire v3.9.0 (OpenCL, 64-bit Windows, build 64586e04c)
[0] AMD: Spectre, 6571 MB -- OpenCL 2.0 AMD-APP (3224.5) -- Device driver 3224.5 -- FP64 Support: True
-1- NVIDIA: NVIDIA GeForce GTX 750 Ti, 2047 MB -- OpenCL 3.0 CUDA -- Device driver 531.61 -- FP64 Support: 

svd/2.Square, where TypeParam = struct af::af_cfloat 
	svd.cpp(150): LAPACKE Error (-5)
svd/2.Rect0, where TypeParam = struct af::af_cfloat
	svd.cpp(150): LAPACKE Error (-5)
svd/2.Rect1, where TypeParam = struct af::af_cfloat
	svd.cpp(150): LAPACKE Error (-5)
svd/2.InPlaceSquare, where TypeParam = struct af::af_cfloat
	svd.cpp(150): LAPACKE Error (-5)
svd/2.InPlaceRect0, where TypeParam = struct af::af_cfloat
	svd.cpp(150): LAPACKE Error (-5)

Cause:
The magma gebrd function, functions in an hybrid mode having host buffers and device buffers in sync.
A new device buffer dwork is created for the corresponding host buffer work.
The host buffer result from a vector object, which initializes all elements to 0.0
The corresponding device buffer is not initialized.
On the AMD, this resulted in NAN values produced by the gebrd function, which is detected in the following 
lapacke copy function resulting in an error -5.

Additional information about the PR answering following questions:

* Can this PR be backported to older versions? yes

Fixes: #3147

Changes to Users
----------------
Fixed occasional bug

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
