### PR TITLE
Fixes to mean and better precision on sum (cpu)

### DIFF
--- a/src/backend/opencl/kernel/mean_ops.cl
+++ b/src/backend/opencl/kernel/mean_ops.cl
@@ -10,12 +10,37 @@
 To transform(Ti in) { return (To)(in); }
 
 void binOp(To *lhs, Tw *l_wt, To rhs, Tw r_wt) {
-    if (((*l_wt) != 0) || (r_wt != 0)) {
-        Tw l_scale = (*l_wt);
-        (*l_wt) += r_wt;
+    Tw l_scale = (*l_wt);
+    (*l_wt) += (r_wt);
+    if (((*l_wt) != 0) || ((r_wt) != 0)) {
         l_scale = l_scale / (*l_wt);
 
-        Tw r_scale = r_wt / (*l_wt);
-        (*lhs)     = (l_scale * (*lhs)) + (r_scale * rhs);
+        Tw r_scale = (r_wt) / (*l_wt);
+        (*lhs)     = (l_scale * (*lhs)) + (r_scale * (rhs));
+    }
+}
+
+//
+// Since only 1 pass is used, the rounding errors will become important because
+// the longer the serie the larger the difference between the 2 numbers to sum
+// See: https://en.wikipedia.org/wiki/Kahan_summation_algorithm to reduce this
+// error
+void binOpWithCorr(To *c, To *lhs, Tw *l_wt, To rhs, Tw r_wt) {
+    (*l_wt) += (r_wt);
+    if (((*l_wt) != 0) || ((r_wt) != 0)) {
+        // (*lhs) = (*lhs) + ((rhs) - (*lhs)) * ((r_wt) / (*l_wt));
+
+        // *c is zero for the first time around
+        To y = ((rhs) - (*lhs)) * ((r_wt) / (*l_wt)) - (*c);
+        // Alas, (*lhs) is big, y small, so low-order digits of y are lost
+        To t = (*lhs) + y;
+        // (t - (*lhs)) cancels the high-order part of y
+        // subtracting y recovers negative (low part of y)
+        (*c) = (t - (*lhs)) - y;
+        // Algebraically, *c should always be zero.  Beware overly-agressive
+        // optimizing compilers!
+        (*lhs) = t;
+        // Next time around, the lost low part will be added to y in a fresh
+        // attempt
     }
 }


### PR DESCRIPTION
When strided weights are used, the mean function typically returned random results.
The produced result of mean is no longer dependent on platform or processing style (linear, strided, on CPU or GPU)

Description
-----------
https://github.com/arrayfire/arrayfire/commit/b74f28f6b9137fadaa42538aa24476fc3ae6a491 [sum on CPU now has the same precision as other platforms](https://github.com/arrayfire/arrayfire/commit/b74f28f6b9137fadaa42538aa24476fc3ae6a491)
* Introduction of Kahan summation algorithm for series.  This algorithm reduced the error when a series of summations are performed with values of varying sizes.
With this introduction, the difference in result of a linear array and strided array is minimal.  The precision in the tests are as a result improved.
As result, the precision of many tests can be improved now since all platforms generate similar results, independent from parallel or serial processing.

https://github.com/arrayfire/arrayfire/commit/9307d6f08b740f694c9f8df19b1e23727e2ed9b0 [Fixes to mean, on all platforms](https://github.com/arrayfire/arrayfire/commit/9307d6f08b740f694c9f8df19b1e23727e2ed9b0)
All: 
* Introduction of Kahan summation algorithm for series.  This algorithm reduced the error when a series of summations are performed with values of varying sizes.
With this introduction, the difference in result of a linear array and strided array is minimal.  The precision in the tests are as a result improved.
* Negative weights can no longer generate a division by zero.
* In most cases sub-arrays would generated random results with strided weights.

CPU:
   - the idxs of the weights array is now calculated according to its own strides iso the strides of the input array.

CUDA:
   - Param<T> were used without full initialisation.  Because the construction of Param<T>’s are deprecated, they are replaced by the createEmptyArray() constructions.
   - Idxs of weights are now calculated according to its own strides.  Idem for the offsets.
   - Small arrays are processed on the CPU.  Strides arrays are now processed on the GPU, independent from size since the CPU version only handles linear arrays.

ONEAPI:
   - Idxs of weights are now calculated according to its own strides.  Idem for offsets.
   - Param<T> were used without full initialisation.  Because the construction of Param<T>’s are deprecated, they are replaced by the createEmptyArray() constructions.
   - Small arrays are processed on the CPU.  Strides arrays are now processed on the GPU, independent from size since the CPU version only handles linear arrays.
   - Offsets are handle for the linear processing.

OPENCL:
   - Idxs of weights are now calculated according to its own strides.  Idem for offsets.
   - When converting a linear array to a vector, the weights offsets were overwritten.
   - The size of the tmpOut and tmpWeight arrays are now correctly sized.  Intermediate results were overwritten resulting in a mean of a part of the array.
   - Small arrays are processed on the CPU.  Strides arrays are now processed on the GPU, independent from size since the CPU version only handles linear arrays.
   - Param<T> were used without full initialisation.  Because the construction of Param<T>’s are deprecated, they are replaced by the createEmptyArray() constructions.

TEST:
    - extra tests added on all temporary formats.
    - allowed fault tolerance for tests is lowered, since now the correct mean is calculated for all backends.
    - MeanAllTest now uses random data iso constants for testing.  This blocked the detection of partial processing of the input.



Additional information about the PR answering following questions:

* Is this a new feature or a bug fix?   BUG
* More detail if necessary to describe all commits in pull request.
* Why these changes are necessary.  CORRECT RESULTS WERE NOT GUARANTEED
* Potential impact on specific hardware, software or backends.  NONE
* New functions and their functionality.  NONE
* Can this PR be backported to older versions?  NO
* Future changes not implemented in this PR.  NO
Fixes: 

Changes to Users
----------------
Better precision in all circumstances, and independent form platform or array format.

Checklist
---------
<!-- Check if done or not applicable -->
- [x] Rebased on latest master
- [x] Code compiles
- [x] Tests pass
- [ ] Functions added to unified API
- [ ] Functions documented
