### PR TITLE
Use correct offset for lookup on oneapi back end.

### DIFF
--- a/src/backend/oneapi/kernel/lookup.hpp
+++ b/src/backend/oneapi/kernel/lookup.hpp
@@ -64,7 +64,7 @@ class lookupNDCreateKernel {
         int gx = g.get_local_range(0) * (g.get_group_id(0) - gz * nBBS0_) + lx;
         int gy = g.get_local_range(1) * (g.get_group_id(1) - gw * nBBS1_) + ly;
 
-        const idx_t *idxPtr = indices_.get_pointer();
+        const idx_t *idxPtr = indices_.get_pointer() + idxInfo_.offset;
 
         int i = iInfo_.strides[0] *
                 (DIM_ == 0 ? trimIndex((int)idxPtr[gx], iInfo_.dims[0]) : gx);

--- a/src/backend/oneapi/lookup.cpp
+++ b/src/backend/oneapi/lookup.cpp
@@ -25,8 +25,8 @@ Array<in_t> lookup(const Array<in_t> &input, const Array<idx_t> &indices,
     const dim4 &iDims = input.dims();
 
     dim4 oDims(1);
-    for (int d = 0; d < 4; ++d) {
-        oDims[d] = (d == int(dim) ? indices.elements() : iDims[d]);
+    for (dim_t d = 0; d < 4; ++d) {
+        oDims[d] = (d == dim ? indices.elements() : iDims[d]);
     }
 
     Array<in_t> out = createEmptyArray<in_t>(oDims);


### PR DESCRIPTION
This was fixed in the opencl back end in PR #3650 but the issue also existed in the oneapi back end and is fixed here.

Fixes: #3606

Changes to Users
----------------
* Lookup will now return with the correct offset on the oneapi back end.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
