### PR TITLE
Fix issue 3542: Fixed opencl, cuda, and oneapi coo2dense kernel launch

### DIFF
--- a/src/backend/cuda/kernel/sparse.cuh
+++ b/src/backend/cuda/kernel/sparse.cuh
@@ -17,15 +17,13 @@ namespace cuda {
 template<typename T>
 __global__ void coo2Dense(Param<T> output, CParam<T> values, CParam<int> rowIdx,
                           CParam<int> colIdx) {
-    int id = blockIdx.x * blockDim.x * reps + threadIdx.x;
-    if (id >= values.dims[0]) return;
+    for (int i = threadIdx.x; i < reps * blockDim.x; i += blockDim.x) {
+        int id = i + blockIdx.x * blockDim.x * reps;
+        if (id >= values.dims[0]) return;
 
-    for (int i = threadIdx.x; i <= reps * blockDim.x; i += blockDim.x) {
-        if (i >= values.dims[0]) return;
-
-        T v   = values.ptr[i];
-        int r = rowIdx.ptr[i];
-        int c = colIdx.ptr[i];
+        T v   = values.ptr[id];
+        int r = rowIdx.ptr[id];
+        int c = colIdx.ptr[id];
 
         int offset = r + c * output.strides[1];
 

--- a/src/backend/cuda/kernel/sparse.hpp
+++ b/src/backend/cuda/kernel/sparse.hpp
@@ -30,7 +30,7 @@ void coo2dense(Param<T> output, CParam<T> values, CParam<int> rowIdx,
 
     dim3 threads(256, 1, 1);
 
-    dim3 blocks(divup(output.dims[0], threads.x * reps), 1, 1);
+    dim3 blocks(divup(values.dims[0], threads.x * reps), 1, 1);
 
     EnqueueArgs qArgs(blocks, threads, getActiveStream());
 

--- a/src/backend/opencl/kernel/coo2dense.cl
+++ b/src/backend/opencl/kernel/coo2dense.cl
@@ -11,18 +11,15 @@ kernel void coo2Dense(global T *oPtr, const KParam output, global const T *vPtr,
                       const KParam values, global const int *rPtr,
                       const KParam rowIdx, global const int *cPtr,
                       const KParam colIdx) {
-    const int id = get_group_id(0) * get_local_size(0) * reps + get_local_id(0);
-
-    if (id >= values.dims[0]) return;
-
     const int dimSize = get_local_size(0);
 
     for (int i = get_local_id(0); i < reps * dimSize; i += dimSize) {
-        if (i >= values.dims[0]) return;
+        const int id = i + get_group_id(0) * dimSize * reps;
+        if (id >= values.dims[0]) return;
 
-        T v   = vPtr[i];
-        int r = rPtr[i];
-        int c = cPtr[i];
+        T v   = vPtr[id];
+        int r = rPtr[id];
+        int c = cPtr[id];
 
         int offset = r + c * output.strides[1];
 

--- a/src/backend/opencl/kernel/sparse.hpp
+++ b/src/backend/opencl/kernel/sparse.hpp
@@ -49,7 +49,8 @@ void coo2dense(Param out, const Param values, const Param rowIdx,
     cl::NDRange local(THREADS_PER_GROUP, 1, 1);
 
     cl::NDRange global(
-        divup(out.info.dims[0], local[0] * REPEAT) * THREADS_PER_GROUP, 1, 1);
+        divup(values.info.dims[0], local[0] * REPEAT) * THREADS_PER_GROUP, 1,
+        1);
 
     coo2dense(cl::EnqueueArgs(getQueue(), global, local), *out.data, out.info,
               *values.data, values.info, *rowIdx.data, rowIdx.info,


### PR DESCRIPTION
Fix kernel and launch dimensions for coo2dense function in opencl, cuda, and oneapi backends.

Description
-----------

* Is this a new feature or a bug fix?: Bug fix
* Why these changes are necessary?: Fixes incorrect behavior of `af::dense`
* Potential impact on specific hardware, software or backends: affects OpenCL, CUDA, oneAPI
* New functions and their functionality.: None
* Can this PR be backported to older versions?: Only changes in OpenCL and CUDA backends can be backported
* Future changes not implemented in this PR.: None

Fixes: #3542

Changes to Users
----------------
* No additional changes added to build
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
