### PR TITLE
Fix interop_cuda.md issue related to afcu::getStream

### DIFF
--- a/docs/pages/interop_cuda.md
+++ b/docs/pages/interop_cuda.md
@@ -80,8 +80,7 @@ int main() {
 
     // 5. Determine ArrayFire's CUDA stream
     int af_id = af::getDevice();
-    int cuda_id = afcu::getNativeId(af_id);
-    cudaStream_t af_cuda_stream = afcu::getStream(cuda_id);
+    cudaStream_t af_cuda_stream = afcu::getStream(af_id);
 
     // 6. Set arguments and run your kernel in ArrayFire's stream
     //    Here launch with 1 block of 10 threads


### PR DESCRIPTION
afcu::getStream() documentation specify that the required id for it's call is the ArrayFire device id. There is not need to retrieve the cuda native id in the example as it may lead to sync issues when using a device with multiple GPUs

