### PR TITLE
fftconvolve oneapi port (includes fft fix)

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -218,6 +218,11 @@ target_sources(afoneapi
     kernel/convolve_separable.cpp
     kernel/diagonal.hpp
     kernel/diff.hpp
+    kernel/fftconvolve_common.hpp
+    kernel/fftconvolve_multiply.hpp
+    kernel/fftconvolve_pack.hpp
+    kernel/fftconvolve_pad.hpp
+    kernel/fftconvolve_reorder.hpp
     kernel/histogram.hpp
     kernel/iir.hpp
     kernel/identity.hpp

--- a/src/backend/oneapi/fft.cpp
+++ b/src/backend/oneapi/fft.cpp
@@ -50,9 +50,9 @@ void fft_inplace(Array<T> &in, const int rank, const bool direction) {
 
     auto desc = [rank, &idims]() {
         if (rank == 1) return desc_ty(idims[0]);
-        if (rank == 2) return desc_ty({idims[0], idims[1]});
-        if (rank == 3) return desc_ty({idims[0], idims[1], idims[2]});
-        return desc_ty({idims[0], idims[1], idims[2], idims[3]});
+        if (rank == 2) return desc_ty({idims[1], idims[0]});
+        if (rank == 3) return desc_ty({idims[2], idims[1], idims[0]});
+        return desc_ty({idims[3], idims[2], idims[1], idims[0]});
     }();
 
     desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT, DFTI_INPLACE);
@@ -139,9 +139,9 @@ Array<Tr> fft_c2r(const Array<Tc> &in, const dim4 &odims, const int rank) {
 
     auto desc = [rank, &odims]() {
         if (rank == 1) return desc_ty(odims[0]);
-        if (rank == 2) return desc_ty({odims[0], odims[1]});
-        if (rank == 3) return desc_ty({odims[0], odims[1], odims[2]});
-        return desc_ty({odims[0], odims[1], odims[2], odims[3]});
+        if (rank == 2) return desc_ty({odims[1], odims[0]});
+        if (rank == 3) return desc_ty({odims[2], odims[1], odims[0]});
+        return desc_ty({odims[3], odims[2], odims[1], odims[0]});
     }();
 
     desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT,

--- a/src/backend/oneapi/kernel/fftconvolve_common.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_common.hpp
@@ -69,11 +69,6 @@ void calcParamSizes(Param<T>& sig_tmp, Param<T>& filter_tmp,
     }
 }
 
-// template<typename T>
-// using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
-// template<typename T>
-// using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
-
 }  // namespace kernel
 }  // namespace oneapi
 }  // namespace arrayfire

--- a/src/backend/oneapi/kernel/fftconvolve_common.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_common.hpp
@@ -1,0 +1,79 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <common/kernel_cache.hpp>
+#include <debug_oneapi.hpp>
+#include <kernel/accessors.hpp>
+#include <af/defines.h>
+
+#include <string>
+#include <vector>
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+constexpr int THREADS = 256;
+
+template<typename T, typename convT>
+void calcParamSizes(Param<T>& sig_tmp, Param<T>& filter_tmp,
+                    Param<convT>& packed, Param<T>& sig, Param<T>& filter,
+                    const int rank, AF_BATCH_KIND kind) {
+    sig_tmp.info.dims[0] = filter_tmp.info.dims[0] = packed.info.dims[0];
+    sig_tmp.info.strides[0] = filter_tmp.info.strides[0] = 1;
+
+    for (int k = 1; k < 4; k++) {
+        if (k < rank) {
+            sig_tmp.info.dims[k]    = packed.info.dims[k];
+            filter_tmp.info.dims[k] = packed.info.dims[k];
+        } else {
+            sig_tmp.info.dims[k]    = sig.info.dims[k];
+            filter_tmp.info.dims[k] = filter.info.dims[k];
+        }
+
+        sig_tmp.info.strides[k] =
+            sig_tmp.info.strides[k - 1] * sig_tmp.info.dims[k - 1];
+        filter_tmp.info.strides[k] =
+            filter_tmp.info.strides[k - 1] * filter_tmp.info.dims[k - 1];
+    }
+
+    // NOTE: The OpenCL implementation on which this oneAPI port is
+    // based treated the incoming `packed` buffer as a string of real
+    // scalars instead of complex numbers. OpenCL accomplished this
+    // with the hack depicted in the trailing two lines. This note
+    // remains here in an explanation of SYCL buffer reinterpret's in
+    // fftconvolve kernel invocations.
+
+    // sig_tmp.data    = packed.data;
+    // filter_tmp.data = packed.data;
+
+    // Calculate memory offsets for packed signal and filter
+    if (kind == AF_BATCH_RHS) {
+        filter_tmp.info.offset = 0;
+        sig_tmp.info.offset =
+            filter_tmp.info.strides[3] * filter_tmp.info.dims[3] * 2;
+    } else {
+        sig_tmp.info.offset = 0;
+        filter_tmp.info.offset =
+            sig_tmp.info.strides[3] * sig_tmp.info.dims[3] * 2;
+    }
+}
+
+// template<typename T>
+// using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
+// template<typename T>
+// using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
+
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/oneapi/kernel/fftconvolve_multiply.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_multiply.hpp
@@ -1,0 +1,155 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <common/kernel_cache.hpp>
+#include <debug_oneapi.hpp>
+#include <af/defines.h>
+
+#include <string>
+#include <vector>
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+template<typename T>
+class fftconvolve_multiplyCreateKernel {
+   public:
+    fftconvolve_multiplyCreateKernel(write_accessor<T> d_out, KParam oInfo,
+                                     read_accessor<T> d_in1, KParam i1Info,
+                                     read_accessor<T> d_in2, KParam i2Info,
+                                     const int nelem, const int kind)
+        : d_out_(d_out)
+        , oInfo_(oInfo)
+        , d_in1_(d_in1)
+        , i1Info_(i1Info)
+        , d_in2_(d_in2)
+        , i2Info_(i2Info)
+        , nelem_(nelem)
+        , kind_(kind) {}
+    void operator()(sycl::nd_item<1> it) const {
+        sycl::group g = it.get_group();
+
+        const int t = it.get_global_id(0);
+
+        if (t >= nelem_) return;
+
+        if (kind_ == AF_BATCH_NONE || kind_ == AF_BATCH_SAME) {
+            // Complex multiply each signal to equivalent filter
+            const int ridx = t * 2;
+            const int iidx = t * 2 + 1;
+
+            T a = d_in1_[i1Info_.offset + ridx];
+            T b = d_in1_[i1Info_.offset + iidx];
+            T c = d_in2_[i2Info_.offset + ridx];
+            T d = d_in2_[i2Info_.offset + iidx];
+
+            d_out_[oInfo_.offset + ridx] = a * c - b * d;
+            d_out_[oInfo_.offset + iidx] = a * d + b * c;
+        } else if (kind_ == AF_BATCH_LHS) {
+            // Complex multiply all signals to filter
+            const int ridx1 = t * 2;
+            const int iidx1 = t * 2 + 1;
+
+            // Treating complex output array as real-only array,
+            // thus, multiply strides by 2
+            const int ridx2 =
+                ridx1 % (i2Info_.strides[3] * i2Info_.dims[3] * 2);
+            const int iidx2 =
+                iidx1 % (i2Info_.strides[3] * i2Info_.dims[3] * 2);
+
+            T a = d_in1_[i1Info_.offset + ridx1];
+            T b = d_in1_[i1Info_.offset + iidx1];
+            T c = d_in2_[i2Info_.offset + ridx2];
+            T d = d_in2_[i2Info_.offset + iidx2];
+
+            d_out_[oInfo_.offset + ridx1] = a * c - b * d;
+            d_out_[oInfo_.offset + iidx1] = a * d + b * c;
+        } else if (kind_ == AF_BATCH_RHS) {
+            // Complex multiply signal to all filters
+            const int ridx2 = t * 2;
+            const int iidx2 = t * 2 + 1;
+
+            // Treating complex output array as real-only array,
+            // thus, multiply strides by 2
+            const int ridx1 =
+                ridx2 % (i1Info_.strides[3] * i1Info_.dims[3] * 2);
+            const int iidx1 =
+                iidx2 % (i1Info_.strides[3] * i1Info_.dims[3] * 2);
+
+            T a = d_in1_[i1Info_.offset + ridx1];
+            T b = d_in1_[i1Info_.offset + iidx1];
+            T c = d_in2_[i2Info_.offset + ridx2];
+            T d = d_in2_[i2Info_.offset + iidx2];
+
+            d_out_[oInfo_.offset + ridx2] = a * c - b * d;
+            d_out_[oInfo_.offset + iidx2] = a * d + b * c;
+        }
+    }
+
+   private:
+    write_accessor<T> d_out_;
+    KParam oInfo_;
+    read_accessor<T> d_in1_;
+    KParam i1Info_;
+    read_accessor<T> d_in2_;
+    KParam i2Info_;
+    const int nelem_;
+    const int kind_;
+};
+
+template<typename convT, typename T>
+void complexMultiplyHelper(Param<convT> packed, Param<T> sig, Param<T> filter,
+                           const int rank, AF_BATCH_KIND kind) {
+    Param<T> sig_tmp, filter_tmp;
+    calcParamSizes(sig_tmp, filter_tmp, packed, sig, filter, rank, kind);
+
+    int sig_packed_elem = sig_tmp.info.strides[3] * sig_tmp.info.dims[3];
+    int filter_packed_elem =
+        filter_tmp.info.strides[3] * filter_tmp.info.dims[3];
+    int mul_elem = (sig_packed_elem < filter_packed_elem) ? filter_packed_elem
+                                                          : sig_packed_elem;
+    int blocks   = divup(mul_elem, THREADS);
+
+    auto local  = sycl::range(THREADS);
+    auto global = sycl::range(blocks * THREADS);
+
+    // Treat complex output as an array of scalars
+    using convScalarT      = typename convT::value_type;
+    auto packed_num_elem   = (*packed.data).get_range().size();
+    auto packed_tmp_buffer = (*packed.data)
+                                 .template reinterpret<convScalarT>(
+                                     sycl::range<1>{packed_num_elem * 2});
+    auto sig_tmp_buffer = (*packed.data)
+                              .template reinterpret<convScalarT>(
+                                  sycl::range<1>{packed_num_elem * 2});
+    auto filter_tmp_buffer = (*packed.data)
+                                 .template reinterpret<convScalarT>(
+                                     sycl::range<1>{packed_num_elem * 2});
+
+    getQueue().submit([&](auto &h) {
+        write_accessor<convScalarT> d_packed    = {packed_tmp_buffer, h};
+        read_accessor<convScalarT> d_sig_tmp    = {sig_tmp_buffer, h};
+        read_accessor<convScalarT> d_filter_tmp = {filter_tmp_buffer, h};
+        h.parallel_for(
+            sycl::nd_range{global, local},
+            fftconvolve_multiplyCreateKernel<typename convT::value_type>(
+                d_packed, packed.info, d_sig_tmp, sig_tmp.info, d_filter_tmp,
+                filter_tmp.info, mul_elem, (int)kind));
+    });
+
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/oneapi/kernel/fftconvolve_pack.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_pack.hpp
@@ -1,0 +1,146 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <common/kernel_cache.hpp>
+#include <debug_oneapi.hpp>
+#include <af/defines.h>
+
+#include <string>
+#include <vector>
+
+#include <iostream>
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+template<typename inputType, typename outputType>
+class fftconvolve_packCreateKernel {
+   public:
+    fftconvolve_packCreateKernel(write_accessor<outputType> d_out, KParam oInfo,
+                                 read_accessor<inputType> d_in, KParam iInfo,
+                                 const int di0_half, const int odd_di0)
+        : d_out_(d_out)
+        , oInfo_(oInfo)
+        , d_in_(d_in)
+        , iInfo_(iInfo)
+        , di0_half_(di0_half)
+        , odd_di0_(odd_di0) {}
+    void operator()(sycl::nd_item<1> it) const {
+        sycl::group g = it.get_group();
+
+        const int t = it.get_global_id(0);
+
+        const int tMax = oInfo_.strides[3] * oInfo_.dims[3];
+
+        if (t >= tMax) return;
+
+        const int do0 = oInfo_.dims[0];
+        const int do1 = oInfo_.dims[1];
+        const int do2 = oInfo_.dims[2];
+
+        const int so1 = oInfo_.strides[1];
+        const int so2 = oInfo_.strides[2];
+        const int so3 = oInfo_.strides[3];
+
+        const int to0 = t % so1;
+        const int to1 = (t / so1) % do1;
+        const int to2 = (t / so2) % do2;
+        const int to3 = t / so3;
+
+        const int di0 = iInfo_.dims[0];
+        const int di1 = iInfo_.dims[1];
+        const int di2 = iInfo_.dims[2];
+
+        const int si1 = iInfo_.strides[1];
+        const int si2 = iInfo_.strides[2];
+        const int si3 = iInfo_.strides[3];
+
+        const int ti0 = to0;
+        const int ti1 = to1 * si1;
+        const int ti2 = to2 * si2;
+        const int ti3 = to3 * si3;
+
+        const int iidx1 = iInfo_.offset + ti3 + ti2 + ti1 + ti0;
+        const int iidx2 = iidx1 + di0_half_;
+
+        // Treating complex output array as real-only array,
+        // thus, multiply strides by 2
+        const int oidx1 = oInfo_.offset + to3 * so3 * 2 + to2 * so2 * 2 +
+                          to1 * so1 * 2 + to0 * 2;
+        const int oidx2 = oidx1 + 1;
+
+        if (to0 < di0_half_ && to1 < di1 && to2 < di2) {
+            d_out_[oidx1] = (outputType)d_in_[iidx1];
+            if (ti0 == di0_half_ - 1 && odd_di0_ == 1)
+                d_out_[oidx2] = (outputType)0;
+            else
+                d_out_[oidx2] = (outputType)d_in_[iidx2];
+        } else {
+            // Pad remaining elements with 0s
+            d_out_[oidx1] = (outputType)0;
+            d_out_[oidx2] = (outputType)0;
+        }
+    }
+
+   private:
+    write_accessor<outputType> d_out_;
+    KParam oInfo_;
+    read_accessor<inputType> d_in_;
+    KParam iInfo_;
+    const int di0_half_;
+    const int odd_di0_;
+};
+
+template<typename convT, typename T>
+void packDataHelper(Param<convT> packed, Param<T> sig, Param<T> filter,
+                    const int rank, AF_BATCH_KIND kind) {
+    Param<T> sig_tmp, filter_tmp;
+    calcParamSizes(sig_tmp, filter_tmp, packed, sig, filter, rank, kind);
+
+    int sig_packed_elem = sig_tmp.info.strides[3] * sig_tmp.info.dims[3];
+    int filter_packed_elem =
+        filter_tmp.info.strides[3] * filter_tmp.info.dims[3];
+
+    // Number of packed complex elements in dimension 0
+    int sig_half_d0     = divup(sig.info.dims[0], 2);
+    int sig_half_d0_odd = sig.info.dims[0] % 2;
+
+    int blocks = divup(sig_packed_elem, THREADS);
+
+    // Locate features kernel sizes
+    auto local  = sycl::range(THREADS);
+    auto global = sycl::range(blocks * THREADS);
+
+    // Treat complex output as an array of scalars
+    using convScalarT    = typename convT::value_type;
+    auto packed_num_elem = (*packed.data).get_range().size();
+    auto sig_tmp_buffer  = (*packed.data)
+                              .template reinterpret<convScalarT>(
+                                  sycl::range<1>{packed_num_elem * 2});
+
+    getQueue().submit([&](auto &h) {
+        read_accessor<T> d_sig                = {*sig.data, h};
+        write_accessor<convScalarT> d_sig_tmp = {sig_tmp_buffer, h};
+        h.parallel_for(sycl::nd_range{global, local},
+                       fftconvolve_packCreateKernel<T, convScalarT>(
+                           d_sig_tmp, sig_tmp.info, d_sig, sig.info,
+                           sig_half_d0, sig_half_d0_odd));
+    });
+
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/oneapi/kernel/fftconvolve_pad.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_pad.hpp
@@ -1,0 +1,129 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <common/kernel_cache.hpp>
+#include <debug_oneapi.hpp>
+#include <af/defines.h>
+
+#include <string>
+#include <vector>
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+template<typename inputType, typename outputType>
+class fftconvolve_padCreateKernel {
+   public:
+    fftconvolve_padCreateKernel(write_accessor<outputType> d_out, KParam oInfo,
+                                read_accessor<inputType> d_in, KParam iInfo)
+        : d_out_(d_out), oInfo_(oInfo), d_in_(d_in), iInfo_(iInfo) {}
+    void operator()(sycl::nd_item<1> it) const {
+        sycl::group g = it.get_group();
+
+        const int t = it.get_global_id(0);
+
+        const int tMax = oInfo_.strides[3] * oInfo_.dims[3];
+
+        if (t >= tMax) return;
+
+        const int do0 = oInfo_.dims[0];
+        const int do1 = oInfo_.dims[1];
+        const int do2 = oInfo_.dims[2];
+
+        const int so1 = oInfo_.strides[1];
+        const int so2 = oInfo_.strides[2];
+        const int so3 = oInfo_.strides[3];
+
+        const int to0 = t % so1;
+        const int to1 = (t / so1) % do1;
+        const int to2 = (t / so2) % do2;
+        const int to3 = (t / so3);
+
+        const int di0 = iInfo_.dims[0];
+        const int di1 = iInfo_.dims[1];
+        const int di2 = iInfo_.dims[2];
+        const int di3 = iInfo_.dims[3];
+
+        const int si1 = iInfo_.strides[1];
+        const int si2 = iInfo_.strides[2];
+        const int si3 = iInfo_.strides[3];
+
+        const int ti0 = to0;
+        const int ti1 = to1 * si1;
+        const int ti2 = to2 * si2;
+        const int ti3 = to3 * si3;
+
+        const int iidx = iInfo_.offset + ti3 + ti2 + ti1 + ti0;
+
+        const int oidx = oInfo_.offset + t * 2;
+
+        if (to0 < di0 && to1 < di1 && to2 < di2 && to3 < di3) {
+            // Copy input elements to real elements, set imaginary elements to 0
+            d_out_[oidx]     = (outputType)d_in_[iidx];
+            d_out_[oidx + 1] = (outputType)0;
+        } else {
+            // Pad remaining of the matrix to 0s
+            d_out_[oidx]     = (outputType)0;
+            d_out_[oidx + 1] = (outputType)0;
+        }
+    }
+
+   private:
+    write_accessor<outputType> d_out_;
+    KParam oInfo_;
+    read_accessor<inputType> d_in_;
+    KParam iInfo_;
+};
+
+template<typename convT, typename T>
+void padDataHelper(Param<convT> packed, Param<T> sig, Param<T> filter,
+                   const int rank, AF_BATCH_KIND kind) {
+    Param<T> sig_tmp, filter_tmp;
+    calcParamSizes(sig_tmp, filter_tmp, packed, sig, filter, rank, kind);
+
+    int sig_packed_elem = sig_tmp.info.strides[3] * sig_tmp.info.dims[3];
+    int filter_packed_elem =
+        filter_tmp.info.strides[3] * filter_tmp.info.dims[3];
+
+    // Number of packed complex elements in dimension 0
+    int sig_half_d0     = divup(sig.info.dims[0], 2);
+    int sig_half_d0_odd = sig.info.dims[0] % 2;
+
+    int blocks = divup(filter_packed_elem, THREADS);
+
+    // Locate features kernel sizes
+    auto local  = sycl::range(THREADS);
+    auto global = sycl::range(blocks * THREADS);
+
+    // Treat complex output as an array of scalars
+    using convScalarT      = typename convT::value_type;
+    auto packed_num_elem   = (*packed.data).get_range().size();
+    auto filter_tmp_buffer = (*packed.data)
+                                 .template reinterpret<convScalarT>(
+                                     sycl::range<1>{packed_num_elem * 2});
+
+    getQueue().submit([&](auto &h) {
+        read_accessor<T> d_filter = {*filter.data, h, sycl::read_only};
+        write_accessor<convScalarT> d_filter_tmp = {filter_tmp_buffer, h};
+        h.parallel_for(
+            sycl::nd_range{global, local},
+            fftconvolve_padCreateKernel<T, convScalarT>(
+                d_filter_tmp, filter_tmp.info, d_filter, filter.info));
+    });
+
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/oneapi/kernel/fftconvolve_reorder.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_reorder.hpp
@@ -1,0 +1,189 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <common/kernel_cache.hpp>
+#include <debug_oneapi.hpp>
+#include <af/defines.h>
+
+#include <string>
+#include <vector>
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+template<typename T>
+class fftconvolve_reorderCreateKernel {
+   public:
+    fftconvolve_reorderCreateKernel(write_accessor<T> d_out, KParam oInfo,
+                                    read_accessor<T> d_in, KParam iInfo,
+                                    KParam fInfo, const int half_di0,
+                                    const int baseDim, const int fftScale,
+                                    const bool EXPAND, const bool ROUND_OUT)
+        : d_out_(d_out)
+        , oInfo_(oInfo)
+        , d_in_(d_in)
+        , iInfo_(iInfo)
+        , fInfo_(fInfo)
+        , half_di0_(half_di0)
+        , baseDim_(baseDim)
+        , fftScale_(fftScale)
+        , EXPAND_(EXPAND)
+        , ROUND_OUT_(ROUND_OUT) {}
+    void operator()(sycl::nd_item<1> it) const {
+        sycl::group g = it.get_group();
+
+        const int t = it.get_global_id(0);
+
+        const int tMax = oInfo_.strides[3] * oInfo_.dims[3];
+
+        if (t >= tMax) return;
+
+        const int do0 = oInfo_.dims[0];
+        const int do1 = oInfo_.dims[1];
+        const int do2 = oInfo_.dims[2];
+
+        const int so1 = oInfo_.strides[1];
+        const int so2 = oInfo_.strides[2];
+        const int so3 = oInfo_.strides[3];
+
+        // Treating complex input array as real-only array,
+        // thus, multiply dimension 0 and strides by 2
+        const int di0 = iInfo_.dims[0] * 2;
+        const int di1 = iInfo_.dims[1];
+        const int di2 = iInfo_.dims[2];
+
+        const int si1 = iInfo_.strides[1] * 2;
+        const int si2 = iInfo_.strides[2] * 2;
+        const int si3 = iInfo_.strides[3] * 2;
+
+        const int to0 = t % so1;
+        const int to1 = (t / so1) % do1;
+        const int to2 = (t / so2) % do2;
+        const int to3 = (t / so3);
+
+        int oidx = to3 * so3 + to2 * so2 + to1 * so1 + to0;
+
+        int ti0, ti1, ti2, ti3;
+        if (EXPAND_) {
+            ti0 = to0;
+            ti1 = to1 * si1;
+            ti2 = to2 * si2;
+            ti3 = to3 * si3;
+        } else {
+            ti0 = to0 + fInfo_.dims[0] / 2;
+            ti1 = (to1 + (baseDim_ > 1) * (fInfo_.dims[1] / 2)) * si1;
+            ti2 = (to2 + (baseDim_ > 2) * (fInfo_.dims[2] / 2)) * si2;
+            ti3 = to3 * si3;
+        }
+
+        // Divide output elements to cuFFT resulting scale, round result if
+        // output type is single or double precision floating-point
+        if (ti0 < half_di0_) {
+            // Copy top elements
+            int iidx = iInfo_.offset + ti3 + ti2 + ti1 + ti0 * 2;
+            if (ROUND_OUT_)
+                d_out_[oidx] = (T)round(d_in_[iidx] / fftScale_);
+            else
+                d_out_[oidx] = (T)(d_in_[iidx] / fftScale_);
+        } else if (ti0 < half_di0_ + fInfo_.dims[0] - 1) {
+            // Add central elements
+            int iidx1 = iInfo_.offset + ti3 + ti2 + ti1 + ti0 * 2;
+            int iidx2 =
+                iInfo_.offset + ti3 + ti2 + ti1 + (ti0 - half_di0_) * 2 + 1;
+            if (ROUND_OUT_)
+                d_out_[oidx] =
+                    (T)round((d_in_[iidx1] + d_in_[iidx2]) / fftScale_);
+            else
+                d_out_[oidx] = (T)((d_in_[iidx1] + d_in_[iidx2]) / fftScale_);
+        } else {
+            // Copy bottom elements
+            const int iidx =
+                iInfo_.offset + ti3 + ti2 + ti1 + (ti0 - half_di0_) * 2 + 1;
+            if (ROUND_OUT_)
+                d_out_[oidx] = (T)round(d_in_[iidx] / fftScale_);
+            else
+                d_out_[oidx] = (T)(d_in_[iidx] / fftScale_);
+        }
+    }
+
+   private:
+    write_accessor<T> d_out_;
+    KParam oInfo_;
+    read_accessor<T> d_in_;
+    KParam iInfo_;
+    KParam fInfo_;
+    const int half_di0_;
+    const int baseDim_;
+    const int fftScale_;
+    const bool EXPAND_;
+    const bool ROUND_OUT_;
+};
+
+template<typename T, typename convT>
+void reorderOutputHelper(Param<T> out, Param<convT> packed, Param<T> sig,
+                         Param<T> filter, const int rank, AF_BATCH_KIND kind,
+                         bool expand) {
+    int fftScale = 1;
+
+    // Calculate the scale by which to divide clFFT results
+    for (int k = 0; k < rank; k++) fftScale *= packed.info.dims[k];
+
+    Param<T> sig_tmp, filter_tmp;
+    calcParamSizes(sig_tmp, filter_tmp, packed, sig, filter, rank, kind);
+
+    // Number of packed complex elements in dimension 0
+    int sig_half_d0 = divup(sig.info.dims[0], 2);
+
+    int blocks = divup(out.info.strides[3] * out.info.dims[3], THREADS);
+
+    constexpr bool round_out = std::is_integral<T>::value;
+
+    auto local  = sycl::range(THREADS);
+    auto global = sycl::range(blocks * THREADS);
+
+    if (kind == AF_BATCH_RHS) {
+        auto packed_num_elem = (*packed.data).get_range().size();
+        auto filter_tmp_buffer =
+            (*packed.data)
+                .template reinterpret<T>(sycl::range<1>{packed_num_elem * 2});
+        getQueue().submit([&](auto &h) {
+            read_accessor<T> d_filter_tmp = {filter_tmp_buffer, h};
+            write_accessor<T> d_out       = {*out.data, h, sycl::write_only};
+            h.parallel_for(
+                sycl::nd_range{global, local},
+                fftconvolve_reorderCreateKernel<T>(
+                    d_out, out.info, d_filter_tmp, filter_tmp.info, filter.info,
+                    sig_half_d0, rank, fftScale, expand, round_out));
+        });
+    } else {
+        auto packed_num_elem = (*packed.data).get_range().size();
+        auto sig_tmp_buffer =
+            (*packed.data)
+                .template reinterpret<T>(sycl::range<1>{packed_num_elem * 2});
+        getQueue().submit([&](auto &h) {
+            read_accessor<T> d_sig_tmp = {sig_tmp_buffer, h, sycl::read_only};
+            write_accessor<T> d_out    = {*out.data, h};
+            h.parallel_for(
+                sycl::nd_range{global, local},
+                fftconvolve_reorderCreateKernel<T>(
+                    d_out, out.info, d_sig_tmp, sig_tmp.info, filter.info,
+                    sig_half_d0, rank, fftScale, expand, round_out));
+        });
+    }
+
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire


### PR DESCRIPTION
`fftconvolve` ported to oneAPI. On a770, test filter `FFTConvolve/2.*` passes. `cfloat` fails, but due to an external (possibly jit) problem.

This port strives to remain as close to the OpenCL implementation as much as possible to match conventions of most of the other ports. See `reinterpret` for kernel invocations and the note in `fftconvolve_common.hpp`. Later, performance will be taken into account. 

Checklist
---------
<!-- Check if done or not applicable -->
- [X] Rebased on latest master
- [X] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
