### PR TITLE
'not' keyword not recognized in msvc

### DIFF
--- a/test/arrayfire_test.cpp
+++ b/test/arrayfire_test.cpp
@@ -2063,13 +2063,13 @@ af::array toTempFormat(tempFormat form, const af::array &in) {
     switch (form) {
         case JIT_FORMAT:
             switch (in.type()) {
-                case b8: ret = not(in); break;
+                case b8: ret = !(in); break;
                 default: ret = in * 2;
             }
             // Make sure that the base array is <> form original
             ret.eval();
             switch (in.type()) {
-                case b8: ret = not(ret); break;
+                case b8: ret = !(ret); break;
                 default: ret /= 2;
             }
             break;


### PR DESCRIPTION
Some versions of msvc do not recognize 'not' causing compilation errors.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [x] Functions added to unified API
- [x] Functions documented
