### PR TITLE
adds reduce by key to oneapi backend

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -1,9 +1,9 @@
-# Copyright (c) 2022, ArrayFire
-# All rights reserved.
+#Copyright(c) 2022, ArrayFire
+#All rights reserved.
 #
-# This file is distributed under 3-clause BSD license.
-# The complete license agreement can be obtained at:
-# http://arrayfire.com/licenses/BSD-3-Clause
+#This file is distributed under 3 - clause BSD license.
+#The complete license agreement can be obtained at:
+#http:  // arrayfire.com/licenses/BSD-3-Clause
 
 include(InternalUtils)
 include(build_cl2hpp)
@@ -241,6 +241,7 @@ target_sources(afoneapi
     kernel/range.hpp
     kernel/reduce.hpp
     kernel/reduce_all.hpp
+    kernel/reduce_by_key.hpp
     kernel/reduce_first.hpp
     kernel/reduce_dim.hpp
     kernel/reorder.hpp

--- a/src/backend/oneapi/kernel/reduce_by_key.hpp
+++ b/src/backend/oneapi/kernel/reduce_by_key.hpp
@@ -1,0 +1,704 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+#pragma once
+
+#include <Param.hpp>
+#include <backend.hpp>
+#include <common/Binary.hpp>
+#include <common/Transform.hpp>
+#include <common/dispatch.hpp>
+#include <debug_oneapi.hpp>
+#include <err_oneapi.hpp>
+#include <kernel/accessors.hpp>
+#include <kernel/reduce_config.hpp>
+#include <math.hpp>
+#include <memory.hpp>
+#include <type_traits>
+
+using std::unique_ptr;
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+// Reduces keys across block boundaries
+template<typename Tk, typename To, af_op_t op>
+class finalBoundaryReduceKernel {
+   public:
+    finalBoundaryReduceKernel(write_accessor<int> reduced_block_sizes,
+                              read_accessor<Tk> iKeys, KParam iKInfo,
+                              sycl::accessor<To> oVals, KParam oVInfo,
+                              const int n)
+        : reduced_block_sizes_(reduced_block_sizes)
+        , iKeys_(iKeys)
+        , iKInfo_(iKInfo)
+        , oVals_(oVals)
+        , oVInfo_(oVInfo)
+        , n_(n) {}
+
+    void operator()(sycl::nd_item<1> it) const {
+        sycl::group g  = it.get_group();
+        const uint lid = it.get_local_id(0);
+        const uint gid = it.get_global_id(0);
+        const uint bid = g.get_group_id(0);
+
+        common::Binary<compute_t<To>, op> binOp;
+        if (gid == ((bid + 1) * it.get_local_range(0)) - 1 &&
+            bid < g.get_group_range(0) - 1) {
+            Tk k0 = iKeys_[gid];
+            Tk k1 = iKeys_[gid + 1];
+
+            if (k0 == k1) {
+                compute_t<To> v0          = compute_t<To>(oVals_[gid]);
+                compute_t<To> v1          = compute_t<To>(oVals_[gid + 1]);
+                oVals_[gid + 1]           = binOp(v0, v1);
+                reduced_block_sizes_[bid] = it.get_local_range(0) - 1;
+            } else {
+                reduced_block_sizes_[bid] = it.get_local_range(0);
+            }
+        }
+
+        // if last block, set block size to difference between n and block
+        // boundary
+        if (lid == 0 && bid == g.get_group_range(0) - 1) {
+            reduced_block_sizes_[bid] = n_ - (bid * it.get_local_range(0));
+        }
+    }
+
+   protected:
+    write_accessor<int> reduced_block_sizes_;
+    read_accessor<Tk> iKeys_;
+    KParam iKInfo_;
+    sycl::accessor<To> oVals_;
+    KParam oVInfo_;
+    int n_;
+};
+
+template<typename Tk, typename To, af_op_t op>
+class finalBoundaryReduceDimKernel {
+   public:
+    finalBoundaryReduceDimKernel(write_accessor<int> reduced_block_sizes,
+                                 read_accessor<Tk> iKeys, KParam iKInfo,
+                                 sycl::accessor<To> oVals, KParam oVInfo,
+                                 const int n, const int nGroupsZ)
+        : reduced_block_sizes_(reduced_block_sizes)
+        , iKeys_(iKeys)
+        , iKInfo_(iKInfo)
+        , oVals_(oVals)
+        , oVInfo_(oVInfo)
+        , n_(n)
+        , nGroupsZ_(nGroupsZ) {}
+
+    void operator()(sycl::nd_item<3> it) const {
+        sycl::group g  = it.get_group();
+        const uint lid = it.get_local_id(0);
+        const uint gid = it.get_global_id(0);
+        const uint bid = g.get_group_id(0);
+
+        const int bidy = g.get_group_id(1);
+        const int bidz = g.get_group_id(2) % nGroupsZ_;
+        const int bidw = g.get_group_id(2) / nGroupsZ_;
+
+        common::Binary<compute_t<To>, op> binOp;
+        if (gid == ((bid + 1) * it.get_local_range(0)) - 1 &&
+            bid < g.get_group_range(0) - 1) {
+            Tk k0 = iKeys_[gid];
+            Tk k1 = iKeys_[gid + 1];
+
+            if (k0 == k1) {
+                compute_t<To> v0          = compute_t<To>(oVals_[gid]);
+                compute_t<To> v1          = compute_t<To>(oVals_[gid + 1]);
+                oVals_[gid + 1]           = binOp(v0, v1);
+                reduced_block_sizes_[bid] = it.get_local_range(0) - 1;
+            } else {
+                reduced_block_sizes_[bid] = it.get_local_range(0);
+            }
+        }
+
+        // if last block, set block size to difference between n and block
+        // boundary
+        if (lid == 0 && bid == g.get_group_range(0) - 1) {
+            reduced_block_sizes_[bid] = n_ - (bid * it.get_local_range(0));
+        }
+    }
+
+   protected:
+    write_accessor<int> reduced_block_sizes_;
+    read_accessor<Tk> iKeys_;
+    KParam iKInfo_;
+    sycl::accessor<To> oVals_;
+    KParam oVInfo_;
+    int n_;
+    int nGroupsZ_;
+};
+
+template<typename T>
+using global_atomic_ref =
+    sycl::atomic_ref<T, sycl::memory_order::relaxed, sycl::memory_scope::system,
+                     sycl::access::address_space::global_space>;
+
+// Tests if data needs further reduction, including across block boundaries
+template<typename Tk>
+class testNeedsReductionKernel {
+   public:
+    testNeedsReductionKernel(sycl::accessor<int> needs_another_reduction,
+                             sycl::accessor<int> needs_block_boundary_reduced,
+                             read_accessor<Tk> iKeys, KParam iKInfo,
+                             const int n, const int DIMX,
+                             sycl::local_accessor<Tk> l_keys)
+        : needs_another_reduction_(needs_another_reduction)
+        , needs_block_boundary_reduced_(needs_block_boundary_reduced)
+        , iKeys_(iKeys)
+        , iKInfo_(iKInfo)
+        , n_(n)
+        , DIMX_(DIMX)
+        , l_keys_(l_keys) {}
+
+    void operator()(sycl::nd_item<1> it) const {
+        sycl::group g  = it.get_group();
+        const uint lid = it.get_local_id(0);
+        const uint gid = it.get_global_id(0);
+        const uint bid = g.get_group_id(0);
+
+        Tk k;
+        if (gid < n_) { k = iKeys_[gid]; }
+
+        l_keys_[lid] = k;
+        it.barrier();
+
+        int update_key =
+            (lid < DIMX_ - 2) && (k == l_keys_[lid + 1]) && (gid < (n_ - 1));
+
+        if (update_key) {
+            global_atomic_ref<int>(needs_another_reduction_[0]) |= update_key;
+        }
+
+        it.barrier();
+
+        // last thread in each block checks if any inter-block keys need further
+        // reduction
+        if (gid == ((bid + 1) * DIMX_) - 1 &&
+            bid < (g.get_group_range(0) - 1)) {
+            int k0 = iKeys_[gid];
+            int k1 = iKeys_[gid + 1];
+            if (k0 == k1) {
+                global_atomic_ref<int>(needs_block_boundary_reduced_[0]) |= 1;
+            }
+        }
+    }
+
+   protected:
+    sycl::accessor<int> needs_another_reduction_;
+    sycl::accessor<int> needs_block_boundary_reduced_;
+    read_accessor<Tk> iKeys_;
+    KParam iKInfo_;
+    int n_;
+    int DIMX_;
+    sycl::local_accessor<Tk> l_keys_;
+};
+
+// Compacts "incomplete" block-sized chunks of data in global memory
+template<typename Tk, typename To>
+class compactKernel {
+   public:
+    compactKernel(read_accessor<int> reduced_block_sizes,
+                  write_accessor<Tk> oKeys, KParam oKInfo,
+                  write_accessor<To> oVals, KParam oVInfo,
+                  read_accessor<Tk> iKeys, KParam iKInfo,
+                  read_accessor<To> iVals, KParam iVInfo, int nGroupsZ)
+        : reduced_block_sizes_(reduced_block_sizes)
+        , oKeys_(oKeys)
+        , oKInfo_(oKInfo)
+        , oVals_(oVals)
+        , oVInfo_(oVInfo)
+        , iKeys_(iKeys)
+        , iKInfo_(iKInfo)
+        , iVals_(iVals)
+        , iVInfo_(iVInfo)
+        , nGroupsZ_(nGroupsZ) {}
+
+    void operator()(sycl::nd_item<3> it) const {
+        sycl::group g  = it.get_group();
+        const uint lid = it.get_local_id(0);
+        const uint bid = g.get_group_id(0);
+        const uint gid = it.get_global_id(0);
+
+        const int bidy = g.get_group_id(1);
+        const int bidz = g.get_group_id(2) % nGroupsZ_;
+        const int bidw = g.get_group_id(2) / nGroupsZ_;
+
+        Tk k;
+        To v;
+
+        const int bOffset = bidw * oVInfo_.strides[3] +
+                            bidz * oVInfo_.strides[2] +
+                            bidy * oVInfo_.strides[1];
+
+        // reduced_block_sizes should have inclusive sum of block sizes
+        int nwrite =
+            (bid == 0)
+                ? reduced_block_sizes_[0]
+                : (reduced_block_sizes_[bid] - reduced_block_sizes_[bid - 1]);
+        int writeloc = (bid == 0) ? 0 : reduced_block_sizes_[bid - 1];
+
+        k = iKeys_[gid];
+        v = iVals_[bOffset + gid];
+
+        if (lid < nwrite) {
+            oKeys_[writeloc + lid]           = k;
+            oVals_[bOffset + writeloc + lid] = v;
+        }
+    }
+
+   protected:
+    read_accessor<int> reduced_block_sizes_;
+    write_accessor<Tk> oKeys_;
+    KParam oKInfo_;
+    write_accessor<To> oVals_;
+    KParam oVInfo_;
+    read_accessor<Tk> iKeys_;
+    KParam iKInfo_;
+    read_accessor<To> iVals_;
+    KParam iVInfo_;
+    int nGroupsZ_;
+};
+
+// Compacts "incomplete" block-sized chunks of data in global memory
+template<typename Tk, typename To>
+class compactDimKernel {
+   public:
+    compactDimKernel(read_accessor<int> reduced_block_sizes,
+                     write_accessor<Tk> oKeys, KParam oKInfo,
+                     write_accessor<To> oVals, KParam oVInfo,
+                     read_accessor<Tk> iKeys, KParam iKInfo,
+                     read_accessor<To> iVals, KParam iVInfo, int nGroupsZ,
+                     int DIM)
+        : reduced_block_sizes_(reduced_block_sizes)
+        , oKeys_(oKeys)
+        , oKInfo_(oKInfo)
+        , oVals_(oVals)
+        , oVInfo_(oVInfo)
+        , iKeys_(iKeys)
+        , iKInfo_(iKInfo)
+        , iVals_(iVals)
+        , iVInfo_(iVInfo)
+        , nGroupsZ_(nGroupsZ)
+        , DIM_(DIM) {}
+
+    void operator()(sycl::nd_item<3> it) const {
+        sycl::group g = it.get_group();
+
+        const uint lid  = it.get_local_id(0);
+        const uint gidx = it.get_global_id(0);
+        const uint bid  = g.get_group_id(0);
+
+        const int bidy = g.get_group_id(1);
+        const int bidz = g.get_group_id(2) % nGroupsZ_;
+        const int bidw = g.get_group_id(2) / nGroupsZ_;
+
+        int dims_ordering[4];
+        dims_ordering[0] = DIM_;
+        int d            = 1;
+        for (int i = 0; i < 4; ++i) {
+            if (i != DIM_) dims_ordering[d++] = i;
+        }
+
+        Tk k;
+        To v;
+
+        // reduced_block_sizes should have inclusive sum of block sizes
+        int nwrite =
+            (bid == 0)
+                ? reduced_block_sizes_[0]
+                : (reduced_block_sizes_[bid] - reduced_block_sizes_[bid - 1]);
+        int writeloc = (bid == 0) ? 0 : reduced_block_sizes_[bid - 1];
+
+        const int tid = bidw * iVInfo_.strides[dims_ordering[3]] +
+                        bidz * iVInfo_.strides[dims_ordering[2]] +
+                        bidy * iVInfo_.strides[dims_ordering[1]] +
+                        gidx * iVInfo_.strides[DIM_];
+        k = iKeys_[gidx];
+        v = iVals_[tid];
+
+        if (lid < nwrite) {
+            oKeys_[writeloc + lid] = k;
+            const int bOffset      = bidw * oVInfo_.strides[dims_ordering[3]] +
+                                bidz * oVInfo_.strides[dims_ordering[2]] +
+                                bidy * oVInfo_.strides[dims_ordering[1]];
+            oVals_[bOffset + (writeloc + lid) * oVInfo_.strides[DIM_]] = v;
+        }
+    }
+
+   protected:
+    read_accessor<int> reduced_block_sizes_;
+    write_accessor<Tk> oKeys_;
+    KParam oKInfo_;
+    write_accessor<To> oVals_;
+    KParam oVInfo_;
+    read_accessor<Tk> iKeys_;
+    KParam iKInfo_;
+    read_accessor<To> iVals_;
+    KParam iVInfo_;
+    int nGroupsZ_;
+    int DIM_;
+};
+
+// Reduces each block by key
+template<typename Ti, typename Tk, typename To, af_op_t op>
+class reduceBlocksByKeyKernel {
+   public:
+    reduceBlocksByKeyKernel(sycl::accessor<int> reduced_block_sizes,
+                            write_accessor<Tk> oKeys, KParam oKInfo,
+                            write_accessor<To> oVals, KParam oVInfo,
+                            read_accessor<Tk> iKeys, KParam iKInfo,
+                            read_accessor<Ti> iVals, KParam iVInfo,
+                            int change_nan, To nanval, int n, int nGroupsZ,
+                            int DIMX, sycl::local_accessor<Tk> l_keys,
+                            sycl::local_accessor<compute_t<To>> l_vals,
+                            sycl::local_accessor<Tk> l_reduced_keys,
+                            sycl::local_accessor<compute_t<To>> l_reduced_vals,
+                            sycl::local_accessor<int> l_unique_ids,
+                            sycl::local_accessor<int> l_wg_temp,
+                            sycl::local_accessor<int> l_unique_flags,
+                            sycl::local_accessor<int> l_reduced_block_size)
+        : reduced_block_sizes_(reduced_block_sizes)
+        , oKeys_(oKeys)
+        , oKInfo_(oKInfo)
+        , oVals_(oVals)
+        , oVInfo_(oVInfo)
+        , iKeys_(iKeys)
+        , iKInfo_(iKInfo)
+        , iVals_(iVals)
+        , iVInfo_(iVInfo)
+        , change_nan_(change_nan)
+        , nanval_(nanval)
+        , n_(n)
+        , nGroupsZ_(nGroupsZ)
+        , DIMX_(DIMX)
+        , l_keys_(l_keys)
+        , l_vals_(l_vals)
+        , l_reduced_keys_(l_reduced_keys)
+        , l_reduced_vals_(l_reduced_vals)
+        , l_unique_ids_(l_unique_ids)
+        , l_wg_temp_(l_wg_temp)
+        , l_unique_flags_(l_unique_flags)
+        , l_reduced_block_size_(l_reduced_block_size) {}
+
+    void operator()(sycl::nd_item<3> it) const {
+        sycl::group g  = it.get_group();
+        const uint lid = it.get_local_id(0);
+        const uint gid = it.get_global_id(0);
+
+        const int bidy = g.get_group_id(1);
+        const int bidz = g.get_group_id(2) % nGroupsZ_;
+        const int bidw = g.get_group_id(2) / nGroupsZ_;
+
+        const compute_t<To> init_val =
+            common::Binary<compute_t<To>, op>::init();
+        common::Binary<compute_t<To>, op> binOp;
+        common::Transform<Ti, compute_t<To>, op> transform;
+
+        if (lid == 0) { l_reduced_block_size_[0] = 0; }
+
+        // load keys and values to threads
+        Tk k;
+        compute_t<To> v;
+        if (gid < n_) {
+            k                 = iKeys_[gid];
+            const int bOffset = bidw * iVInfo_.strides[3] +
+                                bidz * iVInfo_.strides[2] +
+                                bidy * iVInfo_.strides[1];
+            v = transform(iVals_[bOffset + gid]);
+            if (change_nan_) v = IS_NAN(v) ? nanval_ : v;
+        } else {
+            v = init_val;
+        }
+
+        l_keys_[lid] = k;
+        l_vals_[lid] = v;
+
+        l_reduced_keys_[lid] = k;
+        it.barrier();
+
+        // mark threads containing unique keys
+        int eq_check    = (lid > 0) ? (k != l_reduced_keys_[lid - 1]) : 0;
+        int unique_flag = (eq_check || (lid == 0)) && (gid < n_);
+
+        l_unique_flags_[lid] = unique_flag;
+        int unique_id =
+            work_group_scan_inclusive_add(it, l_wg_temp_, l_unique_flags_);
+
+        l_unique_ids_[lid] = unique_id;
+
+        if (lid == DIMX_ - 1) l_reduced_block_size_[0] = unique_id;
+
+        for (int off = 1; off < DIMX_; off *= 2) {
+            it.barrier();
+            int test_unique_id =
+                (lid + off < DIMX_) ? l_unique_ids_[lid + off] : ~unique_id;
+            eq_check = (unique_id == test_unique_id);
+            int update_key =
+                eq_check && (lid < (DIMX_ - off)) &&
+                ((gid + off) <
+                 n_);  // checks if this thread should perform a reduction
+            compute_t<To> uval = (update_key) ? l_vals_[lid + off] : init_val;
+            it.barrier();
+            l_vals_[lid] =
+                binOp(l_vals_[lid], uval);  // update if thread requires it
+        }
+
+        if (unique_flag) {
+            l_reduced_keys_[unique_id - 1] = k;
+            l_reduced_vals_[unique_id - 1] = l_vals_[lid];
+        }
+        it.barrier();
+
+        const int bid = g.get_group_id(0);
+        if (lid < l_reduced_block_size_[0]) {
+            const int bOffset = bidw * oVInfo_.strides[3] +
+                                bidz * oVInfo_.strides[2] +
+                                bidy * oVInfo_.strides[1];
+            oKeys_[bid * DIMX_ + lid]               = l_reduced_keys_[lid];
+            oVals_[bOffset + ((bid * DIMX_) + lid)] = l_reduced_vals_[lid];
+        }
+
+        reduced_block_sizes_[bid] = l_reduced_block_size_[0];
+    }
+
+    int work_group_scan_inclusive_add(sycl::nd_item<3> it,
+                                      sycl::local_accessor<int> wg_temp,
+                                      sycl::local_accessor<int> arr) const {
+        const uint lid = it.get_local_id(0);
+        int *active_buf;
+
+        int val    = arr[lid];
+        active_buf = arr.get_pointer();
+
+        bool swap_buffer = false;
+        for (int off = 1; off <= DIMX_; off *= 2) {
+            it.barrier();
+            if (lid >= off) { val = val + active_buf[lid - off]; }
+            swap_buffer = !swap_buffer;
+            active_buf =
+                swap_buffer ? wg_temp.get_pointer() : arr.get_pointer();
+            active_buf[lid] = val;
+        }
+
+        int res = active_buf[lid];
+        return res;
+    }
+
+   protected:
+    sycl::accessor<int> reduced_block_sizes_;
+    write_accessor<Tk> oKeys_;
+    KParam oKInfo_;
+    write_accessor<To> oVals_;
+    KParam oVInfo_;
+    read_accessor<Tk> iKeys_;
+    KParam iKInfo_;
+    read_accessor<Ti> iVals_;
+    KParam iVInfo_;
+    int change_nan_;
+    To nanval_;
+    int n_;
+    int nGroupsZ_;
+    int DIMX_;
+    sycl::local_accessor<Tk> l_keys_;
+    sycl::local_accessor<compute_t<To>> l_vals_;
+    sycl::local_accessor<Tk> l_reduced_keys_;
+    sycl::local_accessor<compute_t<To>> l_reduced_vals_;
+    sycl::local_accessor<int> l_unique_ids_;
+    sycl::local_accessor<int> l_wg_temp_;
+    sycl::local_accessor<int> l_unique_flags_;
+    sycl::local_accessor<int> l_reduced_block_size_;
+};
+
+// Reduces each block by key
+template<typename Ti, typename Tk, typename To, af_op_t op>
+class reduceBlocksByKeyDimKernel {
+   public:
+    reduceBlocksByKeyDimKernel(
+        sycl::accessor<int> reduced_block_sizes, write_accessor<Tk> oKeys,
+        KParam oKInfo, write_accessor<To> oVals, KParam oVInfo,
+        read_accessor<Tk> iKeys, KParam iKInfo, read_accessor<Ti> iVals,
+        KParam iVInfo, int change_nan, To nanval, int n, int nGroupsZ, int DIMX,
+        int DIM, sycl::local_accessor<Tk> l_keys,
+        sycl::local_accessor<compute_t<To>> l_vals,
+        sycl::local_accessor<Tk> l_reduced_keys,
+        sycl::local_accessor<compute_t<To>> l_reduced_vals,
+        sycl::local_accessor<int> l_unique_ids,
+        sycl::local_accessor<int> l_wg_temp,
+        sycl::local_accessor<int> l_unique_flags,
+        sycl::local_accessor<int> l_reduced_block_size)
+        : reduced_block_sizes_(reduced_block_sizes)
+        , oKeys_(oKeys)
+        , oKInfo_(oKInfo)
+        , oVals_(oVals)
+        , oVInfo_(oVInfo)
+        , iKeys_(iKeys)
+        , iKInfo_(iKInfo)
+        , iVals_(iVals)
+        , iVInfo_(iVInfo)
+        , change_nan_(change_nan)
+        , nanval_(nanval)
+        , n_(n)
+        , nGroupsZ_(nGroupsZ)
+        , DIMX_(DIMX)
+        , DIM_(DIM)
+        , l_keys_(l_keys)
+        , l_vals_(l_vals)
+        , l_reduced_keys_(l_reduced_keys)
+        , l_reduced_vals_(l_reduced_vals)
+        , l_unique_ids_(l_unique_ids)
+        , l_wg_temp_(l_wg_temp)
+        , l_unique_flags_(l_unique_flags)
+        , l_reduced_block_size_(l_reduced_block_size) {}
+
+    void operator()(sycl::nd_item<3> it) const {
+        sycl::group g  = it.get_group();
+        const uint lid = it.get_local_id(0);
+        const uint gid = it.get_global_id(0);
+
+        const int bidy = g.get_group_id(1);
+        const int bidz = g.get_group_id(2) % nGroupsZ_;
+        const int bidw = g.get_group_id(2) / nGroupsZ_;
+
+        const compute_t<To> init_val =
+            common::Binary<compute_t<To>, op>::init();
+        common::Binary<compute_t<To>, op> binOp;
+        common::Transform<Ti, compute_t<To>, op> transform;
+
+        if (lid == 0) { l_reduced_block_size_[0] = 0; }
+
+        int dims_ordering[4];
+        dims_ordering[0] = DIM_;
+        int d            = 1;
+        for (int i = 0; i < 4; ++i) {
+            if (i != DIM_) dims_ordering[d++] = i;
+        }
+        it.barrier();
+
+        // load keys and values to threads
+        Tk k;
+        compute_t<To> v;
+        if (gid < n_) {
+            k                 = iKeys_[gid];
+            const int bOffset = bidw * iVInfo_.strides[dims_ordering[3]] +
+                                bidz * iVInfo_.strides[dims_ordering[2]] +
+                                bidy * iVInfo_.strides[dims_ordering[1]];
+            v = transform(iVals_[bOffset + gid * iVInfo_.strides[DIM_]]);
+            if (change_nan_) v = IS_NAN(v) ? nanval_ : v;
+        } else {
+            v = init_val;
+        }
+
+        l_keys_[lid] = k;
+        l_vals_[lid] = v;
+
+        l_reduced_keys_[lid] = k;
+        it.barrier();
+
+        // mark threads containing unique keys
+        int eq_check    = (lid > 0) ? (k != l_reduced_keys_[lid - 1]) : 0;
+        int unique_flag = (eq_check || (lid == 0)) && (gid < n_);
+
+        l_unique_flags_[lid] = unique_flag;
+        int unique_id =
+            work_group_scan_inclusive_add(it, l_wg_temp_, l_unique_flags_);
+
+        l_unique_ids_[lid] = unique_id;
+
+        if (lid == DIMX_ - 1) l_reduced_block_size_[0] = unique_id;
+
+        for (int off = 1; off < DIMX_; off *= 2) {
+            it.barrier();
+            int test_unique_id =
+                (lid + off < DIMX_) ? l_unique_ids_[lid + off] : ~unique_id;
+            eq_check = (unique_id == test_unique_id);
+            int update_key =
+                eq_check && (lid < (DIMX_ - off)) &&
+                ((gid + off) <
+                 n_);  // checks if this thread should perform a reduction
+            compute_t<To> uval = (update_key) ? l_vals_[lid + off] : init_val;
+            it.barrier();
+            l_vals_[lid] =
+                binOp(l_vals_[lid], uval);  // update if thread requires it
+        }
+
+        if (unique_flag) {
+            l_reduced_keys_[unique_id - 1] = k;
+            l_reduced_vals_[unique_id - 1] = l_vals_[lid];
+        }
+        it.barrier();
+
+        const int bid = g.get_group_id(0);
+        if (lid < l_reduced_block_size_[0]) {
+            const int bOffset = bidw * oVInfo_.strides[dims_ordering[3]] +
+                                bidz * oVInfo_.strides[dims_ordering[2]] +
+                                bidy * oVInfo_.strides[dims_ordering[1]];
+            oKeys_[gid] = l_reduced_keys_[lid];
+            oVals_[bOffset + (gid)*oVInfo_.strides[DIM_]] =
+                l_reduced_vals_[lid];
+        }
+
+        reduced_block_sizes_[bid] = l_reduced_block_size_[0];
+    }
+
+    int work_group_scan_inclusive_add(sycl::nd_item<3> it,
+                                      sycl::local_accessor<int> wg_temp,
+                                      sycl::local_accessor<int> arr) const {
+        const uint lid = it.get_local_id(0);
+        int *active_buf;
+
+        int val    = arr[lid];
+        active_buf = arr.get_pointer();
+
+        bool swap_buffer = false;
+        for (int off = 1; off <= DIMX_; off *= 2) {
+            it.barrier();
+            if (lid >= off) { val = val + active_buf[lid - off]; }
+            swap_buffer = !swap_buffer;
+            active_buf =
+                swap_buffer ? wg_temp.get_pointer() : arr.get_pointer();
+            active_buf[lid] = val;
+        }
+
+        int res = active_buf[lid];
+        return res;
+    }
+
+   protected:
+    sycl::accessor<int> reduced_block_sizes_;
+    write_accessor<Tk> oKeys_;
+    KParam oKInfo_;
+    write_accessor<To> oVals_;
+    KParam oVInfo_;
+    read_accessor<Tk> iKeys_;
+    KParam iKInfo_;
+    read_accessor<Ti> iVals_;
+    KParam iVInfo_;
+    int change_nan_;
+    To nanval_;
+    int n_;
+    int nGroupsZ_;
+    int DIMX_;
+    int DIM_;
+    sycl::local_accessor<Tk> l_keys_;
+    sycl::local_accessor<compute_t<To>> l_vals_;
+    sycl::local_accessor<Tk> l_reduced_keys_;
+    sycl::local_accessor<compute_t<To>> l_reduced_vals_;
+    sycl::local_accessor<int> l_unique_ids_;
+    sycl::local_accessor<int> l_wg_temp_;
+    sycl::local_accessor<int> l_unique_flags_;
+    sycl::local_accessor<int> l_reduced_block_size_;
+};
+
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/oneapi/reduce_impl.hpp
+++ b/src/backend/oneapi/reduce_impl.hpp
@@ -6,11 +6,19 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#pragma once
+
+// oneDPL headers should be included before standard headers
+#define ONEDPL_USE_PREDEFINED_POLICIES 0
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/iterator>
+#include <oneapi/dpl/numeric>
 
 #include <Array.hpp>
 #include <err_oneapi.hpp>
+#include <kernel/accessors.hpp>
 #include <kernel/reduce.hpp>
-// #include <kernel/reduce_by_key.hpp>
+#include <kernel/reduce_by_key.hpp>
 #include <reduce.hpp>
 #include <af/dim4.hpp>
 #include <complex>
@@ -31,11 +39,558 @@ Array<To> reduce(const Array<Ti> &in, const int dim, bool change_nan,
     return out;
 }
 
+template<typename Ti, typename Tk, typename To, af_op_t op>
+void reduceBlocksByKey(sycl::buffer<int> &reduced_block_sizes,
+                       Array<Tk> keys_out, Array<To> vals_out,
+                       const Array<Tk> keys, const Array<Ti> vals,
+                       int change_nan, double nanval, const int n,
+                       const int threads_x) {
+    int numBlocks = divup(n, threads_x);
+
+    sycl::range<3> local(threads_x, 1, 1);
+    sycl::range<3> global(local[0] * numBlocks, vals_out.dims()[1],
+                          vals_out.dims()[2] * vals_out.dims()[3]);
+
+    getQueue().submit([&](sycl::handler &h) {
+        sycl::accessor<int> reduced_block_sizes_acc{reduced_block_sizes, h};
+        write_accessor<Tk> keys_out_acc{*keys_out.get(), h};
+        write_accessor<To> vals_out_acc{*vals_out.get(), h};
+        read_accessor<Tk> keys_acc{*keys.get(), h};
+        read_accessor<Ti> vals_acc{*vals.get(), h};
+
+        auto l_keys         = sycl::local_accessor<Tk>(threads_x, h);
+        auto l_vals         = sycl::local_accessor<compute_t<To>>(threads_x, h);
+        auto l_reduced_keys = sycl::local_accessor<Tk>(threads_x, h);
+        auto l_reduced_vals = sycl::local_accessor<compute_t<To>>(threads_x, h);
+        auto l_unique_ids   = sycl::local_accessor<int>(threads_x, h);
+        auto l_wq_temp      = sycl::local_accessor<int>(threads_x, h);
+        auto l_unique_flags = sycl::local_accessor<int>(threads_x, h);
+        auto l_reduced_block_size = sycl::local_accessor<int>(1, h);
+
+        h.parallel_for(
+            sycl::nd_range<3>(global, local),
+            kernel::reduceBlocksByKeyKernel<Ti, Tk, To, op>(
+                reduced_block_sizes_acc, keys_out_acc, keys_out, vals_out_acc,
+                vals_out, keys_acc, keys, vals_acc, vals, change_nan,
+                scalar<To>(nanval), n, static_cast<int>(vals_out.dims()[2]),
+                threads_x, l_keys, l_vals, l_reduced_keys, l_reduced_vals,
+                l_unique_ids, l_wq_temp, l_unique_flags, l_reduced_block_size));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename Ti, typename Tk, typename To, af_op_t op>
+void reduceBlocksByKeyDim(sycl::buffer<int> &reduced_block_sizes,
+                          Array<Tk> keys_out, Array<To> vals_out,
+                          const Array<Tk> keys, const Array<Ti> vals,
+                          int change_nan, double nanval, const int n,
+                          const int threads_x, const int dim,
+                          std::vector<int> dim_ordering) {
+    int numBlocks = divup(n, threads_x);
+
+    sycl::range<3> local(threads_x, 1, 1);
+    sycl::range<3> global(
+        local[0] * numBlocks, vals_out.dims()[dim_ordering[1]],
+        vals_out.dims()[dim_ordering[2]] * vals_out.dims()[dim_ordering[3]]);
+
+    getQueue().submit([&](sycl::handler &h) {
+        sycl::accessor<int> reduced_block_sizes_acc{reduced_block_sizes, h};
+        write_accessor<Tk> keys_out_acc{*keys_out.get(), h};
+        write_accessor<To> vals_out_acc{*vals_out.get(), h};
+        read_accessor<Tk> keys_acc{*keys.get(), h};
+        read_accessor<Ti> vals_acc{*vals.get(), h};
+
+        auto l_keys         = sycl::local_accessor<Tk>(threads_x, h);
+        auto l_vals         = sycl::local_accessor<compute_t<To>>(threads_x, h);
+        auto l_reduced_keys = sycl::local_accessor<Tk>(threads_x, h);
+        auto l_reduced_vals = sycl::local_accessor<compute_t<To>>(threads_x, h);
+        auto l_unique_ids   = sycl::local_accessor<int>(threads_x, h);
+        auto l_wq_temp      = sycl::local_accessor<int>(threads_x, h);
+        auto l_unique_flags = sycl::local_accessor<int>(threads_x, h);
+        auto l_reduced_block_size = sycl::local_accessor<int>(1, h);
+
+        h.parallel_for(
+            sycl::nd_range<3>(global, local),
+            kernel::reduceBlocksByKeyDimKernel<Ti, Tk, To, op>(
+                reduced_block_sizes_acc, keys_out_acc, keys_out, vals_out_acc,
+                vals_out, keys_acc, keys, vals_acc, vals, change_nan,
+                scalar<To>(nanval), n, static_cast<int>(vals_out.dims()[2]),
+                threads_x, dim, l_keys, l_vals, l_reduced_keys, l_reduced_vals,
+                l_unique_ids, l_wq_temp, l_unique_flags, l_reduced_block_size));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename Tk, typename To, af_op_t op>
+void finalBoundaryReduce(sycl::buffer<int> &reduced_block_sizes, Array<Tk> keys,
+                         Array<To> vals_out, const int n, const int numBlocks,
+                         const int threads_x) {
+    sycl::range<1> local(threads_x);
+    sycl::range<1> global(local[0] * numBlocks);
+
+    getQueue().submit([&](sycl::handler &h) {
+        write_accessor<int> reduced_block_sizes_acc{reduced_block_sizes, h};
+        read_accessor<Tk> keys_acc{*keys.get(), h};
+        sycl::accessor<To> vals_out_acc{*vals_out.get(), h};
+
+        h.parallel_for(sycl::nd_range<1>(global, local),
+                       kernel::finalBoundaryReduceKernel<Tk, To, op>(
+                           reduced_block_sizes_acc, keys_acc, keys,
+                           vals_out_acc, vals_out, n));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename Tk, typename To, af_op_t op>
+void finalBoundaryReduceDim(sycl::buffer<int> &reduced_block_sizes,
+                            Array<Tk> keys, Array<To> vals_out, const int n,
+                            const int numBlocks, const int threads_x,
+                            const int dim, std::vector<int> dim_ordering) {
+    sycl::range<3> local(threads_x, 1, 1);
+    sycl::range<3> global(
+        local[0] * numBlocks, vals_out.dims()[dim_ordering[1]],
+        vals_out.dims()[dim_ordering[2]] * vals_out.dims()[dim_ordering[3]]);
+
+    getQueue().submit([&](sycl::handler &h) {
+        write_accessor<int> reduced_block_sizes_acc{reduced_block_sizes, h};
+        read_accessor<Tk> keys_acc{*keys.get(), h};
+        sycl::accessor<To> vals_out_acc{*vals_out.get(), h};
+
+        // TODO: fold 3,4 dimensions
+        h.parallel_for(
+            sycl::nd_range<3>(global, local),
+            kernel::finalBoundaryReduceDimKernel<Tk, To, op>(
+                reduced_block_sizes_acc, keys_acc, keys, vals_out_acc, vals_out,
+                n, vals_out.dims()[dim_ordering[2]]));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename Tk, typename To>
+void compact(sycl::buffer<int> reduced_block_sizes, Array<Tk> &keys_out,
+             Array<To> &vals_out, const Array<Tk> &keys, const Array<To> &vals,
+             const int numBlocks, const int threads_x) {
+    sycl::range<3> local(threads_x, 1, 1);
+    sycl::range<3> global(local[0] * numBlocks, vals_out.dims()[1],
+                          vals_out.dims()[2] * vals_out.dims()[3]);
+
+    getQueue().submit([&](sycl::handler &h) {
+        read_accessor<int> reduced_block_sizes_acc{reduced_block_sizes, h};
+        write_accessor<Tk> keys_out_acc{*keys_out.get(), h};
+        write_accessor<To> vals_out_acc{*vals_out.get(), h};
+        read_accessor<Tk> keys_acc{*keys.get(), h};
+        read_accessor<To> vals_acc{*vals.get(), h};
+
+        h.parallel_for(sycl::nd_range<3>(global, local),
+                       kernel::compactKernel<Tk, To>(
+                           reduced_block_sizes_acc, keys_out_acc, keys_out,
+                           vals_out_acc, vals_out, keys_acc, keys, vals_acc,
+                           vals, static_cast<int>(vals_out.dims()[2])));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename Tk, typename To>
+void compactDim(sycl::buffer<int> &reduced_block_sizes, Array<Tk> &keys_out,
+                Array<To> &vals_out, const Array<Tk> &keys,
+                const Array<To> &vals, const int numBlocks, const int threads_x,
+                const int dim, std::vector<int> dim_ordering) {
+    sycl::range<3> local(threads_x, 1, 1);
+    sycl::range<3> global(
+        local[0] * numBlocks, vals_out.dims()[dim_ordering[1]],
+        vals_out.dims()[dim_ordering[2]] * vals_out.dims()[dim_ordering[3]]);
+
+    getQueue().submit([&](sycl::handler &h) {
+        read_accessor<int> reduced_block_sizes_acc{reduced_block_sizes, h};
+        write_accessor<Tk> keys_out_acc{*keys_out.get(), h};
+        write_accessor<To> vals_out_acc{*vals_out.get(), h};
+        read_accessor<Tk> keys_acc{*keys.get(), h};
+        read_accessor<To> vals_acc{*vals.get(), h};
+
+        h.parallel_for(
+            sycl::nd_range<3>(global, local),
+            kernel::compactDimKernel<Tk, To>(
+                reduced_block_sizes_acc, keys_out_acc, keys_out, vals_out_acc,
+                vals_out, keys_acc, keys, vals_acc, vals,
+                static_cast<int>(vals_out.dims()[dim_ordering[2]]), dim));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename Tk>
+void testNeedsReduction(sycl::buffer<int> needs_reduction,
+                        sycl::buffer<int> needs_boundary, const Array<Tk> &keys,
+                        const int n, const int numBlocks, const int threads_x) {
+    sycl::range<1> local(threads_x);
+    sycl::range<1> global(local[0] * numBlocks);
+
+    getQueue().submit([&](sycl::handler &h) {
+        sycl::accessor<int> needs_reduction_acc{needs_reduction, h};
+        sycl::accessor<int> needs_boundary_acc{needs_boundary, h};
+        read_accessor<Tk> keys_acc{*keys.get(), h};
+        auto l_keys = sycl::local_accessor<Tk>(threads_x, h);
+
+        h.parallel_for(sycl::nd_range<1>(global, local),
+                       kernel::testNeedsReductionKernel<Tk>(
+                           needs_reduction_acc, needs_boundary_acc, keys_acc,
+                           keys, n, threads_x, l_keys));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<af_op_t op, typename Ti, typename Tk, typename To>
+int reduce_by_key_first(Array<Tk> &keys_out, Array<To> &vals_out,
+                        const Array<Tk> &keys, const Array<Ti> &vals,
+                        bool change_nan, double nanval) {
+    auto dpl_policy = ::oneapi::dpl::execution::make_device_policy(getQueue());
+
+    dim4 kdims = keys.dims();
+    dim4 odims = vals.dims();
+
+    Array<Tk> reduced_keys   = createEmptyArray<Tk>(kdims);
+    Array<To> reduced_vals   = createEmptyArray<To>(odims);
+    Array<Tk> t_reduced_keys = createEmptyArray<Tk>(kdims);
+    Array<To> t_reduced_vals = createEmptyArray<To>(odims);
+
+    // flags determining more reduction is necessary
+    auto needs_another_reduction        = memAlloc<int>(1);
+    auto needs_block_boundary_reduction = memAlloc<int>(1);
+
+    // reset flags
+    getQueue().submit([&](sycl::handler &h) {
+        auto wacc =
+            needs_another_reduction->get_access<sycl::access_mode::write>(h);
+        h.fill(wacc, 0);
+    });
+    getQueue().submit([&](sycl::handler &h) {
+        auto wacc = needs_block_boundary_reduction
+                        ->get_access<sycl::access_mode::write>(h);
+        h.fill(wacc, 0);
+    });
+
+    size_t nelems = kdims[0];
+
+    const unsigned int numThreads = 128;
+    int numBlocksD0               = divup(nelems, numThreads);
+    auto reduced_block_sizes      = memAlloc<int>(numBlocksD0);
+
+    int n_reduced_host = nelems;
+
+    int needs_another_reduction_host        = 0;
+    int needs_block_boundary_reduction_host = 0;
+
+    bool first_pass = true;
+    do {
+        numBlocksD0 = divup(n_reduced_host, numThreads);
+
+        if (first_pass) {
+            reduceBlocksByKey<Ti, Tk, To, op>(
+                *reduced_block_sizes.get(), reduced_keys, reduced_vals, keys,
+                vals, change_nan, nanval, n_reduced_host, numThreads);
+            first_pass = false;
+        } else {
+            constexpr af_op_t op2 = (op == af_notzero_t) ? af_add_t : op;
+            reduceBlocksByKey<To, Tk, To, op2>(
+                *reduced_block_sizes.get(), reduced_keys, reduced_vals,
+                t_reduced_keys, t_reduced_vals, change_nan, nanval,
+                n_reduced_host, numThreads);
+        }
+
+        auto val_buf_begin = ::oneapi::dpl::begin(*reduced_block_sizes.get());
+        auto val_buf_end   = val_buf_begin + numBlocksD0;
+        std::inclusive_scan(dpl_policy, val_buf_begin, val_buf_end,
+                            val_buf_begin);
+
+        compact<Tk, To>(*reduced_block_sizes.get(), t_reduced_keys,
+                        t_reduced_vals, reduced_keys, reduced_vals, numBlocksD0,
+                        numThreads);
+
+        sycl::event reduce_host_event =
+            getQueue().submit([&](sycl::handler &h) {
+                sycl::range rr(1);
+                sycl::id offset_id(numBlocksD0 - 1);
+                auto offset_acc =
+                    reduced_block_sizes
+                        ->template get_access<sycl::access_mode::read>(
+                            h, rr, offset_id);
+                h.copy(offset_acc, &n_reduced_host);
+            });
+
+        // reset flags
+        getQueue().submit([&](sycl::handler &h) {
+            auto wacc =
+                needs_another_reduction->get_access<sycl::access_mode::write>(
+                    h);
+            h.fill(wacc, 0);
+        });
+        getQueue().submit([&](sycl::handler &h) {
+            auto wacc = needs_block_boundary_reduction
+                            ->get_access<sycl::access_mode::write>(h);
+            h.fill(wacc, 0);
+        });
+
+        reduce_host_event.wait();
+
+        numBlocksD0 = divup(n_reduced_host, numThreads);
+
+        testNeedsReduction<Tk>(*needs_another_reduction.get(),
+                               *needs_block_boundary_reduction.get(),
+                               t_reduced_keys, n_reduced_host, numBlocksD0,
+                               numThreads);
+
+        sycl::event host_flag0_event = getQueue().submit([&](sycl::handler &h) {
+            sycl::range rr(1);
+            auto acc =
+                needs_another_reduction
+                    ->template get_access<sycl::access_mode::read>(h, rr);
+            h.copy(acc, &needs_another_reduction_host);
+        });
+        sycl::event host_flag1_event = getQueue().submit([&](sycl::handler &h) {
+            sycl::range rr(1);
+            auto acc =
+                needs_block_boundary_reduction
+                    ->template get_access<sycl::access_mode::read>(h, rr);
+            h.copy(acc, &needs_block_boundary_reduction_host);
+        });
+
+        host_flag1_event.wait();
+        host_flag0_event.wait();
+
+        if (needs_block_boundary_reduction_host &&
+            !needs_another_reduction_host) {
+            finalBoundaryReduce<Tk, To, op>(
+                *reduced_block_sizes.get(), t_reduced_keys, t_reduced_vals,
+                n_reduced_host, numBlocksD0, numThreads);
+
+            auto val_buf_begin =
+                ::oneapi::dpl::begin(*reduced_block_sizes.get());
+            auto val_buf_end = val_buf_begin + numBlocksD0;
+            std::inclusive_scan(dpl_policy, val_buf_begin, val_buf_end,
+                                val_buf_begin);
+
+            sycl::event reduce_host_event =
+                getQueue().submit([&](sycl::handler &h) {
+                    sycl::range rr(1);
+                    sycl::id offset_id(numBlocksD0 - 1);
+                    auto offset_acc =
+                        reduced_block_sizes
+                            ->template get_access<sycl::access_mode::read>(
+                                h, rr, offset_id);
+                    h.copy(offset_acc, &n_reduced_host);
+                });
+
+            compact<Tk, To>(*reduced_block_sizes.get(), reduced_keys,
+                            reduced_vals, t_reduced_keys, t_reduced_vals,
+                            numBlocksD0, numThreads);
+
+            std::swap(t_reduced_keys, reduced_keys);
+            std::swap(t_reduced_vals, reduced_vals);
+            reduce_host_event.wait();
+        }
+    } while (needs_another_reduction_host ||
+             needs_block_boundary_reduction_host);
+
+    keys_out = t_reduced_keys;
+    vals_out = t_reduced_vals;
+    return n_reduced_host;
+}
+
+template<af_op_t op, typename Ti, typename Tk, typename To>
+int reduce_by_key_dim(Array<Tk> &keys_out, Array<To> &vals_out,
+                      const Array<Tk> &keys, const Array<Ti> &vals,
+                      bool change_nan, double nanval, const int dim) {
+    auto dpl_policy = ::oneapi::dpl::execution::make_device_policy(getQueue());
+
+    std::vector<int> dim_ordering = {dim};
+    for (int i = 0; i < 4; ++i) {
+        if (i != dim) { dim_ordering.push_back(i); }
+    }
+
+    dim4 kdims = keys.dims();
+    dim4 odims = vals.dims();
+
+    Array<Tk> reduced_keys   = createEmptyArray<Tk>(kdims);
+    Array<To> reduced_vals   = createEmptyArray<To>(odims);
+    Array<Tk> t_reduced_keys = createEmptyArray<Tk>(kdims);
+    Array<To> t_reduced_vals = createEmptyArray<To>(odims);
+
+    // flags determining more reduction is necessary
+    auto needs_another_reduction        = memAlloc<int>(1);
+    auto needs_block_boundary_reduction = memAlloc<int>(1);
+
+    // reset flags
+    getQueue().submit([&](sycl::handler &h) {
+        auto wacc =
+            needs_another_reduction->get_access<sycl::access_mode::write>(h);
+        h.fill(wacc, 0);
+    });
+    getQueue().submit([&](sycl::handler &h) {
+        auto wacc = needs_block_boundary_reduction
+                        ->get_access<sycl::access_mode::write>(h);
+        h.fill(wacc, 0);
+    });
+
+    int nelems = kdims[0];
+
+    const unsigned int numThreads = 128;
+    int numBlocksD0               = divup(nelems, numThreads);
+    auto reduced_block_sizes      = memAlloc<int>(numBlocksD0);
+
+    int n_reduced_host = nelems;
+
+    int needs_another_reduction_host        = 0;
+    int needs_block_boundary_reduction_host = 0;
+
+    bool first_pass = true;
+    do {
+        numBlocksD0 = divup(n_reduced_host, numThreads);
+
+        if (first_pass) {
+            reduceBlocksByKeyDim<Ti, Tk, To, op>(
+                *reduced_block_sizes.get(), reduced_keys, reduced_vals, keys,
+                vals, change_nan, nanval, n_reduced_host, numThreads, dim,
+                dim_ordering);
+            first_pass = false;
+        } else {
+            constexpr af_op_t op2 = op == af_notzero_t ? af_add_t : op;
+            reduceBlocksByKeyDim<To, Tk, To, op2>(
+                *reduced_block_sizes.get(), reduced_keys, reduced_vals,
+                t_reduced_keys, t_reduced_vals, change_nan, nanval,
+                n_reduced_host, numThreads, dim, dim_ordering);
+        }
+
+        auto val_buf_begin = ::oneapi::dpl::begin(*reduced_block_sizes.get());
+        auto val_buf_end   = val_buf_begin + numBlocksD0;
+        std::inclusive_scan(dpl_policy, val_buf_begin, val_buf_end,
+                            val_buf_begin);
+
+        compactDim<Tk, To>(*reduced_block_sizes.get(), t_reduced_keys,
+                           t_reduced_vals, reduced_keys, reduced_vals,
+                           numBlocksD0, numThreads, dim, dim_ordering);
+
+        sycl::event reduce_host_event =
+            getQueue().submit([&](sycl::handler &h) {
+                sycl::range rr(1);
+                sycl::id offset_id(numBlocksD0 - 1);
+                auto offset_acc =
+                    reduced_block_sizes
+                        ->template get_access<sycl::access_mode::read>(
+                            h, rr, offset_id);
+                h.copy(offset_acc, &n_reduced_host);
+            });
+
+        // reset flags
+        getQueue().submit([&](sycl::handler &h) {
+            auto wacc =
+                needs_another_reduction->get_access<sycl::access_mode::write>(
+                    h);
+            h.fill(wacc, 0);
+        });
+        getQueue().submit([&](sycl::handler &h) {
+            auto wacc = needs_block_boundary_reduction
+                            ->get_access<sycl::access_mode::write>(h);
+            h.fill(wacc, 0);
+        });
+
+        reduce_host_event.wait();
+
+        numBlocksD0 = divup(n_reduced_host, numThreads);
+
+        testNeedsReduction<Tk>(*needs_another_reduction.get(),
+                               *needs_block_boundary_reduction.get(),
+                               t_reduced_keys, n_reduced_host, numBlocksD0,
+                               numThreads);
+
+        sycl::event host_flag0_event = getQueue().submit([&](sycl::handler &h) {
+            sycl::range rr(1);
+            auto acc =
+                needs_another_reduction
+                    ->template get_access<sycl::access_mode::read>(h, rr);
+            h.copy(acc, &needs_another_reduction_host);
+        });
+        sycl::event host_flag1_event = getQueue().submit([&](sycl::handler &h) {
+            sycl::range rr(1);
+            auto acc =
+                needs_block_boundary_reduction
+                    ->template get_access<sycl::access_mode::read>(h, rr);
+            h.copy(acc, &needs_block_boundary_reduction_host);
+        });
+
+        host_flag1_event.wait();
+        host_flag0_event.wait();
+
+        if (needs_block_boundary_reduction_host &&
+            !needs_another_reduction_host) {
+            finalBoundaryReduceDim<Tk, To, op>(
+                *reduced_block_sizes.get(), t_reduced_keys, t_reduced_vals,
+                n_reduced_host, numBlocksD0, numThreads, dim, dim_ordering);
+
+            auto val_buf_begin =
+                ::oneapi::dpl::begin(*reduced_block_sizes.get());
+            auto val_buf_end = val_buf_begin + numBlocksD0;
+            std::inclusive_scan(dpl_policy, val_buf_begin, val_buf_end,
+                                val_buf_begin);
+
+            sycl::event reduce_host_event =
+                getQueue().submit([&](sycl::handler &h) {
+                    sycl::range rr(1);
+                    sycl::id offset_id(numBlocksD0 - 1);
+                    auto offset_acc =
+                        reduced_block_sizes
+                            ->template get_access<sycl::access_mode::read>(
+                                h, rr, offset_id);
+                    h.copy(offset_acc, &n_reduced_host);
+                });
+
+            compactDim<Tk, To>(*reduced_block_sizes.get(), reduced_keys,
+                               reduced_vals, t_reduced_keys, t_reduced_vals,
+                               numBlocksD0, numThreads, dim, dim_ordering);
+
+            std::swap(t_reduced_keys, reduced_keys);
+            std::swap(t_reduced_vals, reduced_vals);
+            reduce_host_event.wait();
+        }
+    } while (needs_another_reduction_host ||
+             needs_block_boundary_reduction_host);
+
+    keys_out = t_reduced_keys;
+    vals_out = t_reduced_vals;
+
+    return n_reduced_host;
+}
+
 template<af_op_t op, typename Ti, typename Tk, typename To>
 void reduce_by_key(Array<Tk> &keys_out, Array<To> &vals_out,
                    const Array<Tk> &keys, const Array<Ti> &vals, const int dim,
                    bool change_nan, double nanval) {
-    ONEAPI_NOT_SUPPORTED("");
+    dim4 kdims = keys.dims();
+    dim4 odims = vals.dims();
+
+    // prepare output arrays
+    Array<Tk> reduced_keys = createEmptyArray<Tk>(dim4());
+    Array<To> reduced_vals = createEmptyArray<To>(dim4());
+
+    size_t n_reduced = 0;
+    if (dim == 0) {
+        n_reduced = reduce_by_key_first<op, Ti, Tk, To>(
+            reduced_keys, reduced_vals, keys, vals, change_nan, nanval);
+    } else {
+        n_reduced = reduce_by_key_dim<op, Ti, Tk, To>(
+            reduced_keys, reduced_vals, keys, vals, change_nan, nanval, dim);
+    }
+
+    kdims[0]   = n_reduced;
+    odims[dim] = n_reduced;
+    std::vector<af_seq> kindex, vindex;
+    for (int i = 0; i < odims.ndims(); ++i) {
+        af_seq sk = {0.0, (double)kdims[i] - 1, 1.0};
+        af_seq sv = {0.0, (double)odims[i] - 1, 1.0};
+        kindex.push_back(sk);
+        vindex.push_back(sv);
+    }
+
+    keys_out = createSubArray<Tk>(reduced_keys, kindex, true);
+    vals_out = createSubArray<To>(reduced_vals, vindex, true);
 }
 
 template<af_op_t op, typename Ti, typename To>


### PR DESCRIPTION
adds reduce by key to oneapi backend

This PR adds reduce by key functionality to oneapi, both for first and nth dim kernels.

Changes to Users
----------------
<!--
* Additional options added to the build.
* What changes will existing users have to make to their code or build steps?
Refer to [wiki](https://github.com/arrayfire/arrayfire/wiki) for development guidelines
-->

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass

