### PR TITLE
Fixed padding comparison in convolve2GradientNN

### DIFF
--- a/src/api/c/convolve.cpp
+++ b/src/api/c/convolve.cpp
@@ -437,7 +437,7 @@ af_err af_convolve2_gradient_nn(
         size_t padding_ndims  = padding.ndims();
         size_t dilation_ndims = dilation.ndims();
         ARG_ASSERT(3, stride_ndims > 0 && stride_ndims <= 2);
-        ARG_ASSERT(5, padding_ndims > 0 && padding_ndims <= 2);
+        ARG_ASSERT(5, padding_ndims >= 0 && padding_ndims <= 2);
         ARG_ASSERT(7, dilation_ndims > 0 && dilation_ndims <= 2);
 
         af_dtype type = oinfo.getType();


### PR DESCRIPTION
A padding issue that was fixed for `convolve2NN` back in 2020 (PR #2820) was not corrected in the corresponding `convolve2GradientNN` function.

This is a simple fix of the comparison, to allow for 0 padding.

This PR does not change any of the interfaces.

Checklist
---------
<!-- Check if done or not applicable -->
- [X] Rebased on latest master
- [X] Code compiles
- [X] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
