### PR TITLE
Override boost build helper version to 1.84.0#3

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -23,6 +23,10 @@
         {
             "name": "jasper",
             "version": "4.2.0"
+        },
+        {
+            "name": "boost-modular-build-helper",
+            "version": "1.84.0#3"
         }
     ],
     "features": {


### PR DESCRIPTION
Override boost build helper version to 1.84.0#3 which fixes a bug that prevents building in Visual Studio 2022

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
