### PR TITLE
Fix Issue 3563: Added message to dependency_check cmake

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,7 +20,7 @@ if(AF_TEST_WITH_MTX_FILES)
 endif()
 
 if(AF_WITH_EXTERNAL_PACKAGES_ONLY)
-    dependency_check(GTest_FOUND)
+  dependency_check(GTest_FOUND "Google Tests not found.")
 elseif(NOT TARGET GTest::gtest)
   af_dep_check_and_populate(${gtest_prefix}
     URI https://github.com/google/googletest.git


### PR DESCRIPTION
Added message to `dependency_check` function in line 23 of `test/CMakeLists.txt` file

Description
-----------
* Is this a new feature or a bug fix?: Bug fix
* Why these changes are necessary: Fix cmake configuring when `AF_WITH_EXTERNAL_PACKAGES_ONLY` enabled
* Potential impact on specific hardware, software or backends: None
* New functions and their functionality: None
* Can this PR be backported to older versions?: Yes
* Future changes not implemented in this PR: None

Fixes: #3563 

Changes to Users
----------------
* No options added to the build
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
