### PR TITLE
Fixed issue 3578: added correct compilation define for coo2dense kernel

### DIFF
--- a/src/backend/opencl/kernel/sparse.hpp
+++ b/src/backend/opencl/kernel/sparse.hpp
@@ -39,7 +39,7 @@ void coo2dense(Param out, const Param values, const Param rowIdx,
     };
     std::vector<std::string> compileOpts = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
-        DefineKeyValue(resp, REPEAT),
+        DefineKeyValue(reps, REPEAT),
     };
     compileOpts.emplace_back(getTypeBuildDefinition<T>());
 


### PR DESCRIPTION
Fixes mispelled compilation define option 

Description
-----------
* Is this a new feature or a bug fix?: Bug fix
* More detail if necessary to describe all commits in pull request.:None
* Why these changes are necessary: Fixes sparse COO to dense array conversion
* Potential impact on specific hardware, software or backends: Fix sparse opencl issues
* New functions and their functionality: None
* Can this PR be backported to older versions?: Yes (some)
* Future changes not implemented in this PR.: None
Fixes: #3578 , #3348

Changes to Users
----------------
* Additional options added to the build: None
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
