### PR TITLE
speedup complexNorm when compiled with AF_WITH_FAST_MATH flag

### DIFF
--- a/src/api/c/deconvolution.cpp
+++ b/src/api/c/deconvolution.cpp
@@ -68,9 +68,8 @@ const dim_t GREATEST_PRIME_FACTOR = 7;
 
 template<typename T, typename CT>
 Array<T> complexNorm(const Array<CT>& input) {
-    auto mag  = detail::abs<T, CT>(input);
-    auto TWOS = createValueArray(input.dims(), scalar<T>(2));
-    return arithOp<T, af_pow_t>(mag, TWOS, input.dims());
+    auto mag = detail::abs<T, CT>(input);
+    return arithOp<T, af_mul_t>(mag, mag, input.dims());
 }
 
 std::vector<af_seq> calcPadInfo(dim4& inLPad, dim4& psfLPad, dim4& inUPad,


### PR DESCRIPTION
on CUDA, the complexNorm function now executes faster when AF_WITH_FAST_MATH flag is used, without precision degradation.
Previously the usage of the flag slowed the execution by a factor of 14x.

Description
-----------
complexNorm of c = (a+bi) is calculated as
```
1.  x = (a^2+b^2)^0.5    (hypotf)
2. result = exp(x , TWO)  (TWO is vector with scalar 2.0)
```
OLD SITUATION:
Normal compilation  --> total time = 0.27ns
```
1. x = hypotf(c)
2. result = powf(x, TWO)
```

-DAF_WITH_FAST_MATH compilation  --> total time = 3.77ns
```
1. x = hypotf(c)
2. result = pow(x.as(f64), TWO.as(f64)).as(f32) --> full execution in double, to avoid enormous error!!
```

NEW SITUATION
independent of flag  --> total time = 0.16ns
```
1. x = hypotf(c)
2. result = x * x
```

Additional information about the PR answering following questions:
* Can this PR be backported to older versions?  Yes

Changes to Users
----------------
Impact of AF_WITH_FAST_MATH flag is now as expected

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
