### PR TITLE
Fix for evaluation containing array and its inverse.

### DIFF
--- a/src/backend/common/jit/BufferNodeBase.hpp
+++ b/src/backend/common/jit/BufferNodeBase.hpp
@@ -119,6 +119,18 @@ class BufferNodeBase : public common::Node {
         }
         return false;
     }
+
+    virtual void modDims(const af::dim4 &newDim) override {
+        af::dim4 strides(1, 1, 1, 1);
+        for(dim_t i = 1; i < 4; ++i) {
+            strides[i] = strides[i - 1] * newDim[i - 1];
+        }
+
+        for(dim_t i = 0; i < 4; ++i) {
+            m_param.dims[i] = newDim[i];
+            m_param.strides[i] = strides[i];
+        }
+    }
 };
 
 }  // namespace common

--- a/src/backend/common/jit/Node.hpp
+++ b/src/backend/common/jit/Node.hpp
@@ -13,6 +13,7 @@
 #include <optypes.hpp>
 #include <types.hpp>
 #include <af/defines.h>
+#include <af/dim4.hpp>
 
 #include <nonstd/span.hpp>
 #include <algorithm>
@@ -310,6 +311,10 @@ class Node {
         return this == &other;
     }
     virtual std::unique_ptr<Node> clone() = 0;
+
+    virtual void modDims(const af::dim4 &newDim) {
+        UNUSED(newDim);
+    }
 
 #ifdef AF_CPU
     template<typename U>

--- a/src/backend/cpu/jit/BufferNode.hpp
+++ b/src/backend/cpu/jit/BufferNode.hpp
@@ -175,6 +175,19 @@ class BufferNode : public TNode<T> {
         }
         return false;
     }
+
+    virtual void modDims(const af::dim4 &newDim) override {
+        af::dim4 strides(1, 1, 1, 1);
+        for(dim_t i = 1; i < 4; ++i) {
+            strides[i] = strides[i - 1] * newDim[i - 1];
+        }
+
+        for(dim_t i = 0; i < 4; ++i) {
+            m_dims[i] = newDim[i];
+            m_strides[i] = strides[i];
+        }
+    }
+
 };
 
 }  // namespace jit

--- a/src/backend/cuda/jit/BufferNode.hpp
+++ b/src/backend/cuda/jit/BufferNode.hpp
@@ -27,7 +27,16 @@ bool BufferNodeBase<DataType, ParamType>::operator==(
     // clang-format off
     return m_data.get() == other.m_data.get() &&
            m_bytes == other.m_bytes &&
-           m_param.ptr == other.m_param.ptr;
+           m_param.ptr == other.m_param.ptr &&
+           m_linear_buffer == other.m_linear_buffer &&
+           m_param.dims[0] == other.m_param.dims[0] &&
+           m_param.dims[1] == other.m_param.dims[1] &&
+           m_param.dims[2] == other.m_param.dims[2] &&
+           m_param.dims[3] == other.m_param.dims[3] &&
+           m_param.strides[0] == other.m_param.strides[0] &&
+           m_param.strides[1] == other.m_param.strides[1] &&
+           m_param.strides[2] == other.m_param.strides[2] &&
+           m_param.strides[3] == other.m_param.strides[3];
     // clang-format on
 }
 

--- a/src/backend/oneapi/jit/BufferNode.hpp
+++ b/src/backend/oneapi/jit/BufferNode.hpp
@@ -31,7 +31,16 @@ bool BufferNodeBase<DataType, ParamType>::operator==(
     // clang-format off
     return m_data.get() == other.m_data.get() &&
            m_bytes == other.m_bytes &&
-           m_param.offset == other.m_param.offset;
+           m_param.offset == other.m_param.offset &&
+           m_linear_buffer == other.m_linear_buffer &&
+           m_param.dims[0] == other.m_param.dims[0] &&
+           m_param.dims[1] == other.m_param.dims[1] &&
+           m_param.dims[2] == other.m_param.dims[2] &&
+           m_param.dims[3] == other.m_param.dims[3] &&
+           m_param.strides[0] == other.m_param.strides[0] &&
+           m_param.strides[1] == other.m_param.strides[1] &&
+           m_param.strides[2] == other.m_param.strides[2] &&
+           m_param.strides[3] == other.m_param.strides[3];
     // clang-format on
 }
 

--- a/src/backend/opencl/jit/BufferNode.hpp
+++ b/src/backend/opencl/jit/BufferNode.hpp
@@ -28,7 +28,16 @@ bool BufferNodeBase<DataType, ParamType>::operator==(
     // clang-format off
     return m_data.get() == other.m_data.get() &&
            m_bytes == other.m_bytes &&
-           m_param.offset == other.m_param.offset;
+           m_param.offset == other.m_param.offset &&
+           m_linear_buffer == other.m_linear_buffer &&
+           m_param.dims[0] == other.m_param.dims[0] &&
+           m_param.dims[1] == other.m_param.dims[1] &&
+           m_param.dims[2] == other.m_param.dims[2] &&
+           m_param.dims[3] == other.m_param.dims[3] &&
+           m_param.strides[0] == other.m_param.strides[0] &&
+           m_param.strides[1] == other.m_param.strides[1] &&
+           m_param.strides[2] == other.m_param.strides[2] &&
+           m_param.strides[3] == other.m_param.strides[3];
     // clang-format on
 }
 


### PR DESCRIPTION
A bug was found in the jit calculation tree where under certain circumstances the incorrect result would be found when both an array and a transpose of the same array are used in the same evaluation. When the transpose method is used on an array the treatment depends on the structure of the jit tree of that array. In the particular case that the array is linear (e.g. not a sub-array) and is not simply a buffer (i.e. a combination of buffers and/or scalars with some operators) a moddim node will be added to the root of the tree with the new dimensions. When the tree is evaluated the dimensions of the child buffer(s) of a moddim node are changed and the moddim node is deleted. If an evaluation happens to include both an array and the transpose of that same array then when the moddim node is applied it changes the dimensions of the children for the remaining lifetime of the evaluation including any subsequent use of these nodes. As a result if the transpose of an array is used in an expression followed by the array itself the second instance will also be transposed.

In this fix instead of creating a moddims node a deep copy of the calculation tree is made at that point with the transpose applied to the child buffer nodes. These buffer node copies will have the transposed dimensions and strides but will still point to the same memory location for the data so no copy of the underlying data needs to be made.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
