### PR TITLE
Add minimum driver version check to allow minor version compatibility.

### DIFF
--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -58,7 +58,6 @@ using std::make_pair;
 using std::pair;
 using std::string;
 using std::stringstream;
-using std::stof;
 
 namespace arrayfire {
 namespace cuda {
@@ -512,7 +511,10 @@ void DeviceManager::checkCudaVsDriverVersion() {
 
     debugRuntimeCheck(getLogger(), runtime, driver);
 
-    if (runtime > driver) {
+    int runtime_major = runtime / 1000;
+    int driver_major = driver / 1000;
+
+    if (runtime_major > driver_major) {
         string msg =
             "ArrayFire was built with CUDA {} which requires GPU driver "
             "version {} or later. Please download and install the latest "
@@ -550,13 +552,11 @@ void DeviceManager::checkCudaVsDriverVersion() {
             runtime_it->unix_min_version;
 #endif
 
-        if (stof(driverVersionString) < minimumDriverVersion) {
-          char buf[buf_size];
-          fmt::format_to_n(buf, buf_size, msg, fromCudaVersion(runtime),
-                           minimumDriverVersion, fromCudaVersion(driver));
+        char buf[buf_size];
+        fmt::format_to_n(buf, buf_size, msg, fromCudaVersion(runtime),
+                         minimumDriverVersion, fromCudaVersion(driver));
 
-          AF_ERROR(buf, AF_ERR_DRIVER);
-        }
+        AF_ERROR(buf, AF_ERR_DRIVER);
     }
 }
 

--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -58,6 +58,7 @@ using std::make_pair;
 using std::pair;
 using std::string;
 using std::stringstream;
+using std::stof;
 
 namespace arrayfire {
 namespace cuda {
@@ -549,11 +550,13 @@ void DeviceManager::checkCudaVsDriverVersion() {
             runtime_it->unix_min_version;
 #endif
 
-        char buf[buf_size];
-        fmt::format_to_n(buf, buf_size, msg, fromCudaVersion(runtime),
-                         minimumDriverVersion, fromCudaVersion(driver));
+        if (stof(driverVersionString) < minimumDriverVersion) {
+          char buf[buf_size];
+          fmt::format_to_n(buf, buf_size, msg, fromCudaVersion(runtime),
+                           minimumDriverVersion, fromCudaVersion(driver));
 
-        AF_ERROR(buf, AF_ERR_DRIVER);
+          AF_ERROR(buf, AF_ERR_DRIVER);
+        }
     }
 }
 


### PR DESCRIPTION
Description
-----------
Previously, the only check performed was to compare the runtime version that the code was compiled with to the cuda version corresponding to the driver. This means that there was no minor version compatibility check. The error message given was also incorrect since it printed out the minimum driver required for minor version compatibility.

Changes to Users
----------------
The actual driver version is now also checked against the minimum required version to allow minor version compatibility.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
