### PR TITLE
Fix Shift bug where there was an empty dimension in Array

### DIFF
--- a/src/api/c/reorder.cpp
+++ b/src/api/c/reorder.cpp
@@ -33,12 +33,14 @@ using std::swap;
 
 template<typename T>
 static inline af_array reorder(const af_array in, const af::dim4 &rdims0) {
-    Array<T> In = getArray<T>(in);
+    Array<T> In = detail::createEmptyArray<T>(af::dim4(0));
     dim4 rdims  = rdims0;
 
     if (rdims[0] == 1 && rdims[1] == 0) {
-        In = transpose(In, false);
+        In = transpose(getArray<T>(in), false);
         std::swap(rdims[0], rdims[1]);
+    } else {
+        In = getArray<T>(in);
     }
     const dim4 idims    = In.dims();
     const dim4 istrides = In.strides();
@@ -48,8 +50,7 @@ static inline af_array reorder(const af_array in, const af::dim4 &rdims0) {
 
     af_array out;
     if (rdims[0] == 0 && rdims[1] == 1 && rdims[2] == 2 && rdims[3] == 3) {
-        const Array<T> &Out = In;
-        out                 = getHandle(Out);
+        out = getHandle(In);
     } else if (rdims[0] == 0) {
         dim4 odims    = dim4(1, 1, 1, 1);
         dim4 ostrides = dim4(1, 1, 1, 1);

--- a/src/backend/common/jit/Node.cpp
+++ b/src/backend/common/jit/Node.cpp
@@ -76,6 +76,12 @@ auto isScalar(const Node &ptr) -> bool { return ptr.isScalar(); }
 
 bool Node::isLinear(const dim_t dims[4]) const { return true; }
 
+/// This function returns true if the \p node is a Shift node or a Buffer node
+auto isBufferOrShift(const Node_ptr &node) -> bool {
+    return node->getNodeType() == kNodeType::Buffer ||
+           node->getNodeType() == kNodeType::Shift;
+}
+
 }  // namespace common
 }  // namespace arrayfire
 

--- a/src/backend/common/jit/ShiftNodeBase.hpp
+++ b/src/backend/common/jit/ShiftNodeBase.hpp
@@ -53,6 +53,8 @@ class ShiftNodeBase : public Node {
         return *this;
     }
 
+    std::array<int, 4> &getShifts() { return m_shifts; }
+
     std::unique_ptr<Node> clone() final {
         return std::make_unique<ShiftNodeBase>(*this);
     }
@@ -65,6 +67,7 @@ class ShiftNodeBase : public Node {
         swap(m_shifts, other.m_shifts);
     }
 
+    BufferNode &getBufferNode() { return *m_buffer_node; }
     const BufferNode &getBufferNode() const { return *m_buffer_node; }
 
     bool isLinear(const dim_t dims[4]) const final {

--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -553,6 +553,7 @@ add_library(afcuda
     wrap.hpp
 
     jit/BufferNode.hpp
+    jit/ShiftNode.hpp
     jit/kernel_generators.hpp
 
     ${scan_by_key_sources}

--- a/src/backend/cuda/Param.hpp
+++ b/src/backend/cuda/Param.hpp
@@ -35,6 +35,9 @@ class Param {
         return dims[0] * dims[1] * dims[2] * dims[3];
     }
 
+    dim_t *dims_ptr() { return dims; }
+    dim_t *strides_ptr() { return strides; }
+
     Param(const Param<T> &other) noexcept               = default;
     Param(Param<T> &&other) noexcept                    = default;
     Param<T> &operator=(const Param<T> &other) noexcept = default;

--- a/src/backend/cuda/jit/ShiftNode.hpp
+++ b/src/backend/cuda/jit/ShiftNode.hpp
@@ -1,0 +1,22 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <common/jit/ShiftNodeBase.hpp>
+#include <jit/BufferNode.hpp>
+
+namespace arrayfire {
+namespace cuda {
+namespace jit {
+
+template<typename T>
+using ShiftNode = common::ShiftNodeBase<BufferNode<T>>;
+
+}  // namespace jit
+}  // namespace cuda
+}  // namespace arrayfire

--- a/src/backend/cuda/shift.cpp
+++ b/src/backend/cuda/shift.cpp
@@ -11,6 +11,7 @@
 #include <common/jit/ShiftNodeBase.hpp>
 #include <err_cuda.hpp>
 #include <jit/BufferNode.hpp>
+#include <jit/ShiftNode.hpp>
 #include <shift.hpp>
 
 #include <memory>
@@ -18,9 +19,8 @@
 using af::dim4;
 
 using arrayfire::common::Node_ptr;
-using arrayfire::common::ShiftNodeBase;
-
 using arrayfire::cuda::jit::BufferNode;
+using arrayfire::cuda::jit::ShiftNode;
 
 using std::array;
 using std::make_shared;
@@ -29,8 +29,6 @@ using std::string;
 
 namespace arrayfire {
 namespace cuda {
-template<typename T>
-using ShiftNode = ShiftNodeBase<BufferNode<T>>;
 
 template<typename T>
 Array<T> shift(const Array<T> &in, const int sdims[4]) {

--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -99,6 +99,7 @@ add_library(afoneapi
   ireduce.hpp
   jit.cpp
   jit/BufferNode.hpp
+  jit/ShiftNode.hpp
   jit/kernel_generators.hpp
   join.cpp
   join.hpp

--- a/src/backend/oneapi/Param.hpp
+++ b/src/backend/oneapi/Param.hpp
@@ -27,6 +27,9 @@ struct Param {
     Param(const Param& other)            = default;
     Param(Param&& other)                 = default;
 
+    dim_t* dims_ptr() { return info.dims; }
+    dim_t* strides_ptr() { return info.strides; }
+
     // AF_DEPRECATED("Use Array<T>")
     Param() : data(nullptr), info{{0, 0, 0, 0}, {0, 0, 0, 0}, 0} {}
 
@@ -53,6 +56,9 @@ struct AParam {
     AParam& operator=(const AParam& other) = default;
     AParam(const AParam& other)            = default;
     AParam(AParam&& other)                 = default;
+
+    dim_t* dims_ptr() { return dims.get(); }
+    dim_t* strides_ptr() { return strides.get(); }
 
     // AF_DEPRECATED("Use Array<T>")
     AParam() : data(), dims{0, 0, 0, 0}, strides{0, 0, 0, 0}, offset(0) {}

--- a/src/backend/oneapi/jit/ShiftNode.hpp
+++ b/src/backend/oneapi/jit/ShiftNode.hpp
@@ -1,0 +1,22 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <common/jit/ShiftNodeBase.hpp>
+#include <jit/BufferNode.hpp>
+
+namespace arrayfire {
+namespace oneapi {
+namespace jit {
+
+template<typename T>
+using ShiftNode = common::ShiftNodeBase<BufferNode<T>>;
+
+}  // namespace jit
+}  // namespace oneapi
+}  // namespace arrayfire

--- a/src/backend/opencl/CMakeLists.txt
+++ b/src/backend/opencl/CMakeLists.txt
@@ -468,6 +468,7 @@ target_sources(afopencl
 target_sources(afopencl
   PRIVATE
     jit/BufferNode.hpp
+    jit/ShiftNode.hpp
     jit/kernel_generators.hpp
   )
 

--- a/src/backend/opencl/Param.hpp
+++ b/src/backend/opencl/Param.hpp
@@ -22,6 +22,9 @@ struct Param {
     Param(const Param& other)            = default;
     Param(Param&& other)                 = default;
 
+    dim_t* dims_ptr() { return info.dims; }
+    dim_t* strides_ptr() { return info.strides; }
+
     // AF_DEPRECATED("Use Array<T>")
     Param();
     // AF_DEPRECATED("Use Array<T>")

--- a/src/backend/opencl/jit/ShiftNode.hpp
+++ b/src/backend/opencl/jit/ShiftNode.hpp
@@ -1,0 +1,21 @@
+/*******************************************************
+ * Copyright (c) 2023, ArrayFire
+ * All rights reserved.
+ *
+ * This file is distributed under 3-clause BSD license.
+ * The complete license agreement can be obtained at:
+ * http://arrayfire.com/licenses/BSD-3-Clause
+ ********************************************************/
+
+#include <common/jit/ShiftNodeBase.hpp>
+#include <jit/BufferNode.hpp>
+
+namespace arrayfire {
+namespace opencl {
+namespace jit {
+
+using ShiftNode = common::ShiftNodeBase<BufferNode>;
+
+}  // namespace jit
+}  // namespace opencl
+}  // namespace arrayfire

--- a/src/backend/opencl/kernel/KParam.hpp
+++ b/src/backend/opencl/kernel/KParam.hpp
@@ -21,6 +21,12 @@ typedef struct {
     dim_t dims[4];
     dim_t strides[4];
     dim_t offset;
+
+#ifndef __OPENCL_VERSION__
+    dim_t *dims_ptr() { return dims; }
+    dim_t *strides_ptr() { return strides; }
+#endif
+
 } KParam;
 
 #endif

--- a/src/backend/opencl/shift.cpp
+++ b/src/backend/opencl/shift.cpp
@@ -9,14 +9,15 @@
 
 #include <shift.hpp>
 
-#include <common/jit/ShiftNodeBase.hpp>
 #include <err_opencl.hpp>
+#include <jit/ShiftNode.hpp>
 #include <traits.hpp>
 
 using af::dim4;
 using arrayfire::common::Node_ptr;
 using arrayfire::common::ShiftNodeBase;
 using arrayfire::opencl::jit::BufferNode;
+using arrayfire::opencl::jit::ShiftNode;
 using std::array;
 using std::make_shared;
 using std::static_pointer_cast;
@@ -24,7 +25,6 @@ using std::string;
 
 namespace arrayfire {
 namespace opencl {
-using ShiftNode = ShiftNodeBase<BufferNode>;
 
 template<typename T>
 Array<T> shift(const Array<T> &in, const int sdims[4]) {

--- a/test/shift.cpp
+++ b/test/shift.cpp
@@ -146,3 +146,12 @@ TEST(Shift, MaxDim) {
     output = abs(input - output);
     ASSERT_EQ(1.f, product<float>(output));
 }
+
+TEST(Shift, RowVector) {
+    const unsigned shift_x = 1;
+    const unsigned shift_y = 1;
+    array input            = iota(dim4(1, 4));
+    array output           = shift(input, shift_x, shift_y);
+    vector<float> gold{3.f, 0.f, 1.f, 2.f};
+    EXPECT_VEC_ARRAY_EQ(gold, dim4(1, 4), output);
+}


### PR DESCRIPTION
Fix bug in shift where there is an empty dimension in array(i.e. 10, 1, 10). This caused an error because of the new compaction of the dimensions in the JIT code generation.

Description
-----------
- Fixes bug in JIT kernel generation when there is a singleton dimension in the Array
- This also addresses an issue in reorder where the reorder function wasn't evaluated.

Fixes: #3475 

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
