### PR TITLE
Fix memory manager test failures in oneAPI backend

### DIFF
--- a/src/backend/common/err_common.cpp
+++ b/src/backend/common/err_common.cpp
@@ -170,7 +170,11 @@ af_err processException() {
         snprintf(oneapi_err_msg, sizeof(oneapi_err_msg),
                  "oneAPI Error (%d): %s", ex.code().value(), ex.what());
 
-        err = set_global_error_string(oneapi_err_msg, AF_ERR_INTERNAL);
+        if (ex.code() == sycl::errc::memory_allocation) {
+            err = set_global_error_string(oneapi_err_msg, AF_ERR_NO_MEM);
+        } else {
+            err = set_global_error_string(oneapi_err_msg, AF_ERR_INTERNAL);
+        }
     } catch (const oneapi::mkl::exception &ex) {
         char oneapi_err_msg[1024];
         snprintf(oneapi_err_msg, sizeof(oneapi_err_msg), "MKL Error: %s",

--- a/src/backend/oneapi/platform.cpp
+++ b/src/backend/oneapi/platform.cpp
@@ -605,7 +605,7 @@ void setMemoryManager(unique_ptr<MemoryManagerBase> mgr) {
 }
 
 void resetMemoryManager() {
-    return DeviceManager::getInstance().resetMemoryManagerPinned();
+    return DeviceManager::getInstance().resetMemoryManager();
 }
 
 void setMemoryManagerPinned(unique_ptr<MemoryManagerBase> mgr) {


### PR DESCRIPTION
Fix several oneAPI memory manager failures.

Description
-----------
* Fixed an error where the memory manager functions were not called during shutdown
* Some functions incorrectly called pinned allocator funcitons instead of the main default allocator function
* Update the sycl::exception handler to return AF_ERR_NO_MEM for out of memory exceptions. (This should eventually work but the sycl runtime is currently returning the wrong error code)

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
