### PR TITLE
Fix JIT source for casting to signed char.

### DIFF
--- a/src/backend/oneapi/cast.hpp
+++ b/src/backend/oneapi/cast.hpp
@@ -34,10 +34,14 @@ struct CastOp {
 
 CAST_FN(int)
 CAST_FN(uint)
-CAST_FN(schar)
 CAST_FN(uchar)
 CAST_FN(float)
 CAST_FN(double)
+
+template<typename Ti>
+struct CastOp<schar, Ti> {
+    const char *name() { return "convert_char"; }
+};
 
 #define CAST_CFN(TYPE)                                    \
     template<typename Ti>                                 \


### PR DESCRIPTION
An incorrect function name for casting to a signed char was used when generating the source for oneAPI JIT kernels resulting in a compilation error. This has been fixed with a template specialization of CastOp.

Changes to Users
----------------
Users will now be able to use oneAPI JIT kernels with the signed char type without a compilation error.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
