### PR TITLE
Fft real even2d fix (again)

### DIFF
--- a/src/backend/oneapi/fft.cpp
+++ b/src/backend/oneapi/fft.cpp
@@ -50,10 +50,21 @@ void fft_inplace(Array<T> &in, const int rank, const bool direction) {
 
     auto desc = [rank, &idims]() {
         if (rank == 1) return desc_ty(idims[0]);
-        if (rank == 2) return desc_ty({idims[1], idims[0]});
-        if (rank == 3) return desc_ty({idims[2], idims[1], idims[0]});
-        return desc_ty({idims[3], idims[2], idims[1], idims[0]});
+        if (rank == 2) return desc_ty({idims[0], idims[1]});
+        if (rank == 3) return desc_ty({idims[0], idims[1], idims[2]});
+        return desc_ty({idims[0], idims[1], idims[2], idims[3]});
     }();
+
+    if (rank > 1) {
+        std::int64_t fft_input_strides[5];
+        fft_input_strides[0] = in.getOffset();
+        fft_input_strides[1] = istrides[0];
+        fft_input_strides[2] = istrides[1];
+        fft_input_strides[3] = istrides[2];
+        fft_input_strides[4] = istrides[3];
+        desc.set_value(::oneapi::mkl::dft::config_param::INPUT_STRIDES,
+                       fft_input_strides);
+    }
 
     desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT, DFTI_INPLACE);
 
@@ -96,15 +107,24 @@ Array<Tc> fft_r2c(const Array<Tr> &in, const int rank) {
     // broken, we're forced to shuffle data like this
     auto desc = [rank, &idims]() {
         if (rank == 1) return desc_ty(idims[0]);
-        if (rank == 2) return desc_ty({idims[1], idims[0]});
-        if (rank == 3) return desc_ty({idims[2], idims[1], idims[0]});
-        return desc_ty({idims[3], idims[2], idims[1], idims[0]});
+        if (rank == 2) return desc_ty({idims[0], idims[1]});
+        if (rank == 3) return desc_ty({idims[0], idims[1], idims[2]});
+        return desc_ty({idims[0], idims[1], idims[2], idims[3]});
     }();
     if (rank > 1) {
+        std::int64_t fft_input_strides[5];
+        fft_input_strides[0] = in.getOffset();
+        fft_input_strides[1] = istrides[0];
+        fft_input_strides[2] = istrides[1];
+        fft_input_strides[3] = istrides[2];
+        fft_input_strides[4] = istrides[3];
+        desc.set_value(::oneapi::mkl::dft::config_param::INPUT_STRIDES,
+                       fft_input_strides);
+
         std::int64_t fft_output_strides[5];
-        fft_output_strides[0] = 0;
-        fft_output_strides[1] = ostrides[1];
-        fft_output_strides[2] = ostrides[0];
+        fft_output_strides[0] = out.getOffset();
+        fft_output_strides[1] = ostrides[0];
+        fft_output_strides[2] = ostrides[1];
         fft_output_strides[3] = ostrides[2];
         fft_output_strides[4] = ostrides[3];
         desc.set_value(::oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
@@ -151,26 +171,35 @@ Array<Tr> fft_c2r(const Array<Tc> &in, const dim4 &odims, const int rank) {
     // forced to shuffle data like this
     auto desc = [rank, &odims]() {
         if (rank == 1) return desc_ty(odims[0]);
-        if (rank == 2) return desc_ty({odims[1], odims[0]});
-        if (rank == 3) return desc_ty({odims[2], odims[1], odims[0]});
-        return desc_ty({odims[3], odims[2], odims[1], odims[0]});
+        if (rank == 2) return desc_ty({odims[0], odims[1]});
+        if (rank == 3) return desc_ty({odims[0], odims[1], odims[2]});
+        return desc_ty({odims[0], odims[1], odims[2], odims[3]});
     }();
     if (rank > 1) {
         std::int64_t fft_input_strides[5];
-        fft_input_strides[0] = 0;
-        fft_input_strides[1] = istrides[1];
-        fft_input_strides[2] = istrides[0];
+        fft_input_strides[0] = in.getOffset();
+        fft_input_strides[1] = istrides[0];
+        fft_input_strides[2] = istrides[1];
         fft_input_strides[3] = istrides[2];
         fft_input_strides[4] = istrides[3];
         desc.set_value(::oneapi::mkl::dft::config_param::INPUT_STRIDES,
                        fft_input_strides);
+
+        std::int64_t fft_output_strides[5];
+        fft_output_strides[0] = out.getOffset();
+        fft_output_strides[1] = ostrides[0];
+        fft_output_strides[2] = ostrides[1];
+        fft_output_strides[3] = ostrides[2];
+        fft_output_strides[4] = ostrides[3];
+        desc.set_value(::oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
+                       fft_output_strides);
     }
 
     desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT,
                    DFTI_NOT_INPLACE);
 
     int batch = 1;
-    for (int i = rank; i < 4; i++) { batch *= idims[i]; }
+    for (int i = rank; i < 4; i++) { batch *= odims[i]; }
     desc.set_value(::oneapi::mkl::dft::config_param::NUMBER_OF_TRANSFORMS,
                    (int64_t)batch);
 

--- a/src/backend/oneapi/fft.cpp
+++ b/src/backend/oneapi/fft.cpp
@@ -92,9 +92,9 @@ Array<Tc> fft_r2c(const Array<Tr> &in, const int rank) {
 
     auto desc = [rank, &idims]() {
         if (rank == 1) return desc_ty(idims[0]);
-        if (rank == 2) return desc_ty({idims[0], idims[1]});
-        if (rank == 3) return desc_ty({idims[0], idims[1], idims[2]});
-        return desc_ty({idims[0], idims[1], idims[2], idims[3]});
+        if (rank == 2) return desc_ty({idims[1], idims[0]});
+        if (rank == 3) return desc_ty({idims[2], idims[1], idims[0]});
+        return desc_ty({idims[3], idims[2], idims[1], idims[0]});
     }();
 
     desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT,

--- a/src/backend/oneapi/fft.cpp
+++ b/src/backend/oneapi/fft.cpp
@@ -101,30 +101,26 @@ Array<Tc> fft_r2c(const Array<Tr> &in, const int rank) {
         ::oneapi::mkl::dft::descriptor<precision,
                                        ::oneapi::mkl::dft::domain::REAL>;
 
+    // TODO: This section defines a descriptor with flipped dimensions
+    // and output strides. oneMKL seems to insist on row-major
+    // computation while arrayfire is column major. Since the
+    // TRANSPOSE option on the oneMKL descriptor causes an immediate
+    // BAD_DESCRIPTOR error, we are forced to shuffle data like this.
+    // This ensures that this function is the inverse of fft_c2r.
     auto desc = [rank, &idims]() {
         if (rank == 1) return desc_ty(idims[0]);
-        if (rank == 2) return desc_ty({idims[0], idims[1]});
-        if (rank == 3) return desc_ty({idims[0], idims[1], idims[2]});
-        return desc_ty({idims[0], idims[1], idims[2], idims[3]});
+        if (rank == 2) return desc_ty({idims[1], idims[0]});
+        if (rank == 3) return desc_ty({idims[1], idims[0], idims[2]});
+        return desc_ty({idims[1], idims[0], idims[2], idims[3]});
     }();
     if (rank > 1) {
-        std::int64_t fft_input_strides[5];
-        fft_input_strides[0] = in.getOffset();
-        fft_input_strides[1] = istrides[0];
-        fft_input_strides[2] = istrides[1];
-        fft_input_strides[3] = istrides[2];
-        fft_input_strides[4] = istrides[3];
-        desc.set_value(::oneapi::mkl::dft::config_param::INPUT_STRIDES,
-                       fft_input_strides);
-
-        std::int64_t fft_output_strides[5];
-        fft_output_strides[0] = out.getOffset();
-        fft_output_strides[1] = ostrides[0];
-        fft_output_strides[2] = ostrides[1];
-        fft_output_strides[3] = ostrides[2];
-        fft_output_strides[4] = ostrides[3];
-        desc.set_value(::oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                       fft_output_strides);
+      std::int64_t fft_output_strides[5];
+      fft_output_strides[0] = 0;
+      fft_output_strides[1] = ostrides[1];
+      fft_output_strides[2] = ostrides[0];
+      fft_output_strides[3] = ostrides[2];
+      fft_output_strides[4] = ostrides[3];
+      desc.set_value(::oneapi::mkl::dft::config_param::OUTPUT_STRIDES, fft_output_strides);
     }
 
     desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT,
@@ -161,30 +157,26 @@ Array<Tr> fft_c2r(const Array<Tc> &in, const dim4 &odims, const int rank) {
         ::oneapi::mkl::dft::descriptor<precision,
                                        ::oneapi::mkl::dft::domain::REAL>;
 
+    // TODO: This section defines a descriptor with flipped dimensions
+    // and output strides. oneMKL seems to insist on row-major
+    // computation while arrayfire is column major. Since the
+    // TRANSPOSE option on the oneMKL descriptor causes an immediate
+    // BAD_DESCRIPTOR error, we are forced to shuffle data like this.
+    // This ensures that this function is the inverse of fft_r2c.
     auto desc = [rank, &odims]() {
         if (rank == 1) return desc_ty(odims[0]);
-        if (rank == 2) return desc_ty({odims[0], odims[1]});
-        if (rank == 3) return desc_ty({odims[0], odims[1], odims[2]});
-        return desc_ty({odims[0], odims[1], odims[2], odims[3]});
+        if (rank == 2) return desc_ty({odims[1], odims[0]});
+        if (rank == 3) return desc_ty({odims[1], odims[0], odims[2]});
+        return desc_ty({odims[1], odims[0], odims[2], odims[3]});
     }();
     if (rank > 1) {
-        std::int64_t fft_input_strides[5];
-        fft_input_strides[0] = in.getOffset();
-        fft_input_strides[1] = istrides[0];
-        fft_input_strides[2] = istrides[1];
-        fft_input_strides[3] = istrides[2];
-        fft_input_strides[4] = istrides[3];
-        desc.set_value(::oneapi::mkl::dft::config_param::INPUT_STRIDES,
-                       fft_input_strides);
-
-        std::int64_t fft_output_strides[5];
-        fft_output_strides[0] = out.getOffset();
-        fft_output_strides[1] = ostrides[0];
-        fft_output_strides[2] = ostrides[1];
-        fft_output_strides[3] = ostrides[2];
-        fft_output_strides[4] = ostrides[3];
-        desc.set_value(::oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                       fft_output_strides);
+      std::int64_t fft_input_strides[5];
+      fft_input_strides[0] = 0;
+      fft_input_strides[1] = istrides[1];
+      fft_input_strides[2] = istrides[0];
+      fft_input_strides[3] = istrides[2];
+      fft_input_strides[4] = istrides[3];
+      desc.set_value(::oneapi::mkl::dft::config_param::INPUT_STRIDES, fft_input_strides);
     }
 
     desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT,

--- a/src/backend/oneapi/fft.cpp
+++ b/src/backend/oneapi/fft.cpp
@@ -161,10 +161,6 @@ Array<Tr> fft_c2r(const Array<Tc> &in, const dim4 &odims, const int rank) {
         ::oneapi::mkl::dft::descriptor<precision,
                                        ::oneapi::mkl::dft::domain::REAL>;
 
-    // this section defines reversed dimension decl and input strides:
-    // onemkl is row-major and arrayfire it column major. since the
-    // TRANSPOSE option on the onemkl descriptor is broken, we're
-    // forced to shuffle data like this
     auto desc = [rank, &odims]() {
         if (rank == 1) return desc_ty(odims[0]);
         if (rank == 2) return desc_ty({odims[0], odims[1]});

--- a/src/backend/oneapi/fft.cpp
+++ b/src/backend/oneapi/fft.cpp
@@ -90,12 +90,25 @@ Array<Tc> fft_r2c(const Array<Tr> &in, const int rank) {
         ::oneapi::mkl::dft::descriptor<precision,
                                        ::oneapi::mkl::dft::domain::REAL>;
 
+    // this section defines reversed dimension decl and output
+    // strides: onemkl is row-major and arrayfire it column
+    // major. since the TRANSPOSE option on the onemkl descriptor is
+    // broken, we're forced to shuffle data like this
     auto desc = [rank, &idims]() {
         if (rank == 1) return desc_ty(idims[0]);
         if (rank == 2) return desc_ty({idims[1], idims[0]});
         if (rank == 3) return desc_ty({idims[2], idims[1], idims[0]});
         return desc_ty({idims[3], idims[2], idims[1], idims[0]});
     }();
+    if (rank > 1) {
+      std::int64_t fft_output_strides[5];
+      fft_output_strides[0] = 0;
+      fft_output_strides[1] = ostrides[1];
+      fft_output_strides[2] = ostrides[0];
+      fft_output_strides[3] = ostrides[2];
+      fft_output_strides[4] = ostrides[3];
+      desc.set_value(::oneapi::mkl::dft::config_param::OUTPUT_STRIDES, fft_output_strides);
+    }
 
     desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT,
                    DFTI_NOT_INPLACE);
@@ -109,12 +122,6 @@ Array<Tc> fft_r2c(const Array<Tr> &in, const int rank) {
                    ostrides[rank]);
     desc.set_value(::oneapi::mkl::dft::config_param::FWD_DISTANCE,
                    istrides[rank]);
-
-    const std::int64_t fft_output_strides[5] = {
-        0, ostrides[(rank == 2) ? 1 : 0], ostrides[(rank == 2) ? 0 : 1],
-        ostrides[2], ostrides[3]};
-    desc.set_value(::oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                   fft_output_strides, rank);
 
     desc.commit(getQueue());
     ::oneapi::mkl::dft::compute_forward(desc, *in.get(), *out.get());
@@ -137,12 +144,25 @@ Array<Tr> fft_c2r(const Array<Tc> &in, const dim4 &odims, const int rank) {
         ::oneapi::mkl::dft::descriptor<precision,
                                        ::oneapi::mkl::dft::domain::REAL>;
 
+    // this section defines reversed dimension decl and input strides:
+    // onemkl is row-major and arrayfire it column major. since the
+    // TRANSPOSE option on the onemkl descriptor is broken, we're
+    // forced to shuffle data like this
     auto desc = [rank, &odims]() {
         if (rank == 1) return desc_ty(odims[0]);
         if (rank == 2) return desc_ty({odims[1], odims[0]});
         if (rank == 3) return desc_ty({odims[2], odims[1], odims[0]});
         return desc_ty({odims[3], odims[2], odims[1], odims[0]});
     }();
+    if (rank > 1) {
+      std::int64_t fft_input_strides[5];
+      fft_input_strides[0] = 0;
+      fft_input_strides[1] = istrides[1];
+      fft_input_strides[2] = istrides[0];
+      fft_input_strides[3] = istrides[2];
+      fft_input_strides[4] = istrides[3];
+      desc.set_value(::oneapi::mkl::dft::config_param::INPUT_STRIDES, fft_input_strides);
+    }
 
     desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT,
                    DFTI_NOT_INPLACE);
@@ -156,12 +176,6 @@ Array<Tr> fft_c2r(const Array<Tc> &in, const dim4 &odims, const int rank) {
                    istrides[rank]);
     desc.set_value(::oneapi::mkl::dft::config_param::FWD_DISTANCE,
                    ostrides[rank]);
-
-    const std::int64_t fft_output_strides[5] = {
-        0, ostrides[(rank == 2) ? 1 : 0], ostrides[(rank == 2) ? 0 : 1],
-        ostrides[2], ostrides[3]};
-    desc.set_value(::oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
-                   fft_output_strides, rank);
 
     desc.commit(getQueue());
     ::oneapi::mkl::dft::compute_backward(desc, *in.get(), *out.get());

--- a/src/backend/oneapi/fft.cpp
+++ b/src/backend/oneapi/fft.cpp
@@ -101,10 +101,6 @@ Array<Tc> fft_r2c(const Array<Tr> &in, const int rank) {
         ::oneapi::mkl::dft::descriptor<precision,
                                        ::oneapi::mkl::dft::domain::REAL>;
 
-    // this section defines reversed dimension decl and output
-    // strides: onemkl is row-major and arrayfire it column
-    // major. since the TRANSPOSE option on the onemkl descriptor is
-    // broken, we're forced to shuffle data like this
     auto desc = [rank, &idims]() {
         if (rank == 1) return desc_ty(idims[0]);
         if (rank == 2) return desc_ty({idims[0], idims[1]});

--- a/src/backend/oneapi/fft.cpp
+++ b/src/backend/oneapi/fft.cpp
@@ -101,13 +101,14 @@ Array<Tc> fft_r2c(const Array<Tr> &in, const int rank) {
         return desc_ty({idims[3], idims[2], idims[1], idims[0]});
     }();
     if (rank > 1) {
-      std::int64_t fft_output_strides[5];
-      fft_output_strides[0] = 0;
-      fft_output_strides[1] = ostrides[1];
-      fft_output_strides[2] = ostrides[0];
-      fft_output_strides[3] = ostrides[2];
-      fft_output_strides[4] = ostrides[3];
-      desc.set_value(::oneapi::mkl::dft::config_param::OUTPUT_STRIDES, fft_output_strides);
+        std::int64_t fft_output_strides[5];
+        fft_output_strides[0] = 0;
+        fft_output_strides[1] = ostrides[1];
+        fft_output_strides[2] = ostrides[0];
+        fft_output_strides[3] = ostrides[2];
+        fft_output_strides[4] = ostrides[3];
+        desc.set_value(::oneapi::mkl::dft::config_param::OUTPUT_STRIDES,
+                       fft_output_strides);
     }
 
     desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT,
@@ -155,13 +156,14 @@ Array<Tr> fft_c2r(const Array<Tc> &in, const dim4 &odims, const int rank) {
         return desc_ty({odims[3], odims[2], odims[1], odims[0]});
     }();
     if (rank > 1) {
-      std::int64_t fft_input_strides[5];
-      fft_input_strides[0] = 0;
-      fft_input_strides[1] = istrides[1];
-      fft_input_strides[2] = istrides[0];
-      fft_input_strides[3] = istrides[2];
-      fft_input_strides[4] = istrides[3];
-      desc.set_value(::oneapi::mkl::dft::config_param::INPUT_STRIDES, fft_input_strides);
+        std::int64_t fft_input_strides[5];
+        fft_input_strides[0] = 0;
+        fft_input_strides[1] = istrides[1];
+        fft_input_strides[2] = istrides[0];
+        fft_input_strides[3] = istrides[2];
+        fft_input_strides[4] = istrides[3];
+        desc.set_value(::oneapi::mkl::dft::config_param::INPUT_STRIDES,
+                       fft_input_strides);
     }
 
     desc.set_value(::oneapi::mkl::dft::config_param::PLACEMENT,


### PR DESCRIPTION
Test `fft_real` passes (except for MKL unsupported 3D cases). Brought back transpose within `fft_r2c` and `fft_c2r`. In-place left alone. Updated comments.

This is an ugly, potentially slow solution, but the `fft_real` finally passes on what we expect it to pass. Missing TRANSPOSE has been reported and acknowledged wrt oneMKL.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
