### PR TITLE
Changed compare function to Strict Weak Ordering criteria.

### DIFF
--- a/examples/machine_learning/mnist_common.h
+++ b/examples/machine_learning/mnist_common.h
@@ -13,7 +13,7 @@
 #include "../common/idxio.h"
 
 bool compare(const std::pair<float, int> l, const std::pair<float, int> r) {
-    return l.first >= r.first;
+    return l.first > r.first;
 }
 
 typedef std::pair<float, int> sort_type;


### PR DESCRIPTION
Current compare function is not "Strict Weak Ordering" since it returns true when both arguments are equal, should be false.

Description
-----------
The "Strict Weak Ordering" criteria is necessary because some sort implementations will end in a dead-loop without it.

Additional information about the PR answering following questions:

* Is this a new feature or a bug fix?     BUG
* More detail if necessary to describe all commits in pull request.
* Why these changes are necessary.   To guarantee that the code runs on any compiler
* Potential impact on specific hardware, software or backends.   None
* New functions and their functionality.   None
* Can this PR be backported to older versions?   Yes
* Future changes not implemented in this PR.  None

Fixes: #3378

Changes to Users
----------------
None

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
