### PR TITLE
oneapi sparse

### DIFF
--- a/src/backend/common/Binary.hpp
+++ b/src/backend/common/Binary.hpp
@@ -41,10 +41,24 @@ struct Binary<T, af_add_t> {
 };
 
 template<typename T>
+struct Binary<T, af_sub_t> {
+    static __DH__ T init() { return scalar<T>(0); }
+
+    __DH__ T operator()(T lhs, T rhs) { return lhs - rhs; }
+};
+
+template<typename T>
 struct Binary<T, af_mul_t> {
     static __DH__ T init() { return scalar<T>(1); }
 
     __DH__ T operator()(T lhs, T rhs) { return lhs * rhs; }
+};
+
+template<typename T>
+struct Binary<T, af_div_t> {
+    static __DH__ T init() { return scalar<T>(1); }
+
+    __DH__ T operator()(T lhs, T rhs) { return lhs / rhs; }
 };
 
 template<typename T>

--- a/src/backend/cpu/kernel/sparse.hpp
+++ b/src/backend/cpu/kernel/sparse.hpp
@@ -42,6 +42,22 @@ void coo2dense(Param<T> output, CParam<T> values, CParam<int> rowIdx,
     }
 }
 
+  template <typename T>
+  void printArray(const char *name, const unsigned N, const T *thing) {
+      printf("%s:\n", name);
+      for (int i = 0; i < N; i++)
+        printf("%f, ", thing[i]);
+      printf("\n\n");
+  }
+
+  template <>
+  void printArray(const char *name, const unsigned N, const int *thing) {
+      printf("%s:\n", name);
+      for (int i = 0; i < N; i++)
+        printf("%d, ", thing[i]);
+      printf("\n\n");
+  }
+
 template<typename T>
 void dense2csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
                CParam<T> in) {
@@ -64,6 +80,10 @@ void dense2csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
         }
     }
     rPtr[dims[0]] = offset;
+
+    printArray("rPtr", values.dims()[0], rPtr);
+    printArray("cPtr", values.dims()[0], cPtr);
+    printArray("vPtr", values.dims()[0], vPtr);
 }
 
 template<typename T>

--- a/src/backend/cpu/kernel/sparse.hpp
+++ b/src/backend/cpu/kernel/sparse.hpp
@@ -42,22 +42,6 @@ void coo2dense(Param<T> output, CParam<T> values, CParam<int> rowIdx,
     }
 }
 
-  template <typename T>
-  void printArray(const char *name, const unsigned N, const T *thing) {
-      printf("%s:\n", name);
-      for (int i = 0; i < N; i++)
-        printf("%f, ", thing[i]);
-      printf("\n\n");
-  }
-
-  template <>
-  void printArray(const char *name, const unsigned N, const int *thing) {
-      printf("%s:\n", name);
-      for (int i = 0; i < N; i++)
-        printf("%d, ", thing[i]);
-      printf("\n\n");
-  }
-
 template<typename T>
 void dense2csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
                CParam<T> in) {
@@ -80,10 +64,6 @@ void dense2csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
         }
     }
     rPtr[dims[0]] = offset;
-
-    printArray("rPtr", values.dims()[0], rPtr);
-    printArray("cPtr", values.dims()[0], cPtr);
-    printArray("vPtr", values.dims()[0], vPtr);
 }
 
 template<typename T>

--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -249,6 +249,8 @@ target_sources(afoneapi
     kernel/scan_dim.hpp
     kernel/sort.hpp
     kernel/sort_by_key.hpp
+    kernel/sparse.hpp
+    kernel/sparse_arith.hpp
     kernel/transpose.hpp
     kernel/transpose_inplace.hpp
     kernel/triangle.hpp

--- a/src/backend/oneapi/kernel/sparse.hpp
+++ b/src/backend/oneapi/kernel/sparse.hpp
@@ -1,0 +1,292 @@
+/*******************************************************
+ * Copyright (c) 2014, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#pragma once
+
+#include <Array.hpp>
+#include <Param.hpp>
+#include <common/dispatch.hpp>
+#include <common/kernel_cache.hpp>
+#include <debug_oneapi.hpp>
+// #include <kernel/config.hpp>
+#include <kernel/reduce.hpp>
+#include <kernel/scan_dim.hpp>
+#include <kernel/scan_first.hpp>
+#include <kernel/sort_by_key.hpp>
+#include <traits.hpp>
+
+#include <string>
+#include <vector>
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+template<typename T>
+using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
+template<typename T>
+using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
+
+
+// template<typename T>
+// void coo2dense(Param out, const Param values, const Param rowIdx,
+//                const Param colIdx) {
+//     std::vector<TemplateArg> tmpltArgs = {
+//         TemplateTypename<T>(),
+//         TemplateArg(REPEAT),
+//     };
+//     std::vector<std::string> compileOpts = {
+//         DefineKeyValue(T, dtype_traits<T>::getName()),
+//         DefineKeyValue(resp, REPEAT),
+//     };
+//     compileOpts.emplace_back(getTypeBuildDefinition<T>());
+
+//     auto coo2dense = common::getKernel("coo2Dense", {{coo2dense_cl_src}},
+//                                        tmpltArgs, compileOpts);
+
+//     cl::NDRange local(THREADS_PER_GROUP, 1, 1);
+
+//     cl::NDRange global(
+//         divup(out.info.dims[0], local[0] * REPEAT) * THREADS_PER_GROUP, 1, 1);
+
+//     coo2dense(cl::EnqueueArgs(getQueue(), global, local), *out.data, out.info,
+//               *values.data, values.info, *rowIdx.data, rowIdx.info,
+//               *colIdx.data, colIdx.info);
+//     CL_DEBUG_FINISH(getQueue());
+// }
+
+// template<typename T>
+// void csr2dense(Param output, const Param values, const Param rowIdx,
+//                const Param colIdx) {
+//     constexpr int MAX_GROUPS = 4096;
+//     // FIXME: This needs to be based non nonzeros per row
+//     constexpr int threads = 64;
+
+//     const int M = rowIdx.info.dims[0] - 1;
+
+//     std::vector<TemplateArg> tmpltArgs = {
+//         TemplateTypename<T>(),
+//         TemplateArg(threads),
+//     };
+//     std::vector<std::string> compileOpts = {
+//         DefineKeyValue(T, dtype_traits<T>::getName()),
+//         DefineKeyValue(THREADS, threads),
+//     };
+//     compileOpts.emplace_back(getTypeBuildDefinition<T>());
+
+//     auto csr2dense = common::getKernel("csr2Dense", {{csr2dense_cl_src}},
+//                                        tmpltArgs, compileOpts);
+
+//     cl::NDRange local(threads, 1);
+//     int groups_x = std::min((int)(divup(M, local[0])), MAX_GROUPS);
+//     cl::NDRange global(local[0] * groups_x, 1);
+
+//     csr2dense(cl::EnqueueArgs(getQueue(), global, local), *output.data,
+//               *values.data, *rowIdx.data, *colIdx.data, M);
+//     CL_DEBUG_FINISH(getQueue());
+// }
+
+template<typename T>
+class dense2csrCreateKernel {
+public:
+  dense2csrCreateKernel(write_accessor<T> svalptr,
+                        write_accessor<int> scolptr,
+                        read_accessor<T> dvalptr,
+                        const KParam valinfo,
+                        read_accessor<int> dcolptr,
+                        const KParam colinfo,
+                        read_accessor<int> rowptr)
+    : svalptr_(svalptr), scolptr_(scolptr), dvalptr_(dvalptr), valinfo_(valinfo), dcolptr_(dcolptr), colinfo_(colinfo), rowptr_(rowptr) {}
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+
+    // int gidx = it.get_global_id(0);
+    // int gidy = it.get_global_id(1);
+
+    // if (gidx >= valinfo_.dims[0]) return;
+    // if (gidy >= valinfo_.dims[1]) return;
+
+    // int rowoff = rowptr_[gidx];
+    // svalptr_ += rowoff;
+    // scolptr_ += rowoff;
+
+    // dvalptr_ += valinfo_.offset;
+    // dcolptr_ += colinfo_.offset;
+
+    // int idx = gidx + gidy * valinfo_.strides[1];
+    // T val   = dvalptr_[gidx + gidy * valinfo_.strides[1]];
+    // if (IS_ZERO(val)) return;
+
+    // int oloc          = dcolptr_[gidx + gidy * colinfo_.strides[1]];
+    // svalptr_[oloc - 1] = val;
+    // scolptr_[oloc - 1] = gidy;
+}
+
+private:
+write_accessor<T> svalptr_;
+write_accessor<int> scolptr_;
+read_accessor<T> dvalptr_;
+const KParam valinfo_;
+read_accessor<int> dcolptr_;
+const KParam colinfo_;
+read_accessor<int> rowptr_;
+};
+
+template<typename T>
+void dense2csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
+               const Param<T> dense) {
+    constexpr bool IsComplex =
+      std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value;
+
+    int num_rows = dense.info.dims[0];
+    int num_cols = dense.info.dims[1];
+
+    // sd1 contains output of scan along dim 1 of dense
+    Array<int> sd1 = createEmptyArray<int>(dim4(num_rows, num_cols));
+    // rd1 contains output of nonzero count along dim 1 along dense
+    Array<int> rd1 = createEmptyArray<int>(num_rows);
+
+    // scanDim<T, int, af_notzero_t>(sd1, dense, 1, true);
+    printf("!!! %d\n", __LINE__);
+    scan_dim<T, int, af_notzero_t, 1>(sd1, dense, true);
+    // reduceDim<T, int, af_notzero_t>(rd1, dense, 0, 0, 1);
+    printf("!!! %d\n", __LINE__);
+    reduce_dim_default<T, int, af_notzero_t, 1>(rd1, dense, 0, 0);
+    // scanFirst<int, int, af_add_t>(rowIdx, rd1, false);
+    printf("!!! %d\n", __LINE__);
+    scan_first<int, int, af_add_t>(rowIdx, rd1, false);
+
+    printf("!!! %d\n", __LINE__);
+    const int nnz = values.info.dims[0];
+    const sycl::range<1> fill_range(rowIdx.info.offset + (rowIdx.info.dims[0] - 1) * sizeof(int));
+    getQueue().submit([&](auto &h) {
+        sycl::accessor d_rowIdx{*rowIdx.data, h, fill_range, sycl::write_only, sycl::no_init};
+        h.fill(d_rowIdx, nnz);
+    });
+
+    auto local   = sycl::range(THREADS_X, THREADS_Y);
+    int groups_x = divup(dense.info.dims[0], local[0]);
+    int groups_y = divup(dense.info.dims[1], local[1]);
+    auto global  = sycl::range(groups_x * local[0], groups_y * local[1]);
+
+    const Param<int> sdParam = sd1;
+
+    getQueue().submit([&](auto &h) {
+        sycl::accessor d_dense{*dense.data, h, sycl::read_only};
+        sycl::accessor d_sdParam{*sdParam.data, h, sycl::read_only};
+        sycl::accessor d_rowIdx{*rowIdx.data, h, sycl::read_only};
+        sycl::accessor d_values{*values.data, h, sycl::write_only, sycl::no_init};
+        sycl::accessor d_colIdx{*colIdx.data, h, sycl::write_only, sycl::no_init};
+        h.parallel_for(sycl::nd_range{global, local},
+                       dense2csrCreateKernel<T>(
+        d_values,
+        d_colIdx,
+        d_dense,
+        dense.info,
+        d_sdParam,
+        sdParam.info,
+        d_rowIdx));
+    });
+
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+// template<typename T>
+// void swapIndex(Param ovalues, Param oindex, const Param ivalues,
+//                const cl::Buffer *iindex, const Param swapIdx) {
+//     std::vector<TemplateArg> tmpltArgs = {
+//         TemplateTypename<T>(),
+//     };
+//     std::vector<std::string> compileOpts = {
+//         DefineKeyValue(T, dtype_traits<T>::getName()),
+//     };
+//     compileOpts.emplace_back(getTypeBuildDefinition<T>());
+
+//     auto swapIndex = common::getKernel("swapIndex", {{csr2coo_cl_src}},
+//                                        tmpltArgs, compileOpts);
+
+//     cl::NDRange global(ovalues.info.dims[0], 1, 1);
+
+//     swapIndex(cl::EnqueueArgs(getQueue(), global), *ovalues.data, *oindex.data,
+//               *ivalues.data, *iindex, *swapIdx.data,
+//               static_cast<int>(ovalues.info.dims[0]));
+//     CL_DEBUG_FINISH(getQueue());
+// }
+
+// template<typename T>
+// void csr2coo(Param ovalues, Param orowIdx, Param ocolIdx, const Param ivalues,
+//              const Param irowIdx, const Param icolIdx, Param index) {
+//     std::vector<TemplateArg> tmpltArgs = {
+//         TemplateTypename<T>(),
+//     };
+//     std::vector<std::string> compileOpts = {
+//         DefineKeyValue(T, dtype_traits<T>::getName()),
+//     };
+//     compileOpts.emplace_back(getTypeBuildDefinition<T>());
+
+//     auto csr2coo = common::getKernel("csr2Coo", {{csr2coo_cl_src}}, tmpltArgs,
+//                                      compileOpts);
+
+//     const int MAX_GROUPS = 4096;
+//     int M                = irowIdx.info.dims[0] - 1;
+//     // FIXME: This needs to be based non nonzeros per row
+//     int threads = 64;
+
+//     cl::Buffer *scratch = bufferAlloc(orowIdx.info.dims[0] * sizeof(int));
+
+//     cl::NDRange local(threads, 1);
+//     int groups_x = std::min((int)(divup(M, local[0])), MAX_GROUPS);
+//     cl::NDRange global(local[0] * groups_x, 1);
+
+//     csr2coo(cl::EnqueueArgs(getQueue(), global, local), *scratch, *ocolIdx.data,
+//             *irowIdx.data, *icolIdx.data, M);
+
+//     // Now we need to sort this into column major
+//     kernel::sort0ByKeyIterative<int, int>(ocolIdx, index, true);
+
+//     // Now use index to sort values and rows
+//     kernel::swapIndex<T>(ovalues, orowIdx, ivalues, scratch, index);
+
+//     CL_DEBUG_FINISH(getQueue());
+
+//     bufferFree(scratch);
+// }
+
+// template<typename T>
+// void coo2csr(Param ovalues, Param orowIdx, Param ocolIdx, const Param ivalues,
+//              const Param irowIdx, const Param icolIdx, Param index,
+//              Param rowCopy, const int M) {
+//     std::vector<TemplateArg> tmpltArgs = {
+//         TemplateTypename<T>(),
+//     };
+//     std::vector<std::string> compileOpts = {
+//         DefineKeyValue(T, dtype_traits<T>::getName()),
+//     };
+//     compileOpts.emplace_back(getTypeBuildDefinition<T>());
+
+//     auto csrReduce = common::getKernel("csrReduce", {{csr2coo_cl_src}},
+//                                        tmpltArgs, compileOpts);
+
+//     // Now we need to sort this into column major
+//     kernel::sort0ByKeyIterative<int, int>(rowCopy, index, true);
+
+//     // Now use index to sort values and rows
+//     kernel::swapIndex<T>(ovalues, ocolIdx, ivalues, icolIdx.data, index);
+
+//     CL_DEBUG_FINISH(getQueue());
+
+//     cl::NDRange global(irowIdx.info.dims[0], 1, 1);
+
+//     csrReduce(cl::EnqueueArgs(getQueue(), global), *orowIdx.data, *rowCopy.data,
+//               M, static_cast<int>(ovalues.info.dims[0]));
+//     CL_DEBUG_FINISH(getQueue());
+// }
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/oneapi/kernel/sparse.hpp
+++ b/src/backend/oneapi/kernel/sparse.hpp
@@ -33,64 +33,121 @@ using read_accessor = sycl::accessor<T, 1, sycl::access::mode::read>;
 template<typename T>
 using write_accessor = sycl::accessor<T, 1, sycl::access::mode::write>;
 
+template<typename T>
+class coo2DenseCreateKernel {
+public:
+    coo2DenseCreateKernel(write_accessor<T> oPtr, const KParam output, write_accessor<T> vPtr, const KParam values, read_accessor<int> rPtr, const KParam rowIdx, read_accessor<int> cPtr, const KParam colIdx) : oPtr_(oPtr), output_(output), vPtr_(vPtr), values_(values), rPtr_(rPtr), rowIdx_(rowIdx), cPtr_(cPtr), colIdx_(colIdx) {}
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
 
-// template<typename T>
-// void coo2dense(Param out, const Param values, const Param rowIdx,
-//                const Param colIdx) {
-//     std::vector<TemplateArg> tmpltArgs = {
-//         TemplateTypename<T>(),
-//         TemplateArg(REPEAT),
-//     };
-//     std::vector<std::string> compileOpts = {
-//         DefineKeyValue(T, dtype_traits<T>::getName()),
-//         DefineKeyValue(resp, REPEAT),
-//     };
-//     compileOpts.emplace_back(getTypeBuildDefinition<T>());
+    const int id = g.get_group_id(0) * g.get_local_range(0) * REPEAT + it.get_local_id(0);
 
-//     auto coo2dense = common::getKernel("coo2Dense", {{coo2dense_cl_src}},
-//                                        tmpltArgs, compileOpts);
+    if (id >= values_.dims[0]) return;
 
-//     cl::NDRange local(THREADS_PER_GROUP, 1, 1);
+    const int dimSize = g.get_local_range(0);
 
-//     cl::NDRange global(
-//         divup(out.info.dims[0], local[0] * REPEAT) * THREADS_PER_GROUP, 1, 1);
+    for (int i = it.get_local_id(0); i < REPEAT * dimSize; i += dimSize) {
+        if (i >= values_.dims[0]) return;
 
-//     coo2dense(cl::EnqueueArgs(getQueue(), global, local), *out.data, out.info,
-//               *values.data, values.info, *rowIdx.data, rowIdx.info,
-//               *colIdx.data, colIdx.info);
-//     CL_DEBUG_FINISH(getQueue());
-// }
+        T v   = vPtr_[i];
+        int r = rPtr_[i];
+        int c = cPtr_[i];
 
-// template<typename T>
-// void csr2dense(Param output, const Param values, const Param rowIdx,
-//                const Param colIdx) {
-//     constexpr int MAX_GROUPS = 4096;
-//     // FIXME: This needs to be based non nonzeros per row
-//     constexpr int threads = 64;
+        int offset = r + c * output_.strides[1];
 
-//     const int M = rowIdx.info.dims[0] - 1;
+        oPtr_[offset] = v;
+    }
+}
 
-//     std::vector<TemplateArg> tmpltArgs = {
-//         TemplateTypename<T>(),
-//         TemplateArg(threads),
-//     };
-//     std::vector<std::string> compileOpts = {
-//         DefineKeyValue(T, dtype_traits<T>::getName()),
-//         DefineKeyValue(THREADS, threads),
-//     };
-//     compileOpts.emplace_back(getTypeBuildDefinition<T>());
+private:
+write_accessor<T> oPtr_;
+const KParam output_;
+write_accessor<T> vPtr_;
+const KParam values_;
+read_accessor<int> rPtr_;
+const KParam rowIdx_;
+read_accessor<int> cPtr_;
+const KParam colIdx_;
+};
 
-//     auto csr2dense = common::getKernel("csr2Dense", {{csr2dense_cl_src}},
-//                                        tmpltArgs, compileOpts);
+template<typename T>
+void coo2dense(Param<T> out, const Param<T> values, const Param<int> rowIdx,
+               const Param<int> colIdx) {
 
-//     cl::NDRange local(threads, 1);
-//     int groups_x = std::min((int)(divup(M, local[0])), MAX_GROUPS);
-//     cl::NDRange global(local[0] * groups_x, 1);
+    auto local = sycl::range(THREADS_PER_BLOCK, 1);
+    auto global = sycl::range(divup(out.info.dims[0], local[0] * REPEAT) * THREADS_PER_BLOCK, 1);
 
-//     csr2dense(cl::EnqueueArgs(getQueue(), global, local), *output.data,
-//               *values.data, *rowIdx.data, *colIdx.data, M);
-//     CL_DEBUG_FINISH(getQueue());
-// }
+getQueue().submit([&](auto &h) {
+sycl::accessor d_rowIdx{*rowIdx.data, h, sycl::read_only};
+sycl::accessor d_colIdx{*colIdx.data, h, sycl::read_only};
+sycl::accessor d_out{*out.data, h, sycl::write_only, sycl::no_init};
+sycl::accessor d_values{*values.data, h, sycl::write_only, sycl::no_init};
+h.parallel_for(
+  sycl::nd_range{global, local},
+  coo2DenseCreateKernel<T>(d_out, out.info, d_values, values.info, d_rowIdx, rowIdx.info, d_colIdx, colIdx.info));
+});
+
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+
+template<typename T, int THREADS>
+class csr2DenseCreateKernel {
+public:
+    csr2DenseCreateKernel(write_accessor<T> output, read_accessor<T> values, read_accessor<int> rowidx, read_accessor<int> colidx, const int M) : output_(output), values_(values), rowidx_(rowidx), colidx_(colidx), M_(M) {}
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+
+    int lid = it.get_local_id(0);
+    for (int rowId = g.get_group_id(0); rowId < M_; rowId += it.get_group_range(0)) {
+        int colStart = rowidx_[rowId];
+        int colEnd   = rowidx_[rowId + 1];
+        for (int colId = colStart + lid; colId < colEnd; colId += THREADS) {
+            output_[rowId + colidx_[colId] * M_] = values_[colId];
+        }
+    }
+}
+
+private:
+write_accessor<T> output_;
+read_accessor<T> values_;
+read_accessor<int> rowidx_;
+read_accessor<int> colidx_;
+const int M_;
+};
+
+
+  template<typename T>
+void csr2dense(Param<T> output, const Param<T> values, const Param<int> rowIdx,
+               const Param<int> colIdx) {
+    constexpr int MAX_GROUPS = 4096;
+    // FIXME: This needs to be based non nonzeros per row
+    constexpr int threads = 64;
+
+    const int M = rowIdx.info.dims[0] - 1;
+
+
+
+
+
+
+
+    auto local = sycl::range(threads, 1);
+    int groups_x = std::min((int)(divup(M, local[0])), MAX_GROUPS);
+    auto global = sycl::range(local[0] * groups_x, 1);
+
+getQueue().submit([&](auto &h) {
+sycl::accessor d_values{*values.data, h, sycl::read_only};
+sycl::accessor d_rowIdx{*rowIdx.data, h, sycl::read_only};
+sycl::accessor d_colIdx{*colIdx.data, h, sycl::read_only};
+sycl::accessor d_output{*output.data, h, sycl::write_only, sycl::no_init};
+h.parallel_for(
+  sycl::nd_range{global, local},
+  csr2DenseCreateKernel<T, threads>(d_output, d_values, d_rowIdx, d_colIdx, M));
+});
+
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
 
 template<typename T>
 class dense2csrCreateKernel {
@@ -104,45 +161,72 @@ public:
                         read_accessor<int> rowptr)
     : svalptr_(svalptr), scolptr_(scolptr), dvalptr_(dvalptr), valinfo_(valinfo), dcolptr_(dcolptr), colinfo_(colinfo), rowptr_(rowptr) {}
     void operator()(sycl::nd_item<2> it) const {
-        sycl::group g = it.get_group();
+        // sycl::group g = it.get_group();
 
-    // int gidx = it.get_global_id(0);
-    // int gidy = it.get_global_id(1);
+        int gidx = it.get_global_id(0);
+        int gidy = it.get_global_id(1);
 
-    // if (gidx >= valinfo_.dims[0]) return;
-    // if (gidy >= valinfo_.dims[1]) return;
+        if (gidx >= (unsigned)valinfo_.dims[0]) return;
+        if (gidy >= (unsigned)valinfo_.dims[1]) return;
 
-    // int rowoff = rowptr_[gidx];
-    // svalptr_ += rowoff;
-    // scolptr_ += rowoff;
+        int rowoff       = rowptr_[gidx];
+        T *svalptr_ptr   = svalptr_.get_pointer();
+        int *scolptr_ptr = scolptr_.get_pointer();
+        svalptr_ptr += rowoff;
+        scolptr_ptr += rowoff;
 
-    // dvalptr_ += valinfo_.offset;
-    // dcolptr_ += colinfo_.offset;
+        T *dvalptr_ptr   = dvalptr_.get_pointer();
+        int *dcolptr_ptr = dcolptr_.get_pointer();
+        dvalptr_ptr += valinfo_.offset;
+        dcolptr_ptr += colinfo_.offset;
 
-    // int idx = gidx + gidy * valinfo_.strides[1];
-    // T val   = dvalptr_[gidx + gidy * valinfo_.strides[1]];
-    // if (IS_ZERO(val)) return;
+        T val   = dvalptr_ptr[gidx + gidy * (unsigned)valinfo_.strides[1]];
 
-    // int oloc          = dcolptr_[gidx + gidy * colinfo_.strides[1]];
-    // svalptr_[oloc - 1] = val;
-    // scolptr_[oloc - 1] = gidy;
+        if constexpr (std::is_same_v<decltype(val), std::complex<float>> ||
+                      std::is_same_v<decltype(val), std::complex<double>>) {
+            if (val.real() == 0 && val.imag() == 0) return;
+        } else {
+            if (val == 0) return;
+        }
+
+        int oloc              = dcolptr_ptr[gidx + gidy * colinfo_.strides[1]];
+        svalptr_ptr[oloc - 1] = val;
+        scolptr_ptr[oloc - 1] = gidy;
+    }
+
+   private:
+    write_accessor<T> svalptr_;
+    write_accessor<int> scolptr_;
+    read_accessor<T> dvalptr_;
+    const KParam valinfo_;
+    read_accessor<int> dcolptr_;
+    const KParam colinfo_;
+    read_accessor<int> rowptr_;
+};
+
+template <typename T>
+void printArray(const char *name, const unsigned N, const Param<T> &thing) {
+    auto blah = sycl::host_accessor<T>(*thing.data);
+    printf("%s:\n", name);
+    for (int i = 0; i < N; i++)
+      printf("%f, ", blah[i]);
+    printf("\n\n");
 }
 
-private:
-write_accessor<T> svalptr_;
-write_accessor<int> scolptr_;
-read_accessor<T> dvalptr_;
-const KParam valinfo_;
-read_accessor<int> dcolptr_;
-const KParam colinfo_;
-read_accessor<int> rowptr_;
-};
+template <>
+void printArray(const char *name, const unsigned N, const Param<int> &thing) {
+    auto blah = sycl::host_accessor<int>(*thing.data);
+    printf("%s:\n", name);
+    for (int i = 0; i < N; i++)
+      printf("%d, ", blah[i]);
+    printf("\n\n");
+}
 
 template<typename T>
 void dense2csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
                const Param<T> dense) {
-    constexpr bool IsComplex =
-      std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value;
+    // constexpr bool IsComplex =
+    //   std::is_same<T, cfloat>::value || std::is_same<T, cdouble>::value;
 
     int num_rows = dense.info.dims[0];
     int num_cols = dense.info.dims[1];
@@ -153,20 +237,20 @@ void dense2csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
     Array<int> rd1 = createEmptyArray<int>(num_rows);
 
     // scanDim<T, int, af_notzero_t>(sd1, dense, 1, true);
-    printf("!!! %d\n", __LINE__);
     scan_dim<T, int, af_notzero_t, 1>(sd1, dense, true);
     // reduceDim<T, int, af_notzero_t>(rd1, dense, 0, 0, 1);
-    printf("!!! %d\n", __LINE__);
     reduce_dim_default<T, int, af_notzero_t, 1>(rd1, dense, 0, 0);
     // scanFirst<int, int, af_add_t>(rowIdx, rd1, false);
-    printf("!!! %d\n", __LINE__);
     scan_first<int, int, af_add_t>(rowIdx, rd1, false);
 
-    printf("!!! %d\n", __LINE__);
+    printArray("rowIdx", rowIdx.info.dims[0], rowIdx);
+
     const int nnz = values.info.dims[0];
-    const sycl::range<1> fill_range(rowIdx.info.offset + (rowIdx.info.dims[0] - 1) * sizeof(int));
+
+    const sycl::id<1> fillOffset(rowIdx.info.offset + (rowIdx.info.dims[0] - 1));
+    const sycl::range<1> fillRange(rowIdx.info.dims[0] - fillOffset[0]);
     getQueue().submit([&](auto &h) {
-        sycl::accessor d_rowIdx{*rowIdx.data, h, fill_range, sycl::write_only, sycl::no_init};
+        sycl::accessor d_rowIdx{*rowIdx.data, h, fillRange, fillOffset};
         h.fill(d_rowIdx, nnz);
     });
 
@@ -184,40 +268,125 @@ void dense2csr(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
         sycl::accessor d_values{*values.data, h, sycl::write_only, sycl::no_init};
         sycl::accessor d_colIdx{*colIdx.data, h, sycl::write_only, sycl::no_init};
         h.parallel_for(sycl::nd_range{global, local},
-                       dense2csrCreateKernel<T>(
-        d_values,
-        d_colIdx,
-        d_dense,
-        dense.info,
-        d_sdParam,
-        sdParam.info,
-        d_rowIdx));
+                       dense2csrCreateKernel<T>(d_values,
+                                                d_colIdx,
+                                                d_dense,
+                                                dense.info,
+                                                d_sdParam,
+                                                sdParam.info,
+                                                d_rowIdx));
     });
 
     ONEAPI_DEBUG_FINISH(getQueue());
 }
 
-// template<typename T>
-// void swapIndex(Param ovalues, Param oindex, const Param ivalues,
-//                const cl::Buffer *iindex, const Param swapIdx) {
-//     std::vector<TemplateArg> tmpltArgs = {
-//         TemplateTypename<T>(),
-//     };
-//     std::vector<std::string> compileOpts = {
-//         DefineKeyValue(T, dtype_traits<T>::getName()),
-//     };
-//     compileOpts.emplace_back(getTypeBuildDefinition<T>());
+template<typename T>
+class swapIndexCreateKernel {
+public:
+    swapIndexCreateKernel(write_accessor<T> ovalues, write_accessor<int> oindex, read_accessor<T> ivalues, read_accessor<int> iindex, read_accessor<int> swapIdx, const int nNZ) : ovalues_(ovalues), oindex_(oindex), ivalues_(ivalues), iindex_(iindex), swapIdx_(swapIdx), nNZ_(nNZ) {}
+    void operator()(sycl::id<1> it) const {
 
-//     auto swapIndex = common::getKernel("swapIndex", {{csr2coo_cl_src}},
-//                                        tmpltArgs, compileOpts);
+    // int id = it.get_global_id(0);
+    // if (id >= nNZ_) return;
 
-//     cl::NDRange global(ovalues.info.dims[0], 1, 1);
+    // int idx = swapIdx_[id];
 
-//     swapIndex(cl::EnqueueArgs(getQueue(), global), *ovalues.data, *oindex.data,
-//               *ivalues.data, *iindex, *swapIdx.data,
-//               static_cast<int>(ovalues.info.dims[0]));
-//     CL_DEBUG_FINISH(getQueue());
-// }
+    // ovalues_[id] = ivalues_[idx];
+    // oindex_[id]  = iindex_[idx];
+    }
+
+private:
+write_accessor<T> ovalues_;
+write_accessor<int> oindex_;
+read_accessor<T> ivalues_;
+read_accessor<int> iindex_;
+read_accessor<int> swapIdx_;
+const int nNZ_;
+};
+
+template<typename T>
+void swapIndex(Param<T> ovalues, Param<int> oindex, const Param<T> ivalues,
+               sycl::buffer<int> iindex, const Param<int> swapIdx) {
+auto global = sycl::range(ovalues.info.dims[0]);
+
+getQueue().submit([&](auto &h) {
+    sycl::accessor d_ivalues{*ivalues.data, h, sycl::read_only};
+    sycl::accessor d_iindex{iindex, h, sycl::read_only};
+    sycl::accessor d_swapIdx{*swapIdx.data, h, sycl::read_only};
+    sycl::accessor d_ovalues{*ovalues.data, h, sycl::write_only, sycl::no_init};
+    sycl::accessor d_oindex{*oindex.data, h, sycl::write_only, sycl::no_init};
+    h.parallel_for(global,
+                   swapIndexCreateKernel<T>(
+                       d_ovalues, d_oindex, d_ivalues, d_iindex, d_swapIdx,
+                       static_cast<int>(ovalues.info.dims[0])));
+});
+
+ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename T>
+class csr2CooCreateKernel {
+public:
+    csr2CooCreateKernel(write_accessor<int> orowidx, write_accessor<int> ocolidx, read_accessor<int> irowidx, read_accessor<int> icolidx, const int M) : orowidx_(orowidx), ocolidx_(ocolidx), irowidx_(irowidx), icolidx_(icolidx), M_(M) {}
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+
+    int lid = it.get_local_id(0);
+    for (int rowId = g.get_group_id(0); rowId < M_; rowId += it.get_group_range(0)) {
+        int colStart = irowidx_[rowId];
+        int colEnd   = irowidx_[rowId + 1];
+        for (int colId = colStart + lid; colId < colEnd;
+             colId += g.get_local_range(0)) {
+            orowidx_[colId] = rowId;
+            ocolidx_[colId] = icolidx_[colId];
+        }
+    }
+}
+
+private:
+write_accessor<int> orowidx_;
+write_accessor<int> ocolidx_;
+read_accessor<int> irowidx_;
+read_accessor<int> icolidx_;
+const int M_;
+};
+
+template<typename T>
+void csr2coo(Param<T> ovalues, Param<int> orowIdx, Param<int> ocolIdx, const Param<T> ivalues,
+             const Param<int> irowIdx, const Param<int> icolIdx, Param<int> index) {
+
+
+    const int MAX_GROUPS = 4096;
+    int M                = irowIdx.info.dims[0] - 1;
+    // FIXME: This needs to be based non nonzeros per row
+    int threads = 64;
+
+    // cl::Buffer *scratch = bufferAlloc(orowIdx.info.dims[0] * sizeof(int));
+    auto scratch = memAlloc<int>(orowIdx.info.dims[0]);
+
+    auto local = sycl::range(threads, 1);
+    int groups_x = std::min((int)(divup(M, local[0])), MAX_GROUPS);
+    auto global = sycl::range(local[0] * groups_x, 1);
+
+    getQueue().submit([&](auto &h) {
+        sycl::accessor d_irowIdx{*irowIdx.data, h, sycl::read_only};
+        sycl::accessor d_icolIdx{*icolIdx.data, h, sycl::read_only};
+        sycl::accessor d_scratch{*scratch, h, sycl::write_only, sycl::no_init};
+        sycl::accessor d_ocolIdx{*ocolIdx.data, h, sycl::write_only,
+                                 sycl::no_init};
+        h.parallel_for(sycl::nd_range{global, local},
+                       csr2CooCreateKernel<T>(d_scratch, d_ocolIdx, d_irowIdx,
+                                              d_icolIdx, M));
+    });
+
+    // Now we need to sort this into column major
+    kernel::sort0ByKeyIterative<int, int>(ocolIdx, index, true);
+
+    // Now use index to sort values and rows
+    kernel::swapIndex<T>(ovalues, orowIdx, ivalues, *scratch, index);
+
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
 
 // template<typename T>
 // void csr2coo(Param ovalues, Param orowIdx, Param ocolIdx, const Param ivalues,

--- a/src/backend/oneapi/kernel/sparse_arith.hpp
+++ b/src/backend/oneapi/kernel/sparse_arith.hpp
@@ -1,0 +1,569 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+#pragma once
+
+#include <Array.hpp>
+#include <Param.hpp>
+#include <common/Binary.hpp>
+#include <common/complex.hpp>
+#include <common/dispatch.hpp>
+#include <common/kernel_cache.hpp>
+#include <debug_oneapi.hpp>
+#include <err_oneapi.hpp>
+#include <kernel/accessors.hpp>
+#include <math.hpp>
+#include <memory.hpp>
+#include <traits.hpp>
+
+#include <string>
+#include <vector>
+
+namespace arrayfire {
+namespace oneapi {
+namespace kernel {
+
+constexpr unsigned TX      = 32;
+constexpr unsigned TY      = 8;
+constexpr unsigned THREADS = TX * TY;
+
+template<typename T>
+using global_atomic_ref =
+    sycl::atomic_ref<T, sycl::memory_order::relaxed, sycl::memory_scope::system,
+                     sycl::access::address_space::global_space>;
+
+template<typename T, af_op_t op>
+class sparseArithCSRKernel {
+   public:
+    sparseArithCSRKernel(write_accessor<T> oPtr, const KParam out,
+                         read_accessor<T> values, read_accessor<int> rowIdx,
+                         read_accessor<int> colIdx, const int nNZ,
+                         read_accessor<T> rPtr, const KParam rhs,
+                         const int reverse)
+        : oPtr_(oPtr)
+        , out_(out)
+        , values_(values)
+        , rowIdx_(rowIdx)
+        , colIdx_(colIdx)
+        , nNZ_(nNZ)
+        , rPtr_(rPtr)
+        , rhs_(rhs)
+        , reverse_(reverse) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+        common::Binary<T, op> binOP;
+
+        const int row =
+            g.get_group_id(0) * g.get_local_range(1) + it.get_local_id(1);
+
+        if (row < out_.dims[0]) {
+            const int rowStartIdx = rowIdx_[row];
+            const int rowEndIdx   = rowIdx_[row + 1];
+
+            // Repeat loop until all values in the row are computed
+            for (int idx = rowStartIdx + it.get_local_id(0); idx < rowEndIdx;
+                 idx += g.get_local_range(0)) {
+                const int col = colIdx_[idx];
+
+                if (row >= out_.dims[0] || col >= out_.dims[1])
+                    continue;  // Bad indices
+
+                // Get Values
+                const T val  = values_[idx];
+                const T rval = rPtr_[col * rhs_.strides[1] + row];
+
+                const int offset = col * out_.strides[1] + row;
+                if (reverse_)
+                    oPtr_[offset] = binOP(rval, val);
+                else
+                    oPtr_[offset] = binOP(val, rval);
+            }
+        }
+    }
+
+   private:
+    write_accessor<T> oPtr_;
+    const KParam out_;
+    read_accessor<T> values_;
+    read_accessor<int> rowIdx_;
+    read_accessor<int> colIdx_;
+    const int nNZ_;
+    read_accessor<T> rPtr_;
+    const KParam rhs_;
+    const int reverse_;
+};
+
+template<typename T, af_op_t op>
+void sparseArithOpCSR(Param<T> out, const Param<T> values,
+                      const Param<int> rowIdx, const Param<int> colIdx,
+                      const Param<T> rhs, const bool reverse) {
+    auto local  = sycl::range(TX, TY);
+    auto global = sycl::range(divup(out.info.dims[0], TY) * TX, TY);
+
+    getQueue().submit([&](auto &h) {
+        sycl::accessor d_out{*out.data, h, sycl::write_only};
+        sycl::accessor d_values{*values.data, h, sycl::read_only};
+        sycl::accessor d_rowIdx{*rowIdx.data, h, sycl::read_only};
+        sycl::accessor d_colIdx{*colIdx.data, h, sycl::read_only};
+        sycl::accessor d_rhs{*rhs.data, h, sycl::read_only};
+
+        h.parallel_for(sycl::nd_range{global, local},
+                       sparseArithCSRKernel<T, op>(
+                           d_out, out.info, d_values, d_rowIdx, d_colIdx,
+                           static_cast<int>(values.info.dims[0]), d_rhs,
+                           rhs.info, static_cast<int>(reverse)));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename T, af_op_t op>
+class sparseArithCOOKernel {
+   public:
+    sparseArithCOOKernel(write_accessor<T> oPtr, const KParam out,
+                         read_accessor<T> values, read_accessor<int> rowIdx,
+                         read_accessor<int> colIdx, const int nNZ,
+                         read_accessor<T> rPtr, const KParam rhs,
+                         const int reverse)
+        : oPtr_(oPtr)
+        , out_(out)
+        , values_(values)
+        , rowIdx_(rowIdx)
+        , colIdx_(colIdx)
+        , nNZ_(nNZ)
+        , rPtr_(rPtr)
+        , rhs_(rhs)
+        , reverse_(reverse) {}
+
+    void operator()(sycl::nd_item<1> it) const {
+        common::Binary<T, op> binOP;
+
+        const int idx = it.get_global_id(0);
+
+        if (idx < nNZ_) {
+            const int row = rowIdx_[idx];
+            const int col = colIdx_[idx];
+
+            if (row >= out_.dims[0] || col >= out_.dims[1])
+                return;  // Bad indices
+
+            // Get Values
+            const T val  = values_[idx];
+            const T rval = rPtr_[col * rhs_.strides[1] + row];
+
+            const int offset = col * out_.strides[1] + row;
+            if (reverse_)
+                oPtr_[offset] = binOP(rval, val);
+            else
+                oPtr_[offset] = binOP(val, rval);
+        }
+    }
+
+   private:
+    write_accessor<T> oPtr_;
+    const KParam out_;
+    read_accessor<T> values_;
+    read_accessor<int> rowIdx_;
+    read_accessor<int> colIdx_;
+    const int nNZ_;
+    read_accessor<T> rPtr_;
+    const KParam rhs_;
+    const int reverse_;
+};
+
+template<typename T, af_op_t op>
+void sparseArithOpCOO(Param<T> out, const Param<T> values,
+                      const Param<int> rowIdx, const Param<int> colIdx,
+                      const Param<T> rhs, const bool reverse) {
+    auto local  = sycl::range(THREADS);
+    auto global = sycl::range(divup(values.info.dims[0], THREADS) * THREADS);
+
+    getQueue().submit([&](auto &h) {
+        sycl::accessor d_out{*out.data, h, sycl::write_only};
+        sycl::accessor d_values{*values.data, h, sycl::read_only};
+        sycl::accessor d_rowIdx{*rowIdx.data, h, sycl::read_only};
+        sycl::accessor d_colIdx{*colIdx.data, h, sycl::read_only};
+        sycl::accessor d_rhs{*rhs.data, h, sycl::read_only};
+
+        h.parallel_for(sycl::nd_range{global, local},
+                       sparseArithCOOKernel<T, op>(
+                           d_out, out.info, d_values, d_rowIdx, d_colIdx,
+                           static_cast<int>(values.info.dims[0]), d_rhs,
+                           rhs.info, static_cast<int>(reverse)));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename T, af_op_t op>
+class sparseArithCSR2Kernel {
+   public:
+    sparseArithCSR2Kernel(sycl::accessor<T> values, read_accessor<int> rowIdx,
+                          read_accessor<int> colIdx, const int nNZ,
+                          read_accessor<T> rPtr, const KParam rhs,
+                          const int reverse)
+        : values_(values)
+        , rowIdx_(rowIdx)
+        , colIdx_(colIdx)
+        , nNZ_(nNZ)
+        , rPtr_(rPtr)
+        , rhs_(rhs)
+        , reverse_(reverse) {}
+
+    void operator()(sycl::nd_item<2> it) const {
+        sycl::group g = it.get_group();
+        common::Binary<T, op> binOP;
+
+        const int row =
+            g.get_group_id(0) * g.get_local_range(1) + it.get_local_id(1);
+
+        if (row < rhs_.dims[0]) {
+            const int rowStartIdx = rowIdx_[row];
+            const int rowEndIdx   = rowIdx_[row + 1];
+
+            // Repeat loop until all values in the row are computed
+            for (int idx = rowStartIdx + it.get_local_id(0); idx < rowEndIdx;
+                 idx += g.get_local_range(0)) {
+                const int col = colIdx_[idx];
+
+                if (row >= rhs_.dims[0] || col >= rhs_.dims[1])
+                    continue;  // Bad indices
+
+                // Get Values
+                const T val  = values_[idx];
+                const T rval = rPtr_[col * rhs_.strides[1] + row];
+
+                if (reverse_)
+                    values_[idx] = binOP(rval, val);
+                else
+                    values_[idx] = binOP(val, rval);
+            }
+        }
+    }
+
+   private:
+    sycl::accessor<T> values_;
+    read_accessor<int> rowIdx_;
+    read_accessor<int> colIdx_;
+    const int nNZ_;
+    read_accessor<T> rPtr_;
+    const KParam rhs_;
+    const int reverse_;
+};
+
+template<typename T, af_op_t op>
+void sparseArithOpCSR(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
+                      const Param<T> rhs, const bool reverse) {
+    auto local  = sycl::range(TX, TY);
+    auto global = sycl::range(divup(values.info.dims[0], TY) * TX, TY);
+
+    getQueue().submit([&](auto &h) {
+        sycl::accessor d_values{*values.data, h, sycl::read_write};
+        sycl::accessor d_rowIdx{*rowIdx.data, h, sycl::read_only};
+        sycl::accessor d_colIdx{*colIdx.data, h, sycl::read_only};
+        sycl::accessor d_rhs{*rhs.data, h, sycl::read_only};
+
+        h.parallel_for(sycl::nd_range{global, local},
+                       sparseArithCSR2Kernel<T, op>(
+                           d_values, d_rowIdx, d_colIdx,
+                           static_cast<int>(values.info.dims[0]), d_rhs,
+                           rhs.info, static_cast<int>(reverse)));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename T, af_op_t op>
+class sparseArithCOO2Kernel {
+   public:
+    sparseArithCOO2Kernel(sycl::accessor<T> values, read_accessor<int> rowIdx,
+                          read_accessor<int> colIdx, const int nNZ,
+                          read_accessor<T> rPtr, const KParam rhs,
+                          const int reverse)
+        : values_(values)
+        , rowIdx_(rowIdx)
+        , colIdx_(colIdx)
+        , nNZ_(nNZ)
+        , rPtr_(rPtr)
+        , rhs_(rhs)
+        , reverse_(reverse) {}
+
+    void operator()(sycl::nd_item<1> it) const {
+        common::Binary<T, op> binOP;
+
+        const int idx = it.get_global_id(0);
+
+        if (idx < nNZ_) {
+            const int row = rowIdx_[idx];
+            const int col = colIdx_[idx];
+
+            if (row >= rhs_.dims[0] || col >= rhs_.dims[1])
+                return;  // Bad indices
+
+            // Get Values
+            const T val  = values_[idx];
+            const T rval = rPtr_[col * rhs_.strides[1] + row];
+
+            if (reverse_)
+                values_[idx] = binOP(rval, val);
+            else
+                values_[idx] = binOP(val, rval);
+        }
+    }
+
+   private:
+    sycl::accessor<T> values_;
+    read_accessor<int> rowIdx_;
+    read_accessor<int> colIdx_;
+    const int nNZ_;
+    read_accessor<T> rPtr_;
+    const KParam rhs_;
+    const int reverse_;
+};
+
+template<typename T, af_op_t op>
+void sparseArithOpCOO(Param<T> values, Param<int> rowIdx, Param<int> colIdx,
+                      const Param<T> rhs, const bool reverse) {
+    auto local  = sycl::range(THREADS);
+    auto global = sycl::range(divup(values.info.dims[0], THREADS) * THREADS);
+
+    getQueue().submit([&](auto &h) {
+        sycl::accessor d_values{*values.data, h, sycl::read_write};
+        sycl::accessor d_rowIdx{*rowIdx.data, h, sycl::read_only};
+        sycl::accessor d_colIdx{*colIdx.data, h, sycl::read_only};
+        sycl::accessor d_rhs{*rhs.data, h, sycl::read_only};
+
+        h.parallel_for(sycl::nd_range{global, local},
+                       sparseArithCOO2Kernel<T, op>(
+                           d_values, d_rowIdx, d_colIdx,
+                           static_cast<int>(values.info.dims[0]), d_rhs,
+                           rhs.info, static_cast<int>(reverse)));
+    });
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+class csrCalcOutNNZKernel {
+   public:
+    csrCalcOutNNZKernel(write_accessor<unsigned> nnzc,
+                        write_accessor<int> oRowIdx, unsigned M,
+                        read_accessor<int> lRowIdx, read_accessor<int> lColIdx,
+                        read_accessor<int> rRowIdx, read_accessor<int> rColIdx,
+                        sycl::local_accessor<unsigned, 1> blkNNZ)
+        : nnzc_(nnzc)
+        , oRowIdx_(oRowIdx)
+        , M_(M)
+        , lRowIdx_(lRowIdx)
+        , lColIdx_(lColIdx)
+        , rRowIdx_(rRowIdx)
+        , rColIdx_(rColIdx)
+        , blkNNZ_(blkNNZ) {}
+
+    void operator()(sycl::nd_item<1> it) const {
+        sycl::group g = it.get_group();
+
+        const uint row = it.get_global_id(0);
+        const uint tid = it.get_local_id(0);
+
+        const bool valid = row < M_;
+
+        const uint lEnd = (valid ? lRowIdx_[row + 1] : 0);
+        const uint rEnd = (valid ? rRowIdx_[row + 1] : 0);
+
+        blkNNZ_[tid] = 0;
+        it.barrier();
+
+        uint l   = (valid ? lRowIdx_[row] : 0);
+        uint r   = (valid ? rRowIdx_[row] : 0);
+        uint nnz = 0;
+        while (l < lEnd && r < rEnd) {
+            uint lci = lColIdx_[l];
+            uint rci = rColIdx_[r];
+            l += (lci <= rci);
+            r += (lci >= rci);
+            nnz++;
+        }
+        nnz += (lEnd - l);
+        nnz += (rEnd - r);
+
+        blkNNZ_[tid] = nnz;
+        it.barrier();
+
+        if (valid) oRowIdx_[row + 1] = nnz;
+
+        for (uint s = g.get_local_range(0) / 2; s > 0; s >>= 1) {
+            if (tid < s) { blkNNZ_[tid] += blkNNZ_[tid + s]; }
+            it.barrier();
+        }
+
+        if (tid == 0) {
+            nnz = blkNNZ_[0];
+            global_atomic_ref<uint>(nnzc_[0]) += nnz;
+        }
+    }
+
+   private:
+    write_accessor<unsigned> nnzc_;
+    write_accessor<int> oRowIdx_;
+    unsigned M_;
+    read_accessor<int> lRowIdx_;
+    read_accessor<int> lColIdx_;
+    read_accessor<int> rRowIdx_;
+    read_accessor<int> rColIdx_;
+    sycl::local_accessor<unsigned, 1> blkNNZ_;
+};
+
+static void csrCalcOutNNZ(Param<int> outRowIdx, unsigned &nnzC, const uint M,
+                          const uint N, uint nnzA, const Param<int> lrowIdx,
+                          const Param<int> lcolIdx, uint nnzB,
+                          const Param<int> rrowIdx, const Param<int> rcolIdx) {
+    UNUSED(N);
+    UNUSED(nnzA);
+    UNUSED(nnzB);
+
+    auto local  = sycl::range(256);
+    auto global = sycl::range(divup(M, local[0]) * local[0]);
+
+    Array<unsigned> out = createValueArray<unsigned>(1, 0);
+
+    getQueue().submit([&](auto &h) {
+        sycl::accessor d_out{*out.get(), h, sycl::write_only};
+        sycl::accessor d_outRowIdx{*outRowIdx.data, h, sycl::write_only};
+        sycl::accessor d_lRowIdx{*lrowIdx.data, h, sycl::read_only};
+        sycl::accessor d_lColIdx{*lcolIdx.data, h, sycl::read_only};
+        sycl::accessor d_rRowIdx{*rrowIdx.data, h, sycl::read_only};
+        sycl::accessor d_rColIdx{*rcolIdx.data, h, sycl::read_only};
+
+        auto blkNNZ = sycl::local_accessor<unsigned, 1>(local[0], h);
+        h.parallel_for(
+            sycl::nd_range{global, local},
+            csrCalcOutNNZKernel(d_out, d_outRowIdx, M, d_lRowIdx, d_lColIdx,
+                                d_rRowIdx, d_rColIdx, blkNNZ));
+    });
+
+    {
+        sycl::host_accessor nnz_acc{*out.get(), sycl::read_only};
+        nnzC = nnz_acc[0];
+    }
+
+    ONEAPI_DEBUG_FINISH(getQueue());
+}
+
+template<typename T, af_op_t op>
+class ssarithCSRKernel {
+   public:
+    ssarithCSRKernel(write_accessor<T> oVals, write_accessor<int> oColIdx,
+                     read_accessor<int> oRowIdx, unsigned M, unsigned N,
+                     unsigned nnza, read_accessor<T> lVals,
+                     read_accessor<int> lRowIdx, read_accessor<int> lColIdx,
+                     unsigned nnzb, read_accessor<T> rVals,
+                     read_accessor<int> rRowIdx, read_accessor<int> rColIdx)
+        : oVals_(oVals)
+        , oColIdx_(oColIdx)
+        , oRowIdx_(oRowIdx)
+        , M_(M)
+        , N_(N)
+        , nnza_(nnza)
+        , lVals_(lVals)
+        , lRowIdx_(lRowIdx)
+        , lColIdx_(lColIdx)
+        , nnzb_(nnzb)
+        , rVals_(rVals)
+        , rRowIdx_(rRowIdx)
+        , rColIdx_(rColIdx) {}
+
+    void operator()(sycl::nd_item<1> it) const {
+        common::Binary<T, op> binOP;
+
+        const uint row = it.get_global_id(0);
+
+        const bool valid  = row < M_;
+        const uint lEnd   = (valid ? lRowIdx_[row + 1] : 0);
+        const uint rEnd   = (valid ? rRowIdx_[row + 1] : 0);
+        const uint offset = (valid ? oRowIdx_[row] : 0);
+
+        T *ovPtr   = oVals_.get_pointer() + offset;
+        int *ocPtr = oColIdx_.get_pointer() + offset;
+
+        uint l = (valid ? lRowIdx_[row] : 0);
+        uint r = (valid ? rRowIdx_[row] : 0);
+
+        uint nnz = 0;
+        while (l < lEnd && r < rEnd) {
+            uint lci = lColIdx_[l];
+            uint rci = rColIdx_[r];
+
+            T lhs = (lci <= rci ? lVals_[l] : common::Binary<T, op>::init());
+            T rhs = (lci >= rci ? rVals_[r] : common::Binary<T, op>::init());
+
+            ovPtr[nnz] = binOP(lhs, rhs);
+            ocPtr[nnz] = (lci <= rci) ? lci : rci;
+
+            l += (lci <= rci);
+            r += (lci >= rci);
+            nnz++;
+        }
+        while (l < lEnd) {
+            ovPtr[nnz] = binOP(lVals_[l], common::Binary<T, op>::init());
+            ocPtr[nnz] = lColIdx_[l];
+            l++;
+            nnz++;
+        }
+        while (r < rEnd) {
+            ovPtr[nnz] = binOP(common::Binary<T, op>::init(), rVals_[r]);
+            ocPtr[nnz] = rColIdx_[r];
+            r++;
+            nnz++;
+        }
+    }
+
+   private:
+    write_accessor<T> oVals_;
+    write_accessor<int> oColIdx_;
+    read_accessor<int> oRowIdx_;
+    unsigned M_, N_;
+    unsigned nnza_;
+    read_accessor<T> lVals_;
+    read_accessor<int> lRowIdx_;
+    read_accessor<int> lColIdx_;
+    unsigned nnzb_;
+    read_accessor<T> rVals_;
+    read_accessor<int> rRowIdx_;
+    read_accessor<int> rColIdx_;
+};
+
+template<typename T, af_op_t op>
+void ssArithCSR(Param<T> oVals, Param<int> oColIdx, const Param<int> oRowIdx,
+                const uint M, const uint N, unsigned nnzA, const Param<T> lVals,
+                const Param<int> lRowIdx, const Param<int> lColIdx,
+                unsigned nnzB, const Param<T> rVals, const Param<int> rRowIdx,
+                const Param<int> rColIdx) {
+    auto local  = sycl::range(256);
+    auto global = sycl::range(divup(M, local[0]) * local[0]);
+
+    getQueue().submit([&](auto &h) {
+        sycl::accessor d_oVals{*oVals.data, h, sycl::write_only};
+        sycl::accessor d_oColIdx{*oColIdx.data, h, sycl::write_only};
+        sycl::accessor d_oRowIdx{*oRowIdx.data, h, sycl::read_only};
+
+        sycl::accessor d_lVals{*lVals.data, h, sycl::read_only};
+        sycl::accessor d_lRowIdx{*lRowIdx.data, h, sycl::read_only};
+        sycl::accessor d_lColIdx{*lColIdx.data, h, sycl::read_only};
+
+        sycl::accessor d_rVals{*rVals.data, h, sycl::read_only};
+        sycl::accessor d_rRowIdx{*rRowIdx.data, h, sycl::read_only};
+        sycl::accessor d_rColIdx{*rColIdx.data, h, sycl::read_only};
+
+        h.parallel_for(
+            sycl::nd_range{global, local},
+            ssarithCSRKernel<T, op>(d_oVals, d_oColIdx, d_oRowIdx, M, N, nnzA,
+                                    d_lVals, d_lRowIdx, d_lColIdx, nnzB,
+                                    d_rVals, d_rRowIdx, d_rColIdx));
+    });
+}
+
+}  // namespace kernel
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/oneapi/sparse.cpp
+++ b/src/backend/oneapi/sparse.cpp
@@ -26,67 +26,60 @@
 #include <stdexcept>
 #include <string>
 
+#include <handle.hpp>
+
+
 namespace arrayfire {
 namespace oneapi {
 
 using namespace common;
 
+
+#define P(exp) af_print_array_gen(#exp, getHandle(exp), 2)
+
+
 // Partial template specialization of sparseConvertDenseToStorage for COO
 // However, template specialization is not allowed
 template<typename T>
 SparseArray<T> sparseConvertDenseToCOO(const Array<T> &in) {
-    ONEAPI_NOT_SUPPORTED("sparseConvertDenseToCOO Not supported");
-    // in.eval();
+    in.eval();
 
-    // Array<uint> nonZeroIdx_ = where<T>(in);
-    // Array<int> nonZeroIdx   = cast<int, uint>(nonZeroIdx_);
+    Array<uint> nonZeroIdx_ = where<T>(in);
+    Array<int> nonZeroIdx   = cast<int, uint>(nonZeroIdx_);
+    nonZeroIdx.eval();
 
-    // dim_t nNZ = nonZeroIdx.elements();
+    dim_t nNZ = nonZeroIdx.elements();
 
-    // Array<int> constDim = createValueArray<int>(dim4(nNZ), in.dims()[0]);
-    // constDim.eval();
+    Array<int> constDim = createValueArray<int>(dim4(nNZ), in.dims()[0]);
+    constDim.eval();
 
-    // Array<int> rowIdx =
-    //     arithOp<int, af_mod_t>(nonZeroIdx, constDim, nonZeroIdx.dims());
-    // Array<int> colIdx =
-    //     arithOp<int, af_div_t>(nonZeroIdx, constDim, nonZeroIdx.dims());
+    Array<int> rowIdx =
+        arithOp<int, af_mod_t>(nonZeroIdx, constDim, nonZeroIdx.dims());
+    Array<int> colIdx =
+        arithOp<int, af_div_t>(nonZeroIdx, constDim, nonZeroIdx.dims());
 
-    // Array<T> values = copyArray<T>(in);
-    // values          = modDims(values, dim4(values.elements()));
-    // values          = lookup<T, int>(values, nonZeroIdx, 0);
+    Array<T> values = copyArray<T>(in);
+    values          = modDims(values, dim4(values.elements()));
+    values          = lookup<T, int>(values, nonZeroIdx, 0);
 
-    // return createArrayDataSparseArray<T>(in.dims(), values, rowIdx, colIdx,
-    //                                      AF_STORAGE_COO);
+    return createArrayDataSparseArray<T>(in.dims(), values, rowIdx, colIdx,
+                                         AF_STORAGE_COO);
 }
 
 template<typename T, af_storage stype>
 SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in_) {
-    // ONEAPI_NOT_SUPPORTED("sparseConvertDenseToStorage Not supported");
     in_.eval();
 
-    printf("FFFUUU %d\n", __LINE__);
-    auto tmp = reduce_all<af_notzero_t, T, uint>(in_);
-    printf("FFFUUU %d\n", __LINE__);
-    uint nNZ = getScalar<uint>(tmp);
+    uint nNZ = getScalar<uint>(reduce_all<af_notzero_t, T, uint>(in_));
 
-    printf("got ... %d\n", nNZ);
-
-    printf("FFFUUU %d\n", __LINE__);
     SparseArray<T> sparse_ = createEmptySparseArray<T>(in_.dims(), nNZ, stype);
-    printf("FFFUUU %d\n", __LINE__);
     sparse_.eval();
-    printf("FFFUUU %d\n", __LINE__);
 
-    printf("FFFUUU %d\n", __LINE__);
     Array<T> &values = sparse_.getValues();
-    printf("FFFUUU %d\n", __LINE__);
     Array<int> &rowIdx = sparse_.getRowIdx();
-    printf("FFFUUU %d\n", __LINE__);
     Array<int> &colIdx = sparse_.getColIdx();
-    printf("FFFUUU %d\n", __LINE__);
 
     kernel::dense2csr<T>(values, rowIdx, colIdx, in_);
-    printf("FFFUUU %d\n", __LINE__);
 
     return sparse_;
 }
@@ -95,98 +88,92 @@ SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in_) {
 // However, template specialization is not allowed
 template<typename T>
 Array<T> sparseConvertCOOToDense(const SparseArray<T> &in) {
-    ONEAPI_NOT_SUPPORTED("sparseConvertCOOToDense Not supported");
-    //    in.eval();
-    //
-    //    Array<T> dense = createValueArray<T>(in.dims(), scalar<T>(0));
-    //    dense.eval();
-    //
-    //    const Array<T> values   = in.getValues();
-    //    const Array<int> rowIdx = in.getRowIdx();
-    //    const Array<int> colIdx = in.getColIdx();
+    in.eval();
 
-    // kernel::coo2dense<T>(dense, values, rowIdx, colIdx);
+    Array<T> dense = createValueArray<T>(in.dims(), scalar<T>(0));
+    dense.eval();
 
-    // return dense;
+    const Array<T> values   = in.getValues();
+    const Array<int> rowIdx = in.getRowIdx();
+    const Array<int> colIdx = in.getColIdx();
+
+    kernel::coo2dense<T>(dense, values, rowIdx, colIdx);
+
+    return dense;
 }
 
 template<typename T, af_storage stype>
 Array<T> sparseConvertStorageToDense(const SparseArray<T> &in_) {
-    ONEAPI_NOT_SUPPORTED("sparseConvertStorageToDense Not supported");
-    //
-    //    if (stype != AF_STORAGE_CSR) {
-    //        AF_ERROR("OpenCL Backend only supports CSR or COO to Dense",
-    //                 AF_ERR_NOT_SUPPORTED);
-    //    }
-    //
-    //    in_.eval();
-    //
-    //    Array<T> dense_ = createValueArray<T>(in_.dims(), scalar<T>(0));
-    //    dense_.eval();
-    //
-    //    const Array<T> &values   = in_.getValues();
-    //    const Array<int> &rowIdx = in_.getRowIdx();
-    //    const Array<int> &colIdx = in_.getColIdx();
-    //
-    //    if (stype == AF_STORAGE_CSR) {
-    //        // kernel::csr2dense<T>(dense_, values, rowIdx, colIdx);
-    //    } else {
-    //        AF_ERROR("OpenCL Backend only supports CSR or COO to Dense",
-    //                 AF_ERR_NOT_SUPPORTED);
-    //    }
-    //
-    //    return dense_;
+    if (stype != AF_STORAGE_CSR) {
+        AF_ERROR("oneAPI Backend only supports CSR or COO to Dense",
+                 AF_ERR_NOT_SUPPORTED);
+    }
+
+    in_.eval();
+
+    Array<T> dense_ = createValueArray<T>(in_.dims(), scalar<T>(0));
+    dense_.eval();
+
+    const Array<T> &values   = in_.getValues();
+    const Array<int> &rowIdx = in_.getRowIdx();
+    const Array<int> &colIdx = in_.getColIdx();
+
+    if (stype == AF_STORAGE_CSR) {
+        kernel::csr2dense<T>(dense_, values, rowIdx, colIdx);
+    } else {
+        AF_ERROR("oneAPI Backend only supports CSR or COO to Dense",
+                 AF_ERR_NOT_SUPPORTED);
+    }
+
+    return dense_;
 }
 
 template<typename T, af_storage dest, af_storage src>
 SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in) {
-    ONEAPI_NOT_SUPPORTED("sparseConvertStorageToStorage Not supported");
-    // in.eval();
+    in.eval();
 
-    // SparseArray<T> converted = createEmptySparseArray<T>(
-    //     in.dims(), static_cast<int>(in.getNNZ()), dest);
-    // converted.eval();
+    SparseArray<T> converted = createEmptySparseArray<T>(
+        in.dims(), static_cast<int>(in.getNNZ()), dest);
+    converted.eval();
 
-    // if (src == AF_STORAGE_CSR && dest == AF_STORAGE_COO) {
-    //     Array<int> index = range<int>(in.getNNZ(), 0);
-    //     index.eval();
+    if (src == AF_STORAGE_CSR && dest == AF_STORAGE_COO) {
+        Array<int> index = range<int>(in.getNNZ(), 0);
+        index.eval();
 
-    //    Array<T> &ovalues         = converted.getValues();
-    //    Array<int> &orowIdx       = converted.getRowIdx();
-    //    Array<int> &ocolIdx       = converted.getColIdx();
-    //    const Array<T> &ivalues   = in.getValues();
-    //    const Array<int> &irowIdx = in.getRowIdx();
-    //    const Array<int> &icolIdx = in.getColIdx();
+        Array<T> &ovalues         = converted.getValues();
+        Array<int> &orowIdx       = converted.getRowIdx();
+        Array<int> &ocolIdx       = converted.getColIdx();
+        const Array<T> &ivalues   = in.getValues();
+        const Array<int> &irowIdx = in.getRowIdx();
+        const Array<int> &icolIdx = in.getColIdx();
 
-    //    // kernel::csr2coo<T>(ovalues, orowIdx, ocolIdx, ivalues, irowIdx,
-    //    // icolIdx,
-    //    //                    index);
+        kernel::csr2coo<T>(ovalues, orowIdx, ocolIdx, ivalues, irowIdx,
+                           icolIdx, index);
 
-    //} else if (src == AF_STORAGE_COO && dest == AF_STORAGE_CSR) {
-    //    Array<int> index = range<int>(in.getNNZ(), 0);
-    //    index.eval();
+    } else if (src == AF_STORAGE_COO && dest == AF_STORAGE_CSR) {
+        // Array<int> index = range<int>(in.getNNZ(), 0);
+        // index.eval();
 
-    //    Array<T> &ovalues         = converted.getValues();
-    //    Array<int> &orowIdx       = converted.getRowIdx();
-    //    Array<int> &ocolIdx       = converted.getColIdx();
-    //    const Array<T> &ivalues   = in.getValues();
-    //    const Array<int> &irowIdx = in.getRowIdx();
-    //    const Array<int> &icolIdx = in.getColIdx();
+        // Array<T> &ovalues         = converted.getValues();
+        // Array<int> &orowIdx       = converted.getRowIdx();
+        // Array<int> &ocolIdx       = converted.getColIdx();
+        // const Array<T> &ivalues   = in.getValues();
+        // const Array<int> &irowIdx = in.getRowIdx();
+        // const Array<int> &icolIdx = in.getColIdx();
 
-    //    Array<int> rowCopy = copyArray<int>(irowIdx);
-    //    rowCopy.eval();
+        // Array<int> rowCopy = copyArray<int>(irowIdx);
+        // rowCopy.eval();
 
-    //    kernel::coo2csr<T>(ovalues, orowIdx, ocolIdx, ivalues, irowIdx,
-    //    icolIdx,
-    //                       index, rowCopy, in.dims()[0]);
+        // kernel::coo2csr<T>(ovalues, orowIdx, ocolIdx, ivalues, irowIdx, icolIdx,
+        //                    index, rowCopy, in.dims()[0]);
 
-    //} else {
-    //    // Should never come here
-    //    AF_ERROR("OpenCL Backend invalid conversion combination",
-    //             AF_ERR_NOT_SUPPORTED);
-    //}
+    } else {
+        // Should never come here
+        AF_ERROR("oneAPI Backend invalid conversion combination",
+                 AF_ERR_NOT_SUPPORTED);
+    }
 
-    // return converted;
+    return converted;
 }
 
 #define INSTANTIATE_TO_STORAGE(T, S)                     \

--- a/src/backend/oneapi/sparse.cpp
+++ b/src/backend/oneapi/sparse.cpp
@@ -7,7 +7,7 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-// #include <kernel/sparse.hpp>
+#include <kernel/sparse.hpp>
 #include <sparse.hpp>
 
 #include <arith.hpp>
@@ -61,21 +61,34 @@ SparseArray<T> sparseConvertDenseToCOO(const Array<T> &in) {
 
 template<typename T, af_storage stype>
 SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in_) {
-    ONEAPI_NOT_SUPPORTED("sparseConvertDenseToStorage Not supported");
-    //     in_.eval();
-    //
-    //     uint nNZ = getScalar<uint>(reduce_all<af_notzero_t, T, uint>(in_));
-    //
-    //     SparseArray<T> sparse_ = createEmptySparseArray<T>(in_.dims(), nNZ,
-    //     stype); sparse_.eval();
-    //
-    //     Array<T> &values   = sparse_.getValues();
-    //     Array<int> &rowIdx = sparse_.getRowIdx();
-    //     Array<int> &colIdx = sparse_.getColIdx();
+    // ONEAPI_NOT_SUPPORTED("sparseConvertDenseToStorage Not supported");
+    in_.eval();
 
-    // kernel::dense2csr<T>(values, rowIdx, colIdx, in_);
+    printf("FFFUUU %d\n", __LINE__);
+    auto tmp = reduce_all<af_notzero_t, T, uint>(in_);
+    printf("FFFUUU %d\n", __LINE__);
+    uint nNZ = getScalar<uint>(tmp);
 
-    // return sparse_;
+    printf("got ... %d\n", nNZ);
+
+    printf("FFFUUU %d\n", __LINE__);
+    SparseArray<T> sparse_ = createEmptySparseArray<T>(in_.dims(), nNZ, stype);
+    printf("FFFUUU %d\n", __LINE__);
+    sparse_.eval();
+    printf("FFFUUU %d\n", __LINE__);
+
+    printf("FFFUUU %d\n", __LINE__);
+    Array<T> &values = sparse_.getValues();
+    printf("FFFUUU %d\n", __LINE__);
+    Array<int> &rowIdx = sparse_.getRowIdx();
+    printf("FFFUUU %d\n", __LINE__);
+    Array<int> &colIdx = sparse_.getColIdx();
+    printf("FFFUUU %d\n", __LINE__);
+
+    kernel::dense2csr<T>(values, rowIdx, colIdx, in_);
+    printf("FFFUUU %d\n", __LINE__);
+
+    return sparse_;
 }
 
 // Partial template specialization of sparseConvertStorageToDense for COO

--- a/src/backend/oneapi/sparse.cpp
+++ b/src/backend/oneapi/sparse.cpp
@@ -28,15 +28,12 @@
 
 #include <handle.hpp>
 
-
 namespace arrayfire {
 namespace oneapi {
 
 using namespace common;
 
-
 #define P(exp) af_print_array_gen(#exp, getHandle(exp), 2)
-
 
 // Partial template specialization of sparseConvertDenseToStorage for COO
 // However, template specialization is not allowed
@@ -75,7 +72,7 @@ SparseArray<T> sparseConvertDenseToStorage(const Array<T> &in_) {
     SparseArray<T> sparse_ = createEmptySparseArray<T>(in_.dims(), nNZ, stype);
     sparse_.eval();
 
-    Array<T> &values = sparse_.getValues();
+    Array<T> &values   = sparse_.getValues();
     Array<int> &rowIdx = sparse_.getRowIdx();
     Array<int> &colIdx = sparse_.getColIdx();
 
@@ -147,25 +144,25 @@ SparseArray<T> sparseConvertStorageToStorage(const SparseArray<T> &in) {
         const Array<int> &irowIdx = in.getRowIdx();
         const Array<int> &icolIdx = in.getColIdx();
 
-        kernel::csr2coo<T>(ovalues, orowIdx, ocolIdx, ivalues, irowIdx,
-                           icolIdx, index);
+        kernel::csr2coo<T>(ovalues, orowIdx, ocolIdx, ivalues, irowIdx, icolIdx,
+                           index);
 
     } else if (src == AF_STORAGE_COO && dest == AF_STORAGE_CSR) {
-        // Array<int> index = range<int>(in.getNNZ(), 0);
-        // index.eval();
+        Array<int> index = range<int>(in.getNNZ(), 0);
+        index.eval();
 
-        // Array<T> &ovalues         = converted.getValues();
-        // Array<int> &orowIdx       = converted.getRowIdx();
-        // Array<int> &ocolIdx       = converted.getColIdx();
-        // const Array<T> &ivalues   = in.getValues();
-        // const Array<int> &irowIdx = in.getRowIdx();
-        // const Array<int> &icolIdx = in.getColIdx();
+        Array<T> &ovalues         = converted.getValues();
+        Array<int> &orowIdx       = converted.getRowIdx();
+        Array<int> &ocolIdx       = converted.getColIdx();
+        const Array<T> &ivalues   = in.getValues();
+        const Array<int> &irowIdx = in.getRowIdx();
+        const Array<int> &icolIdx = in.getColIdx();
 
-        // Array<int> rowCopy = copyArray<int>(irowIdx);
-        // rowCopy.eval();
+        Array<int> rowCopy = copyArray<int>(irowIdx);
+        rowCopy.eval();
 
-        // kernel::coo2csr<T>(ovalues, orowIdx, ocolIdx, ivalues, irowIdx, icolIdx,
-        //                    index, rowCopy, in.dims()[0]);
+        kernel::coo2csr<T>(ovalues, orowIdx, ocolIdx, ivalues, irowIdx, icolIdx,
+                           index, rowCopy, in.dims()[0]);
 
     } else {
         // Should never come here

--- a/src/backend/oneapi/sparse_arith.cpp
+++ b/src/backend/oneapi/sparse_arith.cpp
@@ -7,8 +7,8 @@
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
 
-// #include <kernel/sparse_arith.hpp>
 #include <err_oneapi.hpp>
+#include <kernel/sparse_arith.hpp>
 #include <sparse.hpp>
 
 #include <stdexcept>
@@ -51,104 +51,101 @@ cdouble getInf() {
 template<typename T, af_op_t op>
 Array<T> arithOpD(const SparseArray<T> &lhs, const Array<T> &rhs,
                   const bool reverse) {
-    ONEAPI_NOT_SUPPORTED("arithOpD Not supported");
-    // lhs.eval();
-    // rhs.eval();
+    lhs.eval();
+    rhs.eval();
 
-    // Array<T> out  = createEmptyArray<T>(dim4(0));
-    // Array<T> zero = createValueArray<T>(rhs.dims(), scalar<T>(0));
-    // switch (op) {
-    //     case af_add_t: out = copyArray<T>(rhs); break;
-    //     case af_sub_t:
-    //         out = reverse ? copyArray<T>(rhs)
-    //                       : arithOp<T, af_sub_t>(zero, rhs, rhs.dims());
-    //         break;
-    //     default: out = copyArray<T>(rhs);
-    // }
-    // out.eval();
-    // switch (lhs.getStorage()) {
-    //     case AF_STORAGE_CSR:
-    //         kernel::sparseArithOpCSR<T, op>(out, lhs.getValues(),
-    //                                         lhs.getRowIdx(), lhs.getColIdx(),
-    //                                         rhs, reverse);
-    //         break;
-    //     case AF_STORAGE_COO:
-    //         kernel::sparseArithOpCOO<T, op>(out, lhs.getValues(),
-    //                                         lhs.getRowIdx(), lhs.getColIdx(),
-    //                                         rhs, reverse);
-    //         break;
-    //     default:
-    //         AF_ERROR("Sparse Arithmetic only supported for CSR or COO",
-    //                  AF_ERR_NOT_SUPPORTED);
-    // }
+    Array<T> out  = createEmptyArray<T>(dim4(0));
+    Array<T> zero = createValueArray<T>(rhs.dims(), scalar<T>(0));
+    switch (op) {
+        case af_add_t: out = copyArray<T>(rhs); break;
+        case af_sub_t:
+            out = reverse ? copyArray<T>(rhs)
+                          : arithOp<T, af_sub_t>(zero, rhs, rhs.dims());
+            break;
+        default: out = copyArray<T>(rhs);
+    }
+    out.eval();
+    switch (lhs.getStorage()) {
+        case AF_STORAGE_CSR:
+            kernel::sparseArithOpCSR<T, op>(out, lhs.getValues(),
+                                            lhs.getRowIdx(), lhs.getColIdx(),
+                                            rhs, reverse);
+            break;
+        case AF_STORAGE_COO:
+            kernel::sparseArithOpCOO<T, op>(out, lhs.getValues(),
+                                            lhs.getRowIdx(), lhs.getColIdx(),
+                                            rhs, reverse);
+            break;
+        default:
+            AF_ERROR("Sparse Arithmetic only supported for CSR or COO",
+                     AF_ERR_NOT_SUPPORTED);
+    }
 
-    // return out;
+    return out;
 }
 
 template<typename T, af_op_t op>
 SparseArray<T> arithOp(const SparseArray<T> &lhs, const Array<T> &rhs,
                        const bool reverse) {
-    ONEAPI_NOT_SUPPORTED("arithOp Not supported");
-    // lhs.eval();
-    // rhs.eval();
+    lhs.eval();
+    rhs.eval();
 
-    // SparseArray<T> out = createArrayDataSparseArray<T>(
-    //     lhs.dims(), lhs.getValues(), lhs.getRowIdx(), lhs.getColIdx(),
-    //     lhs.getStorage(), true);
-    // out.eval();
-    // switch (lhs.getStorage()) {
-    //     case AF_STORAGE_CSR:
-    //         kernel::sparseArithOpCSR<T, op>(out.getValues(), out.getRowIdx(),
-    //                                         out.getColIdx(), rhs, reverse);
-    //         break;
-    //     case AF_STORAGE_COO:
-    //         kernel::sparseArithOpCOO<T, op>(out.getValues(), out.getRowIdx(),
-    //                                         out.getColIdx(), rhs, reverse);
-    //         break;
-    //     default:
-    //         AF_ERROR("Sparse Arithmetic only supported for CSR or COO",
-    //                  AF_ERR_NOT_SUPPORTED);
-    // }
+    SparseArray<T> out = createArrayDataSparseArray<T>(
+        lhs.dims(), lhs.getValues(), lhs.getRowIdx(), lhs.getColIdx(),
+        lhs.getStorage(), true);
+    out.eval();
+    switch (lhs.getStorage()) {
+        case AF_STORAGE_CSR:
+            kernel::sparseArithOpCSR<T, op>(out.getValues(), out.getRowIdx(),
+                                            out.getColIdx(), rhs, reverse);
+            break;
+        case AF_STORAGE_COO:
+            kernel::sparseArithOpCOO<T, op>(out.getValues(), out.getRowIdx(),
+                                            out.getColIdx(), rhs, reverse);
+            break;
+        default:
+            AF_ERROR("Sparse Arithmetic only supported for CSR or COO",
+                     AF_ERR_NOT_SUPPORTED);
+    }
 
-    // return out;
+    return out;
 }
 
 template<typename T, af_op_t op>
 SparseArray<T> arithOp(const SparseArray<T> &lhs, const SparseArray<T> &rhs) {
-    ONEAPI_NOT_SUPPORTED("arithOp Not supported");
-    // lhs.eval();
-    // rhs.eval();
-    // af::storage sfmt = lhs.getStorage();
+    lhs.eval();
+    rhs.eval();
+    af::storage sfmt = lhs.getStorage();
 
-    // const dim4 &ldims = lhs.dims();
+    const dim4 &ldims = lhs.dims();
 
-    // const uint M = ldims[0];
-    // const uint N = ldims[1];
+    const uint M = ldims[0];
+    const uint N = ldims[1];
 
-    // const dim_t nnzA = lhs.getNNZ();
-    // const dim_t nnzB = rhs.getNNZ();
+    const dim_t nnzA = lhs.getNNZ();
+    const dim_t nnzB = rhs.getNNZ();
 
-    // auto temp = createValueArray<int>(dim4(M + 1), scalar<int>(0));
-    // temp.eval();
+    auto temp = createValueArray<int>(dim4(M + 1), scalar<int>(0));
+    temp.eval();
 
-    // unsigned nnzC = 0;
-    // kernel::csrCalcOutNNZ(temp, nnzC, M, N, nnzA, lhs.getRowIdx(),
-    //                       lhs.getColIdx(), nnzB, rhs.getRowIdx(),
-    //                       rhs.getColIdx());
+    unsigned nnzC = 0;
+    kernel::csrCalcOutNNZ(temp, nnzC, M, N, nnzA, lhs.getRowIdx(),
+                          lhs.getColIdx(), nnzB, rhs.getRowIdx(),
+                          rhs.getColIdx());
 
-    // auto outRowIdx = scan<af_add_t, int, int>(temp, 0);
+    auto outRowIdx = scan<af_add_t, int, int>(temp, 0);
 
-    // auto outColIdx = createEmptyArray<int>(dim4(nnzC));
-    // auto outValues = createEmptyArray<T>(dim4(nnzC));
+    auto outColIdx = createEmptyArray<int>(dim4(nnzC));
+    auto outValues = createEmptyArray<T>(dim4(nnzC));
 
-    // kernel::ssArithCSR<T, op>(outValues, outColIdx, outRowIdx, M, N, nnzA,
-    //                           lhs.getValues(), lhs.getRowIdx(),
-    //                           lhs.getColIdx(), nnzB, rhs.getValues(),
-    //                           rhs.getRowIdx(), rhs.getColIdx());
+    kernel::ssArithCSR<T, op>(outValues, outColIdx, outRowIdx, M, N, nnzA,
+                              lhs.getValues(), lhs.getRowIdx(), lhs.getColIdx(),
+                              nnzB, rhs.getValues(), rhs.getRowIdx(),
+                              rhs.getColIdx());
 
-    // SparseArray<T> retVal = createArrayDataSparseArray(
-    //     ldims, outValues, outRowIdx, outColIdx, sfmt);
-    // return retVal;
+    SparseArray<T> retVal = createArrayDataSparseArray(
+        ldims, outValues, outRowIdx, outColIdx, sfmt);
+    return retVal;
 }
 
 #define INSTANTIATE(T)                                                         \

--- a/src/backend/oneapi/sparse_blas.cpp
+++ b/src/backend/oneapi/sparse_blas.cpp
@@ -9,15 +9,6 @@
 
 #include <sparse_blas.hpp>
 
-// #include <kernel/cscmm.hpp>
-// #include <kernel/cscmv.hpp>
-// #include <kernel/csrmm.hpp>
-// #include <kernel/csrmv.hpp>
-
-#include <cassert>
-#include <stdexcept>
-#include <string>
-
 #include <common/err_common.hpp>
 #include <complex.hpp>
 #include <err_oneapi.hpp>
@@ -26,68 +17,77 @@
 #include <transpose.hpp>
 #include <af/dim4.hpp>
 
-#if defined(WITH_LINEAR_ALGEBRA)
-// #include <cpu/cpu_sparse_blas.hpp>
-#endif  // WITH_LINEAR_ALGEBRA
+#include <oneapi/mkl/spblas.hpp>
+
+#include <sycl/sycl.hpp>
+
+#include <cassert>
+#include <stdexcept>
+#include <string>
 
 namespace arrayfire {
 namespace oneapi {
 
 using namespace common;
 
+// Converts an af_mat_prop options to a transpose type for mkl
+static ::oneapi::mkl::transpose toBlasTranspose(af_mat_prop opt) {
+    switch (opt) {
+        case AF_MAT_NONE: return ::oneapi::mkl::transpose::nontrans;
+        case AF_MAT_TRANS: return ::oneapi::mkl::transpose::trans;
+        case AF_MAT_CTRANS: return ::oneapi::mkl::transpose::conjtrans;
+        default: AF_ERROR("INVALID af_mat_prop", AF_ERR_ARG);
+    }
+}
+
 template<typename T>
 Array<T> matmul(const common::SparseArray<T>& lhs, const Array<T>& rhsIn,
                 af_mat_prop optLhs, af_mat_prop optRhs) {
-    ONEAPI_NOT_SUPPORTED("sparse matmul Not supported");
-    // #if defined(WITH_LINEAR_ALGEBRA)
-    //     if (OpenCLCPUOffload(
-    //             false)) {  // Do not force offload gemm on OSX Intel devices
-    //         return cpu::matmul(lhs, rhsIn, optLhs, optRhs);
-    //     }
-    // #endif
-    //
-    //     int lRowDim = (optLhs == AF_MAT_NONE) ? 0 : 1;
-    //     // int lColDim = (optLhs == AF_MAT_NONE) ? 1 : 0;
-    //     static const int rColDim =
-    //         1;  // Unsupported : (optRhs == AF_MAT_NONE) ? 1 : 0;
-    //
-    //     dim4 lDims = lhs.dims();
-    //     dim4 rDims = rhsIn.dims();
-    //     int M      = lDims[lRowDim];
-    //     int N      = rDims[rColDim];
-    //     // int K = lDims[lColDim];
-    //
-    //     const Array<T> rhs =
-    //         (N != 1 && optLhs == AF_MAT_NONE) ? transpose(rhsIn, false) :
-    //         rhsIn;
-    //     Array<T> out = createEmptyArray<T>(af::dim4(M, N, 1, 1));
-    //
-    //     static const T alpha = scalar<T>(1.0);
-    //     static const T beta  = scalar<T>(0.0);
-    //
-    //     const Array<T>& values   = lhs.getValues();
-    //     const Array<int>& rowIdx = lhs.getRowIdx();
-    //     const Array<int>& colIdx = lhs.getColIdx();
-    //
-    //     if (optLhs == AF_MAT_NONE) {
-    //         if (N == 1) {
-    //             kernel::csrmv(out, values, rowIdx, colIdx, rhs, alpha, beta);
-    //         } else {
-    //             kernel::csrmm_nt(out, values, rowIdx, colIdx, rhs, alpha,
-    //             beta);
-    //         }
-    //     } else {
-    //         // CSR transpose is a CSC matrix
-    //         if (N == 1) {
-    //             kernel::cscmv(out, values, rowIdx, colIdx, rhs, alpha, beta,
-    //                           optLhs == AF_MAT_CTRANS);
-    //         } else {
-    //             kernel::cscmm_nn(out, values, rowIdx, colIdx, rhs, alpha,
-    //             beta,
-    //                              optLhs == AF_MAT_CTRANS);
-    //         }
-    //     }
-    //     return out;
+    int lRowDim = (optLhs == AF_MAT_NONE) ? 0 : 1;
+    static const int rColDim =
+        1;  // Unsupported : (optRhs == AF_MAT_NONE) ? 1 : 0;
+
+    dim4 lDims    = lhs.dims();
+    dim4 rDims    = rhsIn.dims();
+    dim4 rStrides = rhsIn.strides();
+    int M         = lDims[lRowDim];
+    int N         = rDims[rColDim];
+
+    Array<T> out  = createEmptyArray<T>(af::dim4(M, N, 1, 1));
+    dim4 oStrides = out.strides();
+
+    static const T alpha = scalar<T>(1.0);
+    static const T beta  = scalar<T>(0.0);
+
+    const Array<T>& values      = lhs.getValues();
+    const Array<int>& rowIdx    = lhs.getRowIdx();
+    const Array<int>& colIdx    = lhs.getColIdx();
+    sycl::buffer<T, 1> valBuf   = values.template getBufferWithOffset<T>();
+    sycl::buffer<int, 1> rowBuf = rowIdx.template getBufferWithOffset<int>();
+    sycl::buffer<int, 1> colBuf = colIdx.template getBufferWithOffset<int>();
+
+    const auto lOpts = toBlasTranspose(optLhs);
+    const auto rOpts = toBlasTranspose(optRhs);
+
+    sycl::buffer<T, 1> rhsBuf = rhsIn.template getBufferWithOffset<T>();
+    sycl::buffer<T, 1> outBuf = out.template getBufferWithOffset<T>();
+
+    ::oneapi::mkl::sparse::matrix_handle_t CSRHandle = nullptr;
+    ::oneapi::mkl::sparse::init_matrix_handle(&CSRHandle);
+    ::oneapi::mkl::sparse::set_csr_data(
+        getQueue(), CSRHandle, lDims[0], lDims[1],
+        ::oneapi::mkl::index_base::zero, rowBuf, colBuf, valBuf);
+
+    if (N == 1) {
+        ::oneapi::mkl::sparse::gemv(getQueue(), lOpts, alpha, CSRHandle, rhsBuf,
+                                    beta, outBuf);
+    } else {
+        ::oneapi::mkl::sparse::gemm(
+            getQueue(), ::oneapi::mkl::layout::col_major, lOpts, rOpts, alpha,
+            CSRHandle, rhsBuf, N, rStrides[1], beta, outBuf, oStrides[1]);
+    }
+    ::oneapi::mkl::sparse::release_matrix_handle(getQueue(), &CSRHandle);
+    return out;
 }
 
 #define INSTANTIATE_SPARSE(T)                                            \


### PR DESCRIPTION
Adds sparse to oneapi backend.

Adds sparse, sparse convert, sparse arith, and sparse blas to oneapi backend. Sparse tests are passing other than the functionality currently missing in oneMKL blas -- no LHS transpose option and no complex support for gemm, gemv. CG benchmark still isn't working, tbd why.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
