### PR TITLE
fixes out of bounds iterators for sorts

### DIFF
--- a/src/backend/oneapi/kernel/sort.hpp
+++ b/src/backend/oneapi/kernel/sort.hpp
@@ -80,9 +80,9 @@ void sortBatched(Param<T> pVal, int dim, bool isAscending) {
     auto dpl_policy = ::oneapi::dpl::execution::make_device_policy(getQueue());
 
     auto key_begin    = ::oneapi::dpl::begin(*pKey.get());
-    auto key_end      = ::oneapi::dpl::end(*pKey.get());
+    auto key_end      = key_begin + pKey.dims()[0];
     auto val_begin    = ::oneapi::dpl::begin(*pVal.data);
-    auto val_end      = ::oneapi::dpl::end(*pVal.data);
+    auto val_end      = val_begin + pVal.info.dims[0];
     auto zipped_begin = dpl::make_zip_iterator(key_begin, val_begin);
     auto zipped_end   = dpl::make_zip_iterator(key_end, val_end);
 

--- a/src/backend/oneapi/kernel/sort_by_key_impl.hpp
+++ b/src/backend/oneapi/kernel/sort_by_key_impl.hpp
@@ -98,13 +98,13 @@ void sortByKeyBatched(Param<Tk> pKey, Param<Tv> pVal, const int dim,
 
     // set up iterators for seq, key, val, and new cKey
     auto seq_begin = ::oneapi::dpl::begin(*Seq.get());
-    auto seq_end   = ::oneapi::dpl::end(*Seq.get());
+    auto seq_end   = seq_begin + elements;
     auto key_begin =
         ::oneapi::dpl::begin(pKey.data->template reinterpret<compute_t<Tk>>());
-    auto key_end =
-        ::oneapi::dpl::end(pKey.data->template reinterpret<compute_t<Tk>>());
+    auto key_end = key_begin + elements;
+
     auto val_begin = ::oneapi::dpl::begin(*pVal.data);
-    auto val_end   = ::oneapi::dpl::end(*pVal.data);
+    auto val_end   = val_begin + elements;
 
     auto cKey = memAlloc<Tk>(elements);
     getQueue().submit([&](sycl::handler &h) {
@@ -115,8 +115,7 @@ void sortByKeyBatched(Param<Tk> pKey, Param<Tv> pVal, const int dim,
     });
     auto ckey_begin =
         ::oneapi::dpl::begin(cKey.get()->template reinterpret<compute_t<Tk>>());
-    auto ckey_end =
-        ::oneapi::dpl::end(cKey.get()->template reinterpret<compute_t<Tk>>());
+    auto ckey_end = ckey_begin + elements;
 
     {
         auto zipped_begin_KV  = dpl::make_zip_iterator(key_begin, val_begin);
@@ -150,7 +149,7 @@ void sortByKeyBatched(Param<Tk> pKey, Param<Tv> pVal, const int dim,
                cSeq.get()->get_access(h, elements));
     });
     auto cseq_begin = ::oneapi::dpl::begin(*cSeq.get());
-    auto cseq_end   = ::oneapi::dpl::end(*cSeq.get());
+    auto cseq_end   = cseq_begin + elements;
 
     {
         auto zipped_begin_SV  = dpl::make_zip_iterator(seq_begin, val_begin);

--- a/src/backend/oneapi/sort.cpp
+++ b/src/backend/oneapi/sort.cpp
@@ -22,31 +22,29 @@ namespace oneapi {
 
 template<typename T>
 Array<T> sort(const Array<T> &in, const unsigned dim, bool isAscending) {
-    try {
-        Array<T> out = copyArray<T>(in);
-        switch (dim) {
-            case 0: kernel::sort0<T>(out, isAscending); break;
-            case 1: kernel::sortBatched<T>(out, 1, isAscending); break;
-            case 2: kernel::sortBatched<T>(out, 2, isAscending); break;
-            case 3: kernel::sortBatched<T>(out, 3, isAscending); break;
-            default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
+    Array<T> out = copyArray<T>(in);
+    switch (dim) {
+        case 0: kernel::sort0<T>(out, isAscending); break;
+        case 1: kernel::sortBatched<T>(out, 1, isAscending); break;
+        case 2: kernel::sortBatched<T>(out, 2, isAscending); break;
+        case 3: kernel::sortBatched<T>(out, 3, isAscending); break;
+        default: AF_ERROR("Not Supported", AF_ERR_NOT_SUPPORTED);
+    }
+
+    if (dim != 0) {
+        af::dim4 preorderDims = out.dims();
+        af::dim4 reorderDims(0, 1, 2, 3);
+        reorderDims[dim] = 0;
+        preorderDims[0]  = out.dims()[dim];
+        for (int i = 1; i <= static_cast<int>(dim); i++) {
+            reorderDims[i - 1] = i;
+            preorderDims[i]    = out.dims()[i - 1];
         }
 
-        if (dim != 0) {
-            af::dim4 preorderDims = out.dims();
-            af::dim4 reorderDims(0, 1, 2, 3);
-            reorderDims[dim] = 0;
-            preorderDims[0]  = out.dims()[dim];
-            for (int i = 1; i <= static_cast<int>(dim); i++) {
-                reorderDims[i - 1] = i;
-                preorderDims[i]    = out.dims()[i - 1];
-            }
-
-            out.setDataDims(preorderDims);
-            out = reorder<T>(out, reorderDims);
-        }
-        return out;
-    } catch (std::exception &ex) { AF_ERROR(ex.what(), AF_ERR_INTERNAL); }
+        out.setDataDims(preorderDims);
+        out = reorder<T>(out, reorderDims);
+    }
+    return out;
 }
 
 #define INSTANTIATE(T)                                                \


### PR DESCRIPTION
fixes out of bounds iterators for sorts

determining the start and end iterators of sort, sortByKey iterative and batched would rely on the size of the underlying sycl::buffer. This PR corrects the iterators to use the exact dimension sizes. This restores the sort, sort by key, median and topk tests to passing.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
