### PR TITLE
CUDA 12.2 support and check for Doubles in tests

### DIFF
--- a/.github/workflows/win_cpu_build.yml
+++ b/.github/workflows/win_cpu_build.yml
@@ -13,7 +13,7 @@ jobs:
         name: CPU (fftw, OpenBLAS, windows-latest)
         runs-on: windows-latest
         env:
-          VCPKG_HASH: f14984af3738e69f197bf0e647a8dca12de92996
+          VCPKG_HASH: 9d47b24eacbd1cd94f139457ef6cd35e5d92cc84
           VCPKG_DEFAULT_TRIPLET: x64-windows
         steps:
             - name: Checkout Repository

--- a/src/backend/common/half.hpp
+++ b/src/backend/common/half.hpp
@@ -855,25 +855,24 @@ AF_CONSTEXPR __DH__ native_half_t int2half(T value) noexcept {
 template<std::float_round_style R, bool E, typename T>
 AF_CONSTEXPR T half2int(native_half_t value) {
 #ifdef __CUDA_ARCH__
-    AF_IF_CONSTEXPR(std::is_same_v<T, short> || std::is_same_v<T, char> ||
-                    std::is_same_v<T, unsigned char>) {
+    AF_IF_CONSTEXPR(std::is_same<T, short>::value ||
+                    std::is_same<T, char>::value ||
+                    std::is_same<T, unsigned char>::value) {
         return __half2short_rn(value);
     }
-    else AF_IF_CONSTEXPR(std::is_same_v<T, unsigned short>) {
+    else AF_IF_CONSTEXPR(std::is_same<T, unsigned short>::value) {
         return __half2ushort_rn(value);
     }
-    else AF_IF_CONSTEXPR(std::is_same_v<T, long long>) {
+    else AF_IF_CONSTEXPR(std::is_same<T, long long>::value) {
         return __half2ll_rn(value);
     }
-    else AF_IF_CONSTEXPR(std::is_same_v<T, unsigned long long>) {
+    else AF_IF_CONSTEXPR(std::is_same<T, unsigned long long>::value) {
         return __half2ull_rn(value);
     }
-    else AF_IF_CONSTEXPR(std::is_same_v<T, int>) {
+    else AF_IF_CONSTEXPR(std::is_same<T, int>::value) {
         return __half2int_rn(value);
     }
-    else AF_IF_CONSTEXPR(std::is_same_v<T, unsigned>) {
-        return __half2uint_rn(value);
-    }
+    else { return __half2uint_rn(value); }
 #elif defined(AF_ONEAPI)
     return static_cast<T>(value);
 #else

--- a/src/backend/common/traits.hpp
+++ b/src/backend/common/traits.hpp
@@ -70,11 +70,8 @@ constexpr bool isFloating(af::dtype type) {
 
 template<typename T, typename U, typename... Args>
 constexpr bool is_any_of() {
-    if constexpr (!sizeof...(Args)) {
-        return std::is_same_v<T, U>;
-    } else {
-        return std::is_same_v<T, U> || is_any_of<T, Args...>();
-    }
+    AF_IF_CONSTEXPR(!sizeof...(Args)) { return std::is_same<T, U>::value; }
+    else { return std::is_same<T, U>::value || is_any_of<T, Args...>(); }
 }
 
 }  // namespace

--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -101,6 +101,7 @@ static const int jetsonComputeCapabilities[] = {
 
 // clang-format off
 static const cuNVRTCcompute Toolkit2MaxCompute[] = {
+    {12020, 9, 0, 0},
     {12010, 9, 0, 0},
     {12000, 9, 0, 0},
     {11080, 9, 0, 0},
@@ -139,6 +140,7 @@ struct ComputeCapabilityToStreamingProcessors {
 // clang-format off
 static const ToolkitDriverVersions
     CudaToDriverVersion[] = {
+        {12020, 525.60f, 527.41f},
         {12010, 525.60f, 527.41f},
         {12000, 525.60f, 527.41f},
         {11080, 450.80f, 452.39f},

--- a/test/binary.cpp
+++ b/test/binary.cpp
@@ -373,7 +373,12 @@ class PowPrecisionTest : public ::testing::TestWithParam<T> {
         vector<T> hres(1, 0);                                              \
         B.host(&hres[0]);                                                  \
         std::fesetround(FE_TONEAREST);                                     \
-        T gold = (T)std::rint(std::pow((double)param, 2.0));               \
+        T gold;                                                            \
+        if (!af::isDoubleAvailable(af::getDevice())) {                     \
+            gold = (T)std::rint(std::pow((float)param, 2.0f));             \
+        } else {                                                           \
+            gold = (T)std::rint(std::pow((double)param, 2.0));             \
+        }                                                                  \
         ASSERT_EQ(hres[0], gold);                                          \
     }
 

--- a/test/memory.cpp
+++ b/test/memory.cpp
@@ -917,6 +917,7 @@ TEST_F(MemoryManagerApi, E2ETest4D) {
 }
 
 TEST_F(MemoryManagerApi, E2ETest4DComplexDouble) {
+    SUPPORTED_TYPE_CHECK(double);
     size_t aSize = 8;
 
     af::array a = af::array(aSize, aSize, aSize, aSize, af::dtype::c64);
@@ -932,6 +933,7 @@ TEST_F(MemoryManagerApi, E2ETest4DComplexDouble) {
 }
 
 TEST_F(MemoryManagerApi, E2ETestMultipleAllocations) {
+    SUPPORTED_TYPE_CHECK(double);
     size_t aSize = 8;
 
     af::array a = af::array(aSize, af::dtype::c64);

--- a/test/reduce.cpp
+++ b/test/reduce.cpp
@@ -559,6 +559,9 @@ TEST_P(ReduceByKeyP, SumDim0) {
     if (noHalfTests(GetParam()->kType_)) {
         GTEST_SKIP() << "Half not supported on this device";
     }
+    if (noDoubleTests(GetParam()->vType_)) {
+        GTEST_SKIP() << "Double not supported on this device";
+    }
     array keyRes, valsReduced;
     sumByKey(keyRes, valsReduced, keys, vals, 0, 0);
 
@@ -572,6 +575,9 @@ TEST_P(ReduceByKeyP, SumDim2) {
     }
     if (noHalfTests(GetParam()->kType_)) {
         GTEST_SKIP() << "Half not supported on this device";
+    }
+    if (noDoubleTests(GetParam()->vType_)) {
+        GTEST_SKIP() << "Double not supported on this device";
     }
     const int ntile = 2;
     vals            = tile(vals, 1, ntile, 1, 1);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -83,5 +83,5 @@
             ]
         }
     },
-    "builtin-baseline": "f14984af3738e69f197bf0e647a8dca12de92996"
+    "builtin-baseline": "9d47b24eacbd1cd94f139457ef6cd35e5d92cc84"
 }


### PR DESCRIPTION
Adds support for CUDA 12.2 toolkit and add checks for doubles in tests

Description
-----------
* Fix issues with CUDA 10.2 builds.
* Add support for CUDA 12.2
* Add checks for devices that do not support doubles
* 

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
