### PR TITLE
Fixes sub array (opencl) support for confidenceCC

### DIFF
--- a/src/api/c/confidence_connected.cpp
+++ b/src/api/c/confidence_connected.cpp
@@ -45,6 +45,8 @@ using std::swap;
 template<typename T>
 Array<T> pointList(const Array<T>& in, const Array<uint>& x,
                    const Array<uint>& y) {
+
+    // TODO: Temporary Fix, must fix handling subarrays upstream
     // Array<T> has to be a basic array, to be accepted as af_index
     Array<uint> x_ = (x.getOffset() == 0 && x.isLinear()) ? x : copyArray(x);
     Array<uint> y_ = (y.getOffset() == 0 && y.isLinear()) ? y : copyArray(y);

--- a/src/api/c/confidence_connected.cpp
+++ b/src/api/c/confidence_connected.cpp
@@ -45,8 +45,13 @@ using std::swap;
 template<typename T>
 Array<T> pointList(const Array<T>& in, const Array<uint>& x,
                    const Array<uint>& y) {
-    af_array xcoords                          = getHandle<uint>(x);
-    af_array ycoords                          = getHandle<uint>(y);
+    // Array<T> has to be a basic array, to be accepted as af_index
+    Array<uint> x_ = (x.getOffset() == 0 && x.isLinear()) ? x : copyArray(x);
+    Array<uint> y_ = (y.getOffset() == 0 && y.isLinear()) ? y : copyArray(y);
+
+    af_array xcoords = getHandle<uint>(x_);
+    af_array ycoords = getHandle<uint>(y_);
+
     std::array<af_index_t, AF_MAX_DIMS> idxrs = {{{{xcoords}, false, false},
                                                   {{ycoords}, false, false},
                                                   createSpanIndex(),

--- a/src/backend/opencl/flood_fill.cpp
+++ b/src/backend/opencl/flood_fill.cpp
@@ -6,7 +6,6 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
-#include <iostream>
 
 #include <flood_fill.hpp>
 

--- a/src/backend/opencl/flood_fill.cpp
+++ b/src/backend/opencl/flood_fill.cpp
@@ -6,6 +6,7 @@
  * The complete license agreement can be obtained at:
  * http://arrayfire.com/licenses/BSD-3-Clause
  ********************************************************/
+#include <iostream>
 
 #include <flood_fill.hpp>
 

--- a/src/backend/opencl/kernel/flood_fill.cl
+++ b/src/backend/opencl/kernel/flood_fill.cl
@@ -23,8 +23,8 @@ kernel void init_seeds(global T *out, KParam oInfo, global const uint *seedsx,
                        KParam syInfo) {
     uint tid = get_global_id(0);
     if (tid < sxInfo.dims[0]) {
-        uint x                                             = seedsx[tid];
-        uint y                                             = seedsy[tid];
+        uint x                                             = seedsx[tid + sxInfo.offset];
+        uint y                                             = seedsy[tid + syInfo.offset];
         out[(x * oInfo.strides[0] + y * oInfo.strides[1])] = VALID;
     }
 }
@@ -76,14 +76,15 @@ kernel void flood_step(global T *out, KParam oInfo, global const T *img,
 
     T tImgVal =
         img[(clamp(gx, 0, (int)(iInfo.dims[0] - 1)) * iInfo.strides[0] +
-             clamp(gy, 0, (int)(iInfo.dims[1] - 1)) * iInfo.strides[1])];
+             clamp(gy, 0, (int)(iInfo.dims[1] - 1)) * iInfo.strides[1])+ 
+             iInfo.offset];
     const int isPxBtwnThresholds =
         (tImgVal >= lowValue && tImgVal <= highValue);
 
     int tid = lx + get_local_size(0) * ly;
 
     barrier(CLK_LOCAL_MEM_FENCE);
-
+    
     T origOutVal     = lmem[j][i];
     bool isBorderPxl = (lx == 0 || ly == 0 || lx == (get_local_size(0) - 1) ||
                         ly == (get_local_size(1) - 1));

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -244,10 +244,10 @@ bool noHalfTests(af::dtype ty);
     GTEST_SKIP() << "Device doesn't support Half"
 
 #ifdef SKIP_UNSUPPORTED_TESTS
-#define UNSUPPORTED_BACKEND(backend)                        \
-    if(backend == af::getActiveBackend())                   \
-        GTEST_SKIP() << "Skipping unsupported function on " \
-                        + getBackendName() + " backend"
+#define UNSUPPORTED_BACKEND(backend)                                         \
+    if (backend == af::getActiveBackend())                                   \
+    GTEST_SKIP() << "Skipping unsupported function on " + getBackendName() + \
+                        " backend"
 #else
 #define UNSUPPORTED_BACKEND(backend)
 #endif
@@ -652,6 +652,30 @@ void genTestOutputArray(af_array *out_ptr, double val, const unsigned ndims,
                                          std::string metadataName,
                                          const af_array a, const af_array b,
                                          TestOutputArrayInfo *metadata);
+
+enum tempFormat {
+    LINEAR_FORMAT,    // Linear array (= default)
+    JIT_FORMAT,       // Array which has JIT operations outstanding
+    SUB_FORMAT_dim0,  // Array where only a subset is allocated for dim0
+    SUB_FORMAT_dim1,  // Array where only a subset is allocated for dim1
+    SUB_FORMAT_dim2,  // Array where only a subset is allocated for dim2
+    SUB_FORMAT_dim3,  // Array where only a subset is allocated for dim3
+    REORDERED_FORMAT  // Array where the dimensions are reordered
+};
+// Calls the function fn for all available formats
+#define FOREACH_TEMP_FORMAT(TESTS) \
+    TESTS(LINEAR_FORMAT)           \
+    TESTS(JIT_FORMAT)              \
+    TESTS(SUB_FORMAT_dim0)         \
+    TESTS(SUB_FORMAT_dim1)         \
+    TESTS(SUB_FORMAT_dim2)         \
+    TESTS(SUB_FORMAT_dim3)         \
+    TESTS(REORDERED_FORMAT)
+
+// formats the "in" array according to provided format.  The content remains
+// unchanged.
+af::array toTempFormat(tempFormat form, const af::array &in);
+void toTempFormat(tempFormat form, af_array *out, const af_array &in);
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Using sub-arrays in the confidenceCC function results in undefined behaviour in the opencl backend.

Description
-----------
The offsets were not taken into account in the opencl backend:
- kernel flood_fill
- seeds array to index conversion

28bd6b0:
- Adds the the function toTempFormat to the test helpers. This function generates the different temporary array formats (JIT array, SUB-array, Linear array, ...) used by arrayfire.

6016fd8: 
- Adds the offset to the cl code files
- Copy the seeds (eliminates offset & makes linear) before passing to the index function
- Adds extra tests for scan.

Is this a new feature or a bug fix?
BUG
Why these changes are necessary.
PREVIOUSLY THE RESULT IS UNDEFINED FOR ABOVE SITUATION
Potential impact on specific hardware, software or backends.
OPENCL only  (Unsupported in ONEAPI)
New functions and their functionality.
NO
Can this PR be backported to older versions?
NO
Future changes not implemented in this PR.
NONE, although the function toTempFormat will be used in following PRs.

Changes to Users
----------------
Quality improvement.

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
