### PR TITLE
CMake fixes for building ArrayFire oneAPI backend in windows

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -7,6 +7,24 @@
 
 if(AF_BUILD_ONEAPI)
     enable_language(SYCL)
+    set(OPENCL_INCLUDE_DIR ${SYCL_INCLUDE_DIR}/sycl)
+    set(OPENCL_LIBRARY_DIR ${SYCL_LIBRARY_DIR})
+
+    set(MSVC_RUNTIME "")
+    if(CMAKE_HOST_WIN32)
+      if("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreaded")
+        set(MSVC_RUNTIME "-MT")
+      elseif("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreadedDLL")
+        set(MSVC_RUNTIME "-MD")
+      elseif("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreadedDebug")
+        set(MSVC_RUNTIME "-MTd")
+      elseif("${CMAKE_MSVC_RUNTIME_LIBRARY}" STREQUAL "MultiThreadedDebugDLL")
+        set(MSVC_RUNTIME "-MDd")
+      else()
+        set(MSVC_RUNTIME "-MD$<$<CONFIG:Debug>:d>")
+      endif()
+      set(CMAKE_MSVC_RUNTIME_LIBRARY "")
+    endif()
 endif()
 
 include(InternalUtils)
@@ -270,6 +288,10 @@ function(set_sycl_language)
     set_target_properties(${target}
       PROPERTIES
         LINKER_LANGUAGE SYCL)
+    get_target_property(target_type ${target} TYPE)
+    if (NOT (${target_type} STREQUAL "INTERFACE_LIBRARY"))
+      target_compile_options(${target} PRIVATE ${MSVC_RUNTIME})
+    endif()
 
     get_target_property(TGT_SOURCES ${target} SOURCES)
     if(NOT TGT_SOURCES)
@@ -360,6 +382,7 @@ target_link_libraries(afoneapi
     $<$<PLATFORM_ID:Linux>:-fno-sycl-rdc>
     $<$<PLATFORM_ID:Linux>:-Wl,--build-id>
     -fsycl-max-parallel-link-jobs=${NumberOfThreads}
+    $<$<PLATFORM_ID:Linux>: PUBLIC >
     MKL::MKL_SYCL
   )
   set_sycl_language(afcommon_interface

--- a/src/backend/oneapi/kernel/sort_by_key/CMakeLists.txt
+++ b/src/backend/oneapi/kernel/sort_by_key/CMakeLists.txt
@@ -49,6 +49,7 @@ foreach(SBK_TYPE ${SBK_TYPES})
     PRIVATE
       $<$<COMPILE_LANGUAGE:SYCL>: -fno-sycl-id-queries-fit-in-int
                                   -sycl-std=2020
+                                  ${MSVC_RUNTIME}
                                   $<$<PLATFORM_ID:Linux>: -fno-sycl-rdc>>)
 
   target_include_directories(oneapi_sort_by_key_${SBK_TYPE}


### PR DESCRIPTION
Implement CMake changes to fix building oneAPI in Windows

Description
-----------

* Is this a new feature or a bug fix?: fix
* Why these changes are necessary: enable building oneapi in windows
* New functions and their functionality: None
* Can this PR be backported to older versions?: unsure
* Future changes not implemented in this PR: possible fixes for using the Visual Studio Generator with the Intel Toolchains

Fixes: #3609 

Changes:
-----------
1. Made linking against MKL_SYCL Public in CMake only when building on Windows.
2. Forced `CMAKE_MSVC_RUNTIME_LIBRARY=""` and added manually the correct MSVC Runtime Library compile flag
    (`-MT/MD/MTd/MDd`) for the icx when building oneAPI
4. Forced to use the SYCL OpenCL library from oneAPI when building the oneAPI backend.

Consequences:
-----------------
 [Using the Intel oneAPI DPC++ Compiler Reference as a baseline](https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/2024-2/use-cmake-with-the-compiler.html), the correct way to build the oneAPI backend in windows is as follows (using MSVC2022 and oneapi 2025 for example):
1. Open command prompt (cmd.exe) or powershell.
2. Initialize oneAPI's environment variables
    In command prompt use:
```cmd
C:\Program Files (x86)\Intel\oneAPI\setvars.bat
```
In powershell use
```ps
cmd.exe "/K" '"C:\Program Files (x86)\Intel\oneAPI\setvars.bat" && powershell'  
```
3. Initialize Windows MSVC Compiler Environment Variables
    In command prompt use:
```cmd
C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat
```
In powershell use:
```ps
 cmd.exe "/K" '"C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" && powershell'  
```
5. CMake configure project using the `Ninja` generator with the C and C++ compilers set to `cl` and the SYCL compiler set to `icx`:
```cmd
cmake -B build -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_SYCL_COMPILER=icx -DAF_BUILD_ONEAPI=ON -G Ninja :: ... other options ...
```
6. CMake build project like normal:
```cmd
cmake --build build --target afoneapi -j 4
```
(From testing it seems that the `icx` compiler tends to use a lot of memory and crash if there are lots of jobs being executed. I recommend `-j 4` for an 8-core machine specifically for building the `afoneapi` target. Furthermore, the linking step for `afoneapi.lib` takes a significant amount of time).

Changes to Users
----------------
* Additional options added to the build: None
* What changes will existing users have to make to their code or build steps?: Yes on windows: see [Consequences above](##Consequences)

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
