### PR TITLE
Fix OpenCL memory migration on devices with different contexts

### DIFF
--- a/src/backend/opencl/Array.cpp
+++ b/src/backend/opencl/Array.cpp
@@ -201,10 +201,12 @@ void checkAndMigrate(Array<T> &arr) {
         AF_TRACE("Migrating array from {} to {}.", arr_id, cur_id);
         auto migrated_data           = memAlloc<T>(arr.elements());
         void *mapped_migrated_buffer = getQueue().enqueueMapBuffer(
-            *migrated_data, CL_TRUE, CL_MAP_READ, 0, arr.elements());
+            *migrated_data, CL_TRUE, CL_MAP_WRITE_INVALIDATE_REGION, 0,
+            sizeof(T) * arr.elements());
         setDevice(arr_id);
         Buffer &buf = *arr.get();
-        getQueue().enqueueReadBuffer(buf, CL_TRUE, 0, arr.elements(),
+        getQueue().enqueueReadBuffer(buf, CL_TRUE, 0,
+                                     sizeof(T) * arr.elements(),
                                      mapped_migrated_buffer);
         setDevice(cur_id);
         getQueue().enqueueUnmapMemObject(*migrated_data,

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -501,6 +501,29 @@ TEST(DeviceId, Different) {
     deviceGC();
 }
 
+TEST(Device, MigrateAllDevicesToAllDevices) {
+    int ndevices = getDeviceCount();
+    if (ndevices < 2) GTEST_SKIP() << "Skipping mult-GPU test";
+
+    for (int i = 0; i < ndevices; i++) {
+        for (int j = 0; j < ndevices; j++) {
+            setDevice(i);
+            array a = constant(i * 255, 10, 10);
+            a.eval();
+
+            setDevice(j);
+            array b = constant(j * 256, 10, 10);
+            b.eval();
+
+            array c = a + b;
+
+            std::vector<float> gold(10 * 10, i * 255 + j * 256);
+
+            ASSERT_VEC_ARRAY_EQ(gold, dim4(10, 10), c);
+        }
+    }
+}
+
 TEST(Device, empty) {
     array a = array();
     ASSERT_EQ(a.device<float>(), nullptr);


### PR DESCRIPTION
Fixes an issue with the OpenCL backend where migration to devices in different contexts was breaking due to an invalid array size calculation

Description
-----------
* Fixes the memory size parameter in the enqueueMapBuffer function.

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~[ ] Functions added to unified API~
- ~[ ] Functions documented~
