### PR TITLE
Fix oneAPI failures when tiling with JIT and wrap/unwrap

### DIFF
--- a/src/backend/oneapi/jit/kernel_generators.hpp
+++ b/src/backend/oneapi/jit/kernel_generators.hpp
@@ -61,8 +61,9 @@ inline void generateBufferOffsets(std::stringstream& kerStream, int id,
                   << info_str << ".strides[3] * id3 + (id2 < " << info_str
                   << ".dims[2]) * " << info_str << ".strides[2] * id2 + (id1 < "
                   << info_str << ".dims[1]) * " << info_str
-                  << ".strides[1] * id1 + (id0 < " << info_str
-                  << ".dims[0]) * id0 + " << info_str << ".offset;\n";
+                  << ".strides[1] * id1 + (id0 < " << info_str << ".dims[0]) * "
+                  << info_str << ".strides[0]  * id0 + " << info_str
+                  << ".offset;\n";
     }
 }
 

--- a/src/backend/oneapi/kernel/unwrap.hpp
+++ b/src/backend/oneapi/kernel/unwrap.hpp
@@ -149,7 +149,7 @@ void unwrap(Param<T> out, const Param<T> in, const dim_t wx, const dim_t wy,
         reps = divup((wx * wy), TX);
     } else {
         TX   = THREADS_X;
-        TY   = THREADS_X;
+        TY   = THREADS_Y;
         BX   = divup(out.info.dims[0], TX);
         reps = divup((wx * wy), TY);
     }


### PR DESCRIPTION
Fixes two issues due to failures in the way the JIT kernels were generated with some tile configurations. Additionally this fixes wrap and unwrap failures due to invalid work group sizes

Description
-----------
* The wrap/unwrap failures were failing due to invalid work group sizes. The TY variable was using THREADS_X variable
* Fixes and issue when JIT was used with tile. This was caused because of the way we reconfigure the stride portion of the Param class when tile functions are called.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
