### PR TITLE
Fixed Issue 3378: Added back `classify` into the naive bayes example

### DIFF
--- a/examples/machine_learning/mnist_common.h
+++ b/examples/machine_learning/mnist_common.h
@@ -145,7 +145,7 @@ static void display_results(const af::array &test_images,
             (test_images(span, span, i) > 0.1f).as(u8).host<unsigned char>();
         for (int j = 0; j < 28; j++) {
             for (int k = 0; k < 28; k++) {
-                std::cout << (img[j * 28 + k] ? "\u2588" : " ") << " ";
+                std::cout << (img[k * 28 + j] ? "\u2588" : " ") << " ";
             }
             std::cout << std::endl;
         }

--- a/examples/machine_learning/naive_bayes.cpp
+++ b/examples/machine_learning/naive_bayes.cpp
@@ -135,8 +135,8 @@ void naive_bayes_demo(bool console, int perc) {
     if (!console) {
         test_images = test_images.T();
         test_labels = test_labels.T();
-        // FIXME: Crashing in mnist_common.h::classify
-        // display_results<false>(test_images, res_labels, test_labels , 20);
+
+        display_results<false>(test_images, res_labels, test_labels, 20);
     }
 }
 


### PR DESCRIPTION
Removed a change to display the results of naive bayes example

Description
-----------
* Is this a new feature or a bug fix?: None
* More detail if necessary to describe all commits in pull request.: Changes to mnist_common.h and naive_bayes.cpp to display naive_bayes example
* Why these changes are necessary.: Make this example consistent with other machine learning examples
* Potential impact on specific hardware, software or backends.: None
* New functions and their functionality.: None
* Can this PR be backported to older versions?: Likely no
* Future changes not implemented in this PR.: None

Fixes: #3378 

Changes to Users
----------------
* Additional options added to the build: None
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
