### PR TITLE
Fix cannyEdgeDetector for CUDA when compiled with AF_WITH_FAST_MATH

### DIFF
--- a/src/api/c/canny.cpp
+++ b/src/api/c/canny.cpp
@@ -93,7 +93,6 @@ Array<float> otsuThreshold(const Array<float>& in, const unsigned NUM_BINS,
     seqBegin[0] = af_make_seq(0, static_cast<double>(hDims[0] - 1), 1);
     seqRest[0]  = af_make_seq(0, static_cast<double>(hDims[0] - 1), 1);
 
-    Array<float> TWOS   = createValueArray<float>(oDims, 2.0f);
     Array<float> UnitP  = createValueArray<float>(oDims, 1.0f);
     Array<float> histf  = cast<float, uint>(hist);
     Array<float> totals = createValueArray<float>(hDims, inDims[0] * inDims[1]);
@@ -126,7 +125,7 @@ Array<float> otsuThreshold(const Array<float>& in, const unsigned NUM_BINS,
         auto muL   = arithOp<float, af_div_t>(_muL, qL, oDims);
         auto muH   = arithOp<float, af_div_t>(_muH, qH, oDims);
         auto diff  = arithOp<float, af_sub_t>(muL, muH, oDims);
-        auto sqrd  = arithOp<float, af_pow_t>(diff, TWOS, oDims);
+        auto sqrd  = arithOp<float, af_mul_t>(diff, diff, oDims);
         auto op2   = createSubArray(qLqH, sliceIndex, false);
         auto sigma = arithOp<float, af_mul_t>(sqrd, op2, oDims);
 


### PR DESCRIPTION
When running test_canny_cuda with AF_WITH_FAST_MATH, OtsuThreshold test and BatchOfImagesUsingCPPAPI test result in the same RMSD error of 0.966 while max 0.001 is accepted.
The error resulted from a __powf(x,y) execution with a negative x, resulting a NAN.

Description
-----------
The AF_WITH_FAST_MATH switch, results in the -use_fast_math flag for device code.
Example: powf(x,y) --> __powf(x,y)
All __functions are faster intrinsic functions on the CUDA device, although with more restrictive conditions.  One of the conditions is that x has to be positive.
In the canny_cuda test, JIT code is generated containing powf(x,TWO).  The -use_fast_math flag converts the function to the intrinsic function __powf(x,TWO), which is than executed with a negative value for x, resulting in a NAN value.
Further processing hides the NAN, resulting in the high RMSD error.

Possible solutions:
- change powf(x,TWO) to pow(x,TWO) .  (x and TWO are vectors)
The pow function (variant with doubles) is not converted with the -use_fast_math flag so will continue to produce a correct result.  All calculations are however performed in double precision, and slow execution
- change powf(x,TWO) to pow(x,2.0f).  (x and TWO are vectors, 2.0f is constant)
The same result as pow(x,TWO).
- change powf(x,TWO) to x * x.   (x and TWO are vectors)
Since the exponent is a constant we can directly multiply.  The -use_fast_math will convert the multiply to the intrinsic function resulting in slow drop of precision, although as expected.

Performance impact:  (normal / -use_fast_math)
- powf(x,TWO) --> 0.21ns / 0.11ns per element, produces NAN for negative x with -use_fast_math (original)
- powf(x,2.0f)   --> 0.21ns / 0.11ns per element, produces NAN for negative x with -use_fast_math
- pow(x,TWO)  --> 3.77ns / 3.77ns per element, always correct
- pow(x,2.0)     --> 3.77ns / 3.77ns per element, always correct
- x * x              --> 0.11ns / 0.11ns per element, always correct

The multiplication in float is implemented in this PR, since it delivers the highest precision and the fastest execution independent of the -use_fast_math flag.

* Is this a new feature or a bug fix?  --> Yes
* Why these changes are necessary.  --> The OtsuThreshold and BatchOfImagesUsingCPPAPI tests were unreliable in fast_math mode (no exceptions however).  Chances are high that the enduser even did not realize that the results were corrupted.
* Potential impact on specific hardware, software or backends.  -->  Only on CUDA.
* New functions and their functionality.  --> No
* Can this PR be backported to older versions?  --> Yes, thanks to the limited and local changes

Changes to Users
----------------
None

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
