### PR TITLE
reduce local memory usage in iir

### DIFF
--- a/src/backend/oneapi/iir.cpp
+++ b/src/backend/oneapi/iir.cpp
@@ -37,6 +37,19 @@ Array<T> iir(const Array<T> &b, const Array<T> &a, const Array<T> &x) {
 
     if (num_a == 1) { return c; }
 
+    size_t local_bytes_req = (num_a * 2 + 1) * sizeof(T);
+    if (local_bytes_req >
+        getDevice().get_info<sycl::info::device::local_mem_size>()) {
+        char errMessage[256];
+        snprintf(errMessage, sizeof(errMessage),
+                 "\ncurrent OneAPI device does not have sufficient local "
+                 "memory,\n"
+                 "for iir kernel, %zu(required) > %zu(available)\n",
+                 local_bytes_req,
+                 getDevice().get_info<sycl::info::device::local_mem_size>());
+        AF_ERROR(errMessage, AF_ERR_RUNTIME);
+    }
+
     dim4 ydims = c.dims();
     Array<T> y = createEmptyArray<T>(ydims);
 

--- a/src/backend/oneapi/kernel/iir.hpp
+++ b/src/backend/oneapi/kernel/iir.hpp
@@ -21,8 +21,6 @@ namespace arrayfire {
 namespace oneapi {
 namespace kernel {
 
-constexpr int MAX_A_SIZE = 1024;
-
 template<typename T, bool batch_a>
 class iirKernel {
    public:
@@ -67,10 +65,9 @@ class iirKernel {
         const int repeat =
             (num_a + g.get_local_range(0) - 1) / g.get_local_range(0);
 
-        for (int ii = 0; ii < MAX_A_SIZE / g.get_local_range(0); ii++) {
-            int id   = ii * g.get_local_range(0) + tx;
-            s_z_[id] = scalar<T>(0);
-            s_a_[id] = (id < num_a) ? d_a[id] : scalar<T>(0);
+        for (int ii = tx; ii < num_a; ii += g.get_local_range(0)) {
+            s_z_[ii] = scalar<T>(0);
+            s_a_[ii] = (ii < num_a) ? d_a[ii] : scalar<T>(0);
         }
         group_barrier(g);
 
@@ -81,14 +78,19 @@ class iirKernel {
             }
             group_barrier(g);
 
-#pragma unroll
             for (int ii = 0; ii < repeat; ii++) {
                 int id = ii * g.get_local_range(0) + tx + 1;
 
-                T z = s_z_[id] - s_a_[id] * s_y_[0];
+                T z;
+
+                if (id < num_a) {
+                    z = s_z_[id] - s_a_[id] * s_y_[0];
+                } else {
+                    z = scalar<T>(0);
+                }
                 group_barrier(g);
 
-                s_z_[id - 1] = z;
+                if ((id - 1) < num_a) { s_z_[id - 1] = z; }
                 group_barrier(g);
             }
         }
@@ -124,9 +126,25 @@ void iir(Param<T> y, Param<T> c, Param<T> a) {
         read_accessor<T> cAcc{*c.data, h};
         read_accessor<T> aAcc{*a.data, h};
 
-        auto s_z = sycl::local_accessor<T>(MAX_A_SIZE, h);
-        auto s_a = sycl::local_accessor<T>(MAX_A_SIZE, h);
+        unsigned num_a = a.info.dims[0];
+
+        auto s_z = sycl::local_accessor<T>(num_a, h);
+        auto s_a = sycl::local_accessor<T>(num_a, h);
         auto s_y = sycl::local_accessor<T>(1, h);
+
+        size_t local_bytes_req = (num_a * 2 + 1) * sizeof(T);
+        if (local_bytes_req >
+            getDevice().get_info<sycl::info::device::local_mem_size>()) {
+            char errMessage[256];
+            snprintf(
+                errMessage, sizeof(errMessage),
+                "\ncurrent OneAPI device does not have sufficient local "
+                "memory,\n"
+                "for iir kernel, %lld(required) > %lld(available)\n",
+                local_bytes_req,
+                getDevice().get_info<sycl::info::device::local_mem_size>());
+            AF_ERROR(errMessage, AF_ERR_RUNTIME);
+        }
 
         if (batch_a) {
             h.parallel_for(sycl::nd_range{global, local},

--- a/src/backend/oneapi/kernel/iir.hpp
+++ b/src/backend/oneapi/kernel/iir.hpp
@@ -132,20 +132,6 @@ void iir(Param<T> y, Param<T> c, Param<T> a) {
         auto s_a = sycl::local_accessor<T>(num_a, h);
         auto s_y = sycl::local_accessor<T>(1, h);
 
-        size_t local_bytes_req = (num_a * 2 + 1) * sizeof(T);
-        if (local_bytes_req >
-            getDevice().get_info<sycl::info::device::local_mem_size>()) {
-            char errMessage[256];
-            snprintf(
-                errMessage, sizeof(errMessage),
-                "\ncurrent OneAPI device does not have sufficient local "
-                "memory,\n"
-                "for iir kernel, %lld(required) > %lld(available)\n",
-                local_bytes_req,
-                getDevice().get_info<sycl::info::device::local_mem_size>());
-            AF_ERROR(errMessage, AF_ERR_RUNTIME);
-        }
-
         if (batch_a) {
             h.parallel_for(sycl::nd_range{global, local},
                            iirKernel<T, true>(yAcc, y.info, cAcc, c.info, aAcc,


### PR DESCRIPTION
Reduces local memory requirements for the oneapi iir kernel

The oneapi implementation of iir would greedliy allocate local memory following the opencl implementation. This would result in too much local memory being required. This PR reduces local memory requirements by dynamically allocating local memory, better following common sycl practices. 

Checklist
---------
<!-- Check if done or not applicable -->
- [X] Rebased on latest master
- [X] Code compiles
- [X] Tests pass
