### PR TITLE
Don't restart automatically after installing VC redistributable

### DIFF
--- a/CMakeModules/nsis/NSIS.template.in
+++ b/CMakeModules/nsis/NSIS.template.in
@@ -741,7 +741,7 @@ Section "-Core installation"
 SectionEnd
 
 Section "-Visual C++ installation"
-  ExecWait "$INSTDIR\lib\vc_redist.x64.exe /install /passive"
+  ExecWait "$INSTDIR\lib\vc_redist.x64.exe /install /passive /norestart"
   Delete "$INSTDIR\lib\vc_redist.x64.exe"
 SectionEnd
 


### PR DESCRIPTION
Add flag to VC redistributable installer to prevent it from restarting the computer automatically without prompting the user.