### PR TITLE
Fix for 1693 bug access to deleted memory in array proxy index

### DIFF
--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -389,6 +389,14 @@ static array::array_proxy gen_indexing(const array &ref, const index &s0,
     inds[1] = s1.get();
     inds[2] = s2.get();
     inds[3] = s3.get();
+    
+    for(int i; i < AF_MAX_DIMS; ++i) {
+        if(!inds[i].isSeq) {
+            af_array arr = 0;
+            af_retain_array(&arr, inds[i].idx.arr);
+	    inds[i].idx.arr = arr;
+        }
+    }
 
     return array::array_proxy(const_cast<array &>(ref), inds, linear);
 }

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -380,9 +380,9 @@ INSTANTIATE(sparse)
 
 #undef INSTANTIATE
 
-static array::array_proxy gen_indexing(const array &ref, const index &s0,
-                                       const index &s1, const index &s2,
-                                       const index &s3, bool linear = false) {
+array::array_proxy gen_indexing(const array &ref, const index &s0,
+                                const index &s1, const index &s2,
+                                const index &s3, bool linear = false) {
     ref.eval();
     af_index_t inds[AF_MAX_DIMS];
     inds[0] = s0.get();
@@ -393,7 +393,7 @@ static array::array_proxy gen_indexing(const array &ref, const index &s0,
     for(int i; i < AF_MAX_DIMS; ++i) {
         if(!inds[i].isSeq) {
             af_array arr = 0;
-            af_retain_array(&arr, inds[i].idx.arr);
+            AF_THROW(af_retain_array(&arr, inds[i].idx.arr));
 	    inds[i].idx.arr = arr;
         }
     }

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -164,6 +164,9 @@ struct array::array_proxy::array_proxy_impl {
     void delete_on_destruction(bool val) { delete_on_destruction_ = val; }
 
     ~array_proxy_impl() {
+        for(int i = 0; i < AF_MAX_DIMS; ++i) {
+            if(!indices_[i].isSeq) af_release_array(indices_[i].idx.arr);
+        }
         if (delete_on_destruction_) { delete parent_; }
     }
 

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -390,16 +390,11 @@ array::array_proxy gen_indexing(const array &ref, const index &s0,
     inds[2] = s2.get();
     inds[3] = s3.get();
     
-    for(int i; i < AF_MAX_DIMS; ++i) {
+    for(int i = 0; i < AF_MAX_DIMS; ++i) {
         if(!inds[i].isSeq) {
             af_array arr = 0;
-            auto retain_err = af_retain_array(&arr, inds[i].idx.arr);
+            AF_THROW(af_retain_array(&arr, inds[i].idx.arr));
 	    inds[i].idx.arr = arr;
-	    if(retain_err) {
-                char *retain_err_msg = NULL;
-                af_get_last_error(&retain_err_msg, NULL);
-	        AF_THROW_ERR(retain_err_msg, retain_err);
-	    }
         }
     }
 

--- a/src/api/cpp/array.cpp
+++ b/src/api/cpp/array.cpp
@@ -393,8 +393,13 @@ array::array_proxy gen_indexing(const array &ref, const index &s0,
     for(int i; i < AF_MAX_DIMS; ++i) {
         if(!inds[i].isSeq) {
             af_array arr = 0;
-            AF_THROW(af_retain_array(&arr, inds[i].idx.arr));
+            auto retain_err = af_retain_array(&arr, inds[i].idx.arr);
 	    inds[i].idx.arr = arr;
+	    if(retain_err) {
+                char *retain_err_msg = NULL;
+                af_get_last_error(&retain_err_msg, NULL);
+	        AF_THROW_ERR(retain_err_msg, retain_err);
+	    }
         }
     }
 

--- a/test/array_death_tests.cpp
+++ b/test/array_death_tests.cpp
@@ -24,6 +24,7 @@ using af::seq;
 using af::setDevice;
 using af::sin;
 using af::sort;
+using af::span;
 
 template<typename T>
 class ArrayDeathTest : public ::testing::Test {};
@@ -54,6 +55,10 @@ void deathTest() {
 
     array vals, inds;
     sort(vals, inds, A);
+
+    array cond = constant(1, 3, b8);
+    auto X = A(span, cond);
+    array Y = X;
 
     _exit(0);
 }


### PR DESCRIPTION
Arrays can now be used as an index for creating an array proxy without failure.

Description
-----------

When using an array as an index when creating an array proxy a temporary index object is created and passed to the constructor for the array proxy. However the array underlying the index was not being kept after the temporary index was destroyed, resulting in undefined behavior. This fix ensures that the array is retained until the array proxy is destroyed. Users can now use an array as an index when creating an array proxy without needing to explicitly define an index object.

Fixes: #1693 

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
