### PR TITLE
remove oneapi warnings

### DIFF
--- a/src/backend/oneapi/kernel/convolve_separable.cpp
+++ b/src/backend/oneapi/kernel/convolve_separable.cpp
@@ -163,8 +163,6 @@ void convSep(Param<T> out, const Param<T> signal, const Param<accType> filter,
     }
     constexpr int THREADS_X = 16;
     constexpr int THREADS_Y = 16;
-    constexpr bool IsComplex =
-        std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value;
 
     const int fLen       = filter.info.dims[0] * filter.info.dims[1];
     const size_t C0_SIZE = (THREADS_X + 2 * (fLen - 1)) * THREADS_Y;

--- a/src/backend/oneapi/kernel/convolve_separable.cpp
+++ b/src/backend/oneapi/kernel/convolve_separable.cpp
@@ -76,7 +76,6 @@ class convolveSeparableCreateKernel {
         if (CONV_DIM_ == 0) {
             gx += (EXPAND_ ? 0 : FLEN_ >> 1);
             int endX = ((FLEN_ - 1) << 1) + g.get_local_range(0);
-#pragma unroll
             for (int lx = it.get_local_id(0), glb_x = gx; lx < endX;
                  lx += g.get_local_range(0), glb_x += g.get_local_range(0)) {
                 int i     = glb_x - radius;
@@ -90,7 +89,6 @@ class convolveSeparableCreateKernel {
         } else if (CONV_DIM_ == 1) {
             gy += (EXPAND_ ? 0 : FLEN_ >> 1);
             int endY = ((FLEN_ - 1) << 1) + g.get_local_range(1);
-#pragma unroll
             for (int ly = it.get_local_id(1), glb_y = gy; ly < endY;
                  ly += g.get_local_range(1), glb_y += g.get_local_range(1)) {
                 int i     = gx;
@@ -108,7 +106,6 @@ class convolveSeparableCreateKernel {
             // kernel compilation
             int i         = (CONV_DIM_ == 0 ? lx : ly) + radius;
             accType accum = (accType)(0);
-#pragma unroll
             for (int f = 0; f < FLEN_; ++f) {
                 accType f_val = impulse_[f];
                 // below conditional statement is based on MACRO value passed

--- a/src/backend/oneapi/kernel/fftconvolve_multiply.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_multiply.hpp
@@ -38,8 +38,6 @@ class fftconvolve_multiplyCreateKernel {
         , nelem_(nelem)
         , kind_(kind) {}
     void operator()(sycl::nd_item<1> it) const {
-        sycl::group g = it.get_group();
-
         const int t = it.get_global_id(0);
 
         if (t >= nelem_) return;

--- a/src/backend/oneapi/kernel/fftconvolve_pack.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_pack.hpp
@@ -37,15 +37,13 @@ class fftconvolve_packCreateKernel {
         , di0_half_(di0_half)
         , odd_di0_(odd_di0) {}
     void operator()(sycl::nd_item<1> it) const {
-        sycl::group g = it.get_group();
-
         const int t = it.get_global_id(0);
 
         const int tMax = oInfo_.strides[3] * oInfo_.dims[3];
 
         if (t >= tMax) return;
 
-        const int do0 = oInfo_.dims[0];
+        //const int do0 = oInfo_.dims[0];
         const int do1 = oInfo_.dims[1];
         const int do2 = oInfo_.dims[2];
 
@@ -58,7 +56,7 @@ class fftconvolve_packCreateKernel {
         const int to2 = (t / so2) % do2;
         const int to3 = t / so3;
 
-        const int di0 = iInfo_.dims[0];
+        //const int di0 = iInfo_.dims[0];
         const int di1 = iInfo_.dims[1];
         const int di2 = iInfo_.dims[2];
 
@@ -109,8 +107,6 @@ void packDataHelper(Param<convT> packed, Param<T> sig, Param<T> filter,
     calcParamSizes(sig_tmp, filter_tmp, packed, sig, filter, rank, kind);
 
     int sig_packed_elem = sig_tmp.info.strides[3] * sig_tmp.info.dims[3];
-    int filter_packed_elem =
-        filter_tmp.info.strides[3] * filter_tmp.info.dims[3];
 
     // Number of packed complex elements in dimension 0
     int sig_half_d0     = divup(sig.info.dims[0], 2);

--- a/src/backend/oneapi/kernel/fftconvolve_pack.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_pack.hpp
@@ -43,7 +43,7 @@ class fftconvolve_packCreateKernel {
 
         if (t >= tMax) return;
 
-        //const int do0 = oInfo_.dims[0];
+        // const int do0 = oInfo_.dims[0];
         const int do1 = oInfo_.dims[1];
         const int do2 = oInfo_.dims[2];
 
@@ -56,7 +56,7 @@ class fftconvolve_packCreateKernel {
         const int to2 = (t / so2) % do2;
         const int to3 = t / so3;
 
-        //const int di0 = iInfo_.dims[0];
+        // const int di0 = iInfo_.dims[0];
         const int di1 = iInfo_.dims[1];
         const int di2 = iInfo_.dims[2];
 

--- a/src/backend/oneapi/kernel/fftconvolve_pad.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_pad.hpp
@@ -29,15 +29,13 @@ class fftconvolve_padCreateKernel {
                                 read_accessor<inputType> d_in, KParam iInfo)
         : d_out_(d_out), oInfo_(oInfo), d_in_(d_in), iInfo_(iInfo) {}
     void operator()(sycl::nd_item<1> it) const {
-        sycl::group g = it.get_group();
-
         const int t = it.get_global_id(0);
 
         const int tMax = oInfo_.strides[3] * oInfo_.dims[3];
 
         if (t >= tMax) return;
 
-        const int do0 = oInfo_.dims[0];
+        //const int do0 = oInfo_.dims[0];
         const int do1 = oInfo_.dims[1];
         const int do2 = oInfo_.dims[2];
 
@@ -92,13 +90,8 @@ void padDataHelper(Param<convT> packed, Param<T> sig, Param<T> filter,
     Param<T> sig_tmp, filter_tmp;
     calcParamSizes(sig_tmp, filter_tmp, packed, sig, filter, rank, kind);
 
-    int sig_packed_elem = sig_tmp.info.strides[3] * sig_tmp.info.dims[3];
     int filter_packed_elem =
         filter_tmp.info.strides[3] * filter_tmp.info.dims[3];
-
-    // Number of packed complex elements in dimension 0
-    int sig_half_d0     = divup(sig.info.dims[0], 2);
-    int sig_half_d0_odd = sig.info.dims[0] % 2;
 
     int blocks = divup(filter_packed_elem, THREADS);
 

--- a/src/backend/oneapi/kernel/fftconvolve_pad.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_pad.hpp
@@ -35,7 +35,7 @@ class fftconvolve_padCreateKernel {
 
         if (t >= tMax) return;
 
-        //const int do0 = oInfo_.dims[0];
+        // const int do0 = oInfo_.dims[0];
         const int do1 = oInfo_.dims[1];
         const int do2 = oInfo_.dims[2];
 

--- a/src/backend/oneapi/kernel/fftconvolve_reorder.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_reorder.hpp
@@ -48,7 +48,7 @@ class fftconvolve_reorderCreateKernel {
 
         if (t >= tMax) return;
 
-        //const int do0 = oInfo_.dims[0];
+        // const int do0 = oInfo_.dims[0];
         const int do1 = oInfo_.dims[1];
         const int do2 = oInfo_.dims[2];
 

--- a/src/backend/oneapi/kernel/fftconvolve_reorder.hpp
+++ b/src/backend/oneapi/kernel/fftconvolve_reorder.hpp
@@ -42,15 +42,13 @@ class fftconvolve_reorderCreateKernel {
         , EXPAND_(EXPAND)
         , ROUND_OUT_(ROUND_OUT) {}
     void operator()(sycl::nd_item<1> it) const {
-        sycl::group g = it.get_group();
-
         const int t = it.get_global_id(0);
 
         const int tMax = oInfo_.strides[3] * oInfo_.dims[3];
 
         if (t >= tMax) return;
 
-        const int do0 = oInfo_.dims[0];
+        //const int do0 = oInfo_.dims[0];
         const int do1 = oInfo_.dims[1];
         const int do2 = oInfo_.dims[2];
 
@@ -60,10 +58,6 @@ class fftconvolve_reorderCreateKernel {
 
         // Treating complex input array as real-only array,
         // thus, multiply dimension 0 and strides by 2
-        const int di0 = iInfo_.dims[0] * 2;
-        const int di1 = iInfo_.dims[1];
-        const int di2 = iInfo_.dims[2];
-
         const int si1 = iInfo_.strides[1] * 2;
         const int si2 = iInfo_.strides[2] * 2;
         const int si3 = iInfo_.strides[3] * 2;

--- a/src/backend/oneapi/kernel/mean.hpp
+++ b/src/backend/oneapi/kernel/mean.hpp
@@ -611,12 +611,8 @@ T mean_all_weighted(Param<T> in, Param<Tw> iwt) {
         compute_t<T> val;
         getQueue()
             .submit([&](sycl::handler &h) {
-                auto acc_in =
-                    tmpOut.get()
-                        ->template get_host_access(h);
-                auto acc_wt =
-                    tmpWt.get()
-                        ->template get_host_access(h);
+                auto acc_in = tmpOut.get()->template get_host_access(h);
+                auto acc_wt = tmpWt.get()->template get_host_access(h);
 
                 h.host_task([acc_in, acc_wt, tmp_elements, &val] {
                     val = static_cast<compute_t<T>>(acc_in[0]);
@@ -635,12 +631,10 @@ T mean_all_weighted(Param<T> in, Param<Tw> iwt) {
         compute_t<T> val;
         getQueue()
             .submit([&](sycl::handler &h) {
-                auto acc_in =
-                    in.data->template get_host_access(
-                        h, sycl::range{in_elements});
-                auto acc_wt =
-                    iwt.data->template get_host_access(
-                        h, sycl::range{in_elements});
+                auto acc_in = in.data->template get_host_access(
+                    h, sycl::range{in_elements});
+                auto acc_wt = iwt.data->template get_host_access(
+                    h, sycl::range{in_elements});
 
                 h.host_task([acc_in, acc_wt, in_elements, &val]() {
                     val                  = acc_in[0];
@@ -699,12 +693,8 @@ To mean_all(Param<Ti> in) {
         compute_t<To> val;
         getQueue()
             .submit([&](sycl::handler &h) {
-                auto out =
-                    tmpOut.get()
-                        ->template get_host_access(h);
-                auto ct =
-                    tmpCt.get()
-                        ->template get_host_access(h);
+                auto out = tmpOut.get()->template get_host_access(h);
+                auto ct  = tmpCt.get()->template get_host_access(h);
 
                 h.host_task([out, ct, tmp_elements, &val] {
                     val                  = static_cast<compute_t<To>>(out[0]);
@@ -722,8 +712,7 @@ To mean_all(Param<Ti> in) {
         compute_t<To> val;
         getQueue()
             .submit([&](sycl::handler &h) {
-                auto acc_in =
-                    in.data->template get_host_access(h);
+                auto acc_in = in.data->template get_host_access(h);
                 h.host_task([acc_in, in_elements, &val]() {
                     common::Transform<Ti, compute_t<To>, af_add_t> transform;
                     compute_t<Tw> count = static_cast<compute_t<Tw>>(1);

--- a/src/backend/oneapi/kernel/mean.hpp
+++ b/src/backend/oneapi/kernel/mean.hpp
@@ -1,3 +1,4 @@
+
 /*******************************************************
  * Copyright (c) 2022, ArrayFire
  * All rights reserved.
@@ -612,12 +613,10 @@ T mean_all_weighted(Param<T> in, Param<Tw> iwt) {
             .submit([&](sycl::handler &h) {
                 auto acc_in =
                     tmpOut.get()
-                        ->template get_access<sycl::access_mode::read,
-                                              sycl::target::host_buffer>(h);
+                        ->template get_host_access(h);
                 auto acc_wt =
                     tmpWt.get()
-                        ->template get_access<sycl::access_mode::read,
-                                              sycl::target::host_buffer>(h);
+                        ->template get_host_access(h);
 
                 h.host_task([acc_in, acc_wt, tmp_elements, &val] {
                     val = static_cast<compute_t<T>>(acc_in[0]);
@@ -637,11 +636,10 @@ T mean_all_weighted(Param<T> in, Param<Tw> iwt) {
         getQueue()
             .submit([&](sycl::handler &h) {
                 auto acc_in =
-                    in.data->template get_access<sycl::access_mode::read,
-                                                 sycl::target::host_buffer>(
+                    in.data->template get_host_access(
                         h, sycl::range{in_elements});
                 auto acc_wt =
-                    iwt.data->template get_access<sycl::access_mode::read>(
+                    iwt.data->template get_host_access(
                         h, sycl::range{in_elements});
 
                 h.host_task([acc_in, acc_wt, in_elements, &val]() {
@@ -703,12 +701,10 @@ To mean_all(Param<Ti> in) {
             .submit([&](sycl::handler &h) {
                 auto out =
                     tmpOut.get()
-                        ->template get_access<sycl::access_mode::read,
-                                              sycl::target::host_buffer>(h);
+                        ->template get_host_access(h);
                 auto ct =
                     tmpCt.get()
-                        ->template get_access<sycl::access_mode::read,
-                                              sycl::target::host_buffer>(h);
+                        ->template get_host_access(h);
 
                 h.host_task([out, ct, tmp_elements, &val] {
                     val                  = static_cast<compute_t<To>>(out[0]);
@@ -727,8 +723,7 @@ To mean_all(Param<Ti> in) {
         getQueue()
             .submit([&](sycl::handler &h) {
                 auto acc_in =
-                    in.data->template get_access<sycl::access_mode::read,
-                                                 sycl::target::host_buffer>(h);
+                    in.data->template get_host_access(h);
                 h.host_task([acc_in, in_elements, &val]() {
                     common::Transform<Ti, compute_t<To>, af_add_t> transform;
                     compute_t<Tw> count = static_cast<compute_t<Tw>>(1);

--- a/src/backend/oneapi/kernel/mean.hpp
+++ b/src/backend/oneapi/kernel/mean.hpp
@@ -611,8 +611,10 @@ T mean_all_weighted(Param<T> in, Param<Tw> iwt) {
         compute_t<T> val;
         getQueue()
             .submit([&](sycl::handler &h) {
-                auto acc_in = tmpOut.get()->template get_host_access(h);
-                auto acc_wt = tmpWt.get()->template get_host_access(h);
+                auto acc_in =
+                    tmpOut.get()->template get_host_access(h, sycl::read_only);
+                auto acc_wt =
+                    tmpWt.get()->template get_host_access(h, sycl::read_only);
 
                 h.host_task([acc_in, acc_wt, tmp_elements, &val] {
                     val = static_cast<compute_t<T>>(acc_in[0]);
@@ -632,9 +634,9 @@ T mean_all_weighted(Param<T> in, Param<Tw> iwt) {
         getQueue()
             .submit([&](sycl::handler &h) {
                 auto acc_in = in.data->template get_host_access(
-                    h, sycl::range{in_elements});
+                    h, sycl::range{in_elements}, sycl::read_only);
                 auto acc_wt = iwt.data->template get_host_access(
-                    h, sycl::range{in_elements});
+                    h, sycl::range{in_elements}, sycl::read_only);
 
                 h.host_task([acc_in, acc_wt, in_elements, &val]() {
                     val                  = acc_in[0];
@@ -693,8 +695,10 @@ To mean_all(Param<Ti> in) {
         compute_t<To> val;
         getQueue()
             .submit([&](sycl::handler &h) {
-                auto out = tmpOut.get()->template get_host_access(h);
-                auto ct  = tmpCt.get()->template get_host_access(h);
+                auto out =
+                    tmpOut.get()->template get_host_access(h, sycl::read_only);
+                auto ct =
+                    tmpCt.get()->template get_host_access(h, sycl::read_only);
 
                 h.host_task([out, ct, tmp_elements, &val] {
                     val                  = static_cast<compute_t<To>>(out[0]);
@@ -712,7 +716,8 @@ To mean_all(Param<Ti> in) {
         compute_t<To> val;
         getQueue()
             .submit([&](sycl::handler &h) {
-                auto acc_in = in.data->template get_host_access(h);
+                auto acc_in =
+                    in.data->template get_host_access(h, sycl::read_only);
                 h.host_task([acc_in, in_elements, &val]() {
                     common::Transform<Ti, compute_t<To>, af_add_t> transform;
                     compute_t<Tw> count = static_cast<compute_t<Tw>>(1);

--- a/src/backend/oneapi/kernel/reduce_by_key.hpp
+++ b/src/backend/oneapi/kernel/reduce_by_key.hpp
@@ -400,7 +400,7 @@ class reduceBlocksByKeyKernel {
         if (lid == 0) { l_reduced_block_size_[0] = 0; }
 
         // load keys and values to threads
-        Tk k = scalar<Tk>(0);
+        Tk k            = scalar<Tk>(0);
         compute_t<To> v = init_val;
         if (gid < n_) {
             k                 = iKeys_[gid];
@@ -576,7 +576,7 @@ class reduceBlocksByKeyDimKernel {
         it.barrier();
 
         // load keys and values to threads
-        Tk k = scalar<Tk>(0);
+        Tk k            = scalar<Tk>(0);
         compute_t<To> v = init_val;
         if (gid < n_) {
             k                 = iKeys_[gid];

--- a/src/backend/oneapi/kernel/reduce_by_key.hpp
+++ b/src/backend/oneapi/kernel/reduce_by_key.hpp
@@ -101,10 +101,6 @@ class finalBoundaryReduceDimKernel {
         const uint gid = it.get_global_id(0);
         const uint bid = g.get_group_id(0);
 
-        const int bidy = g.get_group_id(1);
-        const int bidz = g.get_group_id(2) % nGroupsZ_;
-        const int bidw = g.get_group_id(2) / nGroupsZ_;
-
         common::Binary<compute_t<To>, op> binOp;
         if (gid == ((bid + 1) * it.get_local_range(0)) - 1 &&
             bid < g.get_group_range(0) - 1) {
@@ -166,7 +162,7 @@ class testNeedsReductionKernel {
         const uint gid = it.get_global_id(0);
         const uint bid = g.get_group_id(0);
 
-        Tk k;
+        Tk k = scalar<Tk>(0);
         if (gid < n_) { k = iKeys_[gid]; }
 
         l_keys_[lid] = k;
@@ -233,9 +229,6 @@ class compactKernel {
         const int bidz = g.get_group_id(2) % nGroupsZ_;
         const int bidw = g.get_group_id(2) / nGroupsZ_;
 
-        Tk k;
-        To v;
-
         const int bOffset = bidw * oVInfo_.strides[3] +
                             bidz * oVInfo_.strides[2] +
                             bidy * oVInfo_.strides[1];
@@ -247,8 +240,8 @@ class compactKernel {
                 : (reduced_block_sizes_[bid] - reduced_block_sizes_[bid - 1]);
         int writeloc = (bid == 0) ? 0 : reduced_block_sizes_[bid - 1];
 
-        k = iKeys_[gid];
-        v = iVals_[bOffset + gid];
+        Tk k = iKeys_[gid];
+        To v = iVals_[bOffset + gid];
 
         if (lid < nwrite) {
             oKeys_[writeloc + lid]           = k;
@@ -407,8 +400,8 @@ class reduceBlocksByKeyKernel {
         if (lid == 0) { l_reduced_block_size_[0] = 0; }
 
         // load keys and values to threads
-        Tk k;
-        compute_t<To> v;
+        Tk k = scalar<Tk>(0);
+        compute_t<To> v = init_val;
         if (gid < n_) {
             k                 = iKeys_[gid];
             const int bOffset = bidw * iVInfo_.strides[3] +
@@ -416,8 +409,6 @@ class reduceBlocksByKeyKernel {
                                 bidy * iVInfo_.strides[1];
             v = transform(iVals_[bOffset + gid]);
             if (change_nan_) v = IS_NAN(v) ? nanval_ : v;
-        } else {
-            v = init_val;
         }
 
         l_keys_[lid] = k;
@@ -585,8 +576,8 @@ class reduceBlocksByKeyDimKernel {
         it.barrier();
 
         // load keys and values to threads
-        Tk k;
-        compute_t<To> v;
+        Tk k = scalar<Tk>(0);
+        compute_t<To> v = init_val;
         if (gid < n_) {
             k                 = iKeys_[gid];
             const int bOffset = bidw * iVInfo_.strides[dims_ordering[3]] +
@@ -594,8 +585,6 @@ class reduceBlocksByKeyDimKernel {
                                 bidy * iVInfo_.strides[dims_ordering[1]];
             v = transform(iVals_[bOffset + gid * iVInfo_.strides[DIM_]]);
             if (change_nan_) v = IS_NAN(v) ? nanval_ : v;
-        } else {
-            v = init_val;
         }
 
         l_keys_[lid] = k;

--- a/src/backend/oneapi/kernel/sort_by_key_impl.hpp
+++ b/src/backend/oneapi/kernel/sort_by_key_impl.hpp
@@ -8,6 +8,13 @@
  ********************************************************/
 #pragma once
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+// temporary ignores for DPL internals
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 // oneDPL headers should be included before standard headers
 #define ONEDPL_USE_PREDEFINED_POLICIES 0
 #include <oneapi/dpl/algorithm>
@@ -206,3 +213,8 @@ void sort0ByKey(Param<Tk> pKey, Param<Tv> pVal, bool isAscending) {
 }  // namespace kernel
 }  // namespace oneapi
 }  // namespace arrayfire
+
+#if defined(__clang__)
+/* Clang/LLVM */
+#pragma clang diagnostic pop
+#endif

--- a/src/backend/oneapi/reduce_impl.hpp
+++ b/src/backend/oneapi/reduce_impl.hpp
@@ -8,6 +8,13 @@
  ********************************************************/
 #pragma once
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+// temporary ignores for DPL internals
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 // oneDPL headers should be included before standard headers
 #define ONEDPL_USE_PREDEFINED_POLICIES 0
 #include <oneapi/dpl/execution>
@@ -614,3 +621,8 @@ Array<To> reduce_all(const Array<Ti> &in, bool change_nan, double nanval) {
         const Array<Ti> &vals, const int dim, bool change_nan, double nanval); \
     template Array<To> reduce_all<Op, Ti, To>(const Array<Ti> &in,             \
                                               bool change_nan, double nanval);
+
+#if defined(__clang__)
+/* Clang/LLVM */
+#pragma clang diagnostic pop
+#endif

--- a/src/backend/oneapi/sort.cpp
+++ b/src/backend/oneapi/sort.cpp
@@ -7,6 +7,13 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+// temporary ignores for DPL internals
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <kernel/sort.hpp>
 
 #include <Array.hpp>
@@ -64,3 +71,8 @@ INSTANTIATE(uintl)
 
 }  // namespace oneapi
 }  // namespace arrayfire
+
+#if defined(__clang__)
+/* Clang/LLVM */
+#pragma clang diagnostic pop
+#endif


### PR DESCRIPTION
Removes oneapi warnings

This PR removes several warnings from the oneapi backend, including  fftconvolve, mean, reduce by key, and convolve_seperable. Temporary suppression of warning from oneDPL internals is also enabled until those are fixed and released upstream.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass