### PR TITLE
Oneapi lapack scratchsize

### DIFF
--- a/src/api/c/solve.cpp
+++ b/src/api/c/solve.cpp
@@ -95,8 +95,9 @@ static inline af_array solve_lu(const af_array a, const af_array pivot,
 af_err af_solve_lu(af_array* out, const af_array a, const af_array piv,
                    const af_array b, const af_mat_prop options) {
     try {
-        const ArrayInfo& a_info = getInfo(a);
-        const ArrayInfo& b_info = getInfo(b);
+        const ArrayInfo& a_info   = getInfo(a);
+        const ArrayInfo& b_info   = getInfo(b);
+        const ArrayInfo& piv_info = getInfo(piv);
 
         if (a_info.ndims() > 2 || b_info.ndims() > 2) {
             AF_ERROR("solveLU can not be used in batch mode", AF_ERR_BATCH);
@@ -115,6 +116,9 @@ af_err af_solve_lu(af_array* out, const af_array a, const af_array piv,
         ARG_ASSERT(2, b_info.isFloating());  // Only floating and complex types
 
         TYPE_ASSERT(a_type == b_type);
+
+        af_dtype piv_type = piv_info.getType();
+        TYPE_ASSERT(piv_type == s32);  // TODO: add support for 64 bit types
 
         DIM_ASSERT(1, adims[0] == adims[1]);
         DIM_ASSERT(1, bdims[0] == adims[0]);

--- a/src/backend/common/traits.hpp
+++ b/src/backend/common/traits.hpp
@@ -68,6 +68,15 @@ constexpr bool isFloating(af::dtype type) {
     return (!isInteger(type) && !isBool(type));
 }
 
+template<typename T, typename U, typename... Args>
+constexpr bool is_any_of() {
+    if constexpr (!sizeof...(Args)) {
+        return std::is_same_v<T, U>;
+    } else {
+        return std::is_same_v<T, U> || is_any_of<T, Args...>();
+    }
+}
+
 }  // namespace
 }  // namespace common
 }  // namespace arrayfire

--- a/src/backend/oneapi/inverse.cpp
+++ b/src/backend/oneapi/inverse.cpp
@@ -19,9 +19,8 @@ namespace oneapi {
 
 template<typename T>
 Array<T> inverse(const Array<T> &in) {
-    ONEAPI_NOT_SUPPORTED("");
     Array<T> I = identity<T>(in.dims());
-    return I;
+    return solve<T>(in, I);
 }
 
 #define INSTANTIATE(T) template Array<T> inverse<T>(const Array<T> &in);

--- a/src/backend/oneapi/memory.cpp
+++ b/src/backend/oneapi/memory.cpp
@@ -165,6 +165,7 @@ INSTANTIATE(uintl)
 INSTANTIATE(short)
 INSTANTIATE(ushort)
 INSTANTIATE(arrayfire::common::half)
+INSTANTIATE(int64_t)
 
 template<>
 void *pinnedAlloc<void>(const size_t &elements) {

--- a/src/backend/oneapi/solve.hpp
+++ b/src/backend/oneapi/solve.hpp
@@ -12,15 +12,6 @@
 namespace arrayfire {
 namespace oneapi {
 
-template<typename T, typename U, typename... Args>
-static inline constexpr bool is_any_of() {
-    if constexpr (!sizeof...(Args)) {
-        return std::is_same_v<T, U>;
-    } else {
-        return std::is_same_v<T, U> || is_any_of<T, Args...>();
-    }
-}
-
 template<typename T>
 Array<T> solve(const Array<T> &a, const Array<T> &b,
                const af_mat_prop options = AF_MAT_NONE);

--- a/src/backend/oneapi/solve.hpp
+++ b/src/backend/oneapi/solve.hpp
@@ -11,6 +11,16 @@
 
 namespace arrayfire {
 namespace oneapi {
+
+template<typename T, typename U, typename... Args>
+static inline constexpr bool is_any_of() {
+    if constexpr (!sizeof...(Args)) {
+        return std::is_same_v<T, U>;
+    } else {
+        return std::is_same_v<T, U> || is_any_of<T, Args...>();
+    }
+}
+
 template<typename T>
 Array<T> solve(const Array<T> &a, const Array<T> &b,
                const af_mat_prop options = AF_MAT_NONE);

--- a/src/backend/oneapi/svd.cpp
+++ b/src/backend/oneapi/svd.cpp
@@ -38,23 +38,31 @@ void svdInPlace(Array<Tr> &s, Array<T> &u, Array<T> &vt, Array<T> &in) {
     int64_t LDU   = uStrides[1];
     int64_t LDVt  = vStrides[1];
 
-    int64_t scratch_size = ::oneapi::mkl::lapack::gesvd_scratchpad_size<compute_t<T>>(
-        getQueue(), ::oneapi::mkl::jobsvd::vectors,
-        ::oneapi::mkl::jobsvd::vectors, M, N, LDA, LDU, LDVt);
+    // MKL is finicky about exact scratch space size so we'll need to
+    // create sycl::buffer of exact size. if we use memAlloc, this might
+    // require a sub-buffer of a sub-buffer returned by memAlloc which is
+    // currently illegal in sycl
+    int64_t scratch_size =
+        ::oneapi::mkl::lapack::gesvd_scratchpad_size<compute_t<T>>(
+            getQueue(), ::oneapi::mkl::jobsvd::vectors,
+            ::oneapi::mkl::jobsvd::vectors, M, N, LDA, LDU, LDVt);
 
-    auto scratchpadMem  = memAlloc<compute_t<T>>(scratch_size);
-    sycl::buffer<compute_t<T>> scratchpad(*scratchpadMem, 0, scratch_size);
+    sycl::buffer<compute_t<T>> scratchpad(scratch_size);
 
-    sycl::buffer<compute_t<T>> in_buffer = in.template getBufferWithOffset<compute_t<T>>();
+    sycl::buffer<compute_t<T>> in_buffer =
+        in.template getBufferWithOffset<compute_t<T>>();
 
-    sycl::buffer<compute_t<Tr>> sBuf  = s.template getBufferWithOffset<compute_t<Tr>>();
-    sycl::buffer<compute_t<T>> uBuf  = u.template getBufferWithOffset<compute_t<T>>();
-    sycl::buffer<compute_t<T>> vtBuf = vt.template getBufferWithOffset<compute_t<T>>();
+    sycl::buffer<compute_t<Tr>> sBuf =
+        s.template getBufferWithOffset<compute_t<Tr>>();
+    sycl::buffer<compute_t<T>> uBuf =
+        u.template getBufferWithOffset<compute_t<T>>();
+    sycl::buffer<compute_t<T>> vtBuf =
+        vt.template getBufferWithOffset<compute_t<T>>();
 
-    ::oneapi::mkl::lapack::gesvd(
-        getQueue(), ::oneapi::mkl::jobsvd::vectors,
-        ::oneapi::mkl::jobsvd::vectors, M, N, in_buffer, LDA, sBuf,
-        uBuf, LDU, vtBuf, LDVt, scratchpad, scratch_size);
+    ::oneapi::mkl::lapack::gesvd(getQueue(), ::oneapi::mkl::jobsvd::vectors,
+                                 ::oneapi::mkl::jobsvd::vectors, M, N,
+                                 in_buffer, LDA, sBuf, uBuf, LDU, vtBuf, LDVt,
+                                 scratchpad, scratch_size);
 }
 
 template<typename T, typename Tr>


### PR DESCRIPTION
Uses exactly sized buffers for scratch space

This PR removes the use of memAlloc, or createArray for scratch space since these methods return memory managed buffers that may be larger than what MKL expect. Reducing the size of these through the use of sub-buffers may work in most cases, but occasionally will fail if the memory returned by the memory manager is already a sub-buffer (which cannot be used to create a sub-sub-buffer in sycl)

The solve functions were also missing from the lapack functionality. This PR implements solve and pinverse for the oneapi backend.


Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass

