### PR TITLE
Fix issue 3556: cassert not being included for assert macro

### DIFF
--- a/src/backend/common/err_common.hpp
+++ b/src/backend/common/err_common.hpp
@@ -17,6 +17,7 @@
 #include <common/defines.hpp>
 #include <af/defines.h>
 
+#include <cassert>
 #include <sstream>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
Adds `#include <cassert>` in [err_common.hpp](src/backend/common/err_common.hpp) to fix `assert` macro not being defined when compiling in Debug with Visual Studio in Windows.

Description
-----------
* Is this a new feature or a bug fix?: Bug fix
* Why these changes are necessary: correctly includes the assert macro
* Potential impact on specific hardware, software or backends: fixes issue with Microsoft Visual Studio compiler with assert macro
* New functions and their functionality.
* Can this PR be backported to older versions?
* Future changes not implemented in this PR.

Fixes: #3556 

Changes to Users
----------------
* No options added to build
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
