### PR TITLE
Fix cuda_fp16 not finding vector_functions.h

### DIFF
--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -142,6 +142,7 @@ set(nvrtc_src
   ${CUDA_INCLUDE_DIRS}/cuda_fp16.hpp
   ${CUDA_TOOLKIT_ROOT_DIR}/include/cuComplex.h
   ${CUDA_TOOLKIT_ROOT_DIR}/include/math_constants.h
+  ${CUDA_TOOLKIT_ROOT_DIR}/include/vector_functions.h
 
   ${PROJECT_SOURCE_DIR}/src/api/c/optypes.hpp
   ${PROJECT_SOURCE_DIR}/include/af/defines.h

--- a/src/backend/cuda/compile_module.cpp
+++ b/src/backend/cuda/compile_module.cpp
@@ -202,7 +202,7 @@ Module compileModule(const string &moduleKey, span<const string> sources,
             "dims_param.hpp",
             "common/internal_enums.hpp",
             "minmax_op.hpp",
-            "vector_functions.h"
+            "vector_functions.h",
         };
 
         constexpr size_t numHeaders = extent<decltype(includeNames)>::value;

--- a/src/backend/cuda/compile_module.cpp
+++ b/src/backend/cuda/compile_module.cpp
@@ -39,6 +39,7 @@
 #include <nvrtc_kernel_headers/traits_hpp.hpp>
 #include <nvrtc_kernel_headers/types_hpp.hpp>
 #include <nvrtc_kernel_headers/utility_hpp.hpp>
+#include <nvrtc_kernel_headers/vector_functions_h.hpp>
 #include <nvrtc_kernel_headers/version_h.hpp>
 #include <optypes.hpp>
 #include <platform.hpp>
@@ -201,6 +202,7 @@ Module compileModule(const string &moduleKey, span<const string> sources,
             "dims_param.hpp",
             "common/internal_enums.hpp",
             "minmax_op.hpp",
+            "vector_functions.h"
         };
 
         constexpr size_t numHeaders = extent<decltype(includeNames)>::value;
@@ -234,6 +236,7 @@ Module compileModule(const string &moduleKey, span<const string> sources,
             string(dims_param_hpp, dims_param_hpp_len),
             string(internal_enums_hpp, internal_enums_hpp_len),
             string(minmax_op_hpp, minmax_op_hpp_len),
+            string(vector_functions_h, vector_functions_h_len),
         }};
 
         static const char *headers[] = {
@@ -251,7 +254,7 @@ Module compileModule(const string &moduleKey, span<const string> sources,
             sourceStrings[22].c_str(), sourceStrings[23].c_str(),
             sourceStrings[24].c_str(), sourceStrings[25].c_str(),
             sourceStrings[26].c_str(), sourceStrings[27].c_str(),
-            sourceStrings[28].c_str()};
+            sourceStrings[28].c_str(), sourceStrings[29].c_str()};
         static_assert(extent<decltype(headers)>::value == numHeaders,
                       "headers array contains fewer sources than includeNames");
         NVRTC_CHECK(nvrtcCreateProgram(&prog, sources[0].c_str(),


### PR DESCRIPTION

This PR addresses a runtime error with the fft benchmark using the cuda backend. 


Description
-----------

* Fixes nvrtc runtime error where cuda_fp16 cannot find vector_functions.h when running the fft benchmark with the cuda backend. 

Changes to Users
----------------
* FFT Benchmark now runs with the cuda backend. 

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
