### PR TITLE
Fix race condition in OpenCL kernel

### DIFF
--- a/src/backend/opencl/kernel/flood_fill.cl
+++ b/src/backend/opencl/kernel/flood_fill.cl
@@ -42,13 +42,7 @@ int barrierOR(local int *predicates) {
         barrier(CLK_LOCAL_MEM_FENCE);
     }
     int retVal = predicates[0];
-#if AF_IS_PLATFORM_NVIDIA
-    // Without the extra barrier sync after reading the reduction result,
-    // the caller's loop is going into infinite loop occasionally which is
-    // in turn randoms hangs. This doesn't seem to be an issue on non-nvidia
-    // hardware. Hence, the check.
     barrier(CLK_LOCAL_MEM_FENCE);
-#endif
     return retVal;
 }
 

--- a/src/backend/opencl/kernel/flood_fill.hpp
+++ b/src/backend/opencl/kernel/flood_fill.hpp
@@ -84,8 +84,6 @@ void floodFill(Param out, const Param image, const Param seedsx,
         DefineKeyValue(LMEM_WIDTH, (THREADS_X + 2 * RADIUS)),
         DefineKeyValue(LMEM_HEIGHT, (THREADS_Y + 2 * RADIUS)),
         DefineKeyValue(GROUP_SIZE, (THREADS_Y * THREADS_X)),
-        DefineKeyValue(AF_IS_PLATFORM_NVIDIA, (int)(AFCL_PLATFORM_NVIDIA ==
-                                                    getActivePlatformVendor())),
         getTypeBuildDefinition<T>()};
 
     auto floodStep =


### PR DESCRIPTION
<!--
Short description of change

This should be one or two sentences that describe the overall
motivation of the PR. Description of what was done for an unfamiliar
reviewer.
-->



Description
-----------
<!--
Additional information about the PR answering following questions:

* Is this a new feature or a bug fix?
* More detail if necessary to describe all commits in pull request.
* Why these changes are necessary.
* Potential impact on specific hardware, software or backends.
* New functions and their functionality.
* Can this PR be backported to older versions?
* Future changes not implemented in this PR.
-->

Without the barrier at the end of barrierOR, it is possible for work-item 0 to start the next loop iteration and update predicates[0] while other work-items are still inside barrierOR reading `predicates`, meaning they read the next loop iteration's exit condition. This results in a divergent loop, where not all work-items reach the same barriers.

A previous fix identified this as a problem only on NVIDIA platforms, but strictly speaking a barrier is required in all cases to avoid a spec violation and undefined behaviour.


Changes to Users
----------------
<!--
* Additional options added to the build.
* What changes will existing users have to make to their code or build steps?
Refer to [wiki](https://github.com/arrayfire/arrayfire/wiki) for development guidelines
-->

The kernel should produce correct results on more OpenCL implementations.

Locally I tested both `Intel(R) FPGA Emulation Device` and various [oneAPI Construction Kit](https://github.com/codeplaysoftware/oneapi-construction-kit) devices, which all previously failed the `confidence_connected_opencl --gtest_filter="SingleSeed/ConfidenceConnectedDataTest.SegmentARegion/_prefix_background_radius_0_multiplier_1_iterations_5_replace_255"` unit test.

I'm unable to test other OpenCL implementations, sorry.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- ~~[ ] Functions added to unified API~~
- ~~[ ] Functions documented~~
