### PR TITLE
Add support for CUDA Toolkit 12.5

### DIFF
--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -101,6 +101,7 @@ static const int jetsonComputeCapabilities[] = {
 
 // clang-format off
 static const cuNVRTCcompute Toolkit2MaxCompute[] = {
+    {12050, 9, 0, 0},
     {12040, 9, 0, 0},
     {12030, 9, 0, 0},
     {12020, 9, 0, 0},
@@ -142,6 +143,7 @@ struct ComputeCapabilityToStreamingProcessors {
 // clang-format off
 static const ToolkitDriverVersions
     CudaToDriverVersion[] = {
+        {12050, 525.60f, 528.33f},
         {12040, 525.60f, 528.33f},
         {12030, 525.60f, 528.33f},
         {12020, 525.60f, 528.33f},


### PR DESCRIPTION
Adds compatibility for cuda 12.5 toolkit and their respective drivers

Description
-----------
* Is this a new feature or a bug fix?: Feature
* Why these changes are necessary.: Support for more cuda versions
* Potential impact on specific hardware, software or backends.: cuda backend expanded to use 12.5
* New functions and their functionality.: None
* Can this PR be backported to older versions?: Yes
* Future changes not implemented in this PR.: None
-->

Changes to Users
----------------
* No additional build options
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
