### PR TITLE
Add note to write() array class method documentation about copy on write behavior

### DIFF
--- a/include/af/array.h
+++ b/include/af/array.h
@@ -655,6 +655,7 @@ namespace af
 
         /**
            Perform deep copy from host/device pointer to an existing array
+           \note Unlike all other assignment operations, this does NOT result in a copy on write.
         */
         template<typename T> void write(const T *ptr, const size_t bytes, af::source src = afHost);
 


### PR DESCRIPTION
Added note for write method to clarify that it does not result in a copy on write.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Functions documented
