### PR TITLE
SubArray of subArray now returns subArray of original parent

### DIFF
--- a/src/backend/cpu/Array.cpp
+++ b/src/backend/cpu/Array.cpp
@@ -276,10 +276,23 @@ Array<T> createSubArray(const Array<T> &parent, const vector<af_seq> &index,
                         bool copy) {
     parent.eval();
 
-    dim4 dDims          = parent.getDataDims();
-    dim4 parent_strides = parent.strides();
+    const dim4 &dDims          = parent.getDataDims();
+    const dim4 &parent_strides = parent.strides();
 
-    if (parent.isLinear() == false) {
+    // (sub)Arrays remain linear when the strides corresponds to dataStrides
+    bool parent_isLinear = (parent_strides[0] == 1);
+    for (dim_t i = parent.ndims() - 1; i > 0; i--) {
+        parent_isLinear &=
+            parent_strides[i] == dDims[i - 1] * parent_strides[i - 1];
+    }
+
+    if (!parent_isLinear) {
+        if (!copy) {
+            // Linearizing parent through copy, is in conflict with the request
+            // of remaining inLine.
+            AF_ERROR("createSubArray inLine is impossible on non-Linear arrays",
+                     AF_ERR_INVALID_ARRAY);
+        }
         const Array<T> parentCopy = copyArray(parent);
         return createSubArray(parentCopy, index, copy);
     }

--- a/src/backend/cpu/Array.hpp
+++ b/src/backend/cpu/Array.hpp
@@ -239,7 +239,7 @@ class Array {
     dim_t getOffset() const { return info.getOffset(); }
     shared_ptr<T> getData() const { return data; }
 
-    dim4 getDataDims() const { return data_dims; }
+    const dim4 &getDataDims() const { return data_dims; }
 
     void setDataDims(const dim4 &new_dims);
 

--- a/src/backend/cuda/Array.cpp
+++ b/src/backend/cuda/Array.cpp
@@ -388,10 +388,23 @@ Array<T> createSubArray(const Array<T> &parent,
                         const std::vector<af_seq> &index, bool copy) {
     parent.eval();
 
-    dim4 dDims          = parent.getDataDims();
-    dim4 parent_strides = parent.strides();
+    const dim4 &dDims          = parent.getDataDims();
+    const dim4 &parent_strides = parent.strides();
 
-    if (parent.isLinear() == false) {
+    // (sub)Arrays remain linear when the strides corresponds to dataStrides
+    bool parent_isLinear = (parent_strides[0] == 1);
+    for (dim_t i = parent.ndims() - 1; i > 0; i--) {
+        parent_isLinear &=
+            parent_strides[i] == dDims[i - 1] * parent_strides[i - 1];
+    }
+
+    if (!parent_isLinear) {
+        if (!copy) {
+            // Linearizing parent through copy, is in conflict with the request
+            // of remaining inLine.
+            AF_ERROR("createSubArray inLine is impossible on non-Linear arrays",
+                     AF_ERR_INVALID_ARRAY);
+        }
         const Array<T> parentCopy = copyArray(parent);
         return createSubArray(parentCopy, index, copy);
     }

--- a/src/backend/cuda/Array.hpp
+++ b/src/backend/cuda/Array.hpp
@@ -237,7 +237,7 @@ class Array {
 
     dim_t getOffset() const { return info.getOffset(); }
 
-    dim4 getDataDims() const { return data_dims; }
+    const dim4 &getDataDims() const { return data_dims; }
 
     void setDataDims(const dim4 &new_dims);
 

--- a/src/backend/oneapi/Array.cpp
+++ b/src/backend/oneapi/Array.cpp
@@ -431,10 +431,23 @@ Array<T> createSubArray(const Array<T> &parent, const vector<af_seq> &index,
                         bool copy) {
     parent.eval();
 
-    dim4 dDims          = parent.getDataDims();
-    dim4 parent_strides = parent.strides();
+    const dim4 &dDims          = parent.getDataDims();
+    const dim4 &parent_strides = parent.strides();
 
-    if (parent.isLinear() == false) {
+    // (sub)Arrays remain linear when the strides corresponds to dataStrides
+    bool parent_isLinear = (parent_strides[0] == 1);
+    for (dim_t i = parent.ndims() - 1; i > 0; i--) {
+        parent_isLinear &=
+            parent_strides[i] == dDims[i - 1] * parent_strides[i - 1];
+    }
+
+    if (!parent_isLinear) {
+        if (!copy) {
+            // Linearizing parent through copy, is in conflict with the request
+            // of remaining inLine.
+            AF_ERROR("createSubArray inLine is impossible on non-Linear arrays",
+                     AF_ERR_INVALID_ARRAY);
+        }
         const Array<T> parentCopy = copyArray(parent);
         return createSubArray(parentCopy, index, copy);
     }

--- a/src/backend/oneapi/Array.hpp
+++ b/src/backend/oneapi/Array.hpp
@@ -286,7 +286,7 @@ class Array {
 
     dim_t getOffset() const { return info.getOffset(); }
 
-    dim4 getDataDims() const { return data_dims; }
+    const dim4 &getDataDims() const { return data_dims; }
 
     void setDataDims(const dim4 &new_dims);
 

--- a/src/backend/opencl/Array.hpp
+++ b/src/backend/opencl/Array.hpp
@@ -259,7 +259,7 @@ class Array {
 
     dim_t getOffset() const { return info.getOffset(); }
 
-    dim4 getDataDims() const { return data_dims; }
+    const dim4 &getDataDims() const { return data_dims; }
 
     void setDataDims(const dim4 &new_dims);
 

--- a/test/array.cpp
+++ b/test/array.cpp
@@ -420,6 +420,23 @@ TEST(Array, ISSUE_951) {
     array b       = a.cols(0, 20).rows(10, 20);
 }
 
+TEST(Array, ISSUE_3534) {
+    // This works
+    // array a = range(dim4(5,5));
+    // a = a.rows(0,3).copy();
+    // Following assignment failed silently without above copy()
+    // a(0,0) = 1234;
+
+    array a = range(dim4(5, 5));
+    a       = a.rows(1, 4);
+    a(1, 1) = 1234;
+
+    array b = range(dim4(4, 5)) + 1.0;
+    b(1, 1) = 1234;
+
+    ASSERT_ARRAYS_EQ(a, b);
+}
+
 TEST(Array, CreateHandleInvalidNullDimsPointer) {
     af_array out = 0;
     EXPECT_EQ(AF_ERR_ARG, af_create_handle(&out, 1, NULL, f32));


### PR DESCRIPTION
left-hand subArrays always return the parent Array with a new dimensions/strides (copy parameter == false).
When the parent Array however already was an subArray, an internal copy was executed and a subArray on the internal copy was returned.  All updates performed on this left-hand subArray were lost.

Reason:
the subArray calculation assumes that the parent array is linear.  If not, a copy is created before starting the calculation.
For left-hand subArrays, a copy is not allowed because we would no longer write into the parent data buffer.  It is also not necessary for parent subArrays since the original parent array still is linear (although the parent subArray is not).

Solution:
The linear check is changed so that we now verify the original parent array on linearity.  In case of non-linear a copy is still performed when the copy parameter is true, otherwise an AF_ERROR is thrown.

Description
-----------
Additional information about the PR answering following questions:

* Is this a new feature or a bug fix?
  * bug fix
* More detail if necessary to describe all commits in pull request.
* Why these changes are necessary.
  * Without this change, left-hand subArray of an existing subArray would reference an internal copy of the parent.  All data written remains invisible since it is an internal copy.
* Potential impact on specific hardware, software or backends.
  * None
* New functions and their functionality.
  * Existing function
* Can this PR be backported to older versions?
  * Yes
* Future changes not implemented in this PR.
-->
Fixes: #3534

Changes to Users
----------------
No changes

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
