### PR TITLE
Alternative OpenCL kernel for performing the CSC matrix vector multiply

### DIFF
--- a/src/backend/opencl/kernel/cscmv.hpp
+++ b/src/backend/opencl/kernel/cscmv.hpp
@@ -32,39 +32,64 @@ void cscmv(Param out, const Param &values, const Param &colIdx,
            bool is_conj) {
     // TODO: rows_per_group limited by register pressure. Find better way to
     // handle this.
+    constexpr int threads_per_g = 64;
     constexpr int rows_per_group = 64;
 
     const bool use_alpha = (alpha != scalar<T>(1.0));
     const bool use_beta  = (beta != scalar<T>(0.0));
 
-    cl::NDRange local(THREADS_PER_GROUP);
+    cl::NDRange local(threads_per_g);
 
-    std::array<TemplateArg, 6> targs = {
+    int K        = colIdx.info.dims[0] - 1;
+    int M        = out.info.dims[0];
+
+    std::array<TemplateArg, 5> targs = {
         TemplateTypename<T>(),       TemplateArg(use_alpha),
-        TemplateArg(use_beta),       TemplateArg(is_conj),
-        TemplateArg(rows_per_group), TemplateArg(local[0]),
+        TemplateArg(is_conj), TemplateArg(rows_per_group),
+        TemplateArg(local[0]),
     };
-    std::array<std::string, 8> options = {
+    std::array<std::string, 9> options = {
         DefineKeyValue(T, dtype_traits<T>::getName()),
         DefineKeyValue(USE_ALPHA, use_alpha),
-        DefineKeyValue(USE_BETA, use_beta),
         DefineKeyValue(IS_CONJ, is_conj),
         DefineKeyValue(THREADS, local[0]),
         DefineKeyValue(ROWS_PER_GROUP, rows_per_group),
         DefineKeyValue(IS_CPLX, (iscplx<T>() ? 1 : 0)),
+        DefineKeyValue(IS_DBL, (isdbl<T>() ? 1 : 0)),
+        DefineKeyValue(IS_LONG, (islong<T>() ? 1 : 0)),
         getTypeBuildDefinition<T>()};
 
-    auto cscmvBlock =
-        common::getKernel("cscmv_block", {{cscmv_cl_src}}, targs, options);
+    if(use_beta) {
+        std::array<TemplateArg, 4> targs_beta = {
+            TemplateTypename<T>(), TemplateArg(is_conj),
+            TemplateArg(rows_per_group), TemplateArg(local[0])};
+        std::array<std::string, 8> options_beta = {
+            DefineKeyValue(T, dtype_traits<T>::getName()),
+            DefineKeyValue(IS_CONJ, is_conj),
+            DefineKeyValue(THREADS, local[0]),
+            DefineKeyValue(ROWS_PER_GROUP, rows_per_group),
+            DefineKeyValue(IS_CPLX, (iscplx<T>() ? 1 : 0)),
+            DefineKeyValue(IS_DBL, (isdbl<T>() ? 1 : 0)),
+            DefineKeyValue(IS_LONG, (islong<T>() ? 1 : 0)),
+            getTypeBuildDefinition<T>()};
 
-    int K        = colIdx.info.dims[0] - 1;
-    int M        = out.info.dims[0];
+        int groups_x = divup(M, rows_per_group * threads_per_g);
+        cl::NDRange global(local[0] * groups_x, 1);
+        auto cscmvBeta = common::getKernel("cscmv_beta", {{cscmv_cl_src}}, targs_beta, options_beta);
+        cscmvBeta(cl::EnqueueArgs(getQueue(), global, local), *out.data, M, beta);
+
+    } else {
+        getQueue().enqueueFillBuffer(*out.data, 0, 0, M * sizeof(T));
+    }
+
     int groups_x = divup(M, rows_per_group);
     cl::NDRange global(local[0] * groups_x, 1);
 
-    cscmvBlock(cl::EnqueueArgs(getQueue(), global, local), *out.data,
-               *values.data, *colIdx.data, *rowIdx.data, M, K, *rhs.data,
-               rhs.info, alpha, beta);
+    auto cscmvAtomic =
+        common::getKernel("cscmv_atomic", {{cscmv_cl_src}}, targs, options);
+    cscmvAtomic(cl::EnqueueArgs(getQueue(), global, local), *out.data,
+                *values.data, *colIdx.data, *rowIdx.data, K, *rhs.data,
+                rhs.info, alpha);
     CL_DEBUG_FINISH(getQueue());
 }
 }  // namespace kernel

--- a/src/backend/opencl/traits.hpp
+++ b/src/backend/opencl/traits.hpp
@@ -50,6 +50,36 @@ inline bool iscplx<cdouble>() {
 }
 
 template<typename T>
+static bool isdbl() {
+    return false;
+}
+
+template<>
+inline bool isdbl<double>() {
+    return true;
+}
+
+template<>
+inline bool isdbl<cdouble>() {
+    return true;
+}
+
+template<typename T>
+static bool islong() {
+    return false;
+}
+
+template<>
+inline bool islong<long>() {
+    return true;
+}
+
+template<>
+inline bool islong<unsigned long>() {
+    return true;
+}
+
+template<typename T>
 inline std::string scalar_to_option(const T &val) {
     using namespace arrayfire::common;
     using std::to_string;


### PR DESCRIPTION
Alternative OpenCL kernel for performing the CSC matrix vector multiply using atomic operations.

Benchmarking so far has shown it to be ~on par with the CUDA backend~ around 9x slower than the CUDA back end on my Nvidia RTX 4060 GPU. Note that support has been included for the BLAS style matrix vector multiply with alpha and beta parameters however it appears that this is not supported elsewhere in the code for sparse matrices so it has not been tested. Existing sparse matrix vector multiply tests are all passing for single and double precision as well as complex.

Description
-----------
The way that the transpose of the sparse matrix is carried out in the OpenCL backend is to treat the CSR matrix as a CSC matrix. In the CSC matrix, the compressed data is ordered by column rather than by row. The original OpenCL kernel was performing a block matrix vector multiply. This is straightforward to do with the CSR format but is more complicated with CSC format. In order to determine which compressed indices fall in which block for a given column, a binary search was performed. As the matrix dimensions grew larger, the binary search quickly blew up the kernel run time.

As far as I can see the only way to avoid the need for a binary search is to not perform the multiply in blocks. I have created a new OpenCL kernel for the CSC matrix vector multiply which makes use of atomic addition operations instead. While this is not ideal and may run slow on certain devices, ~I have found the runtime of this kernel to be on par with the CUDA backend in testing.~ I have found the runtime of this kernel to be about 9x that of the CUDA backend which is not ideal but much faster than the previous implementation.

It is likely difficult to achieve comparable performance to the CUDA back end on an Nvidia GPU since it makes use of the cuSPARSE library.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
