### PR TITLE
Fix issue 3525: correct handling of array indexing with sequence

### DIFF
--- a/src/backend/cpu/index.cpp
+++ b/src/backend/cpu/index.cpp
@@ -35,7 +35,16 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
     // create seq vector to retrieve output
     // dimensions, offsets & offsets
     for (unsigned x = 0; x < isSeq.size(); ++x) {
-        if (idxrs[x].isSeq) { seqs[x] = idxrs[x].idx.seq; }
+        if (idxrs[x].isSeq) {
+            af_seq seq = idxrs[x].idx.seq;
+            // Handle af_span as a sequence that covers the complete axis
+            if (seq.begin == af_span.begin && seq.end == af_span.end &&
+                seq.step == af_span.step) {
+                seqs[x] = af_seq{0, (double)(in.dims()[x] - 1), 1};
+            } else {
+                seqs[x] = seq;
+            }
+        }
         isSeq[x] = idxrs[x].isSeq;
     }
 

--- a/src/backend/cpu/kernel/index.hpp
+++ b/src/backend/cpu/kernel/index.hpp
@@ -34,25 +34,27 @@ void index(Param<T> out, CParam<T> in, const af::dim4 dDims,
 
     for (dim_t l = 0; l < oDims[3]; ++l) {
         dim_t lOff   = l * oStrides[3];
-        dim_t inIdx3 = trimIndex(isSeq[3] ? l + iOffs[3] : ptr3[l], iDims[3]);
+        dim_t inIdx3 = trimIndex(
+            isSeq[3] ? l * seqs[3].step + iOffs[3] : ptr3[l], iDims[3]);
         dim_t inOff3 = inIdx3 * iStrds[3];
 
         for (dim_t k = 0; k < oDims[2]; ++k) {
-            dim_t kOff = k * oStrides[2];
-            dim_t inIdx2 =
-                trimIndex(isSeq[2] ? k + iOffs[2] : ptr2[k], iDims[2]);
+            dim_t kOff   = k * oStrides[2];
+            dim_t inIdx2 = trimIndex(
+                isSeq[2] ? k * seqs[2].step + iOffs[2] : ptr2[k], iDims[2]);
             dim_t inOff2 = inIdx2 * iStrds[2];
 
             for (dim_t j = 0; j < oDims[1]; ++j) {
-                dim_t jOff = j * oStrides[1];
-                dim_t inIdx1 =
-                    trimIndex(isSeq[1] ? j + iOffs[1] : ptr1[j], iDims[1]);
+                dim_t jOff   = j * oStrides[1];
+                dim_t inIdx1 = trimIndex(
+                    isSeq[1] ? j * seqs[1].step + iOffs[1] : ptr1[j], iDims[1]);
                 dim_t inOff1 = inIdx1 * iStrds[1];
 
                 for (dim_t i = 0; i < oDims[0]; ++i) {
-                    dim_t iOff = i * oStrides[0];
-                    dim_t inIdx0 =
-                        trimIndex(isSeq[0] ? i + iOffs[0] : ptr0[i], iDims[0]);
+                    dim_t iOff   = i * oStrides[0];
+                    dim_t inIdx0 = trimIndex(
+                        isSeq[0] ? i * seqs[0].step + iOffs[0] : ptr0[i],
+                        iDims[0]);
                     dim_t inOff0 = inIdx0 * iStrds[0];
 
                     dst[lOff + kOff + jOff + iOff] =

--- a/src/backend/cuda/assign_kernel_param.hpp
+++ b/src/backend/cuda/assign_kernel_param.hpp
@@ -15,6 +15,7 @@ namespace cuda {
 typedef struct {
     int offs[4];
     int strds[4];
+    int steps[4];
     bool isSeq[4];
     unsigned int* ptr[4];
 } AssignKernelParam;

--- a/src/backend/cuda/index.cpp
+++ b/src/backend/cuda/index.cpp
@@ -44,6 +44,7 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
         p.isSeq[i] = idxrs[i].isSeq;
         p.offs[i]  = iOffs[i];
         p.strds[i] = iStrds[i];
+        p.steps[i] = idxrs[i].isSeq ? idxrs[i].idx.seq.step : 0;
     }
 
     std::vector<Array<uint>> idxArrs(4, createEmptyArray<uint>(dim4()));

--- a/src/backend/cuda/index.cpp
+++ b/src/backend/cuda/index.cpp
@@ -44,7 +44,16 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
         p.isSeq[i] = idxrs[i].isSeq;
         p.offs[i]  = iOffs[i];
         p.strds[i] = iStrds[i];
-        p.steps[i] = idxrs[i].isSeq ? idxrs[i].idx.seq.step : 0;
+        p.steps[i] = 0;
+        if (idxrs[i].isSeq) {
+            af_seq seq = idxrs[i].idx.seq;
+            // The step for af_span used in the kernel must be 1
+            if (seq.begin == af_span.begin && seq.end == af_span.end &&
+                seq.step == af_span.step)
+                p.steps[i] = 1;
+            else
+                p.steps[i] = seq.step;
+        }
     }
 
     std::vector<Array<uint>> idxArrs(4, createEmptyArray<uint>(dim4()));

--- a/src/backend/cuda/kernel/index.cuh
+++ b/src/backend/cuda/kernel/index.cuh
@@ -43,13 +43,17 @@ __global__ void index(Param<T> out, CParam<T> in, const IndexKernelParam p,
         gw < out.dims[3]) {
         // calculate pointer offsets for input
         int i =
-            p.strds[0] * trimIndex(s0 ? gx + p.offs[0] : ptr0[gx], in.dims[0]);
+            p.strds[0] *
+            trimIndex(s0 ? gx * p.steps[0] + p.offs[0] : ptr0[gx], in.dims[0]);
         int j =
-            p.strds[1] * trimIndex(s1 ? gy + p.offs[1] : ptr1[gy], in.dims[1]);
+            p.strds[1] *
+            trimIndex(s1 ? gy * p.steps[1] + p.offs[1] : ptr1[gy], in.dims[1]);
         int k =
-            p.strds[2] * trimIndex(s2 ? gz + p.offs[2] : ptr2[gz], in.dims[2]);
+            p.strds[2] *
+            trimIndex(s2 ? gz * p.steps[2] + p.offs[2] : ptr2[gz], in.dims[2]);
         int l =
-            p.strds[3] * trimIndex(s3 ? gw + p.offs[3] : ptr3[gw], in.dims[3]);
+            p.strds[3] *
+            trimIndex(s3 ? gw * p.steps[3] + p.offs[3] : ptr3[gw], in.dims[3]);
         // offset input and output pointers
         const T* src = (const T*)in.ptr + (i + j + k + l);
         T* dst = (T*)out.ptr + (gx * out.strides[0] + gy * out.strides[1] +

--- a/src/backend/oneapi/index.cpp
+++ b/src/backend/oneapi/index.cpp
@@ -44,6 +44,7 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
         p.isSeq[i] = idxrs[i].isSeq;
         p.offs[i]  = iOffs[i];
         p.strds[i] = iStrds[i];
+        p.steps[i] = idxrs[i].isSeq ? idxrs[i].idx.seq.step : 0;
     }
 
     std::vector<Array<uint>> idxArrs(4, createEmptyArray<uint>(dim4(1)));

--- a/src/backend/oneapi/index.cpp
+++ b/src/backend/oneapi/index.cpp
@@ -44,7 +44,16 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
         p.isSeq[i] = idxrs[i].isSeq;
         p.offs[i]  = iOffs[i];
         p.strds[i] = iStrds[i];
-        p.steps[i] = idxrs[i].isSeq ? idxrs[i].idx.seq.step : 0;
+        p.steps[i] = 0;
+        if (idxrs[i].isSeq) {
+            af_seq seq = idxrs[i].idx.seq;
+            // The step for af_span used in the kernel must be 1
+            if (seq.begin == af_span.begin && seq.end == af_span.end &&
+                seq.step == af_span.step)
+                p.steps[i] = 1;
+            else
+                p.steps[i] = seq.step;
+        }
     }
 
     std::vector<Array<uint>> idxArrs(4, createEmptyArray<uint>(dim4(1)));

--- a/src/backend/oneapi/kernel/assign_kernel_param.hpp
+++ b/src/backend/oneapi/kernel/assign_kernel_param.hpp
@@ -19,6 +19,7 @@ namespace oneapi {
 typedef struct {
     int offs[4];
     int strds[4];
+    int steps[4];
     bool isSeq[4];
     std::array<sycl::accessor<unsigned int, 1, sycl::access::mode::read,
                               sycl::access::target::device>,

--- a/src/backend/oneapi/kernel/index.hpp
+++ b/src/backend/oneapi/kernel/index.hpp
@@ -88,13 +88,17 @@ class indexKernel {
         if (gx < odims0 && gy < odims1 && gz < odims2 && gw < odims3) {
             // calculate pointer offsets for input
             int i = p.strds[0] *
-                    trimIndex(s0 ? gx + p.offs[0] : ptr0[gx], inp.dims[0]);
+                    trimIndex(s0 ? gx * p.steps[0] + p.offs[0] : ptr0[gx],
+                              inp.dims[0]);
             int j = p.strds[1] *
-                    trimIndex(s1 ? gy + p.offs[1] : ptr1[gy], inp.dims[1]);
+                    trimIndex(s1 ? gy * p.steps[1] + p.offs[1] : ptr1[gy],
+                              inp.dims[1]);
             int k = p.strds[2] *
-                    trimIndex(s2 ? gz + p.offs[2] : ptr2[gz], inp.dims[2]);
+                    trimIndex(s2 ? gz * p.steps[2] + p.offs[2] : ptr2[gz],
+                              inp.dims[2]);
             int l = p.strds[3] *
-                    trimIndex(s3 ? gw + p.offs[3] : ptr3[gw], inp.dims[3]);
+                    trimIndex(s3 ? gw * p.steps[3] + p.offs[3] : ptr3[gw],
+                              inp.dims[3]);
             // offset input and output pointers
             const T* src = (const T*)in.get_pointer() + (i + j + k + l);
             T* dst       = (T*)out.get_pointer() +

--- a/src/backend/opencl/index.cpp
+++ b/src/backend/opencl/index.cpp
@@ -42,6 +42,7 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
         p.isSeq[i] = idxrs[i].isSeq ? 1 : 0;
         p.offs[i]  = iOffs[i];
         p.strds[i] = iStrds[i];
+        p.steps[i] = idxrs[i].isSeq ? idxrs[i].idx.seq.step : 0;
     }
 
     cl::Buffer* bPtrs[4];

--- a/src/backend/opencl/index.cpp
+++ b/src/backend/opencl/index.cpp
@@ -42,7 +42,16 @@ Array<T> index(const Array<T>& in, const af_index_t idxrs[]) {
         p.isSeq[i] = idxrs[i].isSeq ? 1 : 0;
         p.offs[i]  = iOffs[i];
         p.strds[i] = iStrds[i];
-        p.steps[i] = idxrs[i].isSeq ? idxrs[i].idx.seq.step : 0;
+        p.steps[i] = 0;
+        if (idxrs[i].isSeq) {
+            af_seq seq = idxrs[i].idx.seq;
+            // The step for af_span used in the kernel must be 1
+            if (seq.begin == af_span.begin && seq.end == af_span.end &&
+                seq.step == af_span.step)
+                p.steps[i] = 1;
+            else
+                p.steps[i] = seq.step;
+        }
     }
 
     cl::Buffer* bPtrs[4];

--- a/src/backend/opencl/kernel/index.cl
+++ b/src/backend/opencl/kernel/index.cl
@@ -10,6 +10,7 @@
 typedef struct {
     int offs[4];
     int strds[4];
+    int steps[4];
     char isSeq[4];
 } IndexKernelParam_t;
 
@@ -47,14 +48,18 @@ kernel void indexKernel(global T* optr, KParam oInfo, global const T* iptr,
     if (gx < oInfo.dims[0] && gy < oInfo.dims[1] && gz < oInfo.dims[2] &&
         gw < oInfo.dims[3]) {
         // calculate pointer offsets for input
-        int i = p.strds[0] *
-                trimIndex(s0 ? gx + p.offs[0] : ptr0[gx], iInfo.dims[0]);
-        int j = p.strds[1] *
-                trimIndex(s1 ? gy + p.offs[1] : ptr1[gy], iInfo.dims[1]);
-        int k = p.strds[2] *
-                trimIndex(s2 ? gz + p.offs[2] : ptr2[gz], iInfo.dims[2]);
-        int l = p.strds[3] *
-                trimIndex(s3 ? gw + p.offs[3] : ptr3[gw], iInfo.dims[3]);
+        int i =
+            p.strds[0] * trimIndex(s0 ? gx * p.steps[0] + p.offs[0] : ptr0[gx],
+                                   iInfo.dims[0]);
+        int j =
+            p.strds[1] * trimIndex(s1 ? gy * p.steps[1] + p.offs[1] : ptr1[gy],
+                                   iInfo.dims[1]);
+        int k =
+            p.strds[2] * trimIndex(s2 ? gz * p.steps[2] + p.offs[2] : ptr2[gz],
+                                   iInfo.dims[2]);
+        int l =
+            p.strds[3] * trimIndex(s3 ? gw * p.steps[3] + p.offs[3] : ptr3[gw],
+                                   iInfo.dims[3]);
         // offset input and output pointers
         global const T* src = iptr + (i + j + k + l) + iInfo.offset;
         global T* dst = optr + (gx * oInfo.strides[0] + gy * oInfo.strides[1] +

--- a/src/backend/opencl/kernel/index.hpp
+++ b/src/backend/opencl/kernel/index.hpp
@@ -26,6 +26,7 @@ namespace kernel {
 typedef struct {
     int offs[4];
     int strds[4];
+    int steps[4];
     char isSeq[4];
 } IndexKernelParam_t;
 


### PR DESCRIPTION
Fixes issue where array indexing with a sequence whose step is not 1 is handled as a sequence with step 1.

Description
-----------
* Is this a new feature or a bug fix?: Bug fix
* More detail if necessary to describe all commits in pull request.: Adds a member variable to all index structs to pass the step into the different kernels and compute the correct index.
* Why these changes are necessary: Incorrect behavior of `af::seq` in array indexing
* Potential impact on specific hardware, software or backends: affects all backends
* New functions and their functionality.: None
* Can this PR be backported to older versions?: All backends except oneAPI can be backported
* Future changes not implemented in this PR.: None

Fixes: #3525

Changes to Users
----------------
* Additional options added to the build.: None
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
