### PR TITLE
Fixes sub array (opencl, cuda, cpu, oneapi) for orb

### DIFF
--- a/src/backend/common/KernelInterface.hpp
+++ b/src/backend/common/KernelInterface.hpp
@@ -64,6 +64,51 @@ class KernelInterface {
     virtual void copyToReadOnly(DevPtrType dst, DevPtrType src,
                                 size_t bytes) = 0;
 
+    /// \brief Copy data from device memory to read-only memory
+    ///
+    /// This function copies data of `bytes` size from the device pointer to a
+    /// read-only memory.
+    ///
+    /// \param[in] dst is the device pointer to which data will be copied
+    /// \param[in] src is the device pointer from which data will be copied
+    /// \param[in] srcXInBytes is offset in Bytes
+    /// \param[in] bytes are the number of bytes of data to be copied
+    virtual void copyToReadOnly(DevPtrType dst, DevPtrType src,
+                                size_t srcXInBytes, size_t bytes) = 0;
+
+    /// \brief Copy strided 2D data from device memory to read-only memory
+    ///
+    /// This function copies data of any 2D array from the device pointer to a
+    /// read-only memory.
+    ///
+    /// \param[in] dst is the device pointer to which data will be copied
+    /// \param[in] src is the device pointer from which data will be copied
+    /// \param[in] srcXInBytes is offset in Bytes
+    /// \param[in] srcPitchInBytes is strides[1] in Bytes
+    /// \param[in] height is the number of elements for dim[1] dst
+    /// \param[in] widthInBytes are #bytes of continous data to copy (dim[0])
+    virtual void copyToReadOnly2D(DevPtrType dst, DevPtrType src,
+                                  size_t srcXInBytes, size_t srcPitchInBytes,
+                                  size_t height, size_t widthInBytes) = 0;
+
+    /// \brief Copy strided 3D data from device memory to read-only memory
+    ///
+    /// This function copies data of any 3D array from the device pointer to a
+    /// read-only memory.
+    ///
+    /// \param[in] dst is the device pointer to which data will be copied
+    /// \param[in] src is the device pointer from which data will be copied
+    /// \param[in] srcXInBytes is offset in Bytes
+    /// \param[in] srcPitchInBytes is strides[1] in Bytes
+    /// \param[in] srcHeight is the number of elements ALLOCATED for dim[1] src
+    /// \param[in] depth is the number of elements for dim[2] dst
+    /// \param[in] height is the number of elements for dim[1] dst
+    /// \param[in] widthInBytes are #bytes of continous data to copy (dim[0])
+    virtual void copyToReadOnly3D(DevPtrType dst, DevPtrType src,
+                                  size_t srcXInBytes, size_t srcPitchInBytes,
+                                  size_t srcHeight, size_t depth, size_t height,
+                                  size_t widthInBytes) = 0;
+
     /// \brief Copy a single scalar to device memory
     ///
     /// This function copies a single value of type T from host variable

--- a/src/backend/cpu/kernel/convolve.hpp
+++ b/src/backend/cpu/kernel/convolve.hpp
@@ -125,8 +125,8 @@ void one2one_3d(InT *optr, InT const *const iptr, AccT const *const fptr,
                 }
                 optr[koff + joff + i - iStart] = InT(accum);
             }  // i loop ends here
-        }      // j loop ends here
-    }          // k loop ends here
+        }  // j loop ends here
+    }  // k loop ends here
 }
 
 template<typename InT, typename AccT>
@@ -217,7 +217,6 @@ void convolve2_separable(InT *optr, InT const *const iptr,
                          dim_t fDim, af::dim4 const &oStrides,
                          af::dim4 const &sStrides, dim_t fStride) {
     UNUSED(orgDims);
-    UNUSED(sStrides);
     UNUSED(fStride);
     for (dim_t j = 0; j < oDims[1]; ++j) {
         dim_t jOff = j * oStrides[1];
@@ -237,14 +236,18 @@ void convolve2_separable(InT *optr, InT const *const iptr,
                     dim_t offi     = ci - f;
                     bool isCIValid = offi >= 0 && offi < sDims[0];
                     bool isCJValid = cj >= 0 && cj < sDims[1];
-                    s_val = (isCJValid && isCIValid ? iptr[cj * sDims[0] + offi]
-                                                    : scalar<InT>(0));
+                    s_val =
+                        (isCJValid && isCIValid ? iptr[cj * sStrides.dims[1] +
+                                                       offi * sStrides.dims[0]]
+                                                : scalar<InT>(0));
                 } else {
                     dim_t offj     = cj - f;
                     bool isCIValid = ci >= 0 && ci < sDims[0];
                     bool isCJValid = offj >= 0 && offj < sDims[1];
-                    s_val = (isCJValid && isCIValid ? iptr[offj * sDims[0] + ci]
-                                                    : scalar<InT>(0));
+                    s_val =
+                        (isCJValid && isCIValid ? iptr[offj * sStrides.dims[1] +
+                                                       ci * sStrides.dims[0]]
+                                                : scalar<InT>(0));
                 }
 
                 accum += AccT(s_val * f_val);

--- a/src/backend/cuda/Kernel.cpp
+++ b/src/backend/cuda/Kernel.cpp
@@ -26,6 +26,67 @@ void Kernel::copyToReadOnly(Kernel::DevPtrType dst, Kernel::DevPtrType src,
     CU_CHECK(cuMemcpyDtoDAsync(dst, src, bytes, getActiveStream()));
 }
 
+void Kernel::copyToReadOnly(Kernel::DevPtrType dst, Kernel::DevPtrType src,
+                            size_t srcXInBytes, size_t bytes) {
+    CU_CHECK(cuMemcpyDtoDAsync(dst, src, bytes, getActiveStream()));
+}
+
+void Kernel::copyToReadOnly2D(Kernel::DevPtrType dst, Kernel::DevPtrType src,
+                              size_t srcXInBytes, size_t srcPitchInBytes,
+                              size_t height, size_t widthInBytes) {
+    CUDA_MEMCPY2D pCopy;
+    pCopy.srcXInBytes   = srcXInBytes;
+    pCopy.srcY          = 0;
+    pCopy.srcMemoryType = CU_MEMORYTYPE_DEVICE;
+    pCopy.srcDevice     = src;
+    pCopy.srcPitch      = srcPitchInBytes;
+
+    pCopy.dstXInBytes   = 0;
+    pCopy.dstY          = 0;
+    pCopy.dstMemoryType = CU_MEMORYTYPE_DEVICE;
+    pCopy.dstDevice     = dst;
+    pCopy.dstPitch      = widthInBytes;
+
+    pCopy.WidthInBytes = widthInBytes;
+    pCopy.Height       = height;
+    // CUdeviceptr srcStart = srcDevice + srcY*srcPitch + srcXInBytes;
+    // CUdeviceptr dstStart = dstDevice + dstY*dstPitch + dstXInBytes;
+
+    CU_CHECK(cuMemcpy2DAsync(&pCopy, getActiveStream()));
+}
+
+void Kernel::copyToReadOnly3D(Kernel::DevPtrType dst, Kernel::DevPtrType src,
+                              size_t srcXInBytes, size_t srcPitchInBytes,
+                              size_t srcHeight, size_t depth, size_t height,
+                              size_t widthInBytes) {
+    CUDA_MEMCPY3D pCopy;
+    pCopy.srcXInBytes   = srcXInBytes;
+    pCopy.srcY          = 0;
+    pCopy.srcZ          = 0;
+    pCopy.srcLOD        = 0;
+    pCopy.srcMemoryType = CU_MEMORYTYPE_DEVICE;
+    pCopy.srcDevice     = src;
+    pCopy.srcPitch      = srcPitchInBytes;
+    pCopy.srcHeight     = srcHeight;
+
+    pCopy.dstXInBytes   = 0;
+    pCopy.dstY          = 0;
+    pCopy.dstZ          = 0;
+    pCopy.dstMemoryType = CU_MEMORYTYPE_DEVICE;
+    pCopy.dstDevice     = dst;
+    pCopy.dstPitch      = widthInBytes;
+    pCopy.dstHeight     = height;
+
+    pCopy.WidthInBytes = widthInBytes;
+    pCopy.Height       = height;
+    pCopy.Depth        = depth;
+    // CUdeviceptr srcStart =
+    //      srcDevice + (srcZ*srcHeight+srcY)*srcPitch + srcXInBytes;
+    // CUdeviceptr dstStart =
+    //      dstDevice + (dstZ*dstHeight+dstY)*dstPitch + dstXInBytes;
+    CU_CHECK(cuMemcpy3DAsync(&pCopy, getActiveStream()));
+}
+
 void Kernel::setFlag(Kernel::DevPtrType dst, int* scalarValPtr,
                      const bool syncCopy) {
     CU_CHECK(

--- a/src/backend/cuda/Kernel.hpp
+++ b/src/backend/cuda/Kernel.hpp
@@ -66,6 +66,18 @@ class Kernel
 
     void copyToReadOnly(DevPtrType dst, DevPtrType src, size_t bytes) final;
 
+    void copyToReadOnly(DevPtrType dst, DevPtrType src, size_t srcXInBytes,
+                        size_t bytes) final;
+
+    void copyToReadOnly2D(DevPtrType dst, DevPtrType src, size_t srcXInBytes,
+                          size_t srcPitchInBytes, size_t height,
+                          size_t widthInBytes) final;
+
+    void copyToReadOnly3D(DevPtrType dst, DevPtrType src, size_t srcXInBytes,
+                          size_t srcPitchInBytes, size_t srcHeight,
+                          size_t depth, size_t height,
+                          size_t widthInBytes) final;
+
     void setFlag(DevPtrType dst, int* scalarValPtr,
                  const bool syncCopy = false) final;
 

--- a/src/backend/cuda/kernel/fast.hpp
+++ b/src/backend/cuda/kernel/fast.hpp
@@ -177,16 +177,17 @@ __device__ void load_shared_image(CParam<T> in, T *local_image, unsigned ix,
     // Copy an image patch to shared memory, with a 3-pixel edge
     if (ix < lx && iy < ly && x - 3 < in.dims[0] && y - 3 < in.dims[1]) {
         local_image[(ix) + (bx + 6) * (iy)] =
-            in.ptr[(x - 3) + in.dims[0] * (y - 3)];
+            in.ptr[in.strides[0] * (x - 3) + in.strides[1] * (y - 3)];
         if (x + lx - 3 < in.dims[0])
             local_image[(ix + lx) + (bx + 6) * (iy)] =
-                in.ptr[(x + lx - 3) + in.dims[0] * (y - 3)];
+                in.ptr[in.strides[0] * (x + lx - 3) + in.strides[1] * (y - 3)];
         if (y + ly - 3 < in.dims[1])
             local_image[(ix) + (bx + 6) * (iy + ly)] =
-                in.ptr[(x - 3) + in.dims[0] * (y + ly - 3)];
+                in.ptr[in.strides[0] * (x - 3) + in.strides[1] * (y + ly - 3)];
         if (x + lx - 3 < in.dims[0] && y + ly - 3 < in.dims[1])
             local_image[(ix + lx) + (bx + 6) * (iy + ly)] =
-                in.ptr[(x + lx - 3) + in.dims[0] * (y + ly - 3)];
+                in.ptr[in.strides[0] * (x + lx - 3) +
+                       in.strides[1] * (y + ly - 3)];
     }
 }
 

--- a/src/backend/cuda/kernel/orb.hpp
+++ b/src/backend/cuda/kernel/orb.hpp
@@ -125,10 +125,14 @@ __global__ void harris_response(float* score_out, float* size_out,
             int j = k % block_size - r;
 
             // Calculate local x and y derivatives
-            float ix = image.ptr[(x + i + 1) * image.dims[0] + y + j] -
-                       image.ptr[(x + i - 1) * image.dims[0] + y + j];
-            float iy = image.ptr[(x + i) * image.dims[0] + y + j + 1] -
-                       image.ptr[(x + i) * image.dims[0] + y + j - 1];
+            float ix = image.ptr[(x + i + 1) * image.strides[1] +
+                                 (y + j) * image.strides[0]] -
+                       image.ptr[(x + i - 1) * image.strides[1] +
+                                 (y + j) * image.strides[0]];
+            float iy = image.ptr[(x + i) * image.strides[1] +
+                                 (y + j + 1) * image.strides[0]] -
+                       image.ptr[(x + i) * image.strides[1] +
+                                 (y + j - 1) * image.strides[0]];
 
             // Accumulate second order derivatives
             ixx += ix * ix;
@@ -181,7 +185,8 @@ __global__ void centroid_angle(const float* x_in, const float* y_in,
             int j = k % patch_size - r;
 
             // Calculate first order moments
-            T p = image.ptr[(x + i) * image.dims[0] + y + j];
+            T p = image.ptr[(x + i) * image.strides[1] +
+                            (y + j) * image.strides[0]];
             m01 += j * p;
             m10 += i * p;
         }
@@ -209,7 +214,7 @@ inline __device__ T get_pixel(unsigned x, unsigned y, const float ori,
     x += round(dist_x * patch_scl * ori_cos - dist_y * patch_scl * ori_sin);
     y += round(dist_x * patch_scl * ori_sin + dist_y * patch_scl * ori_cos);
 
-    return image.ptr[x * image.dims[0] + y];
+    return image.ptr[x * image.strides[1] + y * image.strides[0]];
 }
 
 inline __device__ int lookup(const int n, cudaTextureObject_t tex) {

--- a/src/backend/opencl/Kernel.cpp
+++ b/src/backend/opencl/Kernel.cpp
@@ -27,6 +27,55 @@ void Kernel::copyToReadOnly(Kernel::DevPtrType dst, Kernel::DevPtrType src,
     getQueue().enqueueCopyBuffer(*src, *dst, 0, 0, bytes);
 }
 
+void Kernel::copyToReadOnly(Kernel::DevPtrType dst, Kernel::DevPtrType src,
+                            size_t srcXInBytes, size_t bytes) {
+    getQueue().enqueueCopyBuffer(*src, *dst, srcXInBytes, 0, bytes);
+}
+
+void Kernel::copyToReadOnly2D(Kernel::DevPtrType dst, Kernel::DevPtrType src,
+                              size_t srcXInBytes, size_t srcPitchInBytes,
+                              size_t height, size_t widthInBytes) {
+    std::array<size_t, 3> src_origin = {srcXInBytes, 0, 0};
+    size_t src_row_pitch             = {srcPitchInBytes};
+    size_t src_slice_pitch           = {0};
+
+    std::array<size_t, 3> dst_origin = {0, 0, 0};
+    size_t dst_row_pitch             = {widthInBytes};
+    size_t dst_slice_pitch           = {0};
+
+    std::array<size_t, 3> region = {widthInBytes, height, 1};
+
+    // offset in bytes =
+    // src_origin[1]*src_row_pitch + src_origin[0]
+
+    getQueue().enqueueCopyBufferRect(*src, *dst, src_origin, dst_origin, region,
+                                     src_row_pitch, src_slice_pitch,
+                                     dst_row_pitch, dst_slice_pitch);
+}
+
+void Kernel::copyToReadOnly3D(Kernel::DevPtrType dst, Kernel::DevPtrType src,
+                              size_t srcXInBytes, size_t srcPitchInBytes,
+                              size_t srcHeight, size_t depth, size_t height,
+                              size_t widthInBytes) {
+    std::array<size_t, 3> src_origin = {srcXInBytes, 0, 0};
+    size_t src_row_pitch             = {srcPitchInBytes};
+    size_t src_slice_pitch           = {srcHeight * srcPitchInBytes};
+
+    std::array<size_t, 3> dst_origin = {0, 0, 0};
+    size_t dst_row_pitch             = {widthInBytes};
+    size_t dst_slice_pitch           = {height * widthInBytes};
+
+    std::array<size_t, 3> region = {widthInBytes, height, depth};
+
+    // offset in bytes =
+    // src_origin[2]*src_slice_pitch + src_origin[1]*src_row_pitch +
+    // src_origin[0]
+
+    getQueue().enqueueCopyBufferRect(*src, *dst, src_origin, dst_origin, region,
+                                     src_row_pitch, src_slice_pitch,
+                                     dst_row_pitch, dst_slice_pitch);
+}
+
 void Kernel::setFlag(Kernel::DevPtrType dst, int* scalarValPtr,
                      const bool syncCopy) {
     UNUSED(syncCopy);

--- a/src/backend/opencl/Kernel.hpp
+++ b/src/backend/opencl/Kernel.hpp
@@ -54,6 +54,18 @@ class Kernel
 
     void copyToReadOnly(DevPtrType dst, DevPtrType src, size_t bytes) final;
 
+    void copyToReadOnly(DevPtrType dst, DevPtrType src, size_t srcXInBytes,
+                        size_t bytes) final;
+
+    void copyToReadOnly2D(DevPtrType dst, DevPtrType src, size_t srcXInBytes,
+                          size_t srcPitchInBytes, size_t height,
+                          size_t widthInBytes) final;
+
+    void copyToReadOnly3D(DevPtrType dst, DevPtrType src, size_t srcXInBytes,
+                          size_t srcPitchInBytes, size_t srcHeight,
+                          size_t depth, size_t height,
+                          size_t widthInBytes) final;
+
     void setFlag(DevPtrType dst, int* scalarValPtr,
                  const bool syncCopy = false) final;
 

--- a/src/backend/opencl/kernel/convolve/conv1.cpp
+++ b/src/backend/opencl/kernel/convolve/conv1.cpp
@@ -18,22 +18,16 @@ void conv1(conv_kparam_t& p, Param& out, const Param& sig, const Param& filt,
            const bool expand) {
     size_t se_size = filt.info.dims[0] * sizeof(aT);
     p.impulse      = bufferAlloc(se_size);
-    int f0Off      = filt.info.offset;
+    dim_t f0Off    = filt.info.offset;
 
     for (int b3 = 0; b3 < filt.info.dims[3]; ++b3) {
-        int f3Off = b3 * filt.info.strides[3];
+        dim_t f3Off = b3 * filt.info.strides[3];
 
         for (int b2 = 0; b2 < filt.info.dims[2]; ++b2) {
-            int f2Off = b2 * filt.info.strides[2];
+            dim_t f2Off = b2 * filt.info.strides[2];
 
             for (int b1 = 0; b1 < filt.info.dims[1]; ++b1) {
-                int f1Off = b1 * filt.info.strides[1];
-
-                // FIXME: if the filter array is strided, direct copy of symbols
-                // might cause issues
-                getQueue().enqueueCopyBuffer(
-                    *filt.data, *p.impulse,
-                    (f0Off + f1Off + f2Off + f3Off) * sizeof(aT), 0, se_size);
+                dim_t f1Off = b1 * filt.info.strides[1];
 
                 p.o[0] = (p.outHasNoOffset ? 0 : b1);
                 p.o[1] = (p.outHasNoOffset ? 0 : b2);
@@ -42,7 +36,9 @@ void conv1(conv_kparam_t& p, Param& out, const Param& sig, const Param& filt,
                 p.s[1] = (p.inHasNoOffset ? 0 : b2);
                 p.s[2] = (p.inHasNoOffset ? 0 : b3);
 
-                convNHelper<T, aT>(p, out, sig, filt, 1, expand);
+                convNHelper<T, aT>(p, out, sig, filt,
+                                   (f0Off + f1Off + f2Off + f3Off) * sizeof(aT),
+                                   1, expand);
             }
         }
     }

--- a/src/backend/opencl/kernel/convolve/conv3.cpp
+++ b/src/backend/opencl/kernel/convolve/conv3.cpp
@@ -23,15 +23,11 @@ void conv3(conv_kparam_t& p, Param& out, const Param& sig, const Param& filt,
 
     for (int b3 = 0; b3 < filt.info.dims[3]; ++b3) {
         int f3Off = b3 * filt.info.strides[3];
-        // FIXME: if the filter array is strided, direct copy of symbols
-        // might cause issues
-        getQueue().enqueueCopyBuffer(*filt.data, *p.impulse,
-                                     (f0Off + f3Off) * sizeof(aT), 0, se_size);
+        p.o[2]    = (p.outHasNoOffset ? 0 : b3);
+        p.s[2]    = (p.inHasNoOffset ? 0 : b3);
 
-        p.o[2] = (p.outHasNoOffset ? 0 : b3);
-        p.s[2] = (p.inHasNoOffset ? 0 : b3);
-
-        convNHelper<T, aT>(p, out, sig, filt, 3, expand);
+        convNHelper<T, aT>(p, out, sig, filt, (f0Off + f3Off) * sizeof(aT), 3,
+                           expand);
     }
 }
 

--- a/src/backend/opencl/kernel/fast.cl
+++ b/src/backend/opencl/kernel/fast.cl
@@ -129,17 +129,18 @@ void load_shared_image(global const T* in, KParam iInfo,
                        unsigned lx, unsigned ly) {
     // Copy an image patch to shared memory, with a 3-pixel edge
     if (ix < lx && iy < ly && x - 3 < iInfo.dims[0] && y - 3 < iInfo.dims[1]) {
+        in += iInfo.offset;
         local_image[(ix) + (bx + 6) * (iy)] =
-            in[(x - 3) + iInfo.dims[0] * (y - 3)];
+            in[(x - 3) * iInfo.strides[0] + (y - 3) * iInfo.strides[1]];
         if (x + lx - 3 < iInfo.dims[0])
             local_image[(ix + lx) + (bx + 6) * (iy)] =
-                in[(x + lx - 3) + iInfo.dims[0] * (y - 3)];
+                in[(x + lx -3) * iInfo.strides[0] + (y - 3) * iInfo.strides[1]];
         if (y + ly - 3 < iInfo.dims[1])
             local_image[(ix) + (bx + 6) * (iy + ly)] =
-                in[(x - 3) + iInfo.dims[0] * (y + ly - 3)];
+                in[(x - 3) * iInfo.strides[0] + (y + ly - 3) * iInfo.strides[1]];
         if (x + lx - 3 < iInfo.dims[0] && y + ly - 3 < iInfo.dims[1])
             local_image[(ix + lx) + (bx + 6) * (iy + ly)] =
-                in[(x + lx - 3) + iInfo.dims[0] * (y + ly - 3)];
+                in[(x + lx - 3) * iInfo.strides[0] + (y + ly - 3) * iInfo.strides[1]];
     }
 }
 
@@ -155,7 +156,7 @@ kernel void locate_features(global const T* in, KParam iInfo,
     unsigned lx = bx / 2 + 3;
     unsigned ly = by / 2 + 3;
 
-    load_shared_image(in + iInfo.offset, iInfo, local_image, ix, iy, bx, by, x,
+    load_shared_image(in, iInfo, local_image, ix, iy, bx, by, x,
                       y, lx, ly);
     barrier(CLK_LOCAL_MEM_FENCE);
     locate_features_core(local_image, score, iInfo, thr, x, y, edge);

--- a/src/backend/opencl/kernel/orb.hpp
+++ b/src/backend/opencl/kernel/orb.hpp
@@ -327,13 +327,14 @@ void orb(unsigned* out_feat, Param& x_out, Param& y_out, Param& score_out,
         Param lvl_tmp;
 
         if (blur_img) {
-            lvl_filt = lvl_img;
-            lvl_tmp  = lvl_img;
+            const dim_t pixels = lvl_img.info.dims[0] * lvl_img.info.dims[1];
+            lvl_filt.info = {{lvl_img.info.dims[0], lvl_img.info.dims[1], 1, 1},
+                             {1, lvl_img.info.dims[0], pixels, pixels},
+                             0};
+            lvl_filt.data = bufferAlloc(pixels * sizeof(T));
 
-            lvl_filt.data = bufferAlloc(lvl_filt.info.dims[0] *
-                                        lvl_filt.info.dims[1] * sizeof(T));
-            lvl_tmp.data  = bufferAlloc(lvl_tmp.info.dims[0] *
-                                        lvl_tmp.info.dims[1] * sizeof(T));
+            lvl_tmp.info = lvl_filt.info;
+            lvl_tmp.data = bufferAlloc(pixels * sizeof(T));
 
             // Calculate a separable Gaussian kernel
             if (h_gauss == nullptr) {

--- a/test/testHelpers.hpp
+++ b/test/testHelpers.hpp
@@ -244,10 +244,10 @@ bool noHalfTests(af::dtype ty);
     GTEST_SKIP() << "Device doesn't support Half"
 
 #ifdef SKIP_UNSUPPORTED_TESTS
-#define UNSUPPORTED_BACKEND(backend)                        \
-    if(backend == af::getActiveBackend())                   \
-        GTEST_SKIP() << "Skipping unsupported function on " \
-                        + getBackendName() + " backend"
+#define UNSUPPORTED_BACKEND(backend)                                         \
+    if (backend == af::getActiveBackend())                                   \
+    GTEST_SKIP() << "Skipping unsupported function on " + getBackendName() + \
+                        " backend"
 #else
 #define UNSUPPORTED_BACKEND(backend)
 #endif
@@ -652,6 +652,30 @@ void genTestOutputArray(af_array *out_ptr, double val, const unsigned ndims,
                                          std::string metadataName,
                                          const af_array a, const af_array b,
                                          TestOutputArrayInfo *metadata);
+
+enum tempFormat {
+    LINEAR_FORMAT,    // Linear array (= default)
+    JIT_FORMAT,       // Array which has JIT operations outstanding
+    SUB_FORMAT_dim0,  // Array where only a subset is allocated for dim0
+    SUB_FORMAT_dim1,  // Array where only a subset is allocated for dim1
+    SUB_FORMAT_dim2,  // Array where only a subset is allocated for dim2
+    SUB_FORMAT_dim3,  // Array where only a subset is allocated for dim3
+    REORDERED_FORMAT  // Array where the dimensions are reordered
+};
+// Calls the function fn for all available formats
+#define FOREACH_TEMP_FORMAT(TESTS) \
+    TESTS(LINEAR_FORMAT)           \
+    TESTS(JIT_FORMAT)              \
+    TESTS(SUB_FORMAT_dim0)         \
+    TESTS(SUB_FORMAT_dim1)         \
+    TESTS(SUB_FORMAT_dim2)         \
+    TESTS(SUB_FORMAT_dim3)         \
+    TESTS(REORDERED_FORMAT)
+
+// formats the "in" array according to provided format.  The content remains
+// unchanged.
+af::array toTempFormat(tempFormat form, const af::array &in);
+void toTempFormat(tempFormat form, af_array *out, const af_array &in);
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Using sub-arrays in the orb function results in undefined behaviour in the opencl, cpu and cuda backend.

Description
-----------
Using sub-arrays for input as filters generates random behaviour.

The orb function uses following sub functions, which needed individual sub-array testing (and corrections if needed):

resize(): Works as expected.  A final PR will contain all extended test scripts that did not need corrections.

[28bd6b0](https://github.com/arrayfire/arrayfire/commit/28bd6b0f092b12e25fc313c0ab64307ee5bb2176): Adds test helpers for temporary array formats (JIT, SUB, ...)
Adds the the function toTempFormat to the test helpers. This function generates the different temporary array formats (JIT array, SUB-array, Linear array, ...) used by arrayfire.

[07b089f](https://github.com/arrayfire/arrayfire/pull/3670/commits/07b089f77f89577a38026ed9b509065be3960825): Increased difficulty of sub-array testing
Some random behaviour persisted so the test conditions are harder now for sub-arrays
    - When using without the offset, the full array will be random data
    - When reallocating a data buffer based on dim[0]*dim[1]... size, while reusing the info structure, the buffer will be accessed outside boundaries (hoping this generates a segmentation fault)

[1a4358c](https://github.com/arrayfire/arrayfire/pull/3670/commits/1a4358ceaa856031d61458bd32054e3f445d5edf): Fixes sub-array (cuda, opencl) support for harris
    - Linear temporary buffers copied the info struct from in, while they are linear and in is strided.
    - second_order_deriv kernel was called with blocksize based on #elements of parent of in, iso in (dim[3]*strides[3])
    - many memory allocations were based on #elements of parent of in, iso in (dim[3] * strides[3])

[1fd4bfd](https://github.com/arrayfire/arrayfire/pull/3670/commits/1fd4bfd8e3bcc86e9f18b943a31a9c4d7a78bc6c): Fixes sub-array (cpu, cuda, opencl) support for fast
cuda & cpu:
    - in idx(), test_pixel(), the elements of in were directly (linear) accessed without using strides
opencl:
    - in load_shared_image() ,the elements of in were directly (linear) accessed without using strides and offset

[2e72a4d](https://github.com/arrayfire/arrayfire/pull/3670/commits/2e72a4d1ce3ac7d4853ce20f741c871b3fa0b017): Fixes sub-array (cpu, cuda, opencl, oneapi) support for convolve
    - Kernel object is extended with 2D and 3D memory copy functions
cuda:
    - in conv2Helper(), the elements of in were directly (linear) accessed without using strides
    - In conv2Helper(), the strided 2D memcopy function is added when needed
    - in convolve_3d, convolve2(), the linear memcopy is replaced with strided 3D memcopy function
opencl:
    - in conv1(), conv2(), conv3() the linear memcopy is grouped into convNHelper<> function (same structure as in cuda, ...)
    - in convNHelper<> the linear memcopy is replaced with strided one
    - In conv2Helper(), convSep() the strided 2D memcopy function is added when needed
cpu:
    - in convolve2_separable(), the elements of in were directly (linear) accessed without using strides
oneapi:
    - local defined linear memcopy function (included also conversion) is replaced by the strided memory function defined in kernel/memcopy.hpp.  This strided function is also optimized for linear copies and performs only copy without conversions.  (improved speed)
    - in conv1(), conv2(), conv3(), convSep() linear copy replace with strided one

[ad1413f](https://github.com/arrayfire/arrayfire/pull/3670/commits/ad1413ff8ada13622951eeeea475eb49c3d7b01b): Fixes sub-array (cpu, cuda, opencl, oneapi) support for orb
    - in harris_response(), controid_angle(), get_pixel() the elements of in were directly (linear) accessed without using strides
    - Adds the offset to the cl code files
    - in orb (opencl) the info struct was reused, while the buffer allocation was linear

Is this a new feature or a bug fix?
BUG
Why these changes are necessary.
PREVIOUSLY THE RESULT IS UNDEFINED FOR ABOVE SITUATION
Potential impact on specific hardware, software or backends.
ALL platforms (ONEAPI is not supporting orb)
New functions and their functionality.
NO
Can this PR be backported to older versions?
NO
Future changes not implemented in this PR.
NONE, although the function toTempFormat will be used in following PRs.


Changes to Users
----------------
Quality improvement

Checklist
---------
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
