### PR TITLE
Added CMakeUserPresets.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #CMakeCache.txt
 #./CMakeFiles/
+CMakeUserPresets.json
 build*/
 Release/
 #Makefile


### PR DESCRIPTION
Added CMakeUserPresets.json to .gitignore

Description
-----------
According to the [CMake documentation](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html):
>`CMakePresets.json` may be checked into a version control system, and `CMakeUserPresets.json` should NOT be checked in. For example, if a project is using Git, `CMakePresets.json` may be tracked, and `CMakeUserPresets.json` should be added to the .gitignore.

Changes to Users
----------------
No changes to downstream users.

Checklist
---------
- [X] Rebased on latest master
- [X] Code compiles
- [X] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
