### PR TITLE
Fixes sub-array (oneapi) support for where

### DIFF
--- a/src/backend/oneapi/kernel/where.hpp
+++ b/src/backend/oneapi/kernel/where.hpp
@@ -73,7 +73,7 @@ class whereKernel {
         otptr += wid * otInfo_.strides[3] + zid * otInfo_.strides[2] +
                  yid * otInfo_.strides[1];
         iptr += wid * iInfo_.strides[3] + zid * iInfo_.strides[2] +
-                yid * iInfo_.strides[1];
+                yid * iInfo_.strides[1] + iInfo_.offset;
 
         size_t odims0 = otInfo_.dims[0];
         size_t odims1 = otInfo_.dims[1];

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -244,10 +244,10 @@ bool noHalfTests(af::dtype ty);
     GTEST_SKIP() << "Device doesn't support Half"
 
 #ifdef SKIP_UNSUPPORTED_TESTS
-#define UNSUPPORTED_BACKEND(backend)                        \
-    if(backend == af::getActiveBackend())                   \
-        GTEST_SKIP() << "Skipping unsupported function on " \
-                        + getBackendName() + " backend"
+#define UNSUPPORTED_BACKEND(backend)                                         \
+    if (backend == af::getActiveBackend())                                   \
+    GTEST_SKIP() << "Skipping unsupported function on " + getBackendName() + \
+                        " backend"
 #else
 #define UNSUPPORTED_BACKEND(backend)
 #endif
@@ -652,6 +652,30 @@ void genTestOutputArray(af_array *out_ptr, double val, const unsigned ndims,
                                          std::string metadataName,
                                          const af_array a, const af_array b,
                                          TestOutputArrayInfo *metadata);
+
+enum tempFormat {
+    LINEAR_FORMAT,    // Linear array (= default)
+    JIT_FORMAT,       // Array which has JIT operations outstanding
+    SUB_FORMAT_dim0,  // Array where only a subset is allocated for dim0
+    SUB_FORMAT_dim1,  // Array where only a subset is allocated for dim1
+    SUB_FORMAT_dim2,  // Array where only a subset is allocated for dim2
+    SUB_FORMAT_dim3,  // Array where only a subset is allocated for dim3
+    REORDERED_FORMAT  // Array where the dimensions are reordered
+};
+// Calls the function fn for all available formats
+#define FOREACH_TEMP_FORMAT(TESTS) \
+    TESTS(LINEAR_FORMAT)           \
+    TESTS(JIT_FORMAT)              \
+    TESTS(SUB_FORMAT_dim0)         \
+    TESTS(SUB_FORMAT_dim1)         \
+    TESTS(SUB_FORMAT_dim2)         \
+    TESTS(SUB_FORMAT_dim3)         \
+    TESTS(REORDERED_FORMAT)
+
+// formats the "in" array according to provided format.  The content remains
+// unchanged.
+af::array toTempFormat(tempFormat form, const af::array &in);
+void toTempFormat(tempFormat form, af_array *out, const af_array &in);
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/test/where.cpp
+++ b/test/where.cpp
@@ -136,3 +136,22 @@ TEST(Where, ISSUE_1259) {
     array indices = where(a > 2);
     ASSERT_EQ(indices.elements(), 0);
 }
+
+#define TEST_TEMP_FORMAT(form, dim)                                      \
+    TEST(TEMP_FORMAT, form##_Dim##dim) {                                 \
+        const dim4 dims(2, 3, 4, 5);                                     \
+        const array in(af::moddims(range(dim4(dims.elements())), dims)); \
+        in.eval();                                                       \
+        const array gold = where(in > 3.0);                              \
+                                                                         \
+        array out = where(toTempFormat(form, in) > 3.0);                 \
+        ASSERT_ARRAYS_EQ(gold, out);                                     \
+    }
+
+#define TEST_TEMP_FORMATS(form) \
+    TEST_TEMP_FORMAT(form, 0)   \
+    TEST_TEMP_FORMAT(form, 1)   \
+    TEST_TEMP_FORMAT(form, 2)   \
+    TEST_TEMP_FORMAT(form, 3)
+
+FOREACH_TEMP_FORMAT(TEST_TEMP_FORMATS)


### PR DESCRIPTION
Using sub-arrays in the where function results in undefined behaviour in the oneapi backend.

Description
-----------
The offsets were not taken into account in the oneapi code.

28bd6b0: adds the the function toTempFormat to the test helpers. This function generates the different temporary array formats (JIT array, SUB-array, Linear array, ...) used by arrayfire.
https://github.com/arrayfire/arrayfire/commit/6fe4646d247dafe347fd6e88ab9a225685dc625d: Adds the offset to the cl code files & adds extra tests for scan.

    Is this a new feature or a bug fix?
    BUG
    Why these changes are necessary.
    PREVIOUSLY THE RESULT IS UNDEFINED FOR ABOVE SITUATION
    Potential impact on specific hardware, software or backends.
    ONEAPI only
    New functions and their functionality.
    NO
    Can this PR be backported to older versions?
    YES, changes are very local
    Future changes not implemented in this PR.
    NONE, although the function toTempFormat will be used in following PRs.

Changes to Users
----------------
None

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
