### PR TITLE
Fixed span lite add_subdirectory command missing build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,7 +316,7 @@ if(NOT TARGET nonstd::span-lite)
     URI https://github.com/martinmoene/span-lite
     REF "ccf2351"
     )
-  add_subdirectory(${span-lite_SOURCE_DIR} EXCLUDE_FROM_ALL)
+  add_subdirectory(${span-lite_SOURCE_DIR} ${span-lite_BINARY_DIR} EXCLUDE_FROM_ALL)
   get_property(span_include_dir
     TARGET span-lite
     PROPERTY INTERFACE_INCLUDE_DIRECTORIES)


### PR DESCRIPTION
When building arrayfire python wheels, the cmake build procedure complains of span lite missing an binary directory

Description
-----------
* Is this a new feature or a bug fix?: Bug fix

Changes to Users
----------------
* Additional options added to the build.
* What changes will existing users have to make to their code or build steps?: None

Checklist
---------
<!-- Check if done or not applicable -->
- [ ] Rebased on latest master
- [ ] Code compiles
- [ ] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
