### PR TITLE
Add clang flag to include build id in elf data

### DIFF
--- a/src/backend/oneapi/CMakeLists.txt
+++ b/src/backend/oneapi/CMakeLists.txt
@@ -358,6 +358,7 @@ target_link_libraries(afoneapi
     $<$<PLATFORM_ID:Linux>:-flink-huge-device-code>
     $<$<PLATFORM_ID:Linux>:-fvisibility-inlines-hidden>
     $<$<PLATFORM_ID:Linux>:-fno-sycl-rdc>
+    $<$<PLATFORM_ID:Linux>:-Wl,--build-id>
     -fsycl-max-parallel-link-jobs=${NumberOfThreads}
     MKL::MKL_SYCL
   )


### PR DESCRIPTION
The build id is not generated by default when using intel oneapi. A flag has been added to enable it. This is to satisfy cpack when it is generating the deb file for the oneapi backend.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
