### PR TITLE
fix multiblock offset in scanFirstBcastKernel

### DIFF
--- a/src/backend/oneapi/kernel/scan_first.hpp
+++ b/src/backend/oneapi/kernel/scan_first.hpp
@@ -181,7 +181,7 @@ class scanFirstBcastKernel {
         // Shift broadcast one step to the right for exclusive scan (#2366)
         int offset = !inclusive_scan_;
         for (int k = 0, id = xid + offset; k < lim_ && id < oInfo_.dims[0];
-             k++, id += g.get_group_range(0)) {
+             k++, id += g.get_local_range(0)) {
             optr[id] = binop(accum, optr[id]);
         }
     }


### PR DESCRIPTION
fix offset in scanFirstBcastKernel.

Scan first bcast kernel was using the wrong offset when looping across multiple repeats per block. This would cause extra overlapping additions of the broadcasted value to the final scan. This PR fixes the failing scan tests. 

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass