### PR TITLE
Reverted an error in the interop_cuda example code

### DIFF
--- a/docs/pages/interop_cuda.md
+++ b/docs/pages/interop_cuda.md
@@ -80,8 +80,7 @@ int main() {
 
     // 5. Determine ArrayFire's CUDA stream
     int af_id = af::getDevice();
-    int cuda_id = afcu::getNativeId(af_id);
-    cudaStream_t af_cuda_stream = afcu::getStream(cuda_id);
+    cudaStream_t af_cuda_stream = afcu::getStream(af_id);
 
     // 6. Set arguments and run your kernel in ArrayFire's stream
     //    Here launch with 1 block of 10 threads


### PR DESCRIPTION
Reverted an error in the interop_cuda example code where the cuda steam id was being used instead of the arrayfire stream id.

Fixes: #3404 

Checklist
---------
<!-- Check if done or not applicable -->
- [x ] Rebased on latest master
- [ x] Code compiles
- [ x] Tests pass

