### PR TITLE
1918 sparse matrix not updated in for loop in opencl

### DIFF
--- a/src/backend/opencl/kernel/csr2dense.cl
+++ b/src/backend/opencl/kernel/csr2dense.cl
@@ -9,13 +9,16 @@
 
 kernel void csr2Dense(global T *output, global const T *values,
                       global const int *rowidx, global const int *colidx,
-                      const int M) {
+                      const int M, const int v_off, const int r_off, const int c_off) {
+    T *v = values + v_off;
+    int *r = rowidx + r_off;
+    int *c = colidx + c_off;
     int lid = get_local_id(0);
     for (int rowId = get_group_id(0); rowId < M; rowId += get_num_groups(0)) {
-        int colStart = rowidx[rowId];
-        int colEnd   = rowidx[rowId + 1];
+        int colStart = r[rowId];
+        int colEnd   = r[rowId + 1];
         for (int colId = colStart + lid; colId < colEnd; colId += THREADS) {
-            output[rowId + colidx[colId] * M] = values[colId];
+            output[rowId + c[colId] * M] = v[colId];
         }
     }
 }

--- a/src/backend/opencl/kernel/sparse.hpp
+++ b/src/backend/opencl/kernel/sparse.hpp
@@ -84,7 +84,10 @@ void csr2dense(Param output, const Param values, const Param rowIdx,
     cl::NDRange global(local[0] * groups_x, 1);
 
     csr2dense(cl::EnqueueArgs(getQueue(), global, local), *output.data,
-              *values.data, *rowIdx.data, *colIdx.data, M);
+              *values.data, *rowIdx.data, *colIdx.data, M,
+	      static_cast<int>(values.info.offset),
+	      static_cast<int>(rowIdx.info.offset),
+	      static_cast<int>(colIdx.info.offset));
     CL_DEBUG_FINISH(getQueue());
 }
 

--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -19,6 +19,7 @@ using af::dtype_traits;
 using af::identity;
 using af::randu;
 using af::span;
+using af::seq;
 
 #define SPARSE_TESTS(T, eps)                                                \
     TEST(Sparse, T##Square) { sparseTester<T>(1000, 1000, 100, 5, eps); }   \
@@ -107,6 +108,25 @@ TEST(Sparse, ISSUE_1745) {
     ASSERT_EQ(AF_ERR_ARG, af_create_sparse_array(
                               &A_sparse, A.dims(0), A.dims(1), data.get(),
                               row_idx.get(), col_idx.get(), AF_STORAGE_CSR));
+}
+
+TEST(Sparse, ISSUE_1918) {
+    array reference(2,2);
+    reference(1, span) = 2;
+    array output;
+    float value[] = { 1, 1, 2, 2 };
+    int index[] = { -1, 1, 2 };
+    int row[] = { 0, 2, 2, 0, 0, 2 };
+    int col[] = { 0, 1, 0, 1 };
+    array values(4, 1, value, afHost);
+    array rows(6, 1, row, afHost);
+    array cols(4, 1, col, afHost);
+    array S;
+  
+    S = sparse(2, 2, values(seq(2, 3)), rows(seq(3, 5)), cols(seq(2, 3)));
+    output = dense(S);
+
+    ASSERT_ARRAYS_EQ(reference, output);
 }
 
 TEST(Sparse, ISSUE_2134_COO) {

--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -112,6 +112,7 @@ TEST(Sparse, ISSUE_1745) {
 
 TEST(Sparse, ISSUE_1918) {
     array reference(2,2);
+    reference(0, span) = 0;
     reference(1, span) = 2;
     array output;
     float value[] = { 1, 1, 2, 2 };


### PR DESCRIPTION
Fix for issue in the opencl backend where array offsets for the values and/or row/cols arrays are not accounted for when converting a sparse array to a dense one.

Description
-----------

A sparse csr matrix may be constructed using arrays for the values and the row and column indices. When these arrays are indexed using the seq method, the offsets into them are stored. These offsets were not being accounted for in the sparse to dense conversion function which can result in incorrect values in the resulting dense matrix. This PR fixes that.
Fixes: #1918 

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
