### PR TITLE
Add support for CUDA 12.9

### DIFF
--- a/src/backend/cuda/device_manager.cpp
+++ b/src/backend/cuda/device_manager.cpp
@@ -101,6 +101,7 @@ static const int jetsonComputeCapabilities[] = {
 
 // clang-format off
 static const cuNVRTCcompute Toolkit2MaxCompute[] = {
+    {12090, 9, 0, 0},
     {12080, 9, 0, 0},
     {12070, 9, 0, 0},
     {12060, 9, 0, 0},
@@ -146,6 +147,7 @@ struct ComputeCapabilityToStreamingProcessors {
 // clang-format off
 static const ToolkitDriverVersions
     CudaToDriverVersion[] = {
+        {12090, 525.60f, 528.33f},
         {12080, 525.60f, 528.33f},
         {12070, 525.60f, 528.33f},
         {12060, 525.60f, 528.33f},


### PR DESCRIPTION
Add CUDA 12.9 version to device manager so that it is recognized.

Changes to Users
----------------
Users with CUDA 12.9 can run the CUDA back end without an error message.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
