### PR TITLE
3575 bug   shfl down sync bug causes undefined behavior

### DIFF
--- a/src/backend/cuda/kernel/shfl_intrinsics.hpp
+++ b/src/backend/cuda/kernel/shfl_intrinsics.hpp
@@ -11,11 +11,13 @@ namespace arrayfire {
 namespace cuda {
 namespace kernel {
 
+constexpr unsigned int FULL_MASK = 0xffffffff;
+
 //__all_sync wrapper
 template<typename T>
-__device__ T all_sync(unsigned mask, T var) {
+__device__ T all_sync(T var) {
 #if (CUDA_VERSION >= 9000)
-    return __all_sync(mask, var);
+    return __all_sync(FULL_MASK, var);
 #else
     return __all(var);
 #endif
@@ -23,9 +25,9 @@ __device__ T all_sync(unsigned mask, T var) {
 
 //__all_sync wrapper
 template<typename T>
-__device__ T any_sync(unsigned mask, T var) {
+__device__ T any_sync(T var) {
 #if (CUDA_VERSION >= 9000)
-    return __any_sync(mask, var);
+    return __any_sync(FULL_MASK, var);
 #else
     return __any(var);
 #endif
@@ -33,9 +35,9 @@ __device__ T any_sync(unsigned mask, T var) {
 
 //__shfl_down_sync wrapper
 template<typename T>
-__device__ T ballot_sync(unsigned mask, T var) {
+__device__ T ballot_sync(T var) {
 #if (CUDA_VERSION >= 9000)
-    return __ballot_sync(mask, var);
+    return __ballot_sync(FULL_MASK, var);
 #else
     return __ballot(var);
 #endif
@@ -43,19 +45,19 @@ __device__ T ballot_sync(unsigned mask, T var) {
 
 //__shfl_down_sync wrapper
 template<typename T>
-__device__ T shfl_down_sync(unsigned mask, T var, int delta) {
+__device__ T shfl_down_sync(T var, int delta) {
 #if (CUDA_VERSION >= 9000)
-    return __shfl_down_sync(mask, var, delta);
+    return __shfl_down_sync(FULL_MASK, var, delta);
 #else
     return __shfl_down(var, delta);
 #endif
 }
 // specialization for cfloat
 template<>
-inline __device__ cfloat shfl_down_sync(unsigned mask, cfloat var, int delta) {
+inline __device__ cfloat shfl_down_sync(cfloat var, int delta) {
 #if (CUDA_VERSION >= 9000)
-    cfloat res = {__shfl_down_sync(mask, var.x, delta),
-                  __shfl_down_sync(mask, var.y, delta)};
+    cfloat res = {__shfl_down_sync(FULL_MASK, var.x, delta),
+                  __shfl_down_sync(FULL_MASK, var.y, delta)};
 #else
     cfloat res  = {__shfl_down(var.x, delta), __shfl_down(var.y, delta)};
 #endif
@@ -63,11 +65,11 @@ inline __device__ cfloat shfl_down_sync(unsigned mask, cfloat var, int delta) {
 }
 // specialization for cdouble
 template<>
-inline __device__ cdouble shfl_down_sync(unsigned mask, cdouble var,
+inline __device__ cdouble shfl_down_sync(cdouble var,
                                          int delta) {
 #if (CUDA_VERSION >= 9000)
-    cdouble res = {__shfl_down_sync(mask, var.x, delta),
-                   __shfl_down_sync(mask, var.y, delta)};
+    cdouble res = {__shfl_down_sync(FULL_MASK, var.x, delta),
+                   __shfl_down_sync(FULL_MASK, var.y, delta)};
 #else
     cdouble res = {__shfl_down(var.x, delta), __shfl_down(var.y, delta)};
 #endif
@@ -76,19 +78,19 @@ inline __device__ cdouble shfl_down_sync(unsigned mask, cdouble var,
 
 //__shfl_up_sync wrapper
 template<typename T>
-__device__ T shfl_up_sync(unsigned mask, T var, int delta) {
+__device__ T shfl_up_sync(T var, int delta) {
 #if (CUDA_VERSION >= 9000)
-    return __shfl_up_sync(mask, var, delta);
+    return __shfl_up_sync(FULL_MASK, var, delta);
 #else
     return __shfl_up(var, delta);
 #endif
 }
 // specialization for cfloat
 template<>
-inline __device__ cfloat shfl_up_sync(unsigned mask, cfloat var, int delta) {
+inline __device__ cfloat shfl_up_sync(cfloat var, int delta) {
 #if (CUDA_VERSION >= 9000)
-    cfloat res = {__shfl_up_sync(mask, var.x, delta),
-                  __shfl_up_sync(mask, var.y, delta)};
+    cfloat res = {__shfl_up_sync(FULL_MASK, var.x, delta),
+                  __shfl_up_sync(FULL_MASK, var.y, delta)};
 #else
     cfloat res  = {__shfl_up(var.x, delta), __shfl_up(var.y, delta)};
 #endif
@@ -96,10 +98,10 @@ inline __device__ cfloat shfl_up_sync(unsigned mask, cfloat var, int delta) {
 }
 // specialization for cdouble
 template<>
-inline __device__ cdouble shfl_up_sync(unsigned mask, cdouble var, int delta) {
+inline __device__ cdouble shfl_up_sync(cdouble var, int delta) {
 #if (CUDA_VERSION >= 9000)
-    cdouble res = {__shfl_up_sync(mask, var.x, delta),
-                   __shfl_up_sync(mask, var.y, delta)};
+    cdouble res = {__shfl_up_sync(FULL_MASK, var.x, delta),
+                   __shfl_up_sync(FULL_MASK, var.y, delta)};
 #else
     cdouble res = {__shfl_up(var.x, delta), __shfl_up(var.y, delta)};
 #endif


### PR DESCRIPTION
Fix for bug where warp primitives were called by threads outside mask, triggering a warp illegal instruction exception in CUDA versions > 12.2

Description
-----------
A bug has been uncovered by CUDA versions newer than 12.2 where calls to the __warp_down_sync primitive are being made by threads outside of the thread mask in the reduce_by_key header. Although this results in undefined behavior, in prior CUDA versions the primitive would execute successfully. This has changed since in newer versions since 12.2 where a warp illegal instruction exception is thrown.

The primitive wrapper functions header has been modified so that the full mask is always used to ensure the same behavior with old and new versions of CUDA. If a different mask is required, then the specific new version of the primitive can be called.

Fixes: #3575 


Checklist
---------
<!-- Check if done or not applicable -->
- [x ] Rebased on latest master
- [ x] Code compiles
- [x ] Tests pass
