### PR TITLE
Use offsets for CSR/COO to dense conversion in OpenCL and oneAPI

### DIFF
--- a/src/backend/opencl/kernel/coo2dense.cl
+++ b/src/backend/opencl/kernel/coo2dense.cl
@@ -17,9 +17,9 @@ kernel void coo2Dense(global T *oPtr, const KParam output, global const T *vPtr,
         const int id = i + get_group_id(0) * dimSize * reps;
         if (id >= values.dims[0]) return;
 
-        T v   = vPtr[id];
-        int r = rPtr[id];
-        int c = cPtr[id];
+        T v   = vPtr[id + values.offset];
+        int r = rPtr[id + rowIdx.offset];
+        int c = cPtr[id + colIdx.offset];
 
         int offset = r + c * output.strides[1];
 

--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -114,20 +114,26 @@ TEST(Sparse, ISSUE_1918) {
     array reference(2,2);
     reference(0, span) = 0;
     reference(1, span) = 2;
-    array output;
     float value[] = { 1, 1, 2, 2 };
-    int index[] = { -1, 1, 2 };
-    int row[] = { 0, 2, 2, 0, 0, 2 };
+    int row_csr[] = { 0, 2, 2, 0, 0, 2 };
+    int row_coo[] = { 0, 0, 1, 1 };
     int col[] = { 0, 1, 0, 1 };
     array values(4, 1, value, afHost);
-    array rows(6, 1, row, afHost);
+    array rows_csr(6, 1, row_csr, afHost);
+    array rows_coo(4, 1, row_coo, afHost);
     array cols(4, 1, col, afHost);
-    array S;
+    array S_csr;
+    array S_coo;
   
-    S = sparse(2, 2, values(seq(2, 3)), rows(seq(3, 5)), cols(seq(2, 3)));
-    output = dense(S);
+    S_csr = sparse(2, 2, values(seq(2, 3)), rows_csr(seq(3, 5)), cols(seq(2, 3)));
+    array output_csr = dense(S_csr);
 
-    ASSERT_ARRAYS_EQ(reference, output);
+    EXPECT_ARRAYS_EQ(reference, output_csr);
+
+    S_coo = sparse(2, 2, values(seq(2, 3)), rows_coo(seq(2, 3)), cols(seq(2, 3)), AF_STORAGE_COO);
+    array output_coo = dense(S_coo);
+
+    EXPECT_ARRAYS_EQ(reference, output_coo);
 }
 
 TEST(Sparse, ISSUE_2134_COO) {

--- a/test/sparse.cpp
+++ b/test/sparse.cpp
@@ -110,26 +110,36 @@ TEST(Sparse, ISSUE_1745) {
                               row_idx.get(), col_idx.get(), AF_STORAGE_CSR));
 }
 
-TEST(Sparse, ISSUE_1918) {
+TEST(Sparse, offsets_work_csr_to_dense_ISSUE_1918) {
     array reference(2,2);
     reference(0, span) = 0;
     reference(1, span) = 2;
     float value[] = { 1, 1, 2, 2 };
     int row_csr[] = { 0, 2, 2, 0, 0, 2 };
-    int row_coo[] = { 0, 0, 1, 1 };
     int col[] = { 0, 1, 0, 1 };
     array values(4, 1, value, afHost);
     array rows_csr(6, 1, row_csr, afHost);
-    array rows_coo(4, 1, row_coo, afHost);
     array cols(4, 1, col, afHost);
     array S_csr;
-    array S_coo;
   
     S_csr = sparse(2, 2, values(seq(2, 3)), rows_csr(seq(3, 5)), cols(seq(2, 3)));
     array output_csr = dense(S_csr);
 
     EXPECT_ARRAYS_EQ(reference, output_csr);
+}
 
+TEST(Sparse, offsets_work_coo_to_dense_ISSUE_1918) {
+    array reference(2,2);
+    reference(0, span) = 0;
+    reference(1, span) = 2;
+    float value[] = { 1, 1, 2, 2 };
+    int row_coo[] = { 0, 0, 1, 1 };
+    int col[] = { 0, 1, 0, 1 };
+    array values(4, 1, value, afHost);
+    array rows_coo(4, 1, row_coo, afHost);
+    array cols(4, 1, col, afHost);
+    array S_coo;
+  
     S_coo = sparse(2, 2, values(seq(2, 3)), rows_coo(seq(2, 3)), cols(seq(2, 3)), AF_STORAGE_COO);
     array output_coo = dense(S_coo);
 


### PR DESCRIPTION
Offset values for sparse arrays are now taken into account when converting from sparse CSR/COO to dense for the OpenCL and oneAPI back ends. Test has been updated to also confirm fix for COO sparse format.

Fixes: #1918

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
