### PR TITLE
blas batch reorder 

### DIFF
--- a/src/backend/common/err_common.cpp
+++ b/src/backend/common/err_common.cpp
@@ -25,8 +25,8 @@
 #include <errorcodes.hpp>
 #include <platform.hpp>
 #elif defined(AF_ONEAPI)
-#include <sycl/sycl.hpp>
 #include <oneapi/mkl/exceptions.hpp>
+#include <sycl/sycl.hpp>
 #endif
 
 using boost::stacktrace::stacktrace;
@@ -173,8 +173,8 @@ af_err processException() {
         err = set_global_error_string(oneapi_err_msg, AF_ERR_INTERNAL);
     } catch (const oneapi::mkl::exception &ex) {
         char oneapi_err_msg[1024];
-        snprintf(oneapi_err_msg, sizeof(oneapi_err_msg),
-                 "MKL Error: %s", ex.what());
+        snprintf(oneapi_err_msg, sizeof(oneapi_err_msg), "MKL Error: %s",
+                 ex.what());
 
         err = set_global_error_string(oneapi_err_msg, AF_ERR_INTERNAL);
 #endif
@@ -191,7 +191,8 @@ af_err processException() {
             err = set_global_error_string(opencl_err_msg, AF_ERR_INTERNAL);
         }
 #endif
-    } catch (const std::exception &ex) { err = set_global_error_string(ex.what(), AF_ERR_UNKNOWN);
+    } catch (const std::exception &ex) {
+        err = set_global_error_string(ex.what(), AF_ERR_UNKNOWN);
     } catch (...) { err = set_global_error_string(ss.str(), AF_ERR_UNKNOWN); }
 
     return err;

--- a/src/backend/common/err_common.cpp
+++ b/src/backend/common/err_common.cpp
@@ -26,6 +26,7 @@
 #include <platform.hpp>
 #elif defined(AF_ONEAPI)
 #include <sycl/sycl.hpp>
+#include <oneapi/mkl/exceptions.hpp>
 #endif
 
 using boost::stacktrace::stacktrace;
@@ -170,6 +171,12 @@ af_err processException() {
                  "oneAPI Error (%d): %s", ex.code().value(), ex.what());
 
         err = set_global_error_string(oneapi_err_msg, AF_ERR_INTERNAL);
+    } catch (const oneapi::mkl::exception &ex) {
+        char oneapi_err_msg[1024];
+        snprintf(oneapi_err_msg, sizeof(oneapi_err_msg),
+                 "MKL Error: %s", ex.what());
+
+        err = set_global_error_string(oneapi_err_msg, AF_ERR_INTERNAL);
 #endif
 #ifdef AF_OPENCL
     } catch (const cl::Error &ex) {
@@ -184,6 +191,7 @@ af_err processException() {
             err = set_global_error_string(opencl_err_msg, AF_ERR_INTERNAL);
         }
 #endif
+    } catch (const std::exception &ex) { err = set_global_error_string(ex.what(), AF_ERR_UNKNOWN);
     } catch (...) { err = set_global_error_string(ss.str(), AF_ERR_UNKNOWN); }
 
     return err;

--- a/src/backend/oneapi/Array.hpp
+++ b/src/backend/oneapi/Array.hpp
@@ -260,25 +260,18 @@ class Array {
     }
 
     template<typename outT>
-    sycl::buffer<outT> getBufferWithOffset(dim_t offset=-1) const {
-        offset = (offset == -1) ? getOffset() : offset;
+    sycl::buffer<outT> getBufferWithOffset(dim_t offset = -1) const {
+        offset             = (offset == -1) ? getOffset() : offset;
         dim_t sz_remaining = data_dims.elements() - offset;
-        if constexpr(std::is_same_v<outT, T>) {
-            if(offset == 0) {
-                return *get();
-            }
-            return sycl::buffer<outT, 1>(
-                *get(),
-                sycl::id<1>(offset),
-                sycl::range<1>(sz_remaining));
+        if constexpr (std::is_same_v<outT, T>) {
+            if (offset == 0) { return *get(); }
+            return sycl::buffer<outT, 1>(*get(), sycl::id<1>(offset),
+                                         sycl::range<1>(sz_remaining));
         } else {
-            if(offset == 0) {
-                return get()->template reinterpret<outT, 1>();
-            }
-            return sycl::buffer<T, 1>(
-                *get(),
-                sycl::id<1>(offset),
-                sycl::range<1>(sz_remaining)).template reinterpret<outT, 1>();
+            if (offset == 0) { return get()->template reinterpret<outT, 1>(); }
+            return sycl::buffer<T, 1>(*get(), sycl::id<1>(offset),
+                                      sycl::range<1>(sz_remaining))
+                .template reinterpret<outT, 1>();
         }
     }
 

--- a/src/backend/oneapi/Array.hpp
+++ b/src/backend/oneapi/Array.hpp
@@ -260,26 +260,24 @@ class Array {
     }
 
     template<typename outT>
-    sycl::buffer<outT> getBufferWithOffset() const {
-        dim_t sz_remaining = data_dims.elements() - getOffset();
-        printf("dd%d, elements %d offset %d\n",data_dims.elements(), elements(), getOffset());
+    sycl::buffer<outT> getBufferWithOffset(dim_t offset=-1) const {
+        offset = (offset == -1) ? getOffset() : offset;
+        dim_t sz_remaining = data_dims.elements() - offset;
         if constexpr(std::is_same_v<outT, T>) {
-            if(getOffset() == 0) {
-                printf("off0--noreint\n");
-                *data.get();
+            if(offset == 0) {
+                return *get();
             }
             return sycl::buffer<outT, 1>(
-                *data.get(),
-                sycl::id<1>(getOffset()),
+                *get(),
+                sycl::id<1>(offset),
                 sycl::range<1>(sz_remaining));
         } else {
-            if(getOffset() == 0) {
-                printf("off0--reint\n");
-                data.get()->template reinterpret<outT, 1>();
+            if(offset == 0) {
+                return get()->template reinterpret<outT, 1>();
             }
             return sycl::buffer<T, 1>(
-                *data.get(),
-                sycl::id<1>(getOffset()),
+                *get(),
+                sycl::id<1>(offset),
                 sycl::range<1>(sz_remaining)).template reinterpret<outT, 1>();
         }
     }


### PR DESCRIPTION
Corrects batched behavior for blas functions

This PR fixes several issues with batched blas. First, it adds offset indexing into the underlying sycl::buffer to allow passing in of subarrays to blas functions. This also allows the reinterpret required to support the sycl::half datatype. This PR also adds a fallback batching method in the case that the output is reordered. The current mkl batched functions do not allow this type of output. mkl::exception is now also handled in err_common.

* New functions and their functionality.
This add a helper method to Array.hpp: getBufferWithOffset
Which will return a sycl::buffer from the Array<T> object with the default getOffset() applied. This method can also perform reinterpret type casting through its template argument.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass