### PR TITLE
Fix constness of some kernel pointer types

### DIFF
--- a/src/backend/oneapi/kernel/assign.hpp
+++ b/src/backend/oneapi/kernel/assign.hpp
@@ -88,7 +88,7 @@ class assignKernel {
                 p_.strds[3] *
                 trimIndex(s3 ? gw + p_.offs[3] : p_.ptr[3][gw], oInfo_.dims[3]);
 
-            T* iptr = in_.get_pointer();
+            const T* iptr = in_.get_pointer();
             // offset input and output pointers
             const T* src =
                 iptr + (gx * iInfo_.strides[0] + gy * iInfo_.strides[1] +

--- a/src/backend/oneapi/kernel/ireduce.hpp
+++ b/src/backend/oneapi/kernel/ireduce.hpp
@@ -93,7 +93,7 @@ class ireduceDimKernelSMEM {
             (ids[0] < rlenInfo_.dims[0]) && (ids[1] < rlenInfo_.dims[1]) &&
             (ids[2] < rlenInfo_.dims[2]) && (ids[3] < rlenInfo_.dims[3]);
         const bool rlen_nonnull = rlenValid_;
-        uint *const rlenptr =
+        const uint *rlenptr =
             (rlen_nonnull && rlen_valid)
                 ? rlen_.get_pointer() + ids[3] * rlenInfo_.strides[3] +
                       ids[2] * rlenInfo_.strides[2] +
@@ -105,10 +105,10 @@ class ireduceDimKernelSMEM {
         // add thread offset for reduced dim for inputs
         ids[dim] = ids[dim] * g.get_local_range(1) + lidy;
 
-        T *iptr = in_.get_pointer() + ids[3] * iInfo_.strides[3] +
-                  ids[2] * iInfo_.strides[2] + ids[1] * iInfo_.strides[1] +
-                  ids[0] + iInfo_.offset;
-        uint *ilptr;
+        const T *iptr = in_.get_pointer() + ids[3] * iInfo_.strides[3] +
+                        ids[2] * iInfo_.strides[2] +
+                        ids[1] * iInfo_.strides[1] + ids[0] + iInfo_.offset;
+        const uint *ilptr;
         if (!is_first) {
             ilptr = iloc_.get_pointer() + ids[3] * iInfo_.strides[3] +
                     ids[2] * iInfo_.strides[2] + ids[1] * iInfo_.strides[1] +
@@ -371,7 +371,7 @@ class ireduceFirstKernelSMEM {
         const uint xid = groupId_x * g.get_local_range(0) * repeat_ + lidx;
         const uint yid = groupId_y * g.get_local_range(1) + lidy;
 
-        T *const iptr = in_.get_pointer() + wid * iInfo_.strides[3] +
+        const T *iptr = in_.get_pointer() + wid * iInfo_.strides[3] +
                         zid * iInfo_.strides[2] + yid * iInfo_.strides[1] +
                         iInfo_.offset;
 
@@ -385,7 +385,7 @@ class ireduceFirstKernelSMEM {
                                yid * rlenInfo_.strides[1] + rlenInfo_.offset
                          : nullptr;
 
-        uint *ilptr;
+        const uint *ilptr;
         if (!is_first) {
             ilptr = iloc_.get_pointer() + wid * iInfo_.strides[3] +
                     zid * iInfo_.strides[2] + yid * iInfo_.strides[1] +

--- a/src/backend/oneapi/kernel/lu_split.hpp
+++ b/src/backend/oneapi/kernel/lu_split.hpp
@@ -51,9 +51,9 @@ class luSplitKernel {
         const int incy = groupsPerMatY_ * g.get_local_range(1);
         const int incx = groupsPerMatX_ * g.get_local_range(0);
 
-        T *d_l = lower_.get_pointer();
-        T *d_u = upper_.get_pointer();
-        T *d_i = in_.get_pointer();
+        T *d_l       = lower_.get_pointer();
+        T *d_u       = upper_.get_pointer();
+        const T *d_i = in_.get_pointer();
 
         if (oz < iInfo_.dims[2] && ow < iInfo_.dims[3]) {
             d_i = d_i + oz * iInfo_.strides[2] + ow * iInfo_.strides[3];
@@ -61,9 +61,9 @@ class luSplitKernel {
             d_u = d_u + oz * uInfo_.strides[2] + ow * uInfo_.strides[3];
 
             for (int oy = yy; oy < iInfo_.dims[1]; oy += incy) {
-                T *Yd_i = d_i + oy * iInfo_.strides[1];
-                T *Yd_l = d_l + oy * lInfo_.strides[1];
-                T *Yd_u = d_u + oy * uInfo_.strides[1];
+                const T *Yd_i = d_i + oy * iInfo_.strides[1];
+                T *Yd_l       = d_l + oy * lInfo_.strides[1];
+                T *Yd_u       = d_u + oy * uInfo_.strides[1];
                 for (int ox = xx; ox < iInfo_.dims[0]; ox += incx) {
                     if (ox > oy) {
                         if (same_dims || oy < lInfo_.dims[1])

--- a/src/backend/oneapi/kernel/memcopy.hpp
+++ b/src/backend/oneapi/kernel/memcopy.hpp
@@ -81,7 +81,7 @@ class memCopy {
         const int id0        = group_id_0 * gg.get_local_range(0) + lid0;
         const int id1        = group_id_1 * gg.get_local_range(1) + lid1;
 
-        T *iptr = in_.get_pointer();
+        const T *iptr = in_.get_pointer();
         // FIXME: Do more work per work group
 
         T *optr = out_.get_pointer();

--- a/src/backend/oneapi/kernel/reduce_dim.hpp
+++ b/src/backend/oneapi/kernel/reduce_dim.hpp
@@ -65,14 +65,14 @@ class reduceDimKernelSMEM {
         uint ids[4] = {xid, yid, zid, wid};
         using sycl::global_ptr;
 
-        global_ptr<data_t<To>> optr =
-            out_.get_pointer() + ids[3] * oInfo_.strides[3] +
-            ids[2] * oInfo_.strides[2] + ids[1] * oInfo_.strides[1] + ids[0];
+        data_t<To> *optr = out_.get_pointer() + ids[3] * oInfo_.strides[3] +
+                           ids[2] * oInfo_.strides[2] +
+                           ids[1] * oInfo_.strides[1] + ids[0];
 
         const uint groupIdx_dim = ids[dim];
         ids[dim]                = ids[dim] * g.get_local_range(1) + lidy;
 
-        global_ptr<data_t<Ti>> iptr =
+        const data_t<Ti> *iptr =
             in_.get_pointer() + ids[3] * iInfo_.strides[3] +
             ids[2] * iInfo_.strides[2] + ids[1] * iInfo_.strides[1] + ids[0];
 

--- a/src/backend/oneapi/kernel/reduce_first.hpp
+++ b/src/backend/oneapi/kernel/reduce_first.hpp
@@ -68,7 +68,7 @@ class reduceFirstKernelSMEM {
         common::Binary<compute_t<To>, op> reduce;
         common::Transform<Ti, compute_t<To>, op> transform;
 
-        Ti *const iptr = in_.get_pointer() + wid * iInfo_.strides[3] +
+        const Ti *iptr = in_.get_pointer() + wid * iInfo_.strides[3] +
                          zid * iInfo_.strides[2] + yid * iInfo_.strides[1] +
                          iInfo_.offset;
 

--- a/src/backend/oneapi/kernel/select.hpp
+++ b/src/backend/oneapi/kernel/select.hpp
@@ -59,9 +59,9 @@ class selectKernelCreateKernel {
     void operator()(sycl::nd_item<2> it) const {
         sycl::group g = it.get_group();
 
-        char *cptr = cptr__.get_pointer() + cinfo_.offset;
-        T *aptr    = aptr__.get_pointer() + ainfo_.offset;
-        T *bptr    = bptr__.get_pointer() + binfo_.offset;
+        const char *cptr = cptr__.get_pointer() + cinfo_.offset;
+        const T *aptr    = aptr__.get_pointer() + ainfo_.offset;
+        const T *bptr    = bptr__.get_pointer() + binfo_.offset;
 
         const int idz = g.get_group_id(0) / groups_0_;
         const int idw = g.get_group_id(1) / groups_1_;
@@ -169,8 +169,8 @@ class selectScalarCreateKernel {
     void operator()(sycl::nd_item<2> it) const {
         sycl::group g = it.get_group();
 
-        char *cptr = cptr__.get_pointer() + cinfo_.offset;
-        T *aptr    = aptr__.get_pointer() + ainfo_.offset;
+        const char *cptr = cptr__.get_pointer() + cinfo_.offset;
+        const T *aptr    = aptr__.get_pointer() + ainfo_.offset;
 
         const int idz = g.get_group_id(0) / groups_0_;
         const int idw = g.get_group_id(1) / groups_1_;
@@ -185,7 +185,8 @@ class selectScalarCreateKernel {
                         idy * oinfo_.strides[1];
 
         int ids[] = {idx0, idy, idz, idw};
-        optr_.get_pointer() += off;
+        T *optr   = optr_.get_pointer();
+        optr += off;
         aptr += getOffset(ainfo_.dims, ainfo_.strides, oinfo_.dims, ids);
         cptr += getOffset(cinfo_.dims, cinfo_.strides, oinfo_.dims, ids);
 
@@ -196,7 +197,7 @@ class selectScalarCreateKernel {
 
         for (int idx = idx0; idx < oinfo_.dims[0];
              idx += g.get_local_range(0) * groups_0_) {
-            optr_.get_pointer()[idx] = (cptr[idx] ^ flip_) ? aptr[idx] : b_;
+            optr[idx] = (cptr[idx] ^ flip_) ? aptr[idx] : b_;
         }
     }
 

--- a/src/backend/oneapi/kernel/transpose.hpp
+++ b/src/backend/oneapi/kernel/transpose.hpp
@@ -95,7 +95,8 @@ class transposeKernel {
 
         // offset in_ and out_ based on batch id
         // also add the subBuffer offsets
-        T *iDataPtr = iData_.get_pointer(), *oDataPtr = oData_.get_pointer();
+        const T *iDataPtr = iData_.get_pointer();
+        T *oDataPtr       = oData_.get_pointer();
         iDataPtr += batchId_x * in_.strides[2] + batchId_y * in_.strides[3] +
                     in_.offset;
         oDataPtr += batchId_x * out_.strides[2] + batchId_y * out_.strides[3] +

--- a/src/backend/oneapi/kernel/wrap.hpp
+++ b/src/backend/oneapi/kernel/wrap.hpp
@@ -63,8 +63,8 @@ class wrapCreateKernel {
 
         T *optr = optrAcc_.get_pointer() + idx2 * out_.strides[2] +
                   idx3 * out_.strides[3] + out_.offset;
-        T *iptr = iptrAcc_.get_pointer() + idx2 * in_.strides[2] +
-                  idx3 * in_.strides[3] + in_.offset;
+        const T *iptr = iptrAcc_.get_pointer() + idx2 * in_.strides[2] +
+                        idx3 * in_.strides[3] + in_.offset;
 
         if (oidx0 >= out_.dims[0] || oidx1 >= out_.dims[1]) return;
 

--- a/src/backend/oneapi/kernel/wrap_dilated.hpp
+++ b/src/backend/oneapi/kernel/wrap_dilated.hpp
@@ -66,8 +66,8 @@ class wrapDilatedCreateKernel {
 
         data_t<T> *optr = optrAcc_.get_pointer() + idx2 * out_.strides[2] +
                           idx3 * out_.strides[3];
-        data_t<T> *iptr = iptrAcc_.get_pointer() + idx2 * in_.strides[2] +
-                          idx3 * in_.strides[3] + in_.offset;
+        const data_t<T> *iptr = iptrAcc_.get_pointer() + idx2 * in_.strides[2] +
+                                idx3 * in_.strides[3] + in_.offset;
 
         if (oidx0 >= out_.dims[0] || oidx1 >= out_.dims[1]) return;
 

--- a/test/pinverse.cpp
+++ b/test/pinverse.cpp
@@ -124,6 +124,7 @@ TYPED_TEST_SUITE(Pinverse, TestTypes);
 // Test Moore-Penrose conditions in the following first 4 tests
 // See https://en.wikipedia.org/wiki/Moore%E2%80%93Penrose_inverse#Definition
 TYPED_TEST(Pinverse, AApinvA_A) {
+    SUPPORTED_TYPE_CHECK(TypeParam);
     array in = readTestInput<TypeParam>(
         string(TEST_DIR "/pinverse/pinverse10x8.test"));
     array inpinv = pinverse(in);
@@ -132,6 +133,7 @@ TYPED_TEST(Pinverse, AApinvA_A) {
 }
 
 TYPED_TEST(Pinverse, ApinvAApinv_Apinv) {
+    SUPPORTED_TYPE_CHECK(TypeParam);
     array in = readTestInput<TypeParam>(
         string(TEST_DIR "/pinverse/pinverse10x8.test"));
     array inpinv = pinverse(in);
@@ -140,6 +142,7 @@ TYPED_TEST(Pinverse, ApinvAApinv_Apinv) {
 }
 
 TYPED_TEST(Pinverse, AApinv_IsHermitian) {
+    SUPPORTED_TYPE_CHECK(TypeParam);
     array in = readTestInput<TypeParam>(
         string(TEST_DIR "/pinverse/pinverse10x8.test"));
     array inpinv = pinverse(in);
@@ -149,6 +152,7 @@ TYPED_TEST(Pinverse, AApinv_IsHermitian) {
 }
 
 TYPED_TEST(Pinverse, ApinvA_IsHermitian) {
+    SUPPORTED_TYPE_CHECK(TypeParam);
     array in = readTestInput<TypeParam>(
         string(TEST_DIR "/pinverse/pinverse10x8.test"));
     array inpinv = pinverse(in);
@@ -158,6 +162,7 @@ TYPED_TEST(Pinverse, ApinvA_IsHermitian) {
 }
 
 TYPED_TEST(Pinverse, Large) {
+    SUPPORTED_TYPE_CHECK(TypeParam);
     array in = readTestInput<TypeParam>(
         string(TEST_DIR "/pinverse/pinv_640x480_inputs.test"));
     array inpinv = pinverse(in);
@@ -166,6 +171,7 @@ TYPED_TEST(Pinverse, Large) {
 }
 
 TYPED_TEST(Pinverse, LargeTall) {
+    SUPPORTED_TYPE_CHECK(TypeParam);
     array in = readTestInput<TypeParam>(
                    string(TEST_DIR "/pinverse/pinv_640x480_inputs.test"))
                    .T();
@@ -227,6 +233,7 @@ TEST(Pinverse, SmallSigValExistsFloat) {
 }
 
 TEST(Pinverse, SmallSigValExistsDouble) {
+    SUPPORTED_TYPE_CHECK(double);
     array in =
         readTestInput<double>(string(TEST_DIR "/pinverse/pinverse10x8.test"));
     const dim_t dim0 = in.dims(0);


### PR DESCRIPTION
This PR addresses some failures in the newer version of icx where the constness was causing failures in the oneAPI backend.

Description
-----------
* Fix const correctness in oneAPI kernels

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
