### PR TITLE
fix finding vector_types and vector_functions

### DIFF
--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -142,6 +142,7 @@ set(nvrtc_src
   ${CUDA_INCLUDE_DIRS}/cuda_fp16.hpp
   ${CUDA_TOOLKIT_ROOT_DIR}/include/cuComplex.h
   ${CUDA_TOOLKIT_ROOT_DIR}/include/math_constants.h
+  ${CUDA_TOOLKIT_ROOT_DIR}/include/vector_types.h
   ${CUDA_TOOLKIT_ROOT_DIR}/include/vector_functions.h
 
   ${PROJECT_SOURCE_DIR}/src/api/c/optypes.hpp

--- a/src/backend/cuda/compile_module.cpp
+++ b/src/backend/cuda/compile_module.cpp
@@ -39,8 +39,8 @@
 #include <nvrtc_kernel_headers/traits_hpp.hpp>
 #include <nvrtc_kernel_headers/types_hpp.hpp>
 #include <nvrtc_kernel_headers/utility_hpp.hpp>
-#include <nvrtc_kernel_headers/vector_types_h.hpp>
 #include <nvrtc_kernel_headers/vector_functions_h.hpp>
+#include <nvrtc_kernel_headers/vector_types_h.hpp>
 #include <nvrtc_kernel_headers/version_h.hpp>
 #include <optypes.hpp>
 #include <platform.hpp>
@@ -157,19 +157,12 @@ Module compileModule(const string &moduleKey, span<const string> sources,
     using namespace arrayfire::cuda;
     if (sourceIsJIT) {
         constexpr const char *header_names[] = {
-            "utility",
-            "cuda_fp16.hpp",
-            "cuda_fp16.h",
-            "vector_types.h",
-            "vector_functions.h",
+            "utility",        "cuda_fp16.hpp",      "cuda_fp16.h",
+            "vector_types.h", "vector_functions.h",
         };
         constexpr size_t numHeaders = extent<decltype(header_names)>::value;
         array<const char *, numHeaders> headers = {
-            "",
-            cuda_fp16_hpp,
-            cuda_fp16_h,
-            vector_types_h,
-            vector_functions_h,
+            "", cuda_fp16_hpp, cuda_fp16_h, vector_types_h, vector_functions_h,
         };
         static_assert(headers.size() == numHeaders,
                       "headers array contains fewer sources than header_names");

--- a/src/backend/cuda/compile_module.cpp
+++ b/src/backend/cuda/compile_module.cpp
@@ -159,12 +159,16 @@ Module compileModule(const string &moduleKey, span<const string> sources,
             "utility",
             "cuda_fp16.hpp",
             "cuda_fp16.h",
+            "vector_types.h",
+            "vector_functions.h",
         };
         constexpr size_t numHeaders = extent<decltype(header_names)>::value;
         array<const char *, numHeaders> headers = {
             "",
             cuda_fp16_hpp,
             cuda_fp16_h,
+            vector_types_h,
+            vector_functions_h,
         };
         static_assert(headers.size() == numHeaders,
                       "headers array contains fewer sources than header_names");

--- a/src/backend/cuda/compile_module.cpp
+++ b/src/backend/cuda/compile_module.cpp
@@ -39,6 +39,7 @@
 #include <nvrtc_kernel_headers/traits_hpp.hpp>
 #include <nvrtc_kernel_headers/types_hpp.hpp>
 #include <nvrtc_kernel_headers/utility_hpp.hpp>
+#include <nvrtc_kernel_headers/vector_types_h.hpp>
 #include <nvrtc_kernel_headers/vector_functions_h.hpp>
 #include <nvrtc_kernel_headers/version_h.hpp>
 #include <optypes.hpp>


### PR DESCRIPTION
This PR addresses a runtime error with the fft benchmark using the cuda backend.

Description
-----------
Fixes nvrtc runtime error where cuda_fp16 cannot find vector_functions.h and vector_types.h when running examples in getting_started.

Changes to Users
----------------
Examples in getting_started run with the cuda backend.

Checklist
---------
- [x ] Rebased on latest master
- [x ] Code compiles
- [ ] Tests pass
