### PR TITLE
Fix issue 3574: Specified version for jasper due to upstream build error

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -19,6 +19,10 @@
         {
             "name": "spdlog",
             "version": "1.9.2"
+        },
+        {
+            "name": "jasper",
+            "version": "4.2.0"
         }
     ],
     "features": {


### PR DESCRIPTION
Jasper, a dependency of freeimage, caused a vcpkg build error when using the vcpkg cmake toolchain to build arrayfire. This was caused due to a build error upstream with Jasper. This sets a specific version for jasper which does not have that error.

Description
-----------
* Is this a new feature or a bug fix?: Bug fix
* Why these changes are necessary: Implements a workaround which streamlines the current windows build setup
* Potential impact on specific hardware, software or backends: affects arrayfire Windows builds
* New functions and their functionality: None
* Can this PR be backported to older versions?: Likely no
* Future changes not implemented in this PR: None

Fixes: #3574 

Changes to Users
----------------
* Additional options added to the build: None
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
