### PR TITLE
Update dependencies built with ArrayFire

### DIFF
--- a/CMakeModules/AF_vcpkg_options.cmake
+++ b/CMakeModules/AF_vcpkg_options.cmake
@@ -6,7 +6,6 @@
 # http://arrayfire.com/licenses/BSD-3-Clause
 
 set(ENV{VCPKG_FEATURE_FLAGS} "versions")
-set(ENV{VCPKG_KEEP_ENV_VARS} "MKLROOT")
 set(VCPKG_MANIFEST_NO_DEFAULT_FEATURES ON)
 
 set(VCPKG_OVERLAY_TRIPLETS ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/vcpkg/vcpkg-triplets)
@@ -28,9 +27,7 @@ if(BUILD_TESTING)
   list(APPEND VCPKG_MANIFEST_FEATURES "tests")
 endif()
 
-if(AF_COMPUTE_LIBRARY STREQUAL "Intel-MKL")
-  list(APPEND VCPKG_MANIFEST_FEATURES "mkl")
-else()
+if(NOT AF_COMPUTE_LIBRARY STREQUAL "Intel-MKL")
   list(APPEND VCPKG_MANIFEST_FEATURES "openblasfftw")
 endif()
 

--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -26,7 +26,7 @@ if(TARGET clblast OR AF_WITH_EXTERNAL_PACKAGES_ONLY)
 else()
   af_dep_check_and_populate(${clblast_prefix}
     URI https://github.com/cnugteren/CLBlast.git
-    REF 4500a03440e2cc54998c0edab366babf5e504d67
+    REF 1.6.3
   )
 
   include(ExternalProject)
@@ -69,6 +69,7 @@ else()
       BUILD_BYPRODUCTS ${CLBlast_location}
       CONFIGURE_COMMAND ${CMAKE_COMMAND} ${extproj_gen_opts}
         -Wno-dev <SOURCE_DIR>
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
         "-DCMAKE_CXX_FLAGS:STRING=${CMAKE_CXX_FLAGS}"
         -DOVERRIDE_MSVC_FLAGS_TO_MT:BOOL=OFF

--- a/CMakeModules/build_cl2hpp.cmake
+++ b/CMakeModules/build_cl2hpp.cmake
@@ -27,7 +27,7 @@ if(NOT TARGET OpenCL::cl2hpp)
   elseif (NOT TARGET OpenCL::cl2hpp OR NOT TARGET cl2hpp)
     af_dep_check_and_populate(${cl2hpp_prefix}
       URI https://github.com/KhronosGroup/OpenCL-CLHPP.git
-      REF v2022.09.30)
+      REF v2024.10.24)
 
     find_path(cl2hpp_var
       NAMES CL/cl2.hpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,7 @@ if(AF_WITH_EXTERNAL_PACKAGES_ONLY)
 elseif(NOT TARGET GTest::gtest)
   af_dep_check_and_populate(${gtest_prefix}
     URI https://github.com/google/googletest.git
-    REF release-1.12.1
+    REF v1.16.0
   )
   if(WIN32)
     set(gtest_force_shared_crt ON

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -23,10 +23,6 @@
         {
             "name": "jasper",
             "version": "4.2.0"
-        },
-        {
-            "name": "boost-modular-build-helper",
-            "version": "1.84.0#3"
         }
     ],
     "features": {
@@ -78,12 +74,6 @@
                 "opencl"
             ]
         },
-        "mkl": {
-            "description": "Build with MKL",
-            "dependencies": [
-                "intel-mkl"
-            ]
-        },
         "cudnn": {
             "description": "Build CUDA with support for cuDNN",
             "dependencies": [
@@ -91,5 +81,5 @@
             ]
         }
     },
-    "builtin-baseline": "9d47b24eacbd1cd94f139457ef6cd35e5d92cc84"
+    "builtin-baseline": "b02e341c927f16d991edbd915d8ea43eac52096c"
 }


### PR DESCRIPTION
Update dependencies cloned from git and built along with ArrayFire:
- CLBlast (note that the minimum supported version needs to be overriden to 3.5 to work with the latest version of Cmake (v4.0)
- CL2HPP
- GoogleTest

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [ ] Tests pass
