### PR TITLE
Fix missing try/catch in C API layers

### DIFF
--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -277,87 +277,101 @@ static af_err af_arith_sparse_dense(af_array *out, const af_array lhs,
 
 af_err af_add(af_array *out, const af_array lhs, const af_array rhs,
               const bool batchMode) {
-    // Check if inputs are sparse
-    const ArrayInfo &linfo = getInfo(lhs, false, true);
-    const ArrayInfo &rinfo = getInfo(rhs, false, true);
+    try {
+        // Check if inputs are sparse
+        const ArrayInfo &linfo = getInfo(lhs, false, true);
+        const ArrayInfo &rinfo = getInfo(rhs, false, true);
 
-    if (linfo.isSparse() && rinfo.isSparse()) {
-        return af_arith_sparse<af_add_t>(out, lhs, rhs);
+        if (linfo.isSparse() && rinfo.isSparse()) {
+            return af_arith_sparse<af_add_t>(out, lhs, rhs);
+        }
+        if (linfo.isSparse() && !rinfo.isSparse()) {
+            return af_arith_sparse_dense<af_add_t>(out, lhs, rhs);
+        }
+        if (!linfo.isSparse() && rinfo.isSparse()) {
+            // second operand(Array) of af_arith call should be dense
+            return af_arith_sparse_dense<af_add_t>(out, rhs, lhs, true);
+        }
+        return af_arith<af_add_t>(out, lhs, rhs, batchMode);
     }
-    if (linfo.isSparse() && !rinfo.isSparse()) {
-        return af_arith_sparse_dense<af_add_t>(out, lhs, rhs);
-    }
-    if (!linfo.isSparse() && rinfo.isSparse()) {
-        // second operand(Array) of af_arith call should be dense
-        return af_arith_sparse_dense<af_add_t>(out, rhs, lhs, true);
-    }
-    return af_arith<af_add_t>(out, lhs, rhs, batchMode);
+    CATCHALL;
 }
 
 af_err af_mul(af_array *out, const af_array lhs, const af_array rhs,
               const bool batchMode) {
-    // Check if inputs are sparse
-    const ArrayInfo &linfo = getInfo(lhs, false, true);
-    const ArrayInfo &rinfo = getInfo(rhs, false, true);
+    try {
+        // Check if inputs are sparse
+        const ArrayInfo &linfo = getInfo(lhs, false, true);
+        const ArrayInfo &rinfo = getInfo(rhs, false, true);
 
-    if (linfo.isSparse() && rinfo.isSparse()) {
-        // return af_arith_sparse<af_mul_t>(out, lhs, rhs);
-        // MKL doesn't have mul or div support yet, hence
-        // this is commented out although alternative cpu code exists
-        return AF_ERR_NOT_SUPPORTED;
+        if (linfo.isSparse() && rinfo.isSparse()) {
+            // return af_arith_sparse<af_mul_t>(out, lhs, rhs);
+            // MKL doesn't have mul or div support yet, hence
+            // this is commented out although alternative cpu code exists
+            return AF_ERR_NOT_SUPPORTED;
+        }
+        if (linfo.isSparse() && !rinfo.isSparse()) {
+            return af_arith_sparse_dense<af_mul_t>(out, lhs, rhs);
+        }
+        if (!linfo.isSparse() && rinfo.isSparse()) {
+            return af_arith_sparse_dense<af_mul_t>(
+                out, rhs, lhs,
+                true);  // dense should be rhs
+        }
+        return af_arith<af_mul_t>(out, lhs, rhs, batchMode);
     }
-    if (linfo.isSparse() && !rinfo.isSparse()) {
-        return af_arith_sparse_dense<af_mul_t>(out, lhs, rhs);
-    }
-    if (!linfo.isSparse() && rinfo.isSparse()) {
-        return af_arith_sparse_dense<af_mul_t>(out, rhs, lhs,
-                                               true);  // dense should be rhs
-    }
-    return af_arith<af_mul_t>(out, lhs, rhs, batchMode);
+    CATCHALL;
 }
 
 af_err af_sub(af_array *out, const af_array lhs, const af_array rhs,
               const bool batchMode) {
-    // Check if inputs are sparse
-    const ArrayInfo &linfo = getInfo(lhs, false, true);
-    const ArrayInfo &rinfo = getInfo(rhs, false, true);
+    try {
+        // Check if inputs are sparse
+        const ArrayInfo &linfo = getInfo(lhs, false, true);
+        const ArrayInfo &rinfo = getInfo(rhs, false, true);
 
-    if (linfo.isSparse() && rinfo.isSparse()) {
-        return af_arith_sparse<af_sub_t>(out, lhs, rhs);
+        if (linfo.isSparse() && rinfo.isSparse()) {
+            return af_arith_sparse<af_sub_t>(out, lhs, rhs);
+        }
+        if (linfo.isSparse() && !rinfo.isSparse()) {
+            return af_arith_sparse_dense<af_sub_t>(out, lhs, rhs);
+        }
+        if (!linfo.isSparse() && rinfo.isSparse()) {
+            return af_arith_sparse_dense<af_sub_t>(
+                out, rhs, lhs,
+                true);  // dense should be rhs
+        }
+        return af_arith<af_sub_t>(out, lhs, rhs, batchMode);
     }
-    if (linfo.isSparse() && !rinfo.isSparse()) {
-        return af_arith_sparse_dense<af_sub_t>(out, lhs, rhs);
-    }
-    if (!linfo.isSparse() && rinfo.isSparse()) {
-        return af_arith_sparse_dense<af_sub_t>(out, rhs, lhs,
-                                               true);  // dense should be rhs
-    }
-    return af_arith<af_sub_t>(out, lhs, rhs, batchMode);
+    CATCHALL;
 }
 
 af_err af_div(af_array *out, const af_array lhs, const af_array rhs,
               const bool batchMode) {
-    // Check if inputs are sparse
-    const ArrayInfo &linfo = getInfo(lhs, false, true);
-    const ArrayInfo &rinfo = getInfo(rhs, false, true);
+    try {
+        // Check if inputs are sparse
+        const ArrayInfo &linfo = getInfo(lhs, false, true);
+        const ArrayInfo &rinfo = getInfo(rhs, false, true);
 
-    if (linfo.isSparse() && rinfo.isSparse()) {
-        // return af_arith_sparse<af_div_t>(out, lhs, rhs);
-        // MKL doesn't have mul or div support yet, hence
-        // this is commented out although alternative cpu code exists
-        return AF_ERR_NOT_SUPPORTED;
+        if (linfo.isSparse() && rinfo.isSparse()) {
+            // return af_arith_sparse<af_div_t>(out, lhs, rhs);
+            // MKL doesn't have mul or div support yet, hence
+            // this is commented out although alternative cpu code exists
+            return AF_ERR_NOT_SUPPORTED;
+        }
+        if (linfo.isSparse() && !rinfo.isSparse()) {
+            return af_arith_sparse_dense<af_div_t>(out, lhs, rhs);
+        }
+        if (!linfo.isSparse() && rinfo.isSparse()) {
+            // Division by sparse is currently not allowed - for convinence of
+            // dealing with division by 0
+            // return af_arith_sparse_dense<af_div_t>(out, rhs, lhs, true); //
+            // dense should be rhs
+            return AF_ERR_NOT_SUPPORTED;
+        }
+        return af_arith<af_div_t>(out, lhs, rhs, batchMode);
     }
-    if (linfo.isSparse() && !rinfo.isSparse()) {
-        return af_arith_sparse_dense<af_div_t>(out, lhs, rhs);
-    }
-    if (!linfo.isSparse() && rinfo.isSparse()) {
-        // Division by sparse is currently not allowed - for convinence of
-        // dealing with division by 0
-        // return af_arith_sparse_dense<af_div_t>(out, rhs, lhs, true); // dense
-        // should be rhs
-        return AF_ERR_NOT_SUPPORTED;
-    }
-    return af_arith<af_div_t>(out, lhs, rhs, batchMode);
+    CATCHALL;
 }
 
 af_err af_maxof(af_array *out, const af_array lhs, const af_array rhs,

--- a/src/api/c/fftconvolve.cpp
+++ b/src/api/c/fftconvolve.cpp
@@ -239,18 +239,24 @@ af_err af_fft_convolve1(af_array *out, const af_array signal,
 
 af_err af_fft_convolve2(af_array *out, const af_array signal,
                         const af_array filter, const af_conv_mode mode) {
-    if (getInfo(signal).dims().ndims() < 2 &&
-        getInfo(filter).dims().ndims() < 2) {
-        return fft_convolve(out, signal, filter, mode == AF_CONV_EXPAND, 1);
+    try {
+        if (getInfo(signal).dims().ndims() < 2 &&
+            getInfo(filter).dims().ndims() < 2) {
+            return fft_convolve(out, signal, filter, mode == AF_CONV_EXPAND, 1);
+        }
+        return fft_convolve(out, signal, filter, mode == AF_CONV_EXPAND, 2);
     }
-    return fft_convolve(out, signal, filter, mode == AF_CONV_EXPAND, 2);
+    CATCHALL;
 }
 
 af_err af_fft_convolve3(af_array *out, const af_array signal,
                         const af_array filter, const af_conv_mode mode) {
-    if (getInfo(signal).dims().ndims() < 3 &&
-        getInfo(filter).dims().ndims() < 3) {
-        return fft_convolve(out, signal, filter, mode == AF_CONV_EXPAND, 2);
+    try {
+        if (getInfo(signal).dims().ndims() < 3 &&
+            getInfo(filter).dims().ndims() < 3) {
+            return fft_convolve(out, signal, filter, mode == AF_CONV_EXPAND, 2);
+        }
+        return fft_convolve(out, signal, filter, mode == AF_CONV_EXPAND, 3);
     }
-    return fft_convolve(out, signal, filter, mode == AF_CONV_EXPAND, 3);
+    CATCHALL;
 }

--- a/src/api/c/plot.cpp
+++ b/src/api/c/plot.cpp
@@ -385,40 +385,52 @@ af_err af_draw_plot3(const af_window wind, const af_array P,
 af_err af_draw_scatter_nd(const af_window wind, const af_array in,
                           const af_marker_type af_marker,
                           const af_cell* const props) {
-    fg_marker_type fg_marker = getFGMarker(af_marker);
-    return plotWrapper(wind, in, 1, props, FG_PLOT_SCATTER, fg_marker);
+    try {
+        fg_marker_type fg_marker = getFGMarker(af_marker);
+        return plotWrapper(wind, in, 1, props, FG_PLOT_SCATTER, fg_marker);
+    }
+    CATCHALL;
 }
 
 af_err af_draw_scatter_2d(const af_window wind, const af_array X,
                           const af_array Y, const af_marker_type af_marker,
                           const af_cell* const props) {
-    fg_marker_type fg_marker = getFGMarker(af_marker);
-    return plotWrapper(wind, X, Y, props, FG_PLOT_SCATTER, fg_marker);
+    try {
+        fg_marker_type fg_marker = getFGMarker(af_marker);
+        return plotWrapper(wind, X, Y, props, FG_PLOT_SCATTER, fg_marker);
+    }
+    CATCHALL;
 }
 
 af_err af_draw_scatter_3d(const af_window wind, const af_array X,
                           const af_array Y, const af_array Z,
                           const af_marker_type af_marker,
                           const af_cell* const props) {
-    fg_marker_type fg_marker = getFGMarker(af_marker);
-    return plotWrapper(wind, X, Y, Z, props, FG_PLOT_SCATTER, fg_marker);
+    try {
+        fg_marker_type fg_marker = getFGMarker(af_marker);
+        return plotWrapper(wind, X, Y, Z, props, FG_PLOT_SCATTER, fg_marker);
+    }
+    CATCHALL;
 }
 
 // Deprecated Scatter API
 af_err af_draw_scatter(const af_window wind, const af_array X, const af_array Y,
                        const af_marker_type af_marker,
                        const af_cell* const props) {
-    fg_marker_type fg_marker = getFGMarker(af_marker);
-    return plotWrapper(wind, X, Y, props, FG_PLOT_SCATTER, fg_marker);
+    try {
+        fg_marker_type fg_marker = getFGMarker(af_marker);
+        return plotWrapper(wind, X, Y, props, FG_PLOT_SCATTER, fg_marker);
+    }
+    CATCHALL;
 }
 
 af_err af_draw_scatter3(const af_window wind, const af_array P,
                         const af_marker_type af_marker,
                         const af_cell* const props) {
-    fg_marker_type fg_marker = getFGMarker(af_marker);
     try {
-        const ArrayInfo& info = getInfo(P);
-        af::dim4 dims         = info.dims();
+        fg_marker_type fg_marker = getFGMarker(af_marker);
+        const ArrayInfo& info    = getInfo(P);
+        af::dim4 dims            = info.dims();
 
         if (dims.ndims() == 2 && dims[1] == 3) {
             return plotWrapper(wind, P, 1, props, FG_PLOT_SCATTER, fg_marker);

--- a/src/api/c/type_util.cpp
+++ b/src/api/c/type_util.cpp
@@ -38,6 +38,9 @@ size_t size_of(af_dtype type) {
 }
 
 af_err af_get_size_of(size_t *size, af_dtype type) {
-    *size = size_of(type);
-    return AF_SUCCESS;
+    try {
+        *size = size_of(type);
+        return AF_SUCCESS;
+    }
+    CATCHALL;
 }


### PR DESCRIPTION
Fix missing try/catch's in the C API layer that allowed exceptions to cross the C API interface

Description
-----------
N/A

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
