### PR TITLE
Cuda backend actions

### DIFF
--- a/.github/workflows/unix_cuda_build.yml
+++ b/.github/workflows/unix_cuda_build.yml
@@ -1,0 +1,91 @@
+on:
+  workflow_dispatch:
+  #push:
+  #  branches:
+  #  - master
+  #pull_request:
+  #  branches:
+  #  - master
+
+name: ci_cuda_linux
+
+jobs:
+    build_cuda:
+        name: CUDA
+        runs-on: ubuntu-24.04
+        env:
+          NINJA_VER: 1.12.1
+          CMAKE_VER: 3.30.2
+        strategy:
+            fail-fast: false
+        steps:
+            - name: Install CUDA
+              uses: Jimver/cuda-toolkit@v0.2.18
+              id: cuda-toolkit
+              with:
+                cuda: '12.6.2'
+
+            - name: Checkout Repository
+              uses: actions/checkout@master
+
+            - name: Download Ninja
+              env:
+                  OS_NAME: ubuntu-24.04
+              run: |
+                  wget --quiet "https://github.com/ninja-build/ninja/releases/download/v${NINJA_VER}/ninja-linux.zip"
+                  unzip ./ninja-linux.zip
+                  chmod +x ninja
+                  ${GITHUB_WORKSPACE}/ninja --version
+
+            - name: Download CMake 3.16.3 for Linux
+              env:
+                  OS_NAME: ubuntu-24.04
+                  CC: gcc
+              run: |
+                  cmake_url=$(echo "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-Linux-x86_64.tar.gz")
+                  wget --quiet "${cmake_url}"
+                  tar -xf ./cmake-${CMAKE_VER}-Linux-x86_64.tar.gz
+                  cmake_install_dir=$(echo "cmake-${CMAKE_VER}-x86_64")
+                  mv cmake-${CMAKE_VER}-linux-x86_64 ${cmake_install_dir}
+                  cmake_dir=$(echo "${cmake_install_dir}/bin")
+                  echo "CMAKE_PROGRAM=$(pwd)/${cmake_dir}/cmake" >> $GITHUB_ENV
+                  echo "CXX=g++" >> $GITHUB_ENV
+
+            - name: Install Common Dependencies for Ubuntu
+              run: |
+                  sudo apt-get -qq update
+                  sudo apt-get install -y libboost1.83-dev \
+                                          libfreeimage-dev \
+                                          libglfw3-dev \
+                                          libfftw3-dev \
+                                          liblapacke-dev \
+                                          libfreetype-dev \
+                                          libfontconfig1-dev
+
+            - name: Install OpenBLAS for Ubuntu
+              run: sudo apt-get install -y libopenblas-dev
+
+            - name: CMake Configure
+              env:
+                  BLAS_BACKEND: OpenBLAS
+                  CC: gcc
+                  OS_NAME: ubuntu-24.04
+              run: |
+                  backend="FFTW/LAPACK/BLAS"
+                  buildname="$buildname-cpu-$BLAS_BACKEND"
+                  mkdir build && cd build
+                  ${CMAKE_PROGRAM} -G Ninja \
+                      -DCMAKE_MAKE_PROGRAM:FILEPATH=${GITHUB_WORKSPACE}/ninja \
+                      -DAF_BUILD_CUDA:BOOL=ON -DAF_BUILD_OPENCL:BOOL=OFF \
+                      -DAF_BUILD_UNIFIED:BOOL=OFF -DAF_BUILD_EXAMPLES:BOOL=ON \
+                      -DAF_BUILD_FORGE:BOOL=ON \
+                      -DCUDA_architecture_build_targets:STRING="8.6"\
+                      -DAF_COMPUTE_LIBRARY:STRING=${backend} \
+                      -DBUILDNAME:STRING=${buildname} ..
+
+            - name: Build
+              env:
+                  CC: gcc
+              run: |
+                  cd ${GITHUB_WORKSPACE}/build
+                  ${GITHUB_WORKSPACE}/ninja -j 2

--- a/.github/workflows/unix_cuda_build.yml
+++ b/.github/workflows/unix_cuda_build.yml
@@ -1,11 +1,10 @@
 on:
-  workflow_dispatch:
-  #push:
-  #  branches:
-  #  - master
-  #pull_request:
-  #  branches:
-  #  - master
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 name: ci_cuda_linux
 

--- a/.github/workflows/win_cuda_build.yml
+++ b/.github/workflows/win_cuda_build.yml
@@ -1,11 +1,11 @@
 on:
   workflow_dispatch:
-  #push:
-  #  branches:
-  #  - master
-  #pull_request:
-  #  branches:
-  #  - master
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 name: ci_cuda_win
 

--- a/.github/workflows/win_cuda_build.yml
+++ b/.github/workflows/win_cuda_build.yml
@@ -1,0 +1,76 @@
+on:
+  workflow_dispatch:
+  #push:
+  #  branches:
+  #  - master
+  #pull_request:
+  #  branches:
+  #  - master
+
+name: ci_cuda_win
+
+jobs:
+    build_cuda:
+        name: CUDA
+        runs-on: windows-2022
+        env:
+          VCPKG_HASH: c82f74667287d3dc386bce81e44964370c91a289 #2024.09.30
+          VCPKG_DEFAULT_TRIPLET: x64-windows
+        steps:
+            - name: Install CUDA
+              uses: Jimver/cuda-toolkit@v0.2.18
+              id: cuda-toolkit
+              with:
+                cuda: '12.6.2'
+
+            - name: Checkout Repository
+              uses: actions/checkout@master
+
+            - name: VCPKG Cache
+              id: vcpkg-cache
+              uses: actions/cache@v4
+              with:
+                path: ~/vcpkg
+                key: vcpkg-deps-${{ env.VCPKG_HASH }}
+
+            - name: Install VCPKG Dependencies
+              if: steps.vcpkg-cache.outputs.cache-hit != 'true'
+              run: |
+                pushd .
+                cd ~
+                git clone --quiet --recursive https://github.com/microsoft/vcpkg.git
+                cd vcpkg
+                git checkout $env:VCPKG_HASH
+                .\bootstrap-vcpkg.bat
+                popd
+                ls ~/vcpkg
+                mkdir build && cd build
+                $buildname = "$buildname-cuda"
+                cmake .. -G "Visual Studio 17 2022" -A x64 `
+                      -DVCPKG_ROOT:PATH=~/vcpkg `
+                      -DAF_BUILD_CUDA:BOOL=ON -DAF_BUILD_OPENCL:BOOL=OFF `
+                      -DAF_BUILD_UNIFIED:BOOL=OFF -DAF_BUILD_FORGE:BOOL=ON `
+                      -DCUDA_ARCHITECTURE_BUILD_TARGETS=8.6 `
+                      -DBUILDNAME:STRING="$buildname" `
+                      -DAF_COMPUTE_LIBRARY:STRING="FFTW/LAPACK/BLAS"
+                ls ~/vcpkg
+
+            - name: CMake Configure
+              run: |
+                  $buildname = "$buildname-cuda"
+                  if((Test-Path build) -eq 0) {
+                      mkdir build
+                  }
+                  cd build && set VCPKG_ROOT=
+                  cmake .. -G "Visual Studio 17 2022" -A x64 `
+                      -DVCPKG_ROOT:PATH=~/vcpkg `
+                      -DAF_BUILD_CUDA:BOOL=ON -DAF_BUILD_OPENCL:BOOL=OFF `
+                      -DAF_BUILD_UNIFIED:BOOL=OFF -DAF_BUILD_FORGE:BOOL=ON `
+                      -DAF_BUILD_EXAMPLES:BOOL=ON -DBUILDNAME:STRING="$buildname" `
+                      -DCUDA_architecture_build_targets:STRING="8.6" `
+                      -DAF_COMPUTE_LIBRARY:STRING="FFTW/LAPACK/BLAS"
+
+            - name: Build
+              run: |
+                  cd build
+                  cmake --build . -j 2


### PR DESCRIPTION
CUDA build actions for ArrayFire Github standard runners

Description
-----------
Actions to build CUDA back ends on standard runners. Note that since standard runners do not have GPUs, the code is only built and no tests are run.

Also note that modifications from #3566 are needed for the code to compile successfully on Windows.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
