### PR TITLE
Fix issue 3543: Explicitly added <climits> for C limits constants

### DIFF
--- a/src/backend/cpu/math.hpp
+++ b/src/backend/cpu/math.hpp
@@ -15,6 +15,7 @@
 #include <af/defines.h>
 
 #include <algorithm>
+#include <climits>
 #include <limits>
 #include <numeric>
 

--- a/src/backend/cuda/math.hpp
+++ b/src/backend/cuda/math.hpp
@@ -18,6 +18,7 @@
 #endif  //__CUDACC__
 
 #include <algorithm>
+#include <climits>
 #include <limits>
 
 #endif  //__CUDACC_RTC__

--- a/src/backend/oneapi/math.hpp
+++ b/src/backend/oneapi/math.hpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <complex>
+#include <climits>
 #include <limits>
 
 #if defined(__GNUC__) || defined(__GNUG__)

--- a/src/backend/opencl/math.hpp
+++ b/src/backend/opencl/math.hpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <complex>
+#include <climits>
 #include <limits>
 
 #if defined(__GNUC__) || defined(__GNUG__)


### PR DESCRIPTION
The <limits> header included in `math.hpp` in all backends does not include <climits> depending on the standard library implementation.  <climits> is required for the preprocessor defined limit constants.

Description
-----------
* Is this a new feature or a bug fix?: Bug fix
* Why these changes are necessary: fixes possible include errors when compiling with some compilers
* Potential impact on specific hardware, software or backends: all backends
* New functions and their functionality: None
* Can this PR be backported to older versions?: Yes
* Future changes not implemented in this PR: None
Fixes: #3543 

Changes to Users
----------------
* Additional options added to the build: None
* No action required by the user

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [ ] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
