### PR TITLE
Fixed topk for half, marked sort_index with half unsupported

### DIFF
--- a/src/backend/opencl/sort_index.cpp
+++ b/src/backend/opencl/sort_index.cpp
@@ -25,6 +25,12 @@ namespace opencl {
 template<typename T>
 void sort_index(Array<T> &okey, Array<uint> &oval, const Array<T> &in,
                 const uint dim, bool isAscending) {
+    
+    // TODO: fix half implementation of sort0bykey to support this
+    if (std::is_same_v<T, half>) {
+        OPENCL_NOT_SUPPORTED("sort_index with half");
+    }
+
     try {
         // okey contains values, oval contains indices
         okey = copyArray<T>(in);


### PR DESCRIPTION
Fix for topk with half input. Added unsupported error when calling sort_index with half

Description
-----------

* Is this a new feature or a bug fix? Bug fix
* Potential impact on specific hardware, software or backends: OpenCL backend
* New functions and their functionality: support for topk half
* Can this PR be backported to older versions?
* Future changes not implemented in this PR.

Fixes: #3675 

Changes to Users
----------------
* Additional options added to the build: None
* What changes will existing users have to make to their code or build steps? None

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
