### PR TITLE
Improve memory manager heuristics for JIT memory pressure

### DIFF
--- a/src/backend/oneapi/jit.cpp
+++ b/src/backend/oneapi/jit.cpp
@@ -14,6 +14,7 @@
 #include <kernel_headers/jit.hpp>
 
 #include <Array.hpp>
+#include <Kernel.hpp>
 #include <common/dispatch.hpp>
 #include <common/half.hpp>
 #include <common/jit/ModdimNode.hpp>
@@ -591,6 +592,19 @@ void evalNodes(vector<Param<T>>& outputs, const vector<Node*>& output_nodes) {
                                   (size_t)ap[0].dims[2]};
                         ndims  = 3;
                     }
+
+                    {
+                        using namespace oneapi::kernel_logger;
+                        AF_TRACE(
+                            "Launching {}: Dims: [{},{},{},{}] Global: "
+                            "[{},{},{}] threads: {}",
+                            funcName, ap[0].dims[0], ap[0].dims[1],
+                            ap[0].dims[2], ap[0].dims[3], global[0], global[1],
+                            global[2],
+                            global[0] * std::max<size_t>(1, global[1]) *
+                                std::max<size_t>(1, global[2]));
+                    }
+
                     cl_event kernel_event;
                     CL_CHECK(clEnqueueNDRangeKernel(
                         q, kernel, ndims, offset.data(), global.data(), nullptr,

--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -9,6 +9,7 @@
 
 #include <Array.hpp>
 
+#include <common/Logger.hpp>
 #include <common/half.hpp>
 #include <common/jit/NodeIterator.hpp>
 #include <common/jit/ScalarNode.hpp>
@@ -301,8 +302,13 @@ Node_ptr Array<T>::getNode() const {
 template<typename T>
 kJITHeuristics passesJitHeuristics(span<Node *> root_nodes) {
     if (!evalFlag()) { return kJITHeuristics::Pass; }
+    static auto getLogger = [&] { return common::loggerFactory("jit"); };
     for (const Node *n : root_nodes) {
         if (n->getHeight() > static_cast<int>(getMaxJitSize())) {
+            AF_TRACE(
+                "JIT tree evaluated because of tree height exceeds limit: {} > "
+                "{}",
+                n->getHeight(), getMaxJitSize());
             return kJITHeuristics::TreeHeight;
         }
     }
@@ -377,8 +383,17 @@ kJITHeuristics passesJitHeuristics(span<Node *> root_nodes) {
 
         bool isParamLimit = param_size >= max_param_size;
 
-        if (isParamLimit) { return kJITHeuristics::KernelParameterSize; }
-        if (isBufferLimit) { return kJITHeuristics::MemoryPressure; }
+        if (isParamLimit) {
+            AF_TRACE(
+                "JIT tree evaluated because of kernel parameter size: {} >= {}",
+                param_size, max_param_size);
+            return kJITHeuristics::KernelParameterSize;
+        }
+        if (isBufferLimit) {
+            AF_TRACE("JIT tree evaluated because of memory pressure: {}",
+                     info.total_buffer_size);
+            return kJITHeuristics::MemoryPressure;
+        }
     }
     return kJITHeuristics::Pass;
 }


### PR DESCRIPTION
Update JIT heuristics for memory pressure to determine when the JIT tree should be evaluated

Description
-----------
* Improved logging when JIT nodes are evaluated

Changes to Users
----------------
* Improved performance when most of the operations are JIT operations

Checklist
---------
<!-- Check if done or not applicable -->
- [ ] Rebased on latest master
- [ ] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
