### PR TITLE
Revert clBlast version to original reference.

### DIFF
--- a/CMakeModules/build_CLBlast.cmake
+++ b/CMakeModules/build_CLBlast.cmake
@@ -24,9 +24,10 @@ if(TARGET clblast OR AF_WITH_EXTERNAL_PACKAGES_ONLY)
     message(ERROR "CLBlast now found")
   endif()
 else()
+  # This specific reference passes tests
   af_dep_check_and_populate(${clblast_prefix}
     URI https://github.com/cnugteren/CLBlast.git
-    REF 1.6.3
+    REF 4500a03440e2cc54998c0edab366babf5e504d67
   )
 
   include(ExternalProject)


### PR DESCRIPTION
Newer versions are causing some test failures in the Cholesky decomposition.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
