### PR TITLE
Add Visual Studio 17 2022 to the list of CMakePresets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -221,7 +221,7 @@
     {
       "name": "msvc2022",
       "hidden": true,
-      "description": "Base preset for Visual Studio 16 2022 generator.",
+      "description": "Base preset for Visual Studio 17 2022 generator.",
       "generator": "Visual Studio 17 2022",
       "architecture": "x64"
     },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -219,6 +219,43 @@
         }
     },
     {
+      "name": "msvc2022",
+      "hidden": true,
+      "description": "Base preset for Visual Studio 16 2022 generator.",
+      "generator": "Visual Studio 17 2022",
+      "architecture": "x64"
+    },
+    {
+      "name": "msvc2022-cpu-mkl",
+      "description": "Build CPU Backend using Intel MKL with MSVC 2022 Generator",
+      "inherits": [ "msvc2022", "ninja-cpu-mkl-debug" ]
+    },
+    {
+      "name": "msvc2022-cuda",
+      "description": "Build CUDA Backend with MSVC 2022 Generator",
+      "inherits": [ "msvc2022", "ninja-cuda-debug" ]
+    },
+    {
+      "name": "msvc2022-opencl-mkl",
+      "description": "Build OpenCL Backend with MSVC 2022 Generator. Uses MKL for CPU fallback.",
+      "inherits": [ "msvc2022", "ninja-opencl-mkl-debug" ]
+    },
+    {
+      "name": "msvc2022-all-mkl",
+      "description": "Build all feasible Backends with MSVC 2022 Generator. Uses MKL for CPU fallback.",
+      "inherits": [ "msvc2022", "ninja-all-mkl-debug" ]
+    },
+    {
+      "name": "msvc2022-all-mkl-local-install",
+      "description": "Build all feasible Backends with MSVC 2022 Generator. Installs to specified path prefix.",
+      "inherits": [ "msvc2022", "ninja-all-mkl-local-install" ]
+    },
+    {
+      "name": "msvc2022-all-mkl-standalone-install",
+      "description": "Build all feasible Backends with MSVC 2022 Generator. Also packages dependencies while installing to specified path prefix.",
+      "inherits": [ "msvc2022", "ninja-all-mkl-standalone-install" ]
+    },
+    {
       "name": "msvc2019",
       "hidden": true,
       "description": "Base preset for Visual Studio 16 2019 generator.",


### PR DESCRIPTION
Add Visual Studio 17 2022 to the CMakePresets.txt file

Description
-----------
* Is this a new feature or a bug fix?: Feature
* Why these changes are necessary: Easier setup for more recent Visual Studio Builds
* Potential impact on specific hardware, software or backends: None
* New functions and their functionality: None
* Can this PR be backported to older versions?: Yes
* Future changes not implemented in this PR: None

Changes to Users
----------------
* Added the possibility to use MSVC2022 Generator to build ArrayFire using presets
* No action required by user

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
