### PR TITLE
if not Win check added

### DIFF
--- a/src/backend/cuda/CMakeLists.txt
+++ b/src/backend/cuda/CMakeLists.txt
@@ -49,8 +49,12 @@ set(CUDA_architecture_build_targets "Auto" CACHE
   STRING "The compute architectures targeted by this build. (Options: Auto;3.0;Maxwell;All;Common)")
 
 find_cuda_helper_libs(nvrtc)
-find_cuda_helper_libs(nvrtc-builtins)
-list(APPEND nvrtc_libs ${CUDA_nvrtc_LIBRARY} ${CUDA_nvrtc-builtins_LIBRARY})
+if(NOT WIN32)
+    find_cuda_helper_libs(nvrtc-builtins)
+    list(APPEND nvrtc_libs ${CUDA_nvrtc_LIBRARY} ${CUDA_nvrtc-builtins_LIBRARY})
+else()
+    list(APPEND nvrtc_libs ${CUDA_nvrtc_LIBRARY})
+endif()
 
 if(UNIX AND AF_WITH_STATIC_CUDA_NUMERIC_LIBS)
   # The libraries that may be staticly linked or may be loaded at runtime


### PR DESCRIPTION
Skip nvrtc-builtins dependency on Windows

This PR modifies the CMake configuration to handle the nvrtc-builtins library
differently on Windows platforms where the library naming convention differs.

Description
-----------
This is a bug fix that addresses the issue with CUDA nvrtc-builtins library
not being found on Windows systems. The root cause is that Windows CUDA toolkit
prepends version information to the library name, making the standard library
search fail.

The changes:
- Add platform-specific condition to skip nvrtc-builtins on Windows
- Maintain existing behavior on other platforms
- Fix build issues on Windows without affecting other platforms

Impact:
- Windows builds will now complete successfully
- No impact on other platforms or backends
- No changes to existing functionality or API

This PR can be backported to older versions as it's a build system fix that
doesn't affect the core functionality.

Fixes: #3652

Changes to Users
----------------
No changes required for users. This is a build system fix that doesn't affect
the API or functionality. Existing code will continue to work as before.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented