### PR TITLE
fixes min/max operators' isnan checks

### DIFF
--- a/src/backend/common/complex.hpp
+++ b/src/backend/common/complex.hpp
@@ -6,8 +6,8 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#pragma once
 
-#include <Array.hpp>
 #include <backend.hpp>
 #include <types.hpp>
 

--- a/src/backend/common/half.hpp
+++ b/src/backend/common/half.hpp
@@ -88,6 +88,7 @@ using uint16_t = unsigned short;
 #else
 #include <af/compilers.h>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
 #include <ostream>
 #include <string>

--- a/src/backend/cpu/kernel/ireduce.hpp
+++ b/src/backend/cpu/kernel/ireduce.hpp
@@ -10,7 +10,9 @@
 #pragma once
 #include <Param.hpp>
 #include <common/Binary.hpp>
+#include <common/half.hpp>
 #include <algorithm>
+#include <cmath>
 
 namespace arrayfire {
 namespace cpu {
@@ -23,16 +25,13 @@ double cabs(const T in) {
 static double cabs(const char in) { return (double)(in > 0); }
 static double cabs(const cfloat &in) { return (double)abs(in); }
 static double cabs(const cdouble &in) { return (double)abs(in); }
-template<typename T>
-static bool is_nan(T in) {
-    return in != in;
-}
 
 template<af_op_t op, typename T>
 struct MinMaxOp {
     T m_val;
     uint m_idx;
     MinMaxOp(T val, uint idx) : m_val(val), m_idx(idx) {
+        using arrayfire::cpu::is_nan;
         if (is_nan(val)) { m_val = common::Binary<T, op>::init(); }
     }
 
@@ -50,6 +49,7 @@ struct MinMaxOp<af_max_t, T> {
     T m_val;
     uint m_idx;
     MinMaxOp(T val, uint idx) : m_val(val), m_idx(idx) {
+        using arrayfire::cpu::is_nan;
         if (is_nan(val)) { m_val = common::Binary<T, af_max_t>::init(); }
     }
 

--- a/src/backend/cpu/math.hpp
+++ b/src/backend/cpu/math.hpp
@@ -43,6 +43,36 @@ cfloat max(cfloat lhs, cfloat rhs);
 cdouble max(cdouble lhs, cdouble rhs);
 
 template<typename T>
+static inline auto is_nan(const T &val) -> bool {
+    return false;
+}
+
+template<>
+inline auto is_nan<float>(const float &val) -> bool {
+    return std::isnan(val);
+}
+
+template<>
+inline auto is_nan<double>(const double &val) -> bool {
+    return std::isnan(val);
+}
+
+template<>
+inline auto is_nan<common::half>(const common::half &val) -> bool {
+    return isnan(val);
+}
+
+template<>
+inline auto is_nan<cfloat>(const cfloat &in) -> bool {
+    return std::isnan(real(in)) || std::isnan(imag(in));
+}
+
+template<>
+inline auto is_nan<cdouble>(const cdouble &in) -> bool {
+    return std::isnan(real(in)) || std::isnan(imag(in));
+}
+
+template<typename T>
 static inline T division(T lhs, double rhs) {
     return lhs / rhs;
 }

--- a/src/backend/cuda/compile_module.cpp
+++ b/src/backend/cuda/compile_module.cpp
@@ -176,7 +176,7 @@ Module compileModule(const string &moduleKey, span<const string> sources,
             "stdbool.h",       // DUMMY ENTRY TO SATISFY af/defines.h inclusion
             "stdlib.h",        // DUMMY ENTRY TO SATISFY af/defines.h inclusion
             "vector_types.h",  // DUMMY ENTRY TO SATISFY cuComplex_h inclusion
-            "utility",         // DUMMY ENTRY TO SATISFY cuda_fp16.hpp inclusion
+            "utility",         // DUMMY ENTRY TO SATISFY utility inclusion
             "backend.hpp",
             "cuComplex.h",
             "jit.cuh",

--- a/src/backend/cuda/complex.hpp
+++ b/src/backend/cuda/complex.hpp
@@ -7,6 +7,8 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#pragma once
+
 #include <Array.hpp>
 #include <binary.hpp>
 #include <common/jit/BinaryNode.hpp>

--- a/src/backend/cuda/math.hpp
+++ b/src/backend/cuda/math.hpp
@@ -261,6 +261,42 @@ __SDH__ float imag(cfloat c) { return cuCimagf(c); }
 __SDH__ double imag(cdouble c) { return cuCimag(c); }
 
 template<typename T>
+static inline __DH__ auto is_nan(const T &val) -> bool {
+    return false;
+}
+
+template<>
+inline __DH__ auto is_nan<float>(const float &val) -> bool {
+    return ::isnan(val);
+}
+
+template<>
+inline __DH__ auto is_nan<double>(const double &val) -> bool {
+    return ::isnan(val);
+}
+
+#ifdef __CUDA_ARCH__
+template<>
+inline __device__ auto is_nan<__half>(const __half &val) -> bool {
+#if __CUDA_ARCH__ >= 530
+    return __hisnan(val);
+#else
+    return ::isnan(__half2float(val));
+#endif
+}
+#endif
+
+template<>
+inline auto is_nan<cfloat>(const cfloat &in) -> bool {
+    return ::isnan(real(in)) || ::isnan(imag(in));
+}
+
+template<>
+inline auto is_nan<cdouble>(const cdouble &in) -> bool {
+    return ::isnan(real(in)) || ::isnan(imag(in));
+}
+
+template<typename T>
 T __SDH__ conj(T x) {
     return x;
 }

--- a/src/backend/cuda/minmax_op.hpp
+++ b/src/backend/cuda/minmax_op.hpp
@@ -34,26 +34,12 @@ double cabs<cdouble>(const cdouble &in) {
     return (double)abs(in);
 }
 
-template<typename T>
-static bool is_nan(const T &in) {
-    return in != in;
-}
-
-template<>
-bool is_nan<cfloat>(const cfloat &in) {
-    return in.x != in.x || in.y != in.y;
-}
-
-template<>
-bool is_nan<cdouble>(const cdouble &in) {
-    return in.x != in.x || in.y != in.y;
-}
-
 template<af_op_t op, typename T>
 struct MinMaxOp {
     T m_val;
     uint m_idx;
     MinMaxOp(T val, uint idx) : m_val(val), m_idx(idx) {
+        using arrayfire::cuda::is_nan;
         if (is_nan(val)) { m_val = common::Binary<compute_t<T>, op>::init(); }
     }
 
@@ -71,6 +57,7 @@ struct MinMaxOp<af_max_t, T> {
     T m_val;
     uint m_idx;
     MinMaxOp(T val, uint idx) : m_val(val), m_idx(idx) {
+        using arrayfire::cuda::is_nan;
         if (is_nan(val)) { m_val = common::Binary<T, af_max_t>::init(); }
     }
 

--- a/src/backend/oneapi/math.cpp
+++ b/src/backend/oneapi/math.cpp
@@ -12,43 +12,14 @@
 
 namespace arrayfire {
 namespace oneapi {
-cfloat operator+(cfloat lhs, cfloat rhs) {
-    // cfloat res = {{lhs.s[0] + rhs.s[0], lhs.s[1] + rhs.s[1]}};
-    cfloat res;
-    return res;
-}
-
-cdouble operator+(cdouble lhs, cdouble rhs) {
-    // cdouble res = {{lhs.s[0] + rhs.s[0], lhs.s[1] + rhs.s[1]}};
-    cdouble res;
-    return res;
-}
-
-cfloat operator*(cfloat lhs, cfloat rhs) {
-    cfloat out;
-    // out.s[0] = lhs.s[0] * rhs.s[0] - lhs.s[1] * rhs.s[1];
-    // out.s[1] = lhs.s[0] * rhs.s[1] + lhs.s[1] * rhs.s[0];
-    return out;
-}
-
-cdouble operator*(cdouble lhs, cdouble rhs) {
-    cdouble out;
-    // out.s[0] = lhs.s[0] * rhs.s[0] - lhs.s[1] * rhs.s[1];
-    // out.s[1] = lhs.s[0] * rhs.s[1] + lhs.s[1] * rhs.s[0];
-    return out;
-}
 
 cfloat division(cfloat lhs, double rhs) {
-    cfloat retVal;
-    // retVal.s[0] = real(lhs) / rhs;
-    // retVal.s[1] = imag(lhs) / rhs;
+    cfloat retVal(real(lhs) / rhs, imag(lhs) / rhs);
     return retVal;
 }
 
 cdouble division(cdouble lhs, double rhs) {
-    cdouble retVal;
-    // retVal.s[0] = real(lhs) / rhs;
-    // retVal.s[1] = imag(lhs) / rhs;
+    cdouble retVal(real(lhs) / rhs, imag(lhs) / rhs);
     return retVal;
 }
 }  // namespace oneapi

--- a/src/backend/oneapi/math.hpp
+++ b/src/backend/oneapi/math.hpp
@@ -170,11 +170,6 @@ static inline T imag(T in) {
     return std::imag(in);
 }
 
-inline arrayfire::common::half operator+(arrayfire::common::half lhs,
-                                         arrayfire::common::half rhs) noexcept {
-    return arrayfire::common::half(static_cast<float>(lhs) +
-                                   static_cast<float>(rhs));
-}
 }  // namespace oneapi
 }  // namespace arrayfire
 

--- a/src/backend/oneapi/math.hpp
+++ b/src/backend/oneapi/math.hpp
@@ -72,6 +72,36 @@ inline cdouble min<cdouble>(cdouble lhs, cdouble rhs) {
 }
 
 template<typename T>
+static inline auto is_nan(const T &val) -> bool {
+    return false;
+}
+
+template<>
+inline auto is_nan<sycl::half>(const sycl::half &val) -> bool {
+    return sycl::isnan(val);
+}
+
+template<>
+inline auto is_nan<float>(const float &val) -> bool {
+    return std::isnan(val);
+}
+
+template<>
+inline auto is_nan<double>(const double &val) -> bool {
+    return std::isnan(val);
+}
+
+template<>
+inline auto is_nan<cfloat>(const cfloat &in) -> bool {
+    return std::isnan(real(in)) || std::isnan(imag(in));
+}
+
+template<>
+inline auto is_nan<cdouble>(const cdouble &in) -> bool {
+    return std::isnan(real(in)) || std::isnan(imag(in));
+}
+
+template<typename T>
 static T scalar(double val) {
     return (T)(val);
 }
@@ -79,8 +109,6 @@ static T scalar(double val) {
 template<>
 inline cfloat scalar<cfloat>(double val) {
     cfloat cval(static_cast<float>(val));
-    // cval.real() = (float)val;
-    // cval.imag() = 0;
     return cval;
 }
 

--- a/src/backend/oneapi/minmax_op.hpp
+++ b/src/backend/oneapi/minmax_op.hpp
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <common/Binary.hpp>
+#include <math.hpp>
 
 namespace arrayfire {
 namespace oneapi {
@@ -32,21 +33,6 @@ double cabs<cfloat>(const cfloat &in) {
 template<>
 double cabs<cdouble>(const cdouble &in) {
     return (double)abs(in);
-}
-
-template<typename T>
-static bool is_nan(const T &in) {
-    return in != in;
-}
-
-template<>
-bool is_nan<cfloat>(const cfloat &in) {
-    return in.real() != in.real() || in.imag() != in.imag();
-}
-
-template<>
-bool is_nan<cdouble>(const cdouble &in) {
-    return in.real() != in.real() || in.imag() != in.imag();
 }
 
 template<af_op_t op, typename T>

--- a/src/backend/opencl/kernel/sparse_arith.hpp
+++ b/src/backend/opencl/kernel/sparse_arith.hpp
@@ -20,6 +20,7 @@
 #include <kernel_headers/sparse_arith_csr.hpp>
 #include <kernel_headers/ssarith_calc_out_nnz.hpp>
 #include <math.hpp>
+#include <memory.hpp>
 #include <traits.hpp>
 
 #include <string>


### PR DESCRIPTION
fixes min/max operators' isnan checks

min/max operators were incorrectly testing for is_nan by relying on (float != float) to determine if the value is a nan.
This behavior is not guaranteed on some compilers, and can be wrong depending on the fast-math optimizations.
This PR corrects the common::Binary class in the cuda and oneapi backends to use the correct isnan() functions.
The ireduce in the cpu backend also corrects these functions. OpenCL currently relies on a macro for this check and will need to be addressed in the future.

This PR also incorporates memory-managed functions for intermediate buffers in ireduce, rather than raw calls to oneapi memory allocation.
* Is this a new feature or a bug fix?
Bug fix
* Future changes not implemented in this PR.
OpenCL backend will need isnan fixes. Also, common::Transform class will need similar improvements to replace the MACRO there.

Changes to Users
----------------
<!--
* Additional options added to the build.
* What changes will existing users have to make to their code or build steps?
Refer to [wiki](https://github.com/arrayfire/arrayfire/wiki) for development guidelines
-->

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
