### PR TITLE
Fixes sub-array support for scan by key (opencl)

### DIFF
--- a/src/backend/opencl/kernel/scan_dim_by_key.cl
+++ b/src/backend/opencl/kernel/scan_dim_by_key.cl
@@ -34,7 +34,7 @@ kernel void scanDimByKeyNonfinal(
     // Hence increment ids[kDim] just after offseting out and before offsetting
     // in
     tData += ids[3] * tInfo.strides[3] + ids[2] * tInfo.strides[2] +
-             ids[1] * tInfo.strides[1] + ids[0];
+             ids[1] * tInfo.strides[1] + ids[0] ;
     tfData += ids[3] * tfInfo.strides[3] + ids[2] * tfInfo.strides[2] +
               ids[1] * tfInfo.strides[1] + ids[0];
     tiData += ids[3] * tiInfo.strides[3] + ids[2] * tiInfo.strides[2] +
@@ -45,10 +45,9 @@ kernel void scanDimByKeyNonfinal(
     oData += ids[3] * oInfo.strides[3] + ids[2] * oInfo.strides[2] +
              ids[1] * oInfo.strides[1] + ids[0];
     iData += ids[3] * iInfo.strides[3] + ids[2] * iInfo.strides[2] +
-             ids[1] * iInfo.strides[1] + ids[0];
+             ids[1] * iInfo.strides[1] + ids[0] + iInfo.offset;
     kData += ids[3] * kInfo.strides[3] + ids[2] * kInfo.strides[2] +
-             ids[1] * kInfo.strides[1] + ids[0];
-    iData += iInfo.offset;
+             ids[1] * kInfo.strides[1] + ids[0] + kInfo.offset;
 
     int id_dim        = ids[kDim];
     const int out_dim = oInfo.dims[kDim];
@@ -192,10 +191,9 @@ kernel void scanDimByKeyFinal(global To *oData, KParam oInfo,
     oData += ids[3] * oInfo.strides[3] + ids[2] * oInfo.strides[2] +
              ids[1] * oInfo.strides[1] + ids[0];
     iData += ids[3] * iInfo.strides[3] + ids[2] * iInfo.strides[2] +
-             ids[1] * iInfo.strides[1] + ids[0];
+             ids[1] * iInfo.strides[1] + ids[0] + iInfo.offset;
     kData += ids[3] * kInfo.strides[3] + ids[2] * kInfo.strides[2] +
-             ids[1] * kInfo.strides[1] + ids[0];
-    iData += iInfo.offset;
+             ids[1] * kInfo.strides[1] + ids[0] + kInfo.offset;
 
     int id_dim        = ids[kDim];
     const int out_dim = oInfo.dims[kDim];

--- a/src/backend/opencl/kernel/scan_first_by_key.cl
+++ b/src/backend/opencl/kernel/scan_first_by_key.cl
@@ -39,13 +39,13 @@ kernel void scanFirstByKeyNonfinal(global To *oData, KParam oInfo,
              yid * kInfo.strides[1] + kInfo.offset;
 
     tData += wid * tInfo.strides[3] + zid * tInfo.strides[2] +
-             yid * tInfo.strides[1] + tInfo.offset;
+             yid * tInfo.strides[1];
 
     tfData += wid * tfInfo.strides[3] + zid * tfInfo.strides[2] +
-              yid * tfInfo.strides[1] + tfInfo.offset;
+              yid * tfInfo.strides[1];
 
     tiData += wid * tiInfo.strides[3] + zid * tiInfo.strides[2] +
-              yid * tiInfo.strides[1] + tiInfo.offset;
+              yid * tiInfo.strides[1];
 
     oData += wid * oInfo.strides[3] + zid * oInfo.strides[2] +
              yid * oInfo.strides[1] + oInfo.offset;
@@ -179,7 +179,7 @@ kernel void scanFirstByKeyFinal(global To *oData, KParam oInfo,
              yid * kInfo.strides[1] + kInfo.offset;
 
     oData += wid * oInfo.strides[3] + zid * oInfo.strides[2] +
-             yid * oInfo.strides[1] + oInfo.offset;
+             yid * oInfo.strides[1];
 
     local To l_val0[SHARED_MEM_SIZE];
     local To l_val1[SHARED_MEM_SIZE];
@@ -283,13 +283,13 @@ kernel void bcastFirstByKey(global To *oData, KParam oInfo,
 
         if (cond) {
             tiData += wid * tiInfo.strides[3] + zid * tiInfo.strides[2] +
-                      yid * tiInfo.strides[1] + tiInfo.offset;
+                      yid * tiInfo.strides[1];
 
             tData += wid * tInfo.strides[3] + zid * tInfo.strides[2] +
-                     yid * tInfo.strides[1] + tInfo.offset;
+                     yid * tInfo.strides[1];
 
             oData += wid * oInfo.strides[3] + zid * oInfo.strides[2] +
-                     yid * oInfo.strides[1] + oInfo.offset;
+                     yid * oInfo.strides[1];
 
             int boundary = tiData[groupId_x];
             To accum     = tData[groupId_x - 1];

--- a/test/scan_by_key.cpp
+++ b/test/scan_by_key.cpp
@@ -240,3 +240,26 @@ TEST(ScanByKey, FixOverflowWrite) {
 
     ASSERT_EQ(prior, valsAF(0).scalar<float>());
 }
+
+#define TEST_TEMP_FORMAT(form, dim)                                           \
+    TEST(TEMP_FORMAT, form##_Dim##dim) {                                      \
+        UNSUPPORTED_BACKEND(AF_BACKEND_ONEAPI);                               \
+        const dim4 dims(2, 2, 2, 2);                                          \
+        const array in(af::moddims(range(dim4(dims.elements())), dims));      \
+        in.eval();                                                            \
+        const array keys(af::constant(0, dims, u32));                         \
+        keys.eval();                                                          \
+        const array gold = scanByKey(keys, in, dim);                          \
+                                                                              \
+        array out =                                                           \
+            scanByKey(toTempFormat(form, keys), toTempFormat(form, in), dim); \
+        ASSERT_ARRAYS_EQ(gold, out);                                          \
+    }
+
+#define TEST_TEMP_FORMATS(form) \
+    TEST_TEMP_FORMAT(form, 0)   \
+    TEST_TEMP_FORMAT(form, 1)   \
+    TEST_TEMP_FORMAT(form, 2)   \
+    TEST_TEMP_FORMAT(form, 3)
+
+FOREACH_TEMP_FORMAT(TEST_TEMP_FORMATS)

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -244,10 +244,10 @@ bool noHalfTests(af::dtype ty);
     GTEST_SKIP() << "Device doesn't support Half"
 
 #ifdef SKIP_UNSUPPORTED_TESTS
-#define UNSUPPORTED_BACKEND(backend)                        \
-    if(backend == af::getActiveBackend())                   \
-        GTEST_SKIP() << "Skipping unsupported function on " \
-                        + getBackendName() + " backend"
+#define UNSUPPORTED_BACKEND(backend)                                         \
+    if (backend == af::getActiveBackend())                                   \
+    GTEST_SKIP() << "Skipping unsupported function on " + getBackendName() + \
+                        " backend"
 #else
 #define UNSUPPORTED_BACKEND(backend)
 #endif
@@ -652,6 +652,30 @@ void genTestOutputArray(af_array *out_ptr, double val, const unsigned ndims,
                                          std::string metadataName,
                                          const af_array a, const af_array b,
                                          TestOutputArrayInfo *metadata);
+
+enum tempFormat {
+    LINEAR_FORMAT,    // Linear array (= default)
+    JIT_FORMAT,       // Array which has JIT operations outstanding
+    SUB_FORMAT_dim0,  // Array where only a subset is allocated for dim0
+    SUB_FORMAT_dim1,  // Array where only a subset is allocated for dim1
+    SUB_FORMAT_dim2,  // Array where only a subset is allocated for dim2
+    SUB_FORMAT_dim3,  // Array where only a subset is allocated for dim3
+    REORDERED_FORMAT  // Array where the dimensions are reordered
+};
+// Calls the function fn for all available formats
+#define FOREACH_TEMP_FORMAT(TESTS) \
+    TESTS(LINEAR_FORMAT)           \
+    TESTS(JIT_FORMAT)              \
+    TESTS(SUB_FORMAT_dim0)         \
+    TESTS(SUB_FORMAT_dim1)         \
+    TESTS(SUB_FORMAT_dim2)         \
+    TESTS(SUB_FORMAT_dim3)         \
+    TESTS(REORDERED_FORMAT)
+
+// formats the "in" array according to provided format.  The content remains
+// unchanged.
+af::array toTempFormat(tempFormat form, const af::array &in);
+void toTempFormat(tempFormat form, af_array *out, const af_array &in);
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Using sub-arrays in the scanByKey function results in undefined behaviour in the opencl backend.

Description
-----------
The offsets were not taken into account in the opencl code.

28bd6b0: adds the the function toTempFormat to the test helpers. This function generates the different temporary array formats (JIT array, SUB-array, Linear array, ...) used by arrayfire.
986a0da: Adds the offset to the cl code files & adds extra tests for scan.

    Is this a new feature or a bug fix?
    BUG
    Why these changes are necessary.
    PREVIOUSLY THE RESULT IS UNDEFINED FOR ABOVE SITUATION
    Potential impact on specific hardware, software or backends.
    OPENCL only
    New functions and their functionality.
    NO
    Can this PR be backported to older versions?
    YES, changes are very local
    Future changes not implemented in this PR.
    NONE, although the function toTempFormat will be used in following PRs.

Changes to Users
----------------
None

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
