### PR TITLE
Loosen indexing assertions for af_assign_gen

### DIFF
--- a/include/af/index.h
+++ b/include/af/index.h
@@ -274,7 +274,7 @@ extern "C" {
     ///                     the sequences
     /// \param[in] lhs      is the input array
     /// \param[in] ndims    is the number of \ref af_index_t provided
-    /// \param[in] indices  is an af_array of \ref af_index_t objects
+    /// \param[in] indices  is a C array of \ref af_index_t objects
     /// \param[in] rhs      is the array whose values will be assigned to \p lhs
     ///
     /// \ingroup index_func_assign

--- a/src/api/c/assign.cpp
+++ b/src/api/c/assign.cpp
@@ -260,8 +260,6 @@ af_err af_assign_gen(af_array* out, const af_array lhs, const dim_t ndims,
             return af_create_handle(out, 0, nullptr, lhsType);
         }
 
-        ARG_ASSERT(2, (ndims == 1) || (ndims == (dim_t)lInfo.ndims()));
-
         if (ndims == 1 && ndims != static_cast<dim_t>(lInfo.ndims())) {
             af_array tmp_in  = 0;
             af_array tmp_out = 0;
@@ -279,7 +277,6 @@ af_err af_assign_gen(af_array* out, const af_array lhs, const dim_t ndims,
 
         ARG_ASSERT(1, (lhsType == rhsType));
         ARG_ASSERT(1, (lhsDims.ndims() >= rhsDims.ndims()));
-        ARG_ASSERT(2, (lhsDims.ndims() >= ndims));
 
         af_array output = 0;
         if (*out != lhs) {

--- a/test/gen_assign.cpp
+++ b/test/gen_assign.cpp
@@ -455,3 +455,46 @@ TEST(GeneralAssign, CPP_AANN) {
     freeHost(hIdx0);
     freeHost(hIdx1);
 }
+
+TEST(GeneralAssign, NDimsDoesNotMatchLDims) {
+    af_err err;
+    af_array zeros, l1, l2, sevens;
+    dim_t sevens_size[3] = {5, 1, 1};
+    short hsevens[5]     = {7, 7, 7, 7, 7};
+
+    dim_t zeros_size[3] = {5, 6, 1};
+    short hzeros[5 * 6] = {0};
+
+    dim_t hone[1] = {1};
+
+    ASSERT_SUCCESS(af_create_array(&zeros, hzeros, 3, zeros_size, s16));
+    ASSERT_SUCCESS(af_create_array(&sevens, hsevens, 3, sevens_size, s16));
+    ASSERT_SUCCESS(af_create_array(&l2, hone, 1, hone, s64));
+
+    af_index_t *ix;
+    ASSERT_SUCCESS(af_create_indexers(&ix));
+    ASSERT_SUCCESS(af_set_array_indexer(ix, l2, 1));
+
+    // clang-format off
+    vector<short> gold = {
+            0, 0, 0, 0, 0,
+            7, 7, 7, 7, 7,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0,
+        };
+    // clang-format on
+    for (int number_of_indices = 2; number_of_indices < 4;
+         number_of_indices++) {
+        af_array result = 0;
+        ASSERT_SUCCESS(
+            af_assign_gen(&result, zeros, number_of_indices, ix, sevens));
+
+        ASSERT_VEC_ARRAY_EQ(gold, dim4(3, zeros_size), af::array(result));
+    }
+    ASSERT_SUCCESS(af_release_array(zeros));
+    ASSERT_SUCCESS(af_release_array(sevens));
+    ASSERT_SUCCESS(af_release_array(l2));
+    ASSERT_SUCCESS(af_release_indexers(ix));
+}


### PR DESCRIPTION
This PR removes a set of assertions in af_assign_gen. The assertions were incorrectly used the ndims parameter which is the number of indexes that are passed in against the dimension of the lhs of the assertion.

Description
-----------
* Relaxes some indexing assertions

Changes to Users
----------------
N/A

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
