### PR TITLE
add int8 matmul support to CUDA backend

### DIFF
--- a/docs/details/blas.dox
+++ b/docs/details/blas.dox
@@ -32,6 +32,10 @@ memory allocations either on host or device.
 for Sparse-Dense matrix multiplication. See the notes of the function for usage
 and restrictions.
 
+\par
+\note Limited support for \ref s8 was added to the CUDA backend in ArrayFire
+v3.10.0. See \ref af_gemm "s8 Support" notes for details.
+
 \ingroup blas_mat
 
 =======================================================================

--- a/include/af/blas.h
+++ b/include/af/blas.h
@@ -242,6 +242,14 @@ extern "C" {
 
         \snippet test/blas.cpp ex_af_gemm_overwrite
 
+        \note <b>s8 Support</b>
+        \note Starting with ArrayFire version v3.10.0, the CUDA backend supports
+        \p A, \p B input arrays of type \ref s8.
+        \note Scalars \p alpha, \p beta must be of type \ref f32.
+        \note Output array \p C will be of type \ref f32.
+        \note <br><b>Requires</b>
+        \note CUDA version >= 10 on devices with compute capability >= 5.0
+
         \param[in,out] C     `A` * `B` = `C`
         \param[in]     opA   operation to perform on A before the multiplication
         \param[in]     opB   operation to perform on B before the multiplication

--- a/src/backend/cpu/blas.hpp
+++ b/src/backend/cpu/blas.hpp
@@ -13,9 +13,10 @@
 namespace arrayfire {
 namespace cpu {
 
-template<typename T>
-void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
-          const Array<T> &lhs, const Array<T> &rhs, const T *beta);
+template<typename Ti, typename To = Ti>
+void gemm(Array<To> &out, af_mat_prop optLhs, af_mat_prop optRhs,
+          const To *alpha, const Array<Ti> &lhs, const Array<Ti> &rhs,
+          const To *beta);
 
 template<typename T>
 Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs, af_mat_prop optLhs,

--- a/src/backend/cuda/blas.hpp
+++ b/src/backend/cuda/blas.hpp
@@ -11,9 +11,10 @@
 
 namespace arrayfire {
 namespace cuda {
-template<typename T>
-void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
-          const Array<T> &lhs, const Array<T> &rhs, const T *beta);
+template<typename Ti, typename To = Ti>
+void gemm(Array<To> &out, af_mat_prop optLhs, af_mat_prop optRhs,
+          const To *alpha, const Array<Ti> &lhs, const Array<Ti> &rhs,
+          const To *beta);
 
 template<typename T>
 Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs, af_mat_prop optLhs,

--- a/src/backend/oneapi/blas.hpp
+++ b/src/backend/oneapi/blas.hpp
@@ -20,9 +20,10 @@ namespace oneapi {
 void initBlas();
 void deInitBlas();
 
-template<typename T>
-void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
-          const Array<T> &lhs, const Array<T> &rhs, const T *beta);
+template<typename Ti, typename To = Ti>
+void gemm(Array<To> &out, af_mat_prop optLhs, af_mat_prop optRhs,
+          const To *alpha, const Array<Ti> &lhs, const Array<Ti> &rhs,
+          const To *beta);
 
 template<typename T>
 Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs, af_mat_prop optLhs,

--- a/src/backend/opencl/blas.hpp
+++ b/src/backend/opencl/blas.hpp
@@ -20,9 +20,10 @@ namespace opencl {
 void initBlas();
 void deInitBlas();
 
-template<typename T>
-void gemm(Array<T> &out, af_mat_prop optLhs, af_mat_prop optRhs, const T *alpha,
-          const Array<T> &lhs, const Array<T> &rhs, const T *beta);
+template<typename Ti, typename To = Ti>
+void gemm(Array<To> &out, af_mat_prop optLhs, af_mat_prop optRhs,
+          const To *alpha, const Array<Ti> &lhs, const Array<Ti> &rhs,
+          const To *beta);
 
 template<typename T>
 Array<T> matmul(const Array<T> &lhs, const Array<T> &rhs, af_mat_prop optLhs,


### PR DESCRIPTION
Description
-----------
Adds support for int8 matmul in the CUDA backend using cublasGemmEx functions. This modifies the gemm functions' api to support a different output array type, so all backends were modified.

This PR depends on s8 support: #3507 
Fixes: #1656 

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master with #3507
- [x] Code compiles
- [x] Tests pass
- [x] Functions documented
