### PR TITLE
Fixed Issue 3558 cl::Platform type incompatibility with OpenCL-HPP v2023.12.14

### DIFF
--- a/src/backend/opencl/device_manager.cpp
+++ b/src/backend/opencl/device_manager.cpp
@@ -261,8 +261,11 @@ DeviceManager::DeviceManager()
 
     // Create contexts and queues once the sort is done
     for (int i = 0; i < nDevices; i++) {
-        cl_platform_id device_platform =
-            devices[i]->getInfo<CL_DEVICE_PLATFORM>();
+        // For OpenCL-HPP >= v2023.12.14 type is cl::Platform instead of
+        // cl_platform_id
+        cl::Platform device_platform;
+        device_platform = devices[i]->getInfo<CL_DEVICE_PLATFORM>();
+
         try {
             mContexts.emplace_back(
                 make_unique<cl::Context>(mDeviceContextMap[*devices[i]]));
@@ -272,7 +275,7 @@ DeviceManager::DeviceManager()
             mDeviceTypes.push_back(getDeviceTypeEnum(*devices[i]));
             mPlatforms.push_back(
                 std::make_pair<std::unique_ptr<cl::Platform>, afcl_platform>(
-                    make_unique<cl::Platform>(device_platform, true),
+                    make_unique<cl::Platform>(device_platform(), true),
                     getPlatformEnum(*devices[i])));
             mDevices.emplace_back(std::move(devices[i]));
 

--- a/src/backend/opencl/platform.cpp
+++ b/src/backend/opencl/platform.cpp
@@ -337,7 +337,11 @@ const std::string& getActiveDeviceBaseBuildFlags() {
 }
 
 vector<Version> getOpenCLCDeviceVersion(const Device& device) {
-    Platform device_platform(device.getInfo<CL_DEVICE_PLATFORM>(), false);
+    // For OpenCL-HPP >= v2023.12.14 type is cl::Platform instead of
+    // cl_platform_id
+    Platform device_platform;
+    device_platform = device.getInfo<CL_DEVICE_PLATFORM>();
+
     auto platform_version = device_platform.getInfo<CL_PLATFORM_VERSION>();
     vector<Version> out;
 
@@ -540,10 +544,13 @@ void addDeviceContext(cl_device_id dev, cl_context ctx, cl_command_queue que) {
         devMngr.mDeviceTypes.push_back(
             static_cast<int>(tDevice.getInfo<CL_DEVICE_TYPE>()));
 
-        auto device_platform = tDevice.getInfo<CL_DEVICE_PLATFORM>();
+        // For OpenCL-HPP >= v2023.12.14 type is cl::Platform instead of
+        // cl_platform_id
+        cl::Platform device_platform;
+        device_platform = tDevice.getInfo<CL_DEVICE_PLATFORM>();
         devMngr.mPlatforms.push_back(
             std::make_pair<std::unique_ptr<cl::Platform>, afcl_platform>(
-                make_unique<cl::Platform>(device_platform, true),
+                make_unique<cl::Platform>(device_platform(), true),
                 getPlatformEnum(tDevice)));
 
         devMngr.mDevices.emplace_back(make_unique<cl::Device>(move(tDevice)));


### PR DESCRIPTION
Fix compilation error due to OpenCL HPP headers change in the type returned by getInfo<CL_DEVICE_PLATFORM>()

Description
-----------
* Is this a new feature or a bug fix?: Bug Fix
* More detail if necessary to describe all commits in pull request: change explicit `cl_platform_id` type to  `auto`
* Why these changes are necessary: fixes incompatibility when compilation with a more recent version of opencl hpp headers
* Potential impact on specific hardware, software or backends: greater compatibility of opencl versions
* New functions and their functionality: None
* Can this PR be backported to older versions?: Yes
* Future changes not implemented in this PR.: None

Fixes: #3558 

Changes to Users
----------------
* No options added to the build.
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
