### PR TITLE
Implement simple fix for AF_JIT_KERNEL_TRACE on windows

### DIFF
--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -125,9 +125,9 @@ void saveKernel(const string& funcName, const string& jit_ker,
     // Path to a folder
     const string ffp =
         string(jitKernelsOutput) + AF_PATH_SEPARATOR + funcName + ext;
-		
+
 #if defined(OS_WIN)
-	FILE* f = fopen(ffp.c_str(), "w");
+    FILE* f = fopen(ffp.c_str(), "w");
 #else
     FILE* f = fopen(ffp.c_str(), "we");
 #endif

--- a/src/backend/common/util.cpp
+++ b/src/backend/common/util.cpp
@@ -125,7 +125,13 @@ void saveKernel(const string& funcName, const string& jit_ker,
     // Path to a folder
     const string ffp =
         string(jitKernelsOutput) + AF_PATH_SEPARATOR + funcName + ext;
+		
+#if defined(OS_WIN)
+	FILE* f = fopen(ffp.c_str(), "w");
+#else
     FILE* f = fopen(ffp.c_str(), "we");
+#endif
+
     if (!f) {
         fprintf(stderr, "Cannot open file %s\n", ffp.c_str());
         return;


### PR DESCRIPTION
Avoids assertion on windows when using `AF_JIT_KERNEL_TRACE` with an absolute path for output files.

Description
-----------
Fixes: #3515

Changes to Users
----------------
No changes to users.

Checklist
---------
- [X] Rebased on latest master
- [X] Code compiles
- [X] Tests pass
- [X] Functions added to unified API
- [X] Functions documented
