### PR TITLE
Fix for issue 3528: cmake generator expression space removed

### DIFF
--- a/src/api/unified/CMakeLists.txt
+++ b/src/api/unified/CMakeLists.txt
@@ -82,8 +82,8 @@ target_include_directories(af
 target_include_directories(af
   SYSTEM PRIVATE
     $<TARGET_PROPERTY:afcommon_interface,INTERFACE_INCLUDE_DIRECTORIES>
-    $<$<BOOL:${OpenCL_FOUND}>: $<TARGET_PROPERTY:OpenCL::OpenCL,INTERFACE_INCLUDE_DIRECTORIES>>
-    $<$<BOOL:${CUDA_FOUND}>:  ${CUDA_INCLUDE_DIRS}>
+    $<$<BOOL:${OpenCL_FOUND}>:$<TARGET_PROPERTY:OpenCL::OpenCL,INTERFACE_INCLUDE_DIRECTORIES>>
+    $<$<BOOL:${CUDA_FOUND}>:${CUDA_INCLUDE_DIRS}>
   )
 
 target_link_libraries(af


### PR DESCRIPTION
Fixes CMake Generator Expression Issue with a system with no OpenCL installed compiles arrayfire without the OpenCL backend

Description
-----------
* Is this a new feature or a bug fix?: Bug Fix
* Why these changes are necessary: Fixes CMake Build
* Potential impact on specific hardware, software or backends: Allows building non OpenCL ArrayFire backends without OpenCL installed in Linux
* New functions and their functionality: None
* Can this PR be backported to older versions?: Yes
* Future changes not implemented in this PR: None

Fixes: #3528 

Changes to Users
----------------
* No options added to the build
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
