### PR TITLE
Fix half precision pow function for openCL backend

### DIFF
--- a/src/backend/opencl/binary.hpp
+++ b/src/backend/opencl/binary.hpp
@@ -9,6 +9,9 @@
 
 #pragma once
 #include <optypes.hpp>
+#include <common/half.hpp>
+
+using arrayfire::common::half;
 
 namespace arrayfire {
 namespace opencl {
@@ -98,6 +101,7 @@ struct BinOp<To, Ti, af_pow_t> {
 
 POW_BINARY_OP(double, "pow")
 POW_BINARY_OP(float, "pow")
+POW_BINARY_OP(half, "pow")
 POW_BINARY_OP(intl, "__powll")
 POW_BINARY_OP(uintl, "__powul")
 POW_BINARY_OP(uint, "__powui")


### PR DESCRIPTION
An incorrect power function was being used for half precision variables when building the JIT kernel for the OpenCL backend. Fixes failures on binary and norm failures

Description
-----------

* Is this a new feature or a bug fix? Bug fix
* Potential impact on specific hardware, software or backends: OpenCL
* Can this PR be backported to older versions? Yes
* Future changes not implemented in this PR: None

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
