### PR TITLE
Join does not always respect the order of provided parameters (oneapi) (#3511)(#3513)

### DIFF
--- a/test/join.cpp
+++ b/test/join.cpp
@@ -280,9 +280,9 @@ TEST(Join, respect_parameters_order_ISSUE3511) {
     const af::array jit2{buf2 + 2.0};
     const std::array<af::array, 8> cases{jit1,  -jit1,       jit1 + 1.0, jit2,
                                          -jit2, jit1 + jit2, buf1,       buf2};
-    const std::array<char*, 8> cases_name{"JIT1", "-JIT1", "JIT1+1.0",
-                                          "JIT2", "-JIT2", "JIT1+JIT2",
-                                          "BUF1", "BUF2"};
+    const std::array<const char*, 8> cases_name{"JIT1", "-JIT1", "JIT1+1.0",
+                                                "JIT2", "-JIT2", "JIT1+JIT2",
+                                                "BUF1", "BUF2"};
     assert(cases.size() == cases_name.size());
     for (size_t cl0{0}; cl0 < cases.size(); ++cl0) {
         for (size_t cl1{0}; cl1 < cases.size(); ++cl1) {
@@ -312,3 +312,22 @@ TEST(Join, respect_parameters_order_ISSUE3511) {
         }
     }
 }
+
+#define TEST_TEMP_FORMAT(form, d)                                           \
+    TEST(TEMP_FORMAT, form##_dim##d) {                                      \
+        const dim4 dims(2, 2, 2, 2);                                        \
+        const array a(randu(dims));                                         \
+        const array b(randu(dims));                                         \
+                                                                            \
+        array out  = join(d, toTempFormat(form, a), toTempFormat(form, b)); \
+        array gold = join(d, a, b);                                         \
+        EXPECT_ARRAYS_EQ(gold, out);                                        \
+    }
+
+#define TEST_TEMP_FORMATS(form) \
+    TEST_TEMP_FORMAT(form, 0)   \
+    TEST_TEMP_FORMAT(form, 1)   \
+    TEST_TEMP_FORMAT(form, 2)   \
+    TEST_TEMP_FORMAT(form, 3)
+
+FOREACH_TEMP_FORMAT(TEST_TEMP_FORMATS)

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -244,10 +244,10 @@ bool noHalfTests(af::dtype ty);
     GTEST_SKIP() << "Device doesn't support Half"
 
 #ifdef SKIP_UNSUPPORTED_TESTS
-#define UNSUPPORTED_BACKEND(backend)                        \
-    if(backend == af::getActiveBackend())                   \
-        GTEST_SKIP() << "Skipping unsupported function on " \
-                        + getBackendName() + " backend"
+#define UNSUPPORTED_BACKEND(backend)                                         \
+    if (backend == af::getActiveBackend())                                   \
+    GTEST_SKIP() << "Skipping unsupported function on " + getBackendName() + \
+                        " backend"
 #else
 #define UNSUPPORTED_BACKEND(backend)
 #endif
@@ -652,6 +652,30 @@ void genTestOutputArray(af_array *out_ptr, double val, const unsigned ndims,
                                          std::string metadataName,
                                          const af_array a, const af_array b,
                                          TestOutputArrayInfo *metadata);
+
+enum tempFormat {
+    LINEAR_FORMAT,    // Linear array (= default)
+    JIT_FORMAT,       // Array which has JIT operations outstanding
+    SUB_FORMAT_dim0,  // Array where only a subset is allocated for dim0
+    SUB_FORMAT_dim1,  // Array where only a subset is allocated for dim1
+    SUB_FORMAT_dim2,  // Array where only a subset is allocated for dim2
+    SUB_FORMAT_dim3,  // Array where only a subset is allocated for dim3
+    REORDERED_FORMAT  // Array where the dimensions are reordered
+};
+// Calls the function fn for all available formats
+#define FOREACH_TEMP_FORMAT(TESTS) \
+    TESTS(LINEAR_FORMAT)           \
+    TESTS(JIT_FORMAT)              \
+    TESTS(SUB_FORMAT_dim0)         \
+    TESTS(SUB_FORMAT_dim1)         \
+    TESTS(SUB_FORMAT_dim2)         \
+    TESTS(SUB_FORMAT_dim3)         \
+    TESTS(REORDERED_FORMAT)
+
+// formats the "in" array according to provided format.  The content remains
+// unchanged.
+af::array toTempFormat(tempFormat form, const af::array &in);
+void toTempFormat(tempFormat form, af_array *out, const af_array &in);
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop


### PR DESCRIPTION
When 2 arrays have a common base (JIT), the order of the join was not respected.  This fix is already applied to opencl, cuda an cpu before although not yet for oneapi.

Description
-----------
28bd60b0: adds the the function toTempFormat to the test helpers. This function generates the different temporary array formats (JIT array, SUB-array, Linear array, ...) used by arrayfire.
811669f: The JIT kernel generation is adapted so that the order of the parameters is respected in the write out of the results.

* Is this a new feature or a bug fix?
    BUG
* Why these changes are necessary.
    BEFORE RANDOM RESULTS ARE GENERATED, BECAUSE THE RESULTS were written in the wrong arrays (depending on internal presentation)
* Potential impact on specific hardware, software or backends.
   ONEAPI, BECAUSE ALREADY FIXED IN THE OTHER BACKENDS
* New functions and their functionality.
   NONE
* Can this PR be backported to older versions?
  DIFFICULT
* Future changes not implemented in this PR.
  NONE

Fixes: #3511 #3513

Changes to Users
----------------
BUG FIX, difficult to detect.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
