### PR TITLE
Fixed cmake policy issue for specifc cmake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,9 @@ set_policies(
            CMP0074
            CMP0077
            CMP0079)
-cmake_policy(SET CMP0146 OLD)
+if (CMAKE_VERSION VERSION_GREATER_EQUAL "3.27")
+  cmake_policy(SET CMP0146 OLD)
+endif()
 arrayfire_set_cmake_default_variables()
 
 option(AF_WITH_EXTERNAL_PACKAGES_ONLY "Build ArrayFire with External packages only" OFF)


### PR DESCRIPTION
Fixes cmake configuring issue where specified cmake policy is not available prior to a certain cmake version: https://cmake.org/cmake/help/latest/policy/CMP0146.html

-----------
* Is this a new feature or a bug fix?: Bug fix
* More detail if necessary to describe all commits in pull request: checks the cmake version before setting policy
* Why these changes are necessary: Needed for correct cmake configuration
* Potential impact on specific hardware, software or backends: None
* New functions and their functionality: None
* Can this PR be backported to older versions?: No
* Future changes not implemented in this PR: None

Changes to Users
----------------
* No additional options added to the build
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
