### PR TITLE
enable half for convolve strided in oneapi backend

### DIFF
--- a/src/backend/oneapi/blas.hpp
+++ b/src/backend/oneapi/blas.hpp
@@ -9,6 +9,7 @@
 
 #pragma once
 #include <Array.hpp>
+#include <math.hpp>
 
 // This file contains the common interface for OneAPI BLAS
 // functions
@@ -30,8 +31,8 @@ Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs, af_mat_prop optLhs,
     int Ndim     = optRhs == AF_MAT_NONE ? 1 : 0;
     Array<T> res = createEmptyArray<T>(
         dim4(lhs.dims()[Mdim], rhs.dims()[Ndim], lhs.dims()[2], lhs.dims()[3]));
-    static constexpr T alpha = 1.0;
-    static constexpr T beta  = 0.0;
+    static const T alpha = scalar<T>(1.0);
+    static const T beta  = scalar<T>(0.0);
     gemm(res, optLhs, optRhs, &alpha, lhs, rhs, &beta);
     return res;
 }

--- a/src/backend/oneapi/convolve.cpp
+++ b/src/backend/oneapi/convolve.cpp
@@ -149,15 +149,9 @@ Array<T> convolve2_unwrap(const Array<T> &signal, const Array<T> &filter,
 template<typename T>
 Array<T> convolve2(Array<T> const &signal, Array<T> const &filter,
                    const dim4 stride, const dim4 padding, const dim4 dilation) {
-    if constexpr (!std::is_same<T, half>::value) {
-        Array<T> out =
-            convolve2_unwrap<T>(signal, filter, stride, padding, dilation);
-        return out;
-    } else {
-        ONEAPI_NOT_SUPPORTED("");
-        Array<T> out = createEmptyArray<T>(dim4(1));
-        return out;
-    }
+    Array<T> out =
+        convolve2_unwrap<T>(signal, filter, stride, padding, dilation);
+    return out;
 }
 
 #define INSTANTIATE(T)                                                        \
@@ -177,39 +171,33 @@ Array<T> conv2DataGradient(const Array<T> &incoming_gradient,
                            const Array<T> & /*convolved_output*/,
                            af::dim4 stride, af::dim4 padding,
                            af::dim4 dilation) {
-    if constexpr (!std::is_same<T, half>::value) {
-        const dim4 &cDims = incoming_gradient.dims();
-        const dim4 &sDims = original_signal.dims();
-        const dim4 &fDims = original_filter.dims();
+    const dim4 &cDims = incoming_gradient.dims();
+    const dim4 &sDims = original_signal.dims();
+    const dim4 &fDims = original_filter.dims();
 
-        Array<T> collapsed_filter = original_filter;
+    Array<T> collapsed_filter = original_filter;
 
-        collapsed_filter = flip(collapsed_filter, {1, 1, 0, 0});
-        collapsed_filter = modDims(
-            collapsed_filter, dim4(fDims[0] * fDims[1] * fDims[2], fDims[3]));
+    collapsed_filter = flip(collapsed_filter, {1, 1, 0, 0});
+    collapsed_filter = modDims(collapsed_filter,
+                               dim4(fDims[0] * fDims[1] * fDims[2], fDims[3]));
 
-        Array<T> collapsed_gradient = incoming_gradient;
-        collapsed_gradient = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
-        collapsed_gradient = modDims(
-            collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
+    Array<T> collapsed_gradient = incoming_gradient;
+    collapsed_gradient          = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
+    collapsed_gradient          = modDims(
+        collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
 
-        Array<T> res = matmul(collapsed_gradient, collapsed_filter, AF_MAT_NONE,
-                              AF_MAT_TRANS);
-        res          = modDims(res, dim4(res.dims()[0] / sDims[3], sDims[3],
-                                         fDims[0] * fDims[1], sDims[2]));
-        res          = reorder(res, dim4(0, 2, 3, 1));
+    Array<T> res =
+        matmul(collapsed_gradient, collapsed_filter, AF_MAT_NONE, AF_MAT_TRANS);
+    res = modDims(res, dim4(res.dims()[0] / sDims[3], sDims[3],
+                            fDims[0] * fDims[1], sDims[2]));
+    res = reorder(res, dim4(0, 2, 3, 1));
 
-        const bool retCols = false;
-        res = wrap_dilated(res, sDims[0], sDims[1], fDims[0], fDims[1],
-                           stride[0], stride[1], padding[0], padding[1],
-                           dilation[0], dilation[1], retCols);
+    const bool retCols = false;
+    res = wrap_dilated(res, sDims[0], sDims[1], fDims[0], fDims[1], stride[0],
+                       stride[1], padding[0], padding[1], dilation[0],
+                       dilation[1], retCols);
 
-        return res;
-    } else {
-        ONEAPI_NOT_SUPPORTED("");
-        Array<T> out = createEmptyArray<T>(dim4(1));
-        return out;
-    }
+    return res;
 }
 
 template<typename T>
@@ -219,36 +207,30 @@ Array<T> conv2FilterGradient(const Array<T> &incoming_gradient,
                              const Array<T> & /*convolved_output*/,
                              af::dim4 stride, af::dim4 padding,
                              af::dim4 dilation) {
-    if constexpr (!std::is_same<T, half>::value) {
-        const dim4 &cDims = incoming_gradient.dims();
-        const dim4 &fDims = original_filter.dims();
+    const dim4 &cDims = incoming_gradient.dims();
+    const dim4 &fDims = original_filter.dims();
 
-        const bool retCols = false;
-        Array<T> unwrapped =
-            unwrap(original_signal, fDims[0], fDims[1], stride[0], stride[1],
-                   padding[0], padding[1], dilation[0], dilation[1], retCols);
+    const bool retCols = false;
+    Array<T> unwrapped =
+        unwrap(original_signal, fDims[0], fDims[1], stride[0], stride[1],
+               padding[0], padding[1], dilation[0], dilation[1], retCols);
 
-        unwrapped  = reorder(unwrapped, dim4(1, 2, 0, 3));
-        dim4 uDims = unwrapped.dims();
-        unwrapped =
-            modDims(unwrapped, dim4(uDims[0] * uDims[1], uDims[2] * uDims[3]));
+    unwrapped  = reorder(unwrapped, dim4(1, 2, 0, 3));
+    dim4 uDims = unwrapped.dims();
+    unwrapped =
+        modDims(unwrapped, dim4(uDims[0] * uDims[1], uDims[2] * uDims[3]));
 
-        Array<T> collapsed_gradient = incoming_gradient;
-        collapsed_gradient = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
-        collapsed_gradient = modDims(
-            collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
+    Array<T> collapsed_gradient = incoming_gradient;
+    collapsed_gradient          = reorder(collapsed_gradient, dim4(0, 1, 3, 2));
+    collapsed_gradient          = modDims(
+        collapsed_gradient, dim4(cDims[0] * cDims[1] * cDims[3], cDims[2]));
 
-        Array<T> res =
-            matmul(unwrapped, collapsed_gradient, AF_MAT_NONE, AF_MAT_NONE);
-        res = modDims(res, dim4(fDims[0], fDims[1], fDims[2], fDims[3]));
+    Array<T> res =
+        matmul(unwrapped, collapsed_gradient, AF_MAT_NONE, AF_MAT_NONE);
+    res = modDims(res, dim4(fDims[0], fDims[1], fDims[2], fDims[3]));
 
-        auto out = flip(res, {1, 1, 0, 0});
-        return out;
-    } else {
-        ONEAPI_NOT_SUPPORTED("");
-        Array<T> out = createEmptyArray<T>(dim4(1));
-        return out;
-    }
+    auto out = flip(res, {1, 1, 0, 0});
+    return out;
 }
 
 #define INSTANTIATE(T)                                                      \


### PR DESCRIPTION
Enable half types for convolve strided in oneapi backend.

This PR enables half data types for strided convolutions. This was previously disabled since handling half types in gemm was still under development.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass