### PR TITLE
Fix for issue 3551: Implemented event_impl class for AF_DISABLE_CPU_ASYNC

### DIFF
--- a/src/backend/cpu/queue.hpp
+++ b/src/backend/cpu/queue.hpp
@@ -38,6 +38,45 @@ class queue_impl {
     }
 };
 
+class event_impl {
+   public:
+    event_impl() noexcept = default;
+    ~event_impl() noexcept = default;
+    explicit event_impl(const event_impl &other) = default;
+    event_impl(event_impl &&other) noexcept      = default;
+    event_impl &operator=(event_impl &&other) noexcept = default;
+    event_impl &operator=(event_impl &other) noexcept = default;
+
+    explicit event_impl(const int val) {
+    }
+
+    event_impl &operator=(int val) noexcept {
+        return *this;
+    }
+
+    int create() {
+        AF_ERROR("Incorrectly configured", AF_ERR_INTERNAL);
+        return 0;
+    }
+
+    int mark(queue_impl &queue) {
+        AF_ERROR("Incorrectly configured", AF_ERR_INTERNAL);
+        return 0;
+    }
+
+    int wait(queue_impl &queue) const {
+        AF_ERROR("Incorrectly configured", AF_ERR_INTERNAL);
+        return 0;
+    }
+
+    int sync() const noexcept {
+        AF_ERROR("Incorrectly configured", AF_ERR_INTERNAL);
+        return 0;
+    }
+
+    operator bool() const noexcept { return false; }
+};
+
 #else
 
 #include <threads/async_queue.hpp>

--- a/src/backend/cpu/queue.hpp
+++ b/src/backend/cpu/queue.hpp
@@ -40,19 +40,16 @@ class queue_impl {
 
 class event_impl {
    public:
-    event_impl() noexcept = default;
-    ~event_impl() noexcept = default;
-    explicit event_impl(const event_impl &other) = default;
-    event_impl(event_impl &&other) noexcept      = default;
+    event_impl() noexcept                              = default;
+    ~event_impl() noexcept                             = default;
+    explicit event_impl(const event_impl &other)       = default;
+    event_impl(event_impl &&other) noexcept            = default;
     event_impl &operator=(event_impl &&other) noexcept = default;
-    event_impl &operator=(event_impl &other) noexcept = default;
+    event_impl &operator=(event_impl &other) noexcept  = default;
 
-    explicit event_impl(const int val) {
-    }
+    explicit event_impl(const int val) {}
 
-    event_impl &operator=(int val) noexcept {
-        return *this;
-    }
+    event_impl &operator=(int val) noexcept { return *this; }
 
     int create() {
         AF_ERROR("Incorrectly configured", AF_ERR_INTERNAL);


### PR DESCRIPTION
Fixes compilation issue of class event_impl being not defined when AF_DISABLE_CPU_ASYNC macro is defined.

Description
-----------
* Is this a new feature or a bug fix?: Bug Fix
* Why these changes are necessary: Fixes compilation issue for a possible option in compilation
* Potential impact on specific hardware, software or backends: Same impact on all platforms on CPU backend
* New functions and their functionality: None
* Can this PR be backported to older versions?: Yes
* Future changes not implemented in this PR.: None

Fixes: #3551 

Changes to Users
----------------

* No build options added
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
