### PR TITLE
Fix for issue 3349: added cmake cuda version check

### DIFF
--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -99,7 +99,12 @@ if(UNIX AND AF_WITH_STATIC_CUDA_NUMERIC_LIBS)
     # contains GPU accelerated stedc and bdsqr. The user has to link
     # libcusolver_static.a with liblapack_static.a in order to build
     # successfully.
-    af_find_static_cuda_libs(lapack_static)
+    # Cuda Versions >= 12.0 changed lib name to libcusolver_lapack_static.a
+    if (CUDA_VERSION VERSION_GREATER_EQUAL 12.0)
+      af_find_static_cuda_libs(cusolver_lapack_static)
+    else()
+      af_find_static_cuda_libs(lapack_static)
+    endif()
 
     set(af_cuda_static_flags "${af_cuda_static_flags};-lcusolver_static")
   else()


### PR DESCRIPTION
<!--
Short description of change

This should be one or two sentences that describe the overall
motivation of the PR. Description of what was done for an unfamiliar
reviewer.
-->

Description
-----------

* Is this a new feature or a bug fix?: Bug Fix
* Why these changes are necessary: fix naming issues with the lapack cuda library for cuda >= 12.0
* Potential impact on specific hardware, software or backends: checks for cuda versions for correct linkage
* New functions and their functionality: None
* Can this PR be backported to older versions?: Yes
* Future changes not implemented in this PR: None

Fixes: #3349

Changes to Users
----------------
* Adds check for Cuda Version >= 12.0 for linking against cuda lapack library
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
