### PR TITLE
Solves C7626 error when compiling with MSVC 2019 16.6+

### DIFF
--- a/src/backend/opencl/kernel/KParam.hpp
+++ b/src/backend/opencl/kernel/KParam.hpp
@@ -17,7 +17,7 @@
 #endif
 
 // Defines the size and shape of the data in the OpenCL buffer
-typedef struct {
+typedef struct KParam_t {
     dim_t dims[4];
     dim_t strides[4];
     dim_t offset;


### PR DESCRIPTION
Solves error C7626 when compiling with MSVC 2019 16.6+

Description
-----------
See [Microsoft C7626 description](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/c5208?view=msvc-170).

unnamed typedef classes can generate linkage problems.  Starting from MSVC 2019 16.6+, error C7626 is generated when compiling with /std:c++17 or above.
Solution: give the typedef a name (I chose KParam_t)

PS: The linkage problem also exists with GCC and Clang (see [P1766R1](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1766r1.html).)

Changes to Users
----------------
None

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
