### PR TITLE
adds fft plan caching

### DIFF
--- a/src/backend/oneapi/fft.hpp
+++ b/src/backend/oneapi/fft.hpp
@@ -6,6 +6,7 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#pragma once
 
 #include <Array.hpp>
 

--- a/src/backend/oneapi/onefft.hpp
+++ b/src/backend/oneapi/onefft.hpp
@@ -1,0 +1,39 @@
+/*******************************************************
+ * Copyright (c) 2016, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+#pragma once
+
+#include <common/FFTPlanCache.hpp>
+#include <memory.hpp>
+#include <oneapi/mkl/dfti.hpp>
+
+#include <cstdint>
+
+namespace arrayfire {
+namespace oneapi {
+
+using ::oneapi::mkl::dft::domain;
+using ::oneapi::mkl::dft::precision;
+
+using PlanType   = std::shared_ptr<void>;
+using SharedPlan = std::shared_ptr<PlanType>;
+
+template<precision p, domain d>
+PlanType findPlan(int rank, const bool isInPlace, int *n,
+                  std::int64_t *istrides, int ibatch, std::int64_t *ostrides,
+                  int obatch, int nbatch);
+
+class PlanCache : public common::FFTPlanCache<PlanCache, PlanType> {
+    template<precision p, domain d>
+    friend PlanType findPlan(int rank, const bool isInPlace, int *n,
+                             std::int64_t *istrides, int ibatch,
+                             std::int64_t *ostrides, int obatch, int nbatch);
+};
+
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/oneapi/platform.cpp
+++ b/src/backend/oneapi/platform.cpp
@@ -21,6 +21,7 @@
 #include <err_oneapi.hpp>
 #include <errorcodes.hpp>
 #include <memory.hpp>
+#include <onefft.hpp>
 #include <af/oneapi.h>
 #include <af/version.h>
 
@@ -633,6 +634,16 @@ GraphicsResourceManager& interopManager() {
 
     return *(inst.gfxManagers[id].get());
 }
+
+unique_ptr<PlanCache>& oneFFTManager(const int deviceId) {
+    thread_local unique_ptr<PlanCache> caches[DeviceManager::MAX_DEVICES];
+    thread_local once_flag initFlags[DeviceManager::MAX_DEVICES];
+    call_once(initFlags[deviceId],
+              [&] { caches[deviceId] = make_unique<PlanCache>(); });
+    return caches[deviceId];
+}
+
+PlanCache& fftManager() { return *oneFFTManager(getActiveDeviceId()); }
 
 }  // namespace oneapi
 }  // namespace arrayfire

--- a/src/backend/oneapi/platform.hpp
+++ b/src/backend/oneapi/platform.hpp
@@ -131,6 +131,8 @@ arrayfire::common::ForgeManager& forgeManager();
 
 GraphicsResourceManager& interopManager();
 
+PlanCache& fftManager();
+
 // afcl::platform getPlatformEnum(cl::Device dev);
 
 void setActiveContext(int device);


### PR DESCRIPTION
This PR adds fft plan caching to the oneapi backend.

Plan caching allows re-using descriptors resulting in better performance since the overhead of memory allocation and metadata preparation is avoided for repeated calls to the same configuration. The current implementation of oneMKL's fft descriptors do not allow copying, so the PlanCache currently uses shared_ptr to avoid moving the class. During the setup for the descriptor, the input and output strides were setup in a different order than oneMKL expected. This PR also corrects this mismatch. Different stride ordering has no significant impact on performance. 

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass