### PR TITLE
Extend zero padding test for convolve2GradientNN function

### DIFF
--- a/test/convolve.cpp
+++ b/test/convolve.cpp
@@ -1176,4 +1176,10 @@ TEST(ConvolveNN, ZeroPadding_Issue2817) {
     array convolved = convolve2NN(signal, filter, strides, padding, dilation);
     ASSERT_EQ(sum<float>(abs(signal(seq(1, 3), seq(1, 3)) - convolved)) < 1E-5,
               true);
+
+    array incoming_gradient = constant(1 / 9.f, 3, 3);
+    array convolved_grad = convolve2GradientNN(incoming_gradient, signal, filter,
+                                               convolved, strides, padding, dilation,
+                                               AF_CONV_GRADIENT_FILTER);
+    ASSERT_EQ(sum<float>(abs(convolved - convolved_grad)) < 1E-5, true);
 }


### PR DESCRIPTION
Extend test for convolve2GradientNN function to verify zero padding fix in PR #3519  which addresses #2817 

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
