### PR TITLE
3545 bug fp16 types not allowed for atan2 method

### DIFF
--- a/src/api/c/binary.cpp
+++ b/src/api/c/binary.cpp
@@ -476,7 +476,7 @@ af_err af_atan2(af_array *out, const af_array lhs, const af_array rhs,
     try {
         const af_dtype type = implicit(lhs, rhs);
 
-        if (type != f32 && type != f64) {
+        if (type != f16 && type != f32 && type != f64) {
             AF_ERROR("Only floating point arrays are supported for atan2 ",
                      AF_ERR_NOT_SUPPORTED);
         }
@@ -491,6 +491,7 @@ af_err af_atan2(af_array *out, const af_array lhs, const af_array rhs,
 
         af_array res;
         switch (type) {
+            case f16: res = arithOp<half, af_atan2_t>(lhs, rhs, odims); break;
             case f32: res = arithOp<float, af_atan2_t>(lhs, rhs, odims); break;
             case f64: res = arithOp<double, af_atan2_t>(lhs, rhs, odims); break;
             default: TYPE_ERROR(0, type);
@@ -507,7 +508,7 @@ af_err af_hypot(af_array *out, const af_array lhs, const af_array rhs,
     try {
         const af_dtype type = implicit(lhs, rhs);
 
-        if (type != f32 && type != f64) {
+        if (type != f16 && type != f32 && type != f64) {
             AF_ERROR("Only floating point arrays are supported for hypot ",
                      AF_ERR_NOT_SUPPORTED);
         }
@@ -523,6 +524,7 @@ af_err af_hypot(af_array *out, const af_array lhs, const af_array rhs,
 
         af_array res;
         switch (type) {
+            case f16: res = arithOp<half, af_hypot_t>(lhs, rhs, odims); break;
             case f32: res = arithOp<float, af_hypot_t>(lhs, rhs, odims); break;
             case f64: res = arithOp<double, af_hypot_t>(lhs, rhs, odims); break;
             default: TYPE_ERROR(0, type);

--- a/test/binary.cpp
+++ b/test/binary.cpp
@@ -14,12 +14,16 @@
 #include <af/data.h>
 #include <af/device.h>
 #include <af/random.h>
+#include <af/half.h>
+#include "half.hpp"  //note: NOT common. From extern/half/include/half.hpp
 
 #include <cfenv>
 #include <cmath>
 
 using namespace std;
 using namespace af;
+
+using half_float_half = half_float::half;
 
 const int num = 10000;
 
@@ -122,7 +126,7 @@ af::array randgen(const int num, dtype ty) {
                                                                       \
         af_dtype ta = (af_dtype)dtype_traits<Ta>::af_type;            \
         af::array a = randgen(num, ta);                               \
-        Tb h_b      = 0.3;                                            \
+        Tb h_b      = (Tb)0.3;                                            \
         af::array c = func(a, h_b);                                   \
         Ta *h_a     = a.host<Ta>();                                   \
         Td *h_d     = c.host<Td>();                                   \
@@ -139,7 +143,7 @@ af::array randgen(const int num, dtype ty) {
         SUPPORTED_TYPE_CHECK(Tc);                                     \
                                                                       \
         af_dtype tb = (af_dtype)dtype_traits<Tb>::af_type;            \
-        Ta h_a      = 0.3;                                            \
+        Ta h_a      = (Ta)0.3;                                            \
         af::array b = randgen(num, tb);                               \
         af::array c = func(h_a, b);                                   \
         Tb *h_b     = b.host<Tb>();                                   \
@@ -163,6 +167,8 @@ af::array randgen(const int num, dtype ty) {
 #define BINARY_TESTS_UINT(func) BINARY_TESTS(uint, uint, uint, func)
 #define BINARY_TESTS_INTL(func) BINARY_TESTS(intl, intl, intl, func)
 #define BINARY_TESTS_UINTL(func) BINARY_TESTS(uintl, uintl, uintl, func)
+#define BINARY_TESTS_NEAR_HALF(func) \
+    BINARY_TESTS_NEAR(half_float_half, half_float_half, half_float_half, func, 1e-3)
 #define BINARY_TESTS_NEAR_FLOAT(func) \
     BINARY_TESTS_NEAR(float, float, float, func, 1e-5)
 #define BINARY_TESTS_NEAR_DOUBLE(func) \
@@ -187,6 +193,9 @@ BINARY_TESTS_DOUBLE(mod)
 BINARY_TESTS_NEAR_FLOAT(atan2)
 BINARY_TESTS_NEAR_FLOAT(pow)
 BINARY_TESTS_NEAR_FLOAT(hypot)
+
+BINARY_TESTS_NEAR_HALF(atan2)
+BINARY_TESTS_NEAR_HALF(hypot)
 
 BINARY_TESTS_NEAR_DOUBLE(atan2)
 BINARY_TESTS_NEAR_DOUBLE(pow)


### PR DESCRIPTION
Add ability to use atan2 and hypot functions with fp16 arguments.

Description
-----------
Cases have been added to the atan2 and hypot functions to handle fp16 arguments. Previously an exception was thrown when trying to use fp16 arguments with these functions.

Tests have been added to verify that these functions are working correctly with fp16 arguments. Note that the OpenCL back end does not support half precision.

Several other functions have been identified as not supporting fp16, a new issue will be created for these.

Fixes: #3545 

Changes to Users
----------------
atan2 and hypot functions can now be used on fp16 arrays

Checklist
---------
- [ x] Rebased on latest master
- [ x] Code compiles
- [ x] Tests pass
- [ x] Functions added to unified API
- [ x] Functions documented
