### PR TITLE
Added sparse dense conversion test

### DIFF
--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -416,3 +416,24 @@ TEST(Sparse, CPPDenseToSparseToDenseUsage) {
     ASSERT_ARRAYS_EQ(in, gold);
     ASSERT_ARRAYS_EQ(dense, gold);
 }
+
+TEST(Sparse, CPPDenseToSparseConversions) {
+    array in      = af::randu(200, 200);
+    in(in < 0.75) = 0;
+
+    array coo_sparse_arr = af::sparse(in, AF_STORAGE_COO);
+    array csr_sparse_arr = af::sparse(in, AF_STORAGE_CSR);
+
+    array coo_dense_arr = af::dense(coo_sparse_arr);
+    array csr_dense_arr = af::dense(csr_sparse_arr);
+
+    ASSERT_ARRAYS_EQ(in, coo_dense_arr);
+    ASSERT_ARRAYS_EQ(in, csr_dense_arr);
+
+    array non_zero   = af::flat(in)(af::where(in));
+    array non_zero_T = af::flat(in.T())(af::where(in.T()));
+    ASSERT_ARRAYS_EQ(non_zero, af::sparseGetValues(coo_sparse_arr));
+    ASSERT_ARRAYS_EQ(
+        non_zero_T,
+        af::sparseGetValues(csr_sparse_arr));  // csr values are transposed
+}


### PR DESCRIPTION
When converting a sparse COO matrix to a dense matrix using `af::dense`, the CUDA, oneAPI, and openCL kernels where invoking the `coo2dense` kernel with incorrect dimensions which was only observable for sparse arrays with nnz greater than 1024 (CUDA) and 8192 (oneAPI/openCL). This tests checks this.

Description
-----------

Additional information about the PR answering following questions:

* Is this a new feature or a bug fix?: Adds a test
* Why these changes are necessary: Tests uncovered case
* Potential impact on specific hardware, software or backends: None
* New functions and their functionality: None
* Can this PR be backported to older versions?: Yes
* Future changes not implemented in this PR.: None

Tests pull request #3583

Changes to Users
----------------
* Additional options added to the build: None
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
