### PR TITLE
Fix some maxDims tests in oneAPI and improve link times

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -309,6 +309,9 @@ target_compile_definitions(afoneapi
     CL_HPP_ENABLE_EXCEPTIONS
   )
 
+cmake_host_system_information(RESULT NumberOfThreads
+  QUERY NUMBER_OF_LOGICAL_CORES)
+
 target_link_libraries(afoneapi
   PRIVATE
     -fsycl
@@ -319,10 +322,11 @@ target_link_libraries(afoneapi
     afcommon_interface
     OpenCL::OpenCL
     OpenCL::cl2hpp
-    -fsycl-device-code-split=per_kernel
-    -fsycl-link-huge-device-code
     -fno-sycl-id-queries-fit-in-int
     -fno-sycl-rdc
+    -fsycl-device-code-split=per_kernel
+    -fsycl-link-huge-device-code
+    -fsycl-max-parallel-link-jobs=${NumberOfThreads}
     MKL::MKL_DPCPP
   )
 

--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -294,6 +294,7 @@ target_include_directories(afoneapi
 target_compile_options(afoneapi
   PRIVATE
     -fsycl
+    -fno-sycl-id-queries-fit-in-int
     -sycl-std=2020
 )
 
@@ -317,9 +318,9 @@ target_link_libraries(afoneapi
     afcommon_interface
     OpenCL::OpenCL
     OpenCL::cl2hpp
-    -fsycl
     -fsycl-device-code-split=per_kernel
     -fsycl-link-huge-device-code
+    -fno-sycl-id-queries-fit-in-int
     MKL::MKL_DPCPP
   )
 

--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -296,6 +296,7 @@ target_compile_options(afoneapi
     -fsycl
     -fno-sycl-id-queries-fit-in-int
     -sycl-std=2020
+    -fno-sycl-rdc
 )
 
 target_compile_definitions(afoneapi
@@ -321,6 +322,7 @@ target_link_libraries(afoneapi
     -fsycl-device-code-split=per_kernel
     -fsycl-link-huge-device-code
     -fno-sycl-id-queries-fit-in-int
+    -fno-sycl-rdc
     MKL::MKL_DPCPP
   )
 


### PR DESCRIPTION
Fix some maxDims errors due to launch dimensions exceeding int range. This PR also improves link times using some compiler flags.

Description
-----------
* Some kernels fail due to launch parameters going out of range of an int. This causes an assertion in sycl/oneAPI. This assertion can be removed by passing the `-fno-sycl-id-queries-fit-in-int` flag.
* Update some compiler parameters to improve compile times. This is still slow but does reduce the compile times significantly. 

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
