### PR TITLE
Fix half precision pow function for oneAPI back end

### DIFF
--- a/src/backend/oneapi/binary.hpp
+++ b/src/backend/oneapi/binary.hpp
@@ -9,6 +9,9 @@
 
 #pragma once
 #include <optypes.hpp>
+#include <common/half.hpp>
+
+using arrayfire::common::half;
 
 namespace arrayfire {
 namespace oneapi {
@@ -93,6 +96,7 @@ struct BinOp<To, Ti, af_pow_t> {
 
 POW_BINARY_OP(double, "pow")
 POW_BINARY_OP(float, "pow")
+POW_BINARY_OP(half, "pow")
 POW_BINARY_OP(intl, "__powll")
 POW_BINARY_OP(uintl, "__powul")
 POW_BINARY_OP(uint, "__powui")

--- a/src/backend/opencl/binary.hpp
+++ b/src/backend/opencl/binary.hpp
@@ -9,9 +9,6 @@
 
 #pragma once
 #include <optypes.hpp>
-#include <common/half.hpp>
-  
-using arrayfire::common::half;
 
 namespace arrayfire {
 namespace opencl {
@@ -101,7 +98,6 @@ struct BinOp<To, Ti, af_pow_t> {
 
 POW_BINARY_OP(double, "pow")
 POW_BINARY_OP(float, "pow")
-POW_BINARY_OP(half, "pow")
 POW_BINARY_OP(intl, "__powll")
 POW_BINARY_OP(uintl, "__powul")
 POW_BINARY_OP(uint, "__powui")

--- a/src/backend/opencl/binary.hpp
+++ b/src/backend/opencl/binary.hpp
@@ -9,6 +9,9 @@
 
 #pragma once
 #include <optypes.hpp>
+#include <common/half.hpp>
+  
+using arrayfire::common::half;
 
 namespace arrayfire {
 namespace opencl {
@@ -98,6 +101,7 @@ struct BinOp<To, Ti, af_pow_t> {
 
 POW_BINARY_OP(double, "pow")
 POW_BINARY_OP(float, "pow")
+POW_BINARY_OP(half, "pow")
 POW_BINARY_OP(intl, "__powll")
 POW_BINARY_OP(uintl, "__powul")
 POW_BINARY_OP(uint, "__powui")


### PR DESCRIPTION
An incorrect power function was being used for half precision variables when building the JIT kernel for the oneAPI back end which lead to a fallback to an integer power function causing the result to be rounded. This fixes that.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
