### PR TITLE
Update toolkit driver versions for CUDA 12.4

### DIFF
--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -101,6 +101,8 @@ static const int jetsonComputeCapabilities[] = {
 
 // clang-format off
 static const cuNVRTCcompute Toolkit2MaxCompute[] = {
+    {12040, 9, 0, 0},
+    {12030, 9, 0, 0},
     {12020, 9, 0, 0},
     {12010, 9, 0, 0},
     {12000, 9, 0, 0},
@@ -140,9 +142,11 @@ struct ComputeCapabilityToStreamingProcessors {
 // clang-format off
 static const ToolkitDriverVersions
     CudaToDriverVersion[] = {
-        {12020, 525.60f, 527.41f},
-        {12010, 525.60f, 527.41f},
-        {12000, 525.60f, 527.41f},
+        {12040, 525.60f, 528.33f},
+        {12030, 525.60f, 528.33f},
+        {12020, 525.60f, 528.33f},
+        {12010, 525.60f, 528.33f},
+        {12000, 525.60f, 528.33f},
         {11080, 450.80f, 452.39f},
         {11070, 450.80f, 452.39f},
         {11060, 450.80f, 452.39f},


### PR DESCRIPTION
Updated according to the official documentation:
https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html