### PR TITLE
Fixed N and D comment for KMeans example

### DIFF
--- a/examples/machine_learning/kmeans.cpp
+++ b/examples/machine_learning/kmeans.cpp
@@ -17,7 +17,7 @@
 using namespace af;
 
 array distance(array data, array means) {
-    int n = data.dims(0);   // Number of features
+    int n = data.dims(0);   // Number of data points
     int k = means.dims(1);  // Number of means
 
     array data2  = tile(data, 1, k, 1);
@@ -60,8 +60,8 @@ array new_means(array data, array clusters, int k) {
 // means: output, vector of means
 void kmeans(array &means, array &clusters, const array in, int k,
             int iter = 100) {
-    unsigned n = in.dims(0);  // Num features
-    unsigned d = in.dims(2);  // feature length
+    unsigned n = in.dims(0);  // Num of data points
+    unsigned d = in.dims(2);  // Num of features (will only be 1 in spider image example)
 
     // reshape input
     array data = in * 0;


### PR DESCRIPTION
The machine_learning/kmeans.cpp example has a comment which says n is the number of features and d is the feature size (the code is correct, but the comment explaining it mixes up the values).
It may not seem like a big deal, but I found this example when working on my own project with different dimensions, and it caused me a headache debugging why my dimensions were wrong when using your example since I had flipped N and D.

Checklist
---------
<!-- Check if done or not applicable -->
- [ x] Rebased on latest master
- [ x] Code compiles
- [ x] Tests pass
- [ x] Functions added to unified API
- [ x] Functions documented
