### PR TITLE
Fix source tarball GitHub workflow

### DIFF
--- a/.github/workflows/release_src_artifact.yml
+++ b/.github/workflows/release_src_artifact.yml
@@ -9,7 +9,7 @@ name: ci
 jobs:
     upload_src_tarball:
         name: Upload release source tarball
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-latest
         steps:
             - name: Fetch Repo Info
               run: |
@@ -40,7 +40,7 @@ jobs:
                                           libopenblas-dev \
                                           ocl-icd-opencl-dev \
                                           nvidia-cuda-toolkit \
-                                          libboost1.68-dev
+                                          libboost-dev
 
             - name: CMake Configure
               run: |


### PR DESCRIPTION
Fix tarball GitHub workflow

Description
-----------
Fix the tarball GitHub workflow. This fixes issue #3495 that was caused because the ubuntu 18.04 image is not supported by GithHub. This updates the GitHub image.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master

