### PR TITLE
Workaround fix for issue with inline namespace thrust

### DIFF
--- a/src/backend/cuda/ThrustArrayFirePolicy.hpp
+++ b/src/backend/cuda/ThrustArrayFirePolicy.hpp
@@ -37,7 +37,11 @@ inline void return_temporary_buffer(ThrustArrayFirePolicy, Pointer p) {
 }  // namespace cuda
 }  // namespace arrayfire
 
+#if defined(_WIN32)
+THRUST_NAMESPACE_BEGIN
+#else
 namespace thrust {
+#endif
 namespace cuda_cub {
 template<>
 __DH__ inline cudaStream_t get_stream<arrayfire::cuda::ThrustArrayFirePolicy>(
@@ -47,7 +51,12 @@ __DH__ inline cudaStream_t get_stream<arrayfire::cuda::ThrustArrayFirePolicy>(
 #else
     return arrayfire::cuda::getActiveStream();
 #endif
+
+#if defined(_WIN32)
+THRUST_NAMESPACE_END
+#else
 }
+#endif
 
 __DH__
 inline cudaError_t synchronize_stream(

--- a/src/backend/cuda/ThrustArrayFirePolicy.hpp
+++ b/src/backend/cuda/ThrustArrayFirePolicy.hpp
@@ -51,22 +51,21 @@ __DH__ inline cudaStream_t get_stream<arrayfire::cuda::ThrustArrayFirePolicy>(
 #else
     return arrayfire::cuda::getActiveStream();
 #endif
-
-#if defined(_WIN32)
-    THRUST_NAMESPACE_END
-#else
 }
-#endif
 
-    __DH__
-    inline cudaError_t synchronize_stream(
-        const arrayfire::cuda::ThrustArrayFirePolicy &) {
+__DH__
+inline cudaError_t synchronize_stream(
+    const arrayfire::cuda::ThrustArrayFirePolicy &) {
 #if defined(__CUDA_ARCH__)
-        return cudaSuccess;
+    return cudaSuccess;
 #else
     return cudaStreamSynchronize(arrayfire::cuda::getActiveStream());
 #endif
-    }
+}
 
 }  // namespace cuda_cub
-}  // namespace cuda_cub
+#if defined(_WIN32)
+THRUST_NAMESPACE_END
+#else
+}  // namespace thrust
+#endif

--- a/src/backend/cuda/ThrustArrayFirePolicy.hpp
+++ b/src/backend/cuda/ThrustArrayFirePolicy.hpp
@@ -53,20 +53,20 @@ __DH__ inline cudaStream_t get_stream<arrayfire::cuda::ThrustArrayFirePolicy>(
 #endif
 
 #if defined(_WIN32)
-THRUST_NAMESPACE_END
+    THRUST_NAMESPACE_END
 #else
 }
 #endif
 
-__DH__
-inline cudaError_t synchronize_stream(
-    const arrayfire::cuda::ThrustArrayFirePolicy &) {
+    __DH__
+    inline cudaError_t synchronize_stream(
+        const arrayfire::cuda::ThrustArrayFirePolicy &) {
 #if defined(__CUDA_ARCH__)
-    return cudaSuccess;
+        return cudaSuccess;
 #else
     return cudaStreamSynchronize(arrayfire::cuda::getActiveStream());
 #endif
-}
+    }
 
 }  // namespace cuda_cub
-}  // namespace thrust
+}  // namespace cuda_cub


### PR DESCRIPTION
Temporary fix for inline namespace with thrust compiling with MSVC

Description
-----------
* Is this a new feature or a bug fix?: Temporary fix
* More detail if necessary to describe all commits in pull request.
* Why these changes are necessary: workaround for compiler bug affecting template specialization with inline namespace used in `ThrustArrayFirePolicy.hpp`
* Potential impact on specific hardware, software or backends: CUDA backend on Windows 
* New functions and their functionality.: None
* Can this PR be backported to older versions?: NA
* Future changes not implemented in this PR: None
Fixes: #3565 

Changes to Users
----------------
* No additional options added to the build.
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
