### PR TITLE
 fix wrong number of elements in createStrided for oneapi

### DIFF
--- a/src/backend/oneapi/Array.cpp
+++ b/src/backend/oneapi/Array.cpp
@@ -196,8 +196,7 @@ Array<T>::Array(const dim4 &dims, const dim4 &strides, dim_t offset_,
         data = memAlloc<T>(info.elements());
         getQueue()
             .submit([&](sycl::handler &h) {
-                h.copy(in_data,
-                       data->get_access(h, sycl::range(info.elements())));
+                h.copy(in_data, data->get_access(h, sycl::range(info.total())));
             })
             .wait();
     }


### PR DESCRIPTION
fix wrong number of elements in createStrided for oneapi

CreateStridedArray would not account for the stride when allocating memory, only the total number of elements. This PR updates the calculation to account for the additional required space.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
