### PR TITLE
correct -infinity for half datatype in oneapi

### DIFF
--- a/src/backend/oneapi/math.hpp
+++ b/src/backend/oneapi/math.hpp
@@ -156,8 +156,8 @@ inline double minval() {
     return -std::numeric_limits<double>::infinity();
 }
 template<>
-inline arrayfire::common::half minval() {
-    return -std::numeric_limits<arrayfire::common::half>::infinity();
+inline sycl::half minval() {
+    return -1 * std::numeric_limits<sycl::half>::infinity();
 }
 
 template<typename T>


### PR DESCRIPTION
corrects -infinity for half datatype in oneapi

Using common::half::infinity would result in a -uint16 cast to sycl::half instead of -1 * sycl::infinity(). This would cause failures in 
ireduce(and potenitally others that rely on binaryOp<min/max>::init().

* Is this a new feature or a bug fix?
bug fix
Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass