### PR TITLE
Fix Issue 3502: added installation of spdlog library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,6 +285,9 @@ else()
     target_compile_options(spdlog
       PRIVATE
         $<$<BOOL:${has_cxx_fp_model}>:-fp-model precise>)
+    install(TARGETS spdlog
+      COMPONENT common_backend_dependencies
+      DESTINATION ${AF_INSTALL_BIN_DIR})
     set_target_properties(af_spdlog
       PROPERTIES
         INTERFACE_LINK_LIBRARIES "spdlog")


### PR DESCRIPTION
Add cmake installation for spdlog library when it is not locally available or AF_WITH_SPDLOG_HEADER_ONLY is disabled.

Description
-----------
* Is this a new feature or a bug fix?: Bug fix
* More detail if necessary to describe all commits in pull request.: adds installation of fetched version of spdlog alongside arrayfire
* Why these changes are necessary.: fixes problems when installing ArrayFire when there is no spdlog library installed in the system and ArrayFire is not build with spdlog header only.
* Potential impact on specific hardware, software or backends.: Installation of spdlog library
* New functions and their functionality.: None
* Can this PR be backported to older versions?: Yes
* Future changes not implemented in this PR.: Possibly adding the ability to build ArrayFire with spdlog statically and not needing to install spdlog

Fixes: #3502 

Changes to Users
----------------
* No additional options added to the build
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
