### PR TITLE
Join does not always respect the order of provided parameters (#3511)

### DIFF
--- a/src/backend/common/jit/Node.cpp
+++ b/src/backend/common/jit/Node.cpp
@@ -42,6 +42,7 @@ int Node::getNodesMap(Node_map_t &node_map, vector<Node *> &full_nodes,
 }
 
 std::string getFuncName(const vector<Node *> &output_nodes,
+                        const vector<int> &output_ids,
                         const vector<Node *> &full_nodes,
                         const vector<Node_ids> &full_ids, const bool is_linear,
                         const bool loop0, const bool loop1, const bool loop2,
@@ -57,6 +58,11 @@ std::string getFuncName(const vector<Node *> &output_nodes,
     for (const auto &node : output_nodes) {
         funcName += '_';
         funcName += node->getNameStr();
+    }
+
+    for (const int id : output_ids) {
+        funcName += '-';
+        funcName += std::to_string(id);
     }
 
     for (int i = 0; i < static_cast<int>(full_nodes.size()); i++) {

--- a/src/backend/common/jit/Node.hpp
+++ b/src/backend/common/jit/Node.hpp
@@ -326,6 +326,7 @@ struct Node_ids {
 };
 
 std::string getFuncName(const std::vector<Node *> &output_nodes,
+                        const std::vector<int> &output_ids,
                         const std::vector<Node *> &full_nodes,
                         const std::vector<Node_ids> &full_ids,
                         const bool is_linear, const bool loop0,

--- a/src/backend/oneapi/jit.cpp
+++ b/src/backend/oneapi/jit.cpp
@@ -478,8 +478,8 @@ void evalNodes(vector<Param<T>>& outputs, const vector<Node*>& output_nodes) {
     full_nodes.clear();
     for (Node_ptr& node : node_clones) { full_nodes.push_back(node.get()); }
 
-    const string funcName{getFuncName(output_nodes, full_nodes, full_ids,
-                                      is_linear, false, false, false,
+    const string funcName{getFuncName(output_nodes, output_ids, full_nodes,
+                                      full_ids, is_linear, false, false, false,
                                       outputs[0].info.dims[2] > 1)};
 
     getQueue().submit([&](sycl::handler& h) {

--- a/src/backend/opencl/jit.cpp
+++ b/src/backend/opencl/jit.cpp
@@ -188,62 +188,77 @@ __kernel void )JIT";
     thread_local stringstream outOffsetStream;
     thread_local stringstream inOffsetsStream;
     thread_local stringstream opsStream;
-
-    int oid{0};
-    for (size_t i{0}; i < full_nodes.size(); i++) {
-        const auto& node{full_nodes[i]};
-        const auto& ids_curr{full_ids[i]};
-        // Generate input parameters, only needs current id
-        node->genParams(inParamStream, ids_curr.id, is_linear);
-        // Generate input offsets, only needs current id
-        node->genOffsets(inOffsetsStream, ids_curr.id, is_linear);
-        // Generate the core function body, needs children ids as well
-        node->genFuncs(opsStream, ids_curr);
-        for (auto outIt{begin(output_ids)}, endIt{end(output_ids)};
-             (outIt = find(outIt, endIt, ids_curr.id)) != endIt; ++outIt) {
-            // Generate also output parameters
-            outParamStream << "__global "
-                           << full_nodes[ids_curr.id]->getTypeStr() << " *out"
-                           << oid << ", int offset" << oid << ",\n";
-            // Apply output offset
-            outOffsetStream << "\nout" << oid << " += offset" << oid << ';';
-            // Generate code to write the output
-            opsStream << "out" << oid << "[idx] = val" << ids_curr.id << ";\n";
-            ++oid;
-        }
-    }
-
     thread_local stringstream kerStream;
-    kerStream << kernelVoid << funcName << "(\n"
-              << inParamStream.str() << outParamStream.str() << dimParams << ")"
-              << blockStart;
-    if (is_linear) {
-        kerStream << linearInit << inOffsetsStream.str()
-                  << outOffsetStream.str() << '\n';
-        if (loop0) kerStream << linearLoop0Start;
-        kerStream << "\n\n" << opsStream.str();
-        if (loop0) kerStream << linearLoop0End;
-        kerStream << linearEnd;
-    } else {
-        if (loop0) {
-            kerStream << stridedLoop0Init << outOffsetStream.str() << '\n'
-                      << stridedLoop0Start;
-        } else {
-            kerStream << stridedLoopNInit << outOffsetStream.str() << '\n';
-            if (loop3) kerStream << stridedLoop3Init;
-            if (loop1) kerStream << stridedLoop1Init << stridedLoop1Start;
-            if (loop3) kerStream << stridedLoop3Start;
-        }
-        kerStream << "\n\n" << inOffsetsStream.str() << opsStream.str();
-        if (loop3) kerStream << stridedLoop3End;
-        if (loop1) kerStream << stridedLoop1End;
-        if (loop0) kerStream << stridedLoop0End;
-        kerStream << stridedEnd;
-    }
-    kerStream << blockEnd;
-    const string ret{kerStream.str()};
 
-    // Prepare for next round, limit memory
+    string ret;
+    try {
+        int oid{0};
+        for (size_t i{0}; i < full_nodes.size(); i++) {
+            const auto& node{full_nodes[i]};
+            const auto& ids_curr{full_ids[i]};
+            // Generate input parameters, only needs current id
+            node->genParams(inParamStream, ids_curr.id, is_linear);
+            // Generate input offsets, only needs current id
+            node->genOffsets(inOffsetsStream, ids_curr.id, is_linear);
+            // Generate the core function body, needs children ids as well
+            node->genFuncs(opsStream, ids_curr);
+            for (size_t output_idx{0}; output_idx < output_ids.size();
+                 ++output_idx) {
+                if (output_ids[output_idx] == ids_curr.id) {
+                    outParamStream
+                        << "__global " << full_nodes[ids_curr.id]->getTypeStr()
+                        << " *out" << oid << ", int offset" << oid << ",\n";
+                    // Apply output offset
+                    outOffsetStream << "\nout" << oid << " += offset" << oid
+                                    << ';';
+                    // Generate code to write the output
+                    opsStream << "out" << output_idx << "[idx] = val"
+                              << ids_curr.id << ";\n";
+                    ++oid;
+                }
+            }
+        }
+
+        kerStream << kernelVoid << funcName << "(\n"
+                  << inParamStream.str() << outParamStream.str() << dimParams
+                  << ")" << blockStart;
+        if (is_linear) {
+            kerStream << linearInit << inOffsetsStream.str()
+                      << outOffsetStream.str() << '\n';
+            if (loop0) kerStream << linearLoop0Start;
+            kerStream << "\n\n" << opsStream.str();
+            if (loop0) kerStream << linearLoop0End;
+            kerStream << linearEnd;
+        } else {
+            if (loop0) {
+                kerStream << stridedLoop0Init << outOffsetStream.str() << '\n'
+                          << stridedLoop0Start;
+            } else {
+                kerStream << stridedLoopNInit << outOffsetStream.str() << '\n';
+                if (loop3) kerStream << stridedLoop3Init;
+                if (loop1) kerStream << stridedLoop1Init << stridedLoop1Start;
+                if (loop3) kerStream << stridedLoop3Start;
+            }
+            kerStream << "\n\n" << inOffsetsStream.str() << opsStream.str();
+            if (loop3) kerStream << stridedLoop3End;
+            if (loop1) kerStream << stridedLoop1End;
+            if (loop0) kerStream << stridedLoop0End;
+            kerStream << stridedEnd;
+        }
+        kerStream << blockEnd;
+        ret = kerStream.str();
+    } catch (...) {
+        // Prepare for next round
+        inParamStream.str("");
+        outParamStream.str("");
+        inOffsetsStream.str("");
+        outOffsetStream.str("");
+        opsStream.str("");
+        kerStream.str("");
+        throw;
+    }
+
+    // Prepare for next round
     inParamStream.str("");
     outParamStream.str("");
     inOffsetsStream.str("");
@@ -259,8 +274,9 @@ cl::Kernel getKernel(const vector<Node*>& output_nodes,
                      const vector<Node*>& full_nodes,
                      const vector<Node_ids>& full_ids, const bool is_linear,
                      const bool loop0, const bool loop1, const bool loop3) {
-    const string funcName{getFuncName(output_nodes, full_nodes, full_ids,
-                                      is_linear, loop0, loop1, false, loop3)};
+    const string funcName{getFuncName(output_nodes, output_ids, full_nodes,
+                                      full_ids, is_linear, loop0, loop1, false,
+                                      loop3)};
     // A forward lookup in module cache helps avoid recompiling the JIT
     // source generated from identical JIT-trees.
     const auto entry{

--- a/test/join.cpp
+++ b/test/join.cpp
@@ -15,6 +15,7 @@
 #include <af/index.h>
 #include <af/traits.hpp>
 
+#include <array>
 #include <complex>
 #include <iostream>
 #include <numeric>
@@ -265,4 +266,49 @@ TEST(Join, ManyEmpty) {
     ASSERT_ARRAYS_EQ(gold, eeac);
     ASSERT_ARRAYS_EQ(gold, eace);
     ASSERT_ARRAYS_EQ(gold, acee);
+}
+
+TEST(Join, ISSUE3511) {
+    const float column_host1[] = {1., 2., 3.};
+    const float column_host2[] = {4., 5., 6.};
+    const af::array buf1(3, 1, column_host1);
+    const af::array buf2(3, 1, column_host2);
+
+    // We need to avoid that JIT arrays are evaluated during whatever call,
+    // so we will have to work with copies for single use
+    const af::array jit1{buf1 + 1.0};
+    const af::array jit2{buf2 + 2.0};
+    const std::array<af::array, 8> cases{jit1,  -jit1,       jit1 + 1.0, jit2,
+                                         -jit2, jit1 + jit2, buf1,       buf2};
+    const std::array<char*, 8> cases_name{"JIT1", "-JIT1", "JIT1+1.0",
+                                          "JIT2", "-JIT2", "JIT1+JIT2",
+                                          "BUF1", "BUF2"};
+    assert(cases.size() == cases_name.size());
+    for (size_t cl0{0}; cl0 < cases.size(); ++cl0) {
+        for (size_t cl1{0}; cl1 < cases.size(); ++cl1) {
+            printf("Testing: af::join(1,%s,%s)\n", cases_name[cl0],
+                   cases_name[cl1]);
+            const array col0{cases[cl0]};
+            const array col1{cases[cl1]};
+            const array result{af::join(1, col0, col1)};
+            ASSERT_ARRAYS_EQ(result(af::span, 0), col0);
+            ASSERT_ARRAYS_EQ(result(af::span, 1), col1);
+        }
+    }
+    // Join of 3 arrays
+    for (size_t cl0{0}; cl0 < cases.size(); ++cl0) {
+        for (size_t cl1{0}; cl1 < cases.size(); ++cl1) {
+            for (size_t cl2{0}; cl2 < cases.size(); ++cl2) {
+                printf("Testing: af::join(1,%s,%s,%s)\n", cases_name[cl0],
+                       cases_name[cl1], cases_name[cl2]);
+                const array col0{cases[cl0]};
+                const array col1{cases[cl1]};
+                const array col2{cases[cl2]};
+                const array result{af::join(1, col0, col1, col2)};
+                ASSERT_ARRAYS_EQ(result(af::span, 0), col0);
+                ASSERT_ARRAYS_EQ(result(af::span, 1), col1);
+                ASSERT_ARRAYS_EQ(result(af::span, 2), col2);
+            }
+        }
+    }
 }

--- a/test/join.cpp
+++ b/test/join.cpp
@@ -268,7 +268,7 @@ TEST(Join, ManyEmpty) {
     ASSERT_ARRAYS_EQ(gold, acee);
 }
 
-TEST(Join, ISSUE3511) {
+TEST(Join, respect_parameters_order_ISSUE3511) {
     const float column_host1[] = {1., 2., 3.};
     const float column_host2[] = {4., 5., 6.};
     const af::array buf1(3, 1, column_host1);


### PR DESCRIPTION
Arrays were be joined in the order the JIT engine generated the arrays iso the order of the parameters.

Description
-----------
1. A wrong assumption was made that the JIT engine would generate the arrays in the same order as provided by the parameters.
This assumption is violated when one of the generated arrays is an intermediate result of a previous specified JIT generated array.
Example of error condition: 
```
af::array A{af::constant(1.,10)};
af::array R{af::join(0,-A,A)};  --> generated af::join(0,A,-A) because A is an intermediate result of -A.
```
In this fix, the order of the parameters is imposed, independent from the order of JIT generation.
PS: This bug appears in OPENCL and CUDA.

2. The same 'unique' identifier "funcName" was generated for JIT kernels, with outputs as only difference.
As result, a different kernel could be executed than intended, dependent on the order of the JIT kernel generation.

Additional information about the PR answering following questions:
* bug fix
* can be back ported
* extra test is added covering a large set of possible combinations of similar outputs (567 combinations)

Fixes: #3511

Changes to Users
----------------
None

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented