### PR TITLE
fix fallthrough in reduce_by_key_common for u8

### DIFF
--- a/src/api/c/reduce.cpp
+++ b/src/api/c/reduce.cpp
@@ -280,6 +280,7 @@ static af_err reduce_by_key_common(af_array *keys_out, af_array *vals_out,
             case u8:
                 reduce_key<op, uchar, uchar>(keys_out, vals_out, keys, vals,
                                              dim);
+                break;
             case f16:
                 reduce_key<op, half, half>(keys_out, vals_out, keys, vals, dim);
                 break;


### PR DESCRIPTION
Description
---------
<!--
Additional information about the PR answering following questions:

* Is this a new feature or a bug fix?
* More detail if necessary to describe all commits in pull request.
* Why these changes are necessary.
* Potential impact on specific hardware, software or backends.
* New functions and their functionality.
* Can this PR be backported to older versions?
* Future changes not implemented in this PR.
-->
Bug fix for reduce_by_key_common where u8 would run reduce_key for u8, and then f16 but with the u8 arrays.

Affects af::minByKey and af::maxByKey, which would throw/segfault for u8 depending on backend.

The ReduceByKey tests related to this bug were updated so that they run for each supported type.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
