### PR TITLE
unified reports filled af::exception errors.

### DIFF
--- a/src/api/unified/error.cpp
+++ b/src/api/unified/error.cpp
@@ -42,7 +42,7 @@ void af_get_last_error(char **str, dim_t *len) {
         typedef void (*af_func)(char **, dim_t *);
         void *vfn    = LOAD_SYMBOL();
         af_func func = nullptr;
-        memcpy(&func, vfn, sizeof(void *));
+        memcpy(&func, &vfn, sizeof(void *));
         func(str, len);
     }
 }


### PR DESCRIPTION
The unified version of arrayfire, an std::exception is throw while collecting the arrayfire global error message.
Now the arrayfire error message is collected from the correct platform, resulting in the throwing of an af::exception filled with info.

When checking the unified tests: 18 tests failed because an unexpected exception was thrown

Description
-----------
When collecting the error message from the underlying platform, the address of the corresponding function was incorrect, resulting in an access violation.
Result: 
- Yes, an exception was thrown
- No, af::exception was not thrown, so no info on the real error

Fixes: #3276 #2346

Changes to Users
----------------
None

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
